### PR TITLE
fix import variable overlap

### DIFF
--- a/changelog/pending/20240819--cli--fix-imports-with-transient-dependencies-on-convert.yaml
+++ b/changelog/pending/20240819--cli--fix-imports-with-transient-dependencies-on-convert.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix imports with transient dependencies on convert

--- a/changelog/pending/20240819--cli-plugin--fix-code-generation-with-aliases-in-golang.yaml
+++ b/changelog/pending/20240819--cli-plugin--fix-code-generation-with-aliases-in-golang.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/plugin
+  description: Fix code generation with aliases in golang

--- a/pkg/cmd/pulumi/convert_aliased_imports/gold/main.go.gold
+++ b/pkg/cmd/pulumi/convert_aliased_imports/gold/main.go.gold
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ecs"
+	awslb "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/lb"
 	awsxecs "github.com/pulumi/pulumi-awsx/sdk/v2/go/awsx/ecs"
 	"github.com/pulumi/pulumi-awsx/sdk/v2/go/awsx/lb"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -13,7 +14,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		lb, err := lb.NewApplicationLoadBalancer(ctx, "lb", nil)
+		loadBalancer, err := lb.NewApplicationLoadBalancer(ctx, "loadBalancer", nil)
 		if err != nil {
 			return err
 		}
@@ -27,7 +28,7 @@ func main() {
 					PortMappings: awsxecs.TaskDefinitionPortMappingArray{
 						&awsxecs.TaskDefinitionPortMappingArgs{
 							ContainerPort: pulumi.Int(80),
-							TargetGroup:   lb.DefaultTargetGroup,
+							TargetGroup:   loadBalancer.DefaultTargetGroup,
 						},
 					},
 				},
@@ -36,7 +37,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		ctx.Export("url", lb.LoadBalancer.ApplyT(func(loadBalancer *lb.LoadBalancer) (string, error) {
+		ctx.Export("url", loadBalancer.LoadBalancer.ApplyT(func(loadBalancer *awslb.LoadBalancer) (string, error) {
 			return loadBalancer.DnsName, nil
 		}).(pulumi.StringOutput))
 		return nil

--- a/pkg/cmd/pulumi/convert_aliased_imports/gold/main.go.gold
+++ b/pkg/cmd/pulumi/convert_aliased_imports/gold/main.go.gold
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ecs"
+	awsxecs "github.com/pulumi/pulumi-awsx/sdk/v2/go/awsx/ecs"
+	"github.com/pulumi/pulumi-awsx/sdk/v2/go/awsx/lb"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		cluster, err := ecs.NewCluster(ctx, "cluster", nil)
+		if err != nil {
+			return err
+		}
+		lb, err := lb.NewApplicationLoadBalancer(ctx, "lb", nil)
+		if err != nil {
+			return err
+		}
+		_, err = awsxecs.NewFargateService(ctx, "nginx", &awsxecs.FargateServiceArgs{
+			Cluster: cluster.Arn,
+			TaskDefinitionArgs: &awsxecs.FargateServiceTaskDefinitionArgs{
+				Container: &awsxecs.TaskDefinitionContainerDefinitionArgs{
+					Image:  pulumi.String("nginx:latest"),
+					Cpu:    pulumi.Int(512),
+					Memory: pulumi.Int(128),
+					PortMappings: awsxecs.TaskDefinitionPortMappingArray{
+						&awsxecs.TaskDefinitionPortMappingArgs{
+							ContainerPort: pulumi.Int(80),
+							TargetGroup:   lb.DefaultTargetGroup,
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			return err
+		}
+		ctx.Export("url", lb.LoadBalancer.ApplyT(func(loadBalancer *lb.LoadBalancer) (string, error) {
+			return loadBalancer.DnsName, nil
+		}).(pulumi.StringOutput))
+		return nil
+	})
+}

--- a/pkg/cmd/pulumi/convert_aliased_imports/main.pp
+++ b/pkg/cmd/pulumi/convert_aliased_imports/main.pp
@@ -1,0 +1,28 @@
+resource cluster "aws:ecs/cluster:Cluster" {
+	__logicalName = "cluster"
+}
+
+resource lb "awsx:lb:ApplicationLoadBalancer" {
+	__logicalName = "lb"
+}
+
+resource nginx "awsx:ecs:FargateService" {
+	__logicalName = "nginx"
+	cluster = cluster.arn
+	taskDefinitionArgs = {
+		container = {
+			image = "nginx:latest",
+			cpu = 512,
+			memory = 128,
+			portMappings = [{
+				containerPort = 80,
+				targetGroup = lb.defaultTargetGroup
+			}]
+		}
+	}
+}
+
+output url {
+	__logicalName = "url"
+	value = lb.loadBalancer.dnsName
+}

--- a/pkg/cmd/pulumi/convert_aliased_imports/main.pp
+++ b/pkg/cmd/pulumi/convert_aliased_imports/main.pp
@@ -2,8 +2,8 @@ resource cluster "aws:ecs/cluster:Cluster" {
 	__logicalName = "cluster"
 }
 
-resource lb "awsx:lb:ApplicationLoadBalancer" {
-	__logicalName = "lb"
+resource loadBalancer "awsx:lb:ApplicationLoadBalancer" {
+	__logicalName = "loadBalancer"
 }
 
 resource nginx "awsx:ecs:FargateService" {
@@ -16,7 +16,7 @@ resource nginx "awsx:ecs:FargateService" {
 			memory = 128,
 			portMappings = [{
 				containerPort = 80,
-				targetGroup = lb.defaultTargetGroup
+				targetGroup = loadBalancer.defaultTargetGroup
 			}]
 		}
 	}
@@ -24,5 +24,5 @@ resource nginx "awsx:ecs:FargateService" {
 
 output url {
 	__logicalName = "url"
-	value = lb.loadBalancer.dnsName
+	value = loadBalancer.loadBalancer.dnsName
 }

--- a/pkg/cmd/pulumi/convert_test.go
+++ b/pkg/cmd/pulumi/convert_test.go
@@ -123,3 +123,37 @@ func TestProjectNameOverrides(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, string(yamlBytes), "name: "+name)
 }
+
+// Tests that test for when args are passed to an imported resource that need
+// to be aliased are called with the appropriate alias, see (pulumi/pulumi#9664)
+func TestAliasedImportsWorkInArgs(t *testing.T) {
+	t.Parallel()
+
+	// Arrange.
+	outDir := t.TempDir()
+	cwd, err := filepath.Abs("convert_aliased_imports")
+	assert.NoError(t, err)
+
+	// Act.
+	err = runConvert(
+		env.Global(),
+		[]string{}, /*args*/
+		cwd,        /*cwd*/
+		[]string{}, /*mappings*/
+		"pcl",      /*from*/
+		"go",       /*language*/
+		outDir,
+		true, /*generateOnly*/
+		true, /*strict*/
+		"",
+	)
+	assert.NoError(t, err)
+
+	// Assert.
+	goBytes, err := os.ReadFile(filepath.Join(outDir, "main.go"))
+	assert.NoError(t, err)
+
+	goldBytes, err := os.ReadFile("convert_aliased_imports/gold/main.go.gold")
+	assert.NoError(t, err)
+	assert.Equal(t, string(goldBytes), string(goBytes))
+}

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -767,7 +767,7 @@ func (g *generator) collectTypeImports(program *pcl.Program, t schema.Type) {
 
 	var tokenRange hcl.Range
 	pkg, mod, name, _ := pcl.DecomposeToken(token, tokenRange)
-	vPath, err := g.packageVersionPath(packageRef)
+	vPath, err := packageVersionPath(packageRef)
 	if err != nil {
 		panic(err)
 	}
@@ -896,7 +896,7 @@ func (g *generator) collectConvertImports(
 	}
 }
 
-func (g *generator) packageVersionPath(packageRef schema.PackageReference) (string, error) {
+func packageVersionPath(packageRef schema.PackageReference) (string, error) {
 	if ver := packageRef.Version(); ver != nil && ver.Major > 1 {
 		return fmt.Sprintf("/v%d", ver.Major), nil
 	}

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -1072,7 +1072,15 @@ func (g *generator) genApply(w io.Writer, expr *model.FunctionCallExpression) {
 	applyArgs, then := pcl.ParseApplyCall(expr)
 	isInput := false
 	retType := g.argumentTypeName(then.Signature.ReturnType, isInput)
-	// TODO account for outputs in other namespaces like aws
+
+	// Add all argument/return types to imports.
+	for _, applyArg := range applyArgs {
+		schemaType, _ := pcl.GetSchemaForType(applyArg.Type())
+		g.collectTypeImports(g.program, schemaType)
+	}
+	retSchemaTy, _ := pcl.GetSchemaForType(then.Type())
+	g.collectTypeImports(g.program, retSchemaTy)
+
 	// TODO[pulumi/pulumi#8453] incomplete pattern code below.
 	var typeAssertion string
 	if retType == "[]string" {

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/docs/component/_index.md
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/docs/component/_index.md
@@ -286,38 +286,38 @@ var componentResource = new Example.Component("componentResource", new()
 
 ```go
 example, err := example.NewComponent(ctx, "componentResource", &example.ComponentArgs{
-A: false,
-C: 0,
-E: "string",
-B: false,
-Bar: &.FooArgs{
-A: false,
-C: 0,
-E: "string",
-B: false,
-D: 0,
-F: "string",
-},
-Baz: [].FooArgs{
-{
-A: false,
-C: 0,
-E: "string",
-B: false,
-D: 0,
-F: "string",
-},
-},
-D: 0,
-F: "string",
-Foo: &.FooArgs{
-A: false,
-C: 0,
-E: "string",
-B: false,
-D: 0,
-F: "string",
-},
+	A: false,
+	C: 0,
+	E: "string",
+	B: false,
+	Bar: &example.FooArgs{
+		A: false,
+		C: 0,
+		E: "string",
+		B: false,
+		D: 0,
+		F: "string",
+	},
+	Baz: []example.FooArgs{
+		{
+			A: false,
+			C: 0,
+			E: "string",
+			B: false,
+			D: 0,
+			F: "string",
+		},
+	},
+	D: 0,
+	F: "string",
+	Foo: &example.FooArgs{
+		A: false,
+		C: 0,
+		E: "string",
+		B: false,
+		D: 0,
+		F: "string",
+	},
 })
 ```
 


### PR DESCRIPTION
- **Add the ability to generate aliased import prefixes to go generator.**
- **Fix imports in generated outputs in go converted code.**
