### PR TITLE
Fix rendering of output events in rendering update diffs

### DIFF
--- a/changelog/pending/20240820--cli-display--improve-rendering-of-update-diffs-in-some-circumstances.yaml
+++ b/changelog/pending/20240820--cli-display--improve-rendering-of-update-diffs-in-some-circumstances.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Improve rendering of update diffs in some circumstances.

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -498,7 +498,6 @@ func CreateDiff(events []engine.Event, displayOpts Options) (string, error) {
 		return "", errors.New("color must be specified")
 	}
 
-	outputEventsDiff := make([]string, 0)
 	remediationEventsDiff := make([]string, 0)
 	for _, e := range events {
 		if e.Type == engine.SummaryEvent {
@@ -510,28 +509,15 @@ func CreateDiff(events []engine.Event, displayOpts Options) (string, error) {
 			continue
 		}
 
-		// Keep track of output and remediation events separately, since we print them after the
-		// ordinary resource diff information.
-		if e.Type == engine.ResourceOutputsEvent {
-			outputEventsDiff = append(outputEventsDiff, msg)
-			continue
-		} else if e.Type == engine.PolicyRemediationEvent {
+		// Keep track of remediation events separately, since we print them after the ordinary resource
+		// diff information.
+		if e.Type == engine.PolicyRemediationEvent {
 			remediationEventsDiff = append(remediationEventsDiff, msg)
 			continue
 		}
 
 		_, err := buff.WriteString(msg)
 		contract.IgnoreError(err)
-	}
-
-	// Print resource outputs next.
-	if len(outputEventsDiff) > 0 {
-		_, err := buff.WriteString("\n")
-		contract.IgnoreError(err)
-		for _, msg := range outputEventsDiff {
-			_, err := buff.WriteString(msg)
-			contract.IgnoreError(err)
-		}
 	}
 
 	// Print policy remediations last.

--- a/pkg/backend/display/testdata/json-yaml/json-text-change.json.create-diff.txt
+++ b/pkg/backend/display/testdata/json-yaml/json-text-change.json.create-diff.txt
@@ -1,0 +1,6 @@
+Configuration:
+~ pulumi:pulumi:Stack: (update)
+    [urn=urn:pulumi:dev::pulumi-stack-output-diff::pulumi:pulumi:Stack::pulumi-stack-output-diff-dev]
+  ~ vehicles: {
+      ~ taxi: "\"{\\\"color\\\":\\\"yellow\\\"}\"" => "\"{\\\"color\\\":    \\\"yellow\\\"   }\""
+    }

--- a/pkg/backend/display/testdata/json-yaml/json.json.create-diff.txt
+++ b/pkg/backend/display/testdata/json-yaml/json.json.create-diff.txt
@@ -1,0 +1,8 @@
+Configuration:
+~ pulumi:pulumi:Stack: (update)
+    [urn=urn:pulumi:dev::pulumi-stack-output-diff::pulumi:pulumi:Stack::pulumi-stack-output-diff-dev]
+  ~ vehicles: {
+      ~ taxi: (json) {
+          ~ color: "yellow" => "red"
+        }
+    }

--- a/pkg/backend/display/testdata/json-yaml/yaml-text-change.json.create-diff.txt
+++ b/pkg/backend/display/testdata/json-yaml/yaml-text-change.json.create-diff.txt
@@ -1,0 +1,6 @@
+Configuration:
+~ pulumi:pulumi:Stack: (update)
+    [urn=urn:pulumi:dev::pulumi-stack-output-diff::pulumi:pulumi:Stack::pulumi-stack-output-diff-dev]
+  ~ vehicles: {
+      ~ taxi: "\"color: yellow\\ntype: car\"" => "\"# a comment\\ncolor: yellow  \\ntype: car\""
+    }

--- a/pkg/backend/display/testdata/json-yaml/yaml.json.create-diff.txt
+++ b/pkg/backend/display/testdata/json-yaml/yaml.json.create-diff.txt
@@ -1,0 +1,8 @@
+Configuration:
+~ pulumi:pulumi:Stack: (update)
+    [urn=urn:pulumi:dev::pulumi-stack-output-diff::pulumi:pulumi:Stack::pulumi-stack-output-diff-dev]
+  ~ vehicles: {
+      ~ taxi: (yaml) {
+          ~ color: "yellow" => "red"
+        }
+    }

--- a/pkg/backend/display/testdata/not-truncated/failed-stacks-dont-rewrite-operations.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/failed-stacks-dont-rewrite-operations.json.create-diff.txt
@@ -1,0 +1,9 @@
+Configuration:
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:dev::test::pulumi:pulumi:Stack::test-dev]
+    ~ pulumi-python:dynamic:Resource: (update)
+        [id=quux2]
+        [urn=urn:pulumi:dev::test::pulumi-python:dynamic:Resource::test-x]
+    --pulumi-python:dynamic:Resource: (delete-replaced)
+        [id=foo]
+        [urn=urn:pulumi:dev::test::pulumi-python:dynamic:Resource::test-r]

--- a/pkg/backend/display/testdata/not-truncated/stack-output-resource-diff.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/stack-output-resource-diff.json.create-diff.txt
@@ -1,0 +1,17 @@
+Configuration:
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:dev::pulumi-stack-output-diff::pulumi:pulumi:Stack::pulumi-stack-output-diff-dev]
+      some:demo:Taxi: (same)
+        [urn=urn:pulumi:dev::pulumi-stack-output-diff::some:demo:Taxi::taxi]
+      some:demo:Vehicles: (same)
+        [urn=urn:pulumi:dev::pulumi-stack-output-diff::some:demo:Vehicles::vehicles]
+
+    --outputs:--
+    vehicles: {
+        taxi: {
+            color: "yellow"
+            size : "big"
+            urn  : "urn:pulumi:dev::pulumi-stack-output-diff::some:demo:Taxi::taxi"
+        }
+        urn : "urn:pulumi:dev::pulumi-stack-output-diff::some:demo:Vehicles::vehicles"
+    }

--- a/pkg/backend/display/testdata/not-truncated/stack-output-resource-diff.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/stack-output-resource-diff.json.create-diff.txt
@@ -1,11 +1,6 @@
 Configuration:
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:dev::pulumi-stack-output-diff::pulumi:pulumi:Stack::pulumi-stack-output-diff-dev]
-      some:demo:Taxi: (same)
-        [urn=urn:pulumi:dev::pulumi-stack-output-diff::some:demo:Taxi::taxi]
-      some:demo:Vehicles: (same)
-        [urn=urn:pulumi:dev::pulumi-stack-output-diff::some:demo:Vehicles::vehicles]
-
     --outputs:--
     vehicles: {
         taxi: {
@@ -15,3 +10,7 @@ Configuration:
         }
         urn : "urn:pulumi:dev::pulumi-stack-output-diff::some:demo:Vehicles::vehicles"
     }
+      some:demo:Taxi: (same)
+        [urn=urn:pulumi:dev::pulumi-stack-output-diff::some:demo:Taxi::taxi]
+      some:demo:Vehicles: (same)
+        [urn=urn:pulumi:dev::pulumi-stack-output-diff::some:demo:Vehicles::vehicles]

--- a/pkg/backend/display/testdata/not-truncated/template-body.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/template-body.json.create-diff.txt
@@ -2,6 +2,47 @@ Configuration:
     aws:region: us-west-2
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:dev::aws-ts-eks::pulumi:pulumi:Stack::aws-ts-eks-dev]
+    --outputs:--
+    kubeconfig: {
+        apiVersion     : "v1"
+        clusters       : [
+            [0]: {
+                cluster: {
+                    certificate-authority-data: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdPREEyTWpjMU5Wb1hEVE15TURRd05UQTJNamMxTlZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT2M5Ck9FSTNSLzltTnpWZy9nS284V3dmb3R6dHk5T2F5Y2hadkpXVStjWUJLVzVrUS9jc0lIVWk0M3pGWk52VjdRd2sKSkR5elFwZXI3R29CM3ZrSUlXNlpzZjdIRUVIU2h0QUxvRHJrOTlwU1ltcDJvNEhzMkx2aC9WSHkwZG4zRE9IcwpwSFkxWU9mSmUyK25UcUJ2NHhseTVDWjEzUTV3MGRVMUY1bm56b1RsS1ppTkdmYWhHNEN2QStsS3FPWFZ3dHZiCkcxRmJkVThBQXRDUnZPSmg5eTN6eDN1b0pPWVc0QkU0VDNsM0dpTlk4TVl3eGVRd3JvU0hseE1GbGJQUmQ2YXMKOUEyczNxK1RJZ2VKZzBxNFIrK3Z1QVlBcG5DRzFIbEpieU9kT3d3aldlUHZIVDhMZTJXN283NEFsNSt6bEFXdQptVm9VbE82WUlxc1h3YUl3QUY4Q0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZFV2xRdERXbllFVEs2M0xBd2JSRUQ2TTJtM0ZNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFDVjFFOUVucWhUbkNQZVZEQmxXMURXMTBwdzdVMG9sdk5TWjA0cU9RRVkwNE5oZ29tTgprWC9GeDhQenBnT1h4SWlOYlBZYTdIYVVNZ0RPMHJ1bVNPQjc5ZThtbjNIZ055dlEyM3NOUkpsMnlaUUVDKzBXCllJcXhSM2pwMkV1MG40YkxDQzRyM2UweFRITldwbGd6Z1FkcUpNLzg0NmUxRTR0alV5Ry92V09VV3RGSzRjemoKTS85SXJZWnJRVFRVL1pISDVtMmtFYjRUcmYwZ1hyL2E3UmJWUG91Uzk2dmJpdjdoSE12YVptclpzeTN3bDBYYQpFUDdwMERHdWxCdnh1K3BjUkxVdkZMZUdLODFLY3JRZmpFU2ZqSldSWVYwTERGWnQ4YnlMT0J6V2MvU0Ywd0ZoCkt4ekFLWXkvZHhTNksySCtqeFY1amF2cXNTR1dzSGZ6Q0Q2MQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+                    server                    : "https://8AE853AAF6BD7DFED415A3D30AD938E2.gr7.us-west-2.eks.amazonaws.com"
+                }
+                name   : "kubernetes"
+            }
+        ]
+        contexts       : [
+            [0]: {
+                context: {
+                    cluster: "kubernetes"
+                    user   : "aws"
+                }
+                name   : "aws"
+            }
+        ]
+        current-context: "aws"
+        kind           : "Config"
+        users          : [
+            [0]: {
+                name: "aws"
+                user: {
+                    exec: {
+                        apiVersion: "client.authentication.k8s.io/v1alpha1"
+                        args      : [
+                            [0]: "eks"
+                            [1]: "get-token"
+                            [2]: "--cluster-name"
+                            [3]: "cluster-eksCluster-932639f"
+                        ]
+                        command   : "aws"
+                    }
+                }
+            }
+        ]
+    }
       awsx:x:ec2:Vpc: (same)
         [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc::vpc]
       eks:index:Cluster: (same)
@@ -226,48 +267,6 @@ Configuration:
           pulumi:providers:kubernetes: (same)
             [id=e99e4ebc-d3ed-445c-80f8-e7be504678d4]
             [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$pulumi:providers:kubernetes::cluster-provider]
-
-    --outputs:--
-    kubeconfig: {
-        apiVersion     : "v1"
-        clusters       : [
-            [0]: {
-                cluster: {
-                    certificate-authority-data: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdPREEyTWpjMU5Wb1hEVE15TURRd05UQTJNamMxTlZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT2M5Ck9FSTNSLzltTnpWZy9nS284V3dmb3R6dHk5T2F5Y2hadkpXVStjWUJLVzVrUS9jc0lIVWk0M3pGWk52VjdRd2sKSkR5elFwZXI3R29CM3ZrSUlXNlpzZjdIRUVIU2h0QUxvRHJrOTlwU1ltcDJvNEhzMkx2aC9WSHkwZG4zRE9IcwpwSFkxWU9mSmUyK25UcUJ2NHhseTVDWjEzUTV3MGRVMUY1bm56b1RsS1ppTkdmYWhHNEN2QStsS3FPWFZ3dHZiCkcxRmJkVThBQXRDUnZPSmg5eTN6eDN1b0pPWVc0QkU0VDNsM0dpTlk4TVl3eGVRd3JvU0hseE1GbGJQUmQ2YXMKOUEyczNxK1RJZ2VKZzBxNFIrK3Z1QVlBcG5DRzFIbEpieU9kT3d3aldlUHZIVDhMZTJXN283NEFsNSt6bEFXdQptVm9VbE82WUlxc1h3YUl3QUY4Q0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZFV2xRdERXbllFVEs2M0xBd2JSRUQ2TTJtM0ZNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFDVjFFOUVucWhUbkNQZVZEQmxXMURXMTBwdzdVMG9sdk5TWjA0cU9RRVkwNE5oZ29tTgprWC9GeDhQenBnT1h4SWlOYlBZYTdIYVVNZ0RPMHJ1bVNPQjc5ZThtbjNIZ055dlEyM3NOUkpsMnlaUUVDKzBXCllJcXhSM2pwMkV1MG40YkxDQzRyM2UweFRITldwbGd6Z1FkcUpNLzg0NmUxRTR0alV5Ry92V09VV3RGSzRjemoKTS85SXJZWnJRVFRVL1pISDVtMmtFYjRUcmYwZ1hyL2E3UmJWUG91Uzk2dmJpdjdoSE12YVptclpzeTN3bDBYYQpFUDdwMERHdWxCdnh1K3BjUkxVdkZMZUdLODFLY3JRZmpFU2ZqSldSWVYwTERGWnQ4YnlMT0J6V2MvU0Ywd0ZoCkt4ekFLWXkvZHhTNksySCtqeFY1amF2cXNTR1dzSGZ6Q0Q2MQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
-                    server                    : "https://8AE853AAF6BD7DFED415A3D30AD938E2.gr7.us-west-2.eks.amazonaws.com"
-                }
-                name   : "kubernetes"
-            }
-        ]
-        contexts       : [
-            [0]: {
-                context: {
-                    cluster: "kubernetes"
-                    user   : "aws"
-                }
-                name   : "aws"
-            }
-        ]
-        current-context: "aws"
-        kind           : "Config"
-        users          : [
-            [0]: {
-                name: "aws"
-                user: {
-                    exec: {
-                        apiVersion: "client.authentication.k8s.io/v1alpha1"
-                        args      : [
-                            [0]: "eks"
-                            [1]: "get-token"
-                            [2]: "--cluster-name"
-                            [3]: "cluster-eksCluster-932639f"
-                        ]
-                        command   : "aws"
-                    }
-                }
-            }
-        ]
-    }
     --outputs:--
     kubeconfig: {
         apiVersion     : "v1"

--- a/pkg/backend/display/testdata/not-truncated/template-body.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/template-body.json.create-diff.txt
@@ -1,0 +1,311 @@
+Configuration:
+    aws:region: us-west-2
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:dev::aws-ts-eks::pulumi:pulumi:Stack::aws-ts-eks-dev]
+      awsx:x:ec2:Vpc: (same)
+        [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc::vpc]
+      eks:index:Cluster: (same)
+        [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster::cluster]
+          eks:index:ServiceRole: (same)
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$eks:index:ServiceRole::cluster-instanceRole]
+          eks:index:ServiceRole: (same)
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$eks:index:ServiceRole::cluster-eksRole]
+          awsx:x:ec2:NatGateway: (same)
+            [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:NatGateway::vpc-0]
+          awsx:x:ec2:Subnet: (same)
+            [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet::vpc-public-0]
+          awsx:x:ec2:Subnet: (same)
+            [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet::vpc-private-0]
+          awsx:x:ec2:InternetGateway: (same)
+            [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:InternetGateway::vpc]
+          awsx:x:ec2:Subnet: (same)
+            [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet::vpc-private-1]
+          awsx:x:ec2:Subnet: (same)
+            [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet::vpc-public-1]
+          awsx:x:ec2:NatGateway: (same)
+            [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:NatGateway::vpc-1]
+              aws:iam/role:Role: (same)
+                [id=cluster-eksRole-role-262a7fa]
+                [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$eks:index:ServiceRole$aws:iam/role:Role::cluster-eksRole-role]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:iam/role:Role: (same)
+                [id=cluster-instanceRole-role-f970009]
+                [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$eks:index:ServiceRole$aws:iam/role:Role::cluster-instanceRole-role]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+          eks:index:RandomSuffix: (same)
+            [id=cluster-cfnStackName]
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$eks:index:RandomSuffix::cluster-cfnStackName]
+          aws:ec2/vpc:Vpc: (same)
+            [id=vpc-07f4302f6e57a447a]
+            [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$aws:ec2/vpc:Vpc::vpc]
+            [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/eip:Eip: (same)
+                [id=eipalloc-097ef3ce06d0ff56e]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:NatGateway$aws:ec2/eip:Eip::vpc-0]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/eip:Eip: (same)
+                [id=eipalloc-0b436f419d8000df5]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:NatGateway$aws:ec2/eip:Eip::vpc-1]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/routeTable:RouteTable: (same)
+                [id=rtb-042c28a7a86d02b26]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet$aws:ec2/routeTable:RouteTable::vpc-public-0]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/routeTable:RouteTable: (same)
+                [id=rtb-0e7a3faa0b87573ed]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet$aws:ec2/routeTable:RouteTable::vpc-private-1]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/internetGateway:InternetGateway: (same)
+                [id=igw-01656d8cc8ff48960]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:InternetGateway$aws:ec2/internetGateway:InternetGateway::vpc]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+          aws:ec2/securityGroup:SecurityGroup: (same)
+            [id=sg-05607b7d551164ea7]
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$aws:ec2/securityGroup:SecurityGroup::cluster-eksClusterSecurityGroup]
+            [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/subnet:Subnet: (same)
+                [id=subnet-0028b879bc4eabc11]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet$aws:ec2/subnet:Subnet::vpc-private-1]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/routeTable:RouteTable: (same)
+                [id=rtb-049b808a147c29711]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet$aws:ec2/routeTable:RouteTable::vpc-public-1]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/subnet:Subnet: (same)
+                [id=subnet-0065b9ab25cb0ab6b]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet$aws:ec2/subnet:Subnet::vpc-public-0]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/routeTable:RouteTable: (same)
+                [id=rtb-06ffd3cc9cd4f6b40]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet$aws:ec2/routeTable:RouteTable::vpc-private-0]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/subnet:Subnet: (same)
+                [id=subnet-0760f3666d46304ce]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet$aws:ec2/subnet:Subnet::vpc-private-0]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/subnet:Subnet: (same)
+                [id=subnet-0e7f681a099ea15a1]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet$aws:ec2/subnet:Subnet::vpc-public-1]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+                [id=cluster-eksRole-role-262a7fa-20220408062128998200000004]
+                [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$eks:index:ServiceRole$aws:iam/rolePolicyAttachment:RolePolicyAttachment::cluster-eksRole-4b490823]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+                [id=cluster-eksRole-role-262a7fa-20220408062129023100000005]
+                [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$eks:index:ServiceRole$aws:iam/rolePolicyAttachment:RolePolicyAttachment::cluster-eksRole-90eb1c99]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+                [id=cluster-instanceRole-role-f970009-20220408062123584400000001]
+                [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$eks:index:ServiceRole$aws:iam/rolePolicyAttachment:RolePolicyAttachment::cluster-instanceRole-e1b295bd]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+                [id=cluster-instanceRole-role-f970009-20220408062123733700000002]
+                [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$eks:index:ServiceRole$aws:iam/rolePolicyAttachment:RolePolicyAttachment::cluster-instanceRole-3eb088f2]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+                [id=cluster-instanceRole-role-f970009-20220408062123800200000003]
+                [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$eks:index:ServiceRole$aws:iam/rolePolicyAttachment:RolePolicyAttachment::cluster-instanceRole-03516f97]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/route:Route: (same)
+                [id=r-rtb-042c28a7a86d02b261080289494]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet$aws:ec2/route:Route::vpc-public-0-ig]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+          aws:ec2/securityGroupRule:SecurityGroupRule: (same)
+            [id=sgrule-2860589334]
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$aws:ec2/securityGroupRule:SecurityGroupRule::cluster-eksClusterInternetEgressRule]
+            [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/routeTableAssociation:RouteTableAssociation: (same)
+                [id=rtbassoc-0b253c6381a71b2e4]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet$aws:ec2/routeTableAssociation:RouteTableAssociation::vpc-private-1]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/route:Route: (same)
+                [id=r-rtb-049b808a147c297111080289494]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet$aws:ec2/route:Route::vpc-public-1-ig]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/routeTableAssociation:RouteTableAssociation: (same)
+                [id=rtbassoc-00aa815ae88b3517f]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet$aws:ec2/routeTableAssociation:RouteTableAssociation::vpc-public-0]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/routeTableAssociation:RouteTableAssociation: (same)
+                [id=rtbassoc-008fbbbb67a0cbfaa]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet$aws:ec2/routeTableAssociation:RouteTableAssociation::vpc-private-0]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/routeTableAssociation:RouteTableAssociation: (same)
+                [id=rtbassoc-0ca900348ffc531e8]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet$aws:ec2/routeTableAssociation:RouteTableAssociation::vpc-public-1]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+          aws:iam/instanceProfile:InstanceProfile: (same)
+            [id=cluster-instanceProfile-f6fe53d]
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$aws:iam/instanceProfile:InstanceProfile::cluster-instanceProfile]
+            [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/natGateway:NatGateway: (same)
+                [id=nat-0a90adc6801962207]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:NatGateway$aws:ec2/natGateway:NatGateway::vpc-0]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/natGateway:NatGateway: (same)
+                [id=nat-0eed359c3b8cede53]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:NatGateway$aws:ec2/natGateway:NatGateway::vpc-1]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+          aws:eks/cluster:Cluster: (same)
+            [id=cluster-eksCluster-932639f]
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$aws:eks/cluster:Cluster::cluster-eksCluster]
+            [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/route:Route: (same)
+                [id=r-rtb-06ffd3cc9cd4f6b401080289494]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet$aws:ec2/route:Route::vpc-private-0-nat-0]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+              aws:ec2/route:Route: (same)
+                [id=r-rtb-0e7a3faa0b87573ed1080289494]
+                [urn=urn:pulumi:dev::aws-ts-eks::awsx:x:ec2:Vpc$awsx:x:ec2:Subnet$aws:ec2/route:Route::vpc-private-1-nat-1]
+                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+          eks:index:VpcCni: (same)
+            [id=1d530726ede55308]
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$eks:index:VpcCni::cluster-vpc-cni]
+          aws:ec2/securityGroup:SecurityGroup: (same)
+            [id=sg-0377eac317c3aef31]
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$aws:ec2/securityGroup:SecurityGroup::cluster-nodeSecurityGroup]
+            [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+          pulumi:providers:kubernetes: (same)
+            [id=fac1319d-5ae2-4480-96a2-f702fb3e2c92]
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$pulumi:providers:kubernetes::cluster-eks-k8s]
+          aws:ec2/securityGroupRule:SecurityGroupRule: (same)
+            [id=sgrule-607663483]
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$aws:ec2/securityGroupRule:SecurityGroupRule::cluster-eksExtApiServerClusterIngressRule]
+            [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+          aws:ec2/securityGroupRule:SecurityGroupRule: (same)
+            [id=sgrule-314771918]
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$aws:ec2/securityGroupRule:SecurityGroupRule::cluster-eksClusterIngressRule]
+            [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+          aws:ec2/securityGroupRule:SecurityGroupRule: (same)
+            [id=sgrule-1434770101]
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$aws:ec2/securityGroupRule:SecurityGroupRule::cluster-eksNodeInternetEgressRule]
+            [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+          aws:ec2/securityGroupRule:SecurityGroupRule: (same)
+            [id=sgrule-1912528542]
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$aws:ec2/securityGroupRule:SecurityGroupRule::cluster-eksNodeIngressRule]
+            [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+          aws:ec2/securityGroupRule:SecurityGroupRule: (same)
+            [id=sgrule-288662049]
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$aws:ec2/securityGroupRule:SecurityGroupRule::cluster-eksNodeClusterIngressRule]
+            [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+          kubernetes:core/v1:ConfigMap: (same)
+            [id=kube-system/aws-auth]
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$kubernetes:core/v1:ConfigMap::cluster-nodeAccess]
+            [provider=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$pulumi:providers:kubernetes::cluster-eks-k8s::fac1319d-5ae2-4480-96a2-f702fb3e2c92]
+          aws:ec2/launchConfiguration:LaunchConfiguration: (same)
+            [id=cluster-nodeLaunchConfiguration-1013b9d]
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$aws:ec2/launchConfiguration:LaunchConfiguration::cluster-nodeLaunchConfiguration]
+            [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+        ~ aws:cloudformation/stack:Stack: (update)
+            [id=arn:aws:cloudformation:us-west-2:616138583583:stack/cluster-9085c3f2/838936d0-b705-11ec-b5c6-0a71999bcd3f]
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$aws:cloudformation/stack:Stack::cluster-nodes]
+            [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+          ~ templateBody: 
+                ...
+                                          LaunchConfigurationName: cluster-nodeLaunchConfiguration-1013b9d
+                                          MinSize: 1
+              -                           MaxSize: 2
+              +                           MaxSize: 3
+                                          VPCZoneIdentifier: ["subnet-0065b9ab25cb0ab6b","subnet-0e7f681a099ea15a1"]
+                                          Tags:
+                ...
+        ~ aws:cloudformation/stack:Stack: (update)
+            [id=arn:aws:cloudformation:us-west-2:616138583583:stack/cluster-9085c3f2/838936d0-b705-11ec-b5c6-0a71999bcd3f]
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$aws:cloudformation/stack:Stack::cluster-nodes]
+            [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
+          ~ templateBody: 
+                ...
+                                          LaunchConfigurationName: cluster-nodeLaunchConfiguration-1013b9d
+                                          MinSize: 1
+              -                           MaxSize: 2
+              +                           MaxSize: 3
+                                          VPCZoneIdentifier: ["subnet-0065b9ab25cb0ab6b","subnet-0e7f681a099ea15a1"]
+                                          Tags:
+                ...
+          pulumi:providers:kubernetes: (same)
+            [id=e99e4ebc-d3ed-445c-80f8-e7be504678d4]
+            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$pulumi:providers:kubernetes::cluster-provider]
+
+    --outputs:--
+    kubeconfig: {
+        apiVersion     : "v1"
+        clusters       : [
+            [0]: {
+                cluster: {
+                    certificate-authority-data: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdPREEyTWpjMU5Wb1hEVE15TURRd05UQTJNamMxTlZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT2M5Ck9FSTNSLzltTnpWZy9nS284V3dmb3R6dHk5T2F5Y2hadkpXVStjWUJLVzVrUS9jc0lIVWk0M3pGWk52VjdRd2sKSkR5elFwZXI3R29CM3ZrSUlXNlpzZjdIRUVIU2h0QUxvRHJrOTlwU1ltcDJvNEhzMkx2aC9WSHkwZG4zRE9IcwpwSFkxWU9mSmUyK25UcUJ2NHhseTVDWjEzUTV3MGRVMUY1bm56b1RsS1ppTkdmYWhHNEN2QStsS3FPWFZ3dHZiCkcxRmJkVThBQXRDUnZPSmg5eTN6eDN1b0pPWVc0QkU0VDNsM0dpTlk4TVl3eGVRd3JvU0hseE1GbGJQUmQ2YXMKOUEyczNxK1RJZ2VKZzBxNFIrK3Z1QVlBcG5DRzFIbEpieU9kT3d3aldlUHZIVDhMZTJXN283NEFsNSt6bEFXdQptVm9VbE82WUlxc1h3YUl3QUY4Q0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZFV2xRdERXbllFVEs2M0xBd2JSRUQ2TTJtM0ZNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFDVjFFOUVucWhUbkNQZVZEQmxXMURXMTBwdzdVMG9sdk5TWjA0cU9RRVkwNE5oZ29tTgprWC9GeDhQenBnT1h4SWlOYlBZYTdIYVVNZ0RPMHJ1bVNPQjc5ZThtbjNIZ055dlEyM3NOUkpsMnlaUUVDKzBXCllJcXhSM2pwMkV1MG40YkxDQzRyM2UweFRITldwbGd6Z1FkcUpNLzg0NmUxRTR0alV5Ry92V09VV3RGSzRjemoKTS85SXJZWnJRVFRVL1pISDVtMmtFYjRUcmYwZ1hyL2E3UmJWUG91Uzk2dmJpdjdoSE12YVptclpzeTN3bDBYYQpFUDdwMERHdWxCdnh1K3BjUkxVdkZMZUdLODFLY3JRZmpFU2ZqSldSWVYwTERGWnQ4YnlMT0J6V2MvU0Ywd0ZoCkt4ekFLWXkvZHhTNksySCtqeFY1amF2cXNTR1dzSGZ6Q0Q2MQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+                    server                    : "https://8AE853AAF6BD7DFED415A3D30AD938E2.gr7.us-west-2.eks.amazonaws.com"
+                }
+                name   : "kubernetes"
+            }
+        ]
+        contexts       : [
+            [0]: {
+                context: {
+                    cluster: "kubernetes"
+                    user   : "aws"
+                }
+                name   : "aws"
+            }
+        ]
+        current-context: "aws"
+        kind           : "Config"
+        users          : [
+            [0]: {
+                name: "aws"
+                user: {
+                    exec: {
+                        apiVersion: "client.authentication.k8s.io/v1alpha1"
+                        args      : [
+                            [0]: "eks"
+                            [1]: "get-token"
+                            [2]: "--cluster-name"
+                            [3]: "cluster-eksCluster-932639f"
+                        ]
+                        command   : "aws"
+                    }
+                }
+            }
+        ]
+    }
+    --outputs:--
+    kubeconfig: {
+        apiVersion     : "v1"
+        clusters       : [
+            [0]: {
+                cluster: {
+                    certificate-authority-data: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdPREEyTWpjMU5Wb1hEVE15TURRd05UQTJNamMxTlZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT2M5Ck9FSTNSLzltTnpWZy9nS284V3dmb3R6dHk5T2F5Y2hadkpXVStjWUJLVzVrUS9jc0lIVWk0M3pGWk52VjdRd2sKSkR5elFwZXI3R29CM3ZrSUlXNlpzZjdIRUVIU2h0QUxvRHJrOTlwU1ltcDJvNEhzMkx2aC9WSHkwZG4zRE9IcwpwSFkxWU9mSmUyK25UcUJ2NHhseTVDWjEzUTV3MGRVMUY1bm56b1RsS1ppTkdmYWhHNEN2QStsS3FPWFZ3dHZiCkcxRmJkVThBQXRDUnZPSmg5eTN6eDN1b0pPWVc0QkU0VDNsM0dpTlk4TVl3eGVRd3JvU0hseE1GbGJQUmQ2YXMKOUEyczNxK1RJZ2VKZzBxNFIrK3Z1QVlBcG5DRzFIbEpieU9kT3d3aldlUHZIVDhMZTJXN283NEFsNSt6bEFXdQptVm9VbE82WUlxc1h3YUl3QUY4Q0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZFV2xRdERXbllFVEs2M0xBd2JSRUQ2TTJtM0ZNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFDVjFFOUVucWhUbkNQZVZEQmxXMURXMTBwdzdVMG9sdk5TWjA0cU9RRVkwNE5oZ29tTgprWC9GeDhQenBnT1h4SWlOYlBZYTdIYVVNZ0RPMHJ1bVNPQjc5ZThtbjNIZ055dlEyM3NOUkpsMnlaUUVDKzBXCllJcXhSM2pwMkV1MG40YkxDQzRyM2UweFRITldwbGd6Z1FkcUpNLzg0NmUxRTR0alV5Ry92V09VV3RGSzRjemoKTS85SXJZWnJRVFRVL1pISDVtMmtFYjRUcmYwZ1hyL2E3UmJWUG91Uzk2dmJpdjdoSE12YVptclpzeTN3bDBYYQpFUDdwMERHdWxCdnh1K3BjUkxVdkZMZUdLODFLY3JRZmpFU2ZqSldSWVYwTERGWnQ4YnlMT0J6V2MvU0Ywd0ZoCkt4ekFLWXkvZHhTNksySCtqeFY1amF2cXNTR1dzSGZ6Q0Q2MQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+                    server                    : "https://8AE853AAF6BD7DFED415A3D30AD938E2.gr7.us-west-2.eks.amazonaws.com"
+                }
+                name   : "kubernetes"
+            }
+        ]
+        contexts       : [
+            [0]: {
+                context: {
+                    cluster: "kubernetes"
+                    user   : "aws"
+                }
+                name   : "aws"
+            }
+        ]
+        current-context: "aws"
+        kind           : "Config"
+        users          : [
+            [0]: {
+                name: "aws"
+                user: {
+                    exec: {
+                        apiVersion: "client.authentication.k8s.io/v1alpha1"
+                        args      : [
+                            [0]: "eks"
+                            [1]: "get-token"
+                            [2]: "--cluster-name"
+                            [3]: "cluster-eksCluster-932639f"
+                        ]
+                        command   : "aws"
+                    }
+                }
+            }
+        ]
+    }

--- a/pkg/backend/display/testdata/not-truncated/up-2.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-2.json.create-diff.txt
@@ -6,23 +6,6 @@ Configuration:
         [id=eks-role-24b1266]
         [urn=urn:pulumi:dev::eks::aws:iam/role:Role::eks-role]
         [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
-        [id=eks-role-24b1266-20220209231452499500000001]
-        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-service-policy]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
-        [id=eks-role-24b1266-20220209231452597100000002]
-        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-cluster-policy]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-      aws:ec2/securityGroup:SecurityGroup: (same)
-        [id=sg-0e760e824fba2d002]
-        [urn=urn:pulumi:dev::eks::aws:ec2/securityGroup:SecurityGroup::eks-sg]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-      aws:eks/cluster:Cluster: (same)
-        [id=eks-cluster-fb2cd6e]
-        [urn=urn:pulumi:dev::eks::aws:eks/cluster:Cluster::eks-cluster]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-
         --outputs:--
         arn                : "arn:aws:iam::616138583583:role/eks-role-24b1266"
         assumeRolePolicy   : (json) {
@@ -52,10 +35,22 @@ Configuration:
             [1]: "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
         ]
         uniqueId           : "AROAY65FYVYPWXZQUXMBX"
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-24b1266-20220209231452499500000001]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-service-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
         --outputs:--
         id       : "eks-role-24b1266-20220209231452499500000001"
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-24b1266-20220209231452597100000002]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-cluster-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
         --outputs:--
         id       : "eks-role-24b1266-20220209231452597100000002"
+      aws:ec2/securityGroup:SecurityGroup: (same)
+        [id=sg-0e760e824fba2d002]
+        [urn=urn:pulumi:dev::eks::aws:ec2/securityGroup:SecurityGroup::eks-sg]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
         --outputs:--
         arn                : "arn:aws:ec2:us-west-2:616138583583:security-group/sg-0e760e824fba2d002"
         egress             : [
@@ -90,6 +85,10 @@ Configuration:
             }
         ]
         ownerId            : "616138583583"
+      aws:eks/cluster:Cluster: (same)
+        [id=eks-cluster-fb2cd6e]
+        [urn=urn:pulumi:dev::eks::aws:eks/cluster:Cluster::eks-cluster]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
         --outputs:--
         arn                    : "arn:aws:eks:us-west-2:616138583583:cluster/eks-cluster-fb2cd6e"
         certificateAuthority   : {

--- a/pkg/backend/display/testdata/not-truncated/up-2.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-2.json.create-diff.txt
@@ -1,0 +1,134 @@
+Configuration:
+    aws:region: us-west-2
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:dev::eks::pulumi:pulumi:Stack::eks-dev]
+      aws:iam/role:Role: (same)
+        [id=eks-role-24b1266]
+        [urn=urn:pulumi:dev::eks::aws:iam/role:Role::eks-role]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-24b1266-20220209231452499500000001]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-service-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-24b1266-20220209231452597100000002]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-cluster-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+      aws:ec2/securityGroup:SecurityGroup: (same)
+        [id=sg-0e760e824fba2d002]
+        [urn=urn:pulumi:dev::eks::aws:ec2/securityGroup:SecurityGroup::eks-sg]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+      aws:eks/cluster:Cluster: (same)
+        [id=eks-cluster-fb2cd6e]
+        [urn=urn:pulumi:dev::eks::aws:eks/cluster:Cluster::eks-cluster]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+
+        --outputs:--
+        arn                : "arn:aws:iam::616138583583:role/eks-role-24b1266"
+        assumeRolePolicy   : (json) {
+            Statement: [
+                [0]: {
+                    Action   : "sts:AssumeRole"
+                    Effect   : "Allow"
+                    Principal: {
+                        Service: "eks.amazonaws.com"
+                    }
+                    Sid      : ""
+                }
+            ]
+            Version  : "2008-10-17"
+        }
+
+        createDate         : "2022-02-09T23:14:50Z"
+        id                 : "eks-role-24b1266"
+        inlinePolicies     : [
+            [0]: {
+                name  : ""
+                policy: ""
+            }
+        ]
+        managedPolicyArns  : [
+            [0]: "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+            [1]: "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+        ]
+        uniqueId           : "AROAY65FYVYPWXZQUXMBX"
+        --outputs:--
+        id       : "eks-role-24b1266-20220209231452499500000001"
+        --outputs:--
+        id       : "eks-role-24b1266-20220209231452597100000002"
+        --outputs:--
+        arn                : "arn:aws:ec2:us-west-2:616138583583:security-group/sg-0e760e824fba2d002"
+        egress             : [
+            [0]: {
+                cidrBlocks    : [
+                    [0]: "0.0.0.0/0"
+                ]
+                description   : ""
+                fromPort      : 0
+                ipv6CidrBlocks: []
+                prefixListIds : []
+                protocol      : "-1"
+                securityGroups: []
+                self          : false
+                toPort        : 0
+            }
+        ]
+        id                 : "sg-0e760e824fba2d002"
+        ingress            : [
+            [0]: {
+                cidrBlocks    : [
+                    [0]: "0.0.0.0/0"
+                ]
+                description   : ""
+                fromPort      : 80
+                ipv6CidrBlocks: []
+                prefixListIds : []
+                protocol      : "tcp"
+                securityGroups: []
+                self          : false
+                toPort        : 80
+            }
+        ]
+        ownerId            : "616138583583"
+        --outputs:--
+        arn                    : "arn:aws:eks:us-west-2:616138583583:cluster/eks-cluster-fb2cd6e"
+        certificateAuthority   : {
+            data: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdNVEEzTVRVeE0xb1hEVE15TURNeU9UQTNNVFV4TTFvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTHBPClE3b2FhMjl2ck1VU2hrMVUyRFluQ2F4RVEwMmFOVWZCdGlNZEQ5dC91eXRvb2l5SFNsMGlLNVdOK1pkc0R3ckMKNE9iWERJbk82WFE0V3YybkNiUTFkVU90MlNENTdBVkpaa2h3aStGcFZrcTN5c0ZDZklZWTJndXdnYVFZRTI2NQpLdVFWRitvS2l5TFJRcm9IYm92b0V2S05CZzllaUtMSEkvNW9YNW5CTEFTTmpxcFg1SER1QmRudWc2bTRMeVVYCkhyMlJScnlYUWthRUVudk9NLzR0dnlQQ1hZNWxVMUZEM09NVXNKRU5LNllCeGJDZjNjZHBGZFhaMmtpOXZrcGwKZ3ZiK2liLzZacE5oZ1U1SHViMkI3T0VJSHltZ1JSSks3T2luTUQxV2xOb1k5Q2hXT2tMVHNST1RJSVpma2VHegpWaVNVU2N0aEIzbnNBVzN6bDRFQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZINmpuckovUE9sSFNERDdTNWFEeU5xMEZoWkVNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFBMDJoWmlOSFZpZ2R5WXQ3NVFFVkpCV1psRnF0cHRXc0xud25FVTlxdm9sdmNvVC9yeApKWXU3b2RVZFhuQmlVRXZMZ3RwRUpMZmwrZG5BdTg5TXJKSUpKQzNLTEN1YkFmQnUzUTNCRzk0MG93cEFXMzk0ClNNSEx6TDNLNHlTN1p2L091WXhhS0w0bWcvY1lsQ0xuczdIRkppZWZ3L3JDeHhieitWTmFFOUFqVFRUVWNuSWwKZWswQlU5SWYrbWR2aUZ3YW15b3p4L2VWYWZtMlVXUWlxVTFtWFFDUUw2aXl3S1I0aTFZRk84VzNDdUdlRHZLbQplUjJSaUtROW8vdEdXSGFZeTliR01rdmZsWGZ1RTBUTG94NFgwb1hGdGF5cWxHSDBwNG1YamV0ekw3a243SmFqCm1yNFY4bkZZdEtleWZ5M2M2Z2duSHFINmJoZEc3aTVqaG50awotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+        }
+        createdAt              : "2022-04-01 07:08:48.606 +0000 UTC"
+        endpoint               : "https://535DF14691AA6956D4DB9B36F731D251.gr7.us-west-2.eks.amazonaws.com"
+        id                     : "eks-cluster-fb2cd6e"
+        identities             : [
+            [0]: {
+                oidcs: [
+                    [0]: {
+                        issuer: "https://oidc.eks.us-west-2.amazonaws.com/id/535DF14691AA6956D4DB9B36F731D251"
+                    }
+                ]
+            }
+        ]
+        kubernetesNetworkConfig: {
+            ipFamily       : "ipv4"
+            serviceIpv4Cidr: "10.100.0.0/16"
+        }
+        platformVersion        : "eks.5"
+        status                 : "ACTIVE"
+        version                : "1.21"
+        vpcConfig              : {
+            clusterSecurityGroupId: "sg-091503dadb90587a2"
+            endpointPrivateAccess : false
+            endpointPublicAccess  : true
+            publicAccessCidrs     : [
+                [0]: "0.0.0.0/0"
+            ]
+            securityGroupIds      : [
+                [0]: "sg-0e760e824fba2d002"
+            ]
+            subnetIds             : [
+                [0]: "subnet-0016572b"
+                [1]: "subnet-d7e7fe9c"
+                [2]: "subnet-c7d926bf"
+                [3]: "subnet-43f43a1e"
+            ]
+            vpcId                 : "vpc-4b82e033"
+        }

--- a/pkg/backend/display/testdata/not-truncated/up-3.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-3.json.create-diff.txt
@@ -52,38 +52,6 @@ Configuration:
         name               : "eks-sg-b3dbcb0"
         revokeRulesOnDelete: false
         vpcId              : "vpc-4b82e033"
-    + aws:iam/rolePolicyAttachment:RolePolicyAttachment: (create)
-        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-service-policy]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
-        policyArn : "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
-        role      : "eks-role-be36613"
-    + aws:iam/rolePolicyAttachment:RolePolicyAttachment: (create)
-        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-cluster-policy]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
-        policyArn : "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
-        role      : "eks-role-be36613"
-    + aws:eks/cluster:Cluster: (create)
-        [urn=urn:pulumi:dev::eks::aws:eks/cluster:Cluster::eks-cluster]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
-        name      : "eks-cluster-dc83353"
-        roleArn   : "arn:aws:iam::616138583583:role/eks-role-be36613"
-        vpcConfig : {
-            endpointPrivateAccess: false
-            endpointPublicAccess : true
-            publicAccessCidrs    : [
-                [0]: "0.0.0.0/0"
-            ]
-            securityGroupIds     : [
-                [0]: "sg-0d1f8bb63e78926f4"
-            ]
-            subnetIds            : [
-                [0]: "subnet-0016572b"
-                [1]: "subnet-d7e7fe9c"
-                [2]: "subnet-c7d926bf"
-                [3]: "subnet-43f43a1e"
-            ]
-        }
-
         --outputs:--
         arn                : "arn:aws:iam::616138583583:role/eks-role-be36613"
         assumeRolePolicy   : (json) {
@@ -109,6 +77,16 @@ Configuration:
             }
         ]
         uniqueId           : "AROAY65FYVYPY5QOJG3Q3"
+    + aws:iam/rolePolicyAttachment:RolePolicyAttachment: (create)
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-service-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
+        policyArn : "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+        role      : "eks-role-be36613"
+    + aws:iam/rolePolicyAttachment:RolePolicyAttachment: (create)
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-cluster-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
+        policyArn : "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+        role      : "eks-role-be36613"
         --outputs:--
         id       : "eks-role-be36613-20220401073059037900000001"
         --outputs:--
@@ -147,6 +125,27 @@ Configuration:
             }
         ]
         ownerId            : "616138583583"
+    + aws:eks/cluster:Cluster: (create)
+        [urn=urn:pulumi:dev::eks::aws:eks/cluster:Cluster::eks-cluster]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
+        name      : "eks-cluster-dc83353"
+        roleArn   : "arn:aws:iam::616138583583:role/eks-role-be36613"
+        vpcConfig : {
+            endpointPrivateAccess: false
+            endpointPublicAccess : true
+            publicAccessCidrs    : [
+                [0]: "0.0.0.0/0"
+            ]
+            securityGroupIds     : [
+                [0]: "sg-0d1f8bb63e78926f4"
+            ]
+            subnetIds            : [
+                [0]: "subnet-0016572b"
+                [1]: "subnet-d7e7fe9c"
+                [2]: "subnet-c7d926bf"
+                [3]: "subnet-43f43a1e"
+            ]
+        }
         --outputs:--
         arn                    : "arn:aws:eks:us-west-2:616138583583:cluster/eks-cluster-dc83353"
         certificateAuthority   : {

--- a/pkg/backend/display/testdata/not-truncated/up-3.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-3.json.create-diff.txt
@@ -1,0 +1,191 @@
+Configuration:
+    aws:region: us-west-2
++ pulumi:pulumi:Stack: (create)
+    [urn=urn:pulumi:dev::eks::pulumi:pulumi:Stack::eks-dev]
+    + aws:iam/role:Role: (create)
+        [urn=urn:pulumi:dev::eks::aws:iam/role:Role::eks-role]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
+        assumeRolePolicy   : (json) {
+            Statement: [
+                [0]: {
+                    Action   : "sts:AssumeRole"
+                    Effect   : "Allow"
+                    Principal: {
+                        Service: "eks.amazonaws.com"
+                    }
+                    Sid      : ""
+                }
+            ]
+            Version  : "2008-10-17"
+        }
+
+        forceDetachPolicies: false
+        maxSessionDuration : 3600
+        name               : "eks-role-be36613"
+        path               : "/"
+    + aws:ec2/securityGroup:SecurityGroup: (create)
+        [urn=urn:pulumi:dev::eks::aws:ec2/securityGroup:SecurityGroup::eks-sg]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
+        description        : "Managed by Pulumi"
+        egress             : [
+            [0]: {
+                cidrBlocks: [
+                    [0]: "0.0.0.0/0"
+                ]
+                fromPort  : 0
+                protocol  : "-1"
+                self      : false
+                toPort    : 0
+            }
+        ]
+        ingress            : [
+            [0]: {
+                cidrBlocks: [
+                    [0]: "0.0.0.0/0"
+                ]
+                fromPort  : 80
+                protocol  : "tcp"
+                self      : false
+                toPort    : 80
+            }
+        ]
+        name               : "eks-sg-b3dbcb0"
+        revokeRulesOnDelete: false
+        vpcId              : "vpc-4b82e033"
+    + aws:iam/rolePolicyAttachment:RolePolicyAttachment: (create)
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-service-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
+        policyArn : "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+        role      : "eks-role-be36613"
+    + aws:iam/rolePolicyAttachment:RolePolicyAttachment: (create)
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-cluster-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
+        policyArn : "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+        role      : "eks-role-be36613"
+    + aws:eks/cluster:Cluster: (create)
+        [urn=urn:pulumi:dev::eks::aws:eks/cluster:Cluster::eks-cluster]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
+        name      : "eks-cluster-dc83353"
+        roleArn   : "arn:aws:iam::616138583583:role/eks-role-be36613"
+        vpcConfig : {
+            endpointPrivateAccess: false
+            endpointPublicAccess : true
+            publicAccessCidrs    : [
+                [0]: "0.0.0.0/0"
+            ]
+            securityGroupIds     : [
+                [0]: "sg-0d1f8bb63e78926f4"
+            ]
+            subnetIds            : [
+                [0]: "subnet-0016572b"
+                [1]: "subnet-d7e7fe9c"
+                [2]: "subnet-c7d926bf"
+                [3]: "subnet-43f43a1e"
+            ]
+        }
+
+        --outputs:--
+        arn                : "arn:aws:iam::616138583583:role/eks-role-be36613"
+        assumeRolePolicy   : (json) {
+            Statement: [
+                [0]: {
+                    Action   : "sts:AssumeRole"
+                    Effect   : "Allow"
+                    Principal: {
+                        Service: "eks.amazonaws.com"
+                    }
+                    Sid      : ""
+                }
+            ]
+            Version  : "2008-10-17"
+        }
+
+        createDate         : "2022-04-01T07:30:56Z"
+        id                 : "eks-role-be36613"
+        inlinePolicies     : [
+            [0]: {
+                name  : ""
+                policy: ""
+            }
+        ]
+        uniqueId           : "AROAY65FYVYPY5QOJG3Q3"
+        --outputs:--
+        id       : "eks-role-be36613-20220401073059037900000001"
+        --outputs:--
+        id       : "eks-role-be36613-20220401073059129000000002"
+        --outputs:--
+        arn                : "arn:aws:ec2:us-west-2:616138583583:security-group/sg-0d1f8bb63e78926f4"
+        egress             : [
+            [0]: {
+                cidrBlocks    : [
+                    [0]: "0.0.0.0/0"
+                ]
+                description   : ""
+                fromPort      : 0
+                ipv6CidrBlocks: []
+                prefixListIds : []
+                protocol      : "-1"
+                securityGroups: []
+                self          : false
+                toPort        : 0
+            }
+        ]
+        id                 : "sg-0d1f8bb63e78926f4"
+        ingress            : [
+            [0]: {
+                cidrBlocks    : [
+                    [0]: "0.0.0.0/0"
+                ]
+                description   : ""
+                fromPort      : 80
+                ipv6CidrBlocks: []
+                prefixListIds : []
+                protocol      : "tcp"
+                securityGroups: []
+                self          : false
+                toPort        : 80
+            }
+        ]
+        ownerId            : "616138583583"
+        --outputs:--
+        arn                    : "arn:aws:eks:us-west-2:616138583583:cluster/eks-cluster-dc83353"
+        certificateAuthority   : {
+            data: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdNVEEzTXpZeU5Gb1hEVE15TURNeU9UQTNNell5TkZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTHBWCjRhZUVwNGgrcWcwbDhYeDQ4WlZ1eHlrc3IySFZyUWhkOTVsSm05WnRHUlB3Y2wzelAzNWtKVWV0dWdsMWtWVVkKcmRkc3NnNVBYdEtNK1lwdUlOQldDNTR5ZU14QzczcnpoU2hsYXAwMzliTExWcDI0WDFHQjJobWI3NDliN1JYZworNDRvdjVuRUFWTnc4SWgwU1FXL3g1bXBQNHBNTHVSNlFqOVpJZ3NXSTlDUGJCdG10RGphbHB4U1J3SWs3dXloCjZzOXhIUmFxNE95bmtCdFZ3OWNmd1pBdU5FeXFYbnppN0lrOW1Dc2hOWENuUXJScmFSWmhoMzdtUGVBS3RmdHIKdGV5UkNmQXo4U1UzREQrK0Z0SkJiSVdSZWFhVHBpU2NMclVXU21hQ0xSNlVpOXVhMEg5S2ttRUhZcHI3VGhFdQpMeHYrcnRFVnNxakZSOGhjN1VrQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZBRUlTUWNrVnQyZ0l5bzRRSVJ2eWZFcUQvNDJNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFDUVI2emtsRGIwRDd0ZXF2bEFHVzU3Q0xtWnp2MzRWWVRTRTlXQkcyTmRQcEJ5VFJCcQpZejBvb05VamNqclg2NE94dlZEY1N5MXdoMlQzbU5nYi95ZVQ3ZlhLMU8xMEN2bXRHUWU3UU1kMEEwOUVDNElqCndyWDJjUTRObVEzRVd6Mkc3SW9tSFlNMjQyaUNFRHNtL3pqVm5hK0ZDeVpPdy9yUnE0V2NycEFYL085djR5Z3cKMStPNUJlOFVBYUV5ZzJSZ1RHQ0g4VEp5ZW94cnhnOXJCcnRvNmpUTmVpYXB5djVsRktrK1ZCd3N4dXdicjN2MworWmNlQXpkOWFhc2l5QW9OeEV0V3FIYmN6Mmp6S1dvazBpTWpUUk9iQ1NJQXhCUzhhRWhlejhYOXQxbzVZa0VJCmhNK1BtcUIzbVF2aEhWblJZVWdySUh0MnBneVJXZ1FmaG9SNAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+        }
+        createdAt              : "2022-04-01 07:31:02.127 +0000 UTC"
+        endpoint               : "https://0030743A7B6BDF62E7A8C6F66FC10D8E.gr7.us-west-2.eks.amazonaws.com"
+        id                     : "eks-cluster-dc83353"
+        identities             : [
+            [0]: {
+                oidcs: [
+                    [0]: {
+                        issuer: "https://oidc.eks.us-west-2.amazonaws.com/id/0030743A7B6BDF62E7A8C6F66FC10D8E"
+                    }
+                ]
+            }
+        ]
+        kubernetesNetworkConfig: {
+            ipFamily       : "ipv4"
+            serviceIpv4Cidr: "10.100.0.0/16"
+        }
+        platformVersion        : "eks.5"
+        status                 : "ACTIVE"
+        version                : "1.21"
+        vpcConfig              : {
+            clusterSecurityGroupId: "sg-02bacf2bb5464b516"
+            endpointPrivateAccess : false
+            endpointPublicAccess  : true
+            publicAccessCidrs     : [
+                [0]: "0.0.0.0/0"
+            ]
+            securityGroupIds      : [
+                [0]: "sg-0d1f8bb63e78926f4"
+            ]
+            subnetIds             : [
+                [0]: "subnet-0016572b"
+                [1]: "subnet-d7e7fe9c"
+                [2]: "subnet-c7d926bf"
+                [3]: "subnet-43f43a1e"
+            ]
+            vpcId                 : "vpc-4b82e033"
+        }

--- a/pkg/backend/display/testdata/not-truncated/up-4.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-4.json.create-diff.txt
@@ -1,0 +1,154 @@
+Configuration:
+    aws:region: us-west-2
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:dev::eks::pulumi:pulumi:Stack::eks-dev]
+      aws:iam/role:Role: (same)
+        [id=eks-role-be36613]
+        [urn=urn:pulumi:dev::eks::aws:iam/role:Role::eks-role]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-be36613-20220401073059037900000001]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-service-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-be36613-20220401073059129000000002]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-cluster-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
+    ~ aws:ec2/securityGroup:SecurityGroup: (update)
+        [id=sg-0d1f8bb63e78926f4]
+        [urn=urn:pulumi:dev::eks::aws:ec2/securityGroup:SecurityGroup::eks-sg]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
+      ~ ingress: [
+          + [1]: {
+                  + cidrBlocks: [
+                  +     [0]: "0.0.0.0/0"
+                    ]
+                  + fromPort  : 22
+                  + protocol  : "tcp"
+                  + self      : false
+                  + toPort    : 22
+                }
+        ]
+      aws:eks/cluster:Cluster: (same)
+        [id=eks-cluster-dc83353]
+        [urn=urn:pulumi:dev::eks::aws:eks/cluster:Cluster::eks-cluster]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
+
+        --outputs:--
+        arn                : "arn:aws:iam::616138583583:role/eks-role-be36613"
+        assumeRolePolicy   : (json) {
+            Statement: [
+                [0]: {
+                    Action   : "sts:AssumeRole"
+                    Effect   : "Allow"
+                    Principal: {
+                        Service: "eks.amazonaws.com"
+                    }
+                    Sid      : ""
+                }
+            ]
+            Version  : "2008-10-17"
+        }
+
+        createDate         : "2022-04-01T07:30:56Z"
+        id                 : "eks-role-be36613"
+        inlinePolicies     : [
+            [0]: {
+                name  : ""
+                policy: ""
+            }
+        ]
+        uniqueId           : "AROAY65FYVYPY5QOJG3Q3"
+        --outputs:--
+        id       : "eks-role-be36613-20220401073059037900000001"
+        --outputs:--
+        id       : "eks-role-be36613-20220401073059129000000002"
+        --outputs:--
+        arn                : "arn:aws:ec2:us-west-2:616138583583:security-group/sg-0d1f8bb63e78926f4"
+        egress             : [
+            [0]: {
+                cidrBlocks    : [
+                    [0]: "0.0.0.0/0"
+                ]
+                description   : ""
+                fromPort      : 0
+                ipv6CidrBlocks: []
+                prefixListIds : []
+                protocol      : "-1"
+                securityGroups: []
+                self          : false
+                toPort        : 0
+            }
+        ]
+        id                 : "sg-0d1f8bb63e78926f4"
+      ~ ingress            : [
+            [0]: {
+                    cidrBlocks    : [
+                        [0]: "0.0.0.0/0"
+                    ]
+                    description   : ""
+                    fromPort      : 80
+                    ipv6CidrBlocks: []
+                    prefixListIds : []
+                    protocol      : "tcp"
+                    securityGroups: []
+                    self          : false
+                    toPort        : 80
+                }
+          + [1]: {
+                  + cidrBlocks    : [
+                  +     [0]: "0.0.0.0/0"
+                    ]
+                  + description   : ""
+                  + fromPort      : 22
+                  + ipv6CidrBlocks: []
+                  + prefixListIds : []
+                  + protocol      : "tcp"
+                  + securityGroups: []
+                  + self          : false
+                  + toPort        : 22
+                }
+        ]
+        ownerId            : "616138583583"
+        --outputs:--
+        arn                    : "arn:aws:eks:us-west-2:616138583583:cluster/eks-cluster-dc83353"
+        certificateAuthority   : {
+            data: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdNVEEzTXpZeU5Gb1hEVE15TURNeU9UQTNNell5TkZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTHBWCjRhZUVwNGgrcWcwbDhYeDQ4WlZ1eHlrc3IySFZyUWhkOTVsSm05WnRHUlB3Y2wzelAzNWtKVWV0dWdsMWtWVVkKcmRkc3NnNVBYdEtNK1lwdUlOQldDNTR5ZU14QzczcnpoU2hsYXAwMzliTExWcDI0WDFHQjJobWI3NDliN1JYZworNDRvdjVuRUFWTnc4SWgwU1FXL3g1bXBQNHBNTHVSNlFqOVpJZ3NXSTlDUGJCdG10RGphbHB4U1J3SWs3dXloCjZzOXhIUmFxNE95bmtCdFZ3OWNmd1pBdU5FeXFYbnppN0lrOW1Dc2hOWENuUXJScmFSWmhoMzdtUGVBS3RmdHIKdGV5UkNmQXo4U1UzREQrK0Z0SkJiSVdSZWFhVHBpU2NMclVXU21hQ0xSNlVpOXVhMEg5S2ttRUhZcHI3VGhFdQpMeHYrcnRFVnNxakZSOGhjN1VrQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZBRUlTUWNrVnQyZ0l5bzRRSVJ2eWZFcUQvNDJNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFDUVI2emtsRGIwRDd0ZXF2bEFHVzU3Q0xtWnp2MzRWWVRTRTlXQkcyTmRQcEJ5VFJCcQpZejBvb05VamNqclg2NE94dlZEY1N5MXdoMlQzbU5nYi95ZVQ3ZlhLMU8xMEN2bXRHUWU3UU1kMEEwOUVDNElqCndyWDJjUTRObVEzRVd6Mkc3SW9tSFlNMjQyaUNFRHNtL3pqVm5hK0ZDeVpPdy9yUnE0V2NycEFYL085djR5Z3cKMStPNUJlOFVBYUV5ZzJSZ1RHQ0g4VEp5ZW94cnhnOXJCcnRvNmpUTmVpYXB5djVsRktrK1ZCd3N4dXdicjN2MworWmNlQXpkOWFhc2l5QW9OeEV0V3FIYmN6Mmp6S1dvazBpTWpUUk9iQ1NJQXhCUzhhRWhlejhYOXQxbzVZa0VJCmhNK1BtcUIzbVF2aEhWblJZVWdySUh0MnBneVJXZ1FmaG9SNAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+        }
+        createdAt              : "2022-04-01 07:31:02.127 +0000 UTC"
+        endpoint               : "https://0030743A7B6BDF62E7A8C6F66FC10D8E.gr7.us-west-2.eks.amazonaws.com"
+        id                     : "eks-cluster-dc83353"
+        identities             : [
+            [0]: {
+                oidcs: [
+                    [0]: {
+                        issuer: "https://oidc.eks.us-west-2.amazonaws.com/id/0030743A7B6BDF62E7A8C6F66FC10D8E"
+                    }
+                ]
+            }
+        ]
+        kubernetesNetworkConfig: {
+            ipFamily       : "ipv4"
+            serviceIpv4Cidr: "10.100.0.0/16"
+        }
+        platformVersion        : "eks.5"
+        status                 : "ACTIVE"
+        version                : "1.21"
+        vpcConfig              : {
+            clusterSecurityGroupId: "sg-02bacf2bb5464b516"
+            endpointPrivateAccess : false
+            endpointPublicAccess  : true
+            publicAccessCidrs     : [
+                [0]: "0.0.0.0/0"
+            ]
+            securityGroupIds      : [
+                [0]: "sg-0d1f8bb63e78926f4"
+            ]
+            subnetIds             : [
+                [0]: "subnet-0016572b"
+                [1]: "subnet-d7e7fe9c"
+                [2]: "subnet-c7d926bf"
+                [3]: "subnet-43f43a1e"
+            ]
+            vpcId                 : "vpc-4b82e033"
+        }

--- a/pkg/backend/display/testdata/not-truncated/up-4.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-4.json.create-diff.txt
@@ -6,34 +6,6 @@ Configuration:
         [id=eks-role-be36613]
         [urn=urn:pulumi:dev::eks::aws:iam/role:Role::eks-role]
         [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
-      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
-        [id=eks-role-be36613-20220401073059037900000001]
-        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-service-policy]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
-      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
-        [id=eks-role-be36613-20220401073059129000000002]
-        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-cluster-policy]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
-    ~ aws:ec2/securityGroup:SecurityGroup: (update)
-        [id=sg-0d1f8bb63e78926f4]
-        [urn=urn:pulumi:dev::eks::aws:ec2/securityGroup:SecurityGroup::eks-sg]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
-      ~ ingress: [
-          + [1]: {
-                  + cidrBlocks: [
-                  +     [0]: "0.0.0.0/0"
-                    ]
-                  + fromPort  : 22
-                  + protocol  : "tcp"
-                  + self      : false
-                  + toPort    : 22
-                }
-        ]
-      aws:eks/cluster:Cluster: (same)
-        [id=eks-cluster-dc83353]
-        [urn=urn:pulumi:dev::eks::aws:eks/cluster:Cluster::eks-cluster]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
-
         --outputs:--
         arn                : "arn:aws:iam::616138583583:role/eks-role-be36613"
         assumeRolePolicy   : (json) {
@@ -59,10 +31,33 @@ Configuration:
             }
         ]
         uniqueId           : "AROAY65FYVYPY5QOJG3Q3"
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-be36613-20220401073059037900000001]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-service-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
         --outputs:--
         id       : "eks-role-be36613-20220401073059037900000001"
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-be36613-20220401073059129000000002]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-cluster-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
         --outputs:--
         id       : "eks-role-be36613-20220401073059129000000002"
+    ~ aws:ec2/securityGroup:SecurityGroup: (update)
+        [id=sg-0d1f8bb63e78926f4]
+        [urn=urn:pulumi:dev::eks::aws:ec2/securityGroup:SecurityGroup::eks-sg]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
+      ~ ingress: [
+          + [1]: {
+                  + cidrBlocks: [
+                  +     [0]: "0.0.0.0/0"
+                    ]
+                  + fromPort  : 22
+                  + protocol  : "tcp"
+                  + self      : false
+                  + toPort    : 22
+                }
+        ]
         --outputs:--
         arn                : "arn:aws:ec2:us-west-2:616138583583:security-group/sg-0d1f8bb63e78926f4"
         egress             : [
@@ -110,6 +105,10 @@ Configuration:
                 }
         ]
         ownerId            : "616138583583"
+      aws:eks/cluster:Cluster: (same)
+        [id=eks-cluster-dc83353]
+        [urn=urn:pulumi:dev::eks::aws:eks/cluster:Cluster::eks-cluster]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
         --outputs:--
         arn                    : "arn:aws:eks:us-west-2:616138583583:cluster/eks-cluster-dc83353"
         certificateAuthority   : {

--- a/pkg/backend/display/testdata/not-truncated/up-5.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-5.json.create-diff.txt
@@ -6,40 +6,6 @@ Configuration:
         [id=eks-role-24b1266]
         [urn=urn:pulumi:dev::eks::aws:iam/role:Role::eks-role]
         [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
-        [id=eks-role-24b1266-20220209231452499500000001]
-        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-service-policy]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
-        [id=eks-role-24b1266-20220209231452597100000002]
-        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-cluster-policy]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-      aws:ec2/securityGroup:SecurityGroup: (same)
-        [id=sg-0e760e824fba2d002]
-        [urn=urn:pulumi:dev::eks::aws:ec2/securityGroup:SecurityGroup::eks-sg]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-    + aws:eks/cluster:Cluster: (create)
-        [urn=urn:pulumi:dev::eks::aws:eks/cluster:Cluster::eks-cluster]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-        name      : "eks-cluster-fb2cd6e"
-        roleArn   : "arn:aws:iam::616138583583:role/eks-role-24b1266"
-        vpcConfig : {
-            endpointPrivateAccess: false
-            endpointPublicAccess : true
-            publicAccessCidrs    : [
-                [0]: "0.0.0.0/0"
-            ]
-            securityGroupIds     : [
-                [0]: "sg-0e760e824fba2d002"
-            ]
-            subnetIds            : [
-                [0]: "subnet-0016572b"
-                [1]: "subnet-d7e7fe9c"
-                [2]: "subnet-c7d926bf"
-                [3]: "subnet-43f43a1e"
-            ]
-        }
-
         --outputs:--
         arn                : "arn:aws:iam::616138583583:role/eks-role-24b1266"
         assumeRolePolicy   : (json) {
@@ -69,10 +35,22 @@ Configuration:
             [1]: "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
         ]
         uniqueId           : "AROAY65FYVYPWXZQUXMBX"
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-24b1266-20220209231452499500000001]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-service-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
         --outputs:--
         id       : "eks-role-24b1266-20220209231452499500000001"
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-24b1266-20220209231452597100000002]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-cluster-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
         --outputs:--
         id       : "eks-role-24b1266-20220209231452597100000002"
+      aws:ec2/securityGroup:SecurityGroup: (same)
+        [id=sg-0e760e824fba2d002]
+        [urn=urn:pulumi:dev::eks::aws:ec2/securityGroup:SecurityGroup::eks-sg]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
         --outputs:--
         arn                : "arn:aws:ec2:us-west-2:616138583583:security-group/sg-0e760e824fba2d002"
         egress             : [
@@ -107,6 +85,27 @@ Configuration:
             }
         ]
         ownerId            : "616138583583"
+    + aws:eks/cluster:Cluster: (create)
+        [urn=urn:pulumi:dev::eks::aws:eks/cluster:Cluster::eks-cluster]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+        name      : "eks-cluster-fb2cd6e"
+        roleArn   : "arn:aws:iam::616138583583:role/eks-role-24b1266"
+        vpcConfig : {
+            endpointPrivateAccess: false
+            endpointPublicAccess : true
+            publicAccessCidrs    : [
+                [0]: "0.0.0.0/0"
+            ]
+            securityGroupIds     : [
+                [0]: "sg-0e760e824fba2d002"
+            ]
+            subnetIds            : [
+                [0]: "subnet-0016572b"
+                [1]: "subnet-d7e7fe9c"
+                [2]: "subnet-c7d926bf"
+                [3]: "subnet-43f43a1e"
+            ]
+        }
         --outputs:--
         arn                    : "arn:aws:eks:us-west-2:616138583583:cluster/eks-cluster-fb2cd6e"
         certificateAuthority   : {

--- a/pkg/backend/display/testdata/not-truncated/up-5.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-5.json.create-diff.txt
@@ -1,0 +1,151 @@
+Configuration:
+    aws:region: us-west-2
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:dev::eks::pulumi:pulumi:Stack::eks-dev]
+      aws:iam/role:Role: (same)
+        [id=eks-role-24b1266]
+        [urn=urn:pulumi:dev::eks::aws:iam/role:Role::eks-role]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-24b1266-20220209231452499500000001]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-service-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-24b1266-20220209231452597100000002]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-cluster-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+      aws:ec2/securityGroup:SecurityGroup: (same)
+        [id=sg-0e760e824fba2d002]
+        [urn=urn:pulumi:dev::eks::aws:ec2/securityGroup:SecurityGroup::eks-sg]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+    + aws:eks/cluster:Cluster: (create)
+        [urn=urn:pulumi:dev::eks::aws:eks/cluster:Cluster::eks-cluster]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+        name      : "eks-cluster-fb2cd6e"
+        roleArn   : "arn:aws:iam::616138583583:role/eks-role-24b1266"
+        vpcConfig : {
+            endpointPrivateAccess: false
+            endpointPublicAccess : true
+            publicAccessCidrs    : [
+                [0]: "0.0.0.0/0"
+            ]
+            securityGroupIds     : [
+                [0]: "sg-0e760e824fba2d002"
+            ]
+            subnetIds            : [
+                [0]: "subnet-0016572b"
+                [1]: "subnet-d7e7fe9c"
+                [2]: "subnet-c7d926bf"
+                [3]: "subnet-43f43a1e"
+            ]
+        }
+
+        --outputs:--
+        arn                : "arn:aws:iam::616138583583:role/eks-role-24b1266"
+        assumeRolePolicy   : (json) {
+            Statement: [
+                [0]: {
+                    Action   : "sts:AssumeRole"
+                    Effect   : "Allow"
+                    Principal: {
+                        Service: "eks.amazonaws.com"
+                    }
+                    Sid      : ""
+                }
+            ]
+            Version  : "2008-10-17"
+        }
+
+        createDate         : "2022-02-09T23:14:50Z"
+        id                 : "eks-role-24b1266"
+        inlinePolicies     : [
+            [0]: {
+                name  : ""
+                policy: ""
+            }
+        ]
+        managedPolicyArns  : [
+            [0]: "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+            [1]: "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+        ]
+        uniqueId           : "AROAY65FYVYPWXZQUXMBX"
+        --outputs:--
+        id       : "eks-role-24b1266-20220209231452499500000001"
+        --outputs:--
+        id       : "eks-role-24b1266-20220209231452597100000002"
+        --outputs:--
+        arn                : "arn:aws:ec2:us-west-2:616138583583:security-group/sg-0e760e824fba2d002"
+        egress             : [
+            [0]: {
+                cidrBlocks    : [
+                    [0]: "0.0.0.0/0"
+                ]
+                description   : ""
+                fromPort      : 0
+                ipv6CidrBlocks: []
+                prefixListIds : []
+                protocol      : "-1"
+                securityGroups: []
+                self          : false
+                toPort        : 0
+            }
+        ]
+        id                 : "sg-0e760e824fba2d002"
+        ingress            : [
+            [0]: {
+                cidrBlocks    : [
+                    [0]: "0.0.0.0/0"
+                ]
+                description   : ""
+                fromPort      : 80
+                ipv6CidrBlocks: []
+                prefixListIds : []
+                protocol      : "tcp"
+                securityGroups: []
+                self          : false
+                toPort        : 80
+            }
+        ]
+        ownerId            : "616138583583"
+        --outputs:--
+        arn                    : "arn:aws:eks:us-west-2:616138583583:cluster/eks-cluster-fb2cd6e"
+        certificateAuthority   : {
+            data: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdNVEEzTVRVeE0xb1hEVE15TURNeU9UQTNNVFV4TTFvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTHBPClE3b2FhMjl2ck1VU2hrMVUyRFluQ2F4RVEwMmFOVWZCdGlNZEQ5dC91eXRvb2l5SFNsMGlLNVdOK1pkc0R3ckMKNE9iWERJbk82WFE0V3YybkNiUTFkVU90MlNENTdBVkpaa2h3aStGcFZrcTN5c0ZDZklZWTJndXdnYVFZRTI2NQpLdVFWRitvS2l5TFJRcm9IYm92b0V2S05CZzllaUtMSEkvNW9YNW5CTEFTTmpxcFg1SER1QmRudWc2bTRMeVVYCkhyMlJScnlYUWthRUVudk9NLzR0dnlQQ1hZNWxVMUZEM09NVXNKRU5LNllCeGJDZjNjZHBGZFhaMmtpOXZrcGwKZ3ZiK2liLzZacE5oZ1U1SHViMkI3T0VJSHltZ1JSSks3T2luTUQxV2xOb1k5Q2hXT2tMVHNST1RJSVpma2VHegpWaVNVU2N0aEIzbnNBVzN6bDRFQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZINmpuckovUE9sSFNERDdTNWFEeU5xMEZoWkVNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFBMDJoWmlOSFZpZ2R5WXQ3NVFFVkpCV1psRnF0cHRXc0xud25FVTlxdm9sdmNvVC9yeApKWXU3b2RVZFhuQmlVRXZMZ3RwRUpMZmwrZG5BdTg5TXJKSUpKQzNLTEN1YkFmQnUzUTNCRzk0MG93cEFXMzk0ClNNSEx6TDNLNHlTN1p2L091WXhhS0w0bWcvY1lsQ0xuczdIRkppZWZ3L3JDeHhieitWTmFFOUFqVFRUVWNuSWwKZWswQlU5SWYrbWR2aUZ3YW15b3p4L2VWYWZtMlVXUWlxVTFtWFFDUUw2aXl3S1I0aTFZRk84VzNDdUdlRHZLbQplUjJSaUtROW8vdEdXSGFZeTliR01rdmZsWGZ1RTBUTG94NFgwb1hGdGF5cWxHSDBwNG1YamV0ekw3a243SmFqCm1yNFY4bkZZdEtleWZ5M2M2Z2duSHFINmJoZEc3aTVqaG50awotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+        }
+        createdAt              : "2022-04-01 07:08:48.606 +0000 UTC"
+        endpoint               : "https://535DF14691AA6956D4DB9B36F731D251.gr7.us-west-2.eks.amazonaws.com"
+        id                     : "eks-cluster-fb2cd6e"
+        identities             : [
+            [0]: {
+                oidcs: [
+                    [0]: {
+                        issuer: "https://oidc.eks.us-west-2.amazonaws.com/id/535DF14691AA6956D4DB9B36F731D251"
+                    }
+                ]
+            }
+        ]
+        kubernetesNetworkConfig: {
+            ipFamily       : "ipv4"
+            serviceIpv4Cidr: "10.100.0.0/16"
+        }
+        platformVersion        : "eks.5"
+        status                 : "ACTIVE"
+        version                : "1.21"
+        vpcConfig              : {
+            clusterSecurityGroupId: "sg-091503dadb90587a2"
+            endpointPrivateAccess : false
+            endpointPublicAccess  : true
+            publicAccessCidrs     : [
+                [0]: "0.0.0.0/0"
+            ]
+            securityGroupIds      : [
+                [0]: "sg-0e760e824fba2d002"
+            ]
+            subnetIds             : [
+                [0]: "subnet-0016572b"
+                [1]: "subnet-d7e7fe9c"
+                [2]: "subnet-c7d926bf"
+                [3]: "subnet-43f43a1e"
+            ]
+            vpcId                 : "vpc-4b82e033"
+        }

--- a/pkg/backend/display/testdata/not-truncated/up.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/up.json.create-diff.txt
@@ -6,40 +6,6 @@ Configuration:
         [id=eks-role-24b1266]
         [urn=urn:pulumi:dev::eks::aws:iam/role:Role::eks-role]
         [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
-        [id=eks-role-24b1266-20220209231452499500000001]
-        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-service-policy]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
-        [id=eks-role-24b1266-20220209231452597100000002]
-        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-cluster-policy]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-      aws:ec2/securityGroup:SecurityGroup: (same)
-        [id=sg-0e760e824fba2d002]
-        [urn=urn:pulumi:dev::eks::aws:ec2/securityGroup:SecurityGroup::eks-sg]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-    + aws:eks/cluster:Cluster: (create)
-        [urn=urn:pulumi:dev::eks::aws:eks/cluster:Cluster::eks-cluster]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-        name      : "eks-cluster-fb2cd6e"
-        roleArn   : "arn:aws:iam::616138583583:role/eks-role-24b1266"
-        vpcConfig : {
-            endpointPrivateAccess: false
-            endpointPublicAccess : true
-            publicAccessCidrs    : [
-                [0]: "0.0.0.0/0"
-            ]
-            securityGroupIds     : [
-                [0]: "sg-0e760e824fba2d002"
-            ]
-            subnetIds            : [
-                [0]: "subnet-0016572b"
-                [1]: "subnet-d7e7fe9c"
-                [2]: "subnet-c7d926bf"
-                [3]: "subnet-43f43a1e"
-            ]
-        }
-
         --outputs:--
         arn                : "arn:aws:iam::616138583583:role/eks-role-24b1266"
         assumeRolePolicy   : (json) {
@@ -69,10 +35,22 @@ Configuration:
             [1]: "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
         ]
         uniqueId           : "AROAY65FYVYPWXZQUXMBX"
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-24b1266-20220209231452499500000001]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-service-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
         --outputs:--
         id       : "eks-role-24b1266-20220209231452499500000001"
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-24b1266-20220209231452597100000002]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-cluster-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
         --outputs:--
         id       : "eks-role-24b1266-20220209231452597100000002"
+      aws:ec2/securityGroup:SecurityGroup: (same)
+        [id=sg-0e760e824fba2d002]
+        [urn=urn:pulumi:dev::eks::aws:ec2/securityGroup:SecurityGroup::eks-sg]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
         --outputs:--
         arn                : "arn:aws:ec2:us-west-2:616138583583:security-group/sg-0e760e824fba2d002"
         egress             : [
@@ -107,6 +85,27 @@ Configuration:
             }
         ]
         ownerId            : "616138583583"
+    + aws:eks/cluster:Cluster: (create)
+        [urn=urn:pulumi:dev::eks::aws:eks/cluster:Cluster::eks-cluster]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+        name      : "eks-cluster-fb2cd6e"
+        roleArn   : "arn:aws:iam::616138583583:role/eks-role-24b1266"
+        vpcConfig : {
+            endpointPrivateAccess: false
+            endpointPublicAccess : true
+            publicAccessCidrs    : [
+                [0]: "0.0.0.0/0"
+            ]
+            securityGroupIds     : [
+                [0]: "sg-0e760e824fba2d002"
+            ]
+            subnetIds            : [
+                [0]: "subnet-0016572b"
+                [1]: "subnet-d7e7fe9c"
+                [2]: "subnet-c7d926bf"
+                [3]: "subnet-43f43a1e"
+            ]
+        }
         --outputs:--
         arn                    : "arn:aws:eks:us-west-2:616138583583:cluster/eks-cluster-fb2cd6e"
         certificateAuthority   : {

--- a/pkg/backend/display/testdata/not-truncated/up.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/up.json.create-diff.txt
@@ -1,0 +1,151 @@
+Configuration:
+    aws:region: us-west-2
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:dev::eks::pulumi:pulumi:Stack::eks-dev]
+      aws:iam/role:Role: (same)
+        [id=eks-role-24b1266]
+        [urn=urn:pulumi:dev::eks::aws:iam/role:Role::eks-role]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-24b1266-20220209231452499500000001]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-service-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-24b1266-20220209231452597100000002]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-cluster-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+      aws:ec2/securityGroup:SecurityGroup: (same)
+        [id=sg-0e760e824fba2d002]
+        [urn=urn:pulumi:dev::eks::aws:ec2/securityGroup:SecurityGroup::eks-sg]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+    + aws:eks/cluster:Cluster: (create)
+        [urn=urn:pulumi:dev::eks::aws:eks/cluster:Cluster::eks-cluster]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+        name      : "eks-cluster-fb2cd6e"
+        roleArn   : "arn:aws:iam::616138583583:role/eks-role-24b1266"
+        vpcConfig : {
+            endpointPrivateAccess: false
+            endpointPublicAccess : true
+            publicAccessCidrs    : [
+                [0]: "0.0.0.0/0"
+            ]
+            securityGroupIds     : [
+                [0]: "sg-0e760e824fba2d002"
+            ]
+            subnetIds            : [
+                [0]: "subnet-0016572b"
+                [1]: "subnet-d7e7fe9c"
+                [2]: "subnet-c7d926bf"
+                [3]: "subnet-43f43a1e"
+            ]
+        }
+
+        --outputs:--
+        arn                : "arn:aws:iam::616138583583:role/eks-role-24b1266"
+        assumeRolePolicy   : (json) {
+            Statement: [
+                [0]: {
+                    Action   : "sts:AssumeRole"
+                    Effect   : "Allow"
+                    Principal: {
+                        Service: "eks.amazonaws.com"
+                    }
+                    Sid      : ""
+                }
+            ]
+            Version  : "2008-10-17"
+        }
+
+        createDate         : "2022-02-09T23:14:50Z"
+        id                 : "eks-role-24b1266"
+        inlinePolicies     : [
+            [0]: {
+                name  : ""
+                policy: ""
+            }
+        ]
+        managedPolicyArns  : [
+            [0]: "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+            [1]: "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+        ]
+        uniqueId           : "AROAY65FYVYPWXZQUXMBX"
+        --outputs:--
+        id       : "eks-role-24b1266-20220209231452499500000001"
+        --outputs:--
+        id       : "eks-role-24b1266-20220209231452597100000002"
+        --outputs:--
+        arn                : "arn:aws:ec2:us-west-2:616138583583:security-group/sg-0e760e824fba2d002"
+        egress             : [
+            [0]: {
+                cidrBlocks    : [
+                    [0]: "0.0.0.0/0"
+                ]
+                description   : ""
+                fromPort      : 0
+                ipv6CidrBlocks: []
+                prefixListIds : []
+                protocol      : "-1"
+                securityGroups: []
+                self          : false
+                toPort        : 0
+            }
+        ]
+        id                 : "sg-0e760e824fba2d002"
+        ingress            : [
+            [0]: {
+                cidrBlocks    : [
+                    [0]: "0.0.0.0/0"
+                ]
+                description   : ""
+                fromPort      : 80
+                ipv6CidrBlocks: []
+                prefixListIds : []
+                protocol      : "tcp"
+                securityGroups: []
+                self          : false
+                toPort        : 80
+            }
+        ]
+        ownerId            : "616138583583"
+        --outputs:--
+        arn                    : "arn:aws:eks:us-west-2:616138583583:cluster/eks-cluster-fb2cd6e"
+        certificateAuthority   : {
+            data: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdNVEEzTVRVeE0xb1hEVE15TURNeU9UQTNNVFV4TTFvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTHBPClE3b2FhMjl2ck1VU2hrMVUyRFluQ2F4RVEwMmFOVWZCdGlNZEQ5dC91eXRvb2l5SFNsMGlLNVdOK1pkc0R3ckMKNE9iWERJbk82WFE0V3YybkNiUTFkVU90MlNENTdBVkpaa2h3aStGcFZrcTN5c0ZDZklZWTJndXdnYVFZRTI2NQpLdVFWRitvS2l5TFJRcm9IYm92b0V2S05CZzllaUtMSEkvNW9YNW5CTEFTTmpxcFg1SER1QmRudWc2bTRMeVVYCkhyMlJScnlYUWthRUVudk9NLzR0dnlQQ1hZNWxVMUZEM09NVXNKRU5LNllCeGJDZjNjZHBGZFhaMmtpOXZrcGwKZ3ZiK2liLzZacE5oZ1U1SHViMkI3T0VJSHltZ1JSSks3T2luTUQxV2xOb1k5Q2hXT2tMVHNST1RJSVpma2VHegpWaVNVU2N0aEIzbnNBVzN6bDRFQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZINmpuckovUE9sSFNERDdTNWFEeU5xMEZoWkVNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFBMDJoWmlOSFZpZ2R5WXQ3NVFFVkpCV1psRnF0cHRXc0xud25FVTlxdm9sdmNvVC9yeApKWXU3b2RVZFhuQmlVRXZMZ3RwRUpMZmwrZG5BdTg5TXJKSUpKQzNLTEN1YkFmQnUzUTNCRzk0MG93cEFXMzk0ClNNSEx6TDNLNHlTN1p2L091WXhhS0w0bWcvY1lsQ0xuczdIRkppZWZ3L3JDeHhieitWTmFFOUFqVFRUVWNuSWwKZWswQlU5SWYrbWR2aUZ3YW15b3p4L2VWYWZtMlVXUWlxVTFtWFFDUUw2aXl3S1I0aTFZRk84VzNDdUdlRHZLbQplUjJSaUtROW8vdEdXSGFZeTliR01rdmZsWGZ1RTBUTG94NFgwb1hGdGF5cWxHSDBwNG1YamV0ekw3a243SmFqCm1yNFY4bkZZdEtleWZ5M2M2Z2duSHFINmJoZEc3aTVqaG50awotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+        }
+        createdAt              : "2022-04-01 07:08:48.606 +0000 UTC"
+        endpoint               : "https://535DF14691AA6956D4DB9B36F731D251.gr7.us-west-2.eks.amazonaws.com"
+        id                     : "eks-cluster-fb2cd6e"
+        identities             : [
+            [0]: {
+                oidcs: [
+                    [0]: {
+                        issuer: "https://oidc.eks.us-west-2.amazonaws.com/id/535DF14691AA6956D4DB9B36F731D251"
+                    }
+                ]
+            }
+        ]
+        kubernetesNetworkConfig: {
+            ipFamily       : "ipv4"
+            serviceIpv4Cidr: "10.100.0.0/16"
+        }
+        platformVersion        : "eks.5"
+        status                 : "ACTIVE"
+        version                : "1.21"
+        vpcConfig              : {
+            clusterSecurityGroupId: "sg-091503dadb90587a2"
+            endpointPrivateAccess : false
+            endpointPublicAccess  : true
+            publicAccessCidrs     : [
+                [0]: "0.0.0.0/0"
+            ]
+            securityGroupIds      : [
+                [0]: "sg-0e760e824fba2d002"
+            ]
+            subnetIds             : [
+                [0]: "subnet-0016572b"
+                [1]: "subnet-d7e7fe9c"
+                [2]: "subnet-c7d926bf"
+                [3]: "subnet-43f43a1e"
+            ]
+            vpcId                 : "vpc-4b82e033"
+        }

--- a/pkg/backend/display/testdata/not-truncated/url-encoded-stack-output-diff.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/url-encoded-stack-output-diff.json.create-diff.txt
@@ -1,0 +1,6 @@
+Configuration:
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:dev::urlencodedoutput::pulumi:pulumi:Stack::urlencodedoutput-dev]
+
+    --outputs:--
+  ~ path: "%2F" => "%2f"

--- a/pkg/backend/display/testdata/not-truncated/url-encoded-stack-output-diff.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/url-encoded-stack-output-diff.json.create-diff.txt
@@ -1,6 +1,5 @@
 Configuration:
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:dev::urlencodedoutput::pulumi:pulumi:Stack::urlencodedoutput-dev]
-
     --outputs:--
   ~ path: "%2F" => "%2f"

--- a/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.create-diff.txt
@@ -1,0 +1,34 @@
+Configuration:
+    aws:region: us-west-2
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:dev::aws-ts-webserver::pulumi:pulumi:Stack::aws-ts-webserver-dev]
+      aws:ec2/securityGroup:SecurityGroup: (same)
+        [id=sg-07498abcdbdf88f34]
+        [urn=urn:pulumi:dev::aws-ts-webserver::aws:ec2/securityGroup:SecurityGroup::web-secgrp]
+        [provider=urn:pulumi:dev::aws-ts-webserver::pulumi:providers:aws::default_3_38_1::57baf899-740a-486a-908e-43cf27cce182]
+    ++aws:ec2/instance:Instance: (create-replacement)
+        [id=i-0207dc7a2d8c5135a]
+        [urn=urn:pulumi:dev::aws-ts-webserver::aws:ec2/instance:Instance::web-server-www]
+        [provider=urn:pulumi:dev::aws-ts-webserver::pulumi:providers:aws::default_3_38_1::57baf899-740a-486a-908e-43cf27cce182]
+      ~ userData: 
+            #!/bin/bash
+          - echo "Hello, World!" > index.html
+          + echo "Hello, Pulumi!" > index.html
+            nohup python -m SimpleHTTPServer 80 &
+    +-aws:ec2/instance:Instance: (replace)
+        [id=i-0207dc7a2d8c5135a]
+        [urn=urn:pulumi:dev::aws-ts-webserver::aws:ec2/instance:Instance::web-server-www]
+        [provider=urn:pulumi:dev::aws-ts-webserver::pulumi:providers:aws::default_3_38_1::57baf899-740a-486a-908e-43cf27cce182]
+      ~ userData: 
+            #!/bin/bash
+          - echo "Hello, World!" > index.html
+          + echo "Hello, Pulumi!" > index.html
+            nohup python -m SimpleHTTPServer 80 &
+    --aws:ec2/instance:Instance: (delete-replaced)
+        [id=i-0207dc7a2d8c5135a]
+        [urn=urn:pulumi:dev::aws-ts-webserver::aws:ec2/instance:Instance::web-server-www]
+        [provider=urn:pulumi:dev::aws-ts-webserver::pulumi:providers:aws::default_3_38_1::57baf899-740a-486a-908e-43cf27cce182]
+
+    --outputs:--
+    publicHostName: "ec2-34-211-56-110.us-west-2.compute.amazonaws.com"
+    publicIp      : "34.211.56.110"

--- a/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.create-diff.txt
+++ b/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.create-diff.txt
@@ -2,6 +2,9 @@ Configuration:
     aws:region: us-west-2
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:dev::aws-ts-webserver::pulumi:pulumi:Stack::aws-ts-webserver-dev]
+    --outputs:--
+    publicHostName: "ec2-34-211-56-110.us-west-2.compute.amazonaws.com"
+    publicIp      : "34.211.56.110"
       aws:ec2/securityGroup:SecurityGroup: (same)
         [id=sg-07498abcdbdf88f34]
         [urn=urn:pulumi:dev::aws-ts-webserver::aws:ec2/securityGroup:SecurityGroup::web-secgrp]
@@ -28,7 +31,3 @@ Configuration:
         [id=i-0207dc7a2d8c5135a]
         [urn=urn:pulumi:dev::aws-ts-webserver::aws:ec2/instance:Instance::web-server-www]
         [provider=urn:pulumi:dev::aws-ts-webserver::pulumi:providers:aws::default_3_38_1::57baf899-740a-486a-908e-43cf27cce182]
-
-    --outputs:--
-    publicHostName: "ec2-34-211-56-110.us-west-2.compute.amazonaws.com"
-    publicIp      : "34.211.56.110"

--- a/pkg/backend/display/testdata/truncated/up-truncate.json.create-diff.txt
+++ b/pkg/backend/display/testdata/truncated/up-truncate.json.create-diff.txt
@@ -2,29 +2,12 @@ Configuration:
     aws:region: us-west-2
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:dev::eks::pulumi:pulumi:Stack::eks-dev]
+    --outputs:--
+    readme: "line 1\nline2\nline3\nline4"
       aws:iam/role:Role: (same)
         [id=eks-role-24b1266]
         [urn=urn:pulumi:dev::eks::aws:iam/role:Role::eks-role]
         [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
-        [id=eks-role-24b1266-20220209231452499500000001]
-        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-service-policy]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
-        [id=eks-role-24b1266-20220209231452597100000002]
-        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-cluster-policy]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-      aws:ec2/securityGroup:SecurityGroup: (same)
-        [id=sg-0e760e824fba2d002]
-        [urn=urn:pulumi:dev::eks::aws:ec2/securityGroup:SecurityGroup::eks-sg]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-      aws:eks/cluster:Cluster: (same)
-        [id=eks-cluster-fb2cd6e]
-        [urn=urn:pulumi:dev::eks::aws:eks/cluster:Cluster::eks-cluster]
-        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-
-    --outputs:--
-    readme: "line 1\nline2\nline3\nline4"
         --outputs:--
         arn                : "arn:aws:iam::616138583583:role/eks-role-24b1266"
         assumeRolePolicy   : (json) {
@@ -54,10 +37,22 @@ Configuration:
             [1]: "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
         ]
         uniqueId           : "AROAY65FYVYPWXZQUXMBX"
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-24b1266-20220209231452499500000001]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-service-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
         --outputs:--
         id       : "eks-role-24b1266-20220209231452499500000001"
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-24b1266-20220209231452597100000002]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-cluster-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
         --outputs:--
         id       : "eks-role-24b1266-20220209231452597100000002"
+      aws:ec2/securityGroup:SecurityGroup: (same)
+        [id=sg-0e760e824fba2d002]
+        [urn=urn:pulumi:dev::eks::aws:ec2/securityGroup:SecurityGroup::eks-sg]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
         --outputs:--
         arn                : "arn:aws:ec2:us-west-2:616138583583:security-group/sg-0e760e824fba2d002"
         egress             : [
@@ -92,6 +87,10 @@ Configuration:
             }
         ]
         ownerId            : "616138583583"
+      aws:eks/cluster:Cluster: (same)
+        [id=eks-cluster-fb2cd6e]
+        [urn=urn:pulumi:dev::eks::aws:eks/cluster:Cluster::eks-cluster]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
         --outputs:--
         arn                    : "arn:aws:eks:us-west-2:616138583583:cluster/eks-cluster-fb2cd6e"
         certificateAuthority   : {

--- a/pkg/backend/display/testdata/truncated/up-truncate.json.create-diff.txt
+++ b/pkg/backend/display/testdata/truncated/up-truncate.json.create-diff.txt
@@ -1,0 +1,136 @@
+Configuration:
+    aws:region: us-west-2
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:dev::eks::pulumi:pulumi:Stack::eks-dev]
+      aws:iam/role:Role: (same)
+        [id=eks-role-24b1266]
+        [urn=urn:pulumi:dev::eks::aws:iam/role:Role::eks-role]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-24b1266-20220209231452499500000001]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-service-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+      aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
+        [id=eks-role-24b1266-20220209231452597100000002]
+        [urn=urn:pulumi:dev::eks::aws:iam/rolePolicyAttachment:RolePolicyAttachment::eks-rpa-cluster-policy]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+      aws:ec2/securityGroup:SecurityGroup: (same)
+        [id=sg-0e760e824fba2d002]
+        [urn=urn:pulumi:dev::eks::aws:ec2/securityGroup:SecurityGroup::eks-sg]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+      aws:eks/cluster:Cluster: (same)
+        [id=eks-cluster-fb2cd6e]
+        [urn=urn:pulumi:dev::eks::aws:eks/cluster:Cluster::eks-cluster]
+        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
+
+    --outputs:--
+    readme: "line 1\nline2\nline3\nline4"
+        --outputs:--
+        arn                : "arn:aws:iam::616138583583:role/eks-role-24b1266"
+        assumeRolePolicy   : (json) {
+            Statement: [
+                [0]: {
+                    Action   : "sts:AssumeRole"
+                    Effect   : "Allow"
+                    Principal: {
+                        Service: "eks.amazonaws.com"
+                    }
+                    Sid      : ""
+                }
+            ]
+            Version  : "2008-10-17"
+        }
+
+        createDate         : "2022-02-09T23:14:50Z"
+        id                 : "eks-role-24b1266"
+        inlinePolicies     : [
+            [0]: {
+                name  : ""
+                policy: ""
+            }
+        ]
+        managedPolicyArns  : [
+            [0]: "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+            [1]: "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+        ]
+        uniqueId           : "AROAY65FYVYPWXZQUXMBX"
+        --outputs:--
+        id       : "eks-role-24b1266-20220209231452499500000001"
+        --outputs:--
+        id       : "eks-role-24b1266-20220209231452597100000002"
+        --outputs:--
+        arn                : "arn:aws:ec2:us-west-2:616138583583:security-group/sg-0e760e824fba2d002"
+        egress             : [
+            [0]: {
+                cidrBlocks    : [
+                    [0]: "0.0.0.0/0"
+                ]
+                description   : ""
+                fromPort      : 0
+                ipv6CidrBlocks: []
+                prefixListIds : []
+                protocol      : "-1"
+                securityGroups: []
+                self          : false
+                toPort        : 0
+            }
+        ]
+        id                 : "sg-0e760e824fba2d002"
+        ingress            : [
+            [0]: {
+                cidrBlocks    : [
+                    [0]: "0.0.0.0/0"
+                ]
+                description   : ""
+                fromPort      : 80
+                ipv6CidrBlocks: []
+                prefixListIds : []
+                protocol      : "tcp"
+                securityGroups: []
+                self          : false
+                toPort        : 80
+            }
+        ]
+        ownerId            : "616138583583"
+        --outputs:--
+        arn                    : "arn:aws:eks:us-west-2:616138583583:cluster/eks-cluster-fb2cd6e"
+        certificateAuthority   : {
+            data: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdNVEEzTVRVeE0xb1hEVE15TURNeU9UQTNNVFV4TTFvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTHBPClE3b2FhMjl2ck1VU2hrMVUyRFluQ2F4RVEwMmFOVWZCdGlNZEQ5dC91eXRvb2l5SFNsMGlLNVdOK1pkc0R3ckMKNE9iWERJbk82WFE0V3YybkNiUTFkVU90MlNENTdBVkpaa2h3aStGcFZrcTN5c0ZDZklZWTJndXdnYVFZRTI2NQpLdVFWRitvS2l5TFJRcm9IYm92b0V2S05CZzllaUtMSEkvNW9YNW5CTEFTTmpxcFg1SER1QmRudWc2bTRMeVVYCkhyMlJScnlYUWthRUVudk9NLzR0dnlQQ1hZNWxVMUZEM09NVXNKRU5LNllCeGJDZjNjZHBGZFhaMmtpOXZrcGwKZ3ZiK2liLzZacE5oZ1U1SHViMkI3T0VJSHltZ1JSSks3T2luTUQxV2xOb1k5Q2hXT2tMVHNST1RJSVpma2VHegpWaVNVU2N0aEIzbnNBVzN6bDRFQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZINmpuckovUE9sSFNERDdTNWFEeU5xMEZoWkVNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFBMDJoWmlOSFZpZ2R5WXQ3NVFFVkpCV1psRnF0cHRXc0xud25FVTlxdm9sdmNvVC9yeApKWXU3b2RVZFhuQmlVRXZMZ3RwRUpMZmwrZG5BdTg5TXJKSUpKQzNLTEN1YkFmQnUzUTNCRzk0MG93cEFXMzk0ClNNSEx6TDNLNHlTN1p2L091WXhhS0w0bWcvY1lsQ0xuczdIRkppZWZ3L3JDeHhieitWTmFFOUFqVFRUVWNuSWwKZWswQlU5SWYrbWR2aUZ3YW15b3p4L2VWYWZtMlVXUWlxVTFtWFFDUUw2aXl3S1I0aTFZRk84VzNDdUdlRHZLbQplUjJSaUtROW8vdEdXSGFZeTliR01rdmZsWGZ1RTBUTG94NFgwb1hGdGF5cWxHSDBwNG1YamV0ekw3a243SmFqCm1yNFY4bkZZdEtleWZ5M2M2Z2duSHFINmJoZEc3aTVqaG50awotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+        }
+        createdAt              : "2022-04-01 07:08:48.606 +0000 UTC"
+        endpoint               : "https://535DF14691AA6956D4DB9B36F731D251.gr7.us-west-2.eks.amazonaws.com"
+        id                     : "eks-cluster-fb2cd6e"
+        identities             : [
+            [0]: {
+                oidcs: [
+                    [0]: {
+                        issuer: "https://oidc.eks.us-west-2.amazonaws.com/id/535DF14691AA6956D4DB9B36F731D251"
+                    }
+                ]
+            }
+        ]
+        kubernetesNetworkConfig: {
+            ipFamily       : "ipv4"
+            serviceIpv4Cidr: "10.100.0.0/16"
+        }
+        platformVersion        : "eks.5"
+        status                 : "ACTIVE"
+        version                : "1.21"
+        vpcConfig              : {
+            clusterSecurityGroupId: "sg-091503dadb90587a2"
+            endpointPrivateAccess : false
+            endpointPublicAccess  : true
+            publicAccessCidrs     : [
+                [0]: "0.0.0.0/0"
+            ]
+            securityGroupIds      : [
+                [0]: "sg-0e760e824fba2d002"
+            ]
+            subnetIds             : [
+                [0]: "subnet-0016572b"
+                [1]: "subnet-d7e7fe9c"
+                [2]: "subnet-c7d926bf"
+                [3]: "subnet-43f43a1e"
+            ]
+            vpcId                 : "vpc-4b82e033"
+        }


### PR DESCRIPTION
This fixes a bug found while working on another internal issue. This bug is reproduced in the first commit which adds tests, clearly showing the behavior of the incoherent rendering. The second commit makes the change and updates the tests.

Fixes #17028

Fixes all outputs being printed adjacent without context, as seen in the linked issue and the first commit:

```
    --outputs:--
    readme: "line 1\nline2\nline3\nline4"
        --outputs:--
        arn                : "arn:aws:iam::616138583583:role/eks-role-24b1266"
        assumeRolePolicy   : (json) {
            Statement: [
                [0]: {
                    Action   : "sts:AssumeRole"
                    Effect   : "Allow"
                    Principal: {
                        Service: "eks.amazonaws.com"
                    }
                    Sid      : ""
                }
            ]
            Version  : "2008-10-17"
        }

        createDate         : "2022-02-09T23:14:50Z"
        id                 : "eks-role-24b1266"
        inlinePolicies     : [
            [0]: {
                name  : ""
                policy: ""
            }
        ]
        managedPolicyArns  : [
            [0]: "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
            [1]: "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
        ]
        uniqueId           : "AROAY65FYVYPWXZQUXMBX"
        --outputs:--
        id       : "eks-role-24b1266-20220209231452499500000001"
        --outputs:--
        id       : "eks-role-24b1266-20220209231452597100000002"
        --outputs:--
```
