### PR TITLE
Provider docs: Show envvars for nested types

### DIFF
--- a/changelog/pending/20240815--docs--show-envvars-for-provider-nested-types.yaml
+++ b/changelog/pending/20240815--docs--show-envvars-for-provider-nested-types.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: docs
+  description: Show envvars for provider nested types.

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1102,7 +1102,7 @@ func (mod *modContext) genConstructorPython(r *schema.Resource, argsOptional, ar
 	return params
 }
 
-func (mod *modContext) genNestedTypes(member interface{}, resourceType bool) []docNestedType {
+func (mod *modContext) genNestedTypes(member interface{}, resourceType, isProvider bool) []docNestedType {
 	dctx := mod.docGenContext
 	tokens := nestedTypeUsageInfo{}
 	// Collect all of the types for this "member" as a map of resource names
@@ -1129,7 +1129,7 @@ func (mod *modContext) genNestedTypes(member interface{}, resourceType bool) []d
 				// Create a map to hold the per-language properties of this object.
 				props := make(map[string][]property)
 				for _, lang := range dctx.supportedLanguages {
-					props[lang] = mod.getProperties(typ.Properties, lang, true, true, false)
+					props[lang] = mod.getProperties(typ.Properties, lang, true, true, isProvider)
 				}
 
 				name := strings.Title(tokenToName(typ.Token))
@@ -1859,7 +1859,7 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 		LookupParams:     mod.genLookupParams(r, stateParam),
 		StateInputs:      stateInputs,
 		StateParam:       stateParam,
-		NestedTypes:      mod.genNestedTypes(r, true /*resourceType*/),
+		NestedTypes:      mod.genNestedTypes(r, true /*resourceType*/, r.IsProvider),
 		MaxNestedTypes:   maxNestedTypes,
 
 		Methods: mod.genMethods(r),

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -456,7 +456,7 @@ func (mod *modContext) genFunction(f *schema.Function) functionDocArgs {
 		}
 	}
 
-	nestedTypes := mod.genNestedTypes(f, false /*resourceType*/)
+	nestedTypes := mod.genNestedTypes(f, false /*resourceType*/, false /*isProvider*/)
 
 	// Generate the per-language map for the function name.
 	funcNameMap := map[string]string{}

--- a/tests/testdata/codegen/kubernetes20/docs/provider/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/provider/_index.md
@@ -573,7 +573,7 @@ Kube<wbr>Client<wbr>Settings<pulumi-choosable type="language" values="python,go"
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
     </dt>
-    <dd>Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.</dd></dl>
+    <dd>Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32. It can also be sourced from the following environment variable: <code>PULUMI_K8S_CLIENT_TIMEOUT</code></dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -587,7 +587,7 @@ Kube<wbr>Client<wbr>Settings<pulumi-choosable type="language" values="python,go"
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
     </dt>
-    <dd>Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.</dd></dl>
+    <dd>Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32. It can also be sourced from the following environment variable: <code>PULUMI_K8S_CLIENT_TIMEOUT</code></dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -601,7 +601,7 @@ Kube<wbr>Client<wbr>Settings<pulumi-choosable type="language" values="python,go"
         <span class="property-indicator"></span>
         <span class="property-type">Integer</span>
     </dt>
-    <dd>Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.</dd></dl>
+    <dd>Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32. It can also be sourced from the following environment variable: <code>PULUMI_K8S_CLIENT_TIMEOUT</code></dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -615,7 +615,7 @@ Kube<wbr>Client<wbr>Settings<pulumi-choosable type="language" values="python,go"
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
     </dt>
-    <dd>Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.</dd></dl>
+    <dd>Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32. It can also be sourced from the following environment variable: <code>PULUMI_K8S_CLIENT_TIMEOUT</code></dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -629,7 +629,7 @@ Kube<wbr>Client<wbr>Settings<pulumi-choosable type="language" values="python,go"
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
     </dt>
-    <dd>Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.</dd></dl>
+    <dd>Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32. It can also be sourced from the following environment variable: <code>PULUMI_K8S_CLIENT_TIMEOUT</code></dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -643,7 +643,7 @@ Kube<wbr>Client<wbr>Settings<pulumi-choosable type="language" values="python,go"
         <span class="property-indicator"></span>
         <span class="property-type">Number</span>
     </dt>
-    <dd>Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.</dd></dl>
+    <dd>Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32. It can also be sourced from the following environment variable: <code>PULUMI_K8S_CLIENT_TIMEOUT</code></dd></dl>
 </pulumi-choosable>
 </div>
 

--- a/tests/testdata/codegen/plain-object-defaults/docs/provider/_index.md
+++ b/tests/testdata/codegen/plain-object-defaults/docs/provider/_index.md
@@ -441,7 +441,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
-    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql.</dd><dt class="property-optional"
+    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_DRIVER</code></dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_csharp">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_csharp" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
@@ -449,7 +449,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
-    <dd>The path to the helm plugins directory.</dd></dl>
+    <dd>The path to the helm plugins directory. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_PLUGINS_PATH</code></dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -471,7 +471,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
-    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql.</dd><dt class="property-optional"
+    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_DRIVER</code></dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_go">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_go" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
@@ -479,7 +479,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
-    <dd>The path to the helm plugins directory.</dd></dl>
+    <dd>The path to the helm plugins directory. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_PLUGINS_PATH</code></dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -501,7 +501,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">String</span>
     </dt>
-    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql.</dd><dt class="property-optional"
+    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_DRIVER</code></dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_java">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_java" style="color: inherit; text-decoration: inherit;">plugins<wbr>Path</a>
@@ -509,7 +509,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">String</span>
     </dt>
-    <dd>The path to the helm plugins directory.</dd></dl>
+    <dd>The path to the helm plugins directory. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_PLUGINS_PATH</code></dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -531,7 +531,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
-    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql.</dd><dt class="property-optional"
+    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_DRIVER</code></dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_nodejs">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_nodejs" style="color: inherit; text-decoration: inherit;">plugins<wbr>Path</a>
@@ -539,7 +539,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
-    <dd>The path to the helm plugins directory.</dd></dl>
+    <dd>The path to the helm plugins directory. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_PLUGINS_PATH</code></dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -561,7 +561,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
     </dt>
-    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql.</dd><dt class="property-optional"
+    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_DRIVER</code></dd><dt class="property-optional"
             title="Optional">
         <span id="plugins_path_python">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plugins_path_python" style="color: inherit; text-decoration: inherit;">plugins_<wbr>path</a>
@@ -569,7 +569,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
     </dt>
-    <dd>The path to the helm plugins directory.</dd></dl>
+    <dd>The path to the helm plugins directory. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_PLUGINS_PATH</code></dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -591,7 +591,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">String</span>
     </dt>
-    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql.</dd><dt class="property-optional"
+    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_DRIVER</code></dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_yaml">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_yaml" style="color: inherit; text-decoration: inherit;">plugins<wbr>Path</a>
@@ -599,7 +599,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">String</span>
     </dt>
-    <dd>The path to the helm plugins directory.</dd></dl>
+    <dd>The path to the helm plugins directory. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_PLUGINS_PATH</code></dd></dl>
 </pulumi-choosable>
 </div>
 

--- a/tests/testdata/codegen/plain-object-disable-defaults/docs/provider/_index.md
+++ b/tests/testdata/codegen/plain-object-disable-defaults/docs/provider/_index.md
@@ -441,7 +441,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
-    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql.</dd><dt class="property-optional"
+    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_DRIVER</code></dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_csharp">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_csharp" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
@@ -449,7 +449,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
-    <dd>The path to the helm plugins directory.</dd></dl>
+    <dd>The path to the helm plugins directory. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_PLUGINS_PATH</code></dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -471,7 +471,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
-    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql.</dd><dt class="property-optional"
+    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_DRIVER</code></dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_go">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_go" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
@@ -479,7 +479,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
-    <dd>The path to the helm plugins directory.</dd></dl>
+    <dd>The path to the helm plugins directory. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_PLUGINS_PATH</code></dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -501,7 +501,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">String</span>
     </dt>
-    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql.</dd><dt class="property-optional"
+    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_DRIVER</code></dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_java">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_java" style="color: inherit; text-decoration: inherit;">plugins<wbr>Path</a>
@@ -509,7 +509,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">String</span>
     </dt>
-    <dd>The path to the helm plugins directory.</dd></dl>
+    <dd>The path to the helm plugins directory. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_PLUGINS_PATH</code></dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -531,7 +531,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
-    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql.</dd><dt class="property-optional"
+    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_DRIVER</code></dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_nodejs">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_nodejs" style="color: inherit; text-decoration: inherit;">plugins<wbr>Path</a>
@@ -539,7 +539,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
-    <dd>The path to the helm plugins directory.</dd></dl>
+    <dd>The path to the helm plugins directory. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_PLUGINS_PATH</code></dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -561,7 +561,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
     </dt>
-    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql.</dd><dt class="property-optional"
+    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_DRIVER</code></dd><dt class="property-optional"
             title="Optional">
         <span id="plugins_path_python">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plugins_path_python" style="color: inherit; text-decoration: inherit;">plugins_<wbr>path</a>
@@ -569,7 +569,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
     </dt>
-    <dd>The path to the helm plugins directory.</dd></dl>
+    <dd>The path to the helm plugins directory. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_PLUGINS_PATH</code></dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -591,7 +591,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">String</span>
     </dt>
-    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql.</dd><dt class="property-optional"
+    <dd>The backend storage driver for Helm. Values are: configmap, secret, memory, sql. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_DRIVER</code></dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_yaml">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_yaml" style="color: inherit; text-decoration: inherit;">plugins<wbr>Path</a>
@@ -599,7 +599,7 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
         <span class="property-indicator"></span>
         <span class="property-type">String</span>
     </dt>
-    <dd>The path to the helm plugins directory.</dd></dl>
+    <dd>The path to the helm plugins directory. It can also be sourced from the following environment variable: <code>PULUMI_K8S_HELM_PLUGINS_PATH</code></dd></dl>
 </pulumi-choosable>
 </div>
 


### PR DESCRIPTION
Some providers have nested types whose properties can also be configured via envvars. Until now, only top-level (non-nested) envvars are shown. This change also shows the envvars for nested types.

Fixes #8323