### PR TITLE
Document news ignore changes processing in the provider protocol

### DIFF
--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -18,7 +18,7 @@
 3421371250 793 proto/pulumi/errors.proto
 2542270977 11434 proto/pulumi/language.proto
 2893249402 1992 proto/pulumi/plugin.proto
-3127524323 26543 proto/pulumi/provider.proto
+946000435 27035 proto/pulumi/provider.proto
 1190662922 17848 proto/pulumi/resource.proto
 607478140 1008 proto/pulumi/source.proto
 1507248916 2314 proto/pulumi/testing/language.proto

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -263,7 +263,7 @@ message DiffRequest {
 
     // the new input values of resource to diff.
     //
-    // Note that in case ignoreChanges is specified, news will be pre-processed similarly to CheckRequest.news.
+    // Pre-processed to accommodate ignoreChanges, see the note on CheckRequest.news.
     google.protobuf.Struct news = 4;
 
     repeated string ignoreChanges = 5; // a set of property paths that should be treated as unchanged.
@@ -364,7 +364,12 @@ message UpdateRequest {
     string id = 1;                     // the ID of the resource to update.
     string urn = 2;                    // the Pulumi URN for this resource.
     google.protobuf.Struct olds = 3;   // the old values of provider inputs for the resource to update.
-    google.protobuf.Struct news = 4;   // the new values of provider inputs for the resource to update.
+
+    // the new values of provider inputs for the resource to update.
+    //
+    // Pre-processed to accommodate ignoreChanges, see the note on CheckRequest.news.
+    google.protobuf.Struct news = 4;
+
     double timeout = 5;                // the update request timeout represented in seconds.
     repeated string ignoreChanges = 6; // a set of property paths that should be treated as unchanged.
     bool preview = 7;                   // true if this is a preview and the provider should not actually create the resource.

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -261,9 +261,7 @@ message DiffRequest {
     string urn = 2;                    // the Pulumi URN for this resource.
     google.protobuf.Struct olds = 3;   // the old output values of resource to diff.
 
-    // the new input values of resource to diff.
-    //
-    // Pre-processed to accommodate ignoreChanges, see the note on CheckRequest.news.
+    // the new input values of resource to diff, copied from CheckResponse.inputs.
     google.protobuf.Struct news = 4;
 
     repeated string ignoreChanges = 5; // a set of property paths that should be treated as unchanged.
@@ -365,9 +363,7 @@ message UpdateRequest {
     string urn = 2;                    // the Pulumi URN for this resource.
     google.protobuf.Struct olds = 3;   // the old values of provider inputs for the resource to update.
 
-    // the new values of provider inputs for the resource to update.
-    //
-    // Pre-processed to accommodate ignoreChanges, see the note on CheckRequest.news.
+    // the new values of provider inputs for the resource to update, copied from CheckResponse.inputs.
     google.protobuf.Struct news = 4;
 
     double timeout = 5;                // the update request timeout represented in seconds.

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -37,7 +37,7 @@ service ResourceProvider {
     //
     // Parameterize should work the same for both the `ParametersArgs` input and the `ParametersValue` input. Either way
     // should return the sub-package name and version (which for `ParametersValue` should match the given input).
-    // 
+    //
     // For extension resources their CRUD operations will include the version of which sub-package they correspond to.
     rpc Parameterize(ParameterizeRequest) returns (ParameterizeResponse) {}
 
@@ -229,7 +229,15 @@ message CallResponse {
 message CheckRequest {
     string urn = 1;                  // the Pulumi URN for this resource.
     google.protobuf.Struct olds = 2; // the old Pulumi inputs for this resource, if any.
-    google.protobuf.Struct news = 3; // the new Pulumi inputs for this resource.
+
+    // the new Pulumi inputs for this resource.
+    //
+    // Note that if the user specifies the ignoreChanges resource option, the value of news passed
+    // to the provider here may differ from the values written in the program source. It will be pre-processed by
+    // replacing every ignoreChanges property by a matching value from the old inputs stored in the state.
+    //
+    // See also: https://www.pulumi.com/docs/concepts/options/ignorechanges/
+    google.protobuf.Struct news = 3;
 
     // We used to send sequenceNumber but that has been replaced by randomSeed.
     reserved 4;
@@ -252,7 +260,12 @@ message DiffRequest {
     string id = 1;                     // the ID of the resource to diff.
     string urn = 2;                    // the Pulumi URN for this resource.
     google.protobuf.Struct olds = 3;   // the old output values of resource to diff.
-    google.protobuf.Struct news = 4;   // the new input values of resource to diff.
+
+    // the new input values of resource to diff.
+    //
+    // Note that in case ignoreChanges is specified, news will be pre-processed similarly to CheckRequest.news.
+    google.protobuf.Struct news = 4;
+
     repeated string ignoreChanges = 5; // a set of property paths that should be treated as unchanged.
     google.protobuf.Struct old_inputs = 6;   // the old input values of the resource to diff.
 }

--- a/sdk/nodejs/proto/provider_grpc_pb.js
+++ b/sdk/nodejs/proto/provider_grpc_pb.js
@@ -367,7 +367,7 @@ var ResourceProviderService = exports.ResourceProviderService = {
 //
 // Parameterize should work the same for both the `ParametersArgs` input and the `ParametersValue` input. Either way
 // should return the sub-package name and version (which for `ParametersValue` should match the given input).
-// 
+//
 // For extension resources their CRUD operations will include the version of which sub-package they correspond to.
 parameterize: {
     path: '/pulumirpc.ResourceProvider/Parameterize',

--- a/sdk/proto/go/provider.pb.go
+++ b/sdk/proto/go/provider.pb.go
@@ -912,9 +912,16 @@ type CheckRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Urn        string           `protobuf:"bytes,1,opt,name=urn,proto3" json:"urn,omitempty"`               // the Pulumi URN for this resource.
-	Olds       *structpb.Struct `protobuf:"bytes,2,opt,name=olds,proto3" json:"olds,omitempty"`             // the old Pulumi inputs for this resource, if any.
-	News       *structpb.Struct `protobuf:"bytes,3,opt,name=news,proto3" json:"news,omitempty"`             // the new Pulumi inputs for this resource.
+	Urn  string           `protobuf:"bytes,1,opt,name=urn,proto3" json:"urn,omitempty"`   // the Pulumi URN for this resource.
+	Olds *structpb.Struct `protobuf:"bytes,2,opt,name=olds,proto3" json:"olds,omitempty"` // the old Pulumi inputs for this resource, if any.
+	// the new Pulumi inputs for this resource.
+	//
+	// Note that if the user specifies the ignoreChanges resource option, the value of news passed
+	// to the provider here may differ from the values written in the program source. It will be pre-processed by
+	// replacing every ignoreChanges property by a matching value from the old inputs stored in the state.
+	//
+	// See also: https://www.pulumi.com/docs/concepts/options/ignorechanges/
+	News       *structpb.Struct `protobuf:"bytes,3,opt,name=news,proto3" json:"news,omitempty"`
 	RandomSeed []byte           `protobuf:"bytes,5,opt,name=randomSeed,proto3" json:"randomSeed,omitempty"` // a deterministically random hash, primarily intended for global unique naming.
 }
 
@@ -1093,10 +1100,11 @@ type DiffRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id            string           `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                // the ID of the resource to diff.
-	Urn           string           `protobuf:"bytes,2,opt,name=urn,proto3" json:"urn,omitempty"`                              // the Pulumi URN for this resource.
-	Olds          *structpb.Struct `protobuf:"bytes,3,opt,name=olds,proto3" json:"olds,omitempty"`                            // the old output values of resource to diff.
-	News          *structpb.Struct `protobuf:"bytes,4,opt,name=news,proto3" json:"news,omitempty"`                            // the new input values of resource to diff.
+	Id   string           `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`     // the ID of the resource to diff.
+	Urn  string           `protobuf:"bytes,2,opt,name=urn,proto3" json:"urn,omitempty"`   // the Pulumi URN for this resource.
+	Olds *structpb.Struct `protobuf:"bytes,3,opt,name=olds,proto3" json:"olds,omitempty"` // the old output values of resource to diff.
+	// the new input values of resource to diff, copied from CheckResponse.inputs.
+	News          *structpb.Struct `protobuf:"bytes,4,opt,name=news,proto3" json:"news,omitempty"`
 	IgnoreChanges []string         `protobuf:"bytes,5,rep,name=ignoreChanges,proto3" json:"ignoreChanges,omitempty"`          // a set of property paths that should be treated as unchanged.
 	OldInputs     *structpb.Struct `protobuf:"bytes,6,opt,name=old_inputs,json=oldInputs,proto3" json:"old_inputs,omitempty"` // the old input values of the resource to diff.
 }
@@ -1620,10 +1628,11 @@ type UpdateRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id            string           `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                // the ID of the resource to update.
-	Urn           string           `protobuf:"bytes,2,opt,name=urn,proto3" json:"urn,omitempty"`                              // the Pulumi URN for this resource.
-	Olds          *structpb.Struct `protobuf:"bytes,3,opt,name=olds,proto3" json:"olds,omitempty"`                            // the old values of provider inputs for the resource to update.
-	News          *structpb.Struct `protobuf:"bytes,4,opt,name=news,proto3" json:"news,omitempty"`                            // the new values of provider inputs for the resource to update.
+	Id   string           `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`     // the ID of the resource to update.
+	Urn  string           `protobuf:"bytes,2,opt,name=urn,proto3" json:"urn,omitempty"`   // the Pulumi URN for this resource.
+	Olds *structpb.Struct `protobuf:"bytes,3,opt,name=olds,proto3" json:"olds,omitempty"` // the old values of provider inputs for the resource to update.
+	// the new values of provider inputs for the resource to update, copied from CheckResponse.inputs.
+	News          *structpb.Struct `protobuf:"bytes,4,opt,name=news,proto3" json:"news,omitempty"`
 	Timeout       float64          `protobuf:"fixed64,5,opt,name=timeout,proto3" json:"timeout,omitempty"`                    // the update request timeout represented in seconds.
 	IgnoreChanges []string         `protobuf:"bytes,6,rep,name=ignoreChanges,proto3" json:"ignoreChanges,omitempty"`          // a set of property paths that should be treated as unchanged.
 	Preview       bool             `protobuf:"varint,7,opt,name=preview,proto3" json:"preview,omitempty"`                     // true if this is a preview and the provider should not actually create the resource.

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
@@ -503,7 +503,14 @@ class CheckRequest(google.protobuf.message.Message):
         """the old Pulumi inputs for this resource, if any."""
     @property
     def news(self) -> google.protobuf.struct_pb2.Struct:
-        """the new Pulumi inputs for this resource."""
+        """the new Pulumi inputs for this resource.
+
+        Note that if the user specifies the ignoreChanges resource option, the value of news passed
+        to the provider here may differ from the values written in the program source. It will be pre-processed by
+        replacing every ignoreChanges property by a matching value from the old inputs stored in the state.
+
+        See also: https://www.pulumi.com/docs/concepts/options/ignorechanges/
+        """
     randomSeed: builtins.bytes
     """a deterministically random hash, primarily intended for global unique naming."""
     def __init__(
@@ -581,7 +588,7 @@ class DiffRequest(google.protobuf.message.Message):
         """the old output values of resource to diff."""
     @property
     def news(self) -> google.protobuf.struct_pb2.Struct:
-        """the new input values of resource to diff."""
+        """the new input values of resource to diff, copied from CheckResponse.inputs."""
     @property
     def ignoreChanges(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
         """a set of property paths that should be treated as unchanged."""
@@ -905,7 +912,7 @@ class UpdateRequest(google.protobuf.message.Message):
         """the old values of provider inputs for the resource to update."""
     @property
     def news(self) -> google.protobuf.struct_pb2.Struct:
-        """the new values of provider inputs for the resource to update."""
+        """the new values of provider inputs for the resource to update, copied from CheckResponse.inputs."""
     timeout: builtins.float
     """the update request timeout represented in seconds."""
     @property


### PR DESCRIPTION
This change adds comments in the protobuf definitions of the Engine<->Provider protocol to highlight that the `news` value passed to the provider may be influenced by the state, specifically the old inputs stored in the state, in an Update scenario, and pre-processed to implement ignoreChanges at the engine level. This was not entirely obvious when analyzing provider behavior, and it helps having this documented in the proto files.

Note that this is especially confusing since the engine is also passing ignoreChanges to the provider as if to say "please implement it on your end". This is indeed something that is used to suppress any residual diffs, say in Terraform-bridged providers, but what's not obvious is that the engine performs a bit of processing here already.

The relevant implementation seems to be around https://github.com/pulumi/pulumi/blame/master/pkg/resource/deploy/step.go#L1407 