### PR TITLE
Prepare golangci-lint upgrade

### DIFF
--- a/pkg/backend/display/internal/terminal/term.go
+++ b/pkg/backend/display/internal/terminal/term.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 
 	"github.com/muesli/cancelreader"
@@ -48,6 +49,10 @@ func Open(in io.Reader, out io.Writer, raw bool) (Terminal, error) {
 	if !ok {
 		return nil, ErrNotATerminal
 	}
+	if outFile.Fd() > math.MaxInt32 {
+		return nil, fmt.Errorf("file descriptor too large: %v", outFile.Fd())
+	}
+	//nolint:gosec // uintptr -> int conversion checked above
 	outFd := int(outFile.Fd())
 
 	width, height, err := term.GetSize(outFd)

--- a/pkg/backend/display/watch.go
+++ b/pkg/backend/display/watch.go
@@ -63,8 +63,8 @@ func ShowWatchEvents(op string, events <-chan engine.Event, done chan<- bool, op
 			if p.URN != "" {
 				resourceName = p.URN.Name()
 			}
-			PrintfWithWatchPrefix(time.Now(), resourceName,
-				"%s", renderDiffDiagEvent(p, opts))
+			PrintfWithWatchPrefix(time.Now(), resourceName, "%s",
+				renderDiffDiagEvent(p, opts))
 		case engine.ResourcePreEvent:
 			p := e.Payload().(engine.ResourcePreEventPayload)
 			if shouldShow(p.Metadata, opts) {

--- a/pkg/backend/display/watch.go
+++ b/pkg/backend/display/watch.go
@@ -63,8 +63,8 @@ func ShowWatchEvents(op string, events <-chan engine.Event, done chan<- bool, op
 			if p.URN != "" {
 				resourceName = p.URN.Name()
 			}
-			PrintfWithWatchPrefix(time.Now(), resourceName, "%s",
-				renderDiffDiagEvent(p, opts))
+			PrintfWithWatchPrefix(time.Now(), resourceName,
+				"%s", renderDiffDiagEvent(p, opts))
 		case engine.ResourcePreEvent:
 			p := e.Payload().(engine.ResourcePreEventPayload)
 			if shouldShow(p.Metadata, opts) {

--- a/pkg/backend/diy/backend_test.go
+++ b/pkg/backend/diy/backend_test.go
@@ -775,7 +775,7 @@ func TestLegacyFolderStructure(t *testing.T) {
 	tmpDir := t.TempDir()
 	err := os.MkdirAll(path.Join(tmpDir, ".pulumi", "stacks"), os.ModePerm)
 	require.NoError(t, err)
-	err = os.WriteFile(path.Join(tmpDir, ".pulumi", "stacks", "a.json"), []byte("{}"), os.ModePerm)
+	err = os.WriteFile(path.Join(tmpDir, ".pulumi", "stacks", "a.json"), []byte("{}"), 0o600)
 	require.NoError(t, err)
 
 	// Login to a temp dir diy backend
@@ -951,7 +951,7 @@ func TestProjectFolderStructure(t *testing.T) {
 	require.NoError(t, err)
 	err = os.MkdirAll(path.Join(tmpDir, ".pulumi", "stacks"), os.ModePerm)
 	require.NoError(t, err)
-	err = os.WriteFile(path.Join(tmpDir, ".pulumi", "stacks", "a.txt"), []byte("{}"), os.ModePerm)
+	err = os.WriteFile(path.Join(tmpDir, ".pulumi", "stacks", "a.txt"), []byte("{}"), 0o600)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -967,7 +967,7 @@ func TestProjectFolderStructure(t *testing.T) {
 	// Make a dummy stack file in the new project location
 	err = os.MkdirAll(path.Join(tmpDir, ".pulumi", "stacks", "testproj"), os.ModePerm)
 	assert.NoError(t, err)
-	err = os.WriteFile(path.Join(tmpDir, ".pulumi", "stacks", "testproj", "a.json"), []byte("{}"), os.ModePerm)
+	err = os.WriteFile(path.Join(tmpDir, ".pulumi", "stacks", "testproj", "a.json"), []byte("{}"), 0o600)
 	assert.NoError(t, err)
 
 	// Check that testproj is reported as existing
@@ -1140,7 +1140,7 @@ func TestLegacyUpgrade(t *testing.T) {
 				}
 			]
 		}
-	}`), os.ModePerm)
+	}`), 0o600)
 	require.NoError(t, err)
 
 	var output bytes.Buffer
@@ -1179,7 +1179,7 @@ func TestLegacyUpgrade(t *testing.T) {
 				}
 			]
 		}
-	}`), os.ModePerm)
+	}`), 0o600)
 	require.NoError(t, err)
 
 	err = lb.Upgrade(ctx, nil /* opts */)

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -477,12 +477,12 @@ func (m defaultLoginManager) Login(
 	line1 := "Manage your " + message + " by logging in."
 	line1len := len(line1)
 	line1 = colors.Highlight(line1, message, colors.Underline+colors.Bold)
-	fmt.Printf(opts.Color.Colorize(line1) + "\n")
+	fmt.Println(opts.Color.Colorize(line1))
 	maxlen := line1len
 
 	line2 := fmt.Sprintf("Run `%s login --help` for alternative login options.", command)
 	line2len := len(line2)
-	fmt.Printf(opts.Color.Colorize(line2) + "\n")
+	fmt.Println(opts.Color.Colorize(line2))
 	if line2len > maxlen {
 		maxlen = line2len
 	}
@@ -503,7 +503,7 @@ func (m defaultLoginManager) Login(
 		line3len := len(line3)
 		line3 = colors.Highlight(line3, "access token", colors.BrightCyan+colors.Bold)
 		line3 = colors.Highlight(line3, accountLink, colors.BrightBlue+colors.Underline+colors.Bold)
-		fmt.Printf(opts.Color.Colorize(line3) + "\n")
+		fmt.Println(opts.Color.Colorize(line3))
 		if line3len > maxlen {
 			maxlen = line3len
 		}

--- a/pkg/backend/watch.go
+++ b/pkg/backend/watch.go
@@ -83,7 +83,7 @@ func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation,
 		colors.SpecHeadline+"Watching (%s):"+colors.Reset+"\n"), stack.Ref())
 
 	for range events {
-		display.PrintfWithWatchPrefix(time.Now(), "",
+		display.PrintfWithWatchPrefix(time.Now(), "", "%s",
 			op.Opts.Display.Color.Colorize(colors.SpecImportant+"Updating..."+colors.Reset+"\n"))
 
 		// Perform the update operation
@@ -93,10 +93,10 @@ func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation,
 			if err == context.Canceled {
 				return err
 			}
-			display.PrintfWithWatchPrefix(time.Now(), "",
+			display.PrintfWithWatchPrefix(time.Now(), "", "%s",
 				op.Opts.Display.Color.Colorize(colors.SpecImportant+"Update failed."+colors.Reset+"\n"))
 		} else {
-			display.PrintfWithWatchPrefix(time.Now(), "",
+			display.PrintfWithWatchPrefix(time.Now(), "", "%s",
 				op.Opts.Display.Color.Colorize(colors.SpecImportant+"Update complete."+colors.Reset+"\n"))
 		}
 	}

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -608,6 +608,7 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 			switch {
 			case len(args) == 2:
 				value = args[1]
+			//nolint:gosec // os.Stdin.Fd() == 0: uintptr -> int conversion is always safe
 			case !term.IsTerminal(int(os.Stdin.Fd())):
 				b, readerr := io.ReadAll(os.Stdin)
 				if readerr != nil {

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -141,7 +141,7 @@ func setCommandGroups(cmd *cobra.Command, rootCgs []commandGroup) {
 type loggingWriter struct{}
 
 func (loggingWriter) Write(bytes []byte) (int, error) {
-	logging.Infof(string(bytes))
+	logging.Infof("%s", string(bytes))
 	return len(bytes), nil
 }
 
@@ -502,7 +502,7 @@ func checkForUpdate(ctx context.Context) *diag.Diag {
 			// If we're skipping the check,
 			// still log this to the internal logging system
 			// that users don't see by default.
-			logging.Warningf(msg)
+			logging.Warningf("%s", msg)
 			return nil
 		}
 		return diag.RawMessage("", msg)

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -233,7 +233,7 @@ func (g *generator) genComponentArgs(w io.Writer, componentName string, componen
 	g.Fgenf(w, "type %s struct {\n", argsTypeName)
 	g.Indented(func() {
 		for _, config := range configVariables {
-			g.Fgenf(w, g.Indent)
+			g.Fgen(w, g.Indent)
 			fieldName := Title(config.LogicalName())
 			inputType := componentInputType(config.Type())
 			switch configType := config.Type().(type) {
@@ -299,14 +299,14 @@ func (g *generator) genComponentType(w io.Writer, componentName string, componen
 	componentTypeName := Title(componentName)
 	g.Fgenf(w, "type %s struct {\n", componentTypeName)
 	g.Indented(func() {
-		g.Fgenf(w, g.Indent)
-		g.Fgenf(w, "pulumi.ResourceState\n")
+		g.Fgen(w, g.Indent)
+		g.Fgen(w, "pulumi.ResourceState\n")
 		for _, output := range outputs {
-			g.Fgenf(w, g.Indent)
+			g.Fgen(w, g.Indent)
 			fieldName := Title(output.LogicalName())
 			fieldType := "pulumi.AnyOutput" // TODO: update this
 			g.Fgenf(w, "%s %s\n", fieldName, fieldType)
-			g.Fgenf(w, "")
+			g.Fgen(w, "")
 		}
 	})
 	g.Fgenf(w, "}\n\n")

--- a/pkg/codegen/hcl2/model/diagnostics.go
+++ b/pkg/codegen/hcl2/model/diagnostics.go
@@ -42,7 +42,7 @@ func ExprNotConvertible(destType Type, expr Expression) *hcl.Diagnostic {
 	_, whyF := destType.conversionFrom(expr.Type(), false, map[Type]struct{}{})
 	why := whyF()
 	if len(why) != 0 {
-		return errorf(expr.SyntaxNode().Range(), why[0].Summary)
+		return errorf(expr.SyntaxNode().Range(), "%s", why[0].Summary)
 	}
 	return errorf(expr.SyntaxNode().Range(), "cannot assign expression of type %s to location of type %s: ",
 		expr.Type().Pretty(), destType.Pretty())

--- a/pkg/codegen/pcl/binder_component.go
+++ b/pkg/codegen/pcl/binder_component.go
@@ -138,7 +138,7 @@ func ComponentProgramBinderFromFileSystem() ComponentProgramBinder {
 		// Load all .pp files in the components' directory
 		files, err := os.ReadDir(componentSourceDir)
 		if err != nil {
-			diagnostics = diagnostics.Append(errorf(nodeRange, err.Error()))
+			diagnostics = diagnostics.Append(errorf(nodeRange, "%s", err.Error()))
 			return nil, diagnostics, nil
 		}
 
@@ -157,14 +157,14 @@ func ComponentProgramBinderFromFileSystem() ComponentProgramBinder {
 			if filepath.Ext(fileName) == ".pp" {
 				file, err := os.Open(path)
 				if err != nil {
-					diagnostics = diagnostics.Append(errorf(nodeRange, err.Error()))
+					diagnostics = diagnostics.Append(errorf(nodeRange, "%s", err.Error()))
 					return nil, diagnostics, err
 				}
 
 				err = parser.ParseFile(file, fileName)
 				contract.IgnoreError(file.Close())
 				if err != nil {
-					diagnostics = diagnostics.Append(errorf(nodeRange, err.Error()))
+					diagnostics = diagnostics.Append(errorf(nodeRange, "%s", err.Error()))
 					return nil, diagnostics, err
 				}
 
@@ -305,13 +305,13 @@ func (b *binder) bindComponent(node *Component) hcl.Diagnostics {
 		ComponentNodeRange:           node.SyntaxNode().Range(),
 	})
 	if err != nil {
-		diagnostics = diagnostics.Append(errorf(node.SyntaxNode().Range(), err.Error()))
+		diagnostics = diagnostics.Append(errorf(node.SyntaxNode().Range(), "%s", err.Error()))
 		node.VariableType = model.DynamicType
 		return diagnostics
 	}
 
 	if programDiags.HasErrors() || componentProgram == nil {
-		diagnostics = diagnostics.Append(errorf(node.SyntaxNode().Range(), programDiags.Error()))
+		diagnostics = diagnostics.Append(errorf(node.SyntaxNode().Range(), "%s", programDiags.Error()))
 		node.VariableType = model.DynamicType
 		return diagnostics
 	}

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -997,6 +997,7 @@ func bindConstValue(path, kind string, value interface{}, typ Type) (interface{}
 		if v < math.MinInt32 || v > math.MaxInt32 {
 			return 0, typeError("integer")
 		}
+		//nolint:gosec // int -> int32 conversion is guarded above.
 		return int32(v), nil
 	case NumberType:
 		v, ok := value.(float64)

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1904,7 +1904,7 @@ func (funcSpec FunctionSpec) marshalFunctionSpec() (map[string]interface{}, erro
 		data["overlaySupportedLanguages"] = funcSpec.OverlaySupportedLanguages
 	}
 
-	if funcSpec.Language != nil && len(funcSpec.Language) > 0 {
+	if len(funcSpec.Language) > 0 {
 		data["language"] = funcSpec.Language
 	}
 

--- a/pkg/resource/deploy/deploytest/resourcemonitor.go
+++ b/pkg/resource/deploy/deploytest/resourcemonitor.go
@@ -99,6 +99,7 @@ func parseSourcePosition(raw string) (*pulumirpc.SourcePosition, error) {
 		if err != nil {
 			return nil, err
 		}
+		//nolint:gosec // ParseInt will return an error if the size is too large.
 		pos.Line = int32(l)
 	}
 	if col != "" {
@@ -106,6 +107,7 @@ func parseSourcePosition(raw string) (*pulumirpc.SourcePosition, error) {
 		if err != nil {
 			return nil, err
 		}
+		//nolint:gosec // ParseInt will return an error if the size is too large.
 		pos.Column = int32(c)
 	}
 

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1188,7 +1188,7 @@ func (sg *stepGenerator) generateStepsFromDiff(
 				// we're doing a create before delete replacement we'll execute the create before getting
 				// to the delete error.
 				if !sg.deployment.opts.DryRun {
-					return nil, result.BailErrorf(message)
+					return nil, result.BailErrorf("%s", message)
 				}
 			}
 
@@ -1307,7 +1307,7 @@ func (sg *stepGenerator) generateStepsFromDiff(
 								dependentResource.URN, urn, dependentResource.URN)
 							sg.deployment.ctx.Diag.Errorf(diag.StreamMessage(urn, message, 0))
 							sg.sawError = true
-							return nil, result.BailErrorf(message)
+							return nil, result.BailErrorf("%s", message)
 						}
 						steps = append(steps, NewDeleteReplacementStep(sg.deployment, sg.deletes, dependentResource, true))
 					}

--- a/pkg/testing/integration/pulumi.go
+++ b/pkg/testing/integration/pulumi.go
@@ -32,7 +32,7 @@ func CreateBasicPulumiRepo(e *testing.Environment) {
 	contents := "name: pulumi-test\ndescription: a test\nruntime: nodejs\n"
 	filePath := workspace.ProjectFile + ".yaml"
 	filePath = path.Join(e.CWD, filePath)
-	err := os.WriteFile(filePath, []byte(contents), os.ModePerm)
+	err := os.WriteFile(filePath, []byte(contents), 0o600)
 	assert.NoError(e, err, "writing %s file", filePath)
 }
 
@@ -42,7 +42,7 @@ func CreateBasicPulumiRepo(e *testing.Environment) {
 func CreatePulumiRepo(e *testing.Environment, projectFileContent string) {
 	e.RunCommand("git", "init")
 	filePath := path.Join(e.CWD, workspace.ProjectFile+".yaml")
-	err := os.WriteFile(filePath, []byte(projectFileContent), os.ModePerm)
+	err := os.WriteFile(filePath, []byte(projectFileContent), 0o600)
 	assert.NoError(e, err, "writing %s file", filePath)
 }
 

--- a/pkg/testing/integration/util.go
+++ b/pkg/testing/integration/util.go
@@ -62,7 +62,7 @@ func ReplaceInFile(old, new, path string) error {
 		return err
 	}
 	newContents := strings.ReplaceAll(string(rawContents), old, new)
-	return os.WriteFile(path, []byte(newContents), os.ModePerm)
+	return os.WriteFile(path, []byte(newContents), 0o600)
 }
 
 // getCmdBin returns the binary named bin in location loc or, if it hasn't yet been initialized, will lazily

--- a/pkg/util/tracing/tracing.go
+++ b/pkg/util/tracing/tracing.go
@@ -18,8 +18,10 @@ import (
 	"context"
 )
 
+type key int
+
 // tracingOptionsKey is the value used as the context key for TracingOptions.
-var tracingOptionsKey struct{}
+const tracingOptionsKey key = 0
 
 // TracingOptions describes the set of options available for configuring tracing on a per-request basis.
 type Options struct {

--- a/sdk/go/common/resource/archive/archive.go
+++ b/sdk/go/common/resource/archive/archive.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -970,6 +971,10 @@ func (r *zipArchiveReader) Next() (string, *asset.Blob, error) {
 			return "", nil, fmt.Errorf("failed to read ZIP inner file %v: %w", file.Name, err)
 		}
 
+		if file.UncompressedSize64 > math.MaxInt64 {
+			return "", nil, fmt.Errorf("file %v is too large to read", file.Name)
+		}
+		//nolint:gosec // uint64 -> int64 overflow is checked above.
 		blob := asset.NewRawBlob(body, int64(file.UncompressedSize64))
 		name := filepath.Clean(file.Name)
 		return name, blob, nil

--- a/sdk/go/common/resource/config/plaintext.go
+++ b/sdk/go/common/resource/config/plaintext.go
@@ -38,7 +38,7 @@ type Plaintext struct {
 func NewPlaintext[T PlaintextType](v T) Plaintext {
 	if m, ok := any(v).(map[string]Plaintext); ok && len(m) == 1 {
 		if _, ok := m["secure"].Value().(string); ok {
-			contract.Failf(errSecureReprReserved.Error())
+			contract.Failf("%s", errSecureReprReserved.Error())
 		}
 	}
 

--- a/sdk/go/common/resource/plugin/diagnostic.go
+++ b/sdk/go/common/resource/plugin/diagnostic.go
@@ -49,6 +49,7 @@ func HclDiagnosticToRPCDiagnostic(diag *hcl.Diagnostic) *codegenrpc.Diagnostic {
 	}
 
 	return &codegenrpc.Diagnostic{
+		//nolint:gosec // diag.Seveverity is 0, 1 or 2, the int -> int32 conversion is safe.
 		Severity: codegenrpc.DiagnosticSeverity(diag.Severity),
 		Summary:  diag.Summary,
 		Detail:   diag.Detail,

--- a/sdk/go/common/testing/environment.go
+++ b/sdk/go/common/testing/environment.go
@@ -276,7 +276,7 @@ func (e *Environment) WriteTestFile(filename string, contents string) {
 		e.T.Fatalf("error making directories for test file (%v): %v", filename, err)
 	}
 
-	if err := os.WriteFile(filename, []byte(contents), os.ModePerm); err != nil {
+	if err := os.WriteFile(filename, []byte(contents), 0o600); err != nil {
 		e.T.Fatalf("writing test file (%v): %v", filename, err)
 	}
 }

--- a/sdk/go/common/util/archive/archive.go
+++ b/sdk/go/common/util/archive/archive.go
@@ -22,6 +22,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -86,6 +87,10 @@ func extractFile(r *tar.Reader, header *tar.Header, dir string) error {
 		}
 
 		// Expand files into the target directory.
+		if header.Mode > math.MaxUint32 {
+			return fmt.Errorf("unexpected file mode %v for %s", header.Mode, header.Name)
+		}
+		//nolint:gosec // int64 -> uint32 conversion guarded above
 		dst, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 		if err != nil {
 			return fmt.Errorf("opening file %s for extraction: %w", path, err)

--- a/sdk/go/common/util/cmdutil/console.go
+++ b/sdk/go/common/util/cmdutil/console.go
@@ -62,12 +62,14 @@ func InteractiveTerminal() bool {
 	// if we're piping in stdin, we're clearly not interactive, as there's no way for a user to
 	// provide input.  If we're piping stdout, we also can't be interactive as there's no way for
 	// users to see prompts to interact with them.
+	//nolint:gosec // os.Stdin.Fd() == 0 && os.Stdout.Fd() == 1: uintptr -> int conversion is always safe
 	return term.IsTerminal(int(os.Stdin.Fd())) &&
 		term.IsTerminal(int(os.Stdout.Fd()))
 }
 
 // ReadConsole reads the console with the given prompt text.
 func ReadConsole(prompt string) (string, error) {
+	//nolint:gosec // os.Stdin.Fd() == 0: uintptr -> int conversion is always safe
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		return readConsolePlain(os.Stdout, os.Stdin, prompt)
 	}

--- a/sdk/go/common/util/cmdutil/console_password.go
+++ b/sdk/go/common/util/cmdutil/console_password.go
@@ -26,6 +26,7 @@ func ReadConsoleNoEcho(prompt string) (string, error) {
 	// error when it tries to disable local echo.
 	//
 	// In this case, just read normally
+	//nolint:gosec // os.Stdin.Fd() == 0: uintptr -> int conversion is always safe
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		return readConsolePlain(os.Stdout, os.Stdin, prompt)
 	}

--- a/sdk/go/common/util/cmdutil/exit.go
+++ b/sdk/go/common/util/cmdutil/exit.go
@@ -117,7 +117,7 @@ func RunFunc(run func(cmd *cobra.Command, args []string) error) func(*cobra.Comm
 				msg = DetailedError(err)
 			} else {
 				msg = errorMessage(err)
-				logging.V(3).Infof(DetailedError(err))
+				logging.V(3).Info(DetailedError(err))
 			}
 
 			ExitError(msg)

--- a/sdk/go/common/util/rpcutil/writer_test.go
+++ b/sdk/go/common/util/rpcutil/writer_test.go
@@ -177,6 +177,7 @@ func TestWriter_IsPTY(t *testing.T) {
 		// These will be os.Files if a pty
 		file, ok := stdout.(*os.File)
 		assert.True(t, ok, "stdout was not a File")
+		//nolint:gosec
 		assert.True(t, term.IsTerminal(int(file.Fd())), "stdout was not a terminal")
 	}
 

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -1051,7 +1051,7 @@ func (info *ProjectRuntimeInfo) SetOption(key string, value interface{}) {
 }
 
 func (info ProjectRuntimeInfo) MarshalYAML() (interface{}, error) {
-	if info.options == nil || len(info.options) == 0 {
+	if len(info.options) == 0 {
 		return info.name, nil
 	}
 
@@ -1062,7 +1062,7 @@ func (info ProjectRuntimeInfo) MarshalYAML() (interface{}, error) {
 }
 
 func (info ProjectRuntimeInfo) MarshalJSON() ([]byte, error) {
-	if info.options == nil || len(info.options) == 0 {
+	if len(info.options) == 0 {
 		return json.Marshal(info.name)
 	}
 

--- a/sdk/go/internal/workgroup_test.go
+++ b/sdk/go/internal/workgroup_test.go
@@ -27,20 +27,20 @@ func TestWorkGroupActsAsWaitGroup(t *testing.T) {
 
 	check := func(j int) func(*testing.T) {
 		return func(*testing.T) {
-			var n int32
+			var n int64
 			wg := &WorkGroup{}
 			wg.Add(j)
 
 			for k := 0; k < j; k++ {
 				go func() {
 					time.Sleep(10 * time.Millisecond)
-					atomic.AddInt32(&n, 1)
+					atomic.AddInt64(&n, 1)
 					wg.Done()
 				}()
 			}
 
 			wg.Wait()
-			assert.Equal(t, int32(j), atomic.AddInt32(&n, 0))
+			assert.Equal(t, int64(j), atomic.AddInt64(&n, 0))
 		}
 	}
 

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -1036,6 +1036,7 @@ func (host *goLanguageHost) RunPlugin(
 		if exiterr, ok := err.(*exec.ExitError); ok {
 			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
 				err = server.Send(&pulumirpc.RunPluginResponse{
+					//nolint:gosec // WaitStatus always uses the lower 8 bits for the exit code.
 					Output: &pulumirpc.RunPluginResponse_Exitcode{Exitcode: int32(status.ExitStatus())},
 				})
 			} else {

--- a/sdk/go/pulumi/provider/provider.go
+++ b/sdk/go/pulumi/provider/provider.go
@@ -23,8 +23,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-// This file relies on implementations in ../provider_linked.go that are made available in this package via
-// go:linkname.
+// This file relies on implementations in ../provider_linked.go that are made available in this
+// package via go:linkname.
 
 type ConstructFunc func(ctx *pulumi.Context, typ, name string, inputs ConstructInputs,
 	options pulumi.ResourceOption) (*ConstructResult, error)

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/proxy.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/proxy.go
@@ -154,6 +154,7 @@ func servePipes(ctx context.Context, pipes pipes, target pulumirpc.ResourceMonit
 
 				// write the 4-byte response length
 				logging.V(10).Infoln("Sync invoke: Writing length to request pipe")
+				//nolint:gosec // Max message size for protobuf is 2GB, so the int -> uint32 conversion is safe.
 				if err := binary.Write(pipes.writer(), binary.BigEndian, uint32(len(resBytes))); err != nil {
 					logging.V(10).Infof("Sync invoke: Error writing length to pipe: %s\n", err)
 					return err

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -1104,6 +1104,7 @@ func (host *pythonLanguageHost) RunPlugin(
 		if errors.As(err, &exiterr) {
 			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
 				return server.Send(&pulumirpc.RunPluginResponse{
+					//nolint:gosec // WaitStatus always uses the lower 8 bits for the exit code.
 					Output: &pulumirpc.RunPluginResponse_Exitcode{Exitcode: int32(status.ExitStatus())},
 				})
 			}


### PR DESCRIPTION
The latest version of golangci-lint (1.60.3) flags a bunch of new issues in our code base. This PR addresses part of them ahead of the upgrade.

* A dynamic string passed to printf style functions as first argument, this can lead to bad `%` interpolations. The fix is typically to use `"%s"` as first argument and pass the dynamic string as 2nd argument.
* Using `os.ModePerm` in tests instead of more restricted file permissions. The fix is to use 0o600 for files, or 0o700 for directories.
* Int conversion overflows. The fix has to be done case by case, checking that no overflow can occur.
