### PR TITLE
Remove path usage from deploytest

### DIFF
--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path/filepath"
 	"sync"
 
 	"github.com/blang/semver"
@@ -69,19 +68,12 @@ func WithGrpc(p *PluginLoader) {
 	p.useGRPC = true
 }
 
-func WithPath(path string) func(p *PluginLoader) {
-	return func(p *PluginLoader) {
-		p.path = path
-	}
-}
-
 type PluginLoader struct {
 	kind         apitype.PluginKind
 	name         string
 	version      semver.Version
 	load         LoadPluginFunc
 	loadWithHost LoadPluginWithHostFunc
-	path         string
 	useGRPC      bool
 }
 
@@ -471,11 +463,10 @@ func (host *pluginHost) ResolvePlugin(
 	for _, v := range host.pluginLoaders {
 		v := v
 		p := workspace.PluginInfo{
-			Kind:       v.kind,
-			Name:       v.name,
-			Path:       v.path,
-			Version:    &v.version,
-			SchemaPath: filepath.Join(v.path, v.name+"-"+v.version.String()+".json"),
+			Kind:    v.kind,
+			Name:    v.name,
+			Version: &v.version,
+			// Path and SchemaPath not set as these plugins aren't actually on disk.
 			// SchemaTime not set as caching is indefinite.
 		}
 		plugins = append(plugins, p)

--- a/pkg/resource/deploy/deploytest/pluginhost_test.go
+++ b/pkg/resource/deploy/deploytest/pluginhost_test.go
@@ -35,7 +35,6 @@ func TestNewAnalyzerLoaderWithHost(t *testing.T) {
 	assert.Equal(t, apitype.PluginKind("analyzer"), a.kind)
 	assert.Equal(t, "pkgA", a.name)
 	assert.Equal(t, semver.Version{}, a.version)
-	assert.Equal(t, "", a.path)
 	assert.Equal(t, false, a.useGRPC)
 }
 


### PR DESCRIPTION
These plugins aren't really on disk and setting the path attribute confuses other parts of the system. Instead just make them work like normal in-memory plugins that happen to read their schemas from testdata.