### PR TITLE
🐞 Bugfix: Set secret provider correctly via automation API

### DIFF
--- a/changelog/pending/20240821--sdk-go--set-secret-provider-correctly-via-automation-api.yaml
+++ b/changelog/pending/20240821--sdk-go--set-secret-provider-correctly-via-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+  - type: fix
+    scope: sdk/go
+    description: Set secret provider correctly via automation API

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -130,6 +130,11 @@ func TestWorkspaceSecretsProvider(t *testing.T) {
 		t.FailNow()
 	}
 
+	// -- verify secrets_provider --
+	secretsProviderTag, err := s.workspace.GetTag(ctx, stackName, "pulumi:secrets_provider")
+	require.NoError(t, err, "failed to get tag")
+	assert.Equal(t, "passphrase", secretsProviderTag)
+
 	// -- pulumi up --
 	res, err := s.Up(ctx)
 	if err != nil {


### PR DESCRIPTION
With this update we get the stack once after upserting a local workspace. If there is a secrets provider set and there was no previous update, then we persist the secrets provider.

This achieves expected behavior where a secrets provider is set to anything else but the default `service` by persisting the secrets provider into the state before the first update.

The cost of this is one additional `GET` stack request per upsert, which I think is acceptable.

Fix #16890