### PR TITLE
Remove the PULUMI_API environment variable

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -62,8 +62,6 @@ import (
 )
 
 const (
-	// defaultAPIEnvVar can be set to override the default cloud chosen, if `--cloud` is not present.
-	defaultURLEnvVar = "PULUMI_API"
 	// AccessTokenEnvVar is the environment variable used to bypass a prompt on login.
 	AccessTokenEnvVar = "PULUMI_ACCESS_TOKEN"
 )
@@ -132,9 +130,8 @@ type AIPromptRequestBody struct {
 // Name validation rules enforced by the Pulumi Service.
 var stackOwnerRegexp = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9-_]{1,38}[a-zA-Z0-9]$")
 
-// DefaultURL returns the default cloud URL.  This may be overridden using the PULUMI_API environment
-// variable.  If no override is found, and we are authenticated with a cloud, choose that.  Otherwise,
-// we will default to the https://api.pulumi.com/ endpoint.
+// DefaultURL returns the default cloud URL. If no override is found, and we are authenticated with a cloud, choose
+// that. Otherwise, we will default to the https://api.pulumi.com/ endpoint.
 func DefaultURL() string {
 	return ValueOrDefaultURL("")
 }
@@ -144,11 +141,6 @@ func ValueOrDefaultURL(cloudURL string) string {
 	// If we have a cloud URL, just return it.
 	if cloudURL != "" {
 		return strings.TrimSuffix(cloudURL, "/")
-	}
-
-	// Otherwise, respect the PULUMI_API override.
-	if cloudURL := os.Getenv(defaultURLEnvVar); cloudURL != "" {
-		return cloudURL
 	}
 
 	// If that didn't work, see if we have a current cloud, and use that. Note we need to be careful

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -110,10 +110,6 @@ func TestValueOrDefaultURL(t *testing.T) {
 
 		// Validate no-op case
 		assert.Equal(t, "https://api-test2.pulumi.com", ValueOrDefaultURL("https://api-test2.pulumi.com"))
-
-		// Validate trailing slash in pre-set env var is unchanged
-		t.Setenv("PULUMI_API", "https://api-test3.pulumi.com/")
-		assert.Equal(t, "https://api-test3.pulumi.com/", ValueOrDefaultURL(""))
 	})
 }
 

--- a/pkg/cmd/pulumi/pulumi_test.go
+++ b/pkg/cmd/pulumi/pulumi_test.go
@@ -106,7 +106,7 @@ func TestCheckForUpdate(t *testing.T) {
 		}
 	}))
 	t.Cleanup(srv.Close)
-	t.Setenv("PULUMI_API", srv.URL)
+	t.Setenv("PULUMI_BACKEND_URL", srv.URL)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -163,7 +163,7 @@ func TestCheckForUpdate_allFail(t *testing.T) {
 		}
 	}))
 	t.Cleanup(srv.Close)
-	t.Setenv("PULUMI_API", srv.URL)
+	t.Setenv("PULUMI_BACKEND_URL", srv.URL)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -207,7 +207,7 @@ func TestCheckForUpdate_devVersion(t *testing.T) {
 		}
 	}))
 	t.Cleanup(srv.Close)
-	t.Setenv("PULUMI_API", srv.URL)
+	t.Setenv("PULUMI_BACKEND_URL", srv.URL)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1339,7 +1339,7 @@ func (pt *ProgramTester) TestLifeCycleInitialize() error {
 
 	// Set the default target Pulumi API if not overridden in options.
 	if pt.opts.CloudURL == "" {
-		pulumiAPI := os.Getenv("PULUMI_API")
+		pulumiAPI := os.Getenv("PULUMI_BACKEND_URL")
 		if pulumiAPI != "" {
 			pt.opts.CloudURL = pulumiAPI
 		}
@@ -1352,7 +1352,7 @@ func (pt *ProgramTester) TestLifeCycleInitialize() error {
 	stackInitName := string(pt.opts.GetStackNameWithOwner())
 
 	if os.Getenv("PULUMI_ACCESS_TOKEN") == "" && pt.opts.CloudURL == "" {
-		fmt.Printf("Using existing logged in user for tests.  Set PULUMI_ACCESS_TOKEN and/or PULUMI_API to override.\n")
+		fmt.Printf("Using existing logged in user for tests.  Set PULUMI_ACCESS_TOKEN and/or PULUMI_BACKEND_URL to override.\n")
 	} else {
 		// Set PulumiCredentialsPathEnvVar to our CWD, so we use credentials specific to just this
 		// test.


### PR DESCRIPTION
We already have an environment variable to set the backend URL (PULUMI_BACKEND_URL), there's no need for another one specific to setting the default cloud api url as well.