### PR TITLE
Lift pkgWorkspace.Instance to top level command functions

### DIFF
--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -66,7 +66,7 @@ func newAboutCmd() *cobra.Command {
 		Args: cmdutil.MaximumNArgs(0),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			summary := getSummaryAbout(ctx, transitiveDependencies, stack)
+			summary := getSummaryAbout(ctx, pkgWorkspace.Instance, transitiveDependencies, stack)
 			if jsonOut {
 				return printJSON(summary)
 			}
@@ -104,7 +104,9 @@ type summaryAbout struct {
 	LogMessage    string                   `json:"-"`
 }
 
-func getSummaryAbout(ctx context.Context, transitiveDependencies bool, selectedStack string) summaryAbout {
+func getSummaryAbout(
+	ctx context.Context, ws pkgWorkspace.Context, transitiveDependencies bool, selectedStack string,
+) summaryAbout {
 	var err error
 	cli := getCLIAbout()
 	result := summaryAbout{
@@ -128,7 +130,7 @@ func getSummaryAbout(ctx context.Context, transitiveDependencies bool, selectedS
 
 	var proj *workspace.Project
 	var pwd string
-	if proj, pwd, err = pkgWorkspace.Instance.ReadProject(); err != nil {
+	if proj, pwd, err = ws.ReadProject(); err != nil {
 		addError(err, "Failed to read project")
 	} else {
 		projinfo := &engine.Projinfo{Proj: proj, Root: pwd}

--- a/pkg/cmd/pulumi/cancel.go
+++ b/pkg/cmd/pulumi/cancel.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
@@ -57,7 +58,9 @@ func newCancelCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(ctx, stack, stackLoadOnly, opts)
+			ws := pkgWorkspace.Instance
+
+			s, err := requireStack(ctx, ws, stack, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -64,16 +64,17 @@ func newConfigCmd() *cobra.Command {
 		Args: cmdutil.NoArgs,
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := pkgWorkspace.Instance.ReadProject()
+			project, _, err := ws.ReadProject()
 			if err != nil {
 				return err
 			}
 
-			stack, err := requireStack(ctx, stack, stackOfferNew|stackSetCurrent, opts)
+			stack, err := requireStack(ctx, ws, stack, stackOfferNew|stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -138,17 +139,18 @@ func newConfigCopyCmd(stack *string) *cobra.Command {
 		Args: cmdutil.MaximumNArgs(1),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := pkgWorkspace.Instance.ReadProject()
+			project, _, err := ws.ReadProject()
 			if err != nil {
 				return err
 			}
 
 			// Get current stack and ensure that it is a different stack to the destination stack
-			currentStack, err := requireStack(ctx, *stack, stackSetCurrent, opts)
+			currentStack, err := requireStack(ctx, ws, *stack, stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -161,7 +163,7 @@ func newConfigCopyCmd(stack *string) *cobra.Command {
 			}
 
 			// Get the destination stack
-			destinationStack, err := requireStack(ctx, destinationStackName, stackLoadOnly, opts)
+			destinationStack, err := requireStack(ctx, ws, destinationStackName, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}
@@ -318,11 +320,12 @@ func newConfigGetCmd(stack *string) *cobra.Command {
 		Args: cmdutil.SpecificArgs([]string{"key"}),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(ctx, *stack, stackOfferNew|stackSetCurrent, opts)
+			s, err := requireStack(ctx, ws, *stack, stackOfferNew|stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -332,7 +335,7 @@ func newConfigGetCmd(stack *string) *cobra.Command {
 				return fmt.Errorf("invalid configuration key: %w", err)
 			}
 
-			return getConfig(ctx, s, key, path, jsonOut, open)
+			return getConfig(ctx, ws, s, key, path, jsonOut, open)
 		}),
 	}
 	getCmd.Flags().BoolVarP(
@@ -363,16 +366,17 @@ func newConfigRmCmd(stack *string) *cobra.Command {
 		Args: cmdutil.SpecificArgs([]string{"key"}),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := pkgWorkspace.Instance.ReadProject()
+			project, _, err := ws.ReadProject()
 			if err != nil {
 				return err
 			}
 
-			stack, err := requireStack(ctx, *stack, stackOfferNew|stackSetCurrent, opts)
+			stack, err := requireStack(ctx, ws, *stack, stackOfferNew|stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -417,16 +421,17 @@ func newConfigRmAllCmd(stack *string) *cobra.Command {
 		Args: cmdutil.MinimumNArgs(1),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := pkgWorkspace.Instance.ReadProject()
+			project, _, err := ws.ReadProject()
 			if err != nil {
 				return err
 			}
 
-			stack, err := requireStack(ctx, *stack, stackOfferNew, opts)
+			stack, err := requireStack(ctx, ws, *stack, stackOfferNew, opts)
 			if err != nil {
 				return err
 			}
@@ -466,17 +471,18 @@ func newConfigRefreshCmd(stk *string) *cobra.Command {
 		Args:  cmdutil.NoArgs,
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := pkgWorkspace.Instance.ReadProject()
+			project, _, err := ws.ReadProject()
 			if err != nil {
 				return err
 			}
 
 			// Ensure the stack exists.
-			s, err := requireStack(ctx, *stk, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, *stk, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}
@@ -585,17 +591,18 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 		Args: cmdutil.RangeArgs(1, 2),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := pkgWorkspace.Instance.ReadProject()
+			project, _, err := ws.ReadProject()
 			if err != nil {
 				return err
 			}
 
 			// Ensure the stack exists.
-			s, err := requireStack(ctx, *stack, stackOfferNew|stackSetCurrent, opts)
+			s, err := requireStack(ctx, ws, *stack, stackOfferNew|stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -704,17 +711,18 @@ func newConfigSetAllCmd(stack *string) *cobra.Command {
 		Args: cmdutil.NoArgs,
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := pkgWorkspace.Instance.ReadProject()
+			project, _, err := ws.ReadProject()
 			if err != nil {
 				return err
 			}
 
 			// Ensure the stack exists.
-			stack, err := requireStack(ctx, *stack, stackOfferNew, opts)
+			stack, err := requireStack(ctx, ws, *stack, stackOfferNew, opts)
 			if err != nil {
 				return err
 			}
@@ -1035,8 +1043,10 @@ func listConfig(
 	return nil
 }
 
-func getConfig(ctx context.Context, stack backend.Stack, key config.Key, path, jsonOut, openEnvironment bool) error {
-	project, _, err := pkgWorkspace.Instance.ReadProject()
+func getConfig(
+	ctx context.Context, ws pkgWorkspace.Context, stack backend.Stack, key config.Key, path, jsonOut, openEnvironment bool,
+) error {
+	project, _, err := ws.ReadProject()
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/config_env.go
+++ b/pkg/cmd/pulumi/config_env.go
@@ -69,6 +69,7 @@ type configEnvCmd struct {
 
 	requireStack func(
 		ctx context.Context,
+		ws pkgWorkspace.Context,
 		stackName string,
 		lopt stackLoadOption,
 		opts display.Options,
@@ -95,7 +96,7 @@ func (cmd *configEnvCmd) loadEnvPreamble(ctx context.Context,
 		return nil, nil, nil, err
 	}
 
-	stack, err := cmd.requireStack(ctx, *cmd.stackRef, stackOfferNew|stackSetCurrent, opts)
+	stack, err := cmd.requireStack(ctx, cmd.ws, *cmd.stackRef, stackOfferNew|stackSetCurrent, opts)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/cmd/pulumi/config_env_init.go
+++ b/pkg/cmd/pulumi/config_env_init.go
@@ -104,7 +104,7 @@ func (cmd *configEnvInitCmd) run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	stack, err := cmd.parent.requireStack(ctx, *cmd.parent.stackRef, stackOfferNew|stackSetCurrent, opts)
+	stack, err := cmd.parent.requireStack(ctx, cmd.parent.ws, *cmd.parent.stackRef, stackOfferNew|stackSetCurrent, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/config_env_test.go
+++ b/pkg/cmd/pulumi/config_env_test.go
@@ -96,6 +96,7 @@ func newConfigEnvCmdForTestWithCheckYAMLEnvironment(
 		},
 		requireStack: func(
 			ctx context.Context,
+			ws pkgWorkspace.Context,
 			stackName string,
 			lopt stackLoadOption,
 			opts display.Options,

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -121,6 +121,7 @@ func newConvertCmd() *cobra.Command {
 			}
 
 			return runConvert(
+				pkgWorkspace.Instance,
 				env.Global(),
 				args,
 				cwd,
@@ -235,6 +236,7 @@ func generatorWrapper(generator projectGeneratorFunc, targetLanguage string) pro
 }
 
 func runConvert(
+	ws pkgWorkspace.Context,
 	e env.Env,
 	args []string,
 	cwd string,
@@ -483,7 +485,7 @@ func runConvert(
 			return fmt.Errorf("changing the working directory: %w", err)
 		}
 
-		proj, root, err := pkgWorkspace.Instance.ReadProject()
+		proj, root, err := ws.ReadProject()
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/convert_test.go
+++ b/pkg/cmd/pulumi/convert_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,7 +35,7 @@ func TestYamlConvert(t *testing.T) {
 	}
 
 	result := runConvert(
-		env.Global(), []string{}, "convert_testdata", []string{},
+		pkgWorkspace.Instance, env.Global(), []string{}, "convert_testdata", []string{},
 		"yaml", "go", "convert_testdata/go", true, true, "")
 	require.Nil(t, result, "convert failed: %v", result)
 }
@@ -46,7 +47,7 @@ func TestPclConvert(t *testing.T) {
 	tmp := t.TempDir()
 
 	result := runConvert(
-		env.Global(), []string{}, "pcl_convert_testdata",
+		pkgWorkspace.Instance, env.Global(), []string{}, "pcl_convert_testdata",
 		[]string{}, "pcl", "pcl", tmp, true, true, "")
 	assert.Nil(t, result)
 
@@ -76,6 +77,7 @@ func TestProjectNameDefaults(t *testing.T) {
 
 	// Act.
 	err := runConvert(
+		pkgWorkspace.Instance,
 		env.Global(),
 		[]string{},             /*args*/
 		"pcl_convert_testdata", /*cwd*/
@@ -105,6 +107,7 @@ func TestProjectNameOverrides(t *testing.T) {
 
 	// Act.
 	err := runConvert(
+		pkgWorkspace.Instance,
 		env.Global(),
 		[]string{},             /*args*/
 		"pcl_convert_testdata", /*cwd*/

--- a/pkg/cmd/pulumi/deployment_run.go
+++ b/pkg/cmd/pulumi/deployment_run.go
@@ -43,6 +43,7 @@ func newDeploymentRunCmd() *cobra.Command {
 		Args: cmdutil.RangeArgs(1, 2),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 
 			operation, err := apitype.ParsePulumiOperation(args[0])
 			if err != nil {
@@ -61,7 +62,7 @@ func newDeploymentRunCmd() *cobra.Command {
 				SuppressPermalink: suppressPermalink,
 			}
 
-			project, _, err := pkgWorkspace.Instance.ReadProject()
+			project, _, err := ws.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
@@ -76,7 +77,7 @@ func newDeploymentRunCmd() *cobra.Command {
 					currentBe.Name())
 			}
 
-			s, err := requireStack(ctx, stack, stackOfferNew|stackSetCurrent, display)
+			s, err := requireStack(ctx, ws, stack, stackOfferNew|stackSetCurrent, display)
 			if err != nil {
 				return err
 			}
@@ -85,7 +86,7 @@ func newDeploymentRunCmd() *cobra.Command {
 				return errResult
 			}
 
-			return runDeployment(ctx, cmd, display, operation, s.Ref().FullyQualifiedName().String(), url, remoteArgs)
+			return runDeployment(ctx, ws, cmd, display, operation, s.Ref().FullyQualifiedName().String(), url, remoteArgs)
 		}),
 	}
 

--- a/pkg/cmd/pulumi/deployment_settings_config.go
+++ b/pkg/cmd/pulumi/deployment_settings_config.go
@@ -115,7 +115,7 @@ type deploymentSettingsCommandDependencies struct {
 }
 
 func initializeDeploymentSettingsCmd(
-	ctx context.Context, stack string,
+	ctx context.Context, ws pkgWorkspace.Context, stack string,
 ) (*deploymentSettingsCommandDependencies, error) {
 	interactive := cmdutil.Interactive()
 
@@ -124,7 +124,7 @@ func initializeDeploymentSettingsCmd(
 		IsInteractive: interactive,
 	}
 
-	project, _, err := pkgWorkspace.Instance.ReadProject()
+	project, _, err := ws.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func initializeDeploymentSettingsCmd(
 			be.Name())
 	}
 
-	s, err := requireStack(ctx, stack, stackOfferNew|stackSetCurrent, displayOpts)
+	s, err := requireStack(ctx, ws, stack, stackOfferNew|stackSetCurrent, displayOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +195,7 @@ func newDeploymentSettingsInitCmd() *cobra.Command {
 		Short:      "Initialize the stack's deployment.yaml file",
 		Long:       "",
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
-			d, err := initializeDeploymentSettingsCmd(cmd.Context(), stack)
+			d, err := initializeDeploymentSettingsCmd(cmd.Context(), pkgWorkspace.Instance, stack)
 			if err != nil {
 				return err
 			}
@@ -295,7 +295,7 @@ func newDeploymentSettingsConfigureCmd() *cobra.Command {
 				return errors.New("configure command is only supported in interactive mode")
 			}
 
-			d, err := initializeDeploymentSettingsCmd(cmd.Context(), stack)
+			d, err := initializeDeploymentSettingsCmd(cmd.Context(), pkgWorkspace.Instance, stack)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/deployment_settings_ops.go
+++ b/pkg/cmd/pulumi/deployment_settings_ops.go
@@ -17,6 +17,7 @@ package main
 import (
 	"errors"
 
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -42,7 +43,7 @@ func newDeploymentSettingsPullCmd() *cobra.Command {
 		Short: "Pull the stack's deployment settings from Pulumi Cloud into the deployment.yaml file",
 		Long:  "",
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
-			d, err := initializeDeploymentSettingsCmd(cmd.Context(), stack)
+			d, err := initializeDeploymentSettingsCmd(cmd.Context(), pkgWorkspace.Instance, stack)
 			if err != nil {
 				return err
 			}
@@ -90,7 +91,7 @@ func newDeploymentSettingsUpdateCmd() *cobra.Command {
 				return err
 			}
 
-			d, err := initializeDeploymentSettingsCmd(cmd.Context(), stack)
+			d, err := initializeDeploymentSettingsCmd(cmd.Context(), pkgWorkspace.Instance, stack)
 			if err != nil {
 				return err
 			}
@@ -144,7 +145,7 @@ func newDeploymentSettingsDestroyCmd() *cobra.Command {
 				return err
 			}
 
-			d, err := initializeDeploymentSettingsCmd(cmd.Context(), stack)
+			d, err := initializeDeploymentSettingsCmd(cmd.Context(), pkgWorkspace.Instance, stack)
 			if err != nil {
 				return err
 			}
@@ -187,7 +188,7 @@ func newDeploymentSettingsEnvCmd() *cobra.Command {
 		Long:  "",
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			d, err := initializeDeploymentSettingsCmd(cmd.Context(), stack)
+			d, err := initializeDeploymentSettingsCmd(cmd.Context(), pkgWorkspace.Instance, stack)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -97,6 +97,7 @@ func newDestroyCmd() *cobra.Command {
 		Args: cmdArgs,
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 
 			// Remote implies we're skipping previews.
 			if remoteArgs.remote {
@@ -160,10 +161,10 @@ func newDestroyCmd() *cobra.Command {
 					return errResult
 				}
 
-				return runDeployment(ctx, cmd, opts.Display, apitype.Destroy, stackName, url, remoteArgs)
+				return runDeployment(ctx, ws, cmd, opts.Display, apitype.Destroy, stackName, url, remoteArgs)
 			}
 
-			isDIYBackend, err := isDIYBackend(opts.Display)
+			isDIYBackend, err := isDIYBackend(ws, opts.Display)
 			if err != nil {
 				return err
 			}
@@ -174,12 +175,12 @@ func newDestroyCmd() *cobra.Command {
 				opts.Display.SuppressPermalink = true
 			}
 
-			s, err := requireStack(ctx, stackName, stackLoadOnly, opts.Display)
+			s, err := requireStack(ctx, ws, stackName, stackLoadOnly, opts.Display)
 			if err != nil {
 				return err
 			}
 
-			proj, root, err := pkgWorkspace.Instance.ReadProject()
+			proj, root, err := ws.ReadProject()
 			if err != nil && errors.Is(err, workspace.ErrProjectNotFound) {
 				logging.Warningf("failed to find current Pulumi project, continuing with an empty project"+
 					"using stack %v from backend %v", s.Ref().Name(), s.Backend().Name())

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -783,7 +783,8 @@ func newImportCmd() *cobra.Command {
 			}
 
 			// Fetch the project.
-			proj, root, err := pkgWorkspace.Instance.ReadProject()
+			ws := pkgWorkspace.Instance
+			proj, root, err := ws.ReadProject()
 			if err != nil {
 				return err
 			}
@@ -825,7 +826,7 @@ func newImportCmd() *cobra.Command {
 				opts.Display.SuppressPermalink = false
 			}
 
-			isDIYBackend, err := isDIYBackend(opts.Display)
+			isDIYBackend, err := isDIYBackend(ws, opts.Display)
 			if err != nil {
 				return err
 			}
@@ -837,7 +838,7 @@ func newImportCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack.
-			s, err := requireStack(ctx, stackName, stackLoadOnly, opts.Display)
+			s, err := requireStack(ctx, ws, stackName, stackLoadOnly, opts.Display)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -57,17 +57,18 @@ func newLogsCmd() *cobra.Command {
 		Args: cmdutil.NoArgs,
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
 			// Fetch the project.
-			proj, _, err := pkgWorkspace.Instance.ReadProject()
+			proj, _, err := ws.ReadProject()
 			if err != nil {
 				return err
 			}
 
-			s, err := requireStack(ctx, stackName, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, stackName, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/package_add.go
+++ b/pkg/cmd/pulumi/package_add.go
@@ -47,7 +47,8 @@ as in:
 
   pulumi package add <provider> -- --provider-parameter-flag value`,
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
-			proj, root, err := pkgWorkspace.Instance.ReadProject()
+			ws := pkgWorkspace.Instance
+			proj, root, err := ws.ReadProject()
 			if err != nil && errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
@@ -102,7 +103,7 @@ as in:
 				return fmt.Errorf("failed to remove temporary directory: %w", err)
 			}
 
-			return printLinkInstructions(language, root, pkg, out)
+			return printLinkInstructions(ws, language, root, pkg, out)
 		}),
 	}
 
@@ -111,12 +112,14 @@ as in:
 
 // Prints instructions for linking a locally generated SDK to an existing
 // project, in the absence of us attempting to perform this linking automatically.
-func printLinkInstructions(language string, root string, pkg *schema.Package, out string) error {
+func printLinkInstructions(
+	ws pkgWorkspace.Context, language string, root string, pkg *schema.Package, out string,
+) error {
 	switch language {
 	case "nodejs":
-		return printNodejsLinkInstructions(root, pkg, out)
+		return printNodejsLinkInstructions(ws, root, pkg, out)
 	case "python":
-		return printPythonLinkInstructions(root, pkg, out)
+		return printPythonLinkInstructions(ws, root, pkg, out)
 	case "go":
 		return printGoLinkInstructions(root, pkg, out)
 	case "dotnet":
@@ -131,12 +134,12 @@ func printLinkInstructions(language string, root string, pkg *schema.Package, ou
 
 // Prints instructions for linking a locally generated SDK to an existing NodeJS
 // project, in the absence of us attempting to perform this linking automatically.
-func printNodejsLinkInstructions(root string, pkg *schema.Package, out string) error {
+func printNodejsLinkInstructions(ws pkgWorkspace.Context, root string, pkg *schema.Package, out string) error {
 	fmt.Printf("Successfully generated a Nodejs SDK for the %s package at %s\n", pkg.Name, out)
 	fmt.Println()
 	fmt.Println("To use this SDK in your Nodejs project, run the following command:")
 	fmt.Println()
-	proj, _, err := pkgWorkspace.Instance.ReadProject()
+	proj, _, err := ws.ReadProject()
 	if err != nil {
 		return err
 	}
@@ -190,12 +193,12 @@ func printNodejsLinkInstructions(root string, pkg *schema.Package, out string) e
 
 // Prints instructions for linking a locally generated SDK to an existing Python
 // project, in the absence of us attempting to perform this linking automatically.
-func printPythonLinkInstructions(root string, pkg *schema.Package, out string) error {
+func printPythonLinkInstructions(ws pkgWorkspace.Context, root string, pkg *schema.Package, out string) error {
 	fmt.Printf("Successfully generated a Python SDK for the %s package at %s\n", pkg.Name, out)
 	fmt.Println()
 	fmt.Println("To use this SDK in your Python project, run the following command:")
 	fmt.Println()
-	proj, _, err := pkgWorkspace.Instance.ReadProject()
+	proj, _, err := ws.ReadProject()
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -295,6 +295,7 @@ func newPreviewCmd() *cobra.Command {
 		Args: cmdArgs,
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			displayType := display.DisplayProgress
 			if diffDisplay {
 				displayType = display.DisplayDiff
@@ -342,10 +343,10 @@ func newPreviewCmd() *cobra.Command {
 					return errResult
 				}
 
-				return runDeployment(ctx, cmd, displayOpts, apitype.Preview, stackName, url, remoteArgs)
+				return runDeployment(ctx, ws, cmd, displayOpts, apitype.Preview, stackName, url, remoteArgs)
 			}
 
-			isDIYBackend, err := isDIYBackend(displayOpts)
+			isDIYBackend, err := isDIYBackend(ws, displayOpts)
 			if err != nil {
 				return err
 			}
@@ -360,17 +361,17 @@ func newPreviewCmd() *cobra.Command {
 				return err
 			}
 
-			s, err := requireStack(ctx, stackName, stackOfferNew, displayOpts)
+			s, err := requireStack(ctx, ws, stackName, stackOfferNew, displayOpts)
 			if err != nil {
 				return err
 			}
 
 			// Save any config values passed via flags.
-			if err = parseAndSaveConfigArray(s, configArray, configPath); err != nil {
+			if err = parseAndSaveConfigArray(ws, s, configArray, configPath); err != nil {
 				return err
 			}
 
-			proj, root, err := readProjectForUpdate(pkgWorkspace.Instance, client)
+			proj, root, err := readProjectForUpdate(ws, client)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -90,6 +90,7 @@ func newRefreshCmd() *cobra.Command {
 		Args: cmdArgs,
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 
 			// Remote implies we're skipping previews.
 			if remoteArgs.remote {
@@ -153,10 +154,10 @@ func newRefreshCmd() *cobra.Command {
 					return errResult
 				}
 
-				return runDeployment(ctx, cmd, opts.Display, apitype.Refresh, stackName, url, remoteArgs)
+				return runDeployment(ctx, ws, cmd, opts.Display, apitype.Refresh, stackName, url, remoteArgs)
 			}
 
-			isDIYBackend, err := isDIYBackend(opts.Display)
+			isDIYBackend, err := isDIYBackend(ws, opts.Display)
 			if err != nil {
 				return err
 			}
@@ -167,12 +168,12 @@ func newRefreshCmd() *cobra.Command {
 				opts.Display.SuppressPermalink = true
 			}
 
-			s, err := requireStack(ctx, stackName, stackOfferNew, opts.Display)
+			s, err := requireStack(ctx, ws, stackName, stackOfferNew, opts.Display)
 			if err != nil {
 				return err
 			}
 
-			proj, root, err := pkgWorkspace.Instance.ReadProject()
+			proj, root, err := ws.ReadProject()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -59,11 +60,12 @@ func newStackCmd() *cobra.Command {
 		Args: cmdutil.NoArgs,
 		Run: runCmdFunc(func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(ctx, stackName, stackOfferNew, opts)
+			s, err := requireStack(ctx, ws, stackName, stackOfferNew, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -88,6 +88,8 @@ func (cmd *stackChangeSecretsProviderCmd) Run(ctx context.Context, args []string
 		cmd.secretsProvider = stack.DefaultSecretsProvider
 	}
 
+	ws := pkgWorkspace.Instance
+
 	opts := display.Options{
 		Color: cmdutil.GetGlobalColorization(),
 	}
@@ -96,13 +98,13 @@ func (cmd *stackChangeSecretsProviderCmd) Run(ctx context.Context, args []string
 		return err
 	}
 
-	project, _, err := pkgWorkspace.Instance.ReadProject()
+	project, _, err := ws.ReadProject()
 	if err != nil {
 		return err
 	}
 
 	// Get the current stack and its project
-	currentStack, err := requireStack(ctx, cmd.stack, stackLoadOnly, opts)
+	currentStack, err := requireStack(ctx, ws, cmd.stack, stackLoadOnly, opts)
 	if err != nil {
 		return err
 	}
@@ -132,7 +134,7 @@ func (cmd *stackChangeSecretsProviderCmd) Run(ctx context.Context, args []string
 		// the current secrets provider is empty
 		((secretsProvider == "passphrase") && (currentProjectStack.SecretsProvider == ""))
 	// Create the new secrets provider and set to the currentStack
-	if err := createSecretsManager(ctx, currentStack, secretsProvider, rotateProvider,
+	if err := createSecretsManager(ctx, ws, currentStack, secretsProvider, rotateProvider,
 		false /*creatingStack*/); err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/stack_export.go
+++ b/pkg/cmd/pulumi/stack_export.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -46,12 +47,13 @@ func newStackExportCmd() *cobra.Command {
 			"resources, etc.",
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
 			// Fetch the current stack and export its deployment
-			s, err := requireStack(ctx, stackName, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, stackName, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_graph.go
+++ b/pkg/cmd/pulumi/stack_graph.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/graph/dotconv"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/spf13/cobra"
@@ -66,11 +67,12 @@ func newStackGraphCmd() *cobra.Command {
 			"on your stack's most recent deployment.",
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(ctx, cmdOpts.stackName, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, cmdOpts.stackName, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -39,10 +39,11 @@ func newStackHistoryCmd() *cobra.Command {
 This command displays data about previous updates for a stack.`,
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := requireStack(ctx, stack, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, stack, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}
@@ -53,7 +54,7 @@ This command displays data about previous updates for a stack.`,
 			}
 			var decrypter config.Decrypter
 			if showSecrets {
-				project, _, err := pkgWorkspace.Instance.ReadProject()
+				project, _, err := ws.ReadProject()
 				if err != nil {
 					return fmt.Errorf("loading project: %w", err)
 				}

--- a/pkg/cmd/pulumi/stack_import.go
+++ b/pkg/cmd/pulumi/stack_import.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -50,12 +51,13 @@ func newStackImportCmd() *cobra.Command {
 			"The updated deployment will be read from standard in.",
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
 			// Fetch the current stack and import a deployment.
-			s, err := requireStack(ctx, stackName, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, stackName, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -113,6 +113,8 @@ func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
 		Color: cmdutil.GetGlobalColorization(),
 	}
 
+	ws := pkgWorkspace.Instance
+
 	// Try to read the current project
 	project, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
@@ -164,13 +166,13 @@ func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	proj, root, projectErr := pkgWorkspace.Instance.ReadProject()
+	proj, root, projectErr := ws.ReadProject()
 	if projectErr != nil && !errors.Is(projectErr, workspace.ErrProjectNotFound) {
 		return projectErr
 	}
 
 	createOpts := newCreateStackOptions(cmd.teams)
-	newStack, err := createStack(ctx, b, stackRef, root, createOpts, !cmd.noSelect, cmd.secretsProvider)
+	newStack, err := createStack(ctx, ws, b, stackRef, root, createOpts, !cmd.noSelect, cmd.secretsProvider)
 	if err != nil {
 		if errors.Is(err, backend.ErrTeamsNotSupported) {
 			return fmt.Errorf("stack %s uses the %s backend: "+
@@ -185,7 +187,7 @@ func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
 		}
 
 		// load the old stack and its project
-		copyStack, err := requireStack(ctx, cmd.stackToCopy, stackLoadOnly, opts)
+		copyStack, err := requireStack(ctx, ws, cmd.stackToCopy, stackLoadOnly, opts)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/stack_output_test.go
+++ b/pkg/cmd/pulumi/stack_output_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -108,7 +109,7 @@ func TestStackOutputCmd_plainText(t *testing.T) {
 					},
 				},
 			}
-			requireStack := func(context.Context,
+			requireStack := func(context.Context, pkgWorkspace.Context,
 				string, stackLoadOption, display.Options,
 			) (backend.Stack, error) {
 				return &backend.MockStack{
@@ -220,7 +221,7 @@ func TestStackOutputCmd_json(t *testing.T) {
 					},
 				},
 			}
-			requireStack := func(context.Context,
+			requireStack := func(context.Context, pkgWorkspace.Context,
 				string, stackLoadOption, display.Options,
 			) (backend.Stack, error) {
 				return &backend.MockStack{
@@ -342,7 +343,7 @@ func TestStackOutputCmd_shell(t *testing.T) {
 					},
 				},
 			}
-			requireStack := func(context.Context,
+			requireStack := func(context.Context, pkgWorkspace.Context,
 				string, stackLoadOption, display.Options,
 			) (backend.Stack, error) {
 				return &backend.MockStack{
@@ -380,7 +381,9 @@ func TestStackOutputCmd_jsonAndShellConflict(t *testing.T) {
 	t.Parallel()
 
 	cmd := stackOutputCmd{
-		requireStack: func(context.Context, string, stackLoadOption, display.Options) (backend.Stack, error) {
+		requireStack: func(
+			context.Context, pkgWorkspace.Context, string, stackLoadOption, display.Options,
+		) (backend.Stack, error) {
 			t.Fatal("This function should not be called")
 			return nil, errors.New("should not be called")
 		},

--- a/pkg/cmd/pulumi/stack_rename.go
+++ b/pkg/cmd/pulumi/stack_rename.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -46,12 +47,13 @@ func newStackRenameCmd() *cobra.Command {
 			"to update the name field of Pulumi.yaml, so the project names match.",
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
 			// Look up the stack to be moved, and find the path to the project file's location.
-			s, err := requireStack(ctx, stack, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, stack, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_rm.go
+++ b/pkg/cmd/pulumi/stack_rm.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -49,6 +50,7 @@ func newStackRmCmd() *cobra.Command {
 			"After this command completes, the stack will no longer be available for updates.",
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			yes = yes || skipConfirmations()
 			// Use the stack provided or, if missing, default to the current one.
 			if len(args) > 0 {
@@ -62,7 +64,7 @@ func newStackRmCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(ctx, stack, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, stack, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_select.go
+++ b/pkg/cmd/pulumi/stack_select.go
@@ -46,12 +46,13 @@ func newStackSelectCmd() *cobra.Command {
 		Args: cmdutil.MaximumNArgs(1),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
 			// Try to read the current project
-			project, root, err := pkgWorkspace.Instance.ReadProject()
+			project, root, err := ws.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
@@ -84,7 +85,7 @@ func newStackSelectCmd() *cobra.Command {
 				}
 				// If create flag was passed and stack was not found, create it and select it.
 				if create && stack != "" {
-					s, err := stackInit(ctx, b, stack, root, false, secretsProvider)
+					s, err := stackInit(ctx, ws, b, stack, root, false, secretsProvider)
 					if err != nil {
 						return err
 					}
@@ -95,7 +96,7 @@ func newStackSelectCmd() *cobra.Command {
 			}
 
 			// If no stack was given, prompt the user to select a name from the available ones.
-			stack, err := chooseStack(ctx, b, stackOfferNew|stackSetCurrent, opts)
+			stack, err := chooseStack(ctx, ws, b, stackOfferNew|stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_tag.go
+++ b/pkg/cmd/pulumi/stack_tag.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -60,12 +61,13 @@ func newStackTagGetCmd(stack *string) *cobra.Command {
 		Args:  cmdutil.SpecificArgs([]string{"name"}),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			name := args[0]
 
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := requireStack(ctx, *stack, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, *stack, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}
@@ -94,11 +96,12 @@ func newStackTagLsCmd(stack *string) *cobra.Command {
 		Args:  cmdutil.NoArgs,
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(ctx, *stack, stackSetCurrent, opts)
+			s, err := requireStack(ctx, ws, *stack, stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -150,12 +153,13 @@ func newStackTagRmCmd(stack *string) *cobra.Command {
 		Args:  cmdutil.SpecificArgs([]string{"name"}),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			name := args[0]
 
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := requireStack(ctx, *stack, stackSetCurrent, opts)
+			s, err := requireStack(ctx, ws, *stack, stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -180,13 +184,14 @@ func newStackTagSetCmd(stack *string) *cobra.Command {
 		Args:  cmdutil.SpecificArgs([]string{"name", "value"}),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			name := args[0]
 			value := args[1]
 
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := requireStack(ctx, *stack, stackSetCurrent, opts)
+			s, err := requireStack(ctx, ws, *stack, stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/edit"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -118,10 +119,10 @@ func locateStackResource(opts display.Options, snap *deploy.Snapshot, urn resour
 
 // runStateEdit runs the given state edit function on a resource with the given URN in a given stack.
 func runStateEdit(
-	ctx context.Context, stackName string, showPrompt bool,
+	ctx context.Context, ws pkgWorkspace.Context, stackName string, showPrompt bool,
 	urn resource.URN, operation edit.OperationFunc,
 ) error {
-	return runTotalStateEdit(ctx, stackName, showPrompt, func(opts display.Options, snap *deploy.Snapshot) error {
+	return runTotalStateEdit(ctx, ws, stackName, showPrompt, func(opts display.Options, snap *deploy.Snapshot) error {
 		res, err := locateStackResource(opts, snap, urn)
 		if err != nil {
 			return err
@@ -134,13 +135,13 @@ func runStateEdit(
 // runTotalStateEdit runs a snapshot-mutating function on the entirety of the given stack's snapshot.
 // Before mutating, the user may be prompted to for confirmation if the current session is interactive.
 func runTotalStateEdit(
-	ctx context.Context, stackName string, showPrompt bool,
+	ctx context.Context, ws pkgWorkspace.Context, stackName string, showPrompt bool,
 	operation func(opts display.Options, snap *deploy.Snapshot) error,
 ) error {
 	opts := display.Options{
 		Color: cmdutil.GetGlobalColorization(),
 	}
-	s, err := requireStack(ctx, stackName, stackOfferNew, opts)
+	s, err := requireStack(ctx, ws, stackName, stackOfferNew, opts)
 	if err != nil {
 		return err
 	}
@@ -208,7 +209,7 @@ func totalStateEdit(ctx context.Context, s backend.Stack, showPrompt bool, opts 
 //
 // Prompt is displayed to the user when selecting the URN.
 func getURNFromState(
-	ctx context.Context, stackName string, snap **deploy.Snapshot, prompt string,
+	ctx context.Context, ws pkgWorkspace.Context, stackName string, snap **deploy.Snapshot, prompt string,
 ) (resource.URN, error) {
 	if snap == nil {
 		// This means we won't cache the value.
@@ -219,7 +220,7 @@ func getURNFromState(
 			Color: cmdutil.GetGlobalColorization(),
 		}
 
-		s, err := requireStack(ctx, stackName, stackLoadOnly, opts)
+		s, err := requireStack(ctx, ws, stackName, stackLoadOnly, opts)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/cmd/pulumi/state_delete.go
+++ b/pkg/cmd/pulumi/state_delete.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/edit"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -53,6 +54,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			yes = yes || skipConfirmations()
 			var urn resource.URN
 			if len(args) == 0 {
@@ -61,7 +63,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 				}
 
 				var err error
-				urn, err = getURNFromState(ctx, stack, nil,
+				urn, err = getURNFromState(ctx, ws, stack, nil,
 					"Select the resource to delete")
 				if err != nil {
 					return fmt.Errorf("failed to select resource: %w", err)
@@ -72,7 +74,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 			// Show the confirmation prompt if the user didn't pass the --yes parameter to skip it.
 			showPrompt := !yes
 
-			err := runStateEdit(ctx, stack, showPrompt, urn, func(snap *deploy.Snapshot, res *resource.State) error {
+			err := runStateEdit(ctx, ws, stack, showPrompt, urn, func(snap *deploy.Snapshot, res *resource.State) error {
 				var handleProtected func(*resource.State) error
 				if force {
 					handleProtected = func(res *resource.State) error {

--- a/pkg/cmd/pulumi/state_edit.go
+++ b/pkg/cmd/pulumi/state_edit.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -57,7 +58,8 @@ a preview showing a diff of the altered state.`,
 				return errors.New("pulumi state edit must be run in interactive mode")
 			}
 			ctx := cmd.Context()
-			s, err := requireStack(ctx, stackName, stackLoadOnly, display.Options{
+			ws := pkgWorkspace.Instance
+			s, err := requireStack(ctx, ws, stackName, stackLoadOnly, display.Options{
 				Color:         cmdutil.GetGlobalColorization(),
 				IsInteractive: true,
 			})

--- a/pkg/cmd/pulumi/state_rename.go
+++ b/pkg/cmd/pulumi/state_rename.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/resource/edit"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -172,6 +173,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 		Args:    cmdutil.MaximumNArgs(2),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 			yes = yes || skipConfirmations()
 
 			if len(args) < 2 && !cmdutil.Interactive() {
@@ -185,7 +187,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 				var snap *deploy.Snapshot
 				err := surveyStack(
 					func() (err error) {
-						urn, err = getURNFromState(ctx, stack, &snap, "Select a resource to rename:")
+						urn, err = getURNFromState(ctx, ws, stack, &snap, "Select a resource to rename:")
 						if err != nil {
 							err = fmt.Errorf("failed to select resource: %w", err)
 						}
@@ -225,7 +227,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 			// Show the confirmation prompt if the user didn't pass the --yes parameter to skip it.
 			showPrompt := !yes
 
-			err := runTotalStateEdit(ctx, stack, showPrompt,
+			err := runTotalStateEdit(ctx, ws, stack, showPrompt,
 				func(opts display.Options, snap *deploy.Snapshot) error {
 					return stateRenameOperation(urn, newResourceName, opts, snap)
 				})

--- a/pkg/cmd/pulumi/util_remote.go
+++ b/pkg/cmd/pulumi/util_remote.go
@@ -366,7 +366,7 @@ func validateDeploymentFlags(url string, args RemoteArgs) error {
 }
 
 // runDeployment kicks off a remote deployment.
-func runDeployment(ctx context.Context, cmd *cobra.Command, opts display.Options,
+func runDeployment(ctx context.Context, ws pkgWorkspace.Context, cmd *cobra.Command, opts display.Options,
 	operation apitype.PulumiOperation, stack, url string, args RemoteArgs,
 ) error {
 	// Parse and validate the environment args.
@@ -394,7 +394,7 @@ func runDeployment(ctx context.Context, cmd *cobra.Command, opts display.Options
 	}
 
 	// Try to read the current project
-	project, _, err := pkgWorkspace.Instance.ReadProject()
+	project, _, err := ws.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -67,6 +67,7 @@ func newWatchCmd() *cobra.Command {
 		Args: cmdutil.MaximumNArgs(1),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ws := pkgWorkspace.Instance
 
 			opts, err := updateFlagsToOptions(false /* interactive */, true /* skipPreview */, true, /* autoApprove */
 				false /* previewOnly */)
@@ -91,17 +92,17 @@ func newWatchCmd() *cobra.Command {
 				return err
 			}
 
-			s, err := requireStack(ctx, stackName, stackOfferNew, opts.Display)
+			s, err := requireStack(ctx, ws, stackName, stackOfferNew, opts.Display)
 			if err != nil {
 				return err
 			}
 
 			// Save any config values passed via flags.
-			if err := parseAndSaveConfigArray(s, configArray, configPath); err != nil {
+			if err := parseAndSaveConfigArray(ws, s, configArray, configPath); err != nil {
 				return err
 			}
 
-			proj, root, err := pkgWorkspace.Instance.ReadProject()
+			proj, root, err := ws.ReadProject()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Following on from https://github.com/pulumi/pulumi/pull/17089. This lifts the access of `pkgWorkspace.Instance` to the top level commands. Everything deeper in the engine now takes a `workspace.Context` as a parameter. 