### PR TITLE
Use pulumi.Sprintf in program gen

### DIFF
--- a/changelog/pending/20240801--programgen-go--sprintf-go-programgen.yaml
+++ b/changelog/pending/20240801--programgen-go--sprintf-go-programgen.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/go
+  description: Use `pulumi.Sprintf(...)` instead of `pulumi.String(fmt.Sprintf(...))` in Go program generation

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -719,7 +719,8 @@ func (g *generator) genTemplateExpression(w io.Writer, expr *model.TemplateExpre
 	}
 	argTypeName := g.argumentTypeName(destType, false)
 	isPulumiType := strings.HasPrefix(argTypeName, "pulumi.")
-	if isPulumiType {
+	isPulumiStr := argTypeName == "pulumi.String"
+	if isPulumiType && !isPulumiStr {
 		g.Fgenf(w, "%s(", argTypeName)
 		defer g.Fgenf(w, ")")
 	}
@@ -746,7 +747,11 @@ func (g *generator) genTemplateExpression(w io.Writer, expr *model.TemplateExpre
 		fmtStr.WriteString("%v")
 		g.Fgenf(args, ", %.v", v)
 	}
-	g.Fgenf(w, "fmt.Sprintf(")
+	if isPulumiStr {
+		g.Fgenf(w, "pulumi.Sprintf(")
+	} else {
+		g.Fgenf(w, "fmt.Sprintf(")
+	}
 	g.genStringLiteral(w, fmtStr.String(), canBeRaw)
 	_, err := args.WriteTo(w)
 	contract.AssertNoErrorf(err, "Failed to write arguments")

--- a/tests/integration/aliases/go/retype_parents/step2/main.go
+++ b/tests/integration/aliases/go/retype_parents/step2/main.go
@@ -5,8 +5,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -37,7 +35,7 @@ func NewComponentSix(ctx *pulumi.Context, name string, opts ...pulumi.ResourceOp
 	aliases := make([]pulumi.Alias, 0)
 	for i := 0; i < 100; i++ {
 		aliases = append(aliases, pulumi.Alias{
-			Type: pulumi.StringInput(pulumi.String(fmt.Sprintf("my:module:ComponentSix-v%d", i))),
+			Type: pulumi.StringInput(pulumi.Sprintf("my:module:ComponentSix-v%d", i)),
 		})
 	}
 	err := ctx.RegisterComponentResource(
@@ -61,7 +59,7 @@ func NewComponentSixParent(ctx *pulumi.Context, name string,
 	aliases := make([]pulumi.Alias, 0)
 	for i := 0; i < 10; i++ {
 		aliases = append(aliases, pulumi.Alias{
-			Type: pulumi.StringInput(pulumi.String(fmt.Sprintf("my:module:ComponentSixParent-v%d", i))),
+			Type: pulumi.StringInput(pulumi.Sprintf("my:module:ComponentSixParent-v%d", i)),
 		})
 	}
 	err := ctx.RegisterComponentResource(

--- a/tests/testdata/codegen/aws-eks-pp/go/aws-eks.go
+++ b/tests/testdata/codegen/aws-eks-pp/go/aws-eks.go
@@ -60,10 +60,10 @@ func main() {
 				AssignIpv6AddressOnCreation: pulumi.Bool(false),
 				VpcId:                       eksVpc.ID(),
 				MapPublicIpOnLaunch:         pulumi.Bool(true),
-				CidrBlock:                   pulumi.String(fmt.Sprintf("10.100.%v.0/24", key0)),
+				CidrBlock:                   pulumi.Sprintf("10.100.%v.0/24", key0),
 				AvailabilityZone:            pulumi.String(val0),
 				Tags: pulumi.StringMap{
-					"Name": pulumi.String(fmt.Sprintf("pulumi-sn-%v", val0)),
+					"Name": pulumi.Sprintf("pulumi-sn-%v", val0),
 				},
 			})
 			if err != nil {

--- a/tests/testdata/codegen/output-funcs-tfbridge20/go-extras/tests/codegen_test.go
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/go-extras/tests/codegen_test.go
@@ -174,10 +174,10 @@ func TestListStorageAccountKeysOutput(t *testing.T) {
 func TestGetAmiIdsWorks(t *testing.T) {
 	makeFilter := func(n int) mypkg.GetAmiIdsFilterInput {
 		return &mypkg.GetAmiIdsFilterArgs{
-			Name: pulumi.String(fmt.Sprintf("filter-%d-name", n)),
+			Name: pulumi.Sprintf("filter-%d-name", n),
 			Values: pulumi.StringArray{
-				pulumi.String(fmt.Sprintf("value-%d-1", n)),
-				pulumi.String(fmt.Sprintf("value-%d-2", n)),
+				pulumi.Sprintf("value-%d-1", n),
+				pulumi.Sprintf("value-%d-2", n),
 			},
 		}
 	}

--- a/tests/testdata/codegen/simple-range-pp/go/simple-range.go
+++ b/tests/testdata/codegen/simple-range-pp/go/simple-range.go
@@ -16,7 +16,7 @@ func main() {
 			__res, err := random.NewRandomInteger(ctx, fmt.Sprintf("numbers-%v", key0), &random.RandomIntegerArgs{
 				Min:  pulumi.Int(1),
 				Max:  pulumi.Int(val0),
-				Seed: pulumi.String(fmt.Sprintf("seed%v", val0)),
+				Seed: pulumi.Sprintf("seed%v", val0),
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
Noticed by @thomas11 on Slack (https://pulumi.slack.com/archives/C02FXTZEZ6W/p1722410344206549). We had a number of places doing `pulumi.String(fmt.Sprintf(template, args))`, when they could just use `pulumi.Sprintf`. This updates programgen to use that.