### PR TITLE
Add comment describing how to install PR binaries

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           name: artifacts-cli-${{ inputs.os }}-${{ inputs.arch }}
           overwrite: true
-          retention-days: 1
+          retention-days: 7
           path: |
             goreleaser/*.tar.gz
             goreleaser/*.zip

--- a/.github/workflows/ci-comment-pr-binaries.yml
+++ b/.github/workflows/ci-comment-pr-binaries.yml
@@ -1,0 +1,89 @@
+name: PR Comment with PR Binaries
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+on:
+  workflow_call:
+    inputs:
+      pr-number:
+        required: true
+        description: "GitHub PR number"
+        type: number
+      note:
+        required: true
+        description: Note to add to comment, must be one of "pre", "post"
+        type: string
+      failure:
+        required: false
+        description: Whether the CI build failed, defaults to false. Set this if note is "post"
+        type: boolean
+        default: false
+    secrets:
+      PULUMI_BOT_TOKEN:
+        required: true
+        description: "GitHub access token, required to mitigate GitHub rate limits"
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+
+jobs:
+  pr-download-message:
+    name: PR download message
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 1
+          sparse-checkout: .github/scripts/
+      - name: Find Comment
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ inputs.pr-number }}
+          body-includes: "# PR Binaries"
+      - name: Set note
+        id: note
+        run: |
+          if [[ "${{ inputs.note }}" == "pre" ]]; then
+            ./.github/scripts/set-output note "⚙️ The binaries for this PR are being built and tested, and may not be available yet."
+            exit 0
+          fi
+
+          if [[ "${{ inputs.note }}" == "post" ]]; then
+            if [[ "${{ inputs.failure }}" == "true" ]]; then
+              ./.github/scripts/set-output note "❌ The binaries for this PR may not be available, as the CI job failed."
+              exit 0
+            else
+              ./.github/scripts/set-output note "✅ The binaries for this PR are now available."
+              exit 0
+            fi
+          fi
+
+          ./.github/scripts/set-output note "❌ Invalid note: ${{ inputs.note }}"
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ inputs.pr-number }}
+          body: |
+            # PR Binaries
+
+            Contributors may install the binaries from this PR by running the following command:
+
+            ```sh
+            curl -fsSL https://get.pulumi.com | sh -s -- --version pr#${{ inputs.pr-number }}
+            ```
+
+            ${{ fromJSON(steps.note.outputs.note) }}
+          edit-mode: replace

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -71,6 +71,19 @@ jobs:
       # defined in filters.
       test-codegen: ${{ steps.changes.outputs.test-codegen }}
 
+  pr-download-message-pre:
+    name: PR Binaries In Progress
+    if: ${{ always() }}
+    uses: ./.github/workflows/ci-comment-pr-binaries.yml
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    with:
+      pr-number: ${{ github.event.pull_request.number }}
+      note: pre
+    secrets: inherit
+
   ci:
     name: CI
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
@@ -107,6 +120,21 @@ jobs:
         }}
       # We'll only upload coverage artifacts with the periodic-coverage cron workflow.
       enable-coverage: false
+    secrets: inherit
+
+  pr-download-message-post:
+    name: PR Binaries Ready
+    needs: [ci]
+    if: ${{ always() }}
+    uses: ./.github/workflows/ci-comment-pr-binaries.yml
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    with:
+      pr-number: ${{ github.event.pull_request.number }}
+      note: post
+      failure: ${{ needs.ci.result != 'success' }}
     secrets: inherit
 
   prepare-release:


### PR DESCRIPTION
As the CI job runs, a comment is added to the PR with the instructions to install the binaries with a note that the build is in progress. Once CI completes, the comment is updated with the instructions to install the binaries.

Fixes #16960 