### PR TITLE
Don't add 'version.txt' file twice if RespectSchemaVersion and SupportPack are set

### DIFF
--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -2233,8 +2233,7 @@ func genPackageMetadata(pkg *schema.Package,
 	if pkg.Version != nil && ok && lang.RespectSchemaVersion {
 		version = pkg.Version.String()
 		files.Add("version.txt", []byte(version))
-	}
-	if pkg.SupportPack {
+	} else if pkg.SupportPack {
 		if pkg.Version == nil {
 			return errors.New("package version is required")
 		}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-dotnet/issues/320

If conditions here were such that we could try to add the 'version.txt' file twice if both SupportPack and RespectSchemaVersion were both set.