### PR TITLE
Tiny cleanup to an integration test

### DIFF
--- a/tests/integration/aliases/go/retype_parents/step2/main.go
+++ b/tests/integration/aliases/go/retype_parents/step2/main.go
@@ -35,7 +35,7 @@ func NewComponentSix(ctx *pulumi.Context, name string, opts ...pulumi.ResourceOp
 	aliases := make([]pulumi.Alias, 0)
 	for i := 0; i < 100; i++ {
 		aliases = append(aliases, pulumi.Alias{
-			Type: pulumi.StringInput(pulumi.Sprintf("my:module:ComponentSix-v%d", i)),
+			Type: pulumi.Sprintf("my:module:ComponentSix-v%d", i),
 		})
 	}
 	err := ctx.RegisterComponentResource(
@@ -59,7 +59,7 @@ func NewComponentSixParent(ctx *pulumi.Context, name string,
 	aliases := make([]pulumi.Alias, 0)
 	for i := 0; i < 10; i++ {
 		aliases = append(aliases, pulumi.Alias{
-			Type: pulumi.StringInput(pulumi.Sprintf("my:module:ComponentSixParent-v%d", i)),
+			Type: pulumi.Sprintf("my:module:ComponentSixParent-v%d", i),
 		})
 	}
 	err := ctx.RegisterComponentResource(


### PR DESCRIPTION
This is a quick follow-up to https://github.com/pulumi/pulumi/pull/16852 which tweaked some code to use `pulumi.Sprintf`. The same lines can be simplified further: there's no need to specify `pulumi.StringInput` since the result of `pulumi.Sprintf` (`pulumi.StringOutput`) satisfies `pulumi.StringInput`.