### PR TITLE
state_move: don't move root stack explicitly

### DIFF
--- a/changelog/pending/20240724--cli-state--improve-how-moving-the-root-stack-is-handled-in-pulumi-state-move.yaml
+++ b/changelog/pending/20240724--cli-state--improve-how-moving-the-root-stack-is-handled-in-pulumi-state-move.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Improve how moving the root stack is handled in `pulumi state move`

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -838,3 +838,48 @@ func TestMoveProvider(t *testing.T) {
 
 	assert.Equal(t, 3, len(sourceSnapshot.Resources)) // No resources should be moved
 }
+
+func TestMoveRootStack(t *testing.T) {
+	t.Parallel()
+
+	providerURN := resource.NewURN("sourceStack", "test", "", "pulumi:providers:a", "default_1_0_0")
+	sourceResources := []*resource.State{
+		{
+			URN:  resource.DefaultRootStackURN("sourceStack", "test"),
+			Type: "pulumi:pulumi:Stack",
+		},
+		{
+			URN:    providerURN,
+			Type:   "pulumi:providers:a::default_1_0_0",
+			ID:     "provider_id",
+			Custom: true,
+			Parent: resource.DefaultRootStackURN("sourceStack", "test"),
+		},
+		{
+			URN:      resource.NewURN("sourceStack", "test", "d:e:f", "a:b:c", "name"),
+			Type:     "a:b:c",
+			Provider: string(providerURN) + "::provider_id",
+			Parent:   resource.DefaultRootStackURN("sourceStack", "test"),
+		},
+	}
+
+	sourceSnapshot, destSnapshot, _ := runMove(t, sourceResources, []string{string(sourceResources[0].URN)})
+
+	// Expect only the root stack to remain
+	assert.Equal(t, 1, len(sourceSnapshot.Resources))
+	// All other resources are moved to the destination
+	assert.Equal(t, 3, len(destSnapshot.Resources))
+
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:pulumi:Stack::test-destStack"),
+		destSnapshot.Resources[0].URN)
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:providers:a::default_1_0_0"),
+		destSnapshot.Resources[1].URN)
+	assert.Equal(t, resource.DefaultRootStackURN("destStack", "test"),
+		destSnapshot.Resources[1].Parent)
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::d:e:f$a:b:c::name"),
+		destSnapshot.Resources[2].URN)
+	assert.Equal(t, "urn:pulumi:destStack::test::pulumi:providers:a::default_1_0_0::provider_id",
+		destSnapshot.Resources[2].Provider)
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:pulumi:Stack::test-destStack"),
+		destSnapshot.Resources[2].Parent)
+}


### PR DESCRIPTION
The root stack is a special resource, in that it's supposed to exist in every snapshot. Moving it as we do other resources (and thus re-parenting it on the existing root stack) doesn't quite make sense.

However it does make sense for moving it to mean "move all the children of the root stack", and moving it thusly. We can easily achieve this by just removing the rootstack from the resources to be moved, as it already exists in the destination snapshot, and all the children will be re-parented correctly to the destination root stack.

Fixes https://github.com/pulumi/pulumi/issues/16778