### PR TITLE
state_move: include stack name in the passhprase prompt

### DIFF
--- a/changelog/pending/20240802--cli-state--include-the-stack-name-in-the-passhprase-prompt-in-state-move.yaml
+++ b/changelog/pending/20240802--cli-state--include-the-stack-name-in-the-passhprase-prompt-in-state-move.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Include the stack name in the passhprase prompt in state move

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -86,7 +86,14 @@ splitting a stack into multiple stacks or when merging multiple stacks into one.
 			stateMove.Yes = yes
 			stateMove.IncludeParents = includeParents
 
-			return stateMove.Run(ctx, sourceStack, destStack, args, stack.DefaultSecretsProvider)
+			sourceSecretsProvider := stack.StackSecretsProvider{
+				StackName: sourceStack.Ref().FullyQualifiedName().String(),
+			}
+			destSecretsProvider := stack.StackSecretsProvider{
+				StackName: destStack.Ref().FullyQualifiedName().String(),
+			}
+
+			return stateMove.Run(ctx, sourceStack, destStack, args, sourceSecretsProvider, destSecretsProvider)
 		}),
 	}
 
@@ -101,7 +108,7 @@ splitting a stack into multiple stacks or when merging multiple stacks into one.
 
 func (cmd *stateMoveCmd) Run(
 	ctx context.Context, source backend.Stack, dest backend.Stack, args []string,
-	secretsProvider secrets.Provider,
+	sourceSecretsProvider secrets.Provider, destSecretsProvider secrets.Provider,
 ) error {
 	if cmd.Stdin == nil {
 		cmd.Stdin = os.Stdin
@@ -110,11 +117,11 @@ func (cmd *stateMoveCmd) Run(
 		cmd.Stdout = os.Stdout
 	}
 
-	sourceSnapshot, err := source.Snapshot(ctx, secretsProvider)
+	sourceSnapshot, err := source.Snapshot(ctx, sourceSecretsProvider)
 	if err != nil {
 		return err
 	}
-	destSnapshot, err := dest.Snapshot(ctx, secretsProvider)
+	destSnapshot, err := dest.Snapshot(ctx, destSecretsProvider)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -86,10 +86,10 @@ splitting a stack into multiple stacks or when merging multiple stacks into one.
 			stateMove.Yes = yes
 			stateMove.IncludeParents = includeParents
 
-			sourceSecretsProvider := stack.StackSecretsProvider{
+			sourceSecretsProvider := stack.NamedStackSecretsProvider{
 				StackName: sourceStack.Ref().FullyQualifiedName().String(),
 			}
-			destSecretsProvider := stack.StackSecretsProvider{
+			destSecretsProvider := stack.NamedStackSecretsProvider{
 				StackName: destStack.Ref().FullyQualifiedName().String(),
 			}
 

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -108,7 +108,7 @@ func runMoveWithOptions(
 		Colorizer:      colors.Never,
 		IncludeParents: options.IncludeParents,
 	}
-	err = stateMoveCmd.Run(ctx, sourceStack, destStack, args, mp)
+	err = stateMoveCmd.Run(ctx, sourceStack, destStack, args, mp, mp)
 	assert.NoError(t, err)
 
 	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp)
@@ -391,7 +391,7 @@ func TestMoveWithExistingProvider(t *testing.T) {
 		Stdout:    &stdout,
 		Colorizer: colors.Never,
 	}
-	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[1].URN)}, mp)
+	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[1].URN)}, mp, mp)
 	assert.ErrorContains(t, err, "provider urn:pulumi:destStack::test::pulumi:providers:a::default_1_0_0 "+
 		"already exists in destination stack")
 }
@@ -453,7 +453,7 @@ func TestMoveWithExistingResource(t *testing.T) {
 		Stdout:    &stdout,
 		Colorizer: colors.Never,
 	}
-	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[1].URN)}, mp)
+	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[1].URN)}, mp, mp)
 	assert.ErrorContains(t, err, "resource urn:pulumi:destStack::test::d:e:f$a:b:c::name "+
 		"already exists in destination stack")
 }
@@ -535,7 +535,7 @@ func TestEmptySourceStack(t *testing.T) {
 		Yes:       true,
 		Colorizer: colors.Never,
 	}
-	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{"not-there"}, mp)
+	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{"not-there"}, mp, mp)
 	assert.ErrorContains(t, err, "source stack has no resources")
 }
 
@@ -581,7 +581,7 @@ func TestEmptyDestStack(t *testing.T) {
 		Yes:       true,
 		Colorizer: colors.Never,
 	}
-	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[1].URN)}, mp)
+	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[1].URN)}, mp, mp)
 	assert.NoError(t, err)
 
 	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp)
@@ -663,7 +663,7 @@ func TestMovingProvidersWithSameID(t *testing.T) {
 		Stdout:    &stdout,
 		Colorizer: colors.Never,
 	}
-	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[2].URN)}, mp)
+	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[2].URN)}, mp, mp)
 	assert.NoError(t, err)
 
 	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp)
@@ -677,7 +677,7 @@ func TestMovingProvidersWithSameID(t *testing.T) {
 	// The provider, rootstack and the moved resource are in the destination
 	assert.Equal(t, 3, len(destSnapshot.Resources))
 
-	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[3].URN)}, mp)
+	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[3].URN)}, mp, mp)
 	assert.NoError(t, err)
 
 	sourceSnapshot, err = sourceStack.Snapshot(ctx, mp)
@@ -759,7 +759,7 @@ func TestMoveUnknownResource(t *testing.T) {
 		Stdout:    &stdout,
 		Colorizer: colors.Never,
 	}
-	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{"not-a-urn"}, mp)
+	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{"not-a-urn"}, mp, mp)
 	assert.ErrorContains(t, err, "no resources found to move")
 
 	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp)
@@ -866,7 +866,7 @@ func TestMoveProvider(t *testing.T) {
 		Stdout:    &stdout,
 		Colorizer: colors.Never,
 	}
-	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(providerURN)}, mp)
+	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(providerURN)}, mp, mp)
 	assert.ErrorContains(t, err, "cannot move provider")
 
 	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp)

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -66,7 +66,7 @@ type NamedStackSecretsProvider struct {
 }
 
 // OfType returns a secrets manager for the given secrets type. Returns an error
-// if the type is uknown or the state is invalid.
+// if the type is unknown or the state is invalid.
 func (s NamedStackSecretsProvider) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
 	var sm secrets.Manager
 	var err error

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -57,15 +57,17 @@ func (defaultSecretsProvider) OfType(ty string, state json.RawMessage) (secrets.
 	return NewCachingSecretsManager(sm), nil
 }
 
-// StackSecretsProvider is the same as the default secrets provider, but is aware of the stack name for which it is used.
-// Currently this is only used for prompting passphrase secrets managers to show the stackname in the prompt for the passphrase.
-type StackSecretsProvider struct {
+// NamedStackSecretsProvider is the same as the default secrets provider,
+// but is aware of the stack name for which it is used.  Currently
+// this is only used for prompting passphrase secrets managers to show
+// the stackname in the prompt for the passphrase.
+type NamedStackSecretsProvider struct {
 	StackName string
 }
 
 // OfType returns a secrets manager for the given secrets type. Returns an error
 // if the type is uknown or the state is invalid.
-func (s StackSecretsProvider) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
+func (s NamedStackSecretsProvider) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
 	var sm secrets.Manager
 	var err error
 	switch ty {

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -36,13 +36,41 @@ var DefaultSecretsProvider secrets.Provider = &defaultSecretsProvider{}
 type defaultSecretsProvider struct{}
 
 // OfType returns a secrets manager for the given secrets type. Returns an error
-// if the type is uknown or the state is invalid.
+// if the type is unknown or the state is invalid.
 func (defaultSecretsProvider) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
 	var sm secrets.Manager
 	var err error
 	switch ty {
 	case passphrase.Type:
 		sm, err = passphrase.NewPromptingPassphraseSecretsManagerFromState(state)
+	case service.Type:
+		sm, err = service.NewServiceSecretsManagerFromState(state)
+	case cloud.Type:
+		sm, err = cloud.NewCloudSecretsManagerFromState(state)
+	default:
+		return nil, fmt.Errorf("no known secrets provider for type %q", ty)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("constructing secrets manager of type %q: %w", ty, err)
+	}
+
+	return NewCachingSecretsManager(sm), nil
+}
+
+// StackSecretsProvider is the same as the default secrets provider, but is aware of the stack name for which it is used.
+// Currently this is only used for prompting passphrase secrets managers to show the stackname in the prompt for the passphrase.
+type StackSecretsProvider struct {
+	StackName string
+}
+
+// OfType returns a secrets manager for the given secrets type. Returns an error
+// if the type is uknown or the state is invalid.
+func (s StackSecretsProvider) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
+	var sm secrets.Manager
+	var err error
+	switch ty {
+	case passphrase.Type:
+		sm, err = passphrase.NewStackPromptingPassphraseSecretsManagerFromState(state, s.StackName)
 	case service.Type:
 		sm, err = service.NewServiceSecretsManagerFromState(state)
 	case cloud.Type:

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -218,15 +218,20 @@ func GetPassphraseSecretsManager(phrase string, state string) (secrets.Manager, 
 // newPromptingPassphraseSecretsManagerFromState returns a new passphrase-based secrets manager, from the
 // given state. Will use the passphrase found in PULUMI_CONFIG_PASSPHRASE, the file specified by
 // PULUMI_CONFIG_PASSPHRASE_FILE, or otherwise will prompt for the passphrase if interactive.
-func newPromptingPassphraseSecretsManagerFromState(state string) (secrets.Manager, error) {
+func newPromptingPassphraseSecretsManagerFromState(state, stackName string) (secrets.Manager, error) {
 	// Check the cache first, if we have already seen this state before, return a cached value.
 	if cached, ok := getCachedSecretsManager(state); ok {
 		return cached, nil
 	}
 
 	// Otherwise, prompt for the password.
-	const prompt = "Enter your passphrase to unlock config/secrets\n" +
-		"    (set PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE to remember)"
+	prompt := "Enter your passphrase to unlock config/secrets"
+	if stackName != "" {
+		prompt += " for stack " + stackName + "\n"
+	} else {
+		prompt += "\n"
+	}
+	prompt += "    (set PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE to remember)"
 	for {
 		phrase, interactive, phraseErr := readPassphrase(prompt, true /*useEnv*/)
 		if phraseErr != nil {
@@ -255,7 +260,28 @@ func NewPromptingPassphraseSecretsManagerFromState(state json.RawMessage) (secre
 		return nil, fmt.Errorf("unmarshalling state: %w", err)
 	}
 
-	sm, err := newPromptingPassphraseSecretsManagerFromState(s.Salt)
+	sm, err := newPromptingPassphraseSecretsManagerFromState(s.Salt, "")
+	switch {
+	case err == ErrIncorrectPassphrase:
+		return newLockedPasspharseSecretsManager(state), nil
+	case err != nil:
+		return nil, fmt.Errorf("constructing secrets manager: %w", err)
+	default:
+		return sm, nil
+	}
+}
+
+// NewStackPromptingPassphraseSecretsManager returns a new passphrase-based secrets manager, from the
+// given state. Will use the passphrase found in PULUMI_CONFIG_PASSPHRASE, the file specified by
+// PULUMI_CONFIG_PASSPHRASE_FILE, or otherwise will prompt for the passphrase if interactive.
+// It also takes a stack name to include in the prompt.
+func NewStackPromptingPassphraseSecretsManagerFromState(state json.RawMessage, stackName string) (secrets.Manager, error) {
+	var s localSecretsManagerState
+	if err := json.Unmarshal(state, &s); err != nil {
+		return nil, fmt.Errorf("unmarshalling state: %w", err)
+	}
+
+	sm, err := newPromptingPassphraseSecretsManagerFromState(s.Salt, stackName)
 	switch {
 	case err == ErrIncorrectPassphrase:
 		return newLockedPasspharseSecretsManager(state), nil
@@ -280,7 +306,7 @@ func NewPromptingPassphraseSecretsManager(info *workspace.ProjectStack,
 
 	// If we have a salt, we can just use it.
 	if info.EncryptionSalt != "" {
-		return newPromptingPassphraseSecretsManagerFromState(info.EncryptionSalt)
+		return newPromptingPassphraseSecretsManagerFromState(info.EncryptionSalt, "")
 	}
 
 	// Otherwise, prompt the user for a new passphrase.

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -275,7 +275,9 @@ func NewPromptingPassphraseSecretsManagerFromState(state json.RawMessage) (secre
 // given state. Will use the passphrase found in PULUMI_CONFIG_PASSPHRASE, the file specified by
 // PULUMI_CONFIG_PASSPHRASE_FILE, or otherwise will prompt for the passphrase if interactive.
 // It also takes a stack name to include in the prompt.
-func NewStackPromptingPassphraseSecretsManagerFromState(state json.RawMessage, stackName string) (secrets.Manager, error) {
+func NewStackPromptingPassphraseSecretsManagerFromState(
+	state json.RawMessage, stackName string,
+) (secrets.Manager, error) {
 	var s localSecretsManagerState
 	if err := json.Unmarshal(state, &s); err != nil {
 		return nil, fmt.Errorf("unmarshalling state: %w", err)


### PR DESCRIPTION
When moving resources between projects that use the passphrase secret manager, we automatically prompt for the secret, unless PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE are set. Unfortunately that can be a bit confusing when moving resources between different projects, because the prompt does not specify in any way which stack the passphrase is for.

Fix this by adding a little bit of output to the prompt, showing the user the stack name for which they are supposed to enter the passphrase.