### PR TITLE
Bump .NET version after 3.66.2 release

### DIFF
--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -378,4 +378,4 @@ const (
 )
 
 // PulumiDotnetSDKVersion is the version of the Pulumi .NET SDK to use in program-gen tests
-const PulumiDotnetSDKVersion = "3.66.1"
+const PulumiDotnetSDKVersion = "3.66.2"

--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -32,7 +32,7 @@ download_release() {
 }
 
 # shellcheck disable=SC2043
-for i in "github.com/pulumi/pulumi-java java" "github.com/pulumi/pulumi-yaml yaml" "github.com/pulumi/pulumi-dotnet dotnet v3.66.1"; do
+for i in "github.com/pulumi/pulumi-java java" "github.com/pulumi/pulumi-yaml yaml" "github.com/pulumi/pulumi-dotnet dotnet v3.66.2"; do
   set -- $i # treat strings in loop as args
   REPO="$1"
   PULUMI_LANG="$2"


### PR DESCRIPTION
See https://github.com/pulumi/pulumi-dotnet/releases/tag/v3.66.2