### PR TITLE
Skip TestConfigCommandsUsingEnvironments

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -339,6 +339,8 @@ config:
 }
 
 func TestConfigCommandsUsingEnvironments(t *testing.T) {
+	t.Skip("Skipping due to https://github.com/pulumi/pulumi/issues/16791")
+
 	if getTestOrg() != pulumiTestOrg {
 		t.Skip("Skipping test because the required environment is in the moolumi org.")
 	}


### PR DESCRIPTION
This test has started failing due to changes in the pulumi service. This has been raised to the ESC team to look at. For now skip to unblock pulumi/pulumi pipelines.