### PR TITLE
Add support for ESC Projects

### DIFF
--- a/cmd/pulumi-test-language/go.mod
+++ b/cmd/pulumi-test-language/go.mod
@@ -150,7 +150,7 @@ require (
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
-	github.com/pulumi/esc v0.9.1 // indirect
+	github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870 // indirect
 	github.com/pulumi/inflector v0.1.1 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect

--- a/cmd/pulumi-test-language/go.sum
+++ b/cmd/pulumi-test-language/go.sum
@@ -443,8 +443,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435cARxCW6q9gc0S/Yxz7Mkd38pOb0=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
-github.com/pulumi/esc v0.9.1 h1:HH5eEv8sgyxSpY5a8yePyqFXzA8cvBvapfH8457+mIs=
-github.com/pulumi/esc v0.9.1/go.mod h1:oEJ6bOsjYlQUpjf70GiX+CXn3VBmpwFDxUTlmtUN84c=
+github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870 h1:x2olkM9dngDimVa7OUYxIDa4nb94PAFjr+WSM+AHnuk=
+github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870/go.mod h1:oEJ6bOsjYlQUpjf70GiX+CXn3VBmpwFDxUTlmtUN84c=
 github.com/pulumi/inflector v0.1.1 h1:dvlxlWtXwOJTUUtcYDvwnl6Mpg33prhK+7mzeF+SobA=
 github.com/pulumi/inflector v0.1.1/go.mod h1:HUFCjcPTz96YtTuUlwG3i3EZG4WlniBvR9bd+iJxCUY=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -236,7 +236,8 @@ type EnvironmentsBackend interface {
 	CreateEnvironment(
 		ctx context.Context,
 		org string,
-		name string,
+		projectName string,
+		envName string,
 		yaml []byte,
 	) (apitype.EnvironmentDiagnostics, error)
 

--- a/pkg/backend/httpstate/environments.go
+++ b/pkg/backend/httpstate/environments.go
@@ -44,13 +44,14 @@ func convertESCDiags(diags []client.EnvironmentDiagnostic) apitype.EnvironmentDi
 func (b *cloudBackend) CreateEnvironment(
 	ctx context.Context,
 	org string,
-	name string,
+	projectName string,
+	envName string,
 	yaml []byte,
 ) (apitype.EnvironmentDiagnostics, error) {
-	if err := b.escClient.CreateEnvironment(ctx, org, name); err != nil {
+	if err := b.escClient.CreateEnvironmentWithProject(ctx, org, projectName, envName); err != nil {
 		return nil, err
 	}
-	diags, err := b.escClient.UpdateEnvironment(ctx, org, name, yaml, "")
+	diags, err := b.escClient.UpdateEnvironmentWithProject(ctx, org, projectName, envName, yaml, "")
 	return convertESCDiags(diags), err
 }
 
@@ -73,6 +74,6 @@ func (b *cloudBackend) OpenYAMLEnvironment(
 	if err != nil || len(diags) != 0 {
 		return nil, convertESCDiags(diags), err
 	}
-	env, err := b.escClient.GetOpenEnvironment(ctx, org, "yaml", id)
+	env, err := b.escClient.GetOpenEnvironmentWithProject(ctx, org, "project", "yaml", id)
 	return env, nil, err
 }

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -428,7 +428,8 @@ type MockEnvironmentsBackend struct {
 	CreateEnvironmentF func(
 		ctx context.Context,
 		org string,
-		name string,
+		projectName string,
+		envName string,
 		yaml []byte,
 	) (apitype.EnvironmentDiagnostics, error)
 
@@ -449,11 +450,12 @@ type MockEnvironmentsBackend struct {
 func (be *MockEnvironmentsBackend) CreateEnvironment(
 	ctx context.Context,
 	org string,
-	name string,
+	projectName string,
+	envName string,
 	yaml []byte,
 ) (apitype.EnvironmentDiagnostics, error) {
 	if be.CreateEnvironmentF != nil {
-		return be.CreateEnvironmentF(ctx, org, name, yaml)
+		return be.CreateEnvironmentF(ctx, org, projectName, envName, yaml)
 	}
 	panic("not implemented")
 }

--- a/pkg/cmd/pulumi/config_env.go
+++ b/pkg/cmd/pulumi/config_env.go
@@ -141,7 +141,7 @@ func (cmd *configEnvCmd) listStackEnvironments(ctx context.Context, jsonOut bool
 			}, nil)
 		} else {
 			fprintf(cmd.stdout, "This stack configuration has no environments listed. "+
-				"Try adding one with `pulumi config env add [envName]`.\n")
+				"Try adding one with `pulumi config env add <projectName>/<envName>`.\n")
 		}
 
 	}

--- a/pkg/cmd/pulumi/config_env_init.go
+++ b/pkg/cmd/pulumi/config_env_init.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"text/template"
 
 	"github.com/charmbracelet/glamour"
@@ -58,7 +59,7 @@ func newConfigEnvInitCmd(parent *configEnvCmd) *cobra.Command {
 
 	cmd.Flags().StringVar(
 		&impl.envName, "env", "",
-		`The name of the environment to create. Defaults to "<project name>-<stack name>"`)
+		`The name of the environment to create. Defaults to "<project name>/<stack name>"`)
 	cmd.Flags().BoolVar(
 		&impl.showSecrets, "show-secrets", false,
 		"Show secret values in plaintext instead of ciphertext")
@@ -116,11 +117,20 @@ func (cmd *configEnvInitCmd) run(ctx context.Context, args []string) error {
 
 	orgName := stack.(interface{ OrgName() string }).OrgName()
 
-	if cmd.envName == "" {
-		cmd.envName = fmt.Sprintf("%v-%v", project.Name, stack.Ref().Name())
+	// Parse given environment name
+	// Try to split the given envName into project/env
+	// Default to the stack's project and name if the environment project and/or name are not provided
+	envProject := project.Name.String()
+	envName := stack.Ref().Name().String()
+	first, second, found := strings.Cut(cmd.envName, "/")
+	if found {
+		envProject = first
+		envName = second
+	} else if first != "" {
+		envName = first
 	}
 
-	fmt.Fprintf(cmd.parent.stdout, "Creating environment %v for stack %v...\n", cmd.envName, stack.Ref().Name())
+	fmt.Fprintf(cmd.parent.stdout, "Creating environment %v/%v for stack %v...\n", envProject, envName, stack.Ref().Name())
 
 	projectStack, config, err := cmd.getStackConfig(ctx, project, stack)
 	if err != nil {
@@ -132,12 +142,12 @@ func (cmd *configEnvInitCmd) run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	yaml, err := cmd.renderEnvironmentDefinition(ctx, cmd.envName, crypter, config, cmd.showSecrets)
+	yaml, err := cmd.renderEnvironmentDefinition(ctx, envName, crypter, config, cmd.showSecrets)
 	if err != nil {
 		return err
 	}
 
-	preview, err := cmd.renderPreview(ctx, envBackend, orgName, cmd.envName, yaml, cmd.showSecrets)
+	preview, err := cmd.renderPreview(ctx, envBackend, orgName, envName, yaml, cmd.showSecrets)
 	if err != nil {
 		return err
 	}
@@ -154,13 +164,13 @@ func (cmd *configEnvInitCmd) run(ctx context.Context, args []string) error {
 	}
 
 	if !cmd.showSecrets {
-		yaml, err = eval.DecryptSecrets(ctx, cmd.envName, yaml, crypter)
+		yaml, err = eval.DecryptSecrets(ctx, envName, yaml, crypter)
 		if err != nil {
 			return err
 		}
 	}
 
-	diags, err := envBackend.CreateEnvironment(ctx, orgName, cmd.envName, yaml)
+	diags, err := envBackend.CreateEnvironment(ctx, orgName, envProject, envName, yaml)
 	if err != nil {
 		return fmt.Errorf("creating environment: %w", err)
 	}
@@ -168,7 +178,8 @@ func (cmd *configEnvInitCmd) run(ctx context.Context, args []string) error {
 		return fmt.Errorf("internal error creating environment: %w", diags)
 	}
 
-	projectStack.Environment = projectStack.Environment.Append(cmd.envName)
+	fullName := fmt.Sprintf("%s/%s", envProject, envName)
+	projectStack.Environment = projectStack.Environment.Append(fullName)
 	if !cmd.keepConfig {
 		projectStack.Config = nil
 	}

--- a/pkg/cmd/pulumi/config_env_init_test.go
+++ b/pkg/cmd/pulumi/config_env_init_test.go
@@ -67,7 +67,7 @@ runtime: yaml`
 		err := init.run(ctx, nil)
 		require.NoError(t, err)
 
-		const expectedOut = "Creating environment test-stack for stack stack...\n" +
+		const expectedOut = "Creating environment test/stack for stack stack...\n" +
 			"# Value\n" +
 			"```json\n" +
 			"{\n" +
@@ -85,7 +85,7 @@ runtime: yaml`
 		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
 
 		const expectedYAML = `environment:
-  - test-stack
+  - test/stack
 `
 
 		assert.Equal(t, expectedYAML, newStackYAML)
@@ -126,7 +126,7 @@ runtime: yaml`
 		err = init.run(ctx, nil)
 		require.NoError(t, err)
 
-		const expectedOut = "Creating environment test-stack for stack stack...\n" +
+		const expectedOut = "Creating environment test/stack for stack stack...\n" +
 			"# Value\n" +
 			"```json\n" +
 			"{\n" +
@@ -163,7 +163,7 @@ runtime: yaml`
 		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
 
 		const expectedYAML = `environment:
-  - test-stack
+  - test/stack
 `
 		assert.Equal(t, expectedYAML, newStackYAML)
 	})
@@ -203,7 +203,7 @@ runtime: yaml`
 		err = init.run(ctx, nil)
 		require.NoError(t, err)
 
-		const expectedOut = "Creating environment test-stack for stack stack...\n" +
+		const expectedOut = "Creating environment test/stack for stack stack...\n" +
 			"# Value\n" +
 			"```json\n" +
 			"{\n" +
@@ -239,7 +239,7 @@ runtime: yaml`
 		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
 
 		const expectedYAML = `environment:
-  - test-stack
+  - test/stack
 `
 		assert.Equal(t, expectedYAML, newStackYAML)
 	})
@@ -284,7 +284,7 @@ runtime: yaml`
 		err = init.run(ctx, nil)
 		require.NoError(t, err)
 
-		const expectedOut = "Creating environment test-stack for stack stack...\n" +
+		const expectedOut = "Creating environment test/stack for stack stack...\n" +
 			"# Value\n" +
 			"```json\n" +
 			"{\n" +
@@ -321,7 +321,7 @@ runtime: yaml`
 
 		const expectedYAML = `environment:
   - env
-  - test-stack
+  - test/stack
 `
 		assert.Equal(t, expectedYAML, newStackYAML)
 	})

--- a/pkg/cmd/pulumi/config_env_ls_test.go
+++ b/pkg/cmd/pulumi/config_env_ls_test.go
@@ -55,7 +55,7 @@ runtime: yaml`
 		require.NoError(t, err)
 
 		const expectedOut = "This stack configuration has no environments listed. " +
-			"Try adding one with `pulumi config env add [envName]`.\n"
+			"Try adding one with `pulumi config env add <projectName>/<envName>`.\n"
 
 		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
 	})

--- a/pkg/cmd/pulumi/config_env_test.go
+++ b/pkg/cmd/pulumi/config_env_test.go
@@ -204,7 +204,7 @@ func newConfigEnvCmdForInitTest(
 			if err != nil {
 				return nil, err
 			}
-			_, checkDiags := eval.CheckEnvironment(ctx, name, decl, nil, envs, &esc.ExecContext{})
+			_, checkDiags := eval.CheckEnvironment(ctx, name, decl, nil, nil, envs, &esc.ExecContext{}, false)
 			diags.Extend(checkDiags...)
 			if len(diags) != 0 {
 				return mapEvalDiags(diags), nil
@@ -221,7 +221,7 @@ func newConfigEnvCmdForInitTest(
 			if err != nil {
 				return nil, nil, err
 			}
-			env, checkDiags := eval.CheckEnvironment(ctx, "<yaml>", decl, nil, envs, &esc.ExecContext{})
+			env, checkDiags := eval.CheckEnvironment(ctx, "<yaml>", decl, nil, nil, envs, &esc.ExecContext{}, false)
 			diags.Extend(checkDiags...)
 			return env, mapEvalDiags(diags), nil
 		},

--- a/pkg/cmd/pulumi/config_env_test.go
+++ b/pkg/cmd/pulumi/config_env_test.go
@@ -68,6 +68,7 @@ func newConfigEnvCmdForTestWithCheckYAMLEnvironment(
 	createEnvironment func(
 		ctx context.Context,
 		org string,
+		project string,
 		name string,
 		yaml []byte,
 	) (apitype.EnvironmentDiagnostics, error),
@@ -197,6 +198,7 @@ func newConfigEnvCmdForInitTest(
 		func(
 			ctx context.Context,
 			org string,
+			project string,
 			name string,
 			yaml []byte,
 		) (apitype.EnvironmentDiagnostics, error) {

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231
-	github.com/pulumi/esc v0.9.1
+	github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870
 	github.com/pulumi/pulumi-java/pkg v0.14.0
 	github.com/pulumi/pulumi-yaml v1.9.2
 	github.com/segmentio/encoding v0.3.5

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -543,8 +543,8 @@ github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:Om
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435cARxCW6q9gc0S/Yxz7Mkd38pOb0=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
-github.com/pulumi/esc v0.9.1 h1:HH5eEv8sgyxSpY5a8yePyqFXzA8cvBvapfH8457+mIs=
-github.com/pulumi/esc v0.9.1/go.mod h1:oEJ6bOsjYlQUpjf70GiX+CXn3VBmpwFDxUTlmtUN84c=
+github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870 h1:x2olkM9dngDimVa7OUYxIDa4nb94PAFjr+WSM+AHnuk=
+github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870/go.mod h1:oEJ6bOsjYlQUpjf70GiX+CXn3VBmpwFDxUTlmtUN84c=
 github.com/pulumi/inflector v0.1.1 h1:dvlxlWtXwOJTUUtcYDvwnl6Mpg33prhK+7mzeF+SobA=
 github.com/pulumi/inflector v0.1.1/go.mod h1:HUFCjcPTz96YtTuUlwG3i3EZG4WlniBvR9bd+iJxCUY=
 github.com/pulumi/pulumi-java/pkg v0.14.0 h1:CKL7lLF81Fq6VRhA5TNFsSMnHraTNCUzIhqCzYX8Wzk=

--- a/sdk/go/pulumi-language-go/go.mod
+++ b/sdk/go/pulumi-language-go/go.mod
@@ -136,7 +136,7 @@ require (
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
-	github.com/pulumi/esc v0.9.1 // indirect
+	github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870 // indirect
 	github.com/pulumi/inflector v0.1.1 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect

--- a/sdk/go/pulumi-language-go/go.sum
+++ b/sdk/go/pulumi-language-go/go.sum
@@ -412,8 +412,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435cARxCW6q9gc0S/Yxz7Mkd38pOb0=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
-github.com/pulumi/esc v0.9.1 h1:HH5eEv8sgyxSpY5a8yePyqFXzA8cvBvapfH8457+mIs=
-github.com/pulumi/esc v0.9.1/go.mod h1:oEJ6bOsjYlQUpjf70GiX+CXn3VBmpwFDxUTlmtUN84c=
+github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870 h1:x2olkM9dngDimVa7OUYxIDa4nb94PAFjr+WSM+AHnuk=
+github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870/go.mod h1:oEJ6bOsjYlQUpjf70GiX+CXn3VBmpwFDxUTlmtUN84c=
 github.com/pulumi/inflector v0.1.1 h1:dvlxlWtXwOJTUUtcYDvwnl6Mpg33prhK+7mzeF+SobA=
 github.com/pulumi/inflector v0.1.1/go.mod h1:HUFCjcPTz96YtTuUlwG3i3EZG4WlniBvR9bd+iJxCUY=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
@@ -134,7 +134,7 @@ require (
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
-	github.com/pulumi/esc v0.9.1 // indirect
+	github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870 // indirect
 	github.com/pulumi/inflector v0.1.1 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.sum
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.sum
@@ -410,8 +410,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435cARxCW6q9gc0S/Yxz7Mkd38pOb0=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
-github.com/pulumi/esc v0.9.1 h1:HH5eEv8sgyxSpY5a8yePyqFXzA8cvBvapfH8457+mIs=
-github.com/pulumi/esc v0.9.1/go.mod h1:oEJ6bOsjYlQUpjf70GiX+CXn3VBmpwFDxUTlmtUN84c=
+github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870 h1:x2olkM9dngDimVa7OUYxIDa4nb94PAFjr+WSM+AHnuk=
+github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870/go.mod h1:oEJ6bOsjYlQUpjf70GiX+CXn3VBmpwFDxUTlmtUN84c=
 github.com/pulumi/inflector v0.1.1 h1:dvlxlWtXwOJTUUtcYDvwnl6Mpg33prhK+7mzeF+SobA=
 github.com/pulumi/inflector v0.1.1/go.mod h1:HUFCjcPTz96YtTuUlwG3i3EZG4WlniBvR9bd+iJxCUY=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/sdk/python/cmd/pulumi-language-python/go.mod
+++ b/sdk/python/cmd/pulumi-language-python/go.mod
@@ -133,7 +133,7 @@ require (
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
-	github.com/pulumi/esc v0.9.1 // indirect
+	github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870 // indirect
 	github.com/pulumi/inflector v0.1.1 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect

--- a/sdk/python/cmd/pulumi-language-python/go.sum
+++ b/sdk/python/cmd/pulumi-language-python/go.sum
@@ -408,8 +408,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435cARxCW6q9gc0S/Yxz7Mkd38pOb0=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
-github.com/pulumi/esc v0.9.1 h1:HH5eEv8sgyxSpY5a8yePyqFXzA8cvBvapfH8457+mIs=
-github.com/pulumi/esc v0.9.1/go.mod h1:oEJ6bOsjYlQUpjf70GiX+CXn3VBmpwFDxUTlmtUN84c=
+github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870 h1:x2olkM9dngDimVa7OUYxIDa4nb94PAFjr+WSM+AHnuk=
+github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870/go.mod h1:oEJ6bOsjYlQUpjf70GiX+CXn3VBmpwFDxUTlmtUN84c=
 github.com/pulumi/inflector v0.1.1 h1:dvlxlWtXwOJTUUtcYDvwnl6Mpg33prhK+7mzeF+SobA=
 github.com/pulumi/inflector v0.1.1/go.mod h1:HUFCjcPTz96YtTuUlwG3i3EZG4WlniBvR9bd+iJxCUY=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -143,7 +143,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/pulumi/esc v0.9.1 // indirect
+	github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870 // indirect
 	github.com/pulumi/inflector v0.1.1 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -3252,8 +3252,9 @@ github.com/prometheus/prometheus v0.50.1/go.mod h1:FvE8dtQ1Ww63IlyKBn1V4s+zMwF9k
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435cARxCW6q9gc0S/Yxz7Mkd38pOb0=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
-github.com/pulumi/esc v0.9.1 h1:HH5eEv8sgyxSpY5a8yePyqFXzA8cvBvapfH8457+mIs=
 github.com/pulumi/esc v0.9.1/go.mod h1:oEJ6bOsjYlQUpjf70GiX+CXn3VBmpwFDxUTlmtUN84c=
+github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870 h1:x2olkM9dngDimVa7OUYxIDa4nb94PAFjr+WSM+AHnuk=
+github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870/go.mod h1:oEJ6bOsjYlQUpjf70GiX+CXn3VBmpwFDxUTlmtUN84c=
 github.com/pulumi/inflector v0.1.1 h1:dvlxlWtXwOJTUUtcYDvwnl6Mpg33prhK+7mzeF+SobA=
 github.com/pulumi/inflector v0.1.1/go.mod h1:HUFCjcPTz96YtTuUlwG3i3EZG4WlniBvR9bd+iJxCUY=
 github.com/pulumi/pulumi-java/pkg v0.14.0/go.mod h1:VybuJMWJtJc9ZNbt1kcYH4TbpocMx9mEi7YWL2Co99c=

--- a/tests/integration/construct_component_configure_provider/testcomponent-go/go.mod
+++ b/tests/integration/construct_component_configure_provider/testcomponent-go/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
-	github.com/pulumi/esc v0.9.1 // indirect
+	github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect

--- a/tests/integration/construct_component_configure_provider/testcomponent-go/go.sum
+++ b/tests/integration/construct_component_configure_provider/testcomponent-go/go.sum
@@ -135,8 +135,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435cARxCW6q9gc0S/Yxz7Mkd38pOb0=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
-github.com/pulumi/esc v0.9.1 h1:HH5eEv8sgyxSpY5a8yePyqFXzA8cvBvapfH8457+mIs=
-github.com/pulumi/esc v0.9.1/go.mod h1:oEJ6bOsjYlQUpjf70GiX+CXn3VBmpwFDxUTlmtUN84c=
+github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870 h1:x2olkM9dngDimVa7OUYxIDa4nb94PAFjr+WSM+AHnuk=
+github.com/pulumi/esc v0.9.2-0.20240821222338-4f71a476d870/go.mod h1:oEJ6bOsjYlQUpjf70GiX+CXn3VBmpwFDxUTlmtUN84c=
 github.com/pulumi/pulumi-tls/sdk/v4 v4.10.0 h1:4MC0GyEomAjEZJPXEzBZpZ4+TOUg5WE77k38tMDIvS0=
 github.com/pulumi/pulumi-tls/sdk/v4 v4.10.0/go.mod h1:tNXsM/+RsiVVmBdzJMOOp6gMoi3sPko5u0FKdiei+cE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
This adds supports for ESC Projects (including `pulumi config env` commands)

The main functional changes are to `pulumi config env init`.
(This PR will merge into the `features/esc-projects` branch, only merging to master when we publicly rollout ESC Projects)

## Testing
(my stack is test_project/random5)
```bash
# Confirm parsing of env name with blank or name without project
# If given blank, defaults to existing stack project/name
❯ pulumi config env init
Creating environment test_project/random5 for stack random5...

   Value

    {
      "pulumiConfig": {}
    }

   Definition

    values:
      pulumiConfig: {}


error: prompt aborted

# If given no project, use stack project
❯ pulumi config env init --env abc
Creating environment test_project/abc for stack random5...

   Value

    {
      "pulumiConfig": {}
    }

   Definition

    values:
      pulumiConfig: {}


error: prompt aborted

# Confirm that can create an env
❯ pulumi config env init --env abc/def
Creating environment abc/def for stack random5...

   Value

    {
      "pulumiConfig": {}
    }

   Definition

    values:
      pulumiConfig: {}


Save? Yes

```