### PR TITLE
state_move: set up a secret manager in the dest stack if it doesn't exist

### DIFF
--- a/changelog/pending/20240730--cli-state--fix-moving-resources-with-secrets-when-the-destination-stack-has-no-secrets-manager-defined.yaml
+++ b/changelog/pending/20240730--cli-state--fix-moving-resources-with-secrets-when-the-destination-stack-has-no-secrets-manager-defined.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Fix moving resources with secrets when the destination stack has no secrets manager defined

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -143,21 +143,26 @@ func (cmd *stateMoveCmd) Run(
 		destSnapshot = &deploy.Snapshot{}
 	}
 	if destSnapshot.SecretsManager == nil {
-		// If the destination stack has no secret manager, we need to create one.  This only works if the user is currently in the destination project directory.  If we fail here this indicates that they are not, and we return an error explaining that.
-		error := errors.New("destination stack has no secret manager. To move resources either initialize the stack with a secret manager, or run the pulumi state move command from the destination project directory.")
+		// If the destination stack has no secret manager, we
+		// need to create one.  This only works if the user is
+		// currently in the destination project directory.  If
+		// we fail here this indicates that they are not, and
+		// we return an projectError explaining that.
+		//nolint:lll
+		projectError := errors.New("destination stack has no secret manager. To move resources either initialize the stack with a secret manager, or run the pulumi state move command from the destination project directory")
 		path, err := workspace.DetectProjectPath()
 		if err != nil {
-			return error
+			return projectError
 		}
 		if path == "" {
-			return error
+			return projectError
 		}
 		project, err := workspace.LoadProject(path)
 		if err != nil {
-			return error
+			return projectError
 		}
 		if string(project.Name) != string(dest.Ref().FullyQualifiedName().Namespace().Name()) {
-			return error
+			return projectError
 		}
 
 		// The user is in the right directory.  If we fail below we will return the error of that failure.

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -141,6 +141,9 @@ func (cmd *stateMoveCmd) Run(
 	if destSnapshot == nil {
 		destSnapshot = &deploy.Snapshot{}
 	}
+	if destSnapshot.SecretsManager == nil {
+		destSnapshot.SecretsManager = sourceSnapshot.SecretsManager
+	}
 
 	resourcesToMove := make(map[string]*resource.State)
 	providersToCopy := make(map[string]bool)

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -142,7 +143,38 @@ func (cmd *stateMoveCmd) Run(
 		destSnapshot = &deploy.Snapshot{}
 	}
 	if destSnapshot.SecretsManager == nil {
-		destSnapshot.SecretsManager = sourceSnapshot.SecretsManager
+		// If the destination stack has no secret manager, we need to create one.  This only works if the user is currently in the destination project directory.  If we fail here this indicates that they are not, and we return an error explaining that.
+		error := errors.New("destination stack has no secret manager. To move resources either initialize the stack with a secret manager, or run the pulumi state move command from the destination project directory.")
+		path, err := workspace.DetectProjectPath()
+		if err != nil {
+			return error
+		}
+		if path == "" {
+			return error
+		}
+		project, err := workspace.LoadProject(path)
+		if err != nil {
+			return error
+		}
+		if string(project.Name) != string(dest.Ref().FullyQualifiedName().Namespace().Name()) {
+			return error
+		}
+
+		// The user is in the right directory.  If we fail below we will return the error of that failure.
+		err = createSecretsManager(ctx, dest, "", false, true)
+		if err != nil {
+			return err
+		}
+		ps, err := loadProjectStack(project, dest)
+		if err != nil {
+			return err
+		}
+
+		destSecretManager, err := dest.DefaultSecretManager(ps)
+		if err != nil {
+			return err
+		}
+		destSnapshot.SecretsManager = destSecretManager
 	}
 
 	resourcesToMove := make(map[string]*resource.State)

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -997,7 +997,7 @@ runtime: mock
 		Stdout:    &stdout,
 		Colorizer: colors.Never,
 	}
-	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[2].URN)}, mp)
+	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[2].URN)}, mp, mp)
 	assert.NoError(t, err)
 
 	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp)
@@ -1087,7 +1087,7 @@ func TestMoveSecretOutsideOfProjectDir(t *testing.T) {
 		Colorizer: colors.Never,
 	}
 
-	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[2].URN)}, mp)
+	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[2].URN)}, mp, mp)
 	//nolint:lll
 	assert.ErrorContains(t, err, "destination stack has no secret manager. To move resources either initialize the stack with a secret manager, or run the pulumi state move command from the destination project directory")
 
@@ -1170,7 +1170,7 @@ runtime: mock
 		Colorizer: colors.Never,
 	}
 
-	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[2].URN)}, mp)
+	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[2].URN)}, mp, mp)
 	//nolint:lll
 	assert.ErrorContains(t, err, "destination stack has no secret manager. To move resources either initialize the stack with a secret manager, or run the pulumi state move command from the destination project directory")
 

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -88,7 +88,6 @@ func runMoveWithOptions(
 	assert.NoError(t, err)
 
 	sourceStackName := "organization/test/sourceStack"
-
 	sourceStack := createStackWithResources(t, b, sourceStackName, sourceResources)
 
 	destResources := []*resource.State{}
@@ -918,4 +917,90 @@ func TestMoveRootStack(t *testing.T) {
 		destSnapshot.Resources[2].Provider)
 	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:pulumi:Stack::test-destStack"),
 		destSnapshot.Resources[2].Parent)
+}
+
+func TestMoveSecret(t *testing.T) {
+	t.Parallel()
+
+	providerURN := resource.NewURN("sourceStack", "test", "", "pulumi:providers:a", "default_1_0_0")
+	sourceResources := []*resource.State{
+		{
+			URN:  resource.DefaultRootStackURN("sourceStack", "test"),
+			Type: "pulumi:pulumi:Stack",
+		},
+		{
+			URN:    providerURN,
+			Type:   "pulumi:providers:a::default_1_0_0",
+			ID:     "provider_id",
+			Custom: true,
+			Parent: resource.DefaultRootStackURN("sourceStack", "test"),
+		},
+		{
+			URN:      resource.NewURN("sourceStack", "test", "d:e:f", "a:b:c", "name"),
+			Type:     "a:b:c",
+			Provider: string(providerURN) + "::provider_id",
+			Parent:   resource.DefaultRootStackURN("sourceStack", "test"),
+			Outputs:  resource.PropertyMap{"secret": resource.MakeSecret(resource.NewStringProperty("secret"))},
+		},
+	}
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	b, err := diy.New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	sourceStackName := "organization/test/sourceStack"
+	sourceStack := createStackWithResources(t, b, sourceStackName, sourceResources)
+
+	destStackName := "organization/test/destStack"
+	destRef, err := b.ParseStackReference(destStackName)
+	require.NoError(t, err)
+
+	destStack, err := b.CreateStack(ctx, destRef, "", nil)
+	require.NoError(t, err)
+
+	mp := &secrets.MockProvider{}
+	mp = mp.Add("b64", func(_ json.RawMessage) (secrets.Manager, error) {
+		return b64.NewBase64SecretsManager(), nil
+	})
+
+	var stdout bytes.Buffer
+
+	stateMoveCmd := stateMoveCmd{
+		Yes:       true,
+		Stdout:    &stdout,
+		Colorizer: colors.Never,
+	}
+	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[2].URN)}, mp)
+	assert.NoError(t, err)
+
+	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp)
+	assert.NoError(t, err)
+
+	destStack, err = b.GetStack(ctx, destRef)
+	require.NoError(t, err)
+
+	destSnapshot, err := destStack.Snapshot(ctx, mp)
+	assert.NoError(t, err)
+
+	// Expect the root stack and the provider to remain in the source stack
+	assert.Equal(t, 2, len(sourceSnapshot.Resources))
+	// All other resources are moved to the destination
+	assert.Equal(t, 3, len(destSnapshot.Resources))
+
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:pulumi:Stack::test-destStack"),
+		destSnapshot.Resources[0].URN)
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:providers:a::default_1_0_0"),
+		destSnapshot.Resources[1].URN)
+	assert.Equal(t, resource.DefaultRootStackURN("destStack", "test"),
+		destSnapshot.Resources[1].Parent)
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::d:e:f$a:b:c::name"),
+		destSnapshot.Resources[2].URN)
+	assert.Equal(t, "urn:pulumi:destStack::test::pulumi:providers:a::default_1_0_0::provider_id",
+		destSnapshot.Resources[2].Provider)
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:pulumi:Stack::test-destStack"),
+		destSnapshot.Resources[2].Parent)
+	assert.True(t, destSnapshot.Resources[2].Outputs["secret"].IsSecret())
+	assert.Equal(t, "secret", destSnapshot.Resources[2].Outputs["secret"].SecretValue().Element.V)
 }


### PR DESCRIPTION
The destination snapshot currently doesn't necessarily have a secrets manager set up, e.g. if the stack was just initialized with `pulumi stack init <stack>`.

At the same time, any secrets we're moving need to be re-encrypted with the secret manager in the destination stack.  If the secret manager is not defined there this means we'll create a panicCrypter, and `pulumi state move` will panic.

To prevent this, make the destination stack use the source secret manager if the secret manager is not already defined there.

Fixes https://github.com/pulumi/pulumi/issues/16835