### PR TITLE
Fix potential nil panic in FindExecutable

### DIFF
--- a/sdk/go/common/util/executable/executable.go
+++ b/sdk/go/common/util/executable/executable.go
@@ -26,7 +26,11 @@ func FindExecutable(program string) (string, error) {
 	}
 
 	cwdProgram := filepath.Join(cwd, program)
-	if fileInfo, err := os.Stat(cwdProgram); !os.IsNotExist(err) && !fileInfo.Mode().IsDir() {
+	fileInfo, err := os.Stat(cwdProgram)
+	if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+	if err == nil && !fileInfo.Mode().IsDir() {
 		logging.V(5).Infof("program %s found in CWD", program)
 		return cwdProgram, nil
 	}


### PR DESCRIPTION
Found by https://github.com/uber-go/nilaway

If Stat returned an error other than `IsNotExist` we would attempt to dereference the fileInfo and trigger a nil access.

This fixes it so Stat errors are returned as errors (except for `IsNotExist`).