### PR TITLE
Flow PropertyValues through NewPropertyMapFromMap

### DIFF
--- a/changelog/pending/20240806--sdk-go--newpropertymapfrommap-will-flow-propertyvalues-through-it-rather-than-dropping-them.yaml
+++ b/changelog/pending/20240806--sdk-go--newpropertymapfrommap-will-flow-propertyvalues-through-it-rather-than-dropping-them.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: NewPropertyMapFromMap will flow PropertyValues through it, rather than dropping them

--- a/sdk/go/common/resource/properties.go
+++ b/sdk/go/common/resource/properties.go
@@ -340,6 +340,8 @@ func NewPropertyValueRepl(v interface{},
 		return NewProperty(t)
 	case ResourceReference:
 		return NewProperty(t)
+	case PropertyValue:
+		return t
 	}
 
 	// Next, see if it's an array, slice, pointer or struct, and handle each accordingly.

--- a/sdk/go/common/resource/properties_test.go
+++ b/sdk/go/common/resource/properties_test.go
@@ -402,3 +402,28 @@ func TestHasValue(t *testing.T) {
 		})
 	}
 }
+
+// Test for https://github.com/pulumi/pulumi/issues/16889
+func TestMapFromMapNestedPropertyValues(t *testing.T) {
+	t.Parallel()
+
+	actual := NewPropertyMapFromMap(map[string]interface{}{
+		"prop": NewStringProperty("value"),
+		"nested": map[string]interface{}{
+			"obj": NewObjectProperty(PropertyMap{
+				"k": NewStringProperty("v"),
+			}),
+		},
+	})
+
+	expected := PropertyMap{
+		"prop": NewStringProperty("value"),
+		"nested": NewObjectProperty(PropertyMap{
+			"obj": NewObjectProperty(PropertyMap{
+				"k": NewStringProperty("v"),
+			}),
+		}),
+	}
+
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/16889

Currently `resource.NewPropertyMapFromMap` will drop any `resource.PropertyValue`s from the input map. This is demonstrated succinctly by Ian in the linked ticket:

```go
package main

import (
	"fmt"

	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
)

func main() {
	fmt.Println(resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]any{
		"foo": resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]any{
			"bar": resource.NewNumberProperty(0),
		})),
	})))
	fmt.Println(resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]any{
		"foo": map[string]any{"bar": 0},
	})))
}
```

```
{map[foo:{map[]}]}
{map[foo:{map[bar:{0}]}]}
```

This PR updates `NewPropertyMapFromMap` to instead flow these values through directly resulting in an output of:
```
{map[foo:{map[bar:{0}]}]}
{map[foo:{map[bar:{0}]}]}
```