### PR TITLE
Fix apply in python

### DIFF
--- a/changelog/pending/20240812--programgen-python--fix-generated-apply-calls-with-pulumi-all.yaml
+++ b/changelog/pending/20240812--programgen-python--fix-generated-apply-calls-with-pulumi-all.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/python
+  description: Fix generated apply calls with `pulumi.all`

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -475,7 +475,7 @@ func rewriteApplyLambdaBody(applyLambda *model.AnonymousFunctionExpression, args
 								Name: argsParamName,
 							}),
 							Key: &model.LiteralValueExpression{
-								Value: cty.StringVal(fmt.Sprintf("\"%s\"", param.Name)),
+								Value: cty.StringVal(fmt.Sprintf("'%s'", param.Name)),
 							},
 						}, nil
 					}

--- a/tests/testdata/codegen/iterating-optional-range-expressions-pp/python/iterating-optional-range-expressions.py
+++ b/tests/testdata/codegen/iterating-optional-range-expressions-pp/python/iterating-optional-range-expressions.py
@@ -35,4 +35,4 @@ def create_from_computed_for_expression(range_body):
 pulumi.Output.all(
     array_of_string=root.array_of_string,
     map_of_string=root.map_of_string
-).apply(lambda resolved_outputs: create_from_computed_for_expression([resolved_outputs["map_of_string"][value] for value in resolved_outputs["array_of_string"]]))
+).apply(lambda resolved_outputs: create_from_computed_for_expression([resolved_outputs['map_of_string'][value] for value in resolved_outputs['array_of_string']]))

--- a/tests/testdata/codegen/transpiled_examples/azure-app-service-pp/python/azure-app-service.py
+++ b/tests/testdata/codegen/transpiled_examples/azure-app-service-pp/python/azure-app-service.py
@@ -17,18 +17,24 @@ container = azure_native.storage.BlobContainer("container",
     resource_group_name=appservicegroup.name,
     account_name=sa.name,
     public_access=azure_native.storage.PublicAccess.NONE)
-blob_access_token = pulumi.Output.secret(pulumi.Output.all(sa.name, appservicegroup.name, sa.name, container.name).apply(lambda saName, appservicegroupName, saName1, containerName: azure_native.storage.list_storage_account_service_sas_output(account_name=sa_name,
+blob_access_token = pulumi.Output.secret(pulumi.Output.all(
+    saName=sa.name,
+    appservicegroupName=appservicegroup.name,
+    saName1=sa.name,
+    containerName=container.name
+).apply(lambda resolved_outputs: azure_native.storage.list_storage_account_service_sas_output(account_name=resolved_outputs['saName'],
     protocols=azure_native.storage.HttpProtocol.HTTPS,
     shared_access_start_time="2022-01-01",
     shared_access_expiry_time="2030-01-01",
     resource=azure_native.storage.SignedResource.C,
-    resource_group_name=appservicegroup_name,
+    resource_group_name=resolved_outputs['appservicegroupName'],
     permissions=azure_native.storage.Permissions.R,
-    canonicalized_resource=f"/blob/{sa_name1}/{container_name}",
+    canonicalized_resource=f"/blob/{resolved_outputs['saName1']}/{resolved_outputs['containerName']}",
     content_type="application/json",
     cache_control="max-age=5",
     content_disposition="inline",
-    content_encoding="deflate")).apply(lambda invoke: invoke.service_sas_token))
+    content_encoding="deflate"))
+.apply(lambda invoke: invoke.service_sas_token))
 appserviceplan = azure_native.web.AppServicePlan("appserviceplan",
     resource_group_name=appservicegroup.name,
     kind="App",
@@ -67,7 +73,13 @@ app = azure_native.web.WebApp("app",
         "app_settings": [
             {
                 "name": "WEBSITE_RUN_FROM_PACKAGE",
-                "value": pulumi.Output.all(sa.name, container.name, blob.name, blob_access_token).apply(lambda saName, containerName, blobName, blob_access_token: f"https://{sa_name}.blob.core.windows.net/{container_name}/{blob_name}?{blob_access_token}"),
+                "value": pulumi.Output.all(
+                    saName=sa.name,
+                    containerName=container.name,
+                    blobName=blob.name,
+                    blob_access_token=blob_access_token
+).apply(lambda resolved_outputs: f"https://{resolved_outputs['saName']}.blob.core.windows.net/{resolved_outputs['containerName']}/{resolved_outputs['blobName']}?{resolved_outputs['blob_access_token']}")
+,
             },
             {
                 "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
@@ -85,7 +97,12 @@ app = azure_native.web.WebApp("app",
         "connection_strings": [{
             "name": "db",
             "type": azure_native.web.ConnectionStringType.SQL_AZURE,
-            "connection_string": pulumi.Output.all(sql_server.name, db.name, sql_password.result).apply(lambda sqlServerName, dbName, result: f"Server= tcp:{sql_server_name}.database.windows.net;initial catalog={db_name};userID={sql_admin};password={result};Min Pool Size=0;Max Pool Size=30;Persist Security Info=true;"),
+            "connection_string": pulumi.Output.all(
+                sqlServerName=sql_server.name,
+                dbName=db.name,
+                result=sql_password.result
+).apply(lambda resolved_outputs: f"Server= tcp:{resolved_outputs['sqlServerName']}.database.windows.net;initial catalog={resolved_outputs['dbName']};userID={sql_admin};password={resolved_outputs['result']};Min Pool Size=0;Max Pool Size=30;Persist Security Info=true;")
+,
         }],
     })
 pulumi.export("endpoint", app.default_host_name)


### PR DESCRIPTION
Noticed while working on another codegen related task. Python apply calls weren't being generated correctly, they looked valid but they didn't actually execute. They would fail with an error that the lambda had been called without all required positional arguments.

This fixes it to use `all` in dictionary form and to index into the dictionary in the lambda body.