### PR TITLE
state_move: don't conflict if destination provider with same URN and ID exists

### DIFF
--- a/changelog/pending/20240722--cli-state--allow-a-provider-with-the-same-urn-and-id-to-already-be-in-the-snapshot.yaml
+++ b/changelog/pending/20240722--cli-state--allow-a-provider-with-the-same-urn-and-id-to-already-be-in-the-snapshot.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Allow a provider with the same URN and ID to already be in the snapshot

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -232,9 +232,9 @@ func (cmd *stateMoveCmd) Run(
 		destSnapshot.Resources = append([]*resource.State{rootStack}, destSnapshot.Resources...)
 	}
 
-	destResMap := make(map[urn.URN]bool)
+	destResMap := make(map[urn.URN]*resource.State)
 	for _, res := range destSnapshot.Resources {
-		destResMap[res.URN] = true
+		destResMap[res.URN] = res
 	}
 
 	for _, res := range providers {
@@ -253,7 +253,10 @@ func (cmd *stateMoveCmd) Run(
 			return err
 		}
 
-		if _, ok := destResMap[r.URN]; ok {
+		if destRes, ok := destResMap[r.URN]; ok {
+			if destRes.ID == r.ID {
+				continue
+			}
 			return fmt.Errorf("provider %s already exists in destination stack", r.URN)
 		}
 


### PR DESCRIPTION

When a provider with the same URN and ID already exists in the destination snapshot, we can assume it's the provider that has been copied over.  This is e.g. useful when running the state move command multiple times with different resources that have the same provider.

This also allows moving resources back and forth between stacks.