### PR TITLE
Download Pulumi Cron: allow previous version for homebrew and chocolatey

### DIFF
--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Pulumi Version Details
         id: vars
         run: |
+          # shellcheck disable=SC2129
           echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT}"
           echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT}"
           echo "previous-version=$(curl -sS https://raw.githubusercontent.com/pulumi/docs/master/data/versions.json | jq -r '.[1].version')" >> "${GITHUB_OUTPUT}"
@@ -93,6 +94,7 @@ jobs:
         id: vars
         shell: bash
         run: |
+          # shellcheck disable=SC2129
           echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT}"
           echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT}"
           echo "previous-version=$(curl -sS https://raw.githubusercontent.com/pulumi/docs/master/data/versions.json | jq -r '.[1].version')" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT}"
           echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT}"
-          echo "previous-version=$(curl -sS https://raw.githubusercontent.com/pulumi/docs/master/data/versions.json | jq -r '.[1].version') >> "${GITHUB_OUTPUT}
+          echo "previous-version=$(curl -sS https://raw.githubusercontent.com/pulumi/docs/master/data/versions.json | jq -r '.[1].version')" >> "${GITHUB_OUTPUT}"
       - name: Error if incorrect version found
         if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version && steps.vars.outputs.expected-version != steps.vars.outputs.installed-version}}
         run: |
@@ -95,7 +95,7 @@ jobs:
         run: |
           echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT}"
           echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT}"
-          echo "previous-version=$(curl -sS https://raw.githubusercontent.com/pulumi/docs/master/data/versions.json | jq -r '.[1].version') >> "${GITHUB_OUTPUT}
+          echo "previous-version=$(curl -sS https://raw.githubusercontent.com/pulumi/docs/master/data/versions.json | jq -r '.[1].version')" >> "${GITHUB_OUTPUT}"
       - name: Error if incorrect version found
         if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version && steps.vars.outputs.expected-version != steps.vars.outputs.installed-version}}
         run: |

--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -29,7 +29,7 @@ jobs:
           echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT}"
           echo "previous-version=$(curl -sS https://raw.githubusercontent.com/pulumi/docs/master/data/versions.json | jq -r '.[1].version')" >> "${GITHUB_OUTPUT}"
       - name: Error if incorrect version found
-        if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version && steps.vars.outputs.expected-version != steps.vars.outputs.installed-version}}
+        if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version && steps.vars.outputs.previous-version != steps.vars.outputs.installed-version}}
         run: |
           echo "Expected version ${{ steps.vars.outputs.expected-version }} but found ${{ steps.vars.outputs.installed-version }}"
           exit 1
@@ -97,7 +97,7 @@ jobs:
           echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT}"
           echo "previous-version=$(curl -sS https://raw.githubusercontent.com/pulumi/docs/master/data/versions.json | jq -r '.[1].version')" >> "${GITHUB_OUTPUT}"
       - name: Error if incorrect version found
-        if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version && steps.vars.outputs.expected-version != steps.vars.outputs.installed-version}}
+        if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version && steps.vars.outputs.previous-version != steps.vars.outputs.installed-version}}
         run: |
           echo "Expected version ${{ steps.vars.outputs.expected-version }} but found ${{ steps.vars.outputs.installed-version }}"
           exit 1

--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -27,8 +27,9 @@ jobs:
         run: |
           echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT}"
           echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT}"
+          echo "previous-version=$(curl -sS https://raw.githubusercontent.com/pulumi/docs/master/data/versions.json | jq -r '.[1].version') >> "${GITHUB_OUTPUT}
       - name: Error if incorrect version found
-        if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}
+        if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version && steps.vars.outputs.expected-version != steps.vars.outputs.installed-version}}
         run: |
           echo "Expected version ${{ steps.vars.outputs.expected-version }} but found ${{ steps.vars.outputs.installed-version }}"
           exit 1
@@ -94,8 +95,9 @@ jobs:
         run: |
           echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT}"
           echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT}"
+          echo "previous-version=$(curl -sS https://raw.githubusercontent.com/pulumi/docs/master/data/versions.json | jq -r '.[1].version') >> "${GITHUB_OUTPUT}
       - name: Error if incorrect version found
-        if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}
+        if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version && steps.vars.outputs.expected-version != steps.vars.outputs.installed-version}}
         run: |
           echo "Expected version ${{ steps.vars.outputs.expected-version }} but found ${{ steps.vars.outputs.installed-version }}"
           exit 1


### PR DESCRIPTION
This cron job periodically checks whether package managers have the updated version of pulumi to install.  This is a very useful check to make sure our automation works correctly.

However some of the package managers (homebrew and chocolatey in particular) take a while to act on pulumi-bot's PRs, and thus the versions are frequently not up to date when this cron job runs shortly after a release.  This is just how these package managers work and nothing to worry about.

We shouldn't get an issue every time this happens.  The important thing here is that the version gets updated eventually.  For homebrew and chocolatey we therefore also allow the version to be the previous version.  This means it will take a bit longer for us to notice if a pulumi isn't updated in these package managers, but the issues this script opens will then actually be valuable.

(There's still a risk that multiple releases happen within a short timespan, and the script fails.  This is the case so rarely however that it's probably not worth worrying about).

An alternative to this would be to check the release date in the versions.json file, and make a decision based on the age of the latest release, but that's more complicated to do in bash, and this seems to be good enough for now.

Fixes https://github.com/pulumi/pulumi/issues/16808.  (I finally got tired enough to do something about it :sweat_smile:)