### PR TITLE
state_move improve output slightly

### DIFF
--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -298,15 +298,18 @@ func (cmd *stateMoveCmd) Run(
 
 	if len(brokenSourceDependencies) > 0 {
 		fmt.Fprintf(cmd.Stdout, cmd.Colorizer.Colorize(
-			colors.SpecWarning+"The following resources remaining in %s have dependencies on resources moved to %s:\n"+
+			colors.SpecWarning+"The following resources remaining in %s have dependencies on resources moved to %s:\n\n"+
 				colors.Reset), source.Ref().FullyQualifiedName(), dest.Ref().FullyQualifiedName())
 	}
 
 	cmd.printBrokenDependencyRelationships(brokenSourceDependencies)
 
 	if len(brokenDestDependencies) > 0 {
+		if len(brokenSourceDependencies) > 0 {
+			fmt.Fprintln(cmd.Stdout)
+		}
 		fmt.Fprintf(cmd.Stdout, cmd.Colorizer.Colorize(
-			colors.SpecWarning+"The following resources being moved to %s have dependencies on resources in %s:\n"+
+			colors.SpecWarning+"The following resources being moved to %s have dependencies on resources in %s:\n\n"+
 				colors.Reset), dest.Ref().FullyQualifiedName(), source.Ref().FullyQualifiedName())
 	}
 
@@ -315,11 +318,9 @@ func (cmd *stateMoveCmd) Run(
 	if len(brokenSourceDependencies) > 0 || len(brokenDestDependencies) > 0 {
 		fmt.Fprint(cmd.Stdout, cmd.Colorizer.Colorize(
 			colors.SpecInfo+"\nIf you go ahead with moving these dependencies, it will be necessary to create the "+
-				"appropriate inputs and outputs in the program for the stack the resources are moved to.\n"+
+				"appropriate inputs and outputs in the program for the stack the resources are moved to.\n\n"+
 				colors.Reset))
 	}
-
-	fmt.Fprintf(cmd.Stdout, "\n")
 
 	if !cmd.Yes {
 		yes := "yes"
@@ -507,12 +508,12 @@ func (cmd *stateMoveCmd) printBrokenDependencyRelationships(brokenDeps []brokenD
 	for _, res := range brokenDeps {
 		switch res.dependencyType {
 		case dependency:
-			fmt.Fprintf(cmd.Stdout, "  %s has a dependency on %s\n", res.resourceURN, res.dependencyURN)
+			fmt.Fprintf(cmd.Stdout, "  - %s has a dependency on %s\n", res.resourceURN, res.dependencyURN)
 		case propertyDependency:
-			fmt.Fprintf(cmd.Stdout, "  %s (%s) has a property dependency on %s\n",
+			fmt.Fprintf(cmd.Stdout, "  - %s (%s) has a property dependency on %s\n",
 				res.resourceURN, res.propdepKey, res.dependencyURN)
 		case deletedWith:
-			fmt.Fprintf(cmd.Stdout, "  %s is marked as deleted with %s\n", res.resourceURN, res.dependencyURN)
+			fmt.Fprintf(cmd.Stdout, "  - %s is marked as deleted with %s\n", res.resourceURN, res.dependencyURN)
 		}
 	}
 }

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -145,7 +145,7 @@ func TestMoveLeafResource(t *testing.T) {
 
   - urn:pulumi:sourceStack::test::d:e:f$a:b:c::name
 
-Successfully moved resources from sourceStack to destStack
+Successfully moved resources from organization/test/sourceStack to organization/test/destStack
 `
 	assert.Equal(t, expectedStdout, stdout.String())
 

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -138,7 +138,15 @@ func TestMoveLeafResource(t *testing.T) {
 		},
 	}
 
-	sourceSnapshot, destSnapshot, _ := runMove(t, sourceResources, []string{string(sourceResources[1].URN)})
+	sourceSnapshot, destSnapshot, stdout := runMove(t, sourceResources, []string{string(sourceResources[1].URN)})
+
+	expectedStdout := `Planning to move the following resources from organization/test/sourceStack to organization/test/destStack:
+
+  - urn:pulumi:sourceStack::test::d:e:f$a:b:c::name
+
+Successfully moved resources from sourceStack to destStack
+`
+	assert.Equal(t, expectedStdout, stdout.String())
 
 	assert.Equal(t, 1, len(sourceSnapshot.Resources)) // Only the provider should remain in the source stack
 
@@ -262,11 +270,14 @@ func TestMoveResourceWithDependencies(t *testing.T) {
   - urn:pulumi:sourceStack::test::d:e:f$a:b:c::resToMove
 
 The following resources remaining in organization/test/sourceStack have dependencies on resources moved to organization/test/destStack:
-  urn:pulumi:sourceStack::test::d:e:f$a:b:c::deps has a dependency on urn:pulumi:sourceStack::test::d:e:f$a:b:c::resToMove
-  urn:pulumi:sourceStack::test::d:e:f$a:b:c::deletedWith is marked as deleted with urn:pulumi:sourceStack::test::d:e:f$a:b:c::resToMove
-  urn:pulumi:sourceStack::test::d:e:f$a:b:c::propDeps (key) has a property dependency on urn:pulumi:sourceStack::test::d:e:f$a:b:c::resToMove
+
+  - urn:pulumi:sourceStack::test::d:e:f$a:b:c::deps has a dependency on urn:pulumi:sourceStack::test::d:e:f$a:b:c::resToMove
+  - urn:pulumi:sourceStack::test::d:e:f$a:b:c::deletedWith is marked as deleted with urn:pulumi:sourceStack::test::d:e:f$a:b:c::resToMove
+  - urn:pulumi:sourceStack::test::d:e:f$a:b:c::propDeps (key) has a property dependency on urn:pulumi:sourceStack::test::d:e:f$a:b:c::resToMove
+
 The following resources being moved to organization/test/destStack have dependencies on resources in organization/test/sourceStack:
-  urn:pulumi:sourceStack::test::d:e:f$a:b:c::resToMove has a dependency on urn:pulumi:sourceStack::test::d:e:f$a:b:c::remainingDep
+
+  - urn:pulumi:sourceStack::test::d:e:f$a:b:c::resToMove has a dependency on urn:pulumi:sourceStack::test::d:e:f$a:b:c::remainingDep
 
 If you go ahead with moving these dependencies, it will be necessary to create the appropriate inputs and outputs in the program for the stack the resources are moved to.
 

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -140,6 +140,7 @@ func TestMoveLeafResource(t *testing.T) {
 
 	sourceSnapshot, destSnapshot, stdout := runMove(t, sourceResources, []string{string(sourceResources[1].URN)})
 
+	//nolint:lll
 	expectedStdout := `Planning to move the following resources from organization/test/sourceStack to organization/test/destStack:
 
   - urn:pulumi:sourceStack::test::d:e:f$a:b:c::name


### PR DESCRIPTION
A couple minor UI tweaks, to make the broken dependencies a list, and print a few more newlines to make the blocks more clearly visible. Also avoid a double newline if there are no broken dependencies.