### PR TITLE
Include all engine events in the event log

### DIFF
--- a/changelog/pending/20240829--cli--include-all-engine-events-in-the-event-log.yaml
+++ b/changelog/pending/20240829--cli--include-all-engine-events-in-the-event-log.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Include all engine events in the event-log

--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -64,14 +64,14 @@ func ShowEvents(
 	op string, action apitype.UpdateKind, stack tokens.StackName, proj tokens.PackageName,
 	permalink string, events <-chan engine.Event, done chan<- bool, opts Options, isPreview bool,
 ) {
+	if opts.EventLogPath != "" {
+		events, done = startEventLogger(events, done, opts)
+	}
+
 	// Need to filter the engine events here to exclude any internal events.
 	events = channel.FilterRead(events, func(e engine.Event) bool {
 		return !e.Internal()
 	})
-
-	if opts.EventLogPath != "" {
-		events, done = startEventLogger(events, done, opts)
-	}
 
 	streamPreview := cmdutil.IsTruthy(os.Getenv("PULUMI_ENABLE_STREAMING_JSON_PREVIEW"))
 

--- a/pkg/backend/display/display_test.go
+++ b/pkg/backend/display/display_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestShowEvents(t *testing.T) {
+	t.Parallel()
+
 	// Test that internal events are filtered out.
 	events := make(chan engine.Event)
 	done := make(chan bool)
@@ -36,6 +38,7 @@ func TestShowEvents(t *testing.T) {
 	assert.NoError(t, err)
 
 	eventLog, err := os.CreateTemp("", "event-log-")
+	assert.NoError(t, err)
 
 	go func() {
 		events <- engine.NewEvent(engine.ResourcePreEventPayload{

--- a/pkg/backend/display/display_test.go
+++ b/pkg/backend/display/display_test.go
@@ -1,0 +1,60 @@
+package display
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShowEvents(t *testing.T) {
+	// Test that internal events are filtered out.
+	events := make(chan engine.Event)
+	done := make(chan bool)
+	stack, err := tokens.ParseStackName("stack")
+	assert.NoError(t, err)
+
+	eventLog, err := os.CreateTemp("", "event-log-")
+
+	go func() {
+		events <- engine.NewEvent(engine.ResourcePreEventPayload{
+			Metadata: engine.StepEventMetadata{
+				URN: resource.NewURN(stack.Q(), "proj", "parent", "base", "not-filtered"),
+				Op:  deploy.OpCreate,
+			},
+			Internal: false,
+		})
+		events <- engine.NewEvent(engine.ResourcePreEventPayload{
+			Metadata: engine.StepEventMetadata{
+				URN: resource.NewURN(stack.Q(), "proj", "parent", "base", "this-is-filtered-from-display"),
+				Op:  deploy.OpCreate,
+			},
+			Internal: true,
+		})
+		events <- engine.NewCancelEvent()
+		close(events)
+	}()
+
+	var stdout bytes.Buffer
+	ShowEvents("op", apitype.UpdateUpdate, stack, "proj", "permalink", events, done, Options{
+		EventLogPath: eventLog.Name(),
+		Stdout:       &stdout,
+		Color:        colors.Never,
+	}, false)
+	<-done
+
+	assert.Contains(t, stdout.String(), "not-filtered")
+	assert.NotContains(t, stdout.String(), "this-is-filtered-from-display")
+
+	read, err := os.ReadFile(eventLog.Name())
+	assert.NoError(t, err)
+	assert.Contains(t, string(read), "not-filtered")
+	assert.Contains(t, string(read), "this-is-filtered-from-display")
+}

--- a/pkg/backend/display/display_test.go
+++ b/pkg/backend/display/display_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package display
 
 import (

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -88,17 +88,19 @@ func TestEngineEvents(t *testing.T) {
 			// Ensure that we have a non-empty list of events.
 			assert.NotEmpty(t, stackInfo.Events)
 
-			// Ensure that we have two "ResourcePre" events: one for the stack and one for our resource.
+			// Ensure that we have three "ResourcePre" events: one for the stack and one for our resource and one for the provider
 			preEventResourceTypes := []string{}
 			for _, e := range stackInfo.Events {
 				if e.ResourcePreEvent != nil {
+					fmt.Println(e.ResourcePreEvent.Metadata.Type)
 					preEventResourceTypes = append(preEventResourceTypes, e.ResourcePreEvent.Metadata.Type)
 				}
 			}
 
-			assert.Equal(t, 2, len(preEventResourceTypes))
+			assert.Equal(t, 3, len(preEventResourceTypes))
 			assert.Contains(t, preEventResourceTypes, "pulumi:pulumi:Stack")
 			assert.Contains(t, preEventResourceTypes, "pulumi-nodejs:dynamic:Resource")
+			assert.Contains(t, preEventResourceTypes, "pulumi:providers:pulumi-nodejs")
 		},
 	})
 }

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -88,7 +88,8 @@ func TestEngineEvents(t *testing.T) {
 			// Ensure that we have a non-empty list of events.
 			assert.NotEmpty(t, stackInfo.Events)
 
-			// Ensure that we have three "ResourcePre" events: one for the stack and one for our resource and one for the provider
+			// Ensure that we have three "ResourcePre" events: one for the stack and one for our resource
+			// and one for the provider
 			preEventResourceTypes := []string{}
 			for _, e := range stackInfo.Events {
 				if e.ResourcePreEvent != nil {


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/14607 we introduced filtering of engine events before they are displayed.  However in the process we also started filtering them from the event log.  The event log is used for two things, the automation API and debugging.  The automation API already ignores events it doesn't know about (and it should because a new version of the CLI can always introduce new events that aren't filtered), and for debugging it is very useful to have all events in the event log.

In fact we are going to introduce a new debugging event, which the automation API will need (plugins for IDEs are going to be written using the automation API to intercept the engine events).

Move the filtering after the writing to the event log, so we always have all events there, but still filter events that are not relevant to the service etc.