### PR TITLE
Provide stricter types for config.get_XXX when a default is provided

### DIFF
--- a/changelog/pending/20240723--sdk-python--stricter-types-for-config-get_xxx-when-a-deafult-is-provided.yaml
+++ b/changelog/pending/20240723--sdk-python--stricter-types-for-config-get_xxx-when-a-deafult-is-provided.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Provide stricter types for config.get_XXX when a default is provided

--- a/sdk/python/lib/pulumi/config.py
+++ b/sdk/python/lib/pulumi/config.py
@@ -16,14 +16,12 @@
 The config module contains all configuration management functionality.
 """
 import json
-from typing import Any, Callable, Optional, overload, TypeVar
+from typing import Any, Callable, Optional, overload
 
 from . import errors, log
 from .metadata import get_project
 from .output import Output
 from .runtime.config import get_config, is_config_secret
-
-T = TypeVar("T")
 
 
 class Config:
@@ -317,7 +315,7 @@ class Config:
             raise ConfigTypeError(self.full_key(key), v, "JSON object") from e
 
     @overload
-    def get_object(self, key: str, default: T) -> T:
+    def get_object(self, key: str, default: Any) -> Any:
         ...
     @overload
     def get_object(self, key: str) -> Optional[Any]:
@@ -341,7 +339,7 @@ class Config:
         return config_candidate if config_candidate is not None else default
 
     @overload
-    def get_secret_object(self, key: str, default: T) -> Output[T]:
+    def get_secret_object(self, key: str, default: Any) -> Output[Any]:
         ...
     @overload
     def get_secret_object(self, key: str) -> Optional[Output[Any]]:

--- a/sdk/python/lib/pulumi/config.py
+++ b/sdk/python/lib/pulumi/config.py
@@ -66,11 +66,9 @@ class Config:
         return get_config(full_key)
 
     @overload
-    def get(self, key: str, default: str) -> str:
-        ...
+    def get(self, key: str, default: str) -> str: ...
     @overload
-    def get(self, key: str) -> Optional[str]:
-        ...
+    def get(self, key: str) -> Optional[str]: ...
     def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
         """
         Returns an optional configuration value by its key,
@@ -86,11 +84,9 @@ class Config:
         return config_candidate if config_candidate is not None else default
 
     @overload
-    def get_secret(self, key: str, default: str) -> Output[str]:
-        ...
+    def get_secret(self, key: str, default: str) -> Output[str]: ...
     @overload
-    def get_secret(self, key: str) -> Optional[Output[str]]:
-        ...
+    def get_secret(self, key: str) -> Optional[Output[str]]: ...
     def get_secret(
         self, key: str, default: Optional[str] = None
     ) -> Optional[Output[str]]:
@@ -126,11 +122,9 @@ class Config:
         raise ConfigTypeError(self.full_key(key), v, "bool")
 
     @overload
-    def get_bool(self, key: str, default: bool) -> bool:
-        ...
+    def get_bool(self, key: str, default: bool) -> bool: ...
     @overload
-    def get_bool(self, key: str) -> Optional[bool]:
-        ...
+    def get_bool(self, key: str) -> Optional[bool]: ...
     def get_bool(self, key: str, default: Optional[bool] = None) -> Optional[bool]:
         """
         Returns an optional configuration value, as a bool, by its key,
@@ -148,11 +142,9 @@ class Config:
         return config_candidate if config_candidate is not None else default
 
     @overload
-    def get_secret_bool(self, key: str, default: bool) -> Output[bool]:
-        ...
+    def get_secret_bool(self, key: str, default: bool) -> Output[bool]: ...
     @overload
-    def get_secret_bool(self, key: str) -> Optional[Output[bool]]:
-        ...
+    def get_secret_bool(self, key: str) -> Optional[Output[bool]]: ...
     def get_secret_bool(
         self, key: str, default: Optional[bool] = None
     ) -> Optional[Output[bool]]:
@@ -189,11 +181,9 @@ class Config:
             raise ConfigTypeError(self.full_key(key), v, "int") from e
 
     @overload
-    def get_int(self, key: str, default: int) -> int:
-        ...
+    def get_int(self, key: str, default: int) -> int: ...
     @overload
-    def get_int(self, key: str) -> Optional[int]:
-        ...
+    def get_int(self, key: str) -> Optional[int]: ...
     def get_int(self, key: str, default: Optional[int] = None) -> Optional[int]:
         """
         Returns an optional configuration value, as an int, by its key,
@@ -211,11 +201,9 @@ class Config:
         return config_candidate if config_candidate is not None else default
 
     @overload
-    def get_secret_int(self, key: str, default: int) -> Output[int]:
-        ...
+    def get_secret_int(self, key: str, default: int) -> Output[int]: ...
     @overload
-    def get_secret_int(self, key: str) -> Optional[Output[int]]:
-        ...
+    def get_secret_int(self, key: str) -> Optional[Output[int]]: ...
     def get_secret_int(
         self, key: str, default: Optional[int] = None
     ) -> Optional[Output[int]]:
@@ -252,11 +240,9 @@ class Config:
             raise ConfigTypeError(self.full_key(key), v, "float") from e
 
     @overload
-    def get_float(self, key: str, default: float) -> float:
-        ...
+    def get_float(self, key: str, default: float) -> float: ...
     @overload
-    def get_float(self, key: str) -> Optional[float]:
-        ...
+    def get_float(self, key: str) -> Optional[float]: ...
     def get_float(self, key: str, default: Optional[float] = None) -> Optional[float]:
         """
         Returns an optional configuration value, as a float, by its key, marked as a secret,
@@ -274,11 +260,9 @@ class Config:
         return config_candidate if config_candidate is not None else default
 
     @overload
-    def get_secret_float(self, key: str, default: float) -> Output[float]:
-        ...
+    def get_secret_float(self, key: str, default: float) -> Output[float]: ...
     @overload
-    def get_secret_float(self, key: str) -> Optional[Output[float]]:
-        ...
+    def get_secret_float(self, key: str) -> Optional[Output[float]]: ...
     def get_secret_float(
         self, key: str, default: Optional[float] = None
     ) -> Optional[Output[float]]:
@@ -315,11 +299,9 @@ class Config:
             raise ConfigTypeError(self.full_key(key), v, "JSON object") from e
 
     @overload
-    def get_object(self, key: str, default: Any) -> Any:
-        ...
+    def get_object(self, key: str, default: Any) -> Any: ...
     @overload
-    def get_object(self, key: str) -> Optional[Any]:
-        ...
+    def get_object(self, key: str) -> Optional[Any]: ...
     def get_object(self, key: str, default: Optional[Any] = None) -> Optional[Any]:
         """
         Returns an optional configuration value, as an object, by its key,
@@ -339,11 +321,9 @@ class Config:
         return config_candidate if config_candidate is not None else default
 
     @overload
-    def get_secret_object(self, key: str, default: Any) -> Output[Any]:
-        ...
+    def get_secret_object(self, key: str, default: Any) -> Output[Any]: ...
     @overload
-    def get_secret_object(self, key: str) -> Optional[Output[Any]]:
-        ...
+    def get_secret_object(self, key: str) -> Optional[Output[Any]]: ...
     def get_secret_object(
         self, key: str, default: Optional[Any] = None
     ) -> Optional[Output[Any]]:

--- a/sdk/python/lib/pulumi/config.py
+++ b/sdk/python/lib/pulumi/config.py
@@ -16,12 +16,14 @@
 The config module contains all configuration management functionality.
 """
 import json
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, overload, TypeVar
 
 from . import errors, log
 from .metadata import get_project
 from .output import Output
 from .runtime.config import get_config, is_config_secret
+
+T = TypeVar("T")
 
 
 class Config:
@@ -65,6 +67,12 @@ class Config:
         #         f"use `{use.__name__}` instead of `{instead_of.__name__}`")
         return get_config(full_key)
 
+    @overload
+    def get(self, key: str, default: str) -> str:
+        ...
+    @overload
+    def get(self, key: str) -> Optional[str]:
+        ...
     def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
         """
         Returns an optional configuration value by its key,
@@ -79,6 +87,12 @@ class Config:
         config_candidate = self._get(key, self.get_secret, self.get)
         return config_candidate if config_candidate is not None else default
 
+    @overload
+    def get_secret(self, key: str, default: str) -> Output[str]:
+        ...
+    @overload
+    def get_secret(self, key: str) -> Optional[Output[str]]:
+        ...
     def get_secret(
         self, key: str, default: Optional[str] = None
     ) -> Optional[Output[str]]:
@@ -113,6 +127,12 @@ class Config:
             return False
         raise ConfigTypeError(self.full_key(key), v, "bool")
 
+    @overload
+    def get_bool(self, key: str, default: bool) -> bool:
+        ...
+    @overload
+    def get_bool(self, key: str) -> Optional[bool]:
+        ...
     def get_bool(self, key: str, default: Optional[bool] = None) -> Optional[bool]:
         """
         Returns an optional configuration value, as a bool, by its key,
@@ -129,6 +149,12 @@ class Config:
         config_candidate = self._get_bool(key, self.get_secret_bool, self.get_bool)
         return config_candidate if config_candidate is not None else default
 
+    @overload
+    def get_secret_bool(self, key: str, default: bool) -> Output[bool]:
+        ...
+    @overload
+    def get_secret_bool(self, key: str) -> Optional[Output[bool]]:
+        ...
     def get_secret_bool(
         self, key: str, default: Optional[bool] = None
     ) -> Optional[Output[bool]]:
@@ -164,6 +190,12 @@ class Config:
         except Exception as e:
             raise ConfigTypeError(self.full_key(key), v, "int") from e
 
+    @overload
+    def get_int(self, key: str, default: int) -> int:
+        ...
+    @overload
+    def get_int(self, key: str) -> Optional[int]:
+        ...
     def get_int(self, key: str, default: Optional[int] = None) -> Optional[int]:
         """
         Returns an optional configuration value, as an int, by its key,
@@ -180,6 +212,12 @@ class Config:
         config_candidate = self._get_int(key, self.get_secret_int, self.get_int)
         return config_candidate if config_candidate is not None else default
 
+    @overload
+    def get_secret_int(self, key: str, default: int) -> Output[int]:
+        ...
+    @overload
+    def get_secret_int(self, key: str) -> Optional[Output[int]]:
+        ...
     def get_secret_int(
         self, key: str, default: Optional[int] = None
     ) -> Optional[Output[int]]:
@@ -215,6 +253,12 @@ class Config:
         except Exception as e:
             raise ConfigTypeError(self.full_key(key), v, "float") from e
 
+    @overload
+    def get_float(self, key: str, default: float) -> float:
+        ...
+    @overload
+    def get_float(self, key: str) -> Optional[float]:
+        ...
     def get_float(self, key: str, default: Optional[float] = None) -> Optional[float]:
         """
         Returns an optional configuration value, as a float, by its key, marked as a secret,
@@ -231,6 +275,12 @@ class Config:
         config_candidate = self._get_float(key, self.get_secret_float, self.get_float)
         return config_candidate if config_candidate is not None else default
 
+    @overload
+    def get_secret_float(self, key: str, default: float) -> Output[float]:
+        ...
+    @overload
+    def get_secret_float(self, key: str) -> Optional[Output[float]]:
+        ...
     def get_secret_float(
         self, key: str, default: Optional[float] = None
     ) -> Optional[Output[float]]:
@@ -266,6 +316,12 @@ class Config:
         except Exception as e:
             raise ConfigTypeError(self.full_key(key), v, "JSON object") from e
 
+    @overload
+    def get_object(self, key: str, default: T) -> T:
+        ...
+    @overload
+    def get_object(self, key: str) -> Optional[Any]:
+        ...
     def get_object(self, key: str, default: Optional[Any] = None) -> Optional[Any]:
         """
         Returns an optional configuration value, as an object, by its key,
@@ -284,6 +340,12 @@ class Config:
         )
         return config_candidate if config_candidate is not None else default
 
+    @overload
+    def get_secret_object(self, key: str, default: T) -> Output[T]:
+        ...
+    @overload
+    def get_secret_object(self, key: str) -> Optional[Output[Any]]:
+        ...
     def get_secret_object(
         self, key: str, default: Optional[Any] = None
     ) -> Optional[Output[Any]]:


### PR DESCRIPTION
When calling config.get_XXX with a default value, we know the return
type is never None. Add typing overloads to indicate this. This makes
typing much more pleasant:

```python
server = config.get("server", "example.com") # now str, previously str | None
```

Fixes https://github.com/pulumi/pulumi/issues/16766