### PR TITLE
Fix literal values in generated Go stack outputs

### DIFF
--- a/changelog/pending/20240718--programgen-go--fix-emiting-literal-values-as-stack-outputs.yaml
+++ b/changelog/pending/20240718--programgen-go--fix-emiting-literal-values-as-stack-outputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go
+  description: Fix emiting literal values as stack outputs

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -341,7 +341,6 @@ var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:   "output-literals",
 		Description: "Tests that we can return various literal values via stack outputs",
-		SkipCompile: codegen.NewStringSet("go"),
 	},
 	{
 		Directory:   "dynamic-entries",

--- a/tests/testdata/codegen/output-literals-pp/go/output-literals.go
+++ b/tests/testdata/codegen/output-literals-pp/go/output-literals.go
@@ -6,10 +6,10 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		ctx.Export("output_true", true)
-		ctx.Export("output_false", false)
-		ctx.Export("output_number", 4)
-		ctx.Export("output_string", "hello")
+		ctx.Export("output_true", pulumi.Bool(true))
+		ctx.Export("output_false", pulumi.Bool(false))
+		ctx.Export("output_number", pulumi.Float64(4))
+		ctx.Export("output_string", pulumi.String("hello"))
 		return nil
 	})
 }


### PR DESCRIPTION
Splitting off just the codegen changes from https://github.com/pulumi/pulumi/pull/16698 to see if they pass CI.