### PR TITLE
Get latest version if one not specified in pulumi manifest

### DIFF
--- a/changelog/pending/20240815--cli-install--fix-installation-of-dependencies-that-do-not-specify-a-version-eg-yaml.yaml
+++ b/changelog/pending/20240815--cli-install--fix-installation-of-dependencies-that-do-not-specify-a-version-eg-yaml.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/install
+  description: Fix installation of dependencies that do not specify a version (eg yaml)


### PR DESCRIPTION
Previously, unlike pulumi up, pulumi install did not get latest version of one is not specified for dependencies/plugins.

YAML allows there to not be a version specified so this caused an issue in YAML.

Fixes #16920