### PR TITLE
Clean up multi-error rendering

### DIFF
--- a/sdk/go/common/util/cmdutil/exit_test.go
+++ b/sdk/go/common/util/cmdutil/exit_test.go
@@ -125,6 +125,62 @@ func TestErrorMessage(t *testing.T) {
 			want: "great sadness",
 		},
 		{
+			desc: "error trees (left-nested)",
+			give: errors.Join(
+				errors.Join(
+					errors.New("foo"),
+					errors.New("bar"),
+				),
+				errors.New("baz"),
+			),
+			want: "3 errors occurred:" +
+				"\n    1) foo" +
+				"\n    2) bar" +
+				"\n    3) baz",
+		},
+		{
+			desc: "error trees (right-nested)",
+			give: errors.Join(
+				errors.New("foo"),
+				errors.Join(
+					errors.New("bar"),
+					errors.New("baz"),
+				),
+			),
+			want: "3 errors occurred:" +
+				"\n    1) foo" +
+				"\n    2) bar" +
+				"\n    3) baz",
+		},
+		{
+			desc: "error trees (mixed)",
+			give: errors.Join(
+				errors.Join(
+					errors.New("foo"),
+					errors.Join(
+						errors.New("bar"),
+						errors.New("baz"),
+					),
+				),
+				errors.Join(
+					errors.Join(
+						errors.New("quux"),
+						errors.New("frob"),
+					),
+					errors.New("urk"),
+					errors.New("blog"),
+				),
+			),
+			want: "7 errors occurred:" +
+				"\n    1) foo" +
+				"\n    2) bar" +
+				"\n    3) baz" +
+				"\n    4) quux" +
+				"\n    5) frob" +
+				"\n    6) urk" +
+				"\n    7) blog",
+		},
+		{
 			desc: "multi error inside single wrapped error",
 			give: &multierror.Error{
 				Errors: []error{


### PR DESCRIPTION
When an error occurs in Go, there is often a need to "wrap" the error and propagate it upwards. For instance, if a "file not found" error occurs while trying to read a `Pulumi.yaml`, we want to surface both those pieces of information to the consumer of the error. Since 1.13, Go provides support for natively wrapping errors using e.g. the `%w` format specified in `fmt.Errorf` and the `Unwrap() []error` interface method. Prior to 1.13. libraries such as `multierror` provided a similar function in the absence of standard-library support.

Due to its age, the `pulumi/pulumi` codebase uses both Go-native error wrapping and `multierror`. It would likely be good to converge on the former and lose a dependency/remove extraneous code paths. One key difference between the two approaches is in how multiple errors are combined into a new parent. In `multierror`, the `Append` function takes a set of errors and combines them, _flattening any existing trees of errors_ so that the result is always a flat list of errors. In contrast, Go's built-in `errors.Join` does not flatten and so can produce trees of errors. Practically speaking, this is unlikely to be a huge problem for this codebase, but there are some changes we can make proactively to reduce the risks of trees-vs-lists if and when we migrate. Specifically, when rendering errors, we don't consider the possibility of there being a tree at present. This means that an input such as:

```go
errors.Join(
  errors.Join(
    errors.New("foo"),
    errors.New("bar"),
  ),
  errors.New("baz"),
)
```

results in something like:

```
  1) 2 errors occurred:
  1) foo
  2) bar
  2) baz
```

This commit fixes this so that errors are flattened at the point of rendering, meaning that it shouldn't matter as we move from `multierror.Append` to `errors.Join` whether or not an error chain is a tree or a list.