### PR TITLE
Fix potential nil panic in InitError.Error

### DIFF
--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -1924,6 +1924,9 @@ func (ie *InitError) Error() string {
 	for _, reason := range ie.Reasons {
 		err = multierror.Append(err, errors.New(reason))
 	}
+	if err == nil {
+		return "resource init failed"
+	}
 	return err.Error()
 }
 


### PR DESCRIPTION
Found by https://github.com/uber-go/nilaway

If an `InitError` was constructed without any reasons (possible, nothing checks this on the grpc boundary) then `Error` would panic.

This fixes it to instead return a default error message.