### PR TITLE
Fix StackReference.outputs typing

### DIFF
--- a/changelog/pending/20240813--sdk-python--fix-the-type-of-stackreference-outputs-to-be-dict-str-any.yaml
+++ b/changelog/pending/20240813--sdk-python--fix-the-type-of-stackreference-outputs-to-be-dict-str-any.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix the type of `StackReference.outputs` to be `Dict[str, any]`

--- a/sdk/python/lib/pulumi/stack_reference.py
+++ b/sdk/python/lib/pulumi/stack_reference.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from asyncio import ensure_future
-from typing import Optional, Any, List, Callable
-from copy import deepcopy
+from typing import Optional, Dict, Any, List
 
 from .output import Output, Input
 from .resource import CustomResource, ResourceOptions
@@ -63,7 +62,7 @@ class StackReference(CustomResource):
     The name of the referenced stack.
     """
 
-    outputs: Output[dict]
+    outputs: Output[Dict[str, Any]]
     """
     The outputs of the referenced stack.
     """


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/16955.

`dict` is the same as `Dict[unknown, unknown]` but for stack references we know the keys are strings, and it's more useful to treat the values as any than unknown.