### PR TITLE
Have Read the Docs use `docs/Makefile`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,10 +9,7 @@ build:
   tools:
     python: "3.12"
   commands:
-    - mkdir -p $READTHEDOCS_OUTPUT/html
-    - pip install -r docs/requirements.txt
-    - python -m sphinx -T -c docs/sphinx -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
-    - cp docs/sphinx/index.html.template $READTHEDOCS_OUTPUT/html/index.html
+    - make -C docs build
 
 sphinx:
   configuration: docs/sphinx/conf.py

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,21 +1,34 @@
-.PHONY: build watch
+.PHONY: build ensure ensure-python watch
 
-ensure:: .ensure.phony
-.ensure.phony: requirements.txt
-	python -m venv venv
-	. venv/*/activate && python -m pip install --upgrade pip setuptools wheel
-	. venv/*/activate && python -m pip install -r requirements.txt
-	@touch .ensure.phony
+VENV = venv
 
+ensure-python:: .ensure-python.phony
+.ensure-python.phony: requirements.txt
+	python -m $(VENV) $(VENV)
+	. $(VENV)/*/activate && python -m pip install --upgrade pip setuptools wheel
+	. $(VENV)/*/activate && python -m pip install -r requirements.txt
+	@touch .ensure-python.phony
+
+ensure:: ensure-python
+
+# This target is intended to be called by Read the Docs as part of deployment,
+# whereby the READTHEDOCS_OUTPUT environment variable will be set to a
+# destination that Read the Docs expects to be populated with the generated
+# documentation.
 build: ensure
-	. venv/*/activate && sphinx-build \
+	mkdir -p $$READTHEDOCS_OUTPUT/html
+	. $(VENV)/*/activate && python -m sphinx \
+		-T \
 		-c sphinx \
 		-b html \
+		-d _build/doctrees \
+		-D language=en \
 		.. \
-		_build
+		$$READTHEDOCS_OUTPUT/html
+	cp sphinx/index.html.template $$READTHEDOCS_OUTPUT/html/index.html
 
 watch: ensure
-	. venv/*/activate && sphinx-autobuild \
+	. $(VENV)/*/activate && sphinx-autobuild \
 		-c sphinx \
 		-b html \
 		--ignore "*~" \
@@ -27,3 +40,6 @@ watch: ensure
 		--ignore "_build/*" \
 		.. \
 		_build
+
+format:
+	. $(VENV)/*/activate && black .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@ alabaster==0.7.16
 anyio==4.4.0
 Babel==2.15.0
 beautifulsoup4==4.12.3
+black==24.8.0
 certifi==2024.7.4
 charset-normalizer==3.3.2
 click==8.1.7
@@ -17,8 +18,11 @@ markdown-it-py==3.0.0
 MarkupSafe==2.1.5
 mdit-py-plugins==0.4.1
 mdurl==0.1.2
+mypy-extensions==1.0.0
 myst-parser==3.0.1
 packaging==24.1
+pathspec==0.12.1
+platformdirs==4.2.2
 pydata-sphinx-theme==0.15.4
 Pygments==2.18.0
 PyYAML==6.0.1

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -62,14 +62,12 @@ myst_links_external_new_tab = True
 myst_url_schemes = {
     "http": None,
     "https": None,
-
     # Usage: <gh-file:repository-under-pulumi-org#path/to/file>
     "gh-file": {
         "url": "https://github.com/pulumi/{{path}}/blob/master/{{fragment}}",
         "title": "pulumi/{{path}}:{{fragment}}",
         "classes": ["github"],
     },
-
     # Usage: <gh-file:repository-under-pulumi-org#issue-or-pr-number>
     "gh-issue": {
         "url": "https://github.com/pulumi/{{path}}/issues/{{fragment}}",
@@ -103,16 +101,13 @@ exclude_patterns = [
     ".direnv",
     ".git",
     "node_modules",
-
     # Pulumi-specific cases
-
     ## Standalone documentation files/noise from vendored libraries (CHANGELOGs,
     ## LICENSEs, etc.)
     "CHANGELOG.md",
     "CODE_OF_CONDUCT.md",
     "CONTRIBUTING.md",
     "README.md",
-
     ## Test data
     "**/testdata",
 ]
@@ -133,7 +128,6 @@ html_logo = "https://www.pulumi.com/images/logo/logo-on-white-box.svg"
 html_theme_options = {
     # Show all headings up to level 2 in the sidebar table of contents.
     "show_toc_levels": 2,
-
     # Enable margin notes
     # (https://sphinx-book-theme.readthedocs.io/en/stable/content/content-blocks.html#sidenotes-and-marginnotes).
     "use_sidenotes": True,
@@ -151,13 +145,13 @@ html_css_files = ["custom.css"]
 
 # -- Application-specific setup ----------------------------------------------
 
+
 def setup(app):
     # Connect a listener which ignores any text between ".. AUTODOC-IGNORE"
     # markers when autodoc is processing docstrings. This means that, for
     # example, custom roles and directives can include documentation that talks
     # both about the role API as well as how it should be consumed.
     app.connect(
-        "autodoc-process-docstring",
-        between("^.*\.\. AUTODOC-IGNORE.*$", exclude = True)
+        "autodoc-process-docstring", between("^.*\.\. AUTODOC-IGNORE.*$", exclude=True)
     )
     return app


### PR DESCRIPTION
Rather than embedding commands into the `.readthedocs.yaml` configuration file, this commit has Read the Docs simply call the existing `docs/Makefile`'s `build` target, so that we can centralise instructions for building documentation in one place.