### PR TITLE
Parse conformance programs to decide which packages are needed for SDKs

### DIFF
--- a/cmd/pulumi-test-language/internal_test.go
+++ b/cmd/pulumi-test-language/internal_test.go
@@ -59,5 +59,6 @@ func TestInvalidSchema(t *testing.T) {
 		Test:  "internal-bad-schema",
 	})
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "bind schema for provider bad:")
+	assert.ErrorContains(t, err, "error loading resource type 'bad:index:Resource':")
+	assert.ErrorContains(t, err, "#/resources/bad:index:Resource/properties/value/type: unknown type kind not a type")
 }

--- a/cmd/pulumi-test-language/providers/bad_provider.go
+++ b/cmd/pulumi-test-language/providers/bad_provider.go
@@ -54,10 +54,10 @@ func (p *BadProvider) GetSchema(_ context.Context, request plugin.GetSchemaReque
 	resourceRequired := []string{"value"}
 
 	pkg := schema.PackageSpec{
-		Name:    "simple",
+		Name:    "bad",
 		Version: "3.0.0",
 		Resources: map[string]schema.ResourceSpec{
-			"simple:index:Resource": {
+			"bad:index:Resource": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
 					Type:       "object",
 					Properties: resourceProperties,

--- a/cmd/pulumi-test-language/testdata/internal-bad-schema/main.pp
+++ b/cmd/pulumi-test-language/testdata/internal-bad-schema/main.pp
@@ -1,0 +1,3 @@
+resource "res" "bad:index:Resource" {
+
+}

--- a/cmd/pulumi-test-language/tests.go
+++ b/cmd/pulumi-test-language/tests.go
@@ -72,6 +72,7 @@ var languageTests = map[string]languageTest{
 	// ==========
 	"internal-bad-schema": {
 		providers: []plugin.Provider{&providers.BadProvider{}},
+		runs:      []testRun{{}},
 	},
 	// ==========
 	// L1 (Tests not using providers)


### PR DESCRIPTION
This is in order to support parameterized packages, which show up in the PCL source code, but aren't a true separate provider we can list as a provider in the test case.

Instead of just generating SDKs for each provider listed as used in the test, we parse and bind the PCL program and ask it what packages it needs. For todays tests, this is fundementally the same set of packages either way. But once we add parameterized packages with "package" blocks there could be other packages returned.