### PR TITLE
Make a PULUMI_BACKEND_URL an env.Var instance

### DIFF
--- a/pkg/cmd/pulumi/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/new_acceptance_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 )
@@ -198,7 +199,7 @@ func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 	// Now override to local filesystem backend
 	backendURL := "file://" + filepath.ToSlash(backendDir)
 	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "how now brown cow")
-	t.Setenv(workspace.PulumiBackendURLEnvVar, backendURL)
+	t.Setenv(env.BackendURL.Var().Name(), backendURL)
 
 	tempdir := tempProjectDir(t)
 	chdir(t, tempdir)

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -91,6 +91,9 @@ var SkipVersionCheck = env.Bool("AUTOMATION_API_SKIP_VERSION_CHECK",
 var ContinueOnError = env.Bool("CONTINUE_ON_ERROR",
 	"Continue to perform the update/destroy operation despite the occurrence of errors.")
 
+var BackendURL = env.String("BACKEND_URL",
+	"Set the backend that will be used instead of the currently logged in backend or the current projects backend.")
+
 // List of overrides for Plugin Download URLs. The expected format is `regexp=URL`, and multiple pairs can
 // be specified separated by commas, e.g. `regexp1=URL1,regexp2=URL2`
 //

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -92,7 +92,7 @@ var ContinueOnError = env.Bool("CONTINUE_ON_ERROR",
 	"Continue to perform the update/destroy operation despite the occurrence of errors.")
 
 var BackendURL = env.String("BACKEND_URL",
-	"Set the backend that will be used instead of the currently logged in backend or the current projects backend.")
+	"Set the backend that will be used instead of the currently logged in backend or the current project's backend.")
 
 // List of overrides for Plugin Download URLs. The expected format is `regexp=URL`, and multiple pairs can
 // be specified separated by commas, e.g. `regexp1=URL1,regexp2=URL2`

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/rogpeppe/go-internal/lockedfile"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -35,10 +36,6 @@ import (
 //
 //nolint:gosec
 const PulumiCredentialsPathEnvVar = "PULUMI_CREDENTIALS_PATH"
-
-// PulumiBackendURLEnvVar is an environment variable which can be used to set the backend that will be
-// used instead of the currently logged in backend or the current projects backend.
-const PulumiBackendURLEnvVar = "PULUMI_BACKEND_URL"
 
 // GetAccount returns an account underneath a given key.
 //
@@ -168,7 +165,7 @@ func getCredsFilePath() (string, error) {
 // instead irrespective of the backend for current project or stored credentials.
 func GetCurrentCloudURL(project *Project) (string, error) {
 	// Allow PULUMI_BACKEND_URL to override the current cloud URL selection
-	if backend := os.Getenv(PulumiBackendURLEnvVar); backend != "" {
+	if backend := env.BackendURL.Value(); backend != "" {
 		return backend, nil
 	}
 


### PR DESCRIPTION
Looking into writing some mocked tests for `state destroy` this env var is touched on the login path and is currently not in our "env" system so tricky to mock out. This is a small PR to just lift it into the env system without worrying about plumbing the env instance all the way down to where it's used (yet).