### PR TITLE
finish registering resource outputs before registering more resources

### DIFF
--- a/changelog/pending/20240729--sdk-go--fix-a-race-between-registerresource-and-registerresourceoutput-calls.yaml
+++ b/changelog/pending/20240729--sdk-go--fix-a-race-between-registerresource-and-registerresourceoutput-calls.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: sdk/go
-  description: Fix a race between RegisterResource and RegisterResourceOutput calls
+  description: Fix a race between RegisterResourceOutput calls and resource reads

--- a/changelog/pending/20240729--sdk-go--fix-a-race-between-registerresource-and-registerresourceoutput-calls.yaml
+++ b/changelog/pending/20240729--sdk-go--fix-a-race-between-registerresource-and-registerresourceoutput-calls.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fix a race between RegisterResource and RegisterResourceOutput calls

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -2191,7 +2191,7 @@ func (ctx *Context) endRPC(err error) {
 func (ctx *Context) RegisterResourceOutputs(resource Resource, outs Map) error {
 	// We need to await the URN synchronously because it can potentially do a read, which we can't do after adding
 	// to the waitgroup.  Reads could be blocked on the waitgroup otherwise.
-	urn, _, _, err := resource.URN().awaitURN(context.TODO())
+	urn, _, _, err := resource.URN().awaitURN(ctx.Context())
 	if err != nil {
 		return err
 	}

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -2189,7 +2189,7 @@ func (ctx *Context) endRPC(err error) {
 
 // RegisterResourceOutputs completes the resource registration, attaching an optional set of computed outputs.
 func (ctx *Context) RegisterResourceOutputs(resource Resource, outs Map) error {
-	// We need to await the URN synchronously because it cna potentially do a read, which we can't do after adding
+	// We need to await the URN synchronously because it can potentially do a read, which we can't do after adding
 	// to the waitgroup.  Reads could be blocked on the waitgroup otherwise.
 	urn, _, _, err := resource.URN().awaitURN(context.TODO())
 	if err != nil {


### PR DESCRIPTION
Registering resource outputs is happening async in a Goroutine.  This means this can happen anytime, even after subsequent register resource calls.  However subsequent register resource calls might rely on these outputs being registered already, as they won't resolve in their dependents otherwise.

A future register resource call doesn't have any idea that the outputs are still to be registered, and thus it's impossible for the SDKs awaiting funcions, such as Apply or All to wait for the output to be registered.

Work around this problem by locking ahead of registering a resouce output, and using an rlock in registerResource.

Fixes https://github.com/pulumi/pulumi/issues/16536

I'm not sure this is actually the right solution, but not sure what else we can do here.  We could maybe also just make `RegisterResourceOutputs` sync instead of running it in a goroutine, but it feels like it's always going to be ordering dependent.