### PR TITLE
Print panic banners for snapshot integrity errors

### DIFF
--- a/changelog/pending/20240822--cli-display--print-panic-banners-for-snapshot-integrity-errors.yaml
+++ b/changelog/pending/20240822--cli-display--print-panic-banners-for-snapshot-integrity-errors.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/display
+  description: Print panic banners for snapshot integrity errors


### PR DESCRIPTION
Snapshot integrity errors are generally indicative of a serious issue in the Pulumi engine. When they occur, we'd like users to file issues with as much detail as possible so that we can track them down and fix them. This commit adds a new custom error type for snapshot integrity errors and a case to the top-level error handler that spots these errors and prints out a banner asking the user to file an issue.

Fixes #16950

![image](https://github.com/user-attachments/assets/20c32361-7bf5-4904-b880-f2c3be762786)
