### PR TITLE
Link to Python docs about input types

### DIFF
--- a/changelog/pending/20240723--sdkgen-python--link-to-python-docs-about-input-types.yaml
+++ b/changelog/pending/20240723--sdkgen-python--link-to-python-docs-about-input-types.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdkgen/python
+  description: Link to Python docs about input types

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -134,6 +134,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The {{ .Header.Title }} resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 {{ template "properties" .InputProperties }}

--- a/tests/testdata/codegen/assets-and-archives/docs/provider/_index.md
+++ b/tests/testdata/codegen/assets-and-archives/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/assets-and-archives/docs/resourcewithassets/_index.md
+++ b/tests/testdata/codegen/assets-and-archives/docs/resourcewithassets/_index.md
@@ -359,6 +359,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The ResourceWithAssets resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/azure-native-nested-types/docs/documentdb/sqlresourcesqlcontainer/_index.md
+++ b/tests/testdata/codegen/azure-native-nested-types/docs/documentdb/sqlresourcesqlcontainer/_index.md
@@ -629,6 +629,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The SqlResourceSqlContainer resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/azure-native-nested-types/docs/provider/_index.md
+++ b/tests/testdata/codegen/azure-native-nested-types/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/config-variables/docs/provider/_index.md
+++ b/tests/testdata/codegen/config-variables/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/cyclic-types/docs/provider/_index.md
+++ b/tests/testdata/codegen/cyclic-types/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/dash-named-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/dash-named-schema/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/dash-named-schema/docs/submodule1/fooencryptedbarclass/_index.md
+++ b/tests/testdata/codegen/dash-named-schema/docs/submodule1/fooencryptedbarclass/_index.md
@@ -297,6 +297,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The FOOEncryptedBarClass resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/dash-named-schema/docs/submodule1/moduleresource/_index.md
+++ b/tests/testdata/codegen/dash-named-schema/docs/submodule1/moduleresource/_index.md
@@ -318,6 +318,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The ModuleResource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/dashed-import-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/dashed-import-schema/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/dashed-import-schema/docs/tree/v1/nursery/_index.md
+++ b/tests/testdata/codegen/dashed-import-schema/docs/tree/v1/nursery/_index.md
@@ -332,6 +332,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Nursery resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
+++ b/tests/testdata/codegen/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
@@ -367,6 +367,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The RubberTree resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/different-enum/docs/provider/_index.md
+++ b/tests/testdata/codegen/different-enum/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/different-enum/docs/tree/v1/nursery/_index.md
+++ b/tests/testdata/codegen/different-enum/docs/tree/v1/nursery/_index.md
@@ -332,6 +332,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Nursery resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/different-enum/docs/tree/v1/rubbertree/_index.md
+++ b/tests/testdata/codegen/different-enum/docs/tree/v1/rubbertree/_index.md
@@ -367,6 +367,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The RubberTree resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/docs-collision/docs/overlay/overlay/_index.md
+++ b/tests/testdata/codegen/docs-collision/docs/overlay/overlay/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Overlay resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/docs-collision/docs/provider/_index.md
+++ b/tests/testdata/codegen/docs-collision/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/docs-collision/docs/res-overlay/_index.md
+++ b/tests/testdata/codegen/docs-collision/docs/res-overlay/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Overlay resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/embedded-crd-types/docs/component/_index.md
+++ b/tests/testdata/codegen/embedded-crd-types/docs/component/_index.md
@@ -9587,6 +9587,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Component resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/embedded-crd-types/docs/provider/_index.md
+++ b/tests/testdata/codegen/embedded-crd-types/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/enum-reference/docs/myModule/iamresource/_index.md
+++ b/tests/testdata/codegen/enum-reference/docs/myModule/iamresource/_index.md
@@ -353,6 +353,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The IamResource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/enum-reference/docs/provider/_index.md
+++ b/tests/testdata/codegen/enum-reference/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/external-enum/docs/component/_index.md
+++ b/tests/testdata/codegen/external-enum/docs/component/_index.md
@@ -316,6 +316,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Component resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/external-enum/docs/provider/_index.md
+++ b/tests/testdata/codegen/external-enum/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/external-resource-schema/docs/cat/_index.md
+++ b/tests/testdata/codegen/external-resource-schema/docs/cat/_index.md
@@ -396,6 +396,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Cat resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/external-resource-schema/docs/component/_index.md
+++ b/tests/testdata/codegen/external-resource-schema/docs/component/_index.md
@@ -1742,6 +1742,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Component resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/external-resource-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/external-resource-schema/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/external-resource-schema/docs/workload/_index.md
+++ b/tests/testdata/codegen/external-resource-schema/docs/workload/_index.md
@@ -297,6 +297,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Workload resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/functions-secrets/docs/provider/_index.md
+++ b/tests/testdata/codegen/functions-secrets/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/hyphen-url/docs/provider/_index.md
+++ b/tests/testdata/codegen/hyphen-url/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/hyphen-url/docs/registrygeoreplication/_index.md
+++ b/tests/testdata/codegen/hyphen-url/docs/registrygeoreplication/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The RegistryGeoReplication resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/kubernetes20/docs/core/v1/configmap/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/core/v1/configmap/_index.md
@@ -592,6 +592,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The ConfigMap resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/kubernetes20/docs/core/v1/configmaplist/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/core/v1/configmaplist/_index.md
@@ -655,6 +655,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The ConfigMapList resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/kubernetes20/docs/helm/v3/release/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/helm/v3/release/_index.md
@@ -341,6 +341,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Release resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/kubernetes20/docs/provider/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/provider/_index.md
@@ -226,6 +226,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/kubernetes20/docs/yaml/configgroup/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/yaml/configgroup/_index.md
@@ -349,6 +349,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The ConfigGroup resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/kubernetes20/docs/yaml/v2/configgroup/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/yaml/v2/configgroup/_index.md
@@ -332,6 +332,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The ConfigGroup resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/legacy-names/docs/example_resource/_index.md
+++ b/tests/testdata/codegen/legacy-names/docs/example_resource/_index.md
@@ -349,6 +349,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Example_resource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/legacy-names/docs/provider/_index.md
+++ b/tests/testdata/codegen/legacy-names/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/methods-return-plain-resource/docs/configurer/_index.md
+++ b/tests/testdata/codegen/methods-return-plain-resource/docs/configurer/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Configurer resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/methods-return-plain-resource/docs/provider/_index.md
+++ b/tests/testdata/codegen/methods-return-plain-resource/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/naming-collisions/docs/maincomponent/_index.md
+++ b/tests/testdata/codegen/naming-collisions/docs/maincomponent/_index.md
@@ -297,6 +297,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The MainComponent resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/naming-collisions/docs/mod/component/_index.md
+++ b/tests/testdata/codegen/naming-collisions/docs/mod/component/_index.md
@@ -316,6 +316,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Component resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/naming-collisions/docs/mod/component2/_index.md
+++ b/tests/testdata/codegen/naming-collisions/docs/mod/component2/_index.md
@@ -297,6 +297,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Component2 resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/naming-collisions/docs/provider/_index.md
+++ b/tests/testdata/codegen/naming-collisions/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/naming-collisions/docs/resource/_index.md
+++ b/tests/testdata/codegen/naming-collisions/docs/resource/_index.md
@@ -297,6 +297,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Resource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/naming-collisions/docs/resourceinput/_index.md
+++ b/tests/testdata/codegen/naming-collisions/docs/resourceinput/_index.md
@@ -297,6 +297,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The ResourceInput resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/nested-module-thirdparty/docs/deeply/nested/module/resource/_index.md
+++ b/tests/testdata/codegen/nested-module-thirdparty/docs/deeply/nested/module/resource/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Resource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/nested-module-thirdparty/docs/provider/_index.md
+++ b/tests/testdata/codegen/nested-module-thirdparty/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/nested-module/docs/nested/module/resource/_index.md
+++ b/tests/testdata/codegen/nested-module/docs/nested/module/resource/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Resource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/nested-module/docs/provider/_index.md
+++ b/tests/testdata/codegen/nested-module/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/other-owned/docs/barresource/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/barresource/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The BarResource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/other-owned/docs/fooresource/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/fooresource/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The FooResource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/other-owned/docs/otherresource/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/otherresource/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The OtherResource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/other-owned/docs/overlayresource/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/overlayresource/_index.md
@@ -328,6 +328,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The OverlayResource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/other-owned/docs/provider/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/other-owned/docs/resource/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/resource/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Resource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/other-owned/docs/typeuses/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/typeuses/_index.md
@@ -453,6 +453,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/output-funcs-edgeorder/docs/provider/_index.md
+++ b/tests/testdata/codegen/output-funcs-edgeorder/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/output-funcs-tfbridge20/docs/provider/_index.md
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/output-funcs/docs/provider/_index.md
+++ b/tests/testdata/codegen/output-funcs/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/overlay-supported-languages/docs/overlayresource/_index.md
+++ b/tests/testdata/codegen/overlay-supported-languages/docs/overlayresource/_index.md
@@ -328,6 +328,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The OverlayResource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/overlay-supported-languages/docs/overlayresourceconstrainedlanguages/_index.md
+++ b/tests/testdata/codegen/overlay-supported-languages/docs/overlayresourceconstrainedlanguages/_index.md
@@ -328,6 +328,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The OverlayResourceConstrainedLanguages resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/overlay-supported-languages/docs/provider/_index.md
+++ b/tests/testdata/codegen/overlay-supported-languages/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/overlay-supported-languages/docs/resource/_index.md
+++ b/tests/testdata/codegen/overlay-supported-languages/docs/resource/_index.md
@@ -328,6 +328,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Resource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/plain-and-default/docs/moduleresource/_index.md
+++ b/tests/testdata/codegen/plain-and-default/docs/moduleresource/_index.md
@@ -418,6 +418,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The ModuleResource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/plain-and-default/docs/provider/_index.md
+++ b/tests/testdata/codegen/plain-and-default/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/plain-object-defaults/docs/foo/_index.md
+++ b/tests/testdata/codegen/plain-object-defaults/docs/foo/_index.md
@@ -446,6 +446,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/plain-object-defaults/docs/moduletest/_index.md
+++ b/tests/testdata/codegen/plain-object-defaults/docs/moduletest/_index.md
@@ -394,6 +394,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The ModuleTest resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/plain-object-defaults/docs/provider/_index.md
+++ b/tests/testdata/codegen/plain-object-defaults/docs/provider/_index.md
@@ -224,6 +224,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/plain-object-disable-defaults/docs/foo/_index.md
+++ b/tests/testdata/codegen/plain-object-disable-defaults/docs/foo/_index.md
@@ -446,6 +446,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/plain-object-disable-defaults/docs/moduletest/_index.md
+++ b/tests/testdata/codegen/plain-object-disable-defaults/docs/moduletest/_index.md
@@ -394,6 +394,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The ModuleTest resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/plain-object-disable-defaults/docs/provider/_index.md
+++ b/tests/testdata/codegen/plain-object-disable-defaults/docs/provider/_index.md
@@ -224,6 +224,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/plain-schema-gh6957/docs/provider/_index.md
+++ b/tests/testdata/codegen/plain-schema-gh6957/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/plain-schema-gh6957/docs/staticpage/_index.md
+++ b/tests/testdata/codegen/plain-schema-gh6957/docs/staticpage/_index.md
@@ -328,6 +328,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The StaticPage resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/provider-config-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/provider-config-schema/docs/provider/_index.md
@@ -223,6 +223,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/provider-type-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/provider-type-schema/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/provider-type-schema/docs/submod/provider/_index.md
+++ b/tests/testdata/codegen/provider-type-schema/docs/submod/provider/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/regress-8403/docs/provider/_index.md
+++ b/tests/testdata/codegen/regress-8403/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/regress-node-8110/docs/provider/_index.md
+++ b/tests/testdata/codegen/regress-node-8110/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/replace-on-change/docs/cat/_index.md
+++ b/tests/testdata/codegen/replace-on-change/docs/cat/_index.md
@@ -297,6 +297,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Cat resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/replace-on-change/docs/dog/_index.md
+++ b/tests/testdata/codegen/replace-on-change/docs/dog/_index.md
@@ -297,6 +297,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Dog resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/replace-on-change/docs/god/_index.md
+++ b/tests/testdata/codegen/replace-on-change/docs/god/_index.md
@@ -297,6 +297,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The God resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/replace-on-change/docs/norecursive/_index.md
+++ b/tests/testdata/codegen/replace-on-change/docs/norecursive/_index.md
@@ -297,6 +297,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The NoRecursive resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/replace-on-change/docs/provider/_index.md
+++ b/tests/testdata/codegen/replace-on-change/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/replace-on-change/docs/toystore/_index.md
+++ b/tests/testdata/codegen/replace-on-change/docs/toystore/_index.md
@@ -297,6 +297,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The ToyStore resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/docs/person/_index.md
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/docs/person/_index.md
@@ -333,6 +333,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Person resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/docs/pet/_index.md
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/docs/pet/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Pet resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/docs/provider/_index.md
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/resource-args-python/docs/person/_index.md
+++ b/tests/testdata/codegen/resource-args-python/docs/person/_index.md
@@ -333,6 +333,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Person resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/resource-args-python/docs/pet/_index.md
+++ b/tests/testdata/codegen/resource-args-python/docs/pet/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Pet resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/resource-args-python/docs/provider/_index.md
+++ b/tests/testdata/codegen/resource-args-python/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/resource-property-overlap/docs/provider/_index.md
+++ b/tests/testdata/codegen/resource-property-overlap/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/resource-property-overlap/docs/rec/_index.md
+++ b/tests/testdata/codegen/resource-property-overlap/docs/rec/_index.md
@@ -297,6 +297,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Rec resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/secrets/docs/provider/_index.md
+++ b/tests/testdata/codegen/secrets/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/secrets/docs/resource/_index.md
+++ b/tests/testdata/codegen/secrets/docs/resource/_index.md
@@ -409,6 +409,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Resource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-enum-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-enum-schema/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-enum-schema/docs/tree/v1/nursery/_index.md
+++ b/tests/testdata/codegen/simple-enum-schema/docs/tree/v1/nursery/_index.md
@@ -332,6 +332,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Nursery resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
+++ b/tests/testdata/codegen/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
@@ -367,6 +367,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The RubberTree resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/docs/foo/_index.md
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/docs/foo/_index.md
@@ -297,6 +297,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-methods-schema/docs/foo/_index.md
+++ b/tests/testdata/codegen/simple-methods-schema/docs/foo/_index.md
@@ -297,6 +297,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-methods-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-methods-schema/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/docs/component/_index.md
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/docs/component/_index.md
@@ -496,6 +496,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Component resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-plain-schema/docs/component/_index.md
+++ b/tests/testdata/codegen/simple-plain-schema/docs/component/_index.md
@@ -555,6 +555,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Component resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-plain-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-plain-schema/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/docs/otherresource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/docs/otherresource/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The OtherResource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/docs/resource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/docs/resource/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Resource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-resource-schema/docs/barresource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/barresource/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The BarResource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-resource-schema/docs/fooresource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/fooresource/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The FooResource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-resource-schema/docs/otherresource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/otherresource/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The OtherResource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-resource-schema/docs/overlayresource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/overlayresource/_index.md
@@ -328,6 +328,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The OverlayResource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-resource-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-resource-schema/docs/resource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/resource/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Resource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-resource-schema/docs/typeuses/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/typeuses/_index.md
@@ -453,6 +453,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-resource-with-aliases/docs/basicresource/_index.md
+++ b/tests/testdata/codegen/simple-resource-with-aliases/docs/basicresource/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The BasicResource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-resource-with-aliases/docs/basicresourcev2/_index.md
+++ b/tests/testdata/codegen/simple-resource-with-aliases/docs/basicresourcev2/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The BasicResourceV2 resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-resource-with-aliases/docs/basicresourcev3/_index.md
+++ b/tests/testdata/codegen/simple-resource-with-aliases/docs/basicresourcev3/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The BasicResourceV3 resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-resource-with-aliases/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-resource-with-aliases/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-schema-pyproject/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-schema-pyproject/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-yaml-schema/docs/otherresource/_index.md
+++ b/tests/testdata/codegen/simple-yaml-schema/docs/otherresource/_index.md
@@ -322,6 +322,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The OtherResource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-yaml-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-yaml-schema/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-yaml-schema/docs/resource/_index.md
+++ b/tests/testdata/codegen/simple-yaml-schema/docs/resource/_index.md
@@ -306,6 +306,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Resource resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simple-yaml-schema/docs/typeuses/_index.md
+++ b/tests/testdata/codegen/simple-yaml-schema/docs/typeuses/_index.md
@@ -460,6 +460,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/simplified-invokes/docs/provider/_index.md
+++ b/tests/testdata/codegen/simplified-invokes/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/unions-inline/docs/exampleserver/_index.md
+++ b/tests/testdata/codegen/unions-inline/docs/exampleserver/_index.md
@@ -324,6 +324,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The ExampleServer resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/unions-inline/docs/provider/_index.md
+++ b/tests/testdata/codegen/unions-inline/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/unions-inside-arrays/docs/exampleserver/_index.md
+++ b/tests/testdata/codegen/unions-inside-arrays/docs/exampleserver/_index.md
@@ -329,6 +329,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The ExampleServer resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/unions-inside-arrays/docs/provider/_index.md
+++ b/tests/testdata/codegen/unions-inside-arrays/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/urn-id-properties/docs/provider/_index.md
+++ b/tests/testdata/codegen/urn-id-properties/docs/provider/_index.md
@@ -221,6 +221,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/urn-id-properties/docs/res/_index.md
+++ b/tests/testdata/codegen/urn-id-properties/docs/res/_index.md
@@ -318,6 +318,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Res resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/using-shared-types-in-config/docs/provider/_index.md
+++ b/tests/testdata/codegen/using-shared-types-in-config/docs/provider/_index.md
@@ -225,6 +225,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The Provider resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 

--- a/tests/testdata/codegen/using-shared-types-in-config/docs/user/_index.md
+++ b/tests/testdata/codegen/using-shared-types-in-config/docs/user/_index.md
@@ -318,6 +318,12 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
+<pulumi-choosable type="language" values="python">
+<p>
+In Python, inputs that are objects can be passed either as <a href="/docs/languages-sdks/python/#inputs-and-outputs">argument classes or as dictionary literals</a>.
+</p>
+</pulumi-choosable>
+
 The User resource accepts the following [input](/docs/intro/concepts/inputs-outputs) properties:
 
 


### PR DESCRIPTION
In Python object inputs can either be argument classes or dictionary literals. Link to the [Python input docs](https://www.pulumi.com/docs/languages-sdks/python/#inputs-and-outputs) in the input section of the package docs  when the current language is python.

Fixes https://github.com/pulumi/registry/issues/4936

<img width="738" alt="Screenshot 2024-07-30 at 18 23 53" src="https://github.com/user-attachments/assets/3ad00f45-a81d-4c2d-b3ad-f9ae811735f6">

