### PR TITLE
Add workspace.Context for mocking workspace functions

### DIFF
--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/version"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -127,7 +128,7 @@ func getSummaryAbout(ctx context.Context, transitiveDependencies bool, selectedS
 
 	var proj *workspace.Project
 	var pwd string
-	if proj, pwd, err = readProject(); err != nil {
+	if proj, pwd, err = pkgWorkspace.Instance.ReadProject(); err != nil {
 		addError(err, "Failed to read project")
 	} else {
 		projinfo := &engine.Projinfo{Proj: proj, Root: pwd}

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/cloud"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -67,7 +68,7 @@ func newConfigCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := readProject()
+			project, _, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil {
 				return err
 			}
@@ -141,7 +142,7 @@ func newConfigCopyCmd(stack *string) *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := readProject()
+			project, _, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil {
 				return err
 			}
@@ -366,7 +367,7 @@ func newConfigRmCmd(stack *string) *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := readProject()
+			project, _, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil {
 				return err
 			}
@@ -420,7 +421,7 @@ func newConfigRmAllCmd(stack *string) *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := readProject()
+			project, _, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil {
 				return err
 			}
@@ -469,7 +470,7 @@ func newConfigRefreshCmd(stk *string) *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := readProject()
+			project, _, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil {
 				return err
 			}
@@ -588,7 +589,7 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := readProject()
+			project, _, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil {
 				return err
 			}
@@ -707,7 +708,7 @@ func newConfigSetAllCmd(stack *string) *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := readProject()
+			project, _, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil {
 				return err
 			}
@@ -1035,7 +1036,7 @@ func listConfig(
 }
 
 func getConfig(ctx context.Context, stack backend.Stack, key config.Key, path, jsonOut, openEnvironment bool) error {
-	project, _, err := readProject()
+	project, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/config_env.go
+++ b/pkg/cmd/pulumi/config_env.go
@@ -24,6 +24,7 @@ import (
 	"github.com/erikgeiser/promptkit/confirmation"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -34,7 +35,7 @@ func newConfigEnvCmd(stackRef *string) *cobra.Command {
 	impl := configEnvCmd{
 		stdin:            os.Stdin,
 		stdout:           os.Stdout,
-		readProject:      readProject,
+		ws:               pkgWorkspace.Instance,
 		requireStack:     requireStack,
 		loadProjectStack: loadProjectStack,
 		saveProjectStack: saveProjectStack,
@@ -64,7 +65,7 @@ type configEnvCmd struct {
 	interactive bool
 	color       colors.Colorization
 
-	readProject func() (*workspace.Project, string, error)
+	ws pkgWorkspace.Context
 
 	requireStack func(
 		ctx context.Context,
@@ -89,7 +90,7 @@ func (cmd *configEnvCmd) loadEnvPreamble(ctx context.Context,
 ) (*workspace.ProjectStack, *workspace.Project, *backend.Stack, error) {
 	opts := display.Options{Color: cmd.color}
 
-	project, _, err := cmd.readProject()
+	project, _, err := cmd.ws.ReadProject()
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/cmd/pulumi/config_env_init.go
+++ b/pkg/cmd/pulumi/config_env_init.go
@@ -99,7 +99,7 @@ func (cmd *configEnvInitCmd) run(ctx context.Context, args []string) error {
 
 	opts := display.Options{Color: cmd.parent.color}
 
-	project, _, err := cmd.parent.readProject()
+	project, _, err := cmd.parent.ws.ReadProject()
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/config_env_test.go
+++ b/pkg/cmd/pulumi/config_env_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -84,12 +85,14 @@ func newConfigEnvCmdForTestWithCheckYAMLEnvironment(
 		stdout:      stdout,
 		interactive: true,
 
-		readProject: func() (*workspace.Project, string, error) {
-			p, err := workspace.LoadProjectBytes([]byte(projectYAML), "Pulumi.yaml", encoding.YAML)
-			if err != nil {
-				return nil, "", err
-			}
-			return p, "", nil
+		ws: &pkgWorkspace.MockContext{
+			ReadProjectF: func() (*workspace.Project, string, error) {
+				p, err := workspace.LoadProjectBytes([]byte(projectYAML), "Pulumi.yaml", encoding.YAML)
+				if err != nil {
+					return nil, "", err
+				}
+				return p, "", nil
+			},
 		},
 		requireStack: func(
 			ctx context.Context,

--- a/pkg/cmd/pulumi/console.go
+++ b/pkg/cmd/pulumi/console.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -42,7 +43,7 @@ func newConsoleCmd() *cobra.Command {
 			}
 
 			// Try to read the current project
-			project, _, err := readProject()
+			project, _, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -483,7 +483,7 @@ func runConvert(
 			return fmt.Errorf("changing the working directory: %w", err)
 		}
 
-		proj, root, err := readProject()
+		proj, root, err := pkgWorkspace.Instance.ReadProject()
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/deployment_run.go
+++ b/pkg/cmd/pulumi/deployment_run.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -60,7 +61,7 @@ func newDeploymentRunCmd() *cobra.Command {
 				SuppressPermalink: suppressPermalink,
 			}
 
-			project, _, err := readProject()
+			project, _, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}

--- a/pkg/cmd/pulumi/deployment_settings_config.go
+++ b/pkg/cmd/pulumi/deployment_settings_config.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -123,7 +124,7 @@ func initializeDeploymentSettingsCmd(
 		IsInteractive: interactive,
 	}
 
-	project, _, err := readProject()
+	project, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/graph"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -178,7 +179,7 @@ func newDestroyCmd() *cobra.Command {
 				return err
 			}
 
-			proj, root, err := readProject()
+			proj, root, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil && errors.Is(err, workspace.ErrProjectNotFound) {
 				logging.Warningf("failed to find current Pulumi project, continuing with an empty project"+
 					"using stack %v from backend %v", s.Ref().Name(), s.Backend().Name())

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -783,7 +783,7 @@ func newImportCmd() *cobra.Command {
 			}
 
 			// Fetch the project.
-			proj, root, err := readProject()
+			proj, root, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/install.go
+++ b/pkg/cmd/pulumi/install.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -76,7 +77,7 @@ func newInstallCmd() *cobra.Command {
 			}
 
 			// Load the project
-			proj, root, err := readProject()
+			proj, root, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/diy"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -116,7 +117,7 @@ func newLoginCmd() *cobra.Command {
 			}
 
 			// Try to read the current project
-			project, _, err := readProject()
+			project, _, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}

--- a/pkg/cmd/pulumi/logout.go
+++ b/pkg/cmd/pulumi/logout.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -68,7 +69,7 @@ func newLogoutCmd() *cobra.Command {
 			} else {
 				if cloudURL == "" {
 					// Try to read the current project
-					project, _, err := readProject()
+					project, _, err := pkgWorkspace.Instance.ReadProject()
 					if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 						return err
 					}

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -61,7 +62,7 @@ func newLogsCmd() *cobra.Command {
 			}
 
 			// Fetch the project.
-			proj, _, err := readProject()
+			proj, _, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -157,7 +157,7 @@ func runNew(ctx context.Context, args newArgs) error {
 
 	if args.templateNameOrURL == "" {
 		// Try to read the current project
-		project, _, err := readProject()
+		project, _, err := pkgWorkspace.Instance.ReadProject()
 		if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 			return err
 		}
@@ -319,7 +319,7 @@ func runNew(ctx context.Context, args newArgs) error {
 	fmt.Println()
 
 	// Load the project, update the name & description, remove the template section, and save it.
-	proj, root, err := readProject()
+	proj, root, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil {
 		return err
 	}
@@ -842,7 +842,7 @@ func stackInit(
 
 // saveConfig saves the config for the stack.
 func saveConfig(stack backend.Stack, c config.Map) error {
-	project, _, err := readProject()
+	project, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/org.go
+++ b/pkg/cmd/pulumi/org.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -36,7 +37,7 @@ func newOrgCmd() *cobra.Command {
 		Args: cmdutil.NoArgs,
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			// Try to read the current project
-			project, _, err := readProject()
+			project, _, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
@@ -93,7 +94,7 @@ func newOrgSetDefaultCmd() *cobra.Command {
 			orgName = args[0]
 
 			// Try to read the current project
-			project, _, err := readProject()
+			project, _, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
@@ -136,7 +137,7 @@ func newOrgGetDefaultCmd() *cobra.Command {
 			}
 
 			// Try to read the current project
-			project, _, err := readProject()
+			project, _, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -133,7 +134,7 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 		Type:          display.DisplayQuery,
 	}
 	// Try to read the current project
-	project, _, err := readProject()
+	project, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}

--- a/pkg/cmd/pulumi/org_search_ai.go
+++ b/pkg/cmd/pulumi/org_search_ai.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
@@ -58,7 +59,7 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 		Type:          display.DisplayQuery,
 	}
 	// Try to read the current project
-	project, _, err := readProject()
+	project, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}

--- a/pkg/cmd/pulumi/package_add.go
+++ b/pkg/cmd/pulumi/package_add.go
@@ -24,6 +24,7 @@ import (
 
 	go_gen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
 	"golang.org/x/text/cases"
@@ -46,7 +47,7 @@ as in:
 
   pulumi package add <provider> -- --provider-parameter-flag value`,
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
-			proj, root, err := readProject()
+			proj, root, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil && errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
@@ -135,7 +136,7 @@ func printNodejsLinkInstructions(root string, pkg *schema.Package, out string) e
 	fmt.Println()
 	fmt.Println("To use this SDK in your Nodejs project, run the following command:")
 	fmt.Println()
-	proj, _, err := readProject()
+	proj, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil {
 		return err
 	}
@@ -194,7 +195,7 @@ func printPythonLinkInstructions(root string, pkg *schema.Package, out string) e
 	fmt.Println()
 	fmt.Println("To use this SDK in your Python project, run the following command:")
 	fmt.Println()
-	proj, _, err := readProject()
+	proj, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/plugin.go
+++ b/pkg/cmd/pulumi/plugin.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -55,7 +56,7 @@ func newPluginCmd() *cobra.Command {
 
 // getProjectPlugins fetches a list of plugins used by this project.
 func getProjectPlugins() ([]workspace.PluginSpec, error) {
-	proj, root, err := readProject()
+	proj, root, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +84,7 @@ func getProjectPlugins() ([]workspace.PluginSpec, error) {
 }
 
 func resolvePlugins(plugins []workspace.PluginSpec) ([]workspace.PluginInfo, error) {
-	proj, root, err := readProject()
+	proj, root, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/policy_group_ls.go
+++ b/pkg/cmd/pulumi/policy_group_ls.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -50,7 +51,7 @@ func newPolicyGroupLsCmd() *cobra.Command {
 			ctx := cmd.Context()
 
 			// Try to read the current project
-			project, _, err := readProject()
+			project, _, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}

--- a/pkg/cmd/pulumi/policy_ls.go
+++ b/pkg/cmd/pulumi/policy_ls.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -40,7 +41,7 @@ func newPolicyLsCmd() *cobra.Command {
 			ctx := cmd.Context()
 
 			// Try to read the current project
-			project, _, err := readProject()
+			project, _, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}

--- a/pkg/cmd/pulumi/policy_publish.go
+++ b/pkg/cmd/pulumi/policy_publish.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -67,7 +68,7 @@ func (cmd *policyPublishCmd) Run(ctx context.Context, args []string) error {
 	if len(args) > 0 {
 		orgName = args[0]
 	} else if len(args) == 0 {
-		project, _, err := readProject()
+		project, _, err := pkgWorkspace.Instance.ReadProject()
 		if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 			return err
 		}
@@ -149,7 +150,7 @@ func requirePolicyPack(
 	//
 
 	// Try to read the current project
-	project, _, err := readProject()
+	project, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
@@ -369,7 +370,7 @@ func newPreviewCmd() *cobra.Command {
 				return err
 			}
 
-			proj, root, err := readProjectForUpdate(client)
+			proj, root, err := readProjectForUpdate(pkgWorkspace.Instance, client)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/query.go
+++ b/pkg/cmd/pulumi/query.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
@@ -67,7 +68,7 @@ issue at https://github.com/pulumi/pulumi/issues/16964.
 			}
 
 			// Try to read the current project
-			project, root, err := readProject()
+			project, root, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -171,7 +172,7 @@ func newRefreshCmd() *cobra.Command {
 				return err
 			}
 
-			proj, root, err := readProject()
+			proj, root, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -95,7 +96,7 @@ func (cmd *stackChangeSecretsProviderCmd) Run(ctx context.Context, args []string
 		return err
 	}
 
-	project, _, err := readProject()
+	project, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -52,7 +53,7 @@ This command displays data about previous updates for a stack.`,
 			}
 			var decrypter config.Decrypter
 			if showSecrets {
-				project, _, err := readProject()
+				project, _, err := pkgWorkspace.Instance.ReadProject()
 				if err != nil {
 					return fmt.Errorf("loading project: %w", err)
 				}

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -113,7 +114,7 @@ func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	// Try to read the current project
-	project, _, err := readProject()
+	project, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}
@@ -163,7 +164,7 @@ func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	proj, root, projectErr := readProject()
+	proj, root, projectErr := pkgWorkspace.Instance.ReadProject()
 	if projectErr != nil && !errors.Is(projectErr, workspace.ErrProjectNotFound) {
 		return projectErr
 	}

--- a/pkg/cmd/pulumi/stack_ls.go
+++ b/pkg/cmd/pulumi/stack_ls.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -134,7 +135,7 @@ func runStackLS(ctx context.Context, args stackLSArgs) error {
 	}
 
 	// Try to read the current project
-	project, _, err := readProject()
+	project, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}

--- a/pkg/cmd/pulumi/stack_select.go
+++ b/pkg/cmd/pulumi/stack_select.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -50,7 +51,7 @@ func newStackSelectCmd() *cobra.Command {
 			}
 
 			// Try to read the current project
-			project, root, err := readProject()
+			project, root, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -98,7 +98,7 @@ func newUpCmd() *cobra.Command {
 			return err
 		}
 
-		proj, root, err := readProjectForUpdate(client)
+		proj, root, err := readProjectForUpdate(pkgWorkspace.Instance, client)
 		if err != nil {
 			return err
 		}
@@ -298,7 +298,7 @@ func newUpCmd() *cobra.Command {
 		}
 
 		// Load the project, update the name & description, remove the template section, and save it.
-		proj, root, err := readProject()
+		proj, root, err := pkgWorkspace.Instance.ReadProject()
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -49,6 +49,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets/cloud"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
 	"github.com/pulumi/pulumi/pkg/v3/version"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/constant"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -113,7 +114,7 @@ func isDIYBackend(opts display.Options) (bool, error) {
 	}
 
 	// Try to read the current project
-	project, _, err := readProject()
+	project, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return false, err
 	}
@@ -200,7 +201,7 @@ func createSecretsManager(
 		}
 	}
 
-	project, _, err := readProject()
+	project, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil {
 		return err
 	}
@@ -301,7 +302,7 @@ func requireStack(ctx context.Context,
 	}
 
 	// Try to read the current project
-	project, root, err := readProject()
+	project, root, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return nil, err
 	}
@@ -342,7 +343,7 @@ func requireStack(ctx context.Context,
 
 func requireCurrentStack(ctx context.Context, lopt stackLoadOption, opts display.Options) (backend.Stack, error) {
 	// Try to read the current project
-	project, _, err := readProject()
+	project, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return nil, err
 	}
@@ -379,7 +380,7 @@ func chooseStack(ctx context.Context,
 		return nil, errors.New(chooseStackErr)
 	}
 
-	proj, root, err := readProject()
+	proj, root, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil {
 		return nil, err
 	}
@@ -522,8 +523,8 @@ func parseAndSaveConfigArray(s backend.Stack, configArray []string, path bool) e
 // containing directory, which will be used as the root of the project's Pulumi program. If a
 // client address is present, the returned project will always have the runtime set to "client"
 // with the address option set to the client address.
-func readProjectForUpdate(clientAddress string) (*workspace.Project, string, error) {
-	proj, root, err := readProject()
+func readProjectForUpdate(ws pkgWorkspace.Context, clientAddress string) (*workspace.Project, string, error) {
+	proj, root, err := ws.ReadProject()
 	if err != nil {
 		return nil, "", err
 	}
@@ -533,18 +534,6 @@ func readProjectForUpdate(clientAddress string) (*workspace.Project, string, err
 		})
 	}
 	return proj, root, nil
-}
-
-// readProject attempts to detect and read a Pulumi project for the current workspace. If the
-// project is successfully detected and read, it is returned along with the path to its containing
-// directory, which will be used as the root of the project's Pulumi program.
-func readProject() (*workspace.Project, string, error) {
-	proj, path, err := workspace.DetectProjectAndPath()
-	if err != nil {
-		return nil, "", err
-	}
-
-	return proj, filepath.Dir(path), nil
 }
 
 // readPolicyProject attempts to detect and read a Pulumi PolicyPack project for the current

--- a/pkg/cmd/pulumi/util_remote.go
+++ b/pkg/cmd/pulumi/util_remote.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -393,7 +394,7 @@ func runDeployment(ctx context.Context, cmd *cobra.Command, opts display.Options
 	}
 
 	// Try to read the current project
-	project, _, err := readProject()
+	project, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -100,7 +101,7 @@ func newWatchCmd() *cobra.Command {
 				return err
 			}
 
-			proj, root, err := readProject()
+			proj, root, err := pkgWorkspace.Instance.ReadProject()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/whoami.go
+++ b/pkg/cmd/pulumi/whoami.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
@@ -79,7 +80,7 @@ func (cmd *whoAmICmd) Run(ctx context.Context) error {
 	}
 
 	// Try to read the current project
-	project, _, err := readProject()
+	project, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}

--- a/pkg/workspace/context.go
+++ b/pkg/workspace/context.go
@@ -1,0 +1,43 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace
+
+import (
+	"path/filepath"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// Context is an interface that represents the context of a workspace. It provides access to loading projects and
+// plugins.
+type Context interface {
+	// ReadProject attempts to detect and read a Pulumi project for the current workspace. If the
+	// project is successfully detected and read, it is returned along with the path to its containing
+	// directory, which will be used as the root of the project's Pulumi program.
+	ReadProject() (*workspace.Project, string, error)
+}
+
+var Instance Context = &context{}
+
+type context struct{}
+
+func (c *context) ReadProject() (*workspace.Project, string, error) {
+	proj, path, err := workspace.DetectProjectAndPath()
+	if err != nil {
+		return nil, "", err
+	}
+
+	return proj, filepath.Dir(path), nil
+}

--- a/pkg/workspace/mock.go
+++ b/pkg/workspace/mock.go
@@ -1,0 +1,32 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace
+
+import (
+	"errors"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+type MockContext struct {
+	ReadProjectF func() (*workspace.Project, string, error)
+}
+
+func (c *MockContext) ReadProject() (*workspace.Project, string, error) {
+	if c.ReadProjectF != nil {
+		return c.ReadProjectF()
+	}
+	return nil, "", errors.New("ReadProject function is not implemented")
+}


### PR DESCRIPTION
Prompted by trying to write some more unit tests for `state delete` and hitting the sadness again of how little of the system is interface'd and thus can be mocked out in tests.

This is a start on adding an interface for "workspace" related functions. That's things like loading Pulumi.yaml files, listing plugins etc.

This PR simply adds the minimal interface for a `ReadProject` function and replaces the current function for that in pkg/cmd/util with an implementation in pkg/workspace. All calls of the old `readProject` are replaced with `workspace.Instance.ReadProject`. The intention is to lift this parameter up so the only place `workspace.Instance` gets referred to is in the top level command handlers, everything else should use it via DI so a mock version can be injected in tests.

We had one test that was mocking `readProject` out, and I've replaced that to just use `workspace.Context` instead.

These changes are fairly simple, but they touch a lot of lines of code so I'm breaking this work into lots of separate PRs like this. After this merges I'll do a pass to lift the `workspace.Instance` access to just top level, then look at other workspace functions needed like getting the current backend (which requires accessing user config).