### PR TITLE
Update package add instructions for go

### DIFF
--- a/changelog/pending/20240823--sdkgen-go--update-package-add-instructions-for-go.yaml
+++ b/changelog/pending/20240823--sdkgen-go--update-package-add-instructions-for-go.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/go
+  description: Update package add instructions for go

--- a/pkg/cmd/pulumi/package_add.go
+++ b/pkg/cmd/pulumi/package_add.go
@@ -241,7 +241,6 @@ func printGoLinkInstructions(root string, pkg *schema.Package, out string) error
 	fmt.Println()
 
 	relOut, err := filepath.Rel(root, out)
-	relOut = filepath.Join(relOut, pkg.Name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In https://github.com/pulumi/pulumi-terraform-bridge/pull/2345 we set the `RootPackageName` so that local SDKs generate a flat structure without an extra layer of nesting. Update the instructions to no longer add the package name to the linking instructions.

Fixes https://github.com/pulumi/pulumi/issues/17054
