### PR TITLE
Use publisher and repository fields to default the Go import path

### DIFF
--- a/changelog/pending/20240807--sdkgen-go--go-sdks-will-default-the-import-path-based-on-the-publisher-and-repository-schema-fields.yaml
+++ b/changelog/pending/20240807--sdkgen-go--go-sdks-will-default-the-import-path-based-on-the-publisher-and-repository-schema-fields.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/go
+  description: Go SDKs will default the import path based on the publisher and repository schema fields

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"go/format"
 	"io"
+	"net/url"
 	"os"
 	"path"
 	"reflect"
@@ -3669,7 +3670,11 @@ func extractModulePath(extPkg schema.PackageReference) string {
 	}
 	// And if we have a repository, use that instead of the publisher
 	if extPkg.Repository() != "" {
-		root = extPkg.Repository()
+		url, err := url.Parse(extPkg.Repository())
+		if err == nil {
+			// If there's any errors parsing the URL ignore it. Else use the host and path as go doesn't expect http://
+			root = url.Host + url.Path
+		}
 	}
 
 	// Support pack sdks write a go mod inside the go folder. Old legacy sdks would manually write a go.mod in the sdk

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -3662,8 +3662,8 @@ func extractModulePath(extPkg schema.PackageReference) string {
 		vPath = fmt.Sprintf("/v%d", version.Major)
 	}
 
-	// Default to github.com/pulumi/pulumi-pkg if we have no other information.
-	root := fmt.Sprintf("github.com/pulumi/pulumi-%s", name)
+	// Default to example.com/pulumi-pkg if we have no other information.
+	root := fmt.Sprintf("example.com/pulumi-%s", name)
 	// But if we have a publisher use that instead, assuming it's from github
 	if extPkg.Publisher() != "" {
 		root = fmt.Sprintf("github.com/%s/pulumi-%s", extPkg.Publisher(), name)

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -3663,7 +3663,7 @@ func extractModulePath(extPkg schema.PackageReference) string {
 	}
 
 	// Default to example.com/pulumi-pkg if we have no other information.
-	root := fmt.Sprintf("example.com/pulumi-%s", name)
+	root := "example.com/pulumi-" + name
 	// But if we have a publisher use that instead, assuming it's from github
 	if extPkg.Publisher() != "" {
 		root = fmt.Sprintf("github.com/%s/pulumi-%s", extPkg.Publisher(), name)

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -4932,10 +4932,12 @@ func GeneratePackage(tool string,
 			vPath = fmt.Sprintf("/v%d", pkg.Version.Major)
 		}
 
-		modulePath := fmt.Sprintf("github.com/pulumi/pulumi-%s/sdk/go%s", pkg.Name, vPath)
+		modulePath := extractModulePath(pkg.Reference())
 		if langInfo, found := pkg.Language["go"]; found {
 			goInfo, ok := langInfo.(GoPackageInfo)
-			if ok && goInfo.ImportBasePath != "" {
+			if ok && goInfo.ModulePath != "" {
+				modulePath = goInfo.ModulePath
+			} else if ok && goInfo.ImportBasePath != "" {
 				separatorIndex := strings.Index(goInfo.ImportBasePath, vPath)
 				if separatorIndex >= 0 {
 					modulePrefix := goInfo.ImportBasePath[:separatorIndex]

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -581,18 +581,12 @@ func GenerateProjectFiles(project workspace.Project, program *pcl.Program,
 		if p.Version != nil && p.Version.Major > 1 {
 			vPath = fmt.Sprintf("/v%d", p.Version.Major)
 		}
-		packageName := fmt.Sprintf("github.com/pulumi/pulumi-%s/sdk%s/go/%s", p.Name, vPath, p.Name)
-		if p.SupportPack {
-			// then the default is that we no longer nest source files under the go subdirectory
-			packageName = fmt.Sprintf("github.com/pulumi/pulumi-%s/sdk/go%s", p.Name, vPath)
-		}
+		packageName := extractModulePath(p.Reference())
 		if langInfo, found := p.Language["go"]; found {
 			goInfo, ok := langInfo.(GoPackageInfo)
 			if ok && goInfo.ImportBasePath != "" {
 				separatorIndex := strings.Index(goInfo.ImportBasePath, vPath)
-				if separatorIndex < 0 {
-					packageName = ""
-				} else {
+				if separatorIndex >= 0 {
 					modulePrefix := goInfo.ImportBasePath[:separatorIndex]
 					packageName = fmt.Sprintf("%s%s", modulePrefix, vPath)
 				}

--- a/pkg/codegen/schema/package_reference.go
+++ b/pkg/codegen/schema/package_reference.go
@@ -25,6 +25,11 @@ type PackageReference interface {
 	// Description returns the packages description.
 	Description() string
 
+	// Publisher returns the package publisher.
+	Publisher() string
+	// Repository returns the package repository.
+	Repository() string
+
 	// SupportPack specifies the package definition can be packed by language plugins
 	SupportPack() bool
 
@@ -148,6 +153,14 @@ func (p packageDefRef) Version() *semver.Version {
 
 func (p packageDefRef) Description() string {
 	return p.pkg.Description
+}
+
+func (p packageDefRef) Publisher() string {
+	return p.pkg.Publisher
+}
+
+func (p packageDefRef) Repository() string {
+	return p.pkg.Repository
 }
 
 func (p packageDefRef) SupportPack() bool {
@@ -342,6 +355,26 @@ func (p *PartialPackage) Description() string {
 		return p.def.Description
 	}
 	return p.types.pkg.Description
+}
+
+func (p *PartialPackage) Publisher() string {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	if p.def != nil {
+		return p.def.Publisher
+	}
+	return p.types.pkg.Publisher
+}
+
+func (p *PartialPackage) Repository() string {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	if p.def != nil {
+		return p.def.Repository
+	}
+	return p.types.pkg.Repository
 }
 
 func (p *PartialPackage) SupportPack() bool {

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -508,6 +508,9 @@ func (m *modInfo) readPulumiPluginJSON(moduleRoot string) (*plugin.PulumiPluginJ
 	if path, err := filepath.Glob(filepath.Join(dir, "go", "*", "pulumi-plugin.json")); err == nil {
 		paths = append(paths, path...)
 	}
+	if path, err := filepath.Glob(filepath.Join(dir, "*", "pulumi-plugin.json")); err == nil {
+		paths = append(paths, path...)
+	}
 
 	for _, path := range paths {
 		plugin, err := plugin.LoadPulumiPluginJSON(path)

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-resource-simple/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-resource-simple/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0
-	github.com/pulumi/pulumi-simple/sdk/go/v2 v2.0.0
+	example.com/pulumi-simple/sdk/go/v2 v2.0.0
 )
 
 replace github.com/pulumi/pulumi/sdk/v3 => /ROOT/artifacts/github.com_pulumi_pulumi_sdk_v3
 
-replace github.com/pulumi/pulumi-simple/sdk/go/v2 => /ROOT/artifacts/github.com_pulumi_pulumi-simple_sdk_go_v2
+replace example.com/pulumi-simple/sdk/go/v2 => /ROOT/artifacts/example.com_pulumi-simple_sdk_go_v2

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-resource-simple/main.go
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-resource-simple/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi-simple/sdk/go/v2/simple"
+	"example.com/pulumi-simple/sdk/go/v2/simple"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/sdk/go/pulumi-language-go/testdata/sdks/simple-2.0.0/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/sdks/simple-2.0.0/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi-simple/sdk/go/v2
+module example.com/pulumi-simple/sdk/go/v2
 
 go 1.20
 

--- a/sdk/go/pulumi-language-go/testdata/sdks/simple-2.0.0/simple/init.go
+++ b/sdk/go/pulumi-language-go/testdata/sdks/simple-2.0.0/simple/init.go
@@ -6,8 +6,8 @@ package simple
 import (
 	"fmt"
 
+	"example.com/pulumi-simple/sdk/go/v2/simple/internal"
 	"github.com/blang/semver"
-	"github.com/pulumi/pulumi-simple/sdk/go/v2/simple/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/sdk/go/pulumi-language-go/testdata/sdks/simple-2.0.0/simple/provider.go
+++ b/sdk/go/pulumi-language-go/testdata/sdks/simple-2.0.0/simple/provider.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pulumi/pulumi-simple/sdk/go/v2/simple/internal"
+	"example.com/pulumi-simple/sdk/go/v2/simple/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/sdk/go/pulumi-language-go/testdata/sdks/simple-2.0.0/simple/resource.go
+++ b/sdk/go/pulumi-language-go/testdata/sdks/simple-2.0.0/simple/resource.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 
 	"errors"
-	"github.com/pulumi/pulumi-simple/sdk/go/v2/simple/internal"
+	"example.com/pulumi-simple/sdk/go/v2/simple/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/init.go
+++ b/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/init.go
@@ -6,8 +6,8 @@ package myedgeorder
 import (
 	"fmt"
 
+	"example.com/pulumi-myedgeorder/sdk/go/myedgeorder/internal"
 	"github.com/blang/semver"
-	"github.com/pulumi/pulumi-myedgeorder/sdk/go/myedgeorder/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/listConfigurations.go
+++ b/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/listConfigurations.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pulumi/pulumi-myedgeorder/sdk/go/myedgeorder/internal"
+	"example.com/pulumi-myedgeorder/sdk/go/myedgeorder/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/listProductFamilies.go
+++ b/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/listProductFamilies.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pulumi/pulumi-myedgeorder/sdk/go/myedgeorder/internal"
+	"example.com/pulumi-myedgeorder/sdk/go/myedgeorder/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/provider.go
+++ b/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/provider.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pulumi/pulumi-myedgeorder/sdk/go/myedgeorder/internal"
+	"example.com/pulumi-myedgeorder/sdk/go/myedgeorder/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/pulumiTypes.go
+++ b/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/pulumiTypes.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pulumi/pulumi-myedgeorder/sdk/go/myedgeorder/internal"
+	"example.com/pulumi-myedgeorder/sdk/go/myedgeorder/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/tests/testdata/codegen/provider-config-schema/go/configstation/config/config.go
+++ b/tests/testdata/codegen/provider-config-schema/go/configstation/config/config.go
@@ -4,7 +4,7 @@
 package config
 
 import (
-	"github.com/pulumi/pulumi-configstation/sdk/go/configstation/internal"
+	"example.com/pulumi-configstation/sdk/go/configstation/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )

--- a/tests/testdata/codegen/provider-config-schema/go/configstation/config/pulumiTypes.go
+++ b/tests/testdata/codegen/provider-config-schema/go/configstation/config/pulumiTypes.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pulumi/pulumi-configstation/sdk/go/configstation/internal"
+	"example.com/pulumi-configstation/sdk/go/configstation/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/tests/testdata/codegen/provider-config-schema/go/configstation/funcWithAllOptionalInputs.go
+++ b/tests/testdata/codegen/provider-config-schema/go/configstation/funcWithAllOptionalInputs.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pulumi/pulumi-configstation/sdk/go/configstation/internal"
+	"example.com/pulumi-configstation/sdk/go/configstation/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/tests/testdata/codegen/provider-config-schema/go/configstation/init.go
+++ b/tests/testdata/codegen/provider-config-schema/go/configstation/init.go
@@ -6,8 +6,8 @@ package configstation
 import (
 	"fmt"
 
+	"example.com/pulumi-configstation/sdk/go/configstation/internal"
 	"github.com/blang/semver"
-	"github.com/pulumi/pulumi-configstation/sdk/go/configstation/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/tests/testdata/codegen/provider-config-schema/go/configstation/provider.go
+++ b/tests/testdata/codegen/provider-config-schema/go/configstation/provider.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pulumi/pulumi-configstation/sdk/go/configstation/config"
-	"github.com/pulumi/pulumi-configstation/sdk/go/configstation/internal"
+	"example.com/pulumi-configstation/sdk/go/configstation/config"
+	"example.com/pulumi-configstation/sdk/go/configstation/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/tests/testdata/codegen/provider-config-schema/go/configstation/pulumiTypes.go
+++ b/tests/testdata/codegen/provider-config-schema/go/configstation/pulumiTypes.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pulumi/pulumi-configstation/sdk/go/configstation/internal"
+	"example.com/pulumi-configstation/sdk/go/configstation/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/tests/testdata/codegen/simple-splat-pp/go/simple-splat.go
+++ b/tests/testdata/codegen/simple-splat-pp/go/simple-splat.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi-splat/sdk/go/splat"
+	"example.com/pulumi-splat/sdk/go/splat"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/tests/testdata/codegen/using-dashes-pp/go/using-dashes.go
+++ b/tests/testdata/codegen/using-dashes-pp/go/using-dashes.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	usingDashes "github.com/pulumi/pulumi-using-dashes/sdk/go/using-dashes"
+	usingDashes "example.com/pulumi-using-dashes/sdk/go/using-dashes"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 


### PR DESCRIPTION
Currently we generate an "internal" package in our Go sdks that the other packages in the sdk need to import. This requires them to know the base import path (because Go doesn't have relative imports).

We also want to start writing out go.mod files as part of codegen rather than provider authors manually adding them in the sdk directory above. This _also_ requires the import path for the module.

Rather than requiring every user to specify the base import path in the schema "go language" section we improve the default behaviour to use the provider and repository fields from the schema that users are probably filling in anyway.