### PR TITLE
unmarshal pointers correctly if destination type is any

### DIFF
--- a/changelog/pending/20240809--sdk-go--unmarshal-pointers-correctly-if-destination-type-is-any.yaml
+++ b/changelog/pending/20240809--sdk-go--unmarshal-pointers-correctly-if-destination-type-is-any.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Unmarshal pointers correctly if destination type is any

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -1216,11 +1216,11 @@ func assertHasDeps(
 	expectedDeps ...Resource,
 ) {
 	name := res.getName()
-	resDeps := depTracker.dependencies(urn(t, ctx, res))
+	resDeps := depTracker.dependencies(urnForRes(t, ctx, res))
 
 	expDeps := slice.Prealloc[URN](len(expectedDeps))
 	for _, expDepRes := range expectedDeps {
-		expDep := urn(t, ctx, expDepRes)
+		expDep := urnForRes(t, ctx, expDepRes)
 		expDeps = append(expDeps, expDep)
 		assert.Containsf(t, resDeps, expDep, "Resource %s does not depend on %s",
 			name, expDep)
@@ -1245,7 +1245,7 @@ func newTestRes(t *testing.T, ctx *Context, name string, opts ...ResourceOption)
 	return &res
 }
 
-func urn(t *testing.T, ctx *Context, res Resource) URN {
+func urnForRes(t *testing.T, ctx *Context, res Resource) URN {
 	urn, _, _, err := res.URN().awaitURN(ctx.ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -798,6 +798,9 @@ func unmarshalOutput(ctx *Context, v resource.PropertyValue, dest reflect.Value)
 			return false, err
 		}
 		resV := reflect.ValueOf(res)
+		// If we unmarshal a pointer and the destination is "any", we also want to make sure the result is a
+		// pointer.  We check above whether the destination is a pointer, but that's not true for "any", even
+		// though it can hold a pointer.
 		if !allocatedPointer && resV.Kind() == reflect.Ptr && dest.Type().Kind() == reflect.Interface &&
 			resV.Elem().Type().AssignableTo(dest.Type()) {
 			dest.Set(resV)

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -754,8 +754,10 @@ func unmarshalOutput(ctx *Context, v resource.PropertyValue, dest reflect.Value)
 		return false, nil
 	}
 
+	allocatedPointer := false
 	// Allocate storage as necessary.
 	for dest.Kind() == reflect.Ptr {
+		allocatedPointer = true
 		elem := reflect.New(dest.Type().Elem())
 		dest.Set(elem)
 		dest = elem.Elem()
@@ -796,7 +798,7 @@ func unmarshalOutput(ctx *Context, v resource.PropertyValue, dest reflect.Value)
 			return false, err
 		}
 		resV := reflect.ValueOf(res)
-		if resV.Kind() == reflect.Ptr && dest.Type().Kind() == reflect.Interface &&
+		if !allocatedPointer && resV.Kind() == reflect.Ptr && dest.Type().Kind() == reflect.Interface &&
 			resV.Elem().Type().AssignableTo(dest.Type()) {
 			dest.Set(resV)
 			return secret, nil

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -26,6 +26,7 @@ import (
 	rarchive "github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
 	rasset "github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -868,6 +869,23 @@ func TestInvalidArchive(t *testing.T) {
 
 	_, _, err = marshalInput(d, archiveType, true)
 	assert.EqualError(t, err, "invalid archive")
+}
+
+func TestUnmarshalPointer(t *testing.T) {
+	t.Parallel()
+
+	ctx, err := NewContext(context.Background(), RunInfo{})
+	assert.NoError(t, err)
+
+	res := resource.ResourceReference{
+		URN: urn.New("testStack", "testProj", "", "test:index:component", "test"),
+	}
+
+	var d any
+	RegisterResourceModule("test", "index", &testResourceModule{})
+	_, err = unmarshalOutput(ctx, resource.NewResourceReferenceProperty(res), reflect.ValueOf(&d).Elem())
+	assert.NoError(t, err)
+	assert.IsType(t, &simpleComponentResource{}, d)
 }
 
 func TestDependsOnComponent(t *testing.T) {

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -882,7 +882,9 @@ func TestUnmarshalPointer(t *testing.T) {
 	}
 
 	var d any
-	RegisterResourceModule("test", "index", &testResourceModule{})
+	RegisterResourceModule("test", "index", &testResourceModule{
+		version: semver.MustParse("2.0.0"),
+	})
 	_, err = unmarshalOutput(ctx, resource.NewResourceReferenceProperty(res), reflect.ValueOf(&d).Elem())
 	assert.NoError(t, err)
 	assert.IsType(t, &simpleComponentResource{}, d)


### PR DESCRIPTION
Currently when unmarshalling resource references into a destination that's of type `any`, we loose the pointer information, and just marshal it into the base type, because the destination is not a pointer type.

However for resource references that's not quite correct, as we do want to unmarshal it to the pointer type, so it can be a `pulumi.Resource`, and be used as such.  Make that so here.

Fixes https://github.com/pulumi/pulumi/issues/15788

This could be considered a breaking change, though I think we can consider this a bugfix instead.