### PR TITLE
Ensure no output is lost for nodejs commands when stdout is slow

### DIFF
--- a/changelog/pending/20240720--sdk-nodejs--ensure-no-output-is-lost-for-nodejs-commands-when-stdout-is-slow.yaml
+++ b/changelog/pending/20240720--sdk-nodejs--ensure-no-output-is-lost-for-nodejs-commands-when-stdout-is-slow.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Ensure no output is lost for nodejs commands when stdout is slow


### PR DESCRIPTION
Nodejs sometimes sets stdout/stderr to non-blocking mode. When a nodejs subprocess is directly handed the go process's stdout/stderr file descriptors, nodejs's non-blocking configuration goes unnoticed by go, and a write from go can result in an error `write /dev/stdout: resource temporarily unavailable`.

The solution to this is to not provide nodejs with the go process's stdout/stderr file descriptors, and instead proxy the writes through something else. In https://github.com/pulumi/pulumi/pull/16504 we used Cmd.StdoutPipe/StderrPipe for this. However this introduced a potential bug, as it is not safe to use these specific pipes along with Cmd.Run. The issue is that these pipes will be closed as soon as the process exits, which can lead to missing data when stdout/stderr are slow, or worse an error due to an attempted read from a closed pipe. (Creating our own os.Pipes for this would be fine.)

A better workaround is to wrap stdout/stderr in an io.Writer. As with the pipes, this makes exec.Cmd use a copying goroutine to shuffle the data from the subprocess to stdout/stderr. Cmd.Run will wait for all the data to be copied before returning, ensuring we do not miss any data.

Non-blocking issue: https://github.com/golang/go/issues/58408#issuecomment-1423621323
StdoutPipe/StderrPipe issues: https://pkg.go.dev/os/exec#Cmd.StdoutPipe
Waiting for data: https://cs.opensource.google/go/go/+/refs/tags/go1.22.5:src/os/exec/exec.go;l=201