### PR TITLE
Package versions are required for parameterized packages

### DIFF
--- a/pkg/cmd/pulumi/package.go
+++ b/pkg/cmd/pulumi/package.go
@@ -120,7 +120,7 @@ func schemaFromSchemaSource(ctx context.Context, packageSource string, args []st
 
 		request = plugin.GetSchemaRequest{
 			SubpackageName:    resp.Name,
-			SubpackageVersion: resp.Version,
+			SubpackageVersion: &resp.Version,
 		}
 	}
 

--- a/pkg/resource/deploy/providers/provider.go
+++ b/pkg/resource/deploy/providers/provider.go
@@ -28,13 +28,13 @@ type ProviderParameterization struct {
 	// The name of the parametrized package.
 	name tokens.Package
 	// The version of the parametrized package.
-	version *semver.Version
+	version semver.Version
 	// The value of the parameter.
 	value []byte
 }
 
 // NewProviderParameterization constructs a new provider parameterization.
-func NewProviderParameterization(name tokens.Package, version *semver.Version, value []byte,
+func NewProviderParameterization(name tokens.Package, version semver.Version, value []byte,
 ) *ProviderParameterization {
 	return &ProviderParameterization{
 		name:    name,
@@ -127,7 +127,7 @@ func (p ProviderRequest) DefaultName() string {
 
 	var v *semver.Version
 	if p.parameterization != nil {
-		v = p.parameterization.version
+		v = &p.parameterization.version
 	} else {
 		v = p.version
 	}

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -260,7 +260,7 @@ func GetProviderParameterization(name tokens.Package, inputs resource.PropertyMa
 
 	return &ProviderParameterization{
 		name:    name,
-		version: &sv,
+		version: sv,
 		value:   bytes,
 	}, nil
 }

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -868,13 +868,9 @@ func (rm *resmon) RegisterPackage(ctx context.Context,
 	// Parse the parameterization
 	var parameterization *providers.ProviderParameterization
 	if req.Parameterization != nil {
-		var parameterizationVersion *semver.Version
-		if req.Parameterization.Version != "" {
-			v, err := semver.Parse(req.Parameterization.Version)
-			if err != nil {
-				return nil, fmt.Errorf("parse parameter version %s: %w", req.Parameterization.Version, err)
-			}
-			parameterizationVersion = &v
+		parameterizationVersion, err := semver.Parse(req.Parameterization.Version)
+		if err != nil {
+			return nil, fmt.Errorf("parse parameter version %s: %w", req.Parameterization.Version, err)
 		}
 
 		// RegisterPackageRequest keeps all the plugin information in the root fields "name", "version" etc, while the

--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -47,7 +47,7 @@ type (
 
 	ParameterizeValue struct {
 		Name    string
-		Version *semver.Version
+		Version semver.Version
 		Value   []byte
 	}
 )
@@ -61,7 +61,7 @@ type ParameterizeRequest struct {
 
 type ParameterizeResponse struct {
 	Name    string
-	Version *semver.Version
+	Version semver.Version
 }
 
 type GetSchemaResponse struct {

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -315,14 +315,10 @@ func (p *provider) Parameterize(ctx context.Context, request ParameterizeRequest
 			},
 		}
 	case *ParameterizeValue:
-		var version string
-		if p.Version != nil {
-			version = p.Version.String()
-		}
 		params.Parameters = &pulumirpc.ParameterizeRequest_Value{
 			Value: &pulumirpc.ParameterizeRequest_ParametersValue{
 				Name:    p.Name,
-				Version: version,
+				Version: p.Version.String(),
 				Value:   p.Value,
 			},
 		}
@@ -335,13 +331,9 @@ func (p *provider) Parameterize(ctx context.Context, request ParameterizeRequest
 	if err != nil {
 		return ParameterizeResponse{}, err
 	}
-	var version *semver.Version
-	if resp.Version != "" {
-		v, err := semver.Parse(resp.Version)
-		if err != nil {
-			return ParameterizeResponse{}, err
-		}
-		version = &v
+	version, err := semver.Parse(resp.Version)
+	if err != nil {
+		return ParameterizeResponse{}, err
 	}
 	return ParameterizeResponse{Name: resp.Name, Version: version}, err
 }

--- a/sdk/go/common/resource/plugin/provider_server.go
+++ b/sdk/go/common/resource/plugin/provider_server.go
@@ -138,13 +138,9 @@ func (p *providerServer) Parameterize(
 	case *pulumirpc.ParameterizeRequest_Args:
 		params = &ParameterizeArgs{Args: p.Args.GetArgs()}
 	case *pulumirpc.ParameterizeRequest_Value:
-		var version *semver.Version
-		if v := p.Value.GetVersion(); v != "" {
-			pV, err := semver.Parse(v)
-			if err != nil {
-				return nil, err
-			}
-			version = &pV
+		version, err := semver.Parse(p.Value.GetVersion())
+		if err != nil {
+			return nil, err
 		}
 		params = &ParameterizeValue{
 			Name:    p.Value.GetName(),
@@ -156,13 +152,9 @@ func (p *providerServer) Parameterize(
 	if err != nil {
 		return nil, err
 	}
-	var v string
-	if resp.Version != nil {
-		v = resp.Version.String()
-	}
 	return &pulumirpc.ParameterizeResponse{
 		Name:    resp.Name,
-		Version: v,
+		Version: resp.Version.String(),
 	}, nil
 }
 


### PR DESCRIPTION
Make this more clear by passing plain value of `semver.Version` instead of a pointer for these cases.

This also gets rid of some incorrect empty string checks which would have passed a nil version onwards rather than error'ing (as they should have).