### PR TITLE
Fix deletes not being show in `refresh` when using json output

### DIFF
--- a/changelog/pending/20240731--cli-display--fix-deletes-not-being-show-in-refresh-when-using-json-output.yaml
+++ b/changelog/pending/20240731--cli-display--fix-deletes-not-being-show-in-refresh-when-using-json-output.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Fix deletes not being show in `refresh` when using json output

--- a/pkg/backend/display/json.go
+++ b/pkg/backend/display/json.go
@@ -180,7 +180,7 @@ func ShowPreviewDigest(events <-chan engine.Event, done chan<- bool, opts Option
 					refresh = true
 				}
 
-				if refresh && (m.Op == deploy.OpUpdate || m.Op == deploy.OpDelete) && m.DetailedDiff != nil {
+				if refresh && ((m.Op == deploy.OpUpdate && m.DetailedDiff != nil) || m.Op == deploy.OpDelete) {
 					step := getPreviewMetadataStep(m, opts)
 					for i, s := range digest.Steps {
 						if s.URN == m.URN {


### PR DESCRIPTION
Introduced in https://github.com/pulumi/pulumi/pull/16146

@lukehoban