### PR TITLE
make all changelog entries conform to our style

### DIFF
--- a/changelog/pending/20240730--engine--provider-internal-state-is-now-seperated-from-provider-user-config.yaml
+++ b/changelog/pending/20240730--engine--provider-internal-state-is-now-seperated-from-provider-user-config.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: engine
-  description: Provider internal state is now separated from provider user config. This allows providers to use a config key like "pluginDownloadURL" which previously would have conflicted with the engine's internal state. It also allows the engine to add new internal state fields without concern for clashing with existing or future provider config keys. 
+  description: Separate provider internal from provider user config. This allows providers to use a config key like "pluginDownloadURL" which previously would have conflicted with the engine's internal state. It also allows the engine to add new internal state fields without concern for clashing with existing or future provider config keys.


### PR DESCRIPTION
I noticed this one standing out slightly, and it would be nice to make it conform to our usual style before the 3.128.0 release.