### PR TITLE
Enable l1-main for Go conformance tests

### DIFF
--- a/sdk/go/pulumi-language-go/language_test.go
+++ b/sdk/go/pulumi-language-go/language_test.go
@@ -172,7 +172,6 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 
 // TODO: These tests are not working yet because of issues in sdkgen and programgen
 var expectedFailures = map[string]string{
-	"l1-main":                            "error in compiling Go",
 	"l1-output-array":                    "error in compiling Go",
 	"l1-output-string":                   "error in compiling Go",
 	"l1-output-number":                   "error in compiling Go",

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-main/Pulumi.yaml
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-main/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: l1-main
+runtime: go
+main: subdir

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-main/subdir/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-main/subdir/go.mod
@@ -1,0 +1,7 @@
+module l1-main
+
+go 1.20
+
+require github.com/pulumi/pulumi/sdk/v3 v3.30.0
+
+replace github.com/pulumi/pulumi/sdk/v3/ => /ROOT/artifacts/github.com_pulumi_pulumi_sdk_v3

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-main/subdir/main.go
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-main/subdir/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		ctx.Export("output_true", pulumi.Bool(true))
+		return nil
+	})
+}


### PR DESCRIPTION
Enables the l1-main conformance test for Go. This required fixing up Go programgen to respect the "main" attribute in the projects Pulumi.yaml if present. 