### PR TITLE
Give Node.js and Python coverage files unique names to improve code coverage quality

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -338,7 +338,11 @@ jobs:
         if: ${{ inputs.platform != 'windows-latest' }}
         run: |
           cd sdk/nodejs
-          if [ -e .nyc_output ]; then yarn run nyc report -r cobertura --report-dir "$PULUMI_TEST_COVERAGE_PATH"; fi
+          if [ -e .nyc_output ]; then
+            TS=$(python -c 'import time; print(int(time.time() * 1000))')
+            yarn run nyc report -r cobertura --report-dir "$PULUMI_TEST_COVERAGE_PATH"
+            mv "$PULUMI_TEST_COVERAGE_PATH/cobertura-coverage.xml" "$PULUMI_TEST_COVERAGE_PATH/cobertura-coverage-$TS.xml"
+          fi
       - name: Merge integration test code coverage
         if: ${{ inputs.enable-coverage }}
         run: |

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -339,9 +339,9 @@ jobs:
         run: |
           cd sdk/nodejs
           if [ -e .nyc_output ]; then
-            TS=$(python -c 'import time; print(int(time.time() * 1000))')
+            UUID=$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-')
             yarn run nyc report -r cobertura --report-dir "$PULUMI_TEST_COVERAGE_PATH"
-            mv "$PULUMI_TEST_COVERAGE_PATH/cobertura-coverage.xml" "$PULUMI_TEST_COVERAGE_PATH/cobertura-coverage-$TS.xml"
+            mv "$PULUMI_TEST_COVERAGE_PATH/cobertura-coverage.xml" "$PULUMI_TEST_COVERAGE_PATH/cobertura-coverage-$UUID.xml"
           fi
       - name: Merge integration test code coverage
         if: ${{ inputs.enable-coverage }}
@@ -350,8 +350,8 @@ jobs:
           # if available.
           if [ -n "$(ls -A "$GOCOVERDIR")" ]; then
             # Cross-platform way to get milliseconds since Unix epoch.
-            TS=$(python -c 'import time; print(int(time.time() * 1000))')
-            go tool covdata textfmt -i="$GOCOVERDIR" -o="$PULUMI_TEST_COVERAGE_PATH/integration.$TS.cov"
+            UUID=$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-')
+            go tool covdata textfmt -i="$GOCOVERDIR" -o="$PULUMI_TEST_COVERAGE_PATH/integration.$UUID.cov"
           fi
       - name: Upload code coverage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -339,7 +339,7 @@ jobs:
         run: |
           cd sdk/nodejs
           if [ -e .nyc_output ]; then
-            UUID=$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-')
+            UUID=$(python -c "import uuid; print(str(uuid.uuid4()).replace('-', '').lower())")
             COVERAGE_PATH="${PULUMI_TEST_COVERAGE_PATH:-./coverage}"
             yarn run nyc report -r cobertura --report-dir "$COVERAGE_PATH"
             mv "$COVERAGE_PATH/cobertura-coverage.xml" "$COVERAGE_PATH/cobertura-coverage-$UUID.xml"
@@ -351,8 +351,8 @@ jobs:
           # if available.
           if [ -n "$(ls -A "$GOCOVERDIR")" ]; then
             # Cross-platform way to get milliseconds since Unix epoch.
-            UUID=$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-')
-            go tool covdata textfmt -i="$GOCOVERDIR" -o="$PULUMI_TEST_COVERAGE_PATH/integration.$UUID.cov"
+            UUID=$(python -c "import uuid; print(str(uuid.uuid4()).replace('-', '').lower())")
+            go tool covdata textfmt -i="$GOCOVERDIR" -o="$PULUMI_TEST_COVERAGE_PATH/integration-$UUID.cov"
           fi
       - name: Upload code coverage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -340,8 +340,9 @@ jobs:
           cd sdk/nodejs
           if [ -e .nyc_output ]; then
             UUID=$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-')
-            yarn run nyc report -r cobertura --report-dir "$PULUMI_TEST_COVERAGE_PATH"
-            mv "$PULUMI_TEST_COVERAGE_PATH/cobertura-coverage.xml" "$PULUMI_TEST_COVERAGE_PATH/cobertura-coverage-$UUID.xml"
+            COVERAGE_PATH="${PULUMI_TEST_COVERAGE_PATH:-./coverage}"
+            yarn run nyc report -r cobertura --report-dir "$COVERAGE_PATH"
+            mv "$COVERAGE_PATH/cobertura-coverage.xml" "$COVERAGE_PATH/cobertura-coverage-$UUID.xml"
           fi
       - name: Merge integration test code coverage
         if: ${{ inputs.enable-coverage }}

--- a/sdk/python/scripts/test_auto.sh
+++ b/sdk/python/scripts/test_auto.sh
@@ -8,6 +8,7 @@ coverage run -m pytest lib/test/automation
 
 if [[ "$PULUMI_TEST_COVERAGE_PATH" ]]; then
     if [ -e .coverage ]; then
-        coverage xml -o $PULUMI_TEST_COVERAGE_PATH/python-fast.xml
+        TS=$(python -c 'import time; print(int(time.time() * 1000))')
+        coverage xml -o $PULUMI_TEST_COVERAGE_PATH/python-auto-$TS.xml
     fi
 fi

--- a/sdk/python/scripts/test_auto.sh
+++ b/sdk/python/scripts/test_auto.sh
@@ -8,7 +8,7 @@ coverage run -m pytest lib/test/automation
 
 if [[ "$PULUMI_TEST_COVERAGE_PATH" ]]; then
     if [ -e .coverage ]; then
-        UUID=$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-')
+        UUID=$(python -c "import uuid; print(str(uuid.uuid4()).replace('-', '').lower())")
         coverage xml -o $PULUMI_TEST_COVERAGE_PATH/python-auto-$UUID.xml
     fi
 fi

--- a/sdk/python/scripts/test_auto.sh
+++ b/sdk/python/scripts/test_auto.sh
@@ -8,7 +8,7 @@ coverage run -m pytest lib/test/automation
 
 if [[ "$PULUMI_TEST_COVERAGE_PATH" ]]; then
     if [ -e .coverage ]; then
-        TS=$(python -c 'import time; print(int(time.time() * 1000))')
-        coverage xml -o $PULUMI_TEST_COVERAGE_PATH/python-auto-$TS.xml
+        UUID=$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-')
+        coverage xml -o $PULUMI_TEST_COVERAGE_PATH/python-auto-$UUID.xml
     fi
 fi

--- a/sdk/python/scripts/test_fast.sh
+++ b/sdk/python/scripts/test_fast.sh
@@ -21,6 +21,7 @@ coverage run -m unittest \
 
 if [[ "$PULUMI_TEST_COVERAGE_PATH" ]]; then
     if [ -e .coverage ]; then
-        coverage xml -o $PULUMI_TEST_COVERAGE_PATH/python-fast.xml
+        TS=$(python -c 'import time; print(int(time.time() * 1000))')
+        coverage xml -o $PULUMI_TEST_COVERAGE_PATH/python-fast-$TS.xml
     fi
 fi

--- a/sdk/python/scripts/test_fast.sh
+++ b/sdk/python/scripts/test_fast.sh
@@ -21,7 +21,7 @@ coverage run -m unittest \
 
 if [[ "$PULUMI_TEST_COVERAGE_PATH" ]]; then
     if [ -e .coverage ]; then
-        UUID=$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-')
+        UUID=$(python -c "import uuid; print(str(uuid.uuid4()).replace('-', '').lower())")
         coverage xml -o $PULUMI_TEST_COVERAGE_PATH/python-fast-$UUID.xml
     fi
 fi

--- a/sdk/python/scripts/test_fast.sh
+++ b/sdk/python/scripts/test_fast.sh
@@ -21,7 +21,7 @@ coverage run -m unittest \
 
 if [[ "$PULUMI_TEST_COVERAGE_PATH" ]]; then
     if [ -e .coverage ]; then
-        TS=$(python -c 'import time; print(int(time.time() * 1000))')
-        coverage xml -o $PULUMI_TEST_COVERAGE_PATH/python-fast-$TS.xml
+        UUID=$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-')
+        coverage xml -o $PULUMI_TEST_COVERAGE_PATH/python-fast-$UUID.xml
     fi
 fi


### PR DESCRIPTION
We currently observe that coverage data for Node.js and Python SDKs are not stable between multiple master commits.

My working theory on what happens, taking Node.js as an example:
- Our test runs are spread between multiple independent actions
- Each node-testing action produces coverage data
- We then call the `nyc report` command to produce the `cobertura-coverage.xml` file
- The XML file gets uploaded inside a `coverage-*` artifacts
- We then download all coverage files with `merge-multiple: true` option [here](https://github.com/pulumi/pulumi/blob/master/.github/workflows/ci.yml#L445)
- Only one (random) `cobertura-coverage.xml` file survives and is uploaded to Codecov
- The resulting data are noisy

A similar clash happens for Python too.

This PR adds UUID suffixes to coverage file names. We used to add timestamps to Go's cov files, but I switched those over to UUIDs as well - to avoid collision possibilities.