### PR TITLE
Split windows acceptance tests into 2 partitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
               --version-set current \
               --partition-module pkg 1 \
               --partition-module sdk 1 \
-              --partition-module tests 1 \
+              --partition-module tests 2 \
               --partition-package github.com/pulumi/pulumi/tests/integration tests/integration 8
             )
           fi


### PR DESCRIPTION
We are seeing the job “tests on windows-latest/current” fail in the merge queue somewhat regularly. The job shows up as skipped in the GHA UI, and the summary has a message

> The hosted runner encountered an error while running your job. (Error Type: Disconnect).

This usually happens because the machine becomes unresponsive and GitHub Actions throws out the runner.

Split the windows acceptance tests into 2 partitions to distribute the load on 2 runners.
