### PR TITLE
Use esc/workspace.DefaultPulumiWorkspace in env cmd

### DIFF
--- a/pkg/cmd/pulumi/env.go
+++ b/pkg/cmd/pulumi/env.go
@@ -21,11 +21,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/esc/cmd/esc/cli"
+	escWorkspace "github.com/pulumi/esc/cmd/esc/cli/workspace"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 func newEnvCmd() *cobra.Command {
@@ -33,47 +33,13 @@ func newEnvCmd() *cobra.Command {
 		ParentPath:      "pulumi",
 		Colors:          cmdutil.GetGlobalColorization(),
 		Login:           httpstate.NewLoginManager(),
-		PulumiWorkspace: defaultESCWorkspace(0),
+		PulumiWorkspace: escWorkspace.DefaultPulumiWorkspace(),
 		UserAgent:       client.UserAgent(),
 	})
 
 	// Add the `env` command to the root.
 	envCommand := escCLI.Commands()[0]
 	return envCommand
-}
-
-type defaultESCWorkspace int
-
-func (defaultESCWorkspace) DeleteAccount(backendURL string) error {
-	return workspace.DeleteAccount(backendURL)
-}
-
-func (defaultESCWorkspace) DeleteAllAccounts() error {
-	return workspace.DeleteAllAccounts()
-}
-
-func (defaultESCWorkspace) SetBackendConfigDefaultOrg(backendURL, defaultOrg string) error {
-	return workspace.SetBackendConfigDefaultOrg(backendURL, defaultOrg)
-}
-
-func (defaultESCWorkspace) GetPulumiConfig() (workspace.PulumiConfig, error) {
-	return workspace.GetPulumiConfig()
-}
-
-func (defaultESCWorkspace) GetPulumiPath(elem ...string) (string, error) {
-	return workspace.GetPulumiPath(elem...)
-}
-
-func (defaultESCWorkspace) GetStoredCredentials() (workspace.Credentials, error) {
-	return workspace.GetStoredCredentials()
-}
-
-func (defaultESCWorkspace) StoreAccount(key string, account workspace.Account, current bool) error {
-	return workspace.StoreAccount(key, account, current)
-}
-
-func (defaultESCWorkspace) GetAccount(key string) (workspace.Account, error) {
-	return workspace.GetAccount(key)
 }
 
 func printESCDiagnostics(out io.Writer, diags []apitype.EnvironmentDiagnostic) {


### PR DESCRIPTION
The esc library already defines a default pulumi workspace implementation. We can just use that rather than having another copy here as well.