### PR TITLE
new: capitalize prompts consistently

### DIFF
--- a/changelog/pending/20240722--cli-new--make-prompt-capitalization-consistent.yaml
+++ b/changelog/pending/20240722--cli-new--make-prompt-capitalization-consistent.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/new
+  description: Make prompt capitalization consistent

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -290,7 +290,7 @@ func runNew(ctx context.Context, args newArgs) error {
 		validate := func(s string) error {
 			return validateProjectName(ctx, b, orgName, s, args.generateOnly, opts)
 		}
-		args.name, err = args.prompt(args.yes, "project name", defaultValue, false, validate, opts)
+		args.name, err = args.prompt(args.yes, "Project name", defaultValue, false, validate, opts)
 		if err != nil {
 			return err
 		}
@@ -301,7 +301,7 @@ func runNew(ctx context.Context, args newArgs) error {
 		defaultValue := pkgWorkspace.ValueOrDefaultProjectDescription(
 			args.description, template.ProjectDescription, template.Description)
 		args.description, err = args.prompt(
-			args.yes, "project description", defaultValue, false, pkgWorkspace.ValidateProjectDescription, opts)
+			args.yes, "Project description", defaultValue, false, pkgWorkspace.ValidateProjectDescription, opts)
 		if err != nil {
 			return err
 		}
@@ -807,7 +807,7 @@ func promptAndCreateStack(ctx context.Context, b backend.Backend, prompt promptF
 	}
 
 	for {
-		stackName, err := prompt(yes, "stack name", "dev", false, b.ValidateStackName, opts)
+		stackName, err := prompt(yes, "Stack name", "dev", false, b.ValidateStackName, opts)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
In `pulumi new` we're currently very inconsistent about capitalizing prompts.  It currently looks something like this (just choosing the default for all answers).

```
$ pulumi new
 Would you like to create a project from a template or using a Pulumi AI prompt? template
Please choose a template (227 total):
 aiven-go                           A minimal Aiven Go Pulumi program
This command will walk you through creating a new Pulumi project.

Enter a value or leave blank to accept the (default), and press <ENTER>.
Press ^C at any time to quit.

project name (pulumi-test-new):
project description (A minimal Aiven Go Pulumi program):
Created project 'pulumi-test-new'

Please enter your desired stack name.
To create a stack in an organization, use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).
stack name (dev):
Created stack 'dev'
```

Note how everything is capitalized except for the "project name", "project description" and "stack name" prompts.  Fix that by also capitalizing those prompts.

With this change it looks more consistent:

```
$ pulumi new
 Would you like to create a project from a template or using a Pulumi AI prompt? template
Please choose a template (227 total):
 aiven-go                           A minimal Aiven Go Pulumi program
This command will walk you through creating a new Pulumi project.

Enter a value or leave blank to accept the (default), and press <ENTER>.
Press ^C at any time to quit.

Project name (pulumi-test-new2):
Project description (A minimal Aiven Go Pulumi program):
Created project 'pulumi-test-new2'

Please enter your desired stack name.
To create a stack in an organization, use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).
Stack name (dev):
Created stack 'dev'
```

Note that the prompts still stand out because they are colorized in the terminal.