### PR TITLE
Use `snake_case` for package refences in the Python SDK

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1568,7 +1568,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 		return "", err
 	}
 	if pkg.Parameterization != nil {
-		fmt.Fprintf(w, ",\n            packageRef=_utilities.get_package()")
+		fmt.Fprintf(w, ",\n            package_ref=_utilities.get_package()")
 	}
 	fmt.Fprintf(w, ")\n\n")
 

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -839,7 +839,7 @@ class Resource:
         opts: Optional[ResourceOptions] = None,
         remote: bool = False,
         dependency: bool = False,
-        packageRef: Optional[Awaitable[Optional[str]]] = None,
+        package_ref: Optional[Awaitable[Optional[str]]] = None,
     ) -> None:
         """
         :param str t: The type of this resource.
@@ -853,7 +853,7 @@ class Resource:
                resource.
         :param bool remote: True if this is a remote component resource.
         :param bool dependency: True if this is a synthetic resource used internally for dependency tracking.
-        :param Optional[Awaitable[Optional[str]]] packageRef: The package reference for this resource.
+        :param Optional[Awaitable[Optional[str]]] package_ref: The package reference for this resource.
         """
 
         if dependency:
@@ -985,7 +985,7 @@ class Resource:
                 props,
                 opts,
                 typ,
-                packageRef,
+                package_ref,
             )
 
     def _get_providers(
@@ -1123,7 +1123,7 @@ class CustomResource(Resource):
         props: Optional["Inputs"] = None,
         opts: Optional[ResourceOptions] = None,
         dependency: bool = False,
-        packageRef: Optional[Awaitable[Optional[str]]] = None,
+        package_ref: Optional[Awaitable[Optional[str]]] = None,
     ) -> None:
         """
         :param str t: The type of this resource.
@@ -1132,10 +1132,10 @@ class CustomResource(Resource):
         :param Optional[ResourceOptions] opts: Optional set of :class:`pulumi.ResourceOptions` to use for this
                resource.
         :param bool dependency: True if this is a synthetic resource used internally for dependency tracking.
-        :param Optional[Awaitable[Optional[str]]] packageRef: The package reference for this resource.
+        :param Optional[Awaitable[Optional[str]]] package_ref: The package reference for this resource.
         """
         Resource.__init__(
-            self, t, name, True, props, opts, False, dependency, packageRef
+            self, t, name, True, props, opts, False, dependency, package_ref
         )
 
     @property
@@ -1163,7 +1163,7 @@ class ComponentResource(Resource):
         props: Optional["Inputs"] = None,
         opts: Optional[ResourceOptions] = None,
         remote: bool = False,
-        packageRef: Optional[Awaitable[Optional[str]]] = None,
+        package_ref: Optional[Awaitable[Optional[str]]] = None,
     ) -> None:
         """
         :param str t: The type of this resource.
@@ -1172,9 +1172,9 @@ class ComponentResource(Resource):
         :param Optional[ResourceOptions] opts: Optional set of :class:`pulumi.ResourceOptions` to use for this
                resource.
         :param bool remote: True if this is a remote component resource.
-        :param Optional[Awaitable[Optional[str]]] packageRef: The package reference for this resource.
+        :param Optional[Awaitable[Optional[str]]] package_ref: The package reference for this resource.
         """
-        Resource.__init__(self, t, name, False, props, opts, remote, False, packageRef)
+        Resource.__init__(self, t, name, False, props, opts, remote, False, package_ref)
         if not remote:
             self.__dict__["id"] = None
         self._remote = remote

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -854,7 +854,7 @@ def register_resource(
     props: "Inputs",
     opts: Optional["ResourceOptions"],
     typ: Optional[type] = None,
-    packageRef: Optional[Awaitable[Optional[str]]] = None,
+    package_ref: Optional[Awaitable[Optional[str]]] = None,
 ) -> None:
     """
     Registers a new resource object with a given type t and name.  It returns the
@@ -910,11 +910,11 @@ def register_resource(
             opts = opts if opts is not None else ResourceOptions()
 
             # If we have a package reference, we need to wait for it to resolve.
-            packageRefStr = None
-            if packageRef is not None:
-                packageRefStr = await packageRef
+            package_ref_str = None
+            if package_ref is not None:
+                package_ref_str = await package_ref
                 # If we have a package reference we can clear some of the resource options
-                if packageRefStr is not None:
+                if package_ref_str is not None:
                     opts.plugin_download_url = None
                     opts.version = None
 
@@ -1003,7 +1003,7 @@ def register_resource(
                 sourcePosition=source_position,
                 transforms=callbacks,
                 supportsResultReporting=True,
-                packageRef=packageRefStr or "",
+                packageRef=package_ref_str or "",
             )
 
             mock_urn = await create_urn(name, ty, resolver.parent_urn).future()

--- a/tests/integration/python/parameterized/sdk/python/pulumi_pkg/provider.py
+++ b/tests/integration/python/parameterized/sdk/python/pulumi_pkg/provider.py
@@ -68,5 +68,5 @@ class Provider(pulumi.ProviderResource):
             resource_name,
             __props__,
             opts,
-            packageRef=_utilities.get_package())
+            package_ref=_utilities.get_package())
 

--- a/tests/integration/python/parameterized/sdk/python/pulumi_pkg/random.py
+++ b/tests/integration/python/parameterized/sdk/python/pulumi_pkg/random.py
@@ -110,7 +110,7 @@ class Random(pulumi.CustomResource):
             resource_name,
             __props__,
             opts,
-            packageRef=_utilities.get_package())
+            package_ref=_utilities.get_package())
 
     @staticmethod
     def get(resource_name: str,


### PR DESCRIPTION
In adding support for parameterized providers to the Python SDK, some variables erroneously used `camelCase` instead of `snake_case`. This commit cleans that up ahead of general release.