### PR TITLE
Fix NodeJS OOM detection condition

### DIFF
--- a/changelog/pending/20240822--sdk-nodejs--fix-nodejs-oom-detection-condition.yaml
+++ b/changelog/pending/20240822--sdk-nodejs--fix-nodejs-oom-detection-condition.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix NodeJS OOM detection condition

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1550,6 +1550,7 @@ func (o *oomSniffer) Scan(r io.Reader) {
 			if !o.detected && (strings.Contains(line, "<--- Last few GCs --->") /* "Normal" OOM output */ ||
 				// Because we hook into the debugger API, the OOM error message can be obscured by
 				// a failed assertion in the debugger https://github.com/pulumi/pulumi/issues/16596.
+				//nolint:lll
 				// https://github.com/nodejs/node/blob/cef2047b1fdd797d5125c4cafe9f17220a0774f7/deps/v8/src/debug/debug-scopes.cc#L447
 				strings.Contains(line, "Check failed: needs_context && current_scope_ == closure_scope_")) {
 				o.detected = true

--- a/tests/integration/nodejs/oom/index.js
+++ b/tests/integration/nodejs/oom/index.js
@@ -10,7 +10,7 @@ function heapInfo() {
 }
 
 const data = []
-console.log()
+
 for (let i = 0; i < 1_000_000; i++) {
     if (i % 100 === 0) heapInfo();
     data.push(new Array(1_000_000).fill('a'))


### PR DESCRIPTION
The condition had a single `=` in the string instead of a `==`.

This PR also ensures that stop scanning for errors when the process ends, so we don’t wait for the scanning timeout in case the node process crashes with another error.

Fixes https://github.com/pulumi/pulumi/issues/17040
