### PR TITLE
[nodejs] cancelation support for auto api

### DIFF
--- a/changelog/pending/20240909--auto-nodejs--support-an-abort-channel-for-gracefully-canceling-operations.yaml
+++ b/changelog/pending/20240909--auto-nodejs--support-an-abort-channel-for-gracefully-canceling-operations.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/nodejs
+  description: Support an abort channel for gracefully canceling operations

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -269,7 +269,7 @@ Event: ${line}\n${e.toString()}`);
 
         let upResult: CommandResult;
         try {
-            upResult = await this.runPulumiCmd(args, opts?.onOutput);
+            upResult = await this.runPulumiCmd(args, opts?.onOutput, opts?.signal);
         } catch (e) {
             didError = true;
             throw e;
@@ -409,7 +409,7 @@ Event: ${line}\n${e.toString()}`);
 
         let previewResult: CommandResult;
         try {
-            previewResult = await this.runPulumiCmd(args, opts?.onOutput);
+            previewResult = await this.runPulumiCmd(args, opts?.onOutput, opts?.signal);
         } catch (e) {
             didError = true;
             throw e;
@@ -483,7 +483,7 @@ Event: ${line}\n${e.toString()}`);
 
         let refResult: CommandResult;
         try {
-            refResult = await this.runPulumiCmd(args, opts?.onOutput);
+            refResult = await this.runPulumiCmd(args, opts?.onOutput, opts?.signal);
         } finally {
             await cleanUp(logFile, await logPromise);
         }
@@ -556,7 +556,7 @@ Event: ${line}\n${e.toString()}`);
 
         let desResult: CommandResult;
         try {
-            desResult = await this.runPulumiCmd(args, opts?.onOutput);
+            desResult = await this.runPulumiCmd(args, opts?.onOutput, opts?.signal);
         } finally {
             await cleanUp(logFile, await logPromise);
         }
@@ -887,7 +887,11 @@ Event: ${line}\n${e.toString()}`);
         return this.workspace.importStack(this.name, state);
     }
 
-    private async runPulumiCmd(args: string[], onOutput?: (out: string) => void): Promise<CommandResult> {
+    private async runPulumiCmd(
+        args: string[],
+        onOutput?: (out: string) => void,
+        signal?: AbortSignal,
+    ): Promise<CommandResult> {
         let envs: { [key: string]: string } = {
             PULUMI_DEBUG_COMMANDS: "true",
         };
@@ -901,7 +905,7 @@ Event: ${line}\n${e.toString()}`);
         envs = { ...envs, ...this.workspace.envVars };
         const additionalArgs = await this.workspace.serializeArgsForOp(this.name);
         args = [...args, "--stack", this.name, ...additionalArgs];
-        const result = await this.workspace.pulumiCommand.run(args, this.workspace.workDir, envs, onOutput);
+        const result = await this.workspace.pulumiCommand.run(args, this.workspace.workDir, envs, onOutput, signal);
         await this.workspace.postCommandCallback(this.name);
         return result;
     }
@@ -1333,6 +1337,11 @@ export interface UpOptions extends GlobalOpts {
      * Run the process under a debugger, and pause until a debugger is attached.
      */
     attachDebugger?: boolean;
+
+    /**
+     * A signal to abort an ongoing operation.
+     */
+    signal?: AbortSignal;
 }
 
 /**
@@ -1418,6 +1427,11 @@ export interface PreviewOptions extends GlobalOpts {
      * Run the process under a debugger, and pause until a debugger is attached.
      */
     attachDebugger?: boolean;
+
+    /**
+     * A signal to abort an ongoing operation.
+     */
+    signal?: AbortSignal;
 }
 
 /**
@@ -1463,6 +1477,10 @@ export interface RefreshOptions extends GlobalOpts {
      * Include secrets in the operation summary.
      */
     showSecrets?: boolean;
+    /**
+     * A signal to abort an ongoing operation.
+     */
+    signal?: AbortSignal;
 }
 
 /**
@@ -1523,6 +1541,10 @@ export interface DestroyOptions extends GlobalOpts {
      * Remove the stack and its configuration after all resources in the stack have been deleted.
      */
     remove?: boolean;
+    /**
+     * A signal to abort an ongoing operation.
+     */
+    signal?: AbortSignal;
 }
 
 export interface ImportResource {

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -1450,9 +1450,9 @@ describe("LocalWorkspace", () => {
 
     it("sends SIGINT when aborted", async () => {
         const controller = new AbortController();
-        new Promise((f) => setTimeout(f, 1000)).then(() => controller.abort());
+        new Promise((f) => setTimeout(f, 500)).then(() => controller.abort());
         const program = async () => {
-            await new Promise((f) => setTimeout(f, 60000));
+            await new Promise((f) => setTimeout(f, 600000));
             return {};
         };
         const projectName = "inline_node";

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -1450,15 +1450,15 @@ describe("LocalWorkspace", () => {
 
     it("sends SIGINT when aborted", async () => {
         const controller = new AbortController();
-        new Promise((f) => setTimeout(f, 500)).then(() => controller.abort());
         const program = async () => {
-            await new Promise((f) => setTimeout(f, 600000));
+            await new Promise((f) => setTimeout(f, 60000));
             return {};
         };
         const projectName = "inline_node";
         const stackName = fullyQualifiedStackName(getTestOrg(), projectName, `int_test${getTestSuffix()}`);
         const stack = await LocalWorkspace.createStack({ stackName, projectName, program });
 
+        new Promise((f) => setTimeout(f, 1000)).then(() => controller.abort());
         try {
             // pulumi preview
             const previewRes = await stack.preview({

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -1450,7 +1450,9 @@ describe("LocalWorkspace", () => {
 
     it("sends SIGINT when aborted", async () => {
         const controller = new AbortController();
-        controller.abort();
+        new Promise(async () => {
+            setTimeout(() => controller.abort(), 100);
+        });
         const program = async () => {
             await new Promise((f) => setTimeout(f, 60000));
             return {};
@@ -1466,7 +1468,8 @@ describe("LocalWorkspace", () => {
             });
             assert.fail("expected canceled preview to throw");
         } catch (err) {
-            assert.strictEqual(err.toString(), "Error: ...");
+            assert.match(err.toString(), /stderr: Command was killed with SIGINT/);
+            assert.match(err.toString(), /CommandError: code: -2/);
         }
 
         await stack.workspace.removeStack(stackName);

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -1450,9 +1450,7 @@ describe("LocalWorkspace", () => {
 
     it("sends SIGINT when aborted", async () => {
         const controller = new AbortController();
-        new Promise(async () => {
-            setTimeout(() => controller.abort(), 100);
-        });
+        new Promise((f) => setTimeout(f, 1000)).then(() => controller.abort());
         const program = async () => {
             await new Promise((f) => setTimeout(f, 60000));
             return {};


### PR DESCRIPTION
This PR adds support to the auto api for a cancelation signal to be sent by the caller, causing graceful shutdown of the Pulumi deployment operation (`preview`, `up`, `refresh`, `destroy`).

Uses the standard `AbortSignal` API.

Related: #13160 