### PR TITLE
Use provided ImportBasePath for parameterized SDKs

### DIFF
--- a/changelog/pending/20240821--sdkgen-go--use-provided-importbasepath-for-parameterized-sdks.yaml
+++ b/changelog/pending/20240821--sdkgen-go--use-provided-importbasepath-for-parameterized-sdks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/go
+  description: Use provided ImportBasePath for parameterized SDKs

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -4669,11 +4669,15 @@ func GeneratePackage(tool string,
 	// If the package is parameterized generate a go.mod for it
 	if pkg.Parameterization != nil {
 		mod := modfile.File{}
-		err = mod.AddModuleStmt(extractImportBasePath(pkg.Reference()))
+		err = mod.AddModuleStmt(goPkgInfo.ImportBasePath)
 		contract.AssertNoErrorf(err, "could not add module statement to go.mod")
 		err = mod.AddGoStmt("1.21")
 		contract.AssertNoErrorf(err, "could not add Go statement to go.mod")
-
+		// Parameterized packages need the pulumi SDK >= v3.129.0
+		pulumiPackagePath := "github.com/pulumi/pulumi/sdk/v3"
+		pulumiVersion := "v3.129.0"
+		err = mod.AddRequire(pulumiPackagePath, pulumiVersion)
+		contract.AssertNoErrorf(err, "could not add require statement to go.mod")
 		bytes, err := mod.Format()
 		if err != nil {
 			return nil, fmt.Errorf("format go.mod: %w", err)
@@ -5227,8 +5231,8 @@ func Pkg%[1]sDefaultOpts(opts []pulumi.%[1]sOption) []pulumi.%[1]sOption {
 var packageRef *string
 // PkgGetPackageRef returns the package reference for the current package.
 func PkgGetPackageRef(ctx *pulumi.Context) (string, error) {
-	if packageRef == nil {	
-		
+	if packageRef == nil {
+
 		parameter, err := base64.StdEncoding.DecodeString(%q)
 		if err != nil {
 			return "", err

--- a/tests/integration/go/parameterized/go.mod
+++ b/tests/integration/go/parameterized/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 toolchain go1.22.2
 
-require github.com/pulumi/pulumi/sdk/v3 v3.128.0
+require github.com/pulumi/pulumi/sdk/v3 v3.129.0
 
 require example.com/pulumi-pkg/sdk/go/pkg v1.0.0
 

--- a/tests/integration/go/parameterized/go.sum
+++ b/tests/integration/go/parameterized/go.sum
@@ -150,8 +150,8 @@ github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
 github.com/pulumi/esc v0.9.1 h1:HH5eEv8sgyxSpY5a8yePyqFXzA8cvBvapfH8457+mIs=
 github.com/pulumi/esc v0.9.1/go.mod h1:oEJ6bOsjYlQUpjf70GiX+CXn3VBmpwFDxUTlmtUN84c=
-github.com/pulumi/pulumi/sdk/v3 v3.128.0 h1:5VPFfygxt6rva0bEYVQZXxsGAo2/D1wsb9erGOtXxzk=
-github.com/pulumi/pulumi/sdk/v3 v3.128.0/go.mod h1:p1U24en3zt51agx+WlNboSOV8eLlPWYAkxMzVEXKbnY=
+github.com/pulumi/pulumi/sdk/v3 v3.129.0 h1:uZpTTwWTx7Mk8UT9FgatzxzArim47vZ6hzNCKvgvX6A=
+github.com/pulumi/pulumi/sdk/v3 v3.129.0/go.mod h1:p1U24en3zt51agx+WlNboSOV8eLlPWYAkxMzVEXKbnY=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=

--- a/tests/integration/go/parameterized/sdk/go/pkg/go.mod
+++ b/tests/integration/go/parameterized/sdk/go/pkg/go.mod
@@ -1,3 +1,5 @@
 module example.com/pulumi-pkg/sdk/go/pkg
 
 go 1.21
+
+require github.com/pulumi/pulumi/sdk/v3 v3.129.0

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -1187,7 +1187,7 @@ func TestStackOutputsResourceErrorGo(t *testing.T) {
 // Test a paramaterized provider with go.
 //
 //nolint:paralleltest // ProgramTest calls t.Parallel()
-func TestParamaterizedGo(t *testing.T) {
+func TestParameterizedGo(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
 
 	// We can't use ImportDirectory here because we need to run this in the right directory such that the relative paths


### PR DESCRIPTION
When generating a parameterized SDK, the dynamic tf bridge [provides the appropriate ImportBasePath](https://github.com/pulumi/pulumi-terraform-bridge/blob/87006ca9216a94d8552f1836bdf5b079fa6c7aca/dynamic/info.go#L62) for us, use it instead of trying to determine it ourselves.

Fixes https://github.com/pulumi/pulumi/issues/17018
