### PR TITLE
[Go] Re-enable l1-stack-reference conformance test

### DIFF
--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -377,6 +377,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgen(w, "ctx.Project()")
 	case "cwd":
 		g.Fgen(w, "func(cwd string, err error) string { if err != nil { panic(err) }; return cwd }(os.Getwd())")
+	case "getOutput":
+		g.Fgenf(w, "%v.GetOutput(pulumi.String(%v))", expr.Args[0], expr.Args[1])
 	default:
 		// toJSON and readDir are reduced away, shouldn't see them here
 		reducedFunctions := codegen.NewStringSet("toJSON", "readDir")

--- a/sdk/go/pulumi-language-go/language_test.go
+++ b/sdk/go/pulumi-language-go/language_test.go
@@ -172,7 +172,6 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 
 // TODO: These tests are not working yet because of issues in sdkgen and programgen
 var expectedFailures = map[string]string{
-	"l1-stack-reference":                 "error in compiling Go",
 	"l2-target-up-with-new-dependency":   "missing go.mod",
 	"l2-destroy":                         "missing go.mod",
 	"l2-large-string":                    "missing go.mod",

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-stack-reference/Pulumi.yaml
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-stack-reference/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-stack-reference
+runtime: go

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-stack-reference/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-stack-reference/go.mod
@@ -1,0 +1,7 @@
+module l1-stack-reference
+
+go 1.20
+
+require github.com/pulumi/pulumi/sdk/v3 v3.30.0
+
+replace github.com/pulumi/pulumi/sdk/v3/ => /ROOT/artifacts/github.com_pulumi_pulumi_sdk_v3

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-stack-reference/main.go
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-stack-reference/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		ref, err := pulumi.NewStackReference(ctx, "ref", &pulumi.StackReferenceArgs{
+			Name: pulumi.String("organization/other/dev"),
+		})
+		if err != nil {
+			return err
+		}
+		ctx.Export("plain", ref.GetOutput(pulumi.String("plain")))
+		ctx.Export("secret", ref.GetOutput(pulumi.String("secret")))
+		return nil
+	})
+}


### PR DESCRIPTION
By fixing the emitted function for `getOutput` in Go program-gen which is specific to stack references. 

Locally the generated program compiles but I get a runtime error:
```
Error:      	Not equal: 
expected: resource.PropertyValue{V:"plain"}
actual  : resource.PropertyValue{V:(*resource.Secret)(0x14000aa6050)}

Diff:
--- Expected
+++ Actual
@@ -1,3 +1,7 @@
 (resource.PropertyValue) {
- V: (string) (len=5) "plain"
+ V: (*resource.Secret)({
+  Element: (resource.PropertyValue) {
+   V: (string) (len=5) "plain"
+  }
+ })
 }
Messages:   	expected property "plain" to be {plain}
```
However I _think_ this is a local problem with some cached Go SDK artifacts because when go the implementation of `GetOutput` (from the generated program) it brings me to a different implementation than the one I find on latest SDK so testing in CI to make sure