### PR TITLE
Add Nodejs and Python instructions for `package add`

### DIFF
--- a/pkg/cmd/pulumi/package_add.go
+++ b/pkg/cmd/pulumi/package_add.go
@@ -172,6 +172,22 @@ func printNodejsLinkInstructions(root string, pkg string, out string) error {
 	}
 	fmt.Println("  " + addCmd)
 	fmt.Println()
+	useTypescript := true
+	if typescript, ok := options["typescript"]; ok {
+		if val, ok := typescript.(bool); ok {
+			useTypescript = val
+		}
+	}
+	if useTypescript {
+		fmt.Println("You can then import the SDK in your TypeScript code with:")
+		fmt.Println()
+		fmt.Printf("  import * as %s from \"%s\";\n", pkg, pkg)
+	} else {
+		fmt.Println("You can then import the SDK in your Javascript code with:")
+		fmt.Println()
+		fmt.Printf("  const %s = require(\"%s\");\n", pkg, pkg)
+	}
+	fmt.Println()
 	return nil
 }
 
@@ -212,6 +228,10 @@ func printPythonLinkInstructions(root string, pkg string, out string) error {
 		// Assume pip if no packagemanager is specified
 		pipInstructions()
 	}
+	fmt.Println()
+	fmt.Println("You can then import the SDK in your Python code with:")
+	fmt.Println()
+	fmt.Printf("  import pulumi_%s as %s\n", pkg, pkg)
 	fmt.Println()
 	return nil
 }


### PR DESCRIPTION
The locally generated SDKs can be installed using the project's package management tool, such as poetry, pip, npm ...

Detect the appropriate tool and print out instructions. This logic really should live in the language runtimes, where the detection is a bit more elaborate, but for the initial preview release, this works well enough.

pip example:
```
Successfully generated a Python SDK for the random package at /Users/julien/tmp/test-add-2/sdks/random

To use this SDK in your Python project, run the following command:

  echo sdks/random >> requirements.txt

  pulumi install

You can then import the SDK in your Python code with:

  import pulumi_random as random
```

pnpm example:

```
Successfully generated a Nodejs SDK for the random package at /Users/julien/tmp/test-add-pnpm/sdks/random

To use this SDK in your Nodejs project, run the following command:

  pnpm add random@file:sdks/random

You can then import the SDK in your Javascript code with:

  const random = require("random");
```