### PR TITLE
Add Go automation API for deployment runners

### DIFF
--- a/changelog/pending/20240815--auto-go--add-remote-automation-api-support-for-choosing-a-deployment-runner-pool.yaml
+++ b/changelog/pending/20240815--auto-go--add-remote-automation-api-support-for-choosing-a-deployment-runner-pool.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Add Remote Automation API support for choosing a deployment runner pool.

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -60,6 +60,7 @@ type LocalWorkspace struct {
 	remoteInheritSettings         bool
 	pulumiCommand                 PulumiCommand
 	remoteExecutorImage           *ExecutorImage
+	remoteAgentPoolID             string
 }
 
 var settingsExtensions = []string{".yaml", ".yml", ".json"}
@@ -903,6 +904,7 @@ func NewLocalWorkspace(ctx context.Context, opts ...LocalWorkspaceOption) (Works
 		remoteEnvVars:                 lwOpts.RemoteEnvVars,
 		remoteSkipInstallDependencies: lwOpts.RemoteSkipInstallDependencies,
 		remoteExecutorImage:           lwOpts.RemoteExecutorImage,
+		remoteAgentPoolID:             lwOpts.RemoteAgentPoolID,
 		remoteInheritSettings:         lwOpts.RemoteInheritSettings,
 		repo:                          lwOpts.Repo,
 		pulumiCommand:                 pulumiCommand,
@@ -1000,6 +1002,8 @@ type localWorkspaceOptions struct {
 	RemoteSkipInstallDependencies bool
 	// RemoteExecutorImage is the image to use for the remote Pulumi operation.
 	RemoteExecutorImage *ExecutorImage
+	// RemoteAgentPoolID is the agent pool (also called deployment runner pool) to use for the remote Pulumi operation.
+	RemoteAgentPoolID string
 	// RemoteInheritSettings sets whether to inherit settings from the remote workspace.
 	RemoteInheritSettings bool
 }
@@ -1164,6 +1168,12 @@ func remoteSkipInstallDependencies(skipInstallDependencies bool) LocalWorkspaceO
 func remoteExecutorImage(image *ExecutorImage) LocalWorkspaceOption {
 	return localWorkspaceOption(func(lo *localWorkspaceOptions) {
 		lo.RemoteExecutorImage = image
+	})
+}
+
+func remoteAgentPoolID(agentPoolID string) LocalWorkspaceOption {
+	return localWorkspaceOption(func(lo *localWorkspaceOptions) {
+		lo.RemoteAgentPoolID = agentPoolID
 	})
 }
 

--- a/sdk/go/auto/remote_workspace.go
+++ b/sdk/go/auto/remote_workspace.go
@@ -167,6 +167,7 @@ func remoteToLocalOptions(repo GitRepo, opts ...RemoteWorkspaceOption) ([]LocalW
 		remoteSkipInstallDependencies(remoteOpts.SkipInstallDependencies),
 		Repo(repo),
 		remoteExecutorImage(remoteOpts.ExecutorImage),
+		remoteAgentPoolID(remoteOpts.AgentPoolID),
 	}
 	return localOpts, nil
 }
@@ -183,6 +184,8 @@ type remoteWorkspaceOptions struct {
 	SkipInstallDependencies bool
 	// ExecutorImage is the image to use for the remote executor.
 	ExecutorImage *ExecutorImage
+	// AgentPoolID is the agent pool (also called deployment runner pool) to use for the remote Pulumi operation.
+	AgentPoolID string
 }
 
 type ExecutorImage struct {
@@ -240,6 +243,13 @@ func RemoteInheritSettings(inheritSettings bool) RemoteWorkspaceOption {
 func RemoteExecutorImage(image *ExecutorImage) RemoteWorkspaceOption {
 	return remoteWorkspaceOption(func(opts *remoteWorkspaceOptions) {
 		opts.ExecutorImage = image
+	})
+}
+
+// RemoteExecutorImage sets the image to use for the remote executor.
+func RemoteAgentPoolID(agentPoolID string) RemoteWorkspaceOption {
+	return remoteWorkspaceOption(func(opts *remoteWorkspaceOptions) {
+		opts.AgentPoolID = agentPoolID
 	})
 }
 

--- a/sdk/go/auto/remote_workspace.go
+++ b/sdk/go/auto/remote_workspace.go
@@ -246,7 +246,8 @@ func RemoteExecutorImage(image *ExecutorImage) RemoteWorkspaceOption {
 	})
 }
 
-// RemoteExecutorImage sets the image to use for the remote executor.
+// RemoteExecutorImage sets the agent pool (also called deployment runner pool) to use for the
+// remote Pulumi operation.
 func RemoteAgentPoolID(agentPoolID string) RemoteWorkspaceOption {
 	return remoteWorkspaceOption(func(opts *remoteWorkspaceOptions) {
 		opts.AgentPoolID = agentPoolID

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -1422,7 +1422,7 @@ func (s *Stack) remoteArgs() []string {
 	}
 
 	if remoteAgentPoolID != "" {
-		args = append(args, "--remote-agent-pool-id=" + remoteAgentPoolID)
+		args = append(args, "--remote-agent-pool-id="+remoteAgentPoolID)
 	}
 
 	if skipInstallDependencies {

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -1345,6 +1345,7 @@ func (s *Stack) remoteArgs() []string {
 	var preRunCommands []string
 	var envvars map[string]EnvVarValue
 	var executorImage *ExecutorImage
+	var remoteAgentPoolID string
 	var skipInstallDependencies bool
 	var inheritSettings bool
 	if lws, isLocalWorkspace := s.Workspace().(*LocalWorkspace); isLocalWorkspace {
@@ -1354,6 +1355,7 @@ func (s *Stack) remoteArgs() []string {
 		envvars = lws.remoteEnvVars
 		skipInstallDependencies = lws.remoteSkipInstallDependencies
 		executorImage = lws.remoteExecutorImage
+		remoteAgentPoolID = lws.remoteAgentPoolID
 		inheritSettings = lws.remoteInheritSettings
 	}
 	if !remote {
@@ -1417,6 +1419,10 @@ func (s *Stack) remoteArgs() []string {
 				args = append(args, "--remote-executor-image-password="+executorImage.Credentials.Password)
 			}
 		}
+	}
+
+	if remoteAgentPoolID != "" {
+		args = append(args, "--remote-agent-pool-id=" + remoteAgentPoolID)
 	}
 
 	if skipInstallDependencies {


### PR DESCRIPTION
Adds support to the automation API for specifying a pool of deployment runners. Follows:
- #16492

Fixes #16987 