### PR TITLE
Iter local dependencies in sorted order

### DIFF
--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -610,8 +610,11 @@ func GenerateProjectFiles(project workspace.Project, program *pcl.Program,
 		}
 	}
 
-	// For any local dependencies, add a replace statement
-	for pkg, path := range localDependencies {
+	// For any local dependencies, add a replace statement. Make sure we iter this in sorted order (c.f.
+	// https://github.com/pulumi/pulumi/issues/16859).
+	pkgs := codegen.SortedKeys(localDependencies)
+	for _, pkg := range pkgs {
+		path := localDependencies[pkg]
 		// pkg is the package name, we transformed these into Go paths above so use the map generated there
 		goPath, ok := packagePaths[pkg]
 		if ok {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/16859.

Standard issue map iteration being undefined order and thus giving inconsistent codegen results. This fixes the map iteration to use `SortedKeys` to get a consistent result.