### PR TITLE
Improve Git authentication handling

### DIFF
--- a/changelog/pending/20240814--auto--enable-using-default-ssh-credentials-improve-error-handling-on-systems-without-an-ssh-agent.yaml
+++ b/changelog/pending/20240814--auto--enable-using-default-ssh-credentials-improve-error-handling-on-systems-without-an-ssh-agent.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto
+  description: Enable using default SSH credentials, improve error handling on systems without an SSH Agent.

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
-	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	github.com/xanzy/ssh-agent v0.3.3
 	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	google.golang.org/protobuf v1.33.0

--- a/sdk/go/auto/git_test.go
+++ b/sdk/go/auto/git_test.go
@@ -348,7 +348,7 @@ func TestGitAuthParse(t *testing.T) {
 			if tc.expectedWrappedBasicAuth != nil {
 				wrapper, ok := authMethod.(*gitutil.TransportAuth)
 				require.Truef(t, ok, "expected transport to be of type *gitutil.TransportAuth, got %T", authMethod)
-				basicAuth, ok := authMethod.(*http.BasicAuth)
+				basicAuth, ok := wrapper.AuthMethod.(*http.BasicAuth)
 				require.Truef(t, ok, "expected Auth to be of type *http.BasicAuth, got %T", wrapper.AuthMethod)
 				if basicAuth.Username != tc.expectedWrappedBasicAuth.Username ||
 					basicAuth.Password != tc.expectedWrappedBasicAuth.Password {

--- a/sdk/go/auto/git_test.go
+++ b/sdk/go/auto/git_test.go
@@ -2,14 +2,26 @@ package auto
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/nettest"
 )
 
 // This takes the unusual step of testing an unexported func. The rationale is to be able to test
@@ -170,4 +182,201 @@ func TestGitClone(t *testing.T) {
 			assert.EqualError(t, err, tc.expectedError)
 		})
 	}
+}
+
+//nolint:paralleltest // global environment variables
+func TestGitAuthParse(t *testing.T) {
+	// Set up a fake SSH_AUTH_SOCK for testing
+	l, err := nettest.NewLocalListener("unix")
+	defer contract.IgnoreClose(l)
+	require.NoError(t, err)
+
+	type testcase struct {
+		name              string
+		url               string
+		auth              *GitAuth
+		setSSHAgentSocket bool
+
+		expectedURL                 string
+		expectedError               string
+		expectedPublicKeysTransport bool
+		expectedPublicAuthInstance  *http.BasicAuth
+	}
+
+	for _, tc := range []testcase{
+		{
+			name: "private key path",
+			url:  "git@example.com:repo.git",
+			auth: &GitAuth{
+				SSHPrivateKeyPath: generateSSHKeyFile(t),
+			},
+			expectedURL:                 "git@example.com:repo.git",
+			expectedPublicKeysTransport: true,
+		},
+		{
+			name: "invalid private key path",
+			url:  "git@example.com:repo.git",
+			auth: &GitAuth{
+				SSHPrivateKeyPath: "/invalid/path",
+			},
+			expectedError: "unable to use SSH Private Key Path: open /invalid/path",
+		},
+		{
+			name: "private key value",
+			url:  "git@example.com:repo.git",
+			auth: &GitAuth{
+				SSHPrivateKey: generateSSHKeyString(t),
+			},
+			expectedURL:                 "git@example.com:repo.git",
+			expectedPublicKeysTransport: true,
+		},
+		{
+			name: "invalid private key value",
+			url:  "git@example.com:repo.git",
+			auth: &GitAuth{
+				SSHPrivateKey: "invalid-string",
+			},
+			expectedError: "unable to use SSH Private Key: ssh: no key found",
+		},
+		{
+			name: "personal access token",
+			url:  "git@example.com:repo.git",
+			auth: &GitAuth{
+				PersonalAccessToken: "dummy-token",
+			},
+			expectedURL:                "git@example.com:repo.git",
+			expectedPublicAuthInstance: &http.BasicAuth{Username: "git", Password: "dummy-token"},
+		},
+		{
+			name: "username and password",
+			url:  "git@example.com:repo.git",
+			auth: &GitAuth{
+				Username: "user",
+				Password: "pass",
+			},
+			expectedURL:                "git@example.com:repo.git",
+			expectedError:              "",
+			expectedPublicAuthInstance: &http.BasicAuth{Username: "user", Password: "pass"},
+		},
+		{
+			name: "incompatible auth options",
+			url:  "git@example.com:repo.git",
+			auth: &GitAuth{
+				SSHPrivateKeyPath: "/path/to/private/key",
+				Username:          "user",
+			},
+			expectedError: "please specify one authentication option",
+		},
+		{
+			name: "incompatible auth options",
+			url:  "git@example.com:repo.git",
+			auth: &GitAuth{
+				PersonalAccessToken: "dummy-token",
+				Username:            "user",
+			},
+			expectedError: "please specify one authentication option",
+		},
+		{
+			url:  "git@example.com:repo.git",
+			name: "default auth without SSH agent",
+
+			expectedError: "SSH agent requested but SSH_AUTH_SOCK not-specified",
+		},
+		{
+			url:               "git@example.com:repo.git",
+			name:              "default auth with SSH agent",
+			setSSHAgentSocket: true,
+
+			expectedURL: "git@example.com:repo.git",
+		},
+		{
+			name: "url with basic auth",
+			url:  "https://user:password@example.com/repo.git",
+
+			expectedURL: "https://example.com/repo.git",
+			expectedPublicAuthInstance: &http.BasicAuth{
+				Username: "user",
+				Password: "password",
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setSSHAgentSocket {
+				t.Setenv("SSH_AUTH_SOCK", l.Addr().String())
+			} else {
+				os.Unsetenv("SSH_AUTH_SOCK")
+			}
+
+			url, authMethod, err := func() (string, transport.AuthMethod, error) {
+				var _ context.Context = context.Background()
+				return setupGitRepoAuth(tc.url, tc.auth)
+			}()
+
+			if tc.expectedError != "" {
+				if err == nil {
+					t.Fatalf("expected an error but got nil")
+				}
+				if !strings.Contains(err.Error(), tc.expectedError) {
+					t.Fatalf("expected error %q to contain %q", err.Error(), tc.expectedError)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if url != tc.expectedURL {
+				t.Errorf("expected url %q, got %q", tc.expectedURL, url)
+			}
+
+			if _, ok := authMethod.(*ssh.PublicKeys); ok != tc.expectedPublicKeysTransport {
+				condition := "to be"
+				if !tc.expectedPublicKeysTransport {
+					condition = "not to be"
+				}
+				t.Errorf("expected transport %s of type *ssh.PublicKeys, got %T", condition, authMethod)
+			}
+
+			if tc.expectedPublicAuthInstance != nil {
+				wrapper, ok := authMethod.(*gitutil.TransportAuth)
+				require.Truef(t, ok, "expected transport to be of type *gitutil.TransportAuth, got %T", authMethod)
+				basicAuth, ok := wrapper.AuthMethod.(*http.BasicAuth)
+				require.Truef(t, ok, "expected Auth to be of type *http.BasicAuth, got %T", wrapper.AuthMethod)
+				if basicAuth.Username != tc.expectedPublicAuthInstance.Username ||
+					basicAuth.Password != tc.expectedPublicAuthInstance.Password {
+					t.Errorf("expected BasicAuth to have username %q and password %q, got username %q and password %q",
+						tc.expectedPublicAuthInstance.Username, tc.expectedPublicAuthInstance.Password,
+						basicAuth.Username, basicAuth.Password)
+				}
+			}
+		})
+	}
+}
+
+func generateSSHKeyBlock(t *testing.T) *pem.Block {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	return &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}
+}
+
+func generateSSHKeyFile(t *testing.T) string {
+	block := generateSSHKeyBlock(t)
+
+	path := filepath.Join(t.TempDir(), "test-key")
+	err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600)
+	t.Cleanup(func() {
+		os.Remove(path)
+	})
+	require.NoError(t, err)
+
+	return path
+}
+
+func generateSSHKeyString(t *testing.T) string {
+	block := generateSSHKeyBlock(t)
+
+	return string(pem.EncodeToMemory(block))
 }

--- a/sdk/go/common/util/gitutil/git_auth.go
+++ b/sdk/go/common/util/gitutil/git_auth.go
@@ -1,0 +1,329 @@
+package gitutil
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	gitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"github.com/kevinburke/ssh_config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	sshagent "github.com/xanzy/ssh-agent"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+type AuthMethod interface {
+	transport.AuthMethod
+
+	// For testing the SSH Agent, we want to be able to run the client config synchronously.
+	publicKeys() ([]ssh.Signer, error)
+}
+
+// sshUserSettings allows us to inject mock SSH config.
+type sshUserSettings interface {
+	GetAllStrict(alias, key string) ([]string, error)
+}
+
+var _ sshUserSettings = (*ssh_config.UserSettings)(nil)
+
+type sshAgentBroker interface {
+	Available() bool
+	New() (sshAgentImpl, error)
+}
+
+type sshAgentImpl interface {
+	io.Closer
+
+	Signers() ([]ssh.Signer, error)
+}
+
+type defaultSSHAgentBroker struct{}
+
+var _ sshAgentBroker = (*defaultSSHAgentBroker)(nil)
+
+// Available implements sshAgentBroker.
+func (*defaultSSHAgentBroker) Available() bool {
+	return sshagent.Available()
+}
+
+// New implements sshAgentBroker.
+func (*defaultSSHAgentBroker) New() (sshAgentImpl, error) {
+	agent, conn, err := sshagent.New()
+	if err != nil {
+		return nil, err
+	}
+	return &defaultSSHAgent{agent: agent, Closer: conn}, nil
+}
+
+type defaultSSHAgent struct {
+	io.Closer
+
+	agent agent.Agent
+}
+
+// Signers implements sshAgentImpl.
+func (d *defaultSSHAgent) Signers() ([]ssh.Signer, error) {
+	return d.agent.Signers()
+}
+
+var _ sshAgentImpl = (*defaultSSHAgent)(nil)
+
+// DefaultSSHAuth is an implementation of gitssh.AuthMethod that provides a default set of SSH
+// authentication methods, using a set of provided public keys and an ambient SSH agent if
+// available.
+type DefaultSSHAuth struct {
+	user string
+
+	signers        []ssh.Signer
+	sshAgentBroker sshAgentBroker
+
+	gitssh.HostKeyCallbackHelper
+}
+
+var _ AuthMethod = (*DefaultSSHAuth)(nil)
+
+func NewDefaultSSHAuth(user string) DefaultSSHAuth {
+	return DefaultSSHAuth{user: user}
+}
+
+func (s *DefaultSSHAuth) AddIdentityFiles(host string, settings sshUserSettings, passphrase string) error {
+	path := identityFiles(settings, host)
+
+	for _, key := range path {
+		signer, err := parseKey(keyConfig{path: key, passphrase: passphrase})
+		if err != nil {
+			return err
+		}
+		if signer != nil {
+			logging.V(9).Infof("[gitutils] Adding SSH identity file %q", key)
+			s.signers = append(s.signers, signer)
+		}
+	}
+
+	return nil
+}
+
+func (s *DefaultSSHAuth) AddKeyFiles(files ...string) error {
+	for _, file := range files {
+		signer, err := parseKey(keyConfig{path: file, failOnNotExists: true})
+		if err != nil {
+			return err
+		}
+		if signer != nil {
+			logging.V(9).Infof("[gitutils] Adding SSH public key file %q", file)
+			s.signers = append(s.signers, signer)
+		}
+	}
+	return nil
+}
+
+func (s *DefaultSSHAuth) AddKeyFilesWithPassphrase(files []string, passphrase string) error {
+	for _, file := range files {
+		signer, err := parseKey(keyConfig{
+			path:             file,
+			passphrase:       passphrase,
+			failOnNotExists:  true,
+			failOnPassphrase: passphrase != "",
+		})
+		if err != nil {
+			return err
+		}
+		if signer != nil {
+			logging.V(9).Infof("[gitutils] Adding SSH public key file with passphrase %q", file)
+			s.signers = append(s.signers, signer)
+		}
+	}
+	return nil
+}
+
+func (s *DefaultSSHAuth) AddKeyPem(pemData ...[]byte) error {
+	for _, data := range pemData {
+		signer, err := parseKey(keyConfig{data: data})
+		if err != nil {
+			return err
+		}
+		if signer != nil {
+			logging.V(9).Infof("[gitutils] Adding private key PEM")
+			s.signers = append(s.signers, signer)
+		}
+	}
+	return nil
+}
+
+func (s *DefaultSSHAuth) AddKeyPemWithPassphrase(pemData [][]byte, passphrase string) error {
+	for _, data := range pemData {
+		signer, err := parseKey(keyConfig{
+			data:             data,
+			passphrase:       passphrase,
+			failOnPassphrase: true,
+		})
+		if err != nil {
+			return err
+		}
+		if signer != nil {
+			s.signers = append(s.signers, signer)
+		}
+	}
+	return nil
+}
+
+func (s *DefaultSSHAuth) AddSSHAgentBroker(broker sshAgentBroker) error {
+	if s.sshAgentBroker != nil {
+		return errors.New("SSH agent already set")
+	}
+
+	s.sshAgentBroker = broker
+	return nil
+}
+
+type keyConfig struct {
+	path             string
+	data             []byte
+	passphrase       string
+	failOnNotExists  bool
+	failOnPassphrase bool
+}
+
+var DefaultIdentityFiles = []string{"~/.ssh/id_rsa", "~/.ssh/id_dsa", "~/.ssh/id_ecdsa", "~/.ssh/id_ed25519"}
+
+// ClientConfig implements ssh.AuthMethod.
+func (s *DefaultSSHAuth) ClientConfig() (*ssh.ClientConfig, error) {
+	return s.SetHostKeyCallback(&ssh.ClientConfig{
+		User: s.user,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeysCallback(s.publicKeys),
+		},
+	})
+}
+
+// publicKeys implements AuthMethod.
+func (s *DefaultSSHAuth) publicKeys() ([]ssh.Signer, error) {
+	signers := append([]ssh.Signer{}, s.signers...)
+
+	if s.sshAgentBroker != nil && s.sshAgentBroker.Available() {
+		agent, err := s.sshAgentBroker.New()
+		if err != nil {
+			logging.V(3).Infof("[gitutils] Skipping SSH agent, unable to connect to agent: %v", err)
+		} else {
+			defer func() {
+				err := agent.Close()
+				if err != nil {
+					logging.V(3).Infof("[gitutils] Failed to close SSH agent: %v", err)
+				}
+			}()
+			agentSigners, err := agent.Signers()
+			if err != nil {
+				logging.V(3).Infof("[gitutils] Skipping SSH agent, unable to get agent signers: %v", err)
+			} else {
+				signers = append(signers, agentSigners...)
+			}
+		}
+	} else {
+		logging.V(3).Infof("[gitutils] SSH agent not available, using local public keys only")
+	}
+
+	return signers, nil
+}
+
+// Name implements ssh.AuthMethod.
+func (s *DefaultSSHAuth) Name() string {
+	return "DefaultSSHAuth"
+}
+
+// String implements ssh.AuthMethod.
+func (s *DefaultSSHAuth) String() string {
+	return "DefaultSSHAuth"
+}
+
+func identityFiles(sshUserSettings sshUserSettings, host string) []string {
+	identityFiles, err := sshUserSettings.GetAllStrict(host, "IdentityFile")
+	if err != nil {
+		logging.V(3).Infof("[gitutils] Error reading ssh config for host %q: %v", host, err)
+	}
+	if len(identityFiles) == 0 {
+		logging.V(3).Infof("[gitutils] No IdentityFile found in ssh config for host %q", host)
+	}
+	if len(identityFiles) == 1 && identityFiles[0] == "~/.ssh/identity" {
+		identityFiles = append(identityFiles, DefaultIdentityFiles...)
+	}
+
+	keys := make([]string, 0, len(identityFiles))
+	for _, file := range identityFiles {
+		path, err := expandHomeDir(file)
+		if err != nil {
+			logging.V(3).Infof("[gitutils] Skipping invalid IdentityFile %q: %v", file, err)
+			continue
+		}
+
+		keys = append(keys, path)
+	}
+	return keys
+}
+
+func parseKey(key keyConfig) (ssh.Signer, error) {
+	if key.data == nil {
+		bytes, err := os.ReadFile(key.path)
+		if err != nil {
+			if key.failOnNotExists || !os.IsNotExist(err) {
+				return nil, fmt.Errorf("error reading public key file %q", key.path)
+			}
+			logging.V(5).Infof("[gitutils] Skipping non-existent public key file %q", key.path)
+
+			return nil, nil
+		}
+		key.data = bytes
+	}
+
+	if len(key.data) == 0 {
+		return nil, errors.New("empty key data")
+	}
+
+	signer, err := ssh.ParsePrivateKey(key.data)
+	if err == nil {
+		return signer, nil
+	}
+
+	if _, ok := err.(*ssh.PassphraseMissingError); !ok {
+		return nil, err
+	}
+
+	signer, err = ssh.ParsePrivateKeyWithPassphrase(key.data, []byte(key.passphrase))
+	if err == nil {
+		return signer, nil
+	}
+
+	if key.failOnPassphrase {
+		return nil, fmt.Errorf("Failed to parse private key file %q with provided passphrase: %v", key.path, err)
+	}
+
+	logging.V(3).Infof("[gitutils] Skipping private key file that requires passphrase %q", key.path)
+	return nil, nil
+}
+
+// expandHomeDir expands file paths relative to the user's home directory (~) into absolute paths.
+func expandHomeDir(path string) (string, error) {
+	if len(path) == 0 {
+		return path, nil
+	}
+
+	if path[0] != '~' {
+		// Not a "~/foo" path.
+		return path, nil
+	}
+
+	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+		// We won't expand "~user"-style paths.
+		return "", errors.New("cannot expand user-specific home dir")
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(home, path[1:]), nil
+}

--- a/sdk/go/common/util/gitutil/git_auth.go
+++ b/sdk/go/common/util/gitutil/git_auth.go
@@ -188,10 +188,30 @@ type keyConfig struct {
 	failOnPassphrase bool
 }
 
-var DefaultIdentityFiles = []string{"~/.ssh/id_rsa", "~/.ssh/id_dsa", "~/.ssh/id_ecdsa", "~/.ssh/id_ed25519"}
+// SSH on a modern system (circa 2024, OpenSSH_8.9p1) will try:
+//
+// - ~/.ssh/id_rsa
+// - ~/.ssh/id_ecdsa
+// - ~/.ssh/id_ecdsa_sk
+// - ~/.ssh/id_ed25519
+// - ~/.ssh/id_ed25519_sk
+// - ~/.ssh/id_xmss
+// - ~/.ssh/id_dsa
+//
+// Of these:
+// - id_dsa and id_xmss are not supported in Go
+// - id_ecdsa_sk and id_ed25519_sk require interactive use with FIDO2
+//
+// Producing this list of default identity files:
+var DefaultIdentityFiles = []string{
+	"~/.ssh/id_rsa",
+	"~/.ssh/id_ecdsa",
+	"~/.ssh/id_ed25519",
+}
 
 // ClientConfig implements ssh.AuthMethod.
 func (s *DefaultSSHAuth) ClientConfig() (*ssh.ClientConfig, error) {
+	// Use known hosts alongside our signers, via SetHostKeyCallback
 	return s.SetHostKeyCallback(&ssh.ClientConfig{
 		User: s.user,
 		Auth: []ssh.AuthMethod{

--- a/sdk/go/common/util/gitutil/git_auth_test.go
+++ b/sdk/go/common/util/gitutil/git_auth_test.go
@@ -145,12 +145,11 @@ func TestDefaultIdentityFiles(t *testing.T) {
 		paths: []string{"~/.ssh/identity"},
 	}, "*")
 
-	require.Len(t, keys, 5)
+	require.Len(t, keys, 4)
 
 	require.ElementsMatch(t, keys, []string{
 		mustExpandHomeDir("~/.ssh/identity"),
 		mustExpandHomeDir("~/.ssh/id_rsa"),
-		mustExpandHomeDir("~/.ssh/id_dsa"),
 		mustExpandHomeDir("~/.ssh/id_ecdsa"),
 		mustExpandHomeDir("~/.ssh/id_ed25519"),
 	})

--- a/sdk/go/common/util/gitutil/git_auth_test.go
+++ b/sdk/go/common/util/gitutil/git_auth_test.go
@@ -1,0 +1,487 @@
+package gitutil
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/net/nettest"
+)
+
+// mockSSHConfig allows tests to mock SSH key paths.
+type mockSSHConfig struct {
+	paths []string
+	err   error
+}
+
+var _ sshUserSettings = &mockSSHConfig{}
+
+// GetKeyPath returns a canned response for SSH config.
+func (c *mockSSHConfig) GetAllStrict(host, key string) ([]string, error) {
+	return c.paths, c.err
+}
+
+type mockSSHAgentBroker struct {
+	available    bool
+	newError     error
+	signers      []ssh.Signer
+	signersError error
+	closeError   error
+}
+
+var (
+	_ sshAgentBroker = (*mockSSHAgentBroker)(nil)
+	_ sshAgentImpl   = (*mockSSHAgentBroker)(nil)
+)
+
+// Available implements sshAgentBroker.
+func (m *mockSSHAgentBroker) Available() bool {
+	return m.available
+}
+
+// New implements sshAgentBroker.
+func (m *mockSSHAgentBroker) New() (sshAgentImpl, error) {
+	if m.newError != nil {
+		return nil, m.newError
+	}
+
+	return m, nil
+}
+
+// Close implements sshAgentImpl.
+func (m *mockSSHAgentBroker) Close() error {
+	return m.closeError
+}
+
+// Signers implements sshAgentImpl.
+func (m *mockSSHAgentBroker) Signers() ([]ssh.Signer, error) {
+	if m.signersError != nil {
+		return nil, m.signersError
+	}
+	return m.signers, nil
+}
+
+func captureStderr(t *testing.T, f func()) (string, error) {
+	old := os.Stderr // keep backup of the real stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+
+	outC := make(chan string)
+	// copy the output in a separate goroutine so printing can't block indefinitely
+	go func() {
+		var buf bytes.Buffer
+		_, err := io.Copy(&buf, r)
+		require.NoError(t, err)
+		outC <- buf.String()
+	}()
+
+	prevLog := logging.LogToStderr
+	prevV := logging.Verbose
+	prevFlow := logging.LogFlow
+	logging.InitLogging(true, 9, true)
+
+	// calling function which stderr we are going to capture:
+	f()
+
+	logging.InitLogging(prevLog, prevV, prevFlow)
+
+	// back to normal state
+	w.Close()
+	os.Stderr = old // restoring the real stderr
+	return <-outC, nil
+}
+
+func setupSSHAuthSocket(t *testing.T) {
+	l, err := nettest.NewLocalListener("unix")
+	t.Cleanup(func() {
+		l.Close()
+	})
+	require.NoError(t, err)
+	t.Setenv("SSH_AUTH_SOCK", l.Addr().String())
+}
+
+//nolint:paralleltest // uses mutable state
+func TestNewDefaultSSHAuth(t *testing.T) {
+	auth := NewDefaultSSHAuth("user")
+	require.NotNil(t, auth)
+	require.Len(t, auth.signers, 0)
+}
+
+type sshConfigMock struct {
+	paths []string
+}
+
+var _ sshUserSettings = &sshConfigMock{}
+
+func (c *sshConfigMock) GetAllStrict(host string, key string) ([]string, error) {
+	if host == "*" && key == "IdentityFile" {
+		return c.paths, nil
+	}
+	return nil, errors.New("Invalid key")
+}
+
+func mustExpandHomeDir(path string) string {
+	expanded, err := expandHomeDir(path)
+	if err != nil {
+		panic(err)
+	}
+	return expanded
+}
+
+//nolint:paralleltest // uses mutable state
+func TestDefaultIdentityFiles(t *testing.T) {
+	keys := identityFiles(&sshConfigMock{
+		paths: []string{"~/.ssh/identity"},
+	}, "*")
+
+	require.Len(t, keys, 5)
+
+	require.ElementsMatch(t, keys, []string{
+		mustExpandHomeDir("~/.ssh/identity"),
+		mustExpandHomeDir("~/.ssh/id_rsa"),
+		mustExpandHomeDir("~/.ssh/id_dsa"),
+		mustExpandHomeDir("~/.ssh/id_ecdsa"),
+		mustExpandHomeDir("~/.ssh/id_ed25519"),
+	})
+}
+
+func TestAddIdentityFiles(t *testing.T) {
+	t.Parallel()
+
+	// We're just reimplementing the logic and manually counting the files that exist, verifying that
+	// we found public keys for them.
+	//
+	// The libraries we use make testing this a bit unfortunate, as they hardcode using the user's
+	// home dir, and for safety reasons we do not want to write (even temporarily) key data in tests
+	// to a user's home dir.
+	t.Run("Uses Local IdentityFiles", func(t *testing.T) {
+		t.Parallel()
+
+		auth := NewDefaultSSHAuth("user")
+		require.NotNil(t, auth)
+
+		err := auth.AddIdentityFiles("*", &sshConfigMock{
+			paths: []string{
+				generateSSHKeyFile(t, "good"),
+				generateSSHKeyFile(t, "good"),
+				generateSSHKeyFile(t, "good"),
+				generateSSHKeyFile(t, "good"),
+				generateSSHKeyFile(t, "bad"),
+				generateSSHKeyFile(t, "bad"),
+				generateSSHKeyFile(t, "bad"),
+				"/err/invalid-path",
+			},
+		}, "good")
+		require.NoError(t, err)
+		require.Len(t, auth.signers, 4)
+	})
+}
+
+//nolint:paralleltest // uses mutable state
+func TestBasicAddKeys(t *testing.T) {
+	t.Run("ValidKey", func(t *testing.T) {
+		logs, err := captureStderr(t, func() {
+			auth := NewDefaultSSHAuth("user")
+
+			signerCount := len(auth.signers)
+
+			keyFile := generateSSHKeyFile(t, "")
+			err := auth.AddKeyFiles(keyFile)
+			require.NoError(t, err)
+			require.NotNil(t, auth)
+			require.Len(t, auth.signers, signerCount+1)
+		})
+		require.NoError(t, err)
+		require.Contains(t, logs, "Adding SSH public key file")
+	})
+
+	t.Run("InvalidKeyFile", func(t *testing.T) {
+		logs, err := captureStderr(t, func() {
+			auth := NewDefaultSSHAuth("user")
+			err := auth.AddKeyFiles("nonexistentfile")
+			require.Error(t, err)
+		})
+		require.NoError(t, err)
+		require.Empty(t, logs)
+	})
+}
+
+//nolint:paralleltest // uses mutable state
+func TestNewDefaultSSHAuthFromFilesWithPassphrase(t *testing.T) {
+	t.Run("WithValidKey", func(t *testing.T) {
+		logs, err := captureStderr(t, func() {
+			auth := NewDefaultSSHAuth("user")
+			require.Len(t, auth.signers, 0)
+
+			keyFile := generateSSHKeyFile(t, "passphrase")
+			err := auth.AddKeyFilesWithPassphrase([]string{keyFile}, "passphrase")
+			require.NoError(t, err)
+			require.NotNil(t, auth)
+
+			require.Len(t, auth.signers, 1)
+		})
+		require.NoError(t, err)
+		require.Contains(t, logs, "Adding SSH public key file with passphrase")
+	})
+
+	t.Run("WithInvalidPassphrase", func(t *testing.T) {
+		logs, err := captureStderr(t, func() {
+			auth := NewDefaultSSHAuth("user")
+			require.Len(t, auth.signers, 0)
+
+			keyFile := generateSSHKeyFile(t, "good-passphrase")
+			err := auth.AddKeyFilesWithPassphrase([]string{keyFile}, "bad-passphrase")
+			require.Error(t, err)
+
+			require.Len(t, auth.signers, 0)
+		})
+		require.NoError(t, err)
+		require.Empty(t, logs)
+	})
+
+	t.Run("PassphrasedWithNoPassphrase", func(t *testing.T) {
+		logs, err := captureStderr(t, func() {
+			auth := NewDefaultSSHAuth("user")
+			require.Len(t, auth.signers, 0)
+
+			keyFile := generateSSHKeyFile(t, "good-passphrase")
+			err := auth.AddKeyFiles(keyFile)
+			require.NoError(t, err)
+
+			require.Len(t, auth.signers, 0)
+		})
+		require.NoError(t, err)
+		require.Contains(t, logs, "Skipping private key file that requires passphrase")
+	})
+
+	t.Run("WithValidPassphrase", func(t *testing.T) {
+		auth := NewDefaultSSHAuth("user")
+		require.Len(t, auth.signers, 0)
+
+		keyFile := generateSSHKeyFile(t, "correctpassphrase")
+		err := auth.AddKeyFilesWithPassphrase([]string{keyFile}, "correctpassphrase")
+		require.NoError(t, err)
+		require.NotNil(t, auth)
+		require.Len(t, auth.signers, 1)
+	})
+}
+
+//nolint:paralleltest // uses mutable state
+func TestNewDefaultSSHAuthFromPEMWithPassphrase(t *testing.T) {
+	t.Run("WithValidKey", func(t *testing.T) {
+		logs, err := captureStderr(t, func() {
+			auth := NewDefaultSSHAuth("user")
+			require.Len(t, auth.signers, 0)
+
+			data := generateSSHKeyPEM(t, "passphrase")
+			err := auth.AddKeyPemWithPassphrase([][]byte{data}, "passphrase")
+			require.NoError(t, err)
+			require.NotNil(t, auth)
+
+			require.Len(t, auth.signers, 1)
+		})
+		require.NoError(t, err)
+		require.Empty(t, logs)
+	})
+
+	t.Run("WithInvalidPassphrase", func(t *testing.T) {
+		logs, err := captureStderr(t, func() {
+			auth := NewDefaultSSHAuth("user")
+			require.Len(t, auth.signers, 0)
+
+			data := generateSSHKeyPEM(t, "good-passphrase")
+			err := auth.AddKeyPemWithPassphrase([][]byte{data}, "bad-passphrase")
+			require.Error(t, err)
+
+			require.Len(t, auth.signers, 0)
+		})
+		require.NoError(t, err)
+		require.Empty(t, logs)
+	})
+
+	t.Run("PassphrasedWithNoPassphrase", func(t *testing.T) {
+		logs, err := captureStderr(t, func() {
+			auth := NewDefaultSSHAuth("user")
+			require.Len(t, auth.signers, 0)
+
+			data := generateSSHKeyPEM(t, "good-passphrase")
+			err := auth.AddKeyPem(data)
+			require.NoError(t, err)
+
+			require.Len(t, auth.signers, 0)
+		})
+		require.NoError(t, err)
+		require.Contains(t, logs, "Skipping private key file that requires passphrase")
+	})
+
+	t.Run("WithValidPassphrase", func(t *testing.T) {
+		auth := NewDefaultSSHAuth("user")
+		require.Len(t, auth.signers, 0)
+
+		data := generateSSHKeyPEM(t, "correctpassphrase")
+		err := auth.AddKeyPemWithPassphrase([][]byte{data}, "correctpassphrase")
+		require.NoError(t, err)
+		require.NotNil(t, auth)
+		require.Len(t, auth.signers, 1)
+	})
+}
+
+//nolint:paralleltest // uses mutable state
+func TestNewDefaultSSHAuthFromAgent(t *testing.T) {
+	t.Run("With SSHAgent", func(t *testing.T) {
+		setupSSHAuthSocket(t)
+		auth := NewDefaultSSHAuth("user")
+
+		signer, err := parseKey(keyConfig{path: generateSSHKeyFile(t, "")})
+		require.NoError(t, err)
+
+		err = auth.AddSSHAgentBroker(&mockSSHAgentBroker{
+			available: true,
+			signers:   []ssh.Signer{signer},
+		})
+		require.NoError(t, err)
+
+		publicKeys, err := auth.publicKeys()
+		require.NoError(t, err)
+		require.Len(t, publicKeys, 1)
+	})
+
+	t.Run("Without SSH Agent", func(t *testing.T) {
+		setupSSHAuthSocket(t)
+		auth := NewDefaultSSHAuth("user")
+
+		signer, err := parseKey(keyConfig{path: generateSSHKeyFile(t, "")})
+		require.NoError(t, err)
+
+		logs, err := captureStderr(t, func() {
+			err = auth.AddSSHAgentBroker(&mockSSHAgentBroker{
+				available: false,
+				signers:   []ssh.Signer{signer},
+			})
+			require.NoError(t, err)
+
+			publicKeys, err := auth.publicKeys()
+			require.NoError(t, err)
+			require.Len(t, publicKeys, 0)
+		})
+		require.NoError(t, err)
+		require.Contains(t, logs, "SSH agent not available")
+	})
+
+	t.Run("Erroring SSH Agent on Init", func(t *testing.T) {
+		setupSSHAuthSocket(t)
+		auth := NewDefaultSSHAuth("user")
+
+		signer, err := parseKey(keyConfig{path: generateSSHKeyFile(t, "")})
+		require.NoError(t, err)
+
+		logs, err := captureStderr(t, func() {
+			err = auth.AddSSHAgentBroker(&mockSSHAgentBroker{
+				available: true,
+				signers:   []ssh.Signer{signer},
+				newError:  errors.New("error ssh-sock not available [mock]"),
+			})
+			require.NoError(t, err)
+
+			publicKeys, err := auth.publicKeys()
+			require.NoError(t, err)
+			require.Len(t, publicKeys, 0)
+		})
+		require.NoError(t, err)
+		require.Contains(t, logs, "error ssh-sock not available [mock]")
+	})
+
+	t.Run("Erroring SSH Agent on Use", func(t *testing.T) {
+		setupSSHAuthSocket(t)
+		auth := NewDefaultSSHAuth("user")
+
+		signer, err := parseKey(keyConfig{path: generateSSHKeyFile(t, "")})
+		require.NoError(t, err)
+
+		logs, err := captureStderr(t, func() {
+			err = auth.AddSSHAgentBroker(&mockSSHAgentBroker{
+				available:    true,
+				signers:      []ssh.Signer{signer},
+				signersError: errors.New("error SSH agent invalid socket [mock]"),
+			})
+			require.NoError(t, err)
+
+			publicKeys, err := auth.publicKeys()
+			require.NoError(t, err)
+			require.Len(t, publicKeys, 0)
+		})
+		require.NoError(t, err)
+		require.Contains(t, logs, "error SSH agent invalid socket [mock]")
+	})
+
+	t.Run("Erroring SSH Agent on Close", func(t *testing.T) {
+		setupSSHAuthSocket(t)
+		auth := NewDefaultSSHAuth("user")
+
+		signer, err := parseKey(keyConfig{path: generateSSHKeyFile(t, "")})
+		require.NoError(t, err)
+
+		logs, err := captureStderr(t, func() {
+			err = auth.AddSSHAgentBroker(&mockSSHAgentBroker{
+				available:  true,
+				signers:    []ssh.Signer{signer},
+				closeError: errors.New("error ssh-sock failed to close [mock]"),
+			})
+			require.NoError(t, err)
+
+			publicKeys, err := auth.publicKeys()
+			require.NoError(t, err)
+			require.Len(t, publicKeys, 1)
+		})
+		require.NoError(t, err)
+		require.Contains(t, logs, "error ssh-sock failed to close [mock]")
+	})
+}
+
+func generateSSHKeyBlock(t *testing.T, passphrase string) *pem.Block {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	block := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}
+
+	if passphrase != "" {
+		//nolint: staticcheck
+		block, err = x509.EncryptPEMBlock(rand.Reader, block.Type, block.Bytes, []byte(passphrase), x509.PEMCipherAES256)
+		require.NoError(t, err)
+	}
+
+	return block
+}
+
+func generateSSHKeyFile(t *testing.T, passphrase string) string {
+	block := generateSSHKeyBlock(t, passphrase)
+
+	path := filepath.Join(t.TempDir(), "test-key")
+	err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600)
+	t.Cleanup(func() {
+		os.Remove(path)
+	})
+	require.NoError(t, err)
+
+	return path
+}
+
+func generateSSHKeyPEM(t *testing.T, passphrase string) []byte {
+	block := generateSSHKeyBlock(t, passphrase)
+
+	return pem.EncodeToMemory(block)
+}

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -407,9 +407,6 @@ func TestParseAuthURL(t *testing.T) {
 
 		path := filepath.Join(t.TempDir(), "test-key")
 		err = os.WriteFile(path, pem.EncodeToMemory(block), 0o600)
-		t.Cleanup(func() {
-			os.Remove(path)
-		})
 		require.NoError(t, err)
 
 		return path


### PR DESCRIPTION
The upstream libraries used, `go-git` and `ssh_config`, have deficiencies which result in surprising behavior to those familiar with the default behavior of `git clone`.

First, `go-git` relies on discovering identity files via `ssh_config`, however the identity files returned are incorrect. Only the single file, `~/.ssh/identity` (the SSH v1 protocol default) is returned. This TODO has been outstanding for at least 3 years in `ssh_config`:

https://github.com/kevinburke/ssh_config/blame/1d09c0b50564c4a7f8c56c9d5d6d935e06ee94da/config.go#L254-L257

Instead, we read the [reading the four additional files](https://manpages.ubuntu.com/manpages/xenial/man1/ssh.1.html) SSH uses on modern systems:

- `~/.ssh/id_rsa`
- `~/.ssh/id_ecdsa`
- `~/.ssh/id_ed25519`

(`~/.ssh/id_dsa` is excluded as incompatible with Go's SSH implementation, per a discussion on this pull request.)

Second, `go-git` instantiates an SSH Agent eagerly and errors on failing to access it, regardless of whether it is needed. This is surprising to users who expect `git clone` to work without an SSH Agent.

https://github.com/go-git/go-git/blob/302dddeda962e4bb3477a8e4080bc6f5a253e2bb/plumbing/transport/ssh/auth_method.go#L185-L203

Instead, we treat SSH Agent as a fallible, non-erroring source of additional SSH credentials. Only if it is available do we use it, and should it fail we log an error and continue without it.

With these changes, users on systems without an SSH Agent configured and using any of the standard identity files will be able to clone repositories and use the Automation API with SSH remotes without any additional configuration.

Fixes #16965 