### PR TITLE
sdk/go: fix test_fast Makefile target

### DIFF
--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -35,7 +35,7 @@ test_fast:: $(TEST_ALL_DEPS)
 	@$(GO_TEST_FAST) $(TEST_FAST_PKGS)
 
 	@cd pulumi-language-go && \
-		$(GO_TEST_FAST) $(shell go list ./... | grep -v /vendor/ | grep -v templates)
+		$(GO_TEST_FAST) $(shell cd pulumi-language-go && go list ./... | grep -v /vendor/ | grep -v templates)
 
 test_auto:: $(TEST_ALL_DEPS)
 	@$(GO_TEST) $(TEST_AUTO_PKGS)


### PR DESCRIPTION
This target is currently broken, because the `shell` command in Make doesn't seem to take the `cd pulumi-language-go` into account, and run from the PWD of the `make` invocation instead.  This leads to us trying to run all the `sdk/go` tests from the `pulumi-language-go` directory, which means the test runs use `pulumi-language-go/go.mod` for dependency resolution for the tests in `sdk/go` proper.  This then fails.

Fix it by cd'ing to the right directory before getting the list of tests.