### PR TITLE
Don't call pluginInstallCommand, defer to schemaFromSchemaSource

### DIFF
--- a/changelog/pending/20240815--cli-package--allow-pulumi-package-add-to-work-with-arbitrary-schema-sources.yaml
+++ b/changelog/pending/20240815--cli-package--allow-pulumi-package-add-to-work-with-arbitrary-schema-sources.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/package
+  description: Allow `pulumi package add` to work with arbitrary schema sources

--- a/pkg/cmd/pulumi/package_add.go
+++ b/pkg/cmd/pulumi/package_add.go
@@ -59,15 +59,6 @@ as in:
 			plugin := args[0]
 			parameters := args[1:]
 
-			var pluginInstallCommand pluginInstallCmd
-			err = pluginInstallCommand.Run(ctx, []string{
-				"resource", /*plugin kind*/
-				plugin,
-			})
-			if err != nil {
-				return fmt.Errorf("failed to install plugin: %w", err)
-			}
-
 			pkg, err := schemaFromSchemaSource(ctx, plugin, parameters)
 			if err != nil {
 				return fmt.Errorf("failed to get schema: %w", err)


### PR DESCRIPTION
`schemaFromSchemaSource` is capable of taking multiple types of sources (plugin, plugin@version, path to plugin). If the plugin is specified (possible with a version), then it is already capable of downloading the plugin. 

We don't need to call `pluginInstallCommand.Run`, and by doing so we prevent `pulumi package add` from accepting different source kinds.