### PR TITLE
Build all binaries in pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,6 @@ on:
         required: true
         description: "Version to produce"
         type: string
-      build-all-targets:
-        required: false
-        default: true
-        description: "Build targets to produce, false builds only for Linux amd64."
-        type: boolean
       test-codegen:
         required: false
         default: true
@@ -123,7 +118,6 @@ jobs:
       - name: build matrix
         id: matrix
         env:
-          BUILD_ALL_TARGETS: ${{ inputs.build-all-targets }}
           TEST_CODEGEN: ${{ inputs.test-codegen }}
           TEST_VERSION_SETS: ${{ inputs.test-version-sets }}
           INPUT_INTEGRATION_TEST_PLATFORMS: ${{ inputs.integration-test-platforms }}
@@ -145,18 +139,13 @@ jobs:
           readarray -td' ' INTEGRATION_PLATFORMS < <(echo -n "$INPUT_INTEGRATION_TEST_PLATFORMS"); declare -p INTEGRATION_PLATFORMS;
           readarray -td' ' ACCEPTANCE_PLATFORMS < <(echo -n "$INPUT_ACCEPTANCE_TEST_PLATFORMS"); declare -p ACCEPTANCE_PLATFORMS;
           BUILD_TARGETS='[
-            { "os": "linux",   "arch": "amd64", "build-platform": "ubuntu-latest" }
-          ]'
-          if [ "${BUILD_ALL_TARGETS}" = "true" ]; then
-            BUILD_TARGETS='[
               { "os": "linux",   "arch": "amd64", "build-platform": "ubuntu-latest" },
               { "os": "linux",   "arch": "arm64", "build-platform": "ubuntu-latest" },
               { "os": "windows", "arch": "amd64", "build-platform": "ubuntu-latest" },
               { "os": "windows", "arch": "arm64", "build-platform": "ubuntu-latest" },
               { "os": "darwin",  "arch": "amd64", "build-platform": "ubuntu-latest" },
               { "os": "darwin",  "arch": "arm64", "build-platform": "ubuntu-latest" }
-            ]'
-          fi
+          ]'
 
           CODEGEN_TESTS_FLAG=--codegen-tests
           PKG_UNIT_TEST_PARTITIONS=7

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -84,7 +84,6 @@ jobs:
       ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}
       lint: true
-      build-all-targets: ${{ contains(github.event.pull_request.labels.*.name, 'ci/test') }}
       # codegen tests take quite a while to run.
       # Run them only if ci/test is set,
       # or if one of the codegen files changed.

--- a/.github/workflows/pr-test-acceptance-on-dispatch.yml
+++ b/.github/workflows/pr-test-acceptance-on-dispatch.yml
@@ -61,7 +61,6 @@ jobs:
       ref: refs/pull/${{ github.event.client_payload.pull_request.number }}/merge
       version: ${{ needs.info.outputs.version }}
       lint: true
-      build-all-targets: false
       test-version-sets: current
       integration-test-platforms: ubuntu-latest
       acceptance-test-platforms: ''


### PR DESCRIPTION
With recent changes reducing pressure on minimizing build times, and to support implementing #16960, we can now build all binaries in pull request CI.

Prerequisite for #16960