### PR TITLE
Set minimum version of core SDK when using parameterization

### DIFF
--- a/changelog/pending/20240821--sdkgen-nodejs--set-minimum-version-of-core-sdk-when-using-parameterization.yaml
+++ b/changelog/pending/20240821--sdkgen-nodejs--set-minimum-version-of-core-sdk-when-using-parameterization.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/nodejs
+  description: Set minimum version of core SDK when using parameterization

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -45,11 +45,13 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-// The minimum version of @pulumi/pulumi compatible with the generated SDK.
 const (
-	MinimumValidSDKVersion   string = "^3.42.0"
-	MinimumTypescriptVersion string = "^4.3.5"
-	MinimumNodeTypesVersion  string = "^14"
+	// The minimum version of @pulumi/pulumi compatible with the generated SDK.
+	MinimumValidSDKVersion string = "^3.42.0"
+	// The minumum version of @pulumi/pulumi that supports parameterization.
+	MinimumValidParameterizationSDKVersion string = "^3.129.0"
+	MinimumTypescriptVersion               string = "^4.3.5"
+	MinimumNodeTypesVersion                string = "^14"
 )
 
 type typeDetails struct {
@@ -2525,6 +2527,8 @@ func genNPMPackageMetadata(pkg *schema.Package, info NodePackageInfo, localDepen
 		}
 		if path, ok := localDependencies["pulumi"]; ok {
 			npminfo.Dependencies[sdkPack] = path
+		} else if pkg.Parameterization != nil {
+			npminfo.Dependencies[sdkPack] = MinimumValidParameterizationSDKVersion
 		} else {
 			npminfo.Dependencies[sdkPack] = MinimumValidSDKVersion
 		}

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -48,7 +48,7 @@ import (
 const (
 	// The minimum version of @pulumi/pulumi compatible with the generated SDK.
 	MinimumValidSDKVersion string = "^3.42.0"
-	// The minumum version of @pulumi/pulumi that supports parameterization.
+	// The minimum version of @pulumi/pulumi that supports parameterization.
 	MinimumValidParameterizationSDKVersion string = "^3.129.0"
 	MinimumTypescriptVersion               string = "^4.3.5"
 	MinimumNodeTypesVersion                string = "^14"

--- a/tests/integration/nodejs/parameterized/sdk/nodejs/package.json
+++ b/tests/integration/nodejs/parameterized/sdk/nodejs/package.json
@@ -7,7 +7,7 @@
         "postinstall": "node ./scripts/postinstall.js"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.42.0",
+        "@pulumi/pulumi": "^3.129.0",
         "async-mutex": "^0.5.0"
     },
     "devDependencies": {


### PR DESCRIPTION
When generating an SDK with parameterization (aka local SDK), we need `@pulumi/pulumi@^3.129.0` as the core SDK dependency. Older versions do not support the packageRef argument added the runtime calls.

Fixes https://github.com/pulumi/pulumi/issues/17020
