### PR TITLE
Fix Pyright type checking of "StackReference#outputs"

### DIFF
--- a/changelog/pending/20240813--sdk-python--fix-the-type-of-stackreference-outputs-to-be-dict-str-any.yaml
+++ b/changelog/pending/20240813--sdk-python--fix-the-type-of-stackreference-outputs-to-be-dict-str-any.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix the type of `StackReference.outputs` to be `Dict[str, any]`

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -51,6 +51,8 @@ lint:: ensure
 		MYPYPATH=./stubs python -m mypy ./lib/pulumi --config-file=mypy.ini
 	. venv/*/activate && \
 		python -m pylint ./lib/pulumi --rcfile=.pylintrc
+	. venv/*/activate && \
+		python -m pyright
 
 format:: ensure
 	. venv/*/activate && \

--- a/sdk/python/lib/pulumi/stack_reference.py
+++ b/sdk/python/lib/pulumi/stack_reference.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from asyncio import ensure_future
-from typing import Optional, Any, List, Callable
-from copy import deepcopy
+from typing import Optional, Dict, Any, List
 
 from .output import Output, Input
 from .resource import CustomResource, ResourceOptions
@@ -63,7 +62,7 @@ class StackReference(CustomResource):
     The name of the referenced stack.
     """
 
-    outputs: Output[dict]
+    outputs: Output[Dict[str, Any]]
     """
     The outputs of the referenced stack.
     """

--- a/sdk/python/lib/test_types/stack_reference.py
+++ b/sdk/python/lib/test_types/stack_reference.py
@@ -1,0 +1,4 @@
+import pulumi
+
+ref = pulumi.StackReference("ref")
+ref.outputs["bucket"].apply(lambda bucket: pulumi.log.info(f"Bucket: {bucket}"))

--- a/sdk/python/pyrightconfig.json
+++ b/sdk/python/pyrightconfig.json
@@ -1,0 +1,9 @@
+{
+  "venvPath": "venv",
+  "include": [
+    "lib/test_types"
+  ],
+  "strict": [
+    "lib/test_types",
+  ],
+}

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -10,6 +10,7 @@ pyyaml~=6.0
 # Dev packages only needed during development.
 pylint==3.1.0
 mypy==1.9.0
+pyright==1.1.375
 pytest~=7.4.4
 pytest-timeout
 types-six


### PR DESCRIPTION
Updates the type for the `outputs` property of the `StackReference` class to be a `dict[str, Any]` instead of a `dict` (with unknown keys and values). This change fixes the type error in the referenced issue.

Fixes #16955