### PR TITLE
Improve failure message for wrong stack output types

### DIFF
--- a/changelog/pending/20240808--sdk-go--clearer-failure-message-for-incorrectly-mocked-stackreferences.yaml
+++ b/changelog/pending/20240808--sdk-go--clearer-failure-message-for-incorrectly-mocked-stackreferences.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Clearer failure message for incorrectly mocked StackReferences

--- a/sdk/go/pulumi/stack_reference.go
+++ b/sdk/go/pulumi/stack_reference.go
@@ -28,7 +28,7 @@ func (s *StackReference) GetOutput(name StringInput) AnyOutput {
 		ApplyT(func(args []interface{}) (interface{}, error) {
 			n, stack := args[0].(string), args[1].(resource.PropertyMap)
 			if !stack["outputs"].IsObject() {
-				return Any(nil), fmt.Errorf("failed to convert %T to object", stack)
+				return Any(nil), fmt.Errorf("failed to convert stack output %T to object", stack)
 			}
 			outs := stack["outputs"].ObjectValue()
 			v, ok := outs[resource.PropertyKey(n)]


### PR DESCRIPTION
I ran into this while writing tests.

Following the example for writing pulumi tests in Go (https://www.pulumi.com/docs/using-pulumi/testing/unit/), I was returning `args.Input` as the new resource's property map. In my stack I have a stack reference, and the resulting error was `waiting for RPCs: marshaling properties: awaiting input property "siteConfig": failed to convert resource.PropertyMap to object` (`siteConfig` being the field of an azure-native/web.WebApp where a subfield `linuxFxVersion` was being computed indirectly from a stack output). The message makes no mention of stack outputs, so determining the cause was pure guesswork.