### PR TITLE
Improve the error message for an invalid method name

### DIFF
--- a/changelog/pending/20240820--programgen--improve-the-error-message-for-an-invalid-method-name.yaml
+++ b/changelog/pending/20240820--programgen--improve-the-error-message-for-an-invalid-method-name.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: programgen
+  description: Improve the error message for an invalid method name

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -1318,7 +1318,9 @@ func bindMethods(path, resourceToken string, methods map[string]string,
 		}
 		idx := strings.LastIndex(function.Token, "/")
 		if idx == -1 || function.Token[:idx] != resourceToken {
-			diags = diags.Append(errorf(methodPath, "invalid function token format %s", token))
+			d := errorf(methodPath, "invalid function token format %s", token)
+			d.Detail = fmt.Sprintf(`expected a token of the shape: "%s/<method name>"`, resourceToken)
+			diags = diags.Append(d)
 			continue
 		}
 		if function.Inputs == nil || function.Inputs.Properties == nil || len(function.Inputs.Properties) == 0 ||


### PR DESCRIPTION
As part of investigating https://github.com/pulumi/pulumi/issues/17025, I got an un-actionable error message when trying to come up with something that would fit with `Call`. This improves the error message.