### PR TITLE
Prevent double close on OOM detection channel

### DIFF
--- a/changelog/pending/20240822--sdk-nodejs--prevent-double-close-on-oom-detection-channel.yaml
+++ b/changelog/pending/20240822--sdk-nodejs--prevent-double-close-on-oom-detection-channel.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Prevent double close on OOM detection channel

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1545,10 +1545,10 @@ func (o *oomSniffer) Scan(r io.Reader) {
 	go func() {
 		for scanner.Scan() {
 			line := scanner.Text()
-			if !o.detected && strings.Contains(line, "<--- Last few GCs --->") /* "Normal" OOM output */ ||
+			if !o.detected && (strings.Contains(line, "<--- Last few GCs --->") /* "Normal" OOM output */ ||
 				// Because we hook into the debugger API, the OOM error message can be obscured by
 				// a failed assertion in the debugger https://github.com/pulumi/pulumi/issues/16596.
-				strings.Contains(line, "Check failed: needs_context && current_scope_ = closure_scope_") {
+				strings.Contains(line, "Check failed: needs_context && current_scope_ = closure_scope_")) {
 				o.detected = true
 				close(o.waitChan)
 			}


### PR DESCRIPTION
While looking at https://github.com/pulumi/pulumi/issues/17040 I noticed that the condition in the OOM detection was missing parentheses. This could potentially make us call `close(o.waitChain)` twice, resulting in a panic. In practice this does not happen because we only ever see at most one of the two strings we are looking for.

Note that this does *not* fix https://github.com/pulumi/pulumi/issues/17040