### PR TITLE
Do not rely on auto api for cloning repos on ds tests

### DIFF
--- a/changelog/pending/20240827--pkg--remove-ds-auto-api-dependency-on-tests.yaml
+++ b/changelog/pending/20240827--pkg--remove-ds-auto-api-dependency-on-tests.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: chore
   scope: pkg
-  description: Remove dependency on automation api on deployment settings tests
+  description: Remove dependency on automation api in deployment settings tests

--- a/changelog/pending/20240827--pkg--remove-ds-auto-api-dependency-on-tests.yaml
+++ b/changelog/pending/20240827--pkg--remove-ds-auto-api-dependency-on-tests.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: pkg
+  description: Remove dependency on automation api on deployment settings tests

--- a/pkg/cmd/pulumi/deployment_settings_config_test.go
+++ b/pkg/cmd/pulumi/deployment_settings_config_test.go
@@ -22,13 +22,11 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
-	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type promptAssertion[T any, I any] struct {
@@ -117,18 +115,12 @@ func (p *promptHandlersMock) PromptForValue(
 
 func TestDSConfigureGit(t *testing.T) {
 	t.Parallel()
+
+	repoDir := setUpGitWorkspace(t, context.Background())
+	workDir := filepath.Join(repoDir, "goproj")
+
 	t.Run("using the GH app", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
-
-		repo := auto.GitRepo{
-			URL:         "https://github.com/pulumi/test-repo.git",
-			ProjectPath: "goproj",
-			Shallow:     true,
-			Branch:      "master",
-		}
-		ws, err := auto.NewLocalWorkspace(ctx, auto.Repo(repo))
-		require.NoError(t, err)
 
 		gitSSHPrivateKeyPath := ""
 		gitSSHPrivateKeyValue := ""
@@ -160,7 +152,7 @@ func TestDSConfigureGit(t *testing.T) {
 
 		d := &deploymentSettingsCommandDependencies{
 			Deployment: &workspace.ProjectStackDeployment{},
-			WorkDir:    ws.WorkDir(),
+			WorkDir:    workDir,
 			DisplayOptions: &display.Options{
 				Color:         cmdutil.GetGlobalColorization(),
 				IsInteractive: true,
@@ -168,7 +160,7 @@ func TestDSConfigureGit(t *testing.T) {
 			Prompts: prompts,
 		}
 
-		err = configureGit(d, gitSSHPrivateKeyPath, gitSSHPrivateKeyValue)
+		err := configureGit(d, gitSSHPrivateKeyPath, gitSSHPrivateKeyValue)
 
 		assert.NoError(t, err)
 		assert.Equal(t, "goproj", d.Deployment.DeploymentSettings.SourceContext.Git.RepoDir)
@@ -183,16 +175,6 @@ func TestDSConfigureGit(t *testing.T) {
 
 	t.Run("using the GH app already configured", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
-
-		repo := auto.GitRepo{
-			URL:         "https://github.com/pulumi/test-repo.git",
-			ProjectPath: "goproj",
-			Shallow:     true,
-			Branch:      "master",
-		}
-		ws, err := auto.NewLocalWorkspace(ctx, auto.Repo(repo))
-		require.NoError(t, err)
 
 		gitSSHPrivateKeyPath := ""
 		gitSSHPrivateKeyValue := ""
@@ -236,7 +218,7 @@ func TestDSConfigureGit(t *testing.T) {
 					},
 				},
 			},
-			WorkDir: ws.WorkDir(),
+			WorkDir: workDir,
 			DisplayOptions: &display.Options{
 				Color:         cmdutil.GetGlobalColorization(),
 				IsInteractive: true,
@@ -244,7 +226,7 @@ func TestDSConfigureGit(t *testing.T) {
 			Prompts: prompts,
 		}
 
-		err = configureGit(d, gitSSHPrivateKeyPath, gitSSHPrivateKeyValue)
+		err := configureGit(d, gitSSHPrivateKeyPath, gitSSHPrivateKeyValue)
 
 		assert.NoError(t, err)
 		assert.Equal(t, "goproj", d.Deployment.DeploymentSettings.SourceContext.Git.RepoDir)
@@ -259,16 +241,6 @@ func TestDSConfigureGit(t *testing.T) {
 
 	t.Run("no authentication", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
-
-		repo := auto.GitRepo{
-			URL:         "https://github.com/pulumi/test-repo.git",
-			ProjectPath: "goproj",
-			Shallow:     true,
-			Branch:      "master",
-		}
-		ws, err := auto.NewLocalWorkspace(ctx, auto.Repo(repo))
-		require.NoError(t, err)
 
 		gitSSHPrivateKeyPath := ""
 		gitSSHPrivateKeyValue := ""
@@ -303,7 +275,7 @@ func TestDSConfigureGit(t *testing.T) {
 					},
 				},
 			},
-			WorkDir: ws.WorkDir(),
+			WorkDir: workDir,
 			Backend: &backend.MockBackend{
 				EncryptStackDeploymentSettingsSecretF: func(
 					ctx context.Context, stack backend.Stack, secret string,
@@ -319,7 +291,7 @@ func TestDSConfigureGit(t *testing.T) {
 			Prompts: prompts,
 		}
 
-		err = configureGit(d, gitSSHPrivateKeyPath, gitSSHPrivateKeyValue)
+		err := configureGit(d, gitSSHPrivateKeyPath, gitSSHPrivateKeyValue)
 
 		assert.NoError(t, err)
 		assert.Equal(t, "goproj", d.Deployment.DeploymentSettings.SourceContext.Git.RepoDir)
@@ -332,16 +304,6 @@ func TestDSConfigureGit(t *testing.T) {
 
 	t.Run("using credentials", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
-
-		repo := auto.GitRepo{
-			URL:         "https://github.com/pulumi/test-repo.git",
-			ProjectPath: "goproj",
-			Shallow:     true,
-			Branch:      "master",
-		}
-		ws, err := auto.NewLocalWorkspace(ctx, auto.Repo(repo))
-		require.NoError(t, err)
 
 		gitSSHPrivateKeyPath := ""
 		gitSSHPrivateKeyValue := ""
@@ -365,7 +327,7 @@ func TestDSConfigureGit(t *testing.T) {
 
 		d := &deploymentSettingsCommandDependencies{
 			Deployment: &workspace.ProjectStackDeployment{},
-			WorkDir:    ws.WorkDir(),
+			WorkDir:    workDir,
 			Backend: &backend.MockBackend{
 				EncryptStackDeploymentSettingsSecretF: func(
 					ctx context.Context, stack backend.Stack, secret string,
@@ -381,7 +343,7 @@ func TestDSConfigureGit(t *testing.T) {
 			Prompts: prompts,
 		}
 
-		err = configureGit(d, gitSSHPrivateKeyPath, gitSSHPrivateKeyValue)
+		err := configureGit(d, gitSSHPrivateKeyPath, gitSSHPrivateKeyValue)
 
 		assert.NoError(t, err)
 		assert.Equal(t, "goproj", d.Deployment.DeploymentSettings.SourceContext.Git.RepoDir)
@@ -396,16 +358,6 @@ func TestDSConfigureGit(t *testing.T) {
 
 	t.Run("using ssh", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
-
-		repo := auto.GitRepo{
-			URL:         "https://github.com/pulumi/test-repo.git",
-			ProjectPath: "goproj",
-			Shallow:     true,
-			Branch:      "master",
-		}
-		ws, err := auto.NewLocalWorkspace(ctx, auto.Repo(repo))
-		require.NoError(t, err)
 
 		gitSSHPrivateKeyPath := ""
 		gitSSHPrivateKeyValue := "private_key"
@@ -428,7 +380,7 @@ func TestDSConfigureGit(t *testing.T) {
 
 		d := &deploymentSettingsCommandDependencies{
 			Deployment: &workspace.ProjectStackDeployment{},
-			WorkDir:    ws.WorkDir(),
+			WorkDir:    workDir,
 			Backend: &backend.MockBackend{
 				EncryptStackDeploymentSettingsSecretF: func(
 					ctx context.Context, stack backend.Stack, secret string,
@@ -447,7 +399,7 @@ func TestDSConfigureGit(t *testing.T) {
 			Prompts: prompts,
 		}
 
-		err = configureGit(d, gitSSHPrivateKeyPath, gitSSHPrivateKeyValue)
+		err := configureGit(d, gitSSHPrivateKeyPath, gitSSHPrivateKeyValue)
 
 		assert.NoError(t, err)
 		assert.Equal(t, "goproj", d.Deployment.DeploymentSettings.SourceContext.Git.RepoDir)

--- a/pkg/cmd/pulumi/deployment_settings_config_test.go
+++ b/pkg/cmd/pulumi/deployment_settings_config_test.go
@@ -116,7 +116,7 @@ func (p *promptHandlersMock) PromptForValue(
 func TestDSConfigureGit(t *testing.T) {
 	t.Parallel()
 
-	repoDir := setUpGitWorkspace(t, context.Background())
+	repoDir := setUpGitWorkspace(context.Background(), t)
 	workDir := filepath.Join(repoDir, "goproj")
 
 	t.Run("using the GH app", func(t *testing.T) {

--- a/pkg/cmd/pulumi/deployment_settings_utils_test.go
+++ b/pkg/cmd/pulumi/deployment_settings_utils_test.go
@@ -218,7 +218,7 @@ func TestDSFileParsing(t *testing.T) {
 }
 
 func setUpGitWorkspace(ctx context.Context, t *testing.T) string {
-	workDir, err := os.MkdirTemp("", "pulumi_auto")
+	workDir, err := os.MkdirTemp("", "pulumi_deployment_settings")
 	assert.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/pkg/cmd/pulumi/deployment_settings_utils_test.go
+++ b/pkg/cmd/pulumi/deployment_settings_utils_test.go
@@ -57,9 +57,8 @@ func TestRepoLookup(t *testing.T) {
 
 	t.Run("should handle directories that are a git repo", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
 
-		repoDir := setUpGitWorkspace(t, ctx)
+		repoDir := setUpGitWorkspace(context.Background(), t)
 		workDir := filepath.Join(repoDir, "goproj")
 
 		rl, err := newRepoLookup(workDir)
@@ -90,9 +89,8 @@ type relativeDirectoryValidationCase struct {
 
 func TestValidateRelativeDirectory(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
-	repoDir := setUpGitWorkspace(t, ctx)
+	repoDir := setUpGitWorkspace(context.Background(), t)
 	workDir := filepath.Join(repoDir, "goproj")
 
 	// relative directory values are always linux type paths
@@ -219,7 +217,7 @@ func TestDSFileParsing(t *testing.T) {
 	assert.Equal(t, "51035bee-a4d6-4b63-9ff6-418775c5da8d", *deploymentFile.DeploymentSettings.AgentPoolID)
 }
 
-func setUpGitWorkspace(t *testing.T, ctx context.Context) string {
+func setUpGitWorkspace(ctx context.Context, t *testing.T) string {
 	workDir, err := os.MkdirTemp("", "pulumi_auto")
 	assert.NoError(t, err)
 

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -166,7 +166,6 @@ require (
 	github.com/ettle/strcase v0.1.1 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.5.0 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
@@ -217,7 +216,6 @@ require (
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/nightlyone/lockfile v1.0.0 // indirect
-	github.com/nxadm/tail v1.4.11 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/opentracing/basictracer-go v1.1.0 // indirect
 	github.com/petar-dambovaliev/aho-corasick v0.0.0-20230725210150-fb29fc3c913e // indirect
@@ -262,7 +260,6 @@ require (
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240311173647-c811ad7063a7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240311173647-c811ad7063a7 // indirect
-	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	lukechampine.com/frand v1.4.2 // indirect
 	mvdan.cc/gofumpt v0.5.0 // indirect

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -233,9 +233,6 @@ github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
 github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
-github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
-github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gliderlabs/ssh v0.3.7 h1:iV3Bqi942d9huXnzEF2Mt+CY9gLu8DNM4Obd+8bODRE=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
@@ -505,8 +502,6 @@ github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d h1:AREM5mwr4u1
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=
 github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
-github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
-github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
@@ -864,7 +859,6 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220829200755-d48e67d00261/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1091,8 +1085,6 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Initially I relied `auto.NewLocalWorkspace` to setup the tests workspace and clone the sample git repo. This is required for testing git specific logic (like repo url calculation and remote/branch lookup).

The automation api relies on the pulumi binary to to operate but we don't rely on any of its features on these tests. To simplify it and remove the need of having the binary in the path, I am replacing it by a simple logic to clone the repo in a tmp directory.