### PR TITLE
prefer environment over config for PULUMI_ACCESS_TOKEN

### DIFF
--- a/changelog/pending/20240814--backend-service--prefer-pulumi_access_token-set-in-the-environment-over-the-one-stored-in-the-config-when-they-dont-match.yaml
+++ b/changelog/pending/20240814--backend-service--prefer-pulumi_access_token-set-in-the-environment-over-the-one-stored-in-the-config-when-they-dont-match.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: backend/service
+  description: Prefer PULUMI_ACCESS_TOKEN set in the environment over the one stored in the config when they don't match


### PR DESCRIPTION
The common order of priority for configuration is (in descending order of priority):
- command line flags
- environment variables
- configuration

When a user uses the `PULUMI_ACCESS_TOKEN` environment variable, we also currently save this to a configuration file.  While it could be considered somewhat questionable writing the secret in the environment variable to disk in the first place, it is somewhat likely that users rely on that behaviour and we don't want to change that.

However it is also very confusing to users that if they change the `PULUMI_ACCESS_TOKEN` environment variable that we still keep re-using the access token that is already stored in the configuration.  It could potentially be considered a breaking to prefer the `PULUMI_ACCESS_TOKEN` variable over the access token set in the configuration.  However setting the `PULUMI_ACCESS_TOKEN` to something different is an explicit action, and users are very unlikely to expect the token from the configuration file to be used at this point.

Make the configuration in the environment variable the priority to be less surprising to users.

Fixes https://github.com/pulumi/pulumi/issues/5293
Fixes https://github.com/pulumi/pulumi/issues/13919 (cc @ringods, not sure if we can declare this issue fixed?  We still write the access token to disk because I'm worried about backwards compatibility if we don't.  Happy to keep this issue open if you prefer)
