### PR TITLE
Add winget install test back to download cron workflow

### DIFF
--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -108,6 +108,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Remove Pre-installed Pulumi
+        shell: bash
         run: |
           if command -v "pulumi.exe"; then
             PULUMI_INSTALL_DIR=$(dirname "$(command -v "pulumi.exe")")

--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -103,6 +103,36 @@ jobs:
         run: |
           echo "Expected version ${{ steps.vars.outputs.expected-version }} but found ${{ steps.vars.outputs.installed-version }}"
           exit 1
+  windows-winget-install:
+    name: Install Pulumi with WinGet on Windows
+    runs-on: windows-latest
+    steps:
+      - name: Remove Pre-installed Pulumi
+        run: |
+          if command -v "pulumi.exe"; then
+            PULUMI_INSTALL_DIR=$(dirname "$(command -v "pulumi.exe")")
+            echo "Deleting Pulumi"
+            rm -v "$PULUMI_INSTALL_DIR"/pulumi*
+          fi
+      - name: Install winget
+        uses: Cyberboss/install-winget@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Pulumi Using WinGet
+        run: winget install pulumi --disable-interactivity --accept-source-agreements --verbose
+      - run: echo "C:/Program Files (x86)/Pulumi" >> "${GITHUB_PATH}"
+        shell: bash
+      - name: Pulumi Version Details
+        id: vars
+        shell: bash
+        run: |
+          echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT}"
+          echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT}"
+      - name: Error if incorrect version found
+        if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}
+        run: |
+          echo "Expected version ${{ steps.vars.outputs.expected-version }} but found ${{ steps.vars.outputs.installed-version }}"
+          exit 1
   windows-direct-install:
     name: Install Pulumi via script on Windows
     runs-on: windows-latest


### PR DESCRIPTION
This was originally included in the download cron workflow, but had to be removed because there wasn't a reliable way to use the winget CLI from GitHub's runners. There's now a GitHub Action available for installing the winget CLI, which we should be able to use now for this.

I temporarily set up the workflow to run on PRs (now removed). You can see a successful run here: https://github.com/pulumi/pulumi/actions/runs/10407763146/job/28823717019?pr=16980

Fixes #11342