### PR TITLE
[config] Re-enable TestConfigCommandsUsingEnvironments

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -339,8 +339,6 @@ config:
 }
 
 func TestConfigCommandsUsingEnvironments(t *testing.T) {
-	t.Skip("Skipping due to https://github.com/pulumi/pulumi/issues/16791")
-
 	if getTestOrg() != pulumiTestOrg {
 		t.Skip("Skipping test because the required environment is in the moolumi org.")
 	}


### PR DESCRIPTION
This test was failing due to a bug in the ESC API. Re-enable it now that the bug has been fixed.

Fixes #16791.