### PR TITLE
state_move: calculate remaining resources only when we know all moved resources

### DIFF
--- a/changelog/pending/20240723--cli-state--fix-calculation-of-the-resources-that-are-remaining-in-the-source-stack.yaml
+++ b/changelog/pending/20240723--cli-state--fix-calculation-of-the-resources-that-are-remaining-in-the-source-stack.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Fix calculation of the resources that are remaining in the source stack


### PR DESCRIPTION

Currently we calculate the remaining resources when matching the argument.  That however means that we calculated them too early, when we don't yet know about the child resources and possible parent resources (when `--target-parents` is given).

This means the move then thinks these resources are left behind, and breaks dependencies to them.  This is not correct.  Move the calculation further down, when we calculated all resources that will be moved.

Fixes: https://github.com/pulumi/pulumi/issues/16777