### PR TITLE
state_move: allow providers with same URN if inputs match

### DIFF
--- a/changelog/pending/20240827--cli-state--succeed-when-theres-already-a-provider-with-an-identical-urn-in-the-destination-stack-if-the-inputs-match.yaml
+++ b/changelog/pending/20240827--cli-state--succeed-when-theres-already-a-provider-with-an-identical-urn-in-the-destination-stack-if-the-inputs-match.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/state
+  description: Allow moving resources when there's already a provider with an identical URN in the destination stack, if the inputs match

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -83,6 +83,18 @@ func runMove(
 func runMoveWithOptions(
 	t *testing.T, sourceResources []*resource.State, args []string, options *MoveOptions,
 ) (*deploy.Snapshot, *deploy.Snapshot, bytes.Buffer) {
+	return runMoveWithOptionsAndDestResources(t, sourceResources, []*resource.State{}, args, options)
+}
+
+func runMoveWithDestResources(
+	t *testing.T, sourceResources, destResources []*resource.State, args []string,
+) (*deploy.Snapshot, *deploy.Snapshot, bytes.Buffer) {
+	return runMoveWithOptionsAndDestResources(t, sourceResources, destResources, args, &MoveOptions{})
+}
+
+func runMoveWithOptionsAndDestResources(
+	t *testing.T, sourceResources, destResources []*resource.State, args []string, options *MoveOptions,
+) (*deploy.Snapshot, *deploy.Snapshot, bytes.Buffer) {
 	ctx := context.Background()
 	tmpDir := t.TempDir()
 
@@ -92,7 +104,6 @@ func runMoveWithOptions(
 	sourceStackName := "organization/test/sourceStack"
 	sourceStack := createStackWithResources(t, b, sourceStackName, sourceResources)
 
-	destResources := []*resource.State{}
 	destStackName := "organization/test/destStack"
 	destStack := createStackWithResources(t, b, destStackName, destResources)
 
@@ -1186,4 +1197,128 @@ runtime: mock
 	// Expect no resources to be moved
 	assert.Equal(t, 3, len(sourceSnapshot.Resources))
 	assert.Nil(t, destSnapshot)
+}
+
+func TestMoveProviderWithSameInputs(t *testing.T) {
+	t.Parallel()
+
+	providerURN := resource.NewURN("sourceStack", "test", "", "pulumi:providers:a", "default_1_0_0")
+	sourceResources := []*resource.State{
+		{
+			URN:    providerURN,
+			Type:   "pulumi:providers:a::default_1_0_0",
+			ID:     "provider_id",
+			Custom: true,
+			Inputs: resource.PropertyMap{
+				"key": resource.NewStringProperty("value"),
+			},
+		},
+		{
+			URN:      resource.NewURN("sourceStack", "test", "d:e:f", "a:b:c", "name"),
+			Type:     "a:b:c",
+			Provider: string(providerURN) + "::provider_id",
+		},
+	}
+
+	destProviderURN := resource.NewURN("destStack", "test", "", "pulumi:providers:a", "default_1_0_0")
+	destResources := []*resource.State{
+		{
+			URN:    destProviderURN,
+			Type:   "pulumi:providers:a::default_1_0_0",
+			ID:     "another_provider_id",
+			Custom: true,
+			Inputs: resource.PropertyMap{
+				"key": resource.NewStringProperty("value"),
+			},
+		},
+	}
+
+	sourceSnapshot, destSnapshot, stdout := runMoveWithDestResources(
+		t, sourceResources, destResources, []string{string(sourceResources[1].URN)})
+
+	//nolint:lll
+	expectedStdout := `Planning to move the following resources from organization/test/sourceStack to organization/test/destStack:
+
+  - urn:pulumi:sourceStack::test::d:e:f$a:b:c::name
+
+Successfully moved resources from organization/test/sourceStack to organization/test/destStack
+`
+	assert.Equal(t, expectedStdout, stdout.String())
+
+	assert.Equal(t, 1, len(sourceSnapshot.Resources)) // Only the provider should remain in the source stack
+
+	assert.Equal(t, 3, len(destSnapshot.Resources)) // We expect the root stack, the provider, and the moved resource
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:pulumi:Stack::test-destStack"),
+		destSnapshot.Resources[0].URN)
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:providers:a::default_1_0_0"),
+		destSnapshot.Resources[1].URN)
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::d:e:f$a:b:c::name"),
+		destSnapshot.Resources[2].URN)
+	assert.Equal(t, "urn:pulumi:destStack::test::pulumi:providers:a::default_1_0_0::another_provider_id",
+		destSnapshot.Resources[2].Provider)
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:pulumi:Stack::test-destStack"),
+		destSnapshot.Resources[2].Parent)
+}
+
+func TestMoveProviderWithDifferentInputsFails(t *testing.T) {
+	t.Parallel()
+
+	providerURN := resource.NewURN("sourceStack", "test", "", "pulumi:providers:a", "default_1_0_0")
+	sourceResources := []*resource.State{
+		{
+			URN:    providerURN,
+			Type:   "pulumi:providers:a::default_1_0_0",
+			ID:     "provider_id",
+			Custom: true,
+			Inputs: resource.PropertyMap{
+				"key": resource.NewStringProperty("value"),
+			},
+		},
+		{
+			URN:      resource.NewURN("sourceStack", "test", "d:e:f", "a:b:c", "name"),
+			Type:     "a:b:c",
+			Provider: string(providerURN) + "::provider_id",
+		},
+	}
+
+	destProviderURN := resource.NewURN("destStack", "test", "", "pulumi:providers:a", "default_1_0_0")
+	destResources := []*resource.State{
+		{
+			URN:    destProviderURN,
+			Type:   "pulumi:providers:a::default_1_0_0",
+			ID:     "another_provider_id",
+			Custom: true,
+			Inputs: resource.PropertyMap{
+				"key": resource.NewStringProperty("different value"),
+			},
+		},
+	}
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	b, err := diy.New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	sourceStackName := "organization/test/sourceStack"
+	sourceStack := createStackWithResources(t, b, sourceStackName, sourceResources)
+
+	destStackName := "organization/test/destStack"
+	destStack := createStackWithResources(t, b, destStackName, destResources)
+
+	mp := &secrets.MockProvider{}
+	mp = mp.Add("b64", func(_ json.RawMessage) (secrets.Manager, error) {
+		return b64.NewBase64SecretsManager(), nil
+	})
+
+	var stdout bytes.Buffer
+
+	stateMoveCmd := stateMoveCmd{
+		Yes:       true,
+		Stdout:    &stdout,
+		Colorizer: colors.Never,
+	}
+	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[1].URN)}, mp, mp)
+	assert.ErrorContains(t, err,
+		"urn:pulumi:destStack::test::pulumi:providers:a::default_1_0_0 already exists in destination stack")
 }

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -362,6 +362,9 @@ func TestMoveWithExistingProvider(t *testing.T) {
 			Type:   "pulumi:providers:a::default_1_0_0",
 			ID:     "provider_id",
 			Custom: true,
+			Inputs: resource.PropertyMap{
+				"key": resource.NewStringProperty("value"),
+			},
 		},
 		{
 			URN:      resource.NewURN("destStack", "test", "d:e:f", "a:b:c", "name"),
@@ -376,6 +379,9 @@ func TestMoveWithExistingProvider(t *testing.T) {
 			Type:   "pulumi:providers:a::default_1_0_0",
 			ID:     "other_provider_id",
 			Custom: true,
+			Inputs: resource.PropertyMap{
+				"key": resource.NewStringProperty("different value"),
+			},
 		},
 	}
 
@@ -1258,67 +1264,4 @@ Successfully moved resources from organization/test/sourceStack to organization/
 		destSnapshot.Resources[2].Provider)
 	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:pulumi:Stack::test-destStack"),
 		destSnapshot.Resources[2].Parent)
-}
-
-func TestMoveProviderWithDifferentInputsFails(t *testing.T) {
-	t.Parallel()
-
-	providerURN := resource.NewURN("sourceStack", "test", "", "pulumi:providers:a", "default_1_0_0")
-	sourceResources := []*resource.State{
-		{
-			URN:    providerURN,
-			Type:   "pulumi:providers:a::default_1_0_0",
-			ID:     "provider_id",
-			Custom: true,
-			Inputs: resource.PropertyMap{
-				"key": resource.NewStringProperty("value"),
-			},
-		},
-		{
-			URN:      resource.NewURN("sourceStack", "test", "d:e:f", "a:b:c", "name"),
-			Type:     "a:b:c",
-			Provider: string(providerURN) + "::provider_id",
-		},
-	}
-
-	destProviderURN := resource.NewURN("destStack", "test", "", "pulumi:providers:a", "default_1_0_0")
-	destResources := []*resource.State{
-		{
-			URN:    destProviderURN,
-			Type:   "pulumi:providers:a::default_1_0_0",
-			ID:     "another_provider_id",
-			Custom: true,
-			Inputs: resource.PropertyMap{
-				"key": resource.NewStringProperty("different value"),
-			},
-		},
-	}
-
-	ctx := context.Background()
-	tmpDir := t.TempDir()
-
-	b, err := diy.New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
-	assert.NoError(t, err)
-
-	sourceStackName := "organization/test/sourceStack"
-	sourceStack := createStackWithResources(t, b, sourceStackName, sourceResources)
-
-	destStackName := "organization/test/destStack"
-	destStack := createStackWithResources(t, b, destStackName, destResources)
-
-	mp := &secrets.MockProvider{}
-	mp = mp.Add("b64", func(_ json.RawMessage) (secrets.Manager, error) {
-		return b64.NewBase64SecretsManager(), nil
-	})
-
-	var stdout bytes.Buffer
-
-	stateMoveCmd := stateMoveCmd{
-		Yes:       true,
-		Stdout:    &stdout,
-		Colorizer: colors.Never,
-	}
-	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[1].URN)}, mp, mp)
-	assert.ErrorContains(t, err,
-		"urn:pulumi:destStack::test::pulumi:providers:a::default_1_0_0 already exists in destination stack")
 }


### PR DESCRIPTION
Currently when there's already a provider in the destination stack with the same URN as a provider in the source stack (for a resource that is about to be moved) we error out, unless the IDs match. This is done so we don't assign a provider to a resource that won't work for it (e.g. provider with the same name but that have different AWS region setups).

However we can be a little bit smarter than this, and assign a resource a provider from the destination stack as long as all the provider inputs match.  If all the inputs match, we can assume that the provider will give us a valid situation for the resource.

Fixes https://github.com/pulumi/pulumi/issues/16983