### PR TITLE
wire up command line interface for running programs under a debugger

### DIFF
--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -270,6 +270,7 @@ func newPreviewCmd() *cobra.Command {
 	var replaces []string
 	var targetReplaces []string
 	var targetDependents bool
+	var enableDebugging bool
 
 	use, cmdArgs := "preview", cmdutil.NoArgs
 	if remoteSupported() {
@@ -440,8 +441,9 @@ func newPreviewCmd() *cobra.Command {
 					TargetDependents:          targetDependents,
 					// If we're trying to save a plan then we _need_ to generate it. We also turn this on in
 					// experimental mode to just get more testing of it.
-					GeneratePlan: hasExperimentalCommands() || planFilePath != "",
-					Experimental: hasExperimentalCommands(),
+					GeneratePlan:    hasExperimentalCommands() || planFilePath != "",
+					Experimental:    hasExperimentalCommands(),
+					EnableDebugging: enableDebugging,
 				},
 				Display: displayOpts,
 			}
@@ -619,6 +621,10 @@ func newPreviewCmd() *cobra.Command {
 		&suppressPermalink, "suppress-permalink", "",
 		"Suppress display of the state permalink")
 	cmd.Flag("suppress-permalink").NoOptDefVal = "false"
+	cmd.PersistentFlags().BoolVar(
+		&enableDebugging, "enable-debugging", false,
+		"Enable the ability to attach a debugger to the program being executed")
+	cmd.Flag("enable-debugging").Hidden = true
 
 	// Remote flags
 	remoteArgs.applyFlags(cmd)

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -270,7 +270,7 @@ func newPreviewCmd() *cobra.Command {
 	var replaces []string
 	var targetReplaces []string
 	var targetDependents bool
-	var enableDebugging bool
+	var attachDebugger bool
 
 	use, cmdArgs := "preview", cmdutil.NoArgs
 	if remoteSupported() {
@@ -443,7 +443,7 @@ func newPreviewCmd() *cobra.Command {
 					// experimental mode to just get more testing of it.
 					GeneratePlan:    hasExperimentalCommands() || planFilePath != "",
 					Experimental:    hasExperimentalCommands(),
-					EnableDebugging: enableDebugging,
+					EnableDebugging: attachDebugger,
 				},
 				Display: displayOpts,
 			}
@@ -622,9 +622,9 @@ func newPreviewCmd() *cobra.Command {
 		"Suppress display of the state permalink")
 	cmd.Flag("suppress-permalink").NoOptDefVal = "false"
 	cmd.PersistentFlags().BoolVar(
-		&enableDebugging, "enable-debugging", false,
+		&attachDebugger, "attach-debugger", false,
 		"Enable the ability to attach a debugger to the program being executed")
-	cmd.Flag("enable-debugging").Hidden = true
+	cmd.Flag("attach-debugger").Hidden = true
 
 	// Remote flags
 	remoteArgs.applyFlags(cmd)

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -86,7 +86,7 @@ func newUpCmd() *cobra.Command {
 	var targetReplaces []string
 	var targetDependents bool
 	var planFilePath string
-	var enableDebugging bool
+	var attachDebugger bool
 
 	// up implementation used when the source of the Pulumi program is in the current working directory.
 	upWorkingDirectory := func(
@@ -170,7 +170,7 @@ func newUpCmd() *cobra.Command {
 			GeneratePlan:    true,
 			Experimental:    hasExperimentalCommands(),
 			ContinueOnError: continueOnError,
-			EnableDebugging: enableDebugging,
+			EnableDebugging: attachDebugger,
 		}
 
 		if planFilePath != "" {
@@ -397,7 +397,7 @@ func newUpCmd() *cobra.Command {
 			UseLegacyRefreshDiff: useLegacyRefreshDiff(),
 			ContinueOnError:      continueOnError,
 
-			EnableDebugging: enableDebugging,
+			EnableDebugging: attachDebugger,
 		}
 
 		// TODO for the URL case:
@@ -654,9 +654,9 @@ func newUpCmd() *cobra.Command {
 		"Continue updating resources even if an error is encountered "+
 			"(can also be set with PULUMI_CONTINUE_ON_ERROR environment variable)")
 	cmd.PersistentFlags().BoolVar(
-		&enableDebugging, "enable-debugging", false,
+		&attachDebugger, "attach-debugger", false,
 		"Enable the ability to attach a debugger to the program being executed")
-	cmd.Flag("enable-debugging").Hidden = true
+	cmd.Flag("attach-debugger").Hidden = true
 
 	cmd.PersistentFlags().StringVar(
 		&planFilePath, "plan", "",

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -86,6 +86,7 @@ func newUpCmd() *cobra.Command {
 	var targetReplaces []string
 	var targetDependents bool
 	var planFilePath string
+	var enableDebugging bool
 
 	// up implementation used when the source of the Pulumi program is in the current working directory.
 	upWorkingDirectory := func(
@@ -169,6 +170,7 @@ func newUpCmd() *cobra.Command {
 			GeneratePlan:    true,
 			Experimental:    hasExperimentalCommands(),
 			ContinueOnError: continueOnError,
+			EnableDebugging: enableDebugging,
 		}
 
 		if planFilePath != "" {
@@ -394,6 +396,8 @@ func newUpCmd() *cobra.Command {
 
 			UseLegacyRefreshDiff: useLegacyRefreshDiff(),
 			ContinueOnError:      continueOnError,
+
+			EnableDebugging: enableDebugging,
 		}
 
 		// TODO for the URL case:
@@ -649,6 +653,10 @@ func newUpCmd() *cobra.Command {
 		&continueOnError, "continue-on-error", env.ContinueOnError.Value(),
 		"Continue updating resources even if an error is encountered "+
 			"(can also be set with PULUMI_CONTINUE_ON_ERROR environment variable)")
+	cmd.PersistentFlags().BoolVar(
+		&enableDebugging, "enable-debugging", false,
+		"Enable the ability to attach a debugger to the program being executed")
+	cmd.Flag("enable-debugging").Hidden = true
 
 	cmd.PersistentFlags().StringVar(
 		&planFilePath, "plan", "",


### PR DESCRIPTION
After adding the engine bits for debugging in a previous PR (https://github.com/pulumi/pulumi/pull/17072), implement the option in the CLI that triggers it.  This by itself will have no effect still until the language runtimes have support for it. Therefore we keep it disabled until we've implemented this in the respective language runtimes.

The language runtime implementations will follow in subsequent PRs. I'm a bit unsure about the naming of the flag.  Maybe `--run-in-debugger` would be a better name?  Would be great to get some opinions on that (or any other suggestions fi someone has an idea).