### PR TITLE
Revert "Pin node to 22.4.x to workaround breakage"

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -129,10 +129,7 @@ CURRENT_VERSION_SET = {
     "name": "current",
     "dotnet": "8",
     "go": "1.22.x",
-    # TODO https://github.com/pulumi/pulumi/issues/16707
-    # Node 22.5.0 breaks yarn, the installation stops half way through with a succesfull exit code.
-    # Pin to 22.4.x for now to work around this.
-    "nodejs": "22.4.x",
+    "nodejs": "22.x",
     "python": "3.12.x",
 }
 


### PR DESCRIPTION
Reverts pulumi/pulumi#16709

The underlying issue has been fixed in node 20.5.1 https://github.com/nodejs/node/issues/53902

Fixes https://github.com/pulumi/pulumi/issues/16707