### PR TITLE
Fix panics due to different length `ignoreChanges` arrays

### DIFF
--- a/changelog/pending/20240722--engine--fix-panics-due-to-different-length-ignorechanges-arrays.yaml
+++ b/changelog/pending/20240722--engine--fix-panics-due-to-different-length-ignorechanges-arrays.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix panics due to different length `ignoreChanges` arrays

--- a/sdk/go/common/resource/properties_path.go
+++ b/sdk/go/common/resource/properties_path.go
@@ -424,14 +424,22 @@ func (p PropertyPath) reset(old, new PropertyValue, oldIsSecret, newIsSecret boo
 					return true
 				} else if new.IsArray() {
 					if old.IsArray() {
-						for i := range old.ArrayValue() {
-							v := old.ArrayValue()[i]
+						oldArray := old.ArrayValue()
+						newArray := new.ArrayValue()
+						// If arrays are of different length then this is a path failure because we can't
+						// synchronise the two values.
+						if len(oldArray) != len(newArray) {
+							return false
+						}
+
+						for i := range oldArray {
+							v := oldArray[i]
 							// If this was a secret value in old, but new isn't currently a secret context then we need
 							// to mark this reset value as secret.
 							if oldIsSecret && !newIsSecret {
 								v = MakeSecret(v)
 							}
-							new.ArrayValue()[i] = v
+							newArray[i] = v
 						}
 					}
 					return true

--- a/sdk/go/common/resource/properties_path_test.go
+++ b/sdk/go/common/resource/properties_path_test.go
@@ -161,25 +161,25 @@ func TestPropertyPath(t *testing.T) {
 			value := makeValue()
 
 			v, ok := parsed.Get(value)
-			assert.True(t, ok)
+			assert.True(t, ok, "Failed to get %v from %v", parsed, value)
 			assert.False(t, v.IsNull())
 
 			ok = parsed.Delete(value)
-			assert.True(t, ok)
+			assert.True(t, ok, "Failed to delete %v from %v", parsed, value)
 
 			ok = parsed.Set(value, v)
-			assert.True(t, ok)
+			assert.True(t, ok, "Failed to set %v in %v", v, parsed)
 
 			u, ok := parsed.Get(value)
-			assert.True(t, ok)
+			assert.True(t, ok, "Failed to get %v from %v", parsed, value)
 			assert.Equal(t, v, u)
 
 			vv := PropertyValue{}
 			vv, ok = parsed.Add(vv, v)
-			assert.True(t, ok)
+			assert.True(t, ok, "Failed to add %v at %v", v, parsed)
 
 			u, ok = parsed.Get(vv)
-			assert.True(t, ok)
+			assert.True(t, ok, "Failed to get %v from %v", parsed, vv)
 			assert.Equal(t, v, u)
 		})
 	}
@@ -724,7 +724,7 @@ func TestReset(t *testing.T) {
 			nil,
 		},
 		{
-			"Nested object wildcard reset fails",
+			"Nested object wildcard index reset fails",
 			PropertyPath{"root", "*", 0},
 			PropertyMap{"root": NewProperty(PropertyMap{
 				"passes": NewProperty(1.0),
@@ -737,7 +737,20 @@ func TestReset(t *testing.T) {
 			nil,
 		},
 		{
-			"Nested array wildcard reset fails",
+			"Nested array wildcard, new array is shorter fails",
+			PropertyPath{"root", "array", "*"},
+			PropertyMap{"root": NewProperty(PropertyMap{
+				"array": NewProperty([]PropertyValue{
+					NewProperty(1.0),
+				}),
+			})},
+			PropertyMap{"root": NewProperty(PropertyMap{
+				"array": NewProperty([]PropertyValue{}),
+			})},
+			nil,
+		},
+		{
+			"Nested array wildcard index reset fails",
 			PropertyPath{"root", "*", 0},
 			PropertyMap{"root": NewProperty([]PropertyValue{
 				NewProperty(1.0),
@@ -750,7 +763,7 @@ func TestReset(t *testing.T) {
 			nil,
 		},
 		{
-			"Nested wildcard, old array is longer fails",
+			"Nested array wildcard index, old array is longer fails",
 			PropertyPath{"root", "*", 0},
 			PropertyMap{"root": NewProperty([]PropertyValue{
 				NewProperty(1.0),
@@ -762,7 +775,7 @@ func TestReset(t *testing.T) {
 			nil,
 		},
 		{
-			"Nested wildcard, new array is longer fails",
+			"Nested array wildcard index, new array is longer fails",
 			PropertyPath{"root", "*", 0},
 			PropertyMap{"root": NewProperty([]PropertyValue{
 				NewProperty(1.0),


### PR DESCRIPTION
The `ignoreChanges` resource option accepts a list of paths into a resource that should be ignored when computing whether or not something has changed. For example:

```typescript
const r = new Resource(
  "r",
  {
    a: "a",
    b: [1, 2],
    c: { d: "d" },
  },
  {
    ignoreChanges: [
      "a",
      "b[*]",
    ],
  }
)
```

Here, when diffing `r`, Pulumi will ignore changes to `a` (due to the path `"a"`) as well as changes to any element of `b` (due to the _wildcard_ path `"b[*]"`). Under the hood, `ignoreChanges` is implemented partly by "resetting" pieces of a resource's state to older values -- that is, rather than ignoring changes that might be reported, Pulumi will undo the changes before they are used altogether.

In #16406, a panic encountered when resetting children of arrays of different length was fixed. This commit extends this fix to cover panics that occur when simply resetting arrays themselves (e.g. resetting `[1,2]` to `[1,2,3]`). As part of this, some test cases are renamed to convey that the are actually testing the children of arrays or wildcard-selected objects, in order to accommodate new test cases for this panic.

Fixes #16724