### PR TITLE
Fix panic in remote automation API

### DIFF
--- a/pkg/cmd/pulumi/util_remote.go
+++ b/pkg/cmd/pulumi/util_remote.go
@@ -498,7 +498,8 @@ func runDeployment(ctx context.Context, cmd *cobra.Command, opts display.Options
 
 	// we have a custom marshaller for CreateDeploymentRequest, to handle semantics around
 	// defined/undefined/null values on AgentPoolID
-	if cmd.Flag("agent-pool-id").Changed {
+	agentPoolIdConfig := cmd.Flag("agent-pool-id")
+	if agentPoolIdConfig != nil && agentPoolIdConfig.Changed {
 		// if agent pool id is set, we forward it
 		// if it is empty, we will send a null, to make it default to the shared queue
 		v := apitype.AgentPoolIDMarshaller(args.agentPoolID)


### PR DESCRIPTION
The result of `cmd.Flag` was not checked, resulting in a nil pointer dereference and panic in the remote automation API.

Fixes #16977