### PR TITLE
state_move: reparent provider correctly

### DIFF
--- a/changelog/pending/20240722--cli-state--reparent-providers-correctly-in-state-move.yaml
+++ b/changelog/pending/20240722--cli-state--reparent-providers-correctly-in-state-move.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Reparent providers correctly in state move

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -236,6 +236,13 @@ func (cmd *stateMoveCmd) Run(
 		// Providers stay in the source stack, so we need a copy of the provider to be able to
 		// rewrite the URNs of the resource.
 		r := res.Copy()
+		if _, ok := resourcesToMove[string(r.Parent)]; !ok {
+			rootStack, err := stack.GetRootStackResource(destSnapshot)
+			if err != nil {
+				return err
+			}
+			r.Parent = rootStack.URN
+		}
 		err = rewriteURNs(r, dest)
 		if err != nil {
 			return err

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -657,9 +657,12 @@ func TestProviderIsReparented(t *testing.T) {
 
 	sourceSnapshot, destSnapshot, _ := runMove(t, sourceResources, []string{string(sourceResources[2].URN)})
 
-	assert.Equal(t, 2, len(sourceSnapshot.Resources)) // Only the provider and the root stack should remain in the source stack
-	assert.Equal(t, urn.URN("urn:pulumi:sourceStack::test::pulumi:pulumi:Stack::test-sourceStack"), sourceSnapshot.Resources[0].URN)
-	assert.Equal(t, urn.URN("urn:pulumi:sourceStack::test::pulumi:providers:a::default_1_0_0"), sourceSnapshot.Resources[1].URN)
+	// Only the provider and the root stack should remain in the source stack
+	assert.Equal(t, 2, len(sourceSnapshot.Resources))
+	assert.Equal(t, urn.URN("urn:pulumi:sourceStack::test::pulumi:pulumi:Stack::test-sourceStack"),
+		sourceSnapshot.Resources[0].URN)
+	assert.Equal(t, urn.URN("urn:pulumi:sourceStack::test::pulumi:providers:a::default_1_0_0"),
+		sourceSnapshot.Resources[1].URN)
 
 	assert.Equal(t, 3, len(destSnapshot.Resources)) // We expect the root stack, the provider, and the moved resource
 	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:pulumi:Stack::test-destStack"),

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -630,3 +630,48 @@ func TestMoveUnknownResource(t *testing.T) {
 	assert.Contains(t, stdout.String(), "warning: Resource not-a-urn not found in source stack")
 	assert.Equal(t, 3, len(sourceSnapshot.Resources)) // No resources should be moved
 }
+
+func TestProviderIsReparented(t *testing.T) {
+	t.Parallel()
+
+	providerURN := resource.NewURN("sourceStack", "test", "", "pulumi:providers:a", "default_1_0_0")
+	sourceResources := []*resource.State{
+		{
+			URN:  resource.DefaultRootStackURN("sourceStack", "test"),
+			Type: "pulumi:pulumi:Stack",
+		},
+		{
+			URN:    providerURN,
+			Type:   "pulumi:providers:a::default_1_0_0",
+			ID:     "provider_id",
+			Custom: true,
+			Parent: resource.DefaultRootStackURN("sourceStack", "test"),
+		},
+		{
+			URN:      resource.NewURN("sourceStack", "test", "d:e:f", "a:b:c", "name"),
+			Type:     "a:b:c",
+			Provider: string(providerURN) + "::provider_id",
+			Parent:   resource.DefaultRootStackURN("sourceStack", "test"),
+		},
+	}
+
+	sourceSnapshot, destSnapshot, _ := runMove(t, sourceResources, []string{string(sourceResources[2].URN)})
+
+	assert.Equal(t, 2, len(sourceSnapshot.Resources)) // Only the provider and the root stack should remain in the source stack
+	assert.Equal(t, urn.URN("urn:pulumi:sourceStack::test::pulumi:pulumi:Stack::test-sourceStack"), sourceSnapshot.Resources[0].URN)
+	assert.Equal(t, urn.URN("urn:pulumi:sourceStack::test::pulumi:providers:a::default_1_0_0"), sourceSnapshot.Resources[1].URN)
+
+	assert.Equal(t, 3, len(destSnapshot.Resources)) // We expect the root stack, the provider, and the moved resource
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:pulumi:Stack::test-destStack"),
+		destSnapshot.Resources[0].URN)
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:providers:a::default_1_0_0"),
+		destSnapshot.Resources[1].URN)
+	assert.Equal(t, resource.DefaultRootStackURN("destStack", "test"),
+		destSnapshot.Resources[1].Parent)
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::d:e:f$a:b:c::name"),
+		destSnapshot.Resources[2].URN)
+	assert.Equal(t, "urn:pulumi:destStack::test::pulumi:providers:a::default_1_0_0::provider_id",
+		destSnapshot.Resources[2].Provider)
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:pulumi:Stack::test-destStack"),
+		destSnapshot.Resources[2].Parent)
+}


### PR DESCRIPTION
Currently when a providers Parent is not moved, we just try to rewrite the current one using the regular URN rewrite mechanism.  This is not correct.

Instead, we need to make sure to do the same thing as we do for regular resources.  Namely if the parent is not being moved into the destination, we want the parent to be the root stack of the destination.