### PR TITLE
create unknowns when the provider is not known during construct

### DIFF
--- a/changelog/pending/20240805--engine--allow-provider-to-be-unknown-during-preview.yaml
+++ b/changelog/pending/20240805--engine--allow-provider-to-be-unknown-during-preview.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Allow provider to be unknown during preview

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -2383,8 +2383,8 @@ func TestProviderPreviewUnknowns(t *testing.T) {
 		if preview {
 			// We expect construction of remote component resources to fail during previews if the provider is
 			// configured with unknowns.
-			assert.ErrorContains(t, err, "cannot construct components if the provider is configured with unknown values")
-			assert.Nil(t, respC)
+			assert.NoError(t, err)
+			assert.True(t, respC.Outputs.DeepEquals(resource.PropertyMap{}))
 		} else {
 			assert.NoError(t, err)
 			assert.True(t, respC.Outputs.DeepEquals(resource.PropertyMap{

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -2138,7 +2138,6 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 	var result *RegisterResult
 
 	var outputDeps map[string]*pulumirpc.RegisterResourceResponse_PropertyDependencies
-	fakeNonRemoteBecauseUnknownProvider := false
 	if remote {
 		provider, ok := rm.providers.GetProvider(providerRef)
 		if providers.IsDenyDefaultsProvider(providerRef) {
@@ -2183,35 +2182,29 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 			Inputs:  props,
 			Options: options,
 		})
-		if err != nil && !errors.Is(err, plugin.ProviderNotFullyConfiguredError{}) {
+		if err != nil {
 			return nil, err
 		}
+		result = &RegisterResult{State: &resource.State{URN: constructResult.URN, Outputs: constructResult.Outputs}}
 
-		if errors.Is(err, plugin.ProviderNotFullyConfiguredError{}) {
-			fakeNonRemoteBecauseUnknownProvider = true
-		} else {
-			result = &RegisterResult{State: &resource.State{URN: constructResult.URN, Outputs: constructResult.Outputs}}
-
-			// The provider may have returned OutputValues in "Outputs", we need to downgrade them to Computed or
-			// Secret but also add them to the outputDeps map.
-			if constructResult.OutputDependencies == nil {
-				constructResult.OutputDependencies = map[resource.PropertyKey][]resource.URN{}
-			}
-			for k, v := range result.State.Outputs {
-				constructResult.OutputDependencies[k] = extendOutputDependencies(constructResult.OutputDependencies[k], v)
-			}
-
-			outputDeps = map[string]*pulumirpc.RegisterResourceResponse_PropertyDependencies{}
-			for k, deps := range constructResult.OutputDependencies {
-				urns := make([]string, len(deps))
-				for i, d := range deps {
-					urns[i] = string(d)
-				}
-				outputDeps[string(k)] = &pulumirpc.RegisterResourceResponse_PropertyDependencies{Urns: urns}
-			}
+		// The provider may have returned OutputValues in "Outputs", we need to downgrade them to Computed or
+		// Secret but also add them to the outputDeps map.
+		if constructResult.OutputDependencies == nil {
+			constructResult.OutputDependencies = map[resource.PropertyKey][]resource.URN{}
 		}
-	}
-	if !remote || fakeNonRemoteBecauseUnknownProvider {
+		for k, v := range result.State.Outputs {
+			constructResult.OutputDependencies[k] = extendOutputDependencies(constructResult.OutputDependencies[k], v)
+		}
+
+		outputDeps = map[string]*pulumirpc.RegisterResourceResponse_PropertyDependencies{}
+		for k, deps := range constructResult.OutputDependencies {
+			urns := make([]string, len(deps))
+			for i, d := range deps {
+				urns[i] = string(d)
+			}
+			outputDeps[string(k)] = &pulumirpc.RegisterResourceResponse_PropertyDependencies{Urns: urns}
+		}
+	} else {
 		additionalSecretKeys := slice.Prealloc[resource.PropertyKey](len(additionalSecretOutputs))
 		for _, name := range additionalSecretOutputs {
 			additionalSecretKeys = append(additionalSecretKeys, resource.PropertyKey(name))

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -1387,6 +1387,12 @@ func (p *provider) Delete(ctx context.Context, req DeleteRequest) (DeleteRespons
 	return DeleteResponse{Status: resource.StatusOK}, err
 }
 
+type ProviderNotFullyConfiguredError struct{}
+
+func (e ProviderNotFullyConfiguredError) Error() string {
+	return "provider is not fully configured"
+}
+
 // Construct creates a new component resource from the given type, name, parent, options, and inputs, and returns
 // its URN and outputs.
 func (p *provider) Construct(ctx context.Context, req ConstructRequest) (ConstructResponse, error) {
@@ -1404,10 +1410,9 @@ func (p *provider) Construct(ctx context.Context, req ConstructRequest) (Constru
 		return ConstructResult{}, err
 	}
 
-	// If the provider is not fully configured, we need to error. We can't support unknown URNs but if the
-	// provider isn't configured we can't call into it to get the URN.
+	// If the provider is not fully configured return an empty ConstructResult.
 	if !pcfg.known {
-		return ConstructResult{}, errors.New("cannot construct components if the provider is configured with unknown values")
+		return ConstructResult{}, ProviderNotFullyConfiguredError{}
 	}
 
 	if !pcfg.acceptSecrets {


### PR DESCRIPTION
Currently when a provider is not known when trying to call construct, we error out.  A provider not being known can however legitimately happen during a preview, for example when setting up an eks cluster, and then using that kubeconfig to set up a kubernetes provider.

Users can currently work around that by using `--skip-preview`, and only going through the actual up, where the provider is known.  This is however not a great user experience.

Return a specific error from the provider Construct call, which we can then use in the resource monitor to fake constructing a resource with all unknown outputs.  This way the preview can still succeed, but any dependencies will also end up being unknown.

Fixes https://github.com/pulumi/pulumi/issues/16331