### PR TITLE
Fix deployment settings serialization and keys consistency

### DIFF
--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -282,12 +282,12 @@ func TestDeploymentSettingsApi(t *testing.T) {
 		payload := `{
     "sourceContext": {
         "git": {
-            "repoUrl": "git@github.com:glena/test-action.git",
-            "branch": "cloud-dev-pr",
+            "repoUrl": "git@github.com:pulumi/test-repo.git",
+            "branch": "main",
             "repoDir": ".",
             "gitAuth": {
                 "basicAuth": {
-                    "userName": "asd",
+                    "userName": "jdoe",
                     "password": {
                         "secret": "[secret]",
                         "ciphertext": "AAABAMcGtHDraogfM3Qk4WyaNp3F/syk2cjHPQTb6Hu6ps8="
@@ -301,10 +301,10 @@ func TestDeploymentSettingsApi(t *testing.T) {
             "aws": {
                 "duration": "1h0m0s",
                 "policyArns": [
-                    "asdf"
+                    "policy:arn"
                 ],
-                "roleArn": "asdf",
-                "sessionName": "asdf"
+                "roleArn": "the_role",
+                "sessionName": "the_session_name"
             }
         },
         "options": {
@@ -331,13 +331,13 @@ func TestDeploymentSettingsApi(t *testing.T) {
 		assert.NotNil(t, resp)
 		assert.NotNil(t, resp.SourceContext)
 		assert.NotNil(t, resp.SourceContext.Git)
-		assert.Equal(t, "cloud-dev-pr", resp.SourceContext.Git.Branch)
-		assert.Equal(t, "git@github.com:glena/test-action.git", resp.SourceContext.Git.RepoURL)
+		assert.Equal(t, "main", resp.SourceContext.Git.Branch)
+		assert.Equal(t, "git@github.com:pulumi/test-repo.git", resp.SourceContext.Git.RepoURL)
 		assert.Equal(t, ".", resp.SourceContext.Git.RepoDir)
 		assert.NotNil(t, resp.SourceContext.Git.GitAuth)
 		assert.NotNil(t, resp.SourceContext.Git.GitAuth.BasicAuth)
 		assert.NotNil(t, resp.SourceContext.Git.GitAuth.BasicAuth.UserName)
-		assert.Equal(t, "asd", resp.SourceContext.Git.GitAuth.BasicAuth.UserName.Value)
+		assert.Equal(t, "jdoe", resp.SourceContext.Git.GitAuth.BasicAuth.UserName.Value)
 		assert.NotNil(t, resp.SourceContext.Git.GitAuth.BasicAuth.Password)
 		assert.Equal(t, "AAABAMcGtHDraogfM3Qk4WyaNp3F/syk2cjHPQTb6Hu6ps8=",
 			resp.SourceContext.Git.GitAuth.BasicAuth.Password.Ciphertext)
@@ -351,11 +351,11 @@ func TestDeploymentSettingsApi(t *testing.T) {
 		assert.Nil(t, resp.Operation.OIDC.Azure)
 		assert.Nil(t, resp.Operation.OIDC.GCP)
 		assert.NotNil(t, resp.Operation.OIDC.AWS)
-		assert.Equal(t, "asdf", resp.Operation.OIDC.AWS.SessionName)
-		assert.Equal(t, "asdf", resp.Operation.OIDC.AWS.RoleARN)
+		assert.Equal(t, "the_session_name", resp.Operation.OIDC.AWS.SessionName)
+		assert.Equal(t, "the_role", resp.Operation.OIDC.AWS.RoleARN)
 		duration, _ := time.ParseDuration("1h0m0s")
 		assert.Equal(t, apitype.DurationMarshaller(duration), resp.Operation.OIDC.AWS.Duration)
-		assert.Equal(t, []string{"asdf"}, resp.Operation.OIDC.AWS.PolicyARNs)
+		assert.Equal(t, []string{"policy:arn"}, resp.Operation.OIDC.AWS.PolicyARNs)
 		assert.Equal(t, "51035bee-a4d6-4b63-9ff6-418775c5da8d", *resp.AgentPoolID)
 	})
 }

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -354,7 +354,7 @@ func TestDeploymentSettingsApi(t *testing.T) {
 		assert.Equal(t, "the_session_name", resp.Operation.OIDC.AWS.SessionName)
 		assert.Equal(t, "the_role", resp.Operation.OIDC.AWS.RoleARN)
 		duration, _ := time.ParseDuration("1h0m0s")
-		assert.Equal(t, apitype.DurationMarshaller(duration), resp.Operation.OIDC.AWS.Duration)
+		assert.Equal(t, apitype.DeploymentDuration(duration), resp.Operation.OIDC.AWS.Duration)
 		assert.Equal(t, []string{"policy:arn"}, resp.Operation.OIDC.AWS.PolicyARNs)
 		assert.Equal(t, "51035bee-a4d6-4b63-9ff6-418775c5da8d", *resp.AgentPoolID)
 	})

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -270,5 +271,91 @@ func TestGetCapabilities(t *testing.T) {
 		assert.Equal(t, apitype.DeltaCheckpointUploads, resp.Capabilities[0].Capability)
 		assert.Equal(t, `{"checkpointCutoffSizeBytes":4194304}`,
 			string(resp.Capabilities[0].Configuration))
+	})
+}
+
+func TestDeploymentSettingsApi(t *testing.T) {
+	t.Parallel()
+	t.Run("get-stack-deployment-settings", func(t *testing.T) {
+		t.Parallel()
+
+		payload := `{
+    "sourceContext": {
+        "git": {
+            "repoUrl": "git@github.com:glena/test-action.git",
+            "branch": "cloud-dev-pr",
+            "repoDir": ".",
+            "gitAuth": {
+                "basicAuth": {
+                    "userName": "asd",
+                    "password": {
+                        "secret": "[secret]",
+                        "ciphertext": "AAABAMcGtHDraogfM3Qk4WyaNp3F/syk2cjHPQTb6Hu6ps8="
+                    }
+                }
+            }
+        }
+    },
+    "operationContext": {
+        "oidc": {
+            "aws": {
+                "duration": "1h0m0s",
+                "policyArns": [
+                    "asdf"
+                ],
+                "roleArn": "asdf",
+                "sessionName": "asdf"
+            }
+        },
+        "options": {
+            "skipIntermediateDeployments": true
+        }
+    },
+    "agentPoolID": "51035bee-a4d6-4b63-9ff6-418775c5da8d"
+}`
+
+		s := newMockServerRequestProcessor(200, func(req *http.Request) string {
+			assert.Equal(t, req.RequestURI, "/api/stacks/owner/project/stack/deployments/settings")
+			return payload
+		})
+		defer s.Close()
+
+		c := newMockClient(s)
+		stack, _ := tokens.ParseStackName("stack")
+		resp, err := c.GetStackDeploymentSettings(context.Background(), StackIdentifier{
+			Owner:   "owner",
+			Project: "project",
+			Stack:   stack,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.NotNil(t, resp.SourceContext)
+		assert.NotNil(t, resp.SourceContext.Git)
+		assert.Equal(t, "cloud-dev-pr", resp.SourceContext.Git.Branch)
+		assert.Equal(t, "git@github.com:glena/test-action.git", resp.SourceContext.Git.RepoURL)
+		assert.Equal(t, ".", resp.SourceContext.Git.RepoDir)
+		assert.NotNil(t, resp.SourceContext.Git.GitAuth)
+		assert.NotNil(t, resp.SourceContext.Git.GitAuth.BasicAuth)
+		assert.NotNil(t, resp.SourceContext.Git.GitAuth.BasicAuth.UserName)
+		assert.Equal(t, "asd", resp.SourceContext.Git.GitAuth.BasicAuth.UserName.Value)
+		assert.NotNil(t, resp.SourceContext.Git.GitAuth.BasicAuth.Password)
+		assert.Equal(t, "AAABAMcGtHDraogfM3Qk4WyaNp3F/syk2cjHPQTb6Hu6ps8=",
+			resp.SourceContext.Git.GitAuth.BasicAuth.Password.Ciphertext)
+		assert.NotNil(t, resp.Operation)
+		assert.NotNil(t, resp.Operation.Options)
+		assert.True(t, resp.Operation.Options.SkipIntermediateDeployments)
+		assert.False(t, resp.Operation.Options.DeleteAfterDestroy)
+		assert.False(t, resp.Operation.Options.RemediateIfDriftDetected)
+		assert.False(t, resp.Operation.Options.SkipInstallDependencies)
+		assert.NotNil(t, resp.Operation.OIDC)
+		assert.Nil(t, resp.Operation.OIDC.Azure)
+		assert.Nil(t, resp.Operation.OIDC.GCP)
+		assert.NotNil(t, resp.Operation.OIDC.AWS)
+		assert.Equal(t, "asdf", resp.Operation.OIDC.AWS.SessionName)
+		assert.Equal(t, "asdf", resp.Operation.OIDC.AWS.RoleARN)
+		duration, _ := time.ParseDuration("1h0m0s")
+		assert.Equal(t, apitype.DurationMarshaller(duration), resp.Operation.OIDC.AWS.Duration)
+		assert.Equal(t, []string{"asdf"}, resp.Operation.OIDC.AWS.PolicyARNs)
+		assert.Equal(t, "51035bee-a4d6-4b63-9ff6-418775c5da8d", *resp.AgentPoolID)
 	})
 }

--- a/pkg/cmd/pulumi/deployment_settings_utils_test.go
+++ b/pkg/cmd/pulumi/deployment_settings_utils_test.go
@@ -16,11 +16,15 @@ package main
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -159,4 +163,67 @@ func TestValidateShortInputNonEmpty(t *testing.T) {
 
 	err = ValidateShortInputNonEmpty(strings.Repeat("a", 257))
 	require.Error(t, err, "must be 256 characters or less")
+}
+
+func TestDSFileParsing(t *testing.T) {
+	stackDeploymentConfigFile := "Pulumi.stack.deploy.yaml"
+	projectDir := t.TempDir()
+	pyaml := filepath.Join(projectDir, stackDeploymentConfigFile)
+
+	err := os.WriteFile(pyaml, []byte(`settings:
+  sourceContext:
+    git:
+      repoUrl: git@github.com:pulumi/test-repo.git
+      branch: main
+      repoDir: .
+      gitAuth:
+        basicAuth:
+          userName: jdoe
+          password:
+            ciphertext: AAABAMcGtHDraogfM3Qk4WyaNp3F/syk2cjHPQTb6Hu6ps8=
+  operationContext:
+    oidc:
+      aws:
+        duration: 1h0m0s
+        policyArns:
+          - policy:arn
+        roleArn: the_role
+        sessionName: the_session_name
+    options:
+      skipInstallDependencies: false
+      skipIntermediateDeployments: true
+  agentPoolID: 51035bee-a4d6-4b63-9ff6-418775c5da8d`), 0o600)
+	require.NoError(t, err)
+
+	deploymentFile, err := workspace.LoadProjectStackDeployment(pyaml)
+	require.NoError(t, err)
+	require.NotNil(t, deploymentFile)
+	require.NotNil(t, deploymentFile.DeploymentSettings.SourceContext)
+	require.NotNil(t, deploymentFile.DeploymentSettings.SourceContext.Git)
+	require.Equal(t, "git@github.com:pulumi/test-repo.git", deploymentFile.DeploymentSettings.SourceContext.Git.RepoURL)
+	require.Equal(t, "main", deploymentFile.DeploymentSettings.SourceContext.Git.Branch)
+	require.Equal(t, ".", deploymentFile.DeploymentSettings.SourceContext.Git.RepoDir)
+	assert.NotNil(t, deploymentFile.DeploymentSettings.SourceContext.Git.GitAuth)
+	assert.NotNil(t, deploymentFile.DeploymentSettings.SourceContext.Git.GitAuth.BasicAuth)
+	assert.NotNil(t, deploymentFile.DeploymentSettings.SourceContext.Git.GitAuth.BasicAuth.UserName)
+	assert.Equal(t, "jdoe", deploymentFile.DeploymentSettings.SourceContext.Git.GitAuth.BasicAuth.UserName.Value)
+	assert.NotNil(t, deploymentFile.DeploymentSettings.SourceContext.Git.GitAuth.BasicAuth.Password)
+	assert.Equal(t, "AAABAMcGtHDraogfM3Qk4WyaNp3F/syk2cjHPQTb6Hu6ps8=",
+		deploymentFile.DeploymentSettings.SourceContext.Git.GitAuth.BasicAuth.Password.Ciphertext)
+	require.NotNil(t, deploymentFile.DeploymentSettings.Operation)
+	require.NotNil(t, deploymentFile.DeploymentSettings.Operation.Options)
+	require.False(t, deploymentFile.DeploymentSettings.Operation.Options.SkipInstallDependencies)
+	require.True(t, deploymentFile.DeploymentSettings.Operation.Options.SkipIntermediateDeployments)
+	require.False(t, deploymentFile.DeploymentSettings.Operation.Options.DeleteAfterDestroy)
+	require.False(t, deploymentFile.DeploymentSettings.Operation.Options.RemediateIfDriftDetected)
+	assert.NotNil(t, deploymentFile.DeploymentSettings.Operation.OIDC)
+	assert.Nil(t, deploymentFile.DeploymentSettings.Operation.OIDC.Azure)
+	assert.Nil(t, deploymentFile.DeploymentSettings.Operation.OIDC.GCP)
+	assert.NotNil(t, deploymentFile.DeploymentSettings.Operation.OIDC.AWS)
+	assert.Equal(t, "the_session_name", deploymentFile.DeploymentSettings.Operation.OIDC.AWS.SessionName)
+	assert.Equal(t, "the_role", deploymentFile.DeploymentSettings.Operation.OIDC.AWS.RoleARN)
+	duration, _ := time.ParseDuration("1h0m0s")
+	assert.Equal(t, apitype.DurationMarshaller(duration), deploymentFile.DeploymentSettings.Operation.OIDC.AWS.Duration)
+	assert.Equal(t, []string{"policy:arn"}, deploymentFile.DeploymentSettings.Operation.OIDC.AWS.PolicyARNs)
+	assert.Equal(t, "51035bee-a4d6-4b63-9ff6-418775c5da8d", *deploymentFile.DeploymentSettings.AgentPoolID)
 }

--- a/pkg/cmd/pulumi/deployment_settings_utils_test.go
+++ b/pkg/cmd/pulumi/deployment_settings_utils_test.go
@@ -166,6 +166,8 @@ func TestValidateShortInputNonEmpty(t *testing.T) {
 }
 
 func TestDSFileParsing(t *testing.T) {
+	t.Parallel()
+
 	stackDeploymentConfigFile := "Pulumi.stack.deploy.yaml"
 	projectDir := t.TempDir()
 	pyaml := filepath.Join(projectDir, stackDeploymentConfigFile)

--- a/pkg/cmd/pulumi/deployment_settings_utils_test.go
+++ b/pkg/cmd/pulumi/deployment_settings_utils_test.go
@@ -223,7 +223,7 @@ func TestDSFileParsing(t *testing.T) {
 	assert.Equal(t, "the_session_name", deploymentFile.DeploymentSettings.Operation.OIDC.AWS.SessionName)
 	assert.Equal(t, "the_role", deploymentFile.DeploymentSettings.Operation.OIDC.AWS.RoleARN)
 	duration, _ := time.ParseDuration("1h0m0s")
-	assert.Equal(t, apitype.DurationMarshaller(duration), deploymentFile.DeploymentSettings.Operation.OIDC.AWS.Duration)
+	assert.Equal(t, apitype.DeploymentDuration(duration), deploymentFile.DeploymentSettings.Operation.OIDC.AWS.Duration)
 	assert.Equal(t, []string{"policy:arn"}, deploymentFile.DeploymentSettings.Operation.OIDC.AWS.PolicyARNs)
 	assert.Equal(t, "51035bee-a4d6-4b63-9ff6-418775c5da8d", *deploymentFile.DeploymentSettings.AgentPoolID)
 }

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -1203,9 +1203,11 @@ func promptUserMulti(msg string, options []string, defaultOptions []string, colo
 
 	var response []string
 	if err := survey.AskOne(&survey.MultiSelect{
-		Message: prompt,
-		Options: options,
-		Default: defaultOptions,
+		Message:  prompt,
+		Options:  options,
+		Default:  defaultOptions,
+		Help:     "enter to accept",
+		ShowHelp: true,
 	}, &response, surveyIcons); err != nil {
 		return []string{}
 	}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -1203,11 +1203,9 @@ func promptUserMulti(msg string, options []string, defaultOptions []string, colo
 
 	var response []string
 	if err := survey.AskOne(&survey.MultiSelect{
-		Message:  prompt,
-		Options:  options,
-		Default:  defaultOptions,
-		Help:     "enter to accept",
-		ShowHelp: true,
+		Message: prompt,
+		Options: options,
+		Default: defaultOptions,
 	}, &response, surveyIcons); err != nil {
 		return []string{}
 	}

--- a/sdk/go/common/apitype/deployments.go
+++ b/sdk/go/common/apitype/deployments.go
@@ -55,14 +55,15 @@ func ParsePulumiOperation(o string) (PulumiOperation, error) {
 	}
 }
 
-// A DurationMarshaller
-type DurationMarshaller time.Duration
+// DeploymentDuration, wrapper over time.Duration to properly marshall
+// time durations according to pulumi cloud spec.
+type DeploymentDuration time.Duration
 
-func (v DurationMarshaller) MarshalJSON() ([]byte, error) {
+func (v DeploymentDuration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(time.Duration(v).String())
 }
 
-func (v *DurationMarshaller) UnmarshalJSON(bytes []byte) error {
+func (v *DeploymentDuration) UnmarshalJSON(bytes []byte) error {
 	var s string
 	if err := json.Unmarshal(bytes, &s); err != nil {
 		return err
@@ -72,16 +73,16 @@ func (v *DurationMarshaller) UnmarshalJSON(bytes []byte) error {
 		if err != nil {
 			return err
 		}
-		*v = DurationMarshaller(d)
+		*v = DeploymentDuration(d)
 	}
 	return nil
 }
 
-func (v DurationMarshaller) MarshalYAML() (any, error) {
+func (v DeploymentDuration) MarshalYAML() (any, error) {
 	return time.Duration(v).String(), nil
 }
 
-func (v *DurationMarshaller) UnmarshalYAML(node *yaml.Node) error {
+func (v *DeploymentDuration) UnmarshalYAML(node *yaml.Node) error {
 	var s string
 	if err := node.Decode(&s); err != nil {
 		return err
@@ -91,7 +92,7 @@ func (v *DurationMarshaller) UnmarshalYAML(node *yaml.Node) error {
 		if err != nil {
 			return err
 		}
-		*v = DurationMarshaller(d)
+		*v = DeploymentDuration(d)
 	}
 	return nil
 }
@@ -282,7 +283,7 @@ type OperationContextOIDCConfiguration struct {
 
 type OperationContextAWSOIDCConfiguration struct {
 	// Duration is the duration of the assume-role session.
-	Duration DurationMarshaller `json:"duration,omitempty" yaml:"duration,omitempty"`
+	Duration DeploymentDuration `json:"duration,omitempty" yaml:"duration,omitempty"`
 	// PolicyARNs is an optional set of IAM policy ARNs that further restrict the assume-role session.
 	PolicyARNs []string `json:"policyArns,omitempty" yaml:"policyArns,omitempty"`
 	// The ARN of the role to assume using the OIDC token.
@@ -312,7 +313,7 @@ type OperationContextGCPOIDCConfiguration struct {
 	// ServiceAccount is the email address of the service account to use.
 	ServiceAccount string `json:"serviceAccount" yaml:"serviceAccount"`
 	// TokenLifetime is the lifetime of the temporary credentials.
-	TokenLifetime DurationMarshaller `json:"tokenLifetime,omitempty" yaml:"tokenLifetime,omitempty"`
+	TokenLifetime DeploymentDuration `json:"tokenLifetime,omitempty" yaml:"tokenLifetime,omitempty"`
 }
 
 // OperationContextOptions is a bag of settings to specify or override default behavior in a deployment

--- a/sdk/go/common/apitype/deployments.go
+++ b/sdk/go/common/apitype/deployments.go
@@ -55,6 +55,47 @@ func ParsePulumiOperation(o string) (PulumiOperation, error) {
 	}
 }
 
+// A DurationMarshaller
+type DurationMarshaller time.Duration
+
+func (v DurationMarshaller) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(v).String())
+}
+
+func (v *DurationMarshaller) UnmarshalJSON(bytes []byte) error {
+	var s string
+	if err := json.Unmarshal(bytes, &s); err != nil {
+		return err
+	}
+	if s != "" {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return err
+		}
+		*v = DurationMarshaller(d)
+	}
+	return nil
+}
+
+func (v DurationMarshaller) MarshalYAML() (any, error) {
+	return time.Duration(v).String(), nil
+}
+
+func (v *DurationMarshaller) UnmarshalYAML(node *yaml.Node) error {
+	var s string
+	if err := node.Decode(&s); err != nil {
+		return err
+	}
+	if s != "" {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return err
+		}
+		*v = DurationMarshaller(d)
+	}
+	return nil
+}
+
 // CreateDeploymentRequest defines the request payload that is expected when
 // creating a new deployment.
 type CreateDeploymentRequest struct {
@@ -160,7 +201,7 @@ type SourceContext struct {
 }
 
 type SourceContextGit struct {
-	RepoURL string `json:"repoURL" yaml:"repoURL,omitempty"`
+	RepoURL string `json:"repoUrl" yaml:"repoUrl,omitempty"`
 
 	Branch string `json:"branch" yaml:"branch"`
 
@@ -241,7 +282,7 @@ type OperationContextOIDCConfiguration struct {
 
 type OperationContextAWSOIDCConfiguration struct {
 	// Duration is the duration of the assume-role session.
-	Duration time.Duration `json:"duration,omitempty" yaml:"duration,omitempty"`
+	Duration DurationMarshaller `json:"duration,omitempty" yaml:"duration,omitempty"`
 	// PolicyARNs is an optional set of IAM policy ARNs that further restrict the assume-role session.
 	PolicyARNs []string `json:"policyArns,omitempty" yaml:"policyArns,omitempty"`
 	// The ARN of the role to assume using the OIDC token.
@@ -271,7 +312,7 @@ type OperationContextGCPOIDCConfiguration struct {
 	// ServiceAccount is the email address of the service account to use.
 	ServiceAccount string `json:"serviceAccount" yaml:"serviceAccount"`
 	// TokenLifetime is the lifetime of the temporary credentials.
-	TokenLifetime time.Duration `json:"tokenLifetime,omitempty" yaml:"tokenLifetime,omitempty"`
+	TokenLifetime DurationMarshaller `json:"tokenLifetime,omitempty" yaml:"tokenLifetime,omitempty"`
 }
 
 // OperationContextOptions is a bag of settings to specify or override default behavior in a deployment


### PR DESCRIPTION
This PR fixes deployment settings serialization/deserialization:
- `repoUrl` was being incorrectly serialized as `repoURL`, which for JSON was not a problem as it is case insensitive ([To unmarshal JSON into a struct, Unmarshal matches incoming object keys to the keys used by Marshal ..., preferring an exact match but also accepting a case-insensitive match.](https://pkg.go.dev/encoding/json#Unmarshal)), but YAML is case sensitive.
- `time.Duration` unmarshalling failed as it was not consistent with the way the service "stringifies" the durations. I am bringing the custom marshallers implemented under `DurationMarshaller` (it is called `WorkflowTimeout` in the service but since there is no notion of Workflows here, I renamed to something more explicit).



