### PR TITLE
Run Environment.DeleteIfNotFailed after tests complete

### DIFF
--- a/tests/about_test.go
+++ b/tests/about_test.go
@@ -32,11 +32,7 @@ func TestAboutCommands(t *testing.T) {
 		t.Parallel()
 
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 		integration.CreateBasicPulumiRepo(e)
 		e.SetBackend(e.LocalURL())
 		stdout, _ := e.RunCommand("pulumi", "about", "--json")
@@ -52,11 +48,7 @@ func TestAboutCommands(t *testing.T) {
 		t.Parallel()
 
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 		integration.CreateBasicPulumiRepo(e)
 		e.SetBackend(e.LocalURL())
 		stdout, _ := e.RunCommand("pulumi", "about")

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -37,11 +37,7 @@ func TestConfigCommands(t *testing.T) {
 		t.Parallel()
 
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 
 		integration.CreateBasicPulumiRepo(e)
 		e.SetBackend(e.LocalURL())
@@ -134,11 +130,7 @@ func TestConfigCommands(t *testing.T) {
 		t.Parallel()
 
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 
 		integration.CreateBasicPulumiRepo(e)
 		e.SetBackend(e.LocalURL())
@@ -288,11 +280,7 @@ func TestBasicConfigGetRetrievedValueFromProject(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	pulumiProject := `
 name: pulumi-test
@@ -314,11 +302,7 @@ func TestConfigGetRetrievedValueFromBothStackAndProjectUsingJson(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	pulumiProject := `
 name: pulumi-test
@@ -361,9 +345,7 @@ func TestConfigCommandsUsingEnvironments(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		deleteIfNotFailed(e)
-	}()
+	defer deleteIfNotFailed(e)
 
 	integration.CreateBasicPulumiRepo(e)
 	e.RunCommand("pulumi", "org", "set-default", getTestOrg())

--- a/tests/integration/integration_acceptance_test.go
+++ b/tests/integration/integration_acceptance_test.go
@@ -34,11 +34,7 @@ import (
 func TestConfigSave(t *testing.T) {
 	t.Parallel()
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	// Initialize an empty stack.
 	path := filepath.Join(e.RootPath, "Pulumi.yaml")
@@ -111,11 +107,7 @@ func TestRotatePassphrase(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	e.ImportDirectory("rotate_passphrase")
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
@@ -163,11 +155,7 @@ func TestPassphrasePrompting(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	e.NoPassphrase = true
 	// Setting PULUMI_TEST_PASSPHRASE allows prompting (reading from stdin)

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -43,11 +43,7 @@ func TestBuildTarget(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 	e.ImportDirectory(filepath.Join("go", "go-build-target"))
 
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
@@ -912,11 +908,7 @@ func TestAboutGo(t *testing.T) {
 	dir := filepath.Join("about", "go")
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 	e.ImportDirectory(dir)
 
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
@@ -1021,11 +1013,7 @@ func TestAutomation_externalPluginDownload_issue13301(t *testing.T) {
 	t.Cleanup(cancel)
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 	e.ImportDirectory(filepath.Join("go", "regress-13301"))
 
 	// Rename go.mod.bad to go.mod so that the Go toolchain uses it.

--- a/tests/integration/integration_nodejs_acceptance_test.go
+++ b/tests/integration/integration_nodejs_acceptance_test.go
@@ -199,11 +199,7 @@ func TestNewNodejsUsesNpmByDefault(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 	e.RunCommand("pulumi", "new", "typescript", "--force", "--non-interactive", "--yes", "--generate-only")
@@ -218,11 +214,7 @@ func TestNewNodejsRuntimeOptions(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 	e.RunCommand("pulumi", "new", "typescript", "--force", "--non-interactive", "--yes", "--generate-only",

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -118,11 +118,7 @@ func TestProjectMainNodejs(t *testing.T) {
 		t.Parallel()
 
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 		e.ImportDirectory("project_main_abs")
 
 		// write a new Pulumi.yaml using the absolute path of the environment as "main"
@@ -148,11 +144,7 @@ func TestProjectMainNodejs(t *testing.T) {
 		t.Parallel()
 
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 		e.ImportDirectory("project_main_parent")
 
 		// yarn link first
@@ -187,11 +179,7 @@ func TestRemoveWithResourcesBlocked(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	stackName, err := resource.NewUniqueHex("rm-test-", 8, -1)
 	contract.AssertNoErrorf(err, "resource.NewUniqueHex should not fail with no maximum length is set")
@@ -326,11 +314,7 @@ func TestStackOutputsResourceErrorNodeJS(t *testing.T) {
 func TestStackOutputsJSON(t *testing.T) {
 	t.Parallel()
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 	e.ImportDirectory(filepath.Join("stack_outputs", "nodejs"))
 	e.RunCommand("yarn", "link", "@pulumi/pulumi")
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
@@ -1622,11 +1606,7 @@ func TestNoNegativeTimingsOnRefresh(t *testing.T) {
 
 	dir := filepath.Join("empty", "nodejs")
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 	e.ImportDirectory(dir)
 
 	e.RunCommand("yarn", "link", "@pulumi/pulumi")
@@ -1652,11 +1632,7 @@ func TestAboutNodeJS(t *testing.T) {
 
 	dir := filepath.Join("about", "nodejs")
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 	e.ImportDirectory(dir)
 
 	e.RunCommand("yarn", "link", "@pulumi/pulumi")
@@ -1683,11 +1659,7 @@ func TestTSConfigOption(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 	e.ImportDirectory("tsconfig")
 
 	e.RunCommand("yarn", "link", "@pulumi/pulumi")

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -226,11 +226,7 @@ func TestAutomaticVenvCreation(t *testing.T) {
 
 	check := func(t *testing.T, venvPathTemplate string, dir string) {
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 
 		venvPath := strings.ReplaceAll(venvPathTemplate, "${root}", e.RootPath)
 		t.Logf("venvPath = %s (IsAbs = %v)", venvPath, filepath.IsAbs(venvPath))
@@ -303,11 +299,7 @@ func TestAutomaticVenvCreation(t *testing.T) {
 		t.Parallel()
 
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 
 		dir := filepath.Join("python", "venv")
 		e.ImportDirectory(dir)
@@ -330,11 +322,7 @@ func TestAutomaticVenvCreationPoetry(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	e.ImportDirectory(filepath.Join("python", "poetry"))
 
@@ -437,11 +425,7 @@ func TestNewPythonUsesPip(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 	stdout, _ := e.RunCommand("pulumi", "new", "python", "--force", "--non-interactive", "--yes", "--generate-only")
@@ -461,11 +445,7 @@ func TestNewPythonUsesPipNonInteractive(t *testing.T) {
 	t.Setenv("PULUMI_TEST_INTERACTIVE", "1")
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 	stdout, _ := e.RunCommand("pulumi", "new", "python", "--force", "--yes", "--generate-only")
@@ -490,11 +470,7 @@ func TestNewPythonChoosePoetry(t *testing.T) {
 	t.Setenv("PULUMI_TEST_INTERACTIVE", "1")
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 
@@ -515,11 +491,7 @@ func TestNewPythonRuntimeOptions(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 	e.RunCommand("pulumi", "new", "python", "--force", "--non-interactive", "--yes", "--generate-only",
@@ -540,11 +512,7 @@ func TestNewPythonConvertRequirementsTxt(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	// Add a poetry.toml to make poetry create the virtualenv inside the temp
 	// directory. That way it gets cleaned up with the test.

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1219,11 +1219,7 @@ func TestAboutPython(t *testing.T) {
 	dir := filepath.Join("about", "python")
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 	e.ImportDirectory(dir)
 
 	stdout, _ := e.RunCommand("pulumi", "about", "--json")
@@ -1335,9 +1331,8 @@ func TestFailsOnImplicitDependencyCyclesPython(t *testing.T) {
 //nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestParamaterizedPython(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
-
 	// We can't use ImportDirectory here because we need to run this in the right directory such that the relative paths
-	// work.
+	// work. This also means we don't delete the directory after the test runs.
 	var err error
 	e.CWD, err = filepath.Abs("python/parameterized")
 	require.NoError(t, err)

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -49,11 +49,7 @@ func TestStackTagValidation(t *testing.T) {
 	t.Run("Error_StackName", func(t *testing.T) {
 		t.Parallel()
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 		e.RunCommand("git", "init")
 
 		e.ImportDirectory("stack_project_name")
@@ -77,11 +73,7 @@ func TestStackTagValidation(t *testing.T) {
 		}
 
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 		stackName, err := resource.NewUniqueHex("test-", 8, -1)
 		contract.AssertNoErrorf(err, "resource.NewUniqueHex should not fail with no maximum length is set")
 
@@ -112,11 +104,7 @@ func TestStackInitValidation(t *testing.T) {
 	t.Run("Error_InvalidStackYaml", func(t *testing.T) {
 		t.Parallel()
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 		e.RunCommand("git", "init")
 
 		e.ImportDirectory("stack_project_name")
@@ -141,11 +129,7 @@ func TestConfigPaths(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	// Initialize an empty stack.
 	path := filepath.Join(e.RootPath, "Pulumi.yaml")
@@ -557,11 +541,7 @@ func testDestroyStackRef(e *ptesting.Environment, organization string) {
 //nolint:paralleltest // uses parallel programtest
 func TestDestroyStackRef_LocalProject(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 	testDestroyStackRef(e, "organization")
@@ -570,9 +550,7 @@ func TestDestroyStackRef_LocalProject(t *testing.T) {
 //nolint:paralleltest // uses parallel programtest
 func TestDestroyStackRef_LocalNonProject_NewEnv(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		e.DeleteIfNotFailed()
-	}()
+	defer e.DeleteIfNotFailed()
 
 	t.Setenv("PULUMI_DIY_BACKEND_LEGACY_LAYOUT", "true")
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
@@ -582,9 +560,7 @@ func TestDestroyStackRef_LocalNonProject_NewEnv(t *testing.T) {
 //nolint:paralleltest // uses parallel programtest
 func TestDestroyStackRef_LocalNonProject_OldEnv(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		e.DeleteIfNotFailed()
-	}()
+	defer e.DeleteIfNotFailed()
 
 	t.Setenv("PULUMI_SELF_MANAGED_STATE_LEGACY_LAYOUT", "true")
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
@@ -598,11 +574,7 @@ func TestDestroyStackRef_Cloud(t *testing.T) {
 	}
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	output, _ := e.RunCommand("pulumi", "whoami")
 	organization := strings.TrimSpace(output)
@@ -691,11 +663,7 @@ func TestProviderDownloadURL(t *testing.T) {
 func TestExcludeProtected(t *testing.T) {
 	t.Parallel()
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	e.ImportDirectory("exclude_protected")
 
@@ -719,11 +687,7 @@ func TestInvalidPluginError(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	pulumiProject := `
 name: invalid-plugin
@@ -755,11 +719,7 @@ func TestPassphraseSetAllGet(t *testing.T) {
 
 	e := ptesting.NewEnvironment(t)
 	e.Passphrase = "test-passphrase"
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	pulumiProject := `
 name: passphrase-test
@@ -786,11 +746,7 @@ func TestPassphraseSetGet(t *testing.T) {
 
 	e := ptesting.NewEnvironment(t)
 	e.Passphrase = "test-passphrase"
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	pulumiProject := `
 name: passphrase-test
@@ -1060,11 +1016,7 @@ func testStackRmConfig(e *ptesting.Environment, organization string) {
 //nolint:paralleltest // uses parallel programtest
 func TestStackRmConfig_LocalProject(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 	testStackRmConfig(e, "organization")
@@ -1077,11 +1029,7 @@ func TestStackRmConfig_Cloud(t *testing.T) {
 	}
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	output, _ := e.RunCommand("pulumi", "whoami")
 	organization := strings.TrimSpace(output)
@@ -1091,6 +1039,7 @@ func TestStackRmConfig_Cloud(t *testing.T) {
 //nolint:paralleltest // uses parallel programtest
 func TestAdvisoryPolicyPack(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
 	e.ImportDirectory("single_resource")
 	e.ImportDirectory("policy")
 
@@ -1116,6 +1065,7 @@ func TestAdvisoryPolicyPack(t *testing.T) {
 //nolint:paralleltest // uses parallel programtest
 func TestMandatoryPolicyPack(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
 	e.ImportDirectory("single_resource")
 	e.ImportDirectory("policy")
 
@@ -1142,6 +1092,7 @@ func TestMandatoryPolicyPack(t *testing.T) {
 //nolint:paralleltest // uses parallel programtest
 func TestMultiplePolicyPacks(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
 	e.ImportDirectory("single_resource")
 	e.ImportDirectory("policy")
 
@@ -1174,6 +1125,7 @@ func TestMultiplePolicyPacks(t *testing.T) {
 //nolint:paralleltest // uses parallel programtest
 func TestPolicyPluginExtraArguments(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
 	e.ImportDirectory("single_resource")
 	e.ImportDirectory("policy")
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
@@ -1213,6 +1165,7 @@ func TestPolicyPluginExtraArguments(t *testing.T) {
 //nolint:paralleltest // uses parallel programtest
 func TestPolicyPackNewGenerateOnly(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
 	require.False(t, e.PathExists("venv"))
 	stdout, _ := e.RunCommand("pulumi", "policy", "new", "aws-python", "--force", "--generate-only")
 	require.Contains(t, stdout, "To install dependencies for the Policy Pack, run `pulumi install`")
@@ -1222,6 +1175,7 @@ func TestPolicyPackNewGenerateOnly(t *testing.T) {
 //nolint:paralleltest // uses parallel programtest
 func TestPolicyPackNew(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
 	require.False(t, e.PathExists("venv"))
 	stdout, _ := e.RunCommand("pulumi", "policy", "new", "aws-python", "--force")
 	require.NotContains(t, stdout, "To install dependencies for the Policy Pack, run `pulumi install`")
@@ -1233,6 +1187,7 @@ func TestPolicyPackNew(t *testing.T) {
 //nolint:paralleltest // uses parallel programtest
 func TestPolicyPackInstallDependencies(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
 	e.ImportDirectory("policy/python_policy_pack")
 	require.False(t, e.PathExists("venv"))
 	stdout, _ := e.RunCommand("pulumi", "install")
@@ -1244,6 +1199,7 @@ func TestPolicyPackInstallDependencies(t *testing.T) {
 //nolint:paralleltest // uses parallel programtest
 func TestProjectInstallDependencies(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
 	e.ImportDirectory("single_resource")
 	require.False(t, e.PathExists("node_modules"))
 	stdout, _ := e.RunCommand("pulumi", "install")
@@ -1254,11 +1210,7 @@ func TestProjectInstallDependencies(t *testing.T) {
 //nolint:paralleltest // uses parallel programtest
 func TestInstallDependenciesForPolicyPackWithParentProject(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 	// create a directory structure with a pulumi project and a nested policy pack
 	require.NoError(t, fsutil.CopyFile(e.RootPath, "nodejs/esm-ts", nil))
 	policyPackPath := filepath.Join(e.RootPath, "policy")
@@ -1278,11 +1230,7 @@ func TestInstallDependenciesForPolicyPackWithParentProject(t *testing.T) {
 //nolint:paralleltest // uses parallel programtest
 func TestInstallDependenciesProjectWithParentPolicyPack(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 	// create a directory structure with a policy pack and a nested project
 	require.NoError(t, fsutil.CopyFile(e.RootPath, "policy/mandatory_policy_pack", nil))
 	projectPath := filepath.Join(e.RootPath, "project")

--- a/tests/integration/policy/policy_test.go
+++ b/tests/integration/policy/policy_test.go
@@ -21,11 +21,7 @@ func TestPolicyWithConfig(t *testing.T) {
 	t.Skip("Skip test that is causing unrelated tests to fail - pulumi/pulumi#4149")
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	// Confirm we have credentials.
 	if os.Getenv("PULUMI_ACCESS_TOKEN") == "" {
@@ -98,11 +94,7 @@ func TestPolicyWithoutConfig(t *testing.T) {
 	t.Skip("Skip test that is causing unrelated tests to fail - pulumi/pulumi#4149")
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	// Confirm we have credentials.
 	if os.Getenv("PULUMI_ACCESS_TOKEN") == "" {

--- a/tests/integration/targets/targets_test.go
+++ b/tests/integration/targets/targets_test.go
@@ -27,11 +27,7 @@ func TestUntargetedCreateDuringTargetedUpdate(t *testing.T) {
 	}
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	stackName, err := resource.NewUniqueHex("test-", 8, -1)
 	contract.AssertNoErrorf(err, "resource.NewUniqueHex should not fail with no maximum length is set")
@@ -63,11 +59,7 @@ func TestDeleteManyTargets(t *testing.T) {
 	}
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	// First just spin up the project.
 	projName := "delete_targets_many_deps"

--- a/tests/preview_only_test.go
+++ b/tests/preview_only_test.go
@@ -29,11 +29,7 @@ func TestPreviewOnlyFlag(t *testing.T) {
 		t.Parallel()
 
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 
 		integration.CreateBasicPulumiRepo(e)
 		e.ImportDirectory("integration/single_resource")
@@ -73,11 +69,7 @@ func TestPreviewOnlyFlag(t *testing.T) {
 		t.Parallel()
 
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 
 		integration.CreateBasicPulumiRepo(e)
 		e.ImportDirectory("integration/single_resource")
@@ -117,11 +109,7 @@ func TestPreviewOnlyFlag(t *testing.T) {
 		t.Parallel()
 
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 
 		integration.CreateBasicPulumiRepo(e)
 		e.SetBackend(e.LocalURL())

--- a/tests/roundtrip_test.go
+++ b/tests/roundtrip_test.go
@@ -32,11 +32,7 @@ func TestProjectRoundtripComments(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	pulumiProject := `
 # 🔴 header comment
@@ -115,11 +111,7 @@ func TestConfigRoundtripComments(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	pulumiProject := `
 name: foo

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -49,11 +49,7 @@ func TestStackCommands(t *testing.T) {
 		t.Parallel()
 
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 
 		integration.CreateBasicPulumiRepo(e)
 		e.SetBackend(e.LocalURL())
@@ -80,11 +76,7 @@ func TestStackCommands(t *testing.T) {
 		t.Parallel()
 
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 
 		integration.CreateBasicPulumiRepo(e)
 		e.SetBackend(e.LocalURL())
@@ -157,11 +149,7 @@ func TestStackCommands(t *testing.T) {
 		t.Parallel()
 
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 
 		integration.CreateBasicPulumiRepo(e)
 		e.SetBackend(e.LocalURL())
@@ -187,11 +175,7 @@ func TestStackCommands(t *testing.T) {
 		t.Parallel()
 
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 
 		integration.CreateBasicPulumiRepo(e)
 
@@ -238,11 +222,7 @@ func TestStackCommands(t *testing.T) {
 		for _, deploymentVersion := range versions {
 			t.Run(fmt.Sprintf("Version%d", deploymentVersion), func(t *testing.T) {
 				e := ptesting.NewEnvironment(t)
-				defer func() {
-					if !t.Failed() {
-						e.DeleteEnvironment()
-					}
-				}()
+				defer e.DeleteIfNotFailed()
 
 				integration.CreateBasicPulumiRepo(e)
 				e.SetBackend(e.LocalURL())
@@ -285,11 +265,7 @@ func TestStackCommands(t *testing.T) {
 
 	t.Run("FixingInvalidResources", func(t *testing.T) {
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 		stackName := addRandomSuffix("invalid-resources")
 		integration.CreateBasicPulumiRepo(e)
 		e.ImportDirectory("integration/stack_dependencies")
@@ -357,11 +333,7 @@ func TestStackBackups(t *testing.T) {
 		t.Parallel()
 
 		e := ptesting.NewEnvironment(t)
-		defer func() {
-			if !t.Failed() {
-				e.DeleteEnvironment()
-			}
-		}()
+		defer e.DeleteIfNotFailed()
 
 		integration.CreateBasicPulumiRepo(e)
 		e.ImportDirectory("integration/stack_outputs/nodejs")
@@ -437,11 +409,7 @@ func TestStackBackups(t *testing.T) {
 //nolint:paralleltest // mutates environment variables
 func TestDestroySetsEncryptionsalt(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	const stackName = "imulup"
 	stackFile := filepath.Join(e.RootPath, "Pulumi.imulup.yaml")
@@ -498,11 +466,7 @@ func TestStackRenameAfterCreate(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 	stackName := addRandomSuffix("stack-rename")
 	integration.CreateBasicPulumiRepo(e)
 	e.SetBackend(e.LocalURL())
@@ -518,11 +482,7 @@ func TestStackRenameAfterCreateServiceBackend(t *testing.T) {
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	// Use the current username as the "organization" in certain operations.
 	username, _ := e.RunCommand("pulumi", "whoami")
@@ -560,11 +520,7 @@ func TestLocalStateLocking(t *testing.T) {
 	t.Skip() // TODO[pulumi/pulumi#7269] flaky test
 	t.Parallel()
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 
 	integration.CreateBasicPulumiRepo(e)
 	e.ImportDirectory("integration/single_resource")
@@ -677,11 +633,7 @@ func stackFileFormatAsserters(t *testing.T, e *ptesting.Environment, projectName
 
 func TestLocalStateGzip(t *testing.T) { //nolint:paralleltest
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 	stackName := addRandomSuffix("gzip-state")
 	integration.CreateBasicPulumiRepo(e)
 	e.ImportDirectory("integration/stack_dependencies")
@@ -790,11 +742,7 @@ func TestStackTags(t *testing.T) {
 	}
 
 	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
+	defer e.DeleteIfNotFailed()
 	stackName, err := resource.NewUniqueHex("test-", 8, -1)
 	contract.AssertNoErrorf(err, "resource.NewUniqueHex should not fail with no maximum length is set")
 


### PR DESCRIPTION
Ensure we always run `Environment.DeleteIfNotFailed` in our Environment based tests.

Also standardize on this instead of manually checking with `if t.Failed` and calling `Environment.DeleteEnvironment()`.
