### PR TITLE
Respect .node-version and .nvmrc files in `pulumi install`

### DIFF
--- a/changelog/pending/20240823--sdk-nodejs--respect-node-version-and-nvmrc-files-in-pulumi-install.yaml
+++ b/changelog/pending/20240823--sdk-nodejs--respect-node-version-and-nvmrc-files-in-pulumi-install.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Respect .node-version and .nvmrc files in `pulumi install`

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -991,7 +991,9 @@ func installNodeVersion(cwd string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(stdout, "Setting Nodejs version to %s\n", version)
+	if stdout != nil {
+		fmt.Fprintf(stdout, "Setting Nodejs version to %s\n", version)
+	}
 	// This is a no-op if the version is already installed
 	installCmd := exec.Command("fnm", "install", version, "--progress", "never")
 	out, err := installCmd.CombinedOutput()

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -886,6 +886,14 @@ func (host *nodeLanguageHost) InstallDependencies(
 	tracingSpan, ctx := opentracing.StartSpanFromContext(server.Context(), "npm-install")
 	defer tracingSpan.Finish()
 
+	// Look for a .nvmrc or .node-version file, install the version specified in it, and set it as
+	// the default nodejs version.
+	if req.UseLanguageVersionTools {
+		if err := installNodeVersion(req.Info.ProgramDirectory, stdout); err != nil {
+			return fmt.Errorf("failed to install node version: %w", err)
+		}
+	}
+
 	stdout.Write([]byte("Installing dependencies...\n\n"))
 
 	workspaceRoot := req.Info.ProgramDirectory
@@ -924,6 +932,81 @@ func (host *nodeLanguageHost) InstallDependencies(
 	}
 
 	return closer.Close()
+}
+
+var (
+	errVersionFileNotFound = errors.New("version file not found")
+	errFnmNotFound         = errors.New("fnm not found")
+)
+
+// useFnm checks if the current directory or any of its parents contains a `.nvmrc` or
+// `.node-version` file, and if fnm is installed. If both conditions are met, it returns the
+// the version string specified in the found version file.
+// `.nvmrc` takes precedence over `.node-version`.
+// Note that the version string is not necessarily a semver. The version string can have a `v`
+// prefix, or be a partial version string like `20` or `20.6`.
+func useFnm(cwd string) (string, error) {
+	if _, err := exec.LookPath("fnm"); err != nil {
+		if !errors.Is(err, exec.ErrNotFound) {
+			return "", fmt.Errorf("error while looking for fnm: %w", err)
+		}
+		// fnm is not installed
+		logging.V(9).Infof("Could not find fnm executable")
+		return "", errFnmNotFound
+	}
+	versionFile, err := fsutil.Searchup(cwd, ".nvmrc")
+	if err != nil {
+		if !errors.Is(err, fsutil.ErrNotFound) {
+			return "", fmt.Errorf("error while looking for .nvmrc: %w", err)
+		}
+		// No .nvmrc file found, look for .node-version
+		versionFile, err = fsutil.Searchup(cwd, ".node-version")
+		if err != nil {
+			if !errors.Is(err, fsutil.ErrNotFound) {
+				return "", fmt.Errorf("error while looking for .node-version: %w", err)
+			}
+			// No .nvmrc or .node-version file found
+			return "", errVersionFileNotFound
+		}
+	}
+	versionBytes, err := os.ReadFile(versionFile)
+	if err != nil {
+		return "", err
+	}
+	version := strings.TrimSpace(string(versionBytes))
+	logging.V(9).Infof("Found node version %s in file %s", version, versionFile)
+	return version, nil
+}
+
+// installNodeVersion installs the node version specified in the `.nvmrc` or `.node-version` file.
+// This is meant to be used in container like environments, where we do not run within a shell.
+// When running locally in a shell, fnm, nvm and other similar tools already set the node version
+// via their shell integration.
+func installNodeVersion(cwd string, stdout io.Writer) error {
+	version, err := useFnm(cwd)
+	if err != nil {
+		if errors.Is(err, errVersionFileNotFound) || errors.Is(err, errFnmNotFound) {
+			// No version file found, or no fnm executable found -> nothing to do
+			return nil
+		}
+		return err
+	}
+	fmt.Fprintf(stdout, "Setting Nodejs version to %s\n", version)
+	// This is a no-op if the version is already installed
+	installCmd := exec.Command("fnm", "install", version, "--progress", "never")
+	out, err := installCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to install Nodejs version: %v: %s", err, out)
+	}
+	// Set the requested version as default so it is available at $FNM_DIR/aliases/default/bin
+	// This allows us to set the ambient node version for the whole container, without requiring
+	// us to pass environment variables to every `node` invocation.
+	setDefaultCmd := exec.Command("fnm", "alias", version, "default")
+	out, err = setDefaultCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to set default Nodejs version: %v: %s", err, out)
+	}
+	return nil
 }
 
 func (host *nodeLanguageHost) RuntimeOptionsPrompts(ctx context.Context,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
@@ -489,8 +489,15 @@ func TestRunWithOutputDoesNotMissData(t *testing.T) {
 	require.Equal(t, 100+2 /* "x\n" */, *stderr.nWrites)
 }
 
+//nolint:paralleltest // mutates environment variables
 func TestUseFnm(t *testing.T) {
-	t.Parallel()
+	// Add a fake fnm binary to $tmp/bin and set $PATH to $tmp/bin so that `useFnm` can find it.
+	tmpDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "bin"), 0o755))
+	//nolint:gosec // we want this file to be executable
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "bin", "fnm"), []byte("#!/bin/sh\nexit 0;\n"), 0o700))
+	t.Setenv("PATH", filepath.Join(tmpDir, "bin")+string(os.PathListSeparator)+os.Getenv("PATH"))
+
 	t.Run("no version files", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()


### PR DESCRIPTION
When using the `--use-language-version-tools` flag with `pulumi install`, and `fnm` is installed, we look for `.nvmrc` and `.node-version` files and install the requested version.

This is meant to be used within containers where we don’t run within a shell. When running locally, fnm, nvm and similar tools manage the nodejs version via their shell integration and ensure the correct version is set.

pulumi-docker-containers makes use of this in https://github.com/pulumi/pulumi-docker-containers/pull/253