### PR TITLE
re-enable TestResourceRefsGetResourceNode

### DIFF
--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1729,8 +1729,6 @@ func TestUnsafeSnapshotManagerRetainsResourcesOnError(t *testing.T) {
 //
 //nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestResourceRefsGetResourceNode(t *testing.T) {
-	t.Skip() // TODO[pulumi/pulumi#11677]
-
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:          filepath.Join("resource_refs_get_resource", "nodejs"),
 		Dependencies: []string{"@pulumi/pulumi"},

--- a/tests/integration/resource_refs_get_resource/nodejs/index.ts
+++ b/tests/integration/resource_refs_get_resource/nodejs/index.ts
@@ -28,6 +28,31 @@ class Container extends pulumi.ComponentResource {
     }
 }
 
+async function waitForContainer(container: Container): Promise<void> {
+    // Wait for a maximum of 500ms for the resource outputs to be registered.
+    const end = Date.now() + 500;
+    for (let i = 0; ; i++) {
+	let foundURN = false;
+	let success = new Promise((resolve, reject) => {
+	    container.urn.apply(urn => {
+		const roundTrippedContainer = new Container("mycontainer", undefined, { urn })
+		roundTrippedContainer.child.apply(c => {
+		    if (c != undefined) {
+			foundURN = true;
+		    }
+		    resolve();
+		});
+	    });
+	});
+	await success;
+	if (foundURN) {
+	    break;
+	} else if (Date.now() > end) {
+	    throw new Error("resource outputs not registered correctly");
+	}
+    }
+}
+
 pulumi.runtime.registerResourceModule("test", "index", {
     version: "0.0.1",
     construct: (name: string, type: string, urn: string) => {
@@ -43,14 +68,27 @@ pulumi.runtime.registerResourceModule("test", "index", {
 const child = new Child("mychild", "hello world!");
 const container = new Container("mycontainer", child);
 
-export const childUrn = pulumi.all([child.urn, container.urn]).apply(([childUrn, urn]) => {
-    const roundTrippedContainer = new Container("mycontainer", undefined, { urn })
-    const roundTrippedContainerChildUrn = roundTrippedContainer.child.apply(c => c.urn);
-    const roundTrippedContainerChildMessage = roundTrippedContainer.child.apply(c => c.message);
-    return pulumi.all([childUrn, roundTrippedContainerChildUrn, roundTrippedContainerChildMessage])
-        .apply(([expectedUrn, actualUrn, actualMessage]) => {
-        assert.strictEqual(actualUrn, expectedUrn);
-        assert.strictEqual(actualMessage, "hello world!");
-        return expectedUrn;
+// Wait to make sure registerOutputs has actually finished registering the resource outputs.
+//
+// registerOutputs works asynchronously, as does registering a component resource.  This
+// means registerOutputs is inheritly racy with the resource being read later.  This test explicitly
+// tests roundtripping a container component resource, which means we need to read the outputs registered
+// outputs are registered before we return the container.  Ideally we should find a way to make this non-racy
+// (see the issue linked below)
+//
+// TODO: make RegisterResourceOutputs not racy [pulumi/pulumi#16896]
+waitForContainer(container).then(() => {
+    console.log(child, container);
+
+    pulumi.all([child.urn, container.urn]).apply(([childUrn, urn]) => {
+	const roundTrippedContainer = new Container("mycontainer", undefined, { urn })
+	const roundTrippedContainerChildUrn = roundTrippedContainer.child.apply(c => c.urn);
+	const roundTrippedContainerChildMessage = roundTrippedContainer.child.apply(c => c.message);
+	return pulumi.all([childUrn, roundTrippedContainerChildUrn, roundTrippedContainerChildMessage])
+	    .apply(([expectedUrn, actualUrn, actualMessage]) => {
+		assert.strictEqual(actualUrn, expectedUrn);
+		assert.strictEqual(actualMessage, "hello world!");
+		return expectedUrn;
+	    });
     });
 });


### PR DESCRIPTION
This test was flaky for the same reasons as
TestResourceRefsGetResourceGo, so we can also fix it the same way (see https://github.com/pulumi/pulumi/pull/16897 for the fix of that).

Namely we wait for a bit for the resource to be able to be read.  This way we can unskip the test.

Fixes https://github.com/pulumi/pulumi/issues/11677