### PR TITLE
Fix TypeScript checking of Output maps of "any" values

### DIFF
--- a/changelog/pending/20240813--sdk-nodejs--fix-type-checking-of-output-record-string-any.yaml
+++ b/changelog/pending/20240813--sdk-nodejs--fix-type-checking-of-output-record-string-any.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix type checking of `Output<Record<string, any>>`

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -1093,12 +1093,17 @@ type NonFunctionPropertyNames<T> = {
 // Lift up all the non-function properties.  If it was optional before, keep it optional after.
 // If it's require before, keep it required afterwards.
 export type LiftedObject<T, K extends keyof T> = {
-    [P in K]: T[P] extends OutputInstance<infer T1>
+    [P in K]: IsStrictlyAny<T[P]> extends true // If the record value is `any`, leave it as `any`.
+        ? Output<any>
+        : T[P] extends OutputInstance<infer T1>
         ? Output<T1>
         : T[P] extends Promise<infer T2>
           ? Output<T2>
           : Output<T[P]>;
 };
+
+// Credit to StackOverflow user CRice: https://stackoverflow.com/a/61625831
+type IsStrictlyAny<T> = (T extends never ? true : false) extends false ? false : true;
 
 export type LiftedArray<T> = {
     /**

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -1096,10 +1096,10 @@ export type LiftedObject<T, K extends keyof T> = {
     [P in K]: IsStrictlyAny<T[P]> extends true // If the record value is `any`, leave it as `any`.
         ? Output<any>
         : T[P] extends OutputInstance<infer T1>
-        ? Output<T1>
-        : T[P] extends Promise<infer T2>
-          ? Output<T2>
-          : Output<T[P]>;
+          ? Output<T1>
+          : T[P] extends Promise<infer T2>
+            ? Output<T2>
+            : Output<T[P]>;
 };
 
 // Credit to StackOverflow user CRice: https://stackoverflow.com/a/61625831

--- a/sdk/nodejs/tests/stackReference.spec.ts
+++ b/sdk/nodejs/tests/stackReference.spec.ts
@@ -70,4 +70,17 @@ describe("StackReference.getOutputDetails", () => {
             secretValue: "supersecretpassword",
         });
     });
+
+    it("types applies correctly", async () => {
+        const passwordValue = "supersecretpassword";
+        pulumi.runtime.setMocks(
+            new TestMocks({
+                password: pulumi.secret(passwordValue),
+            }),
+        );
+        const ref = new pulumi.StackReference("foo");
+        const password: pulumi.Output<number> = ref.outputs["password"].apply(x => x.length);
+
+        assert.deepStrictEqual(await password.promise(), passwordValue.length);
+    });
 });

--- a/sdk/nodejs/tests/stackReference.spec.ts
+++ b/sdk/nodejs/tests/stackReference.spec.ts
@@ -79,7 +79,7 @@ describe("StackReference.getOutputDetails", () => {
             }),
         );
         const ref = new pulumi.StackReference("foo");
-        const password: pulumi.Output<number> = ref.outputs["password"].apply(x => x.length);
+        const password: pulumi.Output<number> = ref.outputs["password"].apply((x) => x.length);
 
         assert.deepStrictEqual(await password.promise(), passwordValue.length);
     });


### PR DESCRIPTION
This change fixes the TypeScript checking of output "any" maps. Previously, as in the referenced issue, an `Output<Record<string, any>>` had unusable properties with the lifting mechanisms in TypeScript. That is, for such an output `foo`, using `foo["bar"]` would typically result in a type error, as the type would be:

```typescript
pulumi.OutputInstance<unknown> | pulumi.Output<any>
```

This union type with unknown results in a type error on trying to use `foo["bar"].apply(...)`. This is caused by the conditional type of `Lifted<T>` having a condition `T[P] extends OutputInstance<infer T1>` evaluating to the true branch, with `T1` inferred as `unknown`.

This is because `any extends OutputInstance<unknown>`.

Adding a strict check for `any` in the conditional type `Lifted<T>` fixes the issue.

Fixes #16958