### PR TITLE
Enable GitHub integration in remote automation API

### DIFF
--- a/changelog/pending/20240816--auto-go--add-github-integration-support-for-remote-automation-api.yaml
+++ b/changelog/pending/20240816--auto-go--add-github-integration-support-for-remote-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Add GitHub integration support for remote automation API.

--- a/changelog/pending/20240816--auto-go--add-github-integration-support-for-remote-automation-api.yaml
+++ b/changelog/pending/20240816--auto-go--add-github-integration-support-for-remote-automation-api.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: auto/go
-  description: Add GitHub integration support for remote automation API.
+  description: Add GitHub integration support for remote automation API

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -356,6 +356,6 @@ func TestDeploymentSettingsApi(t *testing.T) {
 		duration, _ := time.ParseDuration("1h0m0s")
 		assert.Equal(t, apitype.DeploymentDuration(duration), resp.Operation.OIDC.AWS.Duration)
 		assert.Equal(t, []string{"policy:arn"}, resp.Operation.OIDC.AWS.PolicyARNs)
-		assert.Equal(t, "51035bee-a4d6-4b63-9ff6-418775c5da8d", *resp.AgentPoolID)
+		assert.Equal(t, "51035bee-a4d6-4b63-9ff6-418775c5da8d", string(*resp.AgentPoolID))
 	})
 }

--- a/pkg/cmd/pulumi/deployment_run.go
+++ b/pkg/cmd/pulumi/deployment_run.go
@@ -85,7 +85,7 @@ func newDeploymentRunCmd() *cobra.Command {
 				return errResult
 			}
 
-			return runDeployment(ctx, cmd, display, operation, s.Ref().FullyQualifiedName().String(), url, remoteArgs)
+			return runDeployment(ctx, display, operation, s.Ref().FullyQualifiedName().String(), url, remoteArgs)
 		}),
 	}
 

--- a/pkg/cmd/pulumi/deployment_settings_utils_test.go
+++ b/pkg/cmd/pulumi/deployment_settings_utils_test.go
@@ -227,5 +227,5 @@ func TestDSFileParsing(t *testing.T) {
 	duration, _ := time.ParseDuration("1h0m0s")
 	assert.Equal(t, apitype.DeploymentDuration(duration), deploymentFile.DeploymentSettings.Operation.OIDC.AWS.Duration)
 	assert.Equal(t, []string{"policy:arn"}, deploymentFile.DeploymentSettings.Operation.OIDC.AWS.PolicyARNs)
-	assert.Equal(t, "51035bee-a4d6-4b63-9ff6-418775c5da8d", *deploymentFile.DeploymentSettings.AgentPoolID)
+	assert.Equal(t, "51035bee-a4d6-4b63-9ff6-418775c5da8d", string(*deploymentFile.DeploymentSettings.AgentPoolID))
 }

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -161,7 +161,7 @@ func newDestroyCmd() *cobra.Command {
 					return errResult
 				}
 
-				return runDeployment(ctx, cmd, opts.Display, apitype.Destroy, stackName, url, remoteArgs)
+				return runDeployment(ctx, opts.Display, apitype.Destroy, stackName, url, remoteArgs)
 			}
 
 			isDIYBackend, err := isDIYBackend(opts.Display)

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -38,6 +38,9 @@ import (
 
 // mockBackendInstance sets the backendInstance for the test and cleans it up after.
 func mockBackendInstance(t *testing.T, b backend.Backend) {
+	// Setenv internally asserts that it's not called in parallel tests we call it here to prevent a
+	// race on setting backendInstance
+	t.Setenv("GO_TEST_IS_PARALLEL", "true")
 	t.Cleanup(func() {
 		backendInstance = nil
 	})

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -342,7 +342,7 @@ func newPreviewCmd() *cobra.Command {
 					return errResult
 				}
 
-				return runDeployment(ctx, cmd, displayOpts, apitype.Preview, stackName, url, remoteArgs)
+				return runDeployment(ctx, displayOpts, apitype.Preview, stackName, url, remoteArgs)
 			}
 
 			isDIYBackend, err := isDIYBackend(displayOpts)

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -154,7 +154,7 @@ func newRefreshCmd() *cobra.Command {
 					return errResult
 				}
 
-				return runDeployment(ctx, cmd, opts.Display, apitype.Refresh, stackName, url, remoteArgs)
+				return runDeployment(ctx, opts.Display, apitype.Refresh, stackName, url, remoteArgs)
 			}
 
 			isDIYBackend, err := isDIYBackend(opts.Display)

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -510,7 +510,7 @@ func newUpCmd() *cobra.Command {
 					return errResult
 				}
 
-				return runDeployment(ctx, cmd, opts.Display, apitype.Update, stackName, url, remoteArgs)
+				return runDeployment(ctx, opts.Display, apitype.Update, stackName, url, remoteArgs)
 			}
 
 			isDIYBackend, err := isDIYBackend(opts.Display)

--- a/pkg/cmd/pulumi/util_remote.go
+++ b/pkg/cmd/pulumi/util_remote.go
@@ -411,7 +411,8 @@ func runDeployment(ctx context.Context, opts display.Options,
 
 	// Ensure the cloud backend is being used.
 	cb, isCloud := b.(httpstate.Backend)
-	if !isCloud && backendInstance == nil /* mock backend */ {
+	isMockBackend := backendInstance != nil
+	if !isCloud && !isMockBackend {
 		return result.FromError(errors.New("the Pulumi Cloud backend must be used for remote operations; " +
 			"use `pulumi login` without arguments to log into the Pulumi Cloud backend"))
 	}

--- a/pkg/cmd/pulumi/util_remote.go
+++ b/pkg/cmd/pulumi/util_remote.go
@@ -314,7 +314,8 @@ func (r *RemoteArgs) applyFlags(cmd *cobra.Command) {
 func validateRemoteDeploymentFlags(url string, args RemoteArgs) result.Result {
 	// Validate args.
 	if url == "" && (!args.inheritSettings && args.gitHubRepository == "") {
-		return result.FromError(errors.New("the url arg must be specified if not passing --remote-inherit-settings or --remote-github-repository"))
+		return result.FromError(
+			errors.New("the url arg must be specified if not passing --remote-inherit-settings or --remote-github-repository"))
 	}
 	if args.gitBranch != "" && args.gitCommit != "" {
 		return result.FromError(errors.New("`--remote-git-branch` and `--remote-git-commit` cannot both be specified"))
@@ -513,7 +514,7 @@ func runDeployment(ctx context.Context, opts display.Options,
 				ExecutorImage: executorImage,
 			},
 			SourceContext: sourceContext,
-			GitHub: gitHub,
+			GitHub:        gitHub,
 			Operation: &apitype.OperationContext{
 				PreRunCommands:       args.preRunCommands,
 				EnvironmentVariables: env,

--- a/pkg/cmd/pulumi/util_remote_test.go
+++ b/pkg/cmd/pulumi/util_remote_test.go
@@ -84,7 +84,7 @@ func TestRemoteExclusiveURL(t *testing.T) {
 		url              string
 		gitHubRepository string
 
-		expectUrlError bool
+		expectURLError bool
 	}
 
 	testCases := []testCase{
@@ -100,11 +100,11 @@ func TestRemoteExclusiveURL(t *testing.T) {
 			name:             "both",
 			url:              "https://example.com/foo/bar.git",
 			gitHubRepository: "thwomp/quux",
-			expectUrlError:   true,
+			expectURLError:   true,
 		},
 		{
 			name:           "neither",
-			expectUrlError: true,
+			expectURLError: true,
 		},
 	}
 
@@ -120,7 +120,7 @@ func TestRemoteExclusiveURL(t *testing.T) {
 
 			err := res.Error()
 			require.Error(t, err)
-			if tc.expectUrlError {
+			if tc.expectURLError {
 				assert.Contains(t, err.Error(), "one of `url` or `github-repository` must be specified, and not both")
 			} else {
 				assert.Contains(t, err.Error(), "no cloud backend available")

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -61,6 +61,7 @@ type LocalWorkspace struct {
 	pulumiCommand                 PulumiCommand
 	remoteExecutorImage           *ExecutorImage
 	remoteAgentPoolID             string
+	remoteGitHubRepository        string
 }
 
 var settingsExtensions = []string{".yaml", ".yml", ".json"}
@@ -905,6 +906,7 @@ func NewLocalWorkspace(ctx context.Context, opts ...LocalWorkspaceOption) (Works
 		remoteSkipInstallDependencies: lwOpts.RemoteSkipInstallDependencies,
 		remoteExecutorImage:           lwOpts.RemoteExecutorImage,
 		remoteAgentPoolID:             lwOpts.RemoteAgentPoolID,
+		remoteGitHubRepository:        lwOpts.RemoteGitHubRepository,
 		remoteInheritSettings:         lwOpts.RemoteInheritSettings,
 		repo:                          lwOpts.Repo,
 		pulumiCommand:                 pulumiCommand,
@@ -1004,6 +1006,9 @@ type localWorkspaceOptions struct {
 	RemoteExecutorImage *ExecutorImage
 	// RemoteAgentPoolID is the agent pool (also called deployment runner pool) to use for the remote Pulumi operation.
 	RemoteAgentPoolID string
+	// RemoteGitHubRepository is the GitHub repository to use for the remote Pulumi operation, using
+	// the GitHub integration. The format is org/repo. Overrides Repo.
+	RemoteGitHubRepository string
 	// RemoteInheritSettings sets whether to inherit settings from the remote workspace.
 	RemoteInheritSettings bool
 }
@@ -1174,6 +1179,12 @@ func remoteExecutorImage(image *ExecutorImage) LocalWorkspaceOption {
 func remoteAgentPoolID(agentPoolID string) LocalWorkspaceOption {
 	return localWorkspaceOption(func(lo *localWorkspaceOptions) {
 		lo.RemoteAgentPoolID = agentPoolID
+	})
+}
+
+func remoteGitHubRepository(repository string) LocalWorkspaceOption {
+	return localWorkspaceOption(func(lo *localWorkspaceOptions) {
+		lo.RemoteGitHubRepository = repository
 	})
 }
 

--- a/sdk/go/auto/remote_workspace.go
+++ b/sdk/go/auto/remote_workspace.go
@@ -111,9 +111,6 @@ func remoteToLocalOptions(repo GitRepo, opts ...RemoteWorkspaceOption) ([]LocalW
 
 	if !remoteOpts.InheritSettings {
 		ifNotSet := " if RemoteInheritSettings(true) is not set"
-		if repo.URL == "" {
-			return nil, errors.New("repo.URL is required" + ifNotSet)
-		}
 		if repo.Branch == "" && repo.CommitHash == "" {
 			return nil, errors.New("either repo.Branch or repo.CommitHash is required" + ifNotSet)
 		}
@@ -168,6 +165,7 @@ func remoteToLocalOptions(repo GitRepo, opts ...RemoteWorkspaceOption) ([]LocalW
 		Repo(repo),
 		remoteExecutorImage(remoteOpts.ExecutorImage),
 		remoteAgentPoolID(remoteOpts.AgentPoolID),
+		remoteGitHubRepository(remoteOpts.GitHubRepository),
 	}
 	return localOpts, nil
 }
@@ -186,6 +184,8 @@ type remoteWorkspaceOptions struct {
 	ExecutorImage *ExecutorImage
 	// AgentPoolID is the agent pool (also called deployment runner pool) to use for the remote Pulumi operation.
 	AgentPoolID string
+	// GitHubRepository is the GitHub repository to use for the remote executor. The format is "owner/repo".
+	GitHubRepository string
 }
 
 type ExecutorImage struct {
@@ -251,6 +251,14 @@ func RemoteExecutorImage(image *ExecutorImage) RemoteWorkspaceOption {
 func RemoteAgentPoolID(agentPoolID string) RemoteWorkspaceOption {
 	return remoteWorkspaceOption(func(opts *remoteWorkspaceOptions) {
 		opts.AgentPoolID = agentPoolID
+	})
+}
+
+// RemoteExecutorImage sets the agent pool (also called deployment runner pool) to use for the
+// remote Pulumi operation.
+func GitHubRepository(repository string) RemoteWorkspaceOption {
+	return remoteWorkspaceOption(func(opts *remoteWorkspaceOptions) {
+		opts.GitHubRepository = repository
 	})
 }
 

--- a/sdk/go/auto/remote_workspace_test.go
+++ b/sdk/go/auto/remote_workspace_test.go
@@ -87,11 +87,6 @@ func testRemoteStackGitSourceErrors(t *testing.T, fn func(ctx context.Context, s
 		"no url": {
 			stack: stack,
 			repo:  GitRepo{},
-			err:   "repo.URL is required if RemoteInheritSettings(true) is not set",
-		},
-		"no branch or commit": {
-			stack: stack,
-			repo:  GitRepo{URL: remoteTestRepo},
 			err:   "either repo.Branch or repo.CommitHash is required if RemoteInheritSettings(true) is not set",
 		},
 		"both branch and commit": {

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -1346,6 +1346,7 @@ func (s *Stack) remoteArgs() []string {
 	var envvars map[string]EnvVarValue
 	var executorImage *ExecutorImage
 	var remoteAgentPoolID string
+	var remoteGitHubRepository string
 	var skipInstallDependencies bool
 	var inheritSettings bool
 	if lws, isLocalWorkspace := s.Workspace().(*LocalWorkspace); isLocalWorkspace {
@@ -1357,6 +1358,7 @@ func (s *Stack) remoteArgs() []string {
 		executorImage = lws.remoteExecutorImage
 		remoteAgentPoolID = lws.remoteAgentPoolID
 		inheritSettings = lws.remoteInheritSettings
+		remoteGitHubRepository = lws.remoteGitHubRepository
 	}
 	if !remote {
 		return nil
@@ -1423,6 +1425,10 @@ func (s *Stack) remoteArgs() []string {
 
 	if remoteAgentPoolID != "" {
 		args = append(args, "--remote-agent-pool-id="+remoteAgentPoolID)
+	}
+
+	if remoteGitHubRepository != "" {
+		args = append(args, "--remote-github-repository="+remoteGitHubRepository)
 	}
 
 	if skipInstallDependencies {

--- a/sdk/go/common/apitype/deployments.go
+++ b/sdk/go/common/apitype/deployments.go
@@ -100,23 +100,14 @@ func (v *DeploymentDuration) UnmarshalYAML(node *yaml.Node) error {
 // CreateDeploymentRequest defines the request payload that is expected when
 // creating a new deployment.
 type CreateDeploymentRequest struct {
+	DeploymentSettings
+
 	// Op
 	Op PulumiOperation `json:"operation"`
 
 	// InheritSettings is a flag that indicates whether the deployment should inherit
 	// deployment settings from the stack.
 	InheritSettings bool `json:"inheritSettings"`
-
-	// Executor defines options that the executor is going to use to run the job.
-	Executor *ExecutorContext `json:"executorContext,omitempty"`
-
-	// Source defines how the source code to the Pulumi program will be gathered.
-	Source *SourceContext `json:"sourceContext,omitempty"`
-
-	// Operation defines the options that the executor will use to run the Pulumi commands.
-	Operation *OperationContext `json:"operationContext,omitempty"`
-
-	AgentPoolID *AgentPoolIDMarshaller `json:"agentPoolID,omitempty"`
 }
 
 type AgentPoolIDMarshaller string
@@ -134,7 +125,7 @@ type DeploymentSettings struct {
 	SourceContext *SourceContext            `json:"sourceContext,omitempty" yaml:"sourceContext,omitempty"`
 	GitHub        *DeploymentSettingsGitHub `json:"gitHub,omitempty" yaml:"gitHub,omitempty"`
 	Operation     *OperationContext         `json:"operationContext,omitempty" yaml:"operationContext,omitempty"`
-	AgentPoolID   *string                   `json:"agentPoolID,omitempty" yaml:"agentPoolID,omitempty"`
+	AgentPoolID   *AgentPoolIDMarshaller    `json:"agentPoolID,omitempty" yaml:"agentPoolID,omitempty"`
 }
 
 type DeploymentSettingsGitHub struct {


### PR DESCRIPTION
Adds the `--remote-github-repository` flag to the experimental remote automation API. This option must not be set with a URL, as _exactly one of_ `--remote-github-repository` or a URL must be provided.

Fixes #16986