### PR TITLE
Use events to report downloads as system messages

### DIFF
--- a/changelog/pending/20240820--cli-display-plugin--render-download-progress-as-part-of-system-messages-during-pulumi-operations.yaml
+++ b/changelog/pending/20240820--cli-display-plugin--render-download-progress-as-part-of-system-messages-during-pulumi-operations.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/display,plugin
+  description: Render download and install progress as part of system messages during Pulumi operations

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -103,6 +103,8 @@ func RenderDiffEvent(event engine.Event, seen map[resource.URN]engine.StepEventM
 		return ""
 	case engine.StartDebuggingEvent:
 		return ""
+	case engine.ProgressEvent:
+		return ""
 
 		// Currently, prelude, summary, and stdout events are printed the same for both the diff and
 		// progress displays.

--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -184,6 +184,20 @@ func ConvertEngineEvent(e engine.Event, showSecrets bool) (apitype.EngineEvent, 
 	case engine.PolicyLoadEvent:
 		apiEvent.PolicyLoadEvent = &apitype.PolicyLoadEvent{}
 
+	case engine.ProgressEvent:
+		p, ok := e.Payload().(engine.ProgressEventPayload)
+		if !ok {
+			return apiEvent, eventTypePayloadMismatch
+		}
+		apiEvent.ProgressEvent = &apitype.ProgressEvent{
+			Type:      apitype.ProgressType(p.Type),
+			ID:        p.ID,
+			Message:   p.Message,
+			Completed: p.Completed,
+			Total:     p.Total,
+			Done:      p.Done,
+		}
+
 	default:
 		return apiEvent, fmt.Errorf("unknown event type %q", e.Type)
 	}
@@ -393,6 +407,17 @@ func ConvertJSONEvent(apiEvent apitype.EngineEvent) (engine.Event, error) {
 
 	case apiEvent.PolicyLoadEvent != nil:
 		event = engine.NewEvent(engine.PolicyLoadEventPayload{})
+
+	case apiEvent.ProgressEvent != nil:
+		p := apiEvent.ProgressEvent
+		event = engine.NewEvent(engine.ProgressEventPayload{
+			Type:      engine.ProgressType(p.Type),
+			ID:        p.ID,
+			Message:   p.Message,
+			Completed: p.Completed,
+			Total:     p.Total,
+			Done:      p.Done,
+		})
 
 	default:
 		return event, errors.New("unknown event type")

--- a/pkg/backend/display/json.go
+++ b/pkg/backend/display/json.go
@@ -204,6 +204,9 @@ func ShowPreviewDigest(events <-chan engine.Event, done chan<- bool, opts Option
 			digest.Duration = p.Duration
 			digest.ChangeSummary = p.ResourceChanges
 			digest.MaybeCorrupt = p.MaybeCorrupt
+		case engine.ProgressEvent:
+			// Progress events are ephemeral and should be skipped.
+			continue
 		default:
 			contract.Failf("unknown event type '%s'", e.Type)
 		}

--- a/pkg/backend/display/progress_bar.go
+++ b/pkg/backend/display/progress_bar.go
@@ -1,0 +1,152 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+)
+
+// ProgressBarRenderer is a function that renders a progress bar.
+type ProgressBarRenderer func(width int, completed int64, total int64) string
+
+// Renders a progress event as a string that is at most width characters, using
+// the supplied progress bar renderer to produce the progress bar.
+func renderProgress(
+	renderProgressBar ProgressBarRenderer,
+	width int,
+	payload engine.ProgressEventPayload,
+) string {
+	// Determine the counts to display based on the type of progress event:
+	//
+	// * Plugin download -- bytes downloaded/total
+	// * Plugin install -- bytes unpacked/total
+	var completed, total string
+	switch payload.Type {
+	case engine.PluginDownload, engine.PluginInstall:
+		completed = formatBytes(payload.Completed)
+		total = formatBytes(payload.Total)
+	}
+
+	totalWidth := len(total)
+	sizesWidth := totalWidth*2 + 1
+	messageWidth := colors.MeasureColorizedString(payload.Message)
+
+	if messageWidth+sizesWidth+minimumBarWidth <= width {
+		// Room for the message, the total, and a progress bar.
+		progressBarWidth := width - (messageWidth + sizesWidth + 2)
+		progressBar := renderProgressBar(progressBarWidth, payload.Completed, payload.Total)
+		return fmt.Sprintf("%s %s %*s/%s", payload.Message, progressBar, totalWidth, completed, total)
+	} else if messageWidth+minimumBarWidth <= width {
+		// Room for the message and a progress bar.
+		progressBarWidth := width - (messageWidth + 1)
+		progressBar := renderProgressBar(progressBarWidth, payload.Completed, payload.Total)
+		return fmt.Sprintf("%s %s", payload.Message, progressBar)
+	} else if messageWidth <= width {
+		// Just room for the message.
+		return payload.Message
+	}
+
+	// Not even room for the message; truncate and display as best we can.
+	return colors.TrimColorizedString(payload.Message, width)
+}
+
+const minimumBarWidth = 10
+
+// A progress bar renderer that uses only ASCII characters to produce e.g.
+// `[--->_____]`
+func renderASCIIProgressBar(width int, completed int64, total int64) string {
+	innerWidth := width - 2
+	if completed <= 0 {
+		return "[" + strings.Repeat("_", innerWidth) + "]"
+	} else if completed >= total {
+		return "[" + strings.Repeat("-", innerWidth) + "]"
+	}
+
+	offset := int(completed * int64(innerWidth) / total)
+	var b strings.Builder
+	b.Grow(width)
+	b.WriteRune('[')
+	for i := 0; i < innerWidth; i++ {
+		if i == offset {
+			b.WriteRune('>')
+		} else if i < offset {
+			b.WriteRune('-')
+		} else {
+			b.WriteRune('_')
+		}
+	}
+	b.WriteRune(']')
+	return b.String()
+}
+
+// A progress bar renderer that uses Unicode block characters. These characters
+// are generally well supported in most terminal fonts and used heavily by
+// libraries like Ncurses, etc. See https://en.wikipedia.org/wiki/Block_Elements
+// for more information.
+func renderUnicodeProgressBar(width int, completed int64, total int64) string {
+	innerWidth := width - 2
+	if completed <= 0 {
+		return "[" + strings.Repeat(" ", innerWidth) + "]"
+	} else if completed >= total {
+		return "[" + strings.Repeat("\u2588", innerWidth) + "]"
+	}
+
+	// As well as the "full block" character, there are seven other characters
+	// that partially fill a block. We use these to try and make the bar as smooth
+	// as possible.
+	offset := int(completed * int64(innerWidth) / total)
+	subOffset := int(completed*int64(innerWidth)*8/total) % 8
+	var b strings.Builder
+	b.Grow(width)
+	b.WriteRune('[')
+	for i := 0; i < innerWidth; i++ {
+		if i == offset {
+			if subOffset == 0 {
+				b.WriteRune(' ')
+			} else {
+				b.WriteRune(rune(0x2590 - subOffset))
+			}
+		} else if i < offset {
+			b.WriteRune('\u2588')
+		} else {
+			b.WriteRune(' ')
+		}
+	}
+	b.WriteRune(']')
+	return b.String()
+}
+
+// Formats an integer number of bytes as a human-readable string, using the
+// largest possible unit (up to gibibytes).
+func formatBytes(n int64) string {
+	if n >= GiB {
+		return fmt.Sprintf("%.2f GiB", float64(n)/GiB)
+	} else if n >= MiB {
+		return fmt.Sprintf("%.2f MiB", float64(n)/MiB)
+	} else if n >= KiB {
+		return fmt.Sprintf("%.2f KiB", float64(n)/KiB)
+	}
+	return fmt.Sprintf("%d B", n)
+}
+
+const (
+	KiB = 1024
+	MiB = 1024 * KiB
+	GiB = 1024 * MiB
+)

--- a/pkg/backend/display/progress_bar_test.go
+++ b/pkg/backend/display/progress_bar_test.go
@@ -1,0 +1,260 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProgressBars(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Size formatting", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		cases := []struct {
+			value    int64
+			expected string
+		}{
+			{value: 0, expected: "0 B"},
+			{value: 1, expected: "1 B"},
+			{value: 1023, expected: "1023 B"},
+			{value: 1024, expected: "1.00 KiB"},
+			{value: 1024 * 1024, expected: "1.00 MiB"},
+			{value: 1024 * 1024 * 1024, expected: "1.00 GiB"},
+			{value: 808866, expected: "789.91 KiB"},
+			{value: 164344, expected: "160.49 KiB"},
+			{value: 174193, expected: "170.11 KiB"},
+			{value: 696525823, expected: "664.26 MiB"},
+			{value: 443626481, expected: "423.08 MiB"},
+			{value: 186137911, expected: "177.51 MiB"},
+		}
+		for _, c := range cases {
+			// Act.
+			actual := formatBytes(c.value)
+
+			// Assert.
+			assert.Equalf(t, c.expected, actual, "%d should render as `%s`", c.value, c.expected)
+		}
+	})
+
+	t.Run("Unicode progress bar formatting", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		cases := []struct {
+			completed int64
+			total     int64
+			width     int
+			expected  string
+		}{
+			{completed: 0, total: 100, width: 20, expected: "[                  ]"},
+			{completed: 50, total: 100, width: 20, expected: "[█████████         ]"},
+			{completed: 100, total: 100, width: 20, expected: "[██████████████████]"},
+			{completed: -1, total: 100, width: 20, expected: "[                  ]"},
+			{completed: 101, total: 100, width: 20, expected: "[██████████████████]"},
+			{completed: 40, total: 80, width: 12, expected: "[█████     ]"},
+			{completed: 41, total: 80, width: 12, expected: "[█████▏    ]"},
+			{completed: 42, total: 80, width: 12, expected: "[█████▎    ]"},
+			{completed: 43, total: 80, width: 12, expected: "[█████▍    ]"},
+			{completed: 44, total: 80, width: 12, expected: "[█████▌    ]"},
+			{completed: 45, total: 80, width: 12, expected: "[█████▋    ]"},
+			{completed: 46, total: 80, width: 12, expected: "[█████▊    ]"},
+			{completed: 47, total: 80, width: 12, expected: "[█████▉    ]"},
+			{completed: 48, total: 80, width: 12, expected: "[██████    ]"},
+		}
+
+		for _, c := range cases {
+			// Act.
+			actual := renderUnicodeProgressBar(c.width, c.completed, c.total)
+
+			// Assert.
+			assert.Equalf(t, c.expected, actual, "r: %d, t: %d, w:%d", c.completed, c.total, c.width)
+		}
+	})
+
+	t.Run("ASCII progress bar formatting", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		cases := []struct {
+			completed int64
+			total     int64
+			width     int
+			expected  string
+		}{
+			{completed: 0, total: 100, width: 20, expected: "[__________________]"},
+			{completed: 50, total: 100, width: 20, expected: "[--------->________]"},
+			{completed: 100, total: 100, width: 20, expected: "[------------------]"},
+			{completed: -1, total: 100, width: 20, expected: "[__________________]"},
+			{completed: 101, total: 100, width: 20, expected: "[------------------]"},
+			{completed: 40, total: 80, width: 12, expected: "[----->____]"},
+			{completed: 41, total: 80, width: 12, expected: "[----->____]"},
+			{completed: 42, total: 80, width: 12, expected: "[----->____]"},
+			{completed: 43, total: 80, width: 12, expected: "[----->____]"},
+			{completed: 44, total: 80, width: 12, expected: "[----->____]"},
+			{completed: 45, total: 80, width: 12, expected: "[----->____]"},
+			{completed: 46, total: 80, width: 12, expected: "[----->____]"},
+			{completed: 47, total: 80, width: 12, expected: "[----->____]"},
+			{completed: 48, total: 80, width: 12, expected: "[------>___]"},
+		}
+
+		for _, c := range cases {
+			// Act.
+			actual := renderASCIIProgressBar(c.width, c.completed, c.total)
+
+			// Assert.
+			assert.Equalf(t, c.expected, actual, "r: %d, t: %d, w:%d", c.completed, c.total, c.width)
+		}
+	})
+
+	t.Run("Unicode progress rendering", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		cases := []struct {
+			typ       engine.ProgressType
+			completed int64
+			total     int64
+			message   string
+			width     int
+			expected  string
+		}{
+			// Room for everything.
+			{
+				typ:       engine.PluginDownload,
+				completed: 20,
+				total:     100,
+				message:   "Downloading plugin",
+				width:     40,
+				expected:  "Downloading plugin [█▍     ]  20 B/100 B",
+			},
+			// Not enough room for completed/total sizes.
+			{
+				typ:       engine.PluginDownload,
+				completed: 20,
+				total:     100,
+				message:   "Downloading plugin",
+				width:     30,
+				expected:  "Downloading plugin [█▊       ]",
+			},
+			// Not enough room for the progress bar.
+			{
+				typ:       engine.PluginDownload,
+				completed: 20,
+				total:     100,
+				message:   "Downloading plugin",
+				width:     20,
+				expected:  "Downloading plugin",
+			},
+			// Not enough room for the entire message.
+			{
+				typ:       engine.PluginDownload,
+				completed: 20,
+				total:     100,
+				message:   "Downloading plugin",
+				width:     15,
+				expected:  "Downloading plu",
+			},
+		}
+
+		for _, c := range cases {
+			payload := engine.ProgressEventPayload{
+				Type:      c.typ,
+				Completed: c.completed,
+				Total:     c.total,
+				Message:   c.message,
+				ID:        "id",
+			}
+
+			// Act.
+			actual := renderProgress(renderUnicodeProgressBar, c.width, payload)
+
+			// Assert.
+			assert.Equal(t, c.expected, actual)
+		}
+	})
+
+	t.Run("ASCII progress rendering", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		cases := []struct {
+			typ       engine.ProgressType
+			completed int64
+			total     int64
+			message   string
+			width     int
+			expected  string
+		}{
+			// Room for everything.
+			{
+				typ:       engine.PluginDownload,
+				completed: 20,
+				total:     100,
+				message:   "Downloading plugin",
+				width:     40,
+				expected:  "Downloading plugin [->_____]  20 B/100 B",
+			},
+			// Not enough room for completed/total sizes.
+			{
+				typ:       engine.PluginDownload,
+				completed: 20,
+				total:     100,
+				message:   "Downloading plugin",
+				width:     30,
+				expected:  "Downloading plugin [->_______]",
+			},
+			// Not enough room for the progress bar.
+			{
+				typ:       engine.PluginDownload,
+				completed: 20,
+				total:     100,
+				message:   "Downloading plugin",
+				width:     20,
+				expected:  "Downloading plugin",
+			},
+			// Not enough room for the entire message.
+			{
+				typ:       engine.PluginDownload,
+				completed: 20,
+				total:     100,
+				message:   "Downloading plugin",
+				width:     15,
+				expected:  "Downloading plu",
+			},
+		}
+
+		for _, c := range cases {
+			payload := engine.ProgressEventPayload{
+				Completed: c.completed,
+				Total:     c.total,
+				Message:   c.message,
+				Type:      engine.PluginDownload,
+				ID:        "id",
+			}
+
+			// Act.
+			actual := renderProgress(renderASCIIProgressBar, c.width, payload)
+
+			// Assert.
+			assert.Equal(t, c.expected, actual)
+		}
+	})
+}

--- a/pkg/backend/display/query.go
+++ b/pkg/backend/display/query.go
@@ -99,6 +99,9 @@ func renderQueryEvent(event engine.Event, opts Options) string {
 	case engine.PolicyLoadEvent, engine.PolicyViolationEvent, engine.PolicyRemediationEvent:
 		return ""
 
+	case engine.ProgressEvent:
+		return ""
+
 	default:
 		contract.Failf("unknown event type '%s'", event.Type)
 		return ""

--- a/pkg/backend/display/watch.go
+++ b/pkg/backend/display/watch.go
@@ -85,6 +85,9 @@ func ShowWatchEvents(op string, events <-chan engine.Event, done chan<- bool, op
 				PrintfWithWatchPrefix(time.Now(), p.Metadata.URN.Name(),
 					"failed %s %s\n", p.Metadata.Op, p.Metadata.URN.Type())
 			}
+		case engine.ProgressEvent:
+			// Progress events are ephemeral and should be skipped.
+			continue
 		default:
 			contract.Failf("unknown event type '%s'", e.Type)
 		}

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -303,9 +303,10 @@ func persistEngineEvents(
 		close(done)
 	}()
 
-	// Need to filter the engine events here to exclude any internal events.
+	// We need to filter the engine events here to exclude any internal and
+	// ephemeral events, since these by definition should not be persisted.
 	events = channel.FilterRead(events, func(e engine.Event) bool {
-		return !e.Internal()
+		return !e.Internal() && !e.Ephemeral()
 	})
 
 	var eventBatch []engine.Event

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -240,8 +240,16 @@ func newDeployment(
 			plugctx, deplOpts, actions, target, target.Snapshot, opts.Plan, source,
 			localPolicyPackPaths, ctx.BackendClient)
 	} else {
-		_, defaultProviderInfo, pluginErr := installPlugins(cancelCtx, proj, pwd, main, target, plugctx,
-			false /*returnInstallErrors*/)
+		_, defaultProviderInfo, pluginErr := installPlugins(
+			cancelCtx,
+			proj,
+			pwd,
+			main,
+			target,
+			opts,
+			plugctx,
+			false, /*returnInstallErrors*/
+		)
 		if pluginErr != nil {
 			return nil, pluginErr
 		}

--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -80,7 +80,7 @@ func newDestroySource(
 
 	// Like Update, if we're missing plugins, attempt to download the missing plugins.
 
-	if err := ensurePluginsAreInstalled(ctx, plugctx.Diag, plugins.Deduplicate(),
+	if err := ensurePluginsAreInstalled(ctx, opts, plugctx.Diag, plugins.Deduplicate(),
 		plugctx.Host.GetProjectPlugins()); err != nil {
 		logging.V(7).Infof("newDestroySource(): failed to install missing plugins: %v", err)
 	}

--- a/pkg/engine/progress.go
+++ b/pkg/engine/progress.go
@@ -1,0 +1,106 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"io"
+	"time"
+)
+
+// Creates a new ReadCloser that reports ProgressEvents as bytes are read and
+// when it is closed. A Done ProgressEvent will only be reported once, on the
+// first call to Close(). Subsequent calls to Close() will be forwarded to the
+// underlying ReadCloser, but will not yield duplicate ProgressEvents.
+func NewProgressReportingCloser(
+	events eventEmitter,
+	typ ProgressType,
+	id string,
+	message string,
+	size int64,
+	reportingInterval time.Duration,
+	closer io.ReadCloser,
+) io.ReadCloser {
+	if size == -1 {
+		return closer
+	}
+
+	return &progressReportingCloser{
+		events:            events,
+		typ:               typ,
+		id:                id,
+		message:           message,
+		received:          0,
+		total:             size,
+		lastReported:      time.Now(),
+		reportingInterval: reportingInterval,
+		closed:            false,
+		closer:            closer,
+	}
+}
+
+// A ReadCloser implementation that reports ProgressEvents to an
+// underlying eventEmitter as bytes are read and when it is closed.
+type progressReportingCloser struct {
+	// The eventEmitter to report progress events to.
+	events eventEmitter
+	// The type of progress being reported.
+	typ ProgressType
+	// A unique ID for the download being reported.
+	id string
+	// A message to include in progress events.
+	message string
+	// The number of bytes received so far.
+	received int64
+	// The total number of bytes expected.
+	total int64
+	// The last time a progress event was reported.
+	lastReported time.Time
+	// The interval at which progress events should be reported.
+	reportingInterval time.Duration
+	// True if the underlying ReadCloser has been closed.
+	closed bool
+	// The underlying ReadCloser to read from.
+	closer io.ReadCloser
+}
+
+func (d *progressReportingCloser) Read(p []byte) (n int, err error) {
+	n, err = d.closer.Read(p)
+	if n != 0 {
+		d.received += int64(n)
+
+		now := time.Now()
+		interval := now.Sub(d.lastReported)
+
+		if interval > d.reportingInterval {
+			d.lastReported = now
+			d.events.progressEvent(d.typ, d.id, d.message, d.received, d.total, false)
+		}
+	}
+
+	return
+}
+
+func (d *progressReportingCloser) Close() error {
+	// We'll always forward the Close() call to the underlying ReadCloser, but
+	// we'll only report a Done event once.
+	err := d.closer.Close()
+
+	if !d.closed {
+		d.events.progressEvent(d.typ, d.id, d.message, d.received, d.total, true)
+	}
+
+	d.closed = true
+	return err
+}

--- a/pkg/engine/progress_test.go
+++ b/pkg/engine/progress_test.go
@@ -1,0 +1,81 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProgressReportingCloser(t *testing.T) {
+	t.Parallel()
+
+	// Arrange.
+	events := make(chan Event)
+	done := make(chan bool)
+
+	size := 1024
+	read := 512
+
+	eventEmitter := eventEmitter{ch: events}
+	closer := NewProgressReportingCloser(
+		eventEmitter,
+		PluginDownload,
+		"test-id",
+		"Test message",
+		int64(size),
+		0, /*reportingInterval*/
+		&constantReadCloser{read: read},
+	)
+
+	buf := make([]byte, size)
+
+	var payload ProgressEventPayload
+	f := func() {
+		e := <-events
+		payload = e.Payload().(ProgressEventPayload)
+		done <- true
+	}
+
+	go f()
+
+	// Act.
+	n, err := closer.Read(buf)
+
+	// Assert.
+	<-done
+
+	assert.Equal(t, read, n)
+	assert.NoError(t, err)
+
+	assert.Equal(t, PluginDownload, payload.Type)
+	assert.Equal(t, "test-id", payload.ID)
+	assert.Equal(t, "Test message", payload.Message)
+	assert.Equal(t, int64(read), payload.Completed)
+	assert.Equal(t, int64(size), payload.Total)
+}
+
+type constantReadCloser struct {
+	read int
+}
+
+func (c *constantReadCloser) Read(p []byte) (n int, err error) {
+	return c.read, nil
+}
+
+func (c *constantReadCloser) Close() error {
+	return nil
+}

--- a/pkg/engine/query.go
+++ b/pkg/engine/query.go
@@ -93,8 +93,16 @@ func Query(ctx *Context, q QueryInfo, opts UpdateOptions) error {
 func newQuerySource(cancel context.Context, client deploy.BackendClient, q QueryInfo,
 	opts QueryOptions,
 ) (deploy.QuerySource, error) {
-	allPlugins, defaultProviderVersions, err := installPlugins(cancel, q.GetProject(), opts.pwd, opts.main,
-		nil, opts.plugctx, false /*returnInstallErrors*/)
+	allPlugins, defaultProviderVersions, err := installPlugins(
+		cancel,
+		q.GetProject(),
+		opts.pwd,
+		opts.main,
+		nil, /*target*/
+		nil, /*opts*/
+		opts.plugctx,
+		false, /*returnInstallErrors*/
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -82,7 +82,7 @@ func newRefreshSource(
 	}
 
 	// Like Update, if we're missing plugins, attempt to download the missing plugins.
-	if err := ensurePluginsAreInstalled(ctx, plugctx.Diag, plugins.Deduplicate(),
+	if err := ensurePluginsAreInstalled(ctx, opts, plugctx.Diag, plugins.Deduplicate(),
 		plugctx.Host.GetProjectPlugins()); err != nil {
 		logging.V(7).Infof("newRefreshSource(): failed to install missing plugins: %v", err)
 	}

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -227,15 +227,34 @@ func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (
 
 // RunInstallPlugins calls installPlugins and just returns the error (avoids having to export pluginSet).
 func RunInstallPlugins(
-	proj *workspace.Project, pwd, main string, target *deploy.Target, plugctx *plugin.Context,
+	proj *workspace.Project,
+	pwd string,
+	main string,
+	target *deploy.Target,
+	plugctx *plugin.Context,
 ) error {
-	_, _, err := installPlugins(context.Background(), proj, pwd, main, target, plugctx, true /*returnInstallErrors*/)
+	_, _, err := installPlugins(
+		context.Background(),
+		proj,
+		pwd,
+		main,
+		target,
+		nil, /*opts*/
+		plugctx,
+		true, /*returnInstallErrors*/
+	)
 	return err
 }
 
-func installPlugins(ctx context.Context,
-	proj *workspace.Project, pwd, main string, target *deploy.Target,
-	plugctx *plugin.Context, returnInstallErrors bool,
+func installPlugins(
+	ctx context.Context,
+	proj *workspace.Project,
+	pwd string,
+	main string,
+	target *deploy.Target,
+	opts *deploymentOptions,
+	plugctx *plugin.Context,
+	returnInstallErrors bool,
 ) (pluginSet, map[tokens.Package]workspace.PluginSpec, error) {
 	// Before launching the source, ensure that we have all of the plugins that we need in order to proceed.
 	//
@@ -272,7 +291,7 @@ func installPlugins(ctx context.Context,
 	// Note that this is purely a best-effort thing. If we can't install missing plugins, just proceed; we'll fail later
 	// with an error message indicating exactly what plugins are missing. If `returnInstallErrors` is set, then return
 	// the error.
-	if err := ensurePluginsAreInstalled(ctx, plugctx.Diag, allPlugins.Deduplicate(),
+	if err := ensurePluginsAreInstalled(ctx, opts, plugctx.Diag, allPlugins.Deduplicate(),
 		plugctx.Host.GetProjectPlugins()); err != nil {
 		if returnInstallErrors {
 			return nil, nil, err
@@ -441,8 +460,16 @@ func newUpdateSource(ctx context.Context,
 	// Step 1: Install and load plugins.
 	//
 
-	allPlugins, defaultProviderVersions, err := installPlugins(ctx, proj, pwd, main, target,
-		plugctx, false /*returnInstallErrors*/)
+	allPlugins, defaultProviderVersions, err := installPlugins(
+		ctx,
+		proj,
+		pwd,
+		main,
+		target,
+		opts,
+		plugctx,
+		false, /*returnInstallErrors*/
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/common/apitype/events.go
+++ b/sdk/go/common/apitype/events.go
@@ -205,6 +205,34 @@ type ResOpFailedEvent struct {
 // PolicyLoadEvent is emitted when a policy starts loading
 type PolicyLoadEvent struct{}
 
+// ProgressEvent is emitted when a potentially long-running engine process is in
+// progress.
+type ProgressEvent struct {
+	// The type of process (e.g. plugin download, plugin install).
+	Type ProgressType `json:"type"`
+	// A unique identifier for the process.
+	ID string `json:"id"`
+	// A message accompanying the process.
+	Message string `json:"message"`
+	// The number of items completed so far (e.g. bytes received, items installed,
+	// etc.)
+	Completed int64 `json:"received"`
+	// The total number of items that must be completed.
+	Total int64 `json:"total"`
+	// True if and only if the process has completed.
+	Done bool `json:"done"`
+}
+
+// ProgressType is the type of process occurring.
+type ProgressType string
+
+const (
+	// PluginDownload represents a download of a plugin.
+	PluginDownload ProgressType = "plugin-download"
+	// PluginInstall represents the installation of a plugin.
+	PluginInstall ProgressType = "plugin-install"
+)
+
 // EngineEvent describes a Pulumi engine event, such as a change to a resource or diagnostic
 // message. EngineEvent is a discriminated union of all possible event types, and exactly one
 // field will be non-nil.
@@ -233,6 +261,7 @@ type EngineEvent struct {
 	PolicyRemediationEvent *PolicyRemediationEvent `json:"policyRemediationEvent,omitempty"`
 	PolicyLoadEvent        *PolicyLoadEvent        `json:"policyLoadEvent,omitempty"`
 	StartDebuggingEvent    *StartDebuggingEvent    `json:"startDebuggingEvent,omitempty"`
+	ProgressEvent          *ProgressEvent          `json:"progressEvent,omitempty"`
 }
 
 // EngineEventBatch is a group of engine events.


### PR DESCRIPTION
When running a Pulumi operation such as a preview or an update, Pulumi will detect if plugins (e.g. an AWS provider) are missing and download and install them appropriately. Presently the user experience when this happens isn't great (see e.g. https://github.com/pulumi/pulumi/issues/14250), making it hard for the user to see what is happening/what is taking so long when required plugins are large.

This commit attempts to rectify this by continuing the work in https://github.com/pulumi/pulumi/pull/16094 that tracks download progress using engine events. In doing so, we are able to render multiple downloads as part of the existing "system messages" panel in the Pulumi output, and provide a clean view of what is going on when downloads must occur before program execution. Moreover, we generalise that PR to handle any engine process, enabling us to play a similar trick with plugin installations (which can also take a while).

To preserve existing behaviour, we introduce a new class for these events which we call "ephemeral", meaning that they are not persisted or rendered in contexts such as diffs, for instance. Specifically, ephemeral events are *not* sent to HTTP backends (i.e. the service), so this commit should not require any changes to the service before merging and releasing.

Fixes #14250
Closes #16094
Closes #16937 


https://github.com/user-attachments/assets/f0fac5e9-b3c8-4ea7-9cb7-075fc4b625d9

https://github.com/user-attachments/assets/7a761aa9-10ad-4f66-afa3-e4550b4553a5