### PR TITLE
Fix ld issue on go 1.23

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ builds:
   goamd64: ['v1']
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version=v{{.Env.PULUMI_VERSION}}
+    - "-checklinkname=0" #(pulumi/pulumi#17003) This is required until text dependency is fixed.
   mod_timestamp: '{{ .CommitTimestamp }}'
 - <<: *pulumibin
   id: pulumi-language-go

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ LINT_GOLANG_PKGS := sdk pkg tests sdk/go/pulumi-language-go sdk/nodejs/cmd/pulum
 GOLANGCI_LINT_ARGS ?=
 
 # Additional flags to pass to the go compiler ldflags
+#
+# TODO: revert this once [pgavlin/text#1] is fixed.
 ISSUE_17003_WORKAROUND := "-checklinkname=0"
 
 ifeq ($(DEBUG),"true")

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ LINT_GOLANG_PKGS := sdk pkg tests sdk/go/pulumi-language-go sdk/nodejs/cmd/pulum
 # Additional arguments to pass to golangci-lint.
 GOLANGCI_LINT_ARGS ?=
 
+# Additional flags to pass to the go compiler ldflags
+ISSUE_17003_WORKAROUND := "-checklinkname=0"
+
 ifeq ($(DEBUG),"true")
 $(info    SHELL           = ${SHELL})
 $(info    VERSION         = ${VERSION})
@@ -65,21 +68,21 @@ generate::
 	echo "This command does not do anything anymore. It will be removed in a future version."
 
 build:: build_proto build_display_wasm go.ensure
-	cd pkg && go install -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION}" ${PROJECT}
+	cd pkg && go install -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION} ${ISSUE_17003_WORKAROUND}" ${PROJECT}
 
 build_display_wasm:: go.ensure
-	cd pkg && GOOS=js GOARCH=wasm go build -o ../bin/pulumi-display.wasm -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION}" ./backend/display/wasm
+	cd pkg && GOOS=js GOARCH=wasm go build -o ../bin/pulumi-display.wasm -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION} ${ISSUE_17003_WORKAROUND}" ./backend/display/wasm
 
 install:: .ensure.phony go.ensure
-	cd pkg && GOBIN=$(PULUMI_BIN) go install -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION}" ${PROJECT}
+	cd pkg && GOBIN=$(PULUMI_BIN) go install -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION} ${ISSUE_17003_WORKAROUND}" ${PROJECT}
 
 build_debug::
-	cd pkg && go install -gcflags="all=-N -l" -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION}" ${PROJECT}
+	cd pkg && go install -gcflags="all=-N -l" -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION} ${ISSUE_17003_WORKAROUND}" ${PROJECT}
 
 build_cover::
 	cd pkg && go build -cover -o ../bin/pulumi \
 		-coverpkg github.com/pulumi/pulumi/pkg/v3/...,github.com/pulumi/pulumi/sdk/v3/... \
-		-ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION}" ${PROJECT}
+		-ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION} ${ISSUE_17003_WORKAROUND}" ${PROJECT}
 
 install_cover:: build_cover
 	cp bin/pulumi $(PULUMI_BIN)
@@ -90,7 +93,7 @@ developer_docs::
 install_all:: install
 
 dist:: build
-	cd pkg && go install -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION}" ${PROJECT}
+	cd pkg && go install -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION} ${ISSUE_17003_WORKAROUND}" ${PROJECT}
 
 .PHONY: brew
 # NOTE: the brew target intentionally avoids the dependency on `build`, as each language SDK has its own brew target

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -128,7 +128,7 @@ MINIMUM_SUPPORTED_VERSION_SET = {
 CURRENT_VERSION_SET = {
     "name": "current",
     "dotnet": "8",
-    "go": "1.22.x",
+    "go": "1.23.x",
     "nodejs": "22.x",
     "python": "3.12.x",
 }


### PR DESCRIPTION
As per pgavlin/text#1, a workaround for this so go 1.23 works is this ld
flag -checklintname=0 until they get around to fixing it.
