### PR TITLE
Show a better message when logging out with --all

### DIFF
--- a/changelog/pending/20240816--cli--show-a-better-message-when-logging-out-with-all.yaml
+++ b/changelog/pending/20240816--cli--show-a-better-message-when-logging-out-with-all.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Show a better message when logging out with `--all`.

--- a/pkg/cmd/pulumi/logout.go
+++ b/pkg/cmd/pulumi/logout.go
@@ -64,6 +64,7 @@ func newLogoutCmd() *cobra.Command {
 			var err error
 			if all {
 				err = workspace.DeleteAllAccounts()
+				fmt.Println("Logged out of everything")
 			} else {
 				if cloudURL == "" {
 					// Try to read the current project
@@ -83,8 +84,9 @@ func newLogoutCmd() *cobra.Command {
 				}
 
 				err = workspace.DeleteAccount(cloudURL)
+				fmt.Printf("Logged out of %s\n", cloudURL)
 			}
-			fmt.Printf("Logged out of %s\n", cloudURL)
+
 			return err
 		}),
 	}


### PR DESCRIPTION
When logging out with `--all` you get a bad message:

```
$ pulumi logout --all
Logged out of
```

This is because with `--all` there is no cloud URL to print out at the end.

This change improves the message to say "Logged out of everything".

Fixes #16997