### PR TITLE
fix help text for --stack in state edit

### DIFF
--- a/pkg/cmd/pulumi/state_edit.go
+++ b/pkg/cmd/pulumi/state_edit.go
@@ -73,7 +73,7 @@ a preview showing a diff of the altered state.`,
 	}
 	cmd.PersistentFlags().StringVar(
 		&stackName, "stack", "",
-		"Remove the stack and its config file after all resources in the stack have been deleted")
+		"The name of the stack to operation on. Defaults to the current stack")
 	return cmd
 }
 


### PR DESCRIPTION
This help text was just wrong before (probably copy pasted).  Correct it.