### PR TITLE
Enable l1-output-number conformance test for Go

### DIFF
--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -191,9 +191,12 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		from := expr.Args[0]
 		to := pcl.LowerConversion(from, expr.Signature.ReturnType)
 		output, isOutput := to.(*model.OutputType)
+		originalTo := to
 		if isOutput {
 			to = output.ElementType
 		}
+		_, isFromOutput := from.Type().(*model.OutputType)
+
 		switch to := to.(type) {
 		case *model.EnumType:
 			var underlyingType string
@@ -235,7 +238,34 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		case *model.ScopeTraversalExpression:
 			g.genScopeTraversalExpression(w, arg, expr.Type())
 		default:
-			g.Fgenf(w, "%.v", expr.Args[0])
+			// Add a cast to the type we expect if needed
+			if originalTo.AssignableFrom(from.Type()) && (isOutput == isFromOutput) {
+				g.Fgenf(w, "%.v", from)
+			} else {
+				typeName := g.argumentTypeName(from, to, isOutput)
+				// IDOutput has a special case where it can be converted to a string
+				var isID bool
+				if expr, ok := from.(*model.ScopeTraversalExpression); ok {
+					last := expr.Traversal[len(expr.Traversal)-1]
+					if attr, ok := last.(hcl.TraverseAttr); ok && attr.Name == "id" {
+						isID = true
+					}
+				}
+				if expr, ok := from.(*model.RelativeTraversalExpression); ok {
+					last := expr.Traversal[len(expr.Traversal)-1]
+					if attr, ok := last.(hcl.TraverseAttr); ok && attr.Name == "id" {
+						isID = true
+					}
+				}
+
+				if typeName == "" {
+					g.Fgenf(w, "%.v", from)
+				} else if typeName == "pulumi.String" && isID {
+					g.Fgenf(w, "%.v", from)
+				} else {
+					g.Fgenf(w, "%s(%.v)", typeName, from)
+				}
+			}
 		}
 	case pcl.IntrinsicApply:
 		g.genApply(w, expr)

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -245,13 +245,13 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 				typeName := g.argumentTypeName(from, to, isOutput)
 				// IDOutput has a special case where it can be converted to a string
 				var isID bool
-				if expr, ok := from.(*model.ScopeTraversalExpression); ok {
+				switch expr := from.(type) {
+				case *model.ScopeTraversalExpression:
 					last := expr.Traversal[len(expr.Traversal)-1]
 					if attr, ok := last.(hcl.TraverseAttr); ok && attr.Name == "id" {
 						isID = true
 					}
-				}
-				if expr, ok := from.(*model.RelativeTraversalExpression); ok {
+				case *model.RelativeTraversalExpression:
 					last := expr.Traversal[len(expr.Traversal)-1]
 					if attr, ok := last.(hcl.TraverseAttr); ok && attr.Name == "id" {
 						isID = true

--- a/pkg/codegen/go/gen_program_test/batch1/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test/batch1/gen_program_test.go
@@ -26,5 +26,5 @@ import (
 
 func TestGenerateProgram(t *testing.T) {
 	os.Chdir("../../../go") // chdir into codegen/go
-	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(1, 6))
+	codegen.GenerateProgramBatchTest(t, test.PulumiPulumiProgramTests) //test.ProgramTestBatch(1, 6))
 }

--- a/pkg/codegen/go/gen_program_test/batch1/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test/batch1/gen_program_test.go
@@ -26,5 +26,5 @@ import (
 
 func TestGenerateProgram(t *testing.T) {
 	os.Chdir("../../../go") // chdir into codegen/go
-	codegen.GenerateProgramBatchTest(t, test.PulumiPulumiProgramTests) //test.ProgramTestBatch(1, 6))
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(1, 6))
 }

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -351,10 +351,6 @@ var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:   "single-or-none",
 		Description: "Tests using the singleOrNone function",
-		// TODO[pulumi/pulumi#4899]: Skip compiling for Go because it is trying to pass a value of type float64
-		// as an argument to ctx.Export but float64 does not implement pulumi.Input. The value needs to be
-		// wrapped as a pulumi.Float64.
-		SkipCompile: codegen.NewStringSet("go"),
 	},
 	{
 		Directory:   "simple-splat",

--- a/sdk/go/pulumi-language-go/language_test.go
+++ b/sdk/go/pulumi-language-go/language_test.go
@@ -174,7 +174,6 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 var expectedFailures = map[string]string{
 	"l1-output-array":                    "error in compiling Go",
 	"l1-output-string":                   "error in compiling Go",
-	"l1-output-number":                   "error in compiling Go",
 	"l1-stack-reference":                 "error in compiling Go",
 	"l2-target-up-with-new-dependency":   "missing go.mod",
 	"l2-destroy":                         "missing go.mod",

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-output-number/Pulumi.yaml
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-output-number/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-output-number
+runtime: go

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-output-number/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-output-number/go.mod
@@ -1,0 +1,7 @@
+module l1-output-number
+
+go 1.20
+
+require github.com/pulumi/pulumi/sdk/v3 v3.30.0
+
+replace github.com/pulumi/pulumi/sdk/v3/ => /ROOT/artifacts/github.com_pulumi_pulumi_sdk_v3

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-output-number/main.go
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-output-number/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		ctx.Export("zero", pulumi.Float64(0))
+		ctx.Export("one", pulumi.Float64(1))
+		ctx.Export("e", pulumi.Float64(2.718))
+		ctx.Export("minInt32", pulumi.Float64(-2147483648))
+		ctx.Export("max", pulumi.Float64(1.7976931348623157e+308))
+		ctx.Export("min", pulumi.Float64(5e-324))
+		return nil
+	})
+}

--- a/tests/testdata/codegen/single-or-none-pp/go/single-or-none.go
+++ b/tests/testdata/codegen/single-or-none-pp/go/single-or-none.go
@@ -15,9 +15,9 @@ func singleOrNone[T any](elements []T) T {
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		ctx.Export("result", singleOrNone([]float64{
+		ctx.Export("result", pulumi.Float64(singleOrNone([]float64{
 			1,
-		}))
+		})))
 		return nil
 	})
 }

--- a/tests/testdata/codegen/throw-not-implemented-pp/go/throw-not-implemented.go
+++ b/tests/testdata/codegen/throw-not-implemented-pp/go/throw-not-implemented.go
@@ -10,7 +10,7 @@ func notImplemented(message string) pulumi.AnyOutput {
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		ctx.Export("result", notImplemented("expression here is not implemented yet"))
+		ctx.Export("result", pulumi.Any(notImplemented("expression here is not implemented yet")))
 		return nil
 	})
 }


### PR DESCRIPTION
This required fixing `__convert` in Go programgen to handle expressions that needed to result in input-y values. This also fixed the "single-or-none" codegen test.