### PR TITLE
Add regression test for config overloads

### DIFF
--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1439,10 +1439,10 @@ func TestConfigGetterOverloads(t *testing.T) {
 	// handle editable packages well. We have to manually install the SDK without `-e` flag instead.
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
-	sdkPath := filepath.Join(cwd, "../../sdk/python/env/src")
+	sdkPath := filepath.Join(cwd, "..", "..", "sdk", "python", "env", "src")
 	pythonBin := "./venv/bin/python"
 	if runtime.GOOS == "windows" {
-		pythonBin = "./venv/Scripts/python.exe"
+		pythonBin = ".\\venv\\Scripts\\python.exe"
 	}
 	e.RunCommand(pythonBin, "-m", "pip", "install", sdkPath)
 

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1441,7 +1441,6 @@ func TestConfigGetterOverloads(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	sdkPath := filepath.Join(cwd, "../../sdk/python/env/src")
-	fmt.Println("localSDKPath: ", sdkPath)
 	pythonBin := "./venv/bin/python"
 	if runtime.GOOS == "windows" {
 		pythonBin = "./venv/Scripts/python.exe"

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1423,7 +1423,6 @@ func TestParameterizedPython(t *testing.T) {
 	})
 }
 
-//nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestConfigGetterOverloads(t *testing.T) {
 	t.Parallel()
 	e := ptesting.NewEnvironment(t)

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1422,3 +1422,37 @@ func TestParameterizedPython(t *testing.T) {
 		},
 	})
 }
+
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestConfigGetterOverloads(t *testing.T) {
+	t.Parallel()
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+	e.ImportDirectory("python/config-getter-types")
+
+	stackName := ptesting.RandomStackName()
+	e.RunCommand("pulumi", "install")
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.RunCommand("pulumi", "stack", "init", stackName)
+	defer e.RunCommand("pulumi", "stack", "rm", "--yes", "--stack", stackName)
+
+	// ProgramTest installs extra dependencies as editable packages using the `-e` flag, but typecheckers do not
+	// handle editable packages well. We have to manually install the SDK without `-e` flag instead.
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	sdkPath := filepath.Join(cwd, "../../sdk/python/env/src")
+	fmt.Println("localSDKPath: ", sdkPath)
+	pythonBin := "./venv/bin/python"
+	if runtime.GOOS == "windows" {
+		pythonBin = "./venv/Scripts/python.exe"
+	}
+	e.RunCommand(pythonBin, "-m", "pip", "install", sdkPath)
+
+	// Add some config values
+	e.RunCommand("pulumi", "config", "set", "foo", "bar")
+	e.RunCommand("pulumi", "config", "set", "foo_int", "42")
+	e.RunCommand("pulumi", "config", "set", "--secret", "foo_secret", "3")
+
+	// Run a preview. This will typecheck the program and fail if typechecking has errors.
+	e.RunCommand("pulumi", "preview")
+}

--- a/tests/integration/python/config-getter-types/.gitignore
+++ b/tests/integration/python/config-getter-types/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+/.pulumi/
+/dist/
+/*.egg-info
+venv/

--- a/tests/integration/python/config-getter-types/Pulumi.yaml
+++ b/tests/integration/python/config-getter-types/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: pulumi-python-pyright
+description: A simple Python Pulumi program that type checks with pyright.
+runtime:
+  name: python
+  options:
+    virtualenv: venv
+    typechecker: pyright

--- a/tests/integration/python/config-getter-types/__main__.py
+++ b/tests/integration/python/config-getter-types/__main__.py
@@ -1,0 +1,21 @@
+# Copyright 2024, Pulumi Corporation.  All rights reserved.
+
+"""An program that type checks config getters"""
+
+from typing import Optional
+import pulumi
+
+c = pulumi.Config()
+
+a1 = c.get("foo")
+a2 = c.get("foo", default="bar")
+a3 = c.get("foo", default=None)
+
+b1: Optional[int] = c.get_int("foo_int")
+b2: int = c.get_int("foo_int", default=3)
+b3: Optional[int] = c.get_int("foo_int", default=None)
+
+c1: Optional[pulumi.Output[str]] = c.get_secret("foo_secret")
+c2 = c.require("foo")
+c3: int = c.require_int("foo_int")
+c4: pulumi.Output[int] = c.require_secret_int("foo_secret")

--- a/tests/integration/python/config-getter-types/requirements.txt
+++ b/tests/integration/python/config-getter-types/requirements.txt
@@ -1,0 +1,1 @@
+pyright


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/16879

I verified that the test fails without the additional overloads from https://github.com/pulumi/pulumi/pull/16878.