### PR TITLE
Log error in symmetricCrypterFromPhraseAndState

### DIFF
--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -64,6 +65,7 @@ func symmetricCrypterFromPhraseAndState(phrase string, state string) (config.Cry
 	ignoredCtx := context.Background()
 	decrypted, err := decrypter.DecryptValue(ignoredCtx, state[indexN(state, ":", 2)+1:])
 	if err != nil || decrypted != "pulumi" {
+		logging.V(7).Infof("incorrect passphrase: %v", err)
 		return nil, ErrIncorrectPassphrase
 	}
 


### PR DESCRIPTION
Pointed out in https://github.com/pulumi/home/issues/3601#issuecomment-2306413266.

If DecryptValue fails we don't currently propagate the information about that error anywhere, instead just returning a ErrIncorrectPassphrase error. This adds a log statement so we can at least ask users to run with `-v=7` to see what error is happening.