### PR TITLE
Fixing a few pylint errors in the python test folder

### DIFF
--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -484,7 +484,7 @@ class TestLocalWorkspace(unittest.TestCase):
             "ten": ConfigValue(value="ten"),
         }
         stack.set_all_config(config)
-        stack.remove_all_config([key for key in config])
+        stack.remove_all_config(list(config))
 
         ws.remove_stack(stack_name)
 

--- a/sdk/python/lib/test/langhost/inheritance_translation/__main__.py
+++ b/sdk/python/lib/test/langhost/inheritance_translation/__main__.py
@@ -59,7 +59,7 @@ class MyResourceSubclassSubclass(MyResourceSubclass):
 class MyLegacyTranslationResource(pulumi.CustomResource):
     def __init__(self, name):
         # Pass a regular dict to use the old translation behavior.
-        props = dict()
+        props = {}
         props["some_value"] = None
         props["another_value"] = None
         super().__init__("test:index:MyResource", name, props)

--- a/sdk/python/lib/test/langhost/input_values_for_outputs/__main__.py
+++ b/sdk/python/lib/test/langhost/input_values_for_outputs/__main__.py
@@ -31,7 +31,7 @@ class Instance(pulumi.CustomResource):
             opts = pulumi.ResourceOptions()
         if name is None and not opts.urn:
             raise TypeError("Missing required property 'name'")
-        __props__: dict = dict()
+        __props__ = {}
         __props__["public_ip"] = None
         __props__["name"] = name
         __props__["value"] = value

--- a/sdk/python/lib/test/langhost/output_property_dependencies/__main__.py
+++ b/sdk/python/lib/test/langhost/output_property_dependencies/__main__.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import pulumi
 from typing import Optional
+import pulumi
 
 
 @pulumi.input_type

--- a/sdk/python/lib/test/langhost/stack_output/__main__.py
+++ b/sdk/python/lib/test/langhost/stack_output/__main__.py
@@ -11,9 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import pulumi
-
 from typing import Any, Dict
+import pulumi
 
 
 class TestClass:

--- a/sdk/python/lib/test/test_broken_dynamic_provider.py
+++ b/sdk/python/lib/test/test_broken_dynamic_provider.py
@@ -20,8 +20,8 @@ https://github.com/pulumi/pulumi/issues/6981
 
 import contextlib
 from typing import Dict
-import pytest
 import uuid
+import pytest
 
 from pulumi import Input, Output
 from pulumi.runtime import settings, mocks

--- a/sdk/python/lib/test/test_deprecated.py
+++ b/sdk/python/lib/test/test_deprecated.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pulumi
 import unittest
 import unittest.mock
+import pulumi
 
 
 class Resource1(pulumi.Resource):

--- a/sdk/python/lib/test/test_monitor_termination.py
+++ b/sdk/python/lib/test/test_monitor_termination.py
@@ -15,8 +15,8 @@
 from typing import Any, Optional
 import asyncio
 import functools
-import grpc
 import logging
+import grpc
 import pytest
 
 import pulumi

--- a/sdk/python/lib/test/test_resource.py
+++ b/sdk/python/lib/test/test_resource.py
@@ -15,8 +15,8 @@
 from typing import Optional, TypeVar, Awaitable, List, Any
 import asyncio
 import os
-import pytest
 import unittest
+import pytest
 
 from pulumi.resource import DependencyProviderResource
 from pulumi.runtime import settings, mocks

--- a/sdk/python/lib/test/test_stack_reference.py
+++ b/sdk/python/lib/test/test_stack_reference.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import asyncio
-import pytest
 import unittest
+import pytest
 
 import pulumi
 from pulumi.runtime import mocks

--- a/sdk/python/lib/test/test_stack_registers_outputs.py
+++ b/sdk/python/lib/test/test_stack_registers_outputs.py
@@ -20,11 +20,11 @@ Regresses https://github.com/pulumi/pulumi/issues/8273
 
 """
 
+from copy import deepcopy
+
 import pytest
 from pulumi.runtime import settings, mocks
 import pulumi
-
-from copy import deepcopy
 
 
 class MyMocks(pulumi.runtime.Mocks):

--- a/sdk/python/lib/test/test_stack_registers_outputs.py
+++ b/sdk/python/lib/test/test_stack_registers_outputs.py
@@ -61,7 +61,7 @@ def my_mocks():
         # place them inside a test and make the code run after the
         # test stack completes constructing.
         assert monitor.outputs is not None
-        assert type(monitor.outputs.urn) == str
+        assert isinstance(monitor.outputs.urn, str)
 
 
 @pulumi.runtime.test

--- a/sdk/python/lib/test/test_types_input_type.py
+++ b/sdk/python/lib/test/test_types_input_type.py
@@ -16,7 +16,7 @@ import unittest
 from typing import Optional
 
 import pulumi
-import pulumi._types as _types
+from pulumi import _types
 
 
 @pulumi.input_type

--- a/sdk/python/lib/test/test_types_output_type.py
+++ b/sdk/python/lib/test/test_types_output_type.py
@@ -16,7 +16,7 @@ import unittest
 from typing import Optional
 
 import pulumi
-import pulumi._types as _types
+from pulumi import _types
 
 
 CAMEL_TO_SNAKE_CASE_TABLE = {


### PR DESCRIPTION
These were found by running `python -m pylint ./lib/test --rcfile=.pylintrc` in the python SDK folder. Currently we don't consistently run pylint (or mypy for that matter) against the test folder and it's built up a number of issues before we can turn it on.

This PR fixes some of the smaller less common ones, a baby step towards getting the tests fully linted and type checked. Each issue is resolved in a single commit named for the pylint issue it fixed.