### PR TITLE
always show the fully qualified stackname in state move

### DIFF
--- a/changelog/pending/20240723--cli-state--always-show-the-fully-qualified-stack-name-when-moving-resources.yaml
+++ b/changelog/pending/20240723--cli-state--always-show-the-fully-qualified-stack-name-when-moving-resources.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Always show the fully qualified stack name when moving resources

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -265,7 +265,7 @@ func (cmd *stateMoveCmd) Run(
 
 	fmt.Fprintf(cmd.Stdout, cmd.Colorizer.Colorize(
 		colors.SpecHeadline+"Planning to move the following resources from %s to %s:\n"+colors.Reset),
-		source.Ref().Name(), dest.Ref().Name())
+		source.Ref().FullyQualifiedName(), dest.Ref().FullyQualifiedName())
 
 	fmt.Fprintf(cmd.Stdout, "\n")
 	for _, res := range resourcesToMoveOrdered {
@@ -299,7 +299,7 @@ func (cmd *stateMoveCmd) Run(
 	if len(brokenSourceDependencies) > 0 {
 		fmt.Fprintf(cmd.Stdout, cmd.Colorizer.Colorize(
 			colors.SpecWarning+"The following resources remaining in %s have dependencies on resources moved to %s:\n"+
-				colors.Reset), source.Ref().Name(), dest.Ref().Name())
+				colors.Reset), source.Ref().FullyQualifiedName(), dest.Ref().FullyQualifiedName())
 	}
 
 	cmd.printBrokenDependencyRelationships(brokenSourceDependencies)
@@ -307,7 +307,7 @@ func (cmd *stateMoveCmd) Run(
 	if len(brokenDestDependencies) > 0 {
 		fmt.Fprintf(cmd.Stdout, cmd.Colorizer.Colorize(
 			colors.SpecWarning+"The following resources being moved to %s have dependencies on resources in %s:\n"+
-				colors.Reset), dest.Ref().Name(), source.Ref().Name())
+				colors.Reset), dest.Ref().FullyQualifiedName(), source.Ref().FullyQualifiedName())
 	}
 
 	cmd.printBrokenDependencyRelationships(brokenDestDependencies)
@@ -373,7 +373,7 @@ source stack.  Please remove the resources from the source stack manually using 
 
 	fmt.Fprintf(cmd.Stdout, cmd.Colorizer.Colorize(
 		colors.SpecHeadline+"Successfully moved resources from %s to %s\n"+colors.Reset),
-		source.Ref().Name(), dest.Ref().Name())
+		source.Ref().FullyQualifiedName(), dest.Ref().FullyQualifiedName())
 
 	return nil
 }

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -181,9 +181,10 @@ func TestChildrenAreBeingMoved(t *testing.T) {
 
 	sourceSnapshot, destSnapshot, stdout := runMove(t, sourceResources, []string{string(sourceResources[1].URN)})
 
-	assert.Contains(t, stdout.String(), "Planning to move the following resources from sourceStack to destStack:\n\n"+
-		"  - urn:pulumi:sourceStack::test::d:e:f$a:b:c::name\n"+
-		"  - urn:pulumi:sourceStack::test::d:e:f$a:b:c::name2")
+	assert.Contains(t, stdout.String(),
+		"Planning to move the following resources from organization/test/sourceStack to organization/test/destStack:\n\n"+
+			"  - urn:pulumi:sourceStack::test::d:e:f$a:b:c::name\n"+
+			"  - urn:pulumi:sourceStack::test::d:e:f$a:b:c::name2")
 
 	assert.Equal(t, 1, len(sourceSnapshot.Resources)) // Only the provider should remain in the source stack
 
@@ -256,20 +257,20 @@ func TestMoveResourceWithDependencies(t *testing.T) {
 	sourceSnapshot, destSnapshot, stdout := runMove(t, sourceResources, []string{string(resToMoveURN)})
 
 	//nolint:lll
-	expectedStdout := `Planning to move the following resources from sourceStack to destStack:
+	expectedStdout := `Planning to move the following resources from organization/test/sourceStack to organization/test/destStack:
 
   - urn:pulumi:sourceStack::test::d:e:f$a:b:c::resToMove
 
-The following resources remaining in sourceStack have dependencies on resources moved to destStack:
+The following resources remaining in organization/test/sourceStack have dependencies on resources moved to organization/test/destStack:
   urn:pulumi:sourceStack::test::d:e:f$a:b:c::deps has a dependency on urn:pulumi:sourceStack::test::d:e:f$a:b:c::resToMove
   urn:pulumi:sourceStack::test::d:e:f$a:b:c::deletedWith is marked as deleted with urn:pulumi:sourceStack::test::d:e:f$a:b:c::resToMove
   urn:pulumi:sourceStack::test::d:e:f$a:b:c::propDeps (key) has a property dependency on urn:pulumi:sourceStack::test::d:e:f$a:b:c::resToMove
-The following resources being moved to destStack have dependencies on resources in sourceStack:
+The following resources being moved to organization/test/destStack have dependencies on resources in organization/test/sourceStack:
   urn:pulumi:sourceStack::test::d:e:f$a:b:c::resToMove has a dependency on urn:pulumi:sourceStack::test::d:e:f$a:b:c::remainingDep
 
 If you go ahead with moving these dependencies, it will be necessary to create the appropriate inputs and outputs in the program for the stack the resources are moved to.
 
-Successfully moved resources from sourceStack to destStack
+Successfully moved resources from organization/test/sourceStack to organization/test/destStack
 `
 	assert.Equal(t, expectedStdout, stdout.String())
 


### PR DESCRIPTION
The `state move` commands main use case is to move resources between different projects, not just stacks.  Always show the fully qualifiend stackname to make sure the stack name is unambiguous.