### PR TITLE
Fix marshalling of plain properties

### DIFF
--- a/changelog/pending/20240726--sdkgen-go-nodejs-python--fix-generation-of-nested-plain-input-types.yaml
+++ b/changelog/pending/20240726--sdkgen-go-nodejs-python--fix-generation-of-nested-plain-input-types.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/go,nodejs,python
+  description: Fix generation of nested plain input types.

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1313,7 +1313,7 @@ func (pkg *Package) marshalProperties(props []*Property, plain bool) (required [
 func (pkg *Package) marshalType(t Type, plain bool) TypeSpec {
 	switch t := t.(type) {
 	case *InputType:
-		el := pkg.marshalType(t.ElementType, plain)
+		el := pkg.marshalType(t.ElementType, false)
 		el.Plain = false
 		return el
 	case *ArrayType:
@@ -1356,11 +1356,20 @@ func (pkg *Package) marshalType(t Type, plain bool) TypeSpec {
 			Plain:         !plain,
 		}
 	case *ObjectType:
-		return TypeSpec{Ref: pkg.marshalTypeRef(t.PackageReference, "types", t.Token)}
+		return TypeSpec{
+			Ref:   pkg.marshalTypeRef(t.PackageReference, "types", t.Token),
+			Plain: !plain,
+		}
 	case *EnumType:
-		return TypeSpec{Ref: pkg.marshalTypeRef(t.PackageReference, "types", t.Token)}
+		return TypeSpec{
+			Ref:   pkg.marshalTypeRef(t.PackageReference, "types", t.Token),
+			Plain: !plain,
+		}
 	case *ResourceType:
-		return TypeSpec{Ref: pkg.marshalTypeRef(t.Resource.PackageReference, "resources", t.Token)}
+		return TypeSpec{
+			Ref:   pkg.marshalTypeRef(t.Resource.PackageReference, "resources", t.Token),
+			Plain: !plain,
+		}
 	case *TokenType:
 		var defaultType string
 		if t.UnderlyingType != nil {
@@ -1368,27 +1377,52 @@ func (pkg *Package) marshalType(t Type, plain bool) TypeSpec {
 		}
 
 		return TypeSpec{
-			Type: defaultType,
-			Ref:  pkg.marshalTypeRef(pkg.Reference(), "types", t.Token),
+			Type:  defaultType,
+			Ref:   pkg.marshalTypeRef(pkg.Reference(), "types", t.Token),
+			Plain: !plain,
 		}
 	default:
 		switch t {
 		case BoolType:
-			return TypeSpec{Type: "boolean"}
+			return TypeSpec{
+				Type:  "boolean",
+				Plain: !plain,
+			}
 		case StringType:
-			return TypeSpec{Type: "string"}
+			return TypeSpec{
+				Type:  "string",
+				Plain: !plain,
+			}
 		case IntType:
-			return TypeSpec{Type: "integer"}
+			return TypeSpec{
+				Type:  "integer",
+				Plain: !plain,
+			}
 		case NumberType:
-			return TypeSpec{Type: "number"}
+			return TypeSpec{
+				Type:  "number",
+				Plain: !plain,
+			}
 		case AnyType:
-			return TypeSpec{Ref: "pulumi.json#/Any"}
+			return TypeSpec{
+				Ref:   "pulumi.json#/Any",
+				Plain: !plain,
+			}
 		case ArchiveType:
-			return TypeSpec{Ref: "pulumi.json#/Archive"}
+			return TypeSpec{
+				Ref:   "pulumi.json#/Archive",
+				Plain: !plain,
+			}
 		case AssetType:
-			return TypeSpec{Ref: "pulumi.json#/Asset"}
+			return TypeSpec{
+				Ref:   "pulumi.json#/Asset",
+				Plain: !plain,
+			}
 		case JSONType:
-			return TypeSpec{Ref: "pulumi.json#/Json"}
+			return TypeSpec{
+				Ref:   "pulumi.json#/Json",
+				Plain: !plain,
+			}
 		default:
 			panic(fmt.Errorf("unexepcted type %v (%T)", t, t))
 		}

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -151,9 +151,10 @@ func TestRoundtripPlainProperties(t *testing.T) {
 		exampleObjectType, ok := exampleType.(*ObjectType)
 		assert.True(t, ok)
 
-		assert.Equal(t, 2, len(exampleObjectType.Properties))
+		assert.Equal(t, 3, len(exampleObjectType.Properties))
 		var exampleProperty *Property
 		var nonPlainProperty *Property
+		var nestedProperty *Property
 		for _, p := range exampleObjectType.Properties {
 			if p.Name == "exampleProperty" {
 				exampleProperty = p
@@ -162,13 +163,27 @@ func TestRoundtripPlainProperties(t *testing.T) {
 			if p.Name == "nonPlainProperty" {
 				nonPlainProperty = p
 			}
+
+			if p.Name == "nestedProperty" {
+				nestedProperty = p
+			}
 		}
 
 		assert.NotNil(t, exampleProperty)
 		assert.NotNil(t, nonPlainProperty)
+		assert.NotNil(t, nestedProperty)
 
 		assert.True(t, exampleProperty.Plain)
 		assert.False(t, nonPlainProperty.Plain)
+		assert.True(t, nestedProperty.Plain)
+
+		opt, ok := nestedProperty.Type.(*OptionalType)
+		assert.True(t, ok)
+		arr, ok := opt.ElementType.(*ArrayType)
+		assert.True(t, ok)
+		str, ok := arr.ElementType.(primitiveType)
+		assert.True(t, ok)
+		assert.Equal(t, stringType, str)
 	}
 
 	assertPlainnessFromResource := func(t *testing.T, pkg *Package) {
@@ -176,9 +191,12 @@ func TestRoundtripPlainProperties(t *testing.T) {
 		assert.True(t, ok)
 
 		check := func(properties []*Property) {
+			assert.Equal(t, 3, len(properties))
+
 			var exampleProperty *Property
 			var nonPlainProperty *Property
-			for _, p := range exampleResource.InputProperties {
+			var nestedProperty *Property
+			for _, p := range properties {
 				if p.Name == "exampleProperty" {
 					exampleProperty = p
 				}
@@ -186,15 +204,27 @@ func TestRoundtripPlainProperties(t *testing.T) {
 				if p.Name == "nonPlainProperty" {
 					nonPlainProperty = p
 				}
+
+				if p.Name == "nestedProperty" {
+					nestedProperty = p
+				}
 			}
 
-			// assert that the input property "exampleProperty" is plain
 			assert.NotNil(t, exampleProperty)
-			assert.True(t, exampleProperty.Plain)
-
-			// assert that the output property is not plain
 			assert.NotNil(t, nonPlainProperty)
+			assert.NotNil(t, nestedProperty)
+
+			assert.True(t, exampleProperty.Plain)
 			assert.False(t, nonPlainProperty.Plain)
+			assert.True(t, nestedProperty.Plain)
+
+			opt, ok := nestedProperty.Type.(*OptionalType)
+			assert.True(t, ok)
+			arr, ok := opt.ElementType.(*ArrayType)
+			assert.True(t, ok)
+			str, ok := arr.ElementType.(primitiveType)
+			assert.True(t, ok)
+			assert.Equal(t, stringType, str)
 		}
 
 		check(exampleResource.InputProperties)

--- a/tests/testdata/codegen/plain-properties-1.0.0.json
+++ b/tests/testdata/codegen/plain-properties-1.0.0.json
@@ -11,6 +11,14 @@
         },
         "nonPlainProperty": {
           "type": "string"
+        },
+        "nestedProperty": {
+          "type": "array",
+          "plain": true,
+          "items": {
+            "type": "string",
+            "plain": true
+          }
         }
       }
     }
@@ -25,6 +33,14 @@
         },
         "nonPlainProperty": {
           "type": "string"
+        },
+        "nestedProperty": {
+          "type": "array",
+          "plain": true,
+          "items": {
+            "type": "string",
+            "plain": true
+          }
         }
       },
       "inputProperties": {
@@ -34,6 +50,14 @@
         },
         "nonPlainProperty": {
           "type": "string"
+        },
+        "nestedProperty": {
+          "type": "array",
+          "plain": true,
+          "items": {
+            "type": "string",
+            "plain": true
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/16810.

The container types already marshalled correctly here, but other types like refs and primitives didn't keep their Plain attribute.