### PR TITLE
Move GetBackendConfigDefaultOrg to pkg workspace

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -46,6 +46,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -745,7 +746,7 @@ func (b *cloudBackend) ParseStackReference(s string) (backend.StackReference, er
 	if qualifiedName.Owner == "" {
 		// if the qualifiedName doesn't include an owner then let's check to see if there is a default org which *will*
 		// be the stack owner. If there is no defaultOrg, then we revert to checking the CurrentUser
-		defaultOrg, err := workspace.GetBackendConfigDefaultOrg(b.currentProject)
+		defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(b.currentProject)
 		if err != nil {
 			return nil, err
 		}
@@ -885,7 +886,7 @@ func (b *cloudBackend) DoesProjectExist(ctx context.Context, orgName string, pro
 	}
 
 	getDefaultOrg := func() (string, error) {
-		return workspace.GetBackendConfigDefaultOrg(nil)
+		return pkgWorkspace.GetBackendConfigDefaultOrg(nil)
 	}
 	getUserOrg := func() (string, error) {
 		orgName, _, _, err := b.currentUser(ctx)

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/service"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -64,7 +65,7 @@ func (c cloudBackendReference) String() string {
 	if currentProject != nil && c.project == tokens.Name(currentProject.Name) {
 
 		// Elide owner too, if it is the default owner.
-		defaultOrg, err := workspace.GetBackendConfigDefaultOrg(currentProject)
+		defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(currentProject)
 		if err == nil && defaultOrg != "" {
 			// The default owner is the org
 			if c.owner == defaultOrg {

--- a/pkg/cmd/pulumi/org.go
+++ b/pkg/cmd/pulumi/org.go
@@ -47,7 +47,7 @@ func newOrgCmd() *cobra.Command {
 				return err
 			}
 
-			defaultOrg, err := workspace.GetBackendConfigDefaultOrg(project)
+			defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(project)
 			if err != nil {
 				return err
 			}
@@ -151,7 +151,7 @@ func newOrgGetDefaultCmd() *cobra.Command {
 					currentBe.Name())
 			}
 
-			defaultOrg, err := workspace.GetBackendConfigDefaultOrg(project)
+			defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(project)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -147,7 +147,7 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 	if !isCloud {
 		return errors.New("Pulumi AI search is only supported for the Pulumi Cloud")
 	}
-	defaultOrg, err := workspace.GetBackendConfigDefaultOrg(project)
+	defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(project)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/org_search_ai.go
+++ b/pkg/cmd/pulumi/org_search_ai.go
@@ -72,7 +72,7 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 	if !isCloud {
 		return errors.New("Pulumi AI search is only supported for the Pulumi Cloud")
 	}
-	defaultOrg, err := workspace.GetBackendConfigDefaultOrg(project)
+	defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(project)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/policy_publish.go
+++ b/pkg/cmd/pulumi/policy_publish.go
@@ -62,7 +62,7 @@ func (cmd *policyPublishCmd) Run(ctx context.Context, args []string) error {
 		cmd.loginToCloud = loginToCloud
 	}
 	if cmd.defaultOrg == nil {
-		cmd.defaultOrg = workspace.GetBackendConfigDefaultOrg
+		cmd.defaultOrg = pkgWorkspace.GetBackendConfigDefaultOrg
 	}
 	var orgName string
 	if len(args) > 0 {

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -1004,7 +1004,7 @@ func buildStackName(stackName string) (string, error) {
 
 	// We never have a project at the point of calling buildStackName (only called from new), so we just pass
 	// nil for the project and only check the global settings.
-	defaultOrg, err := workspace.GetBackendConfigDefaultOrg(nil)
+	defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(nil)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/workspace/creds.go
+++ b/pkg/workspace/creds.go
@@ -1,0 +1,27 @@
+package workspace
+
+import (
+	"os"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func GetBackendConfigDefaultOrg(project *workspace.Project) (string, error) {
+	config, err := workspace.GetPulumiConfig()
+	if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+
+	backendURL, err := workspace.GetCurrentCloudURL(project)
+	if err != nil {
+		return "", err
+	}
+
+	if beConfig, ok := config.BackendConfig[backendURL]; ok {
+		if beConfig.DefaultOrg != "" {
+			return beConfig.DefaultOrg, nil
+		}
+	}
+
+	return "", nil
+}

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -354,23 +354,3 @@ func SetBackendConfigDefaultOrg(backendURL, defaultOrg string) error {
 
 	return StorePulumiConfig(config)
 }
-
-func GetBackendConfigDefaultOrg(project *Project) (string, error) {
-	config, err := GetPulumiConfig()
-	if err != nil && !os.IsNotExist(err) {
-		return "", err
-	}
-
-	backendURL, err := GetCurrentCloudURL(project)
-	if err != nil {
-		return "", err
-	}
-
-	if beConfig, ok := config.BackendConfig[backendURL]; ok {
-		if beConfig.DefaultOrg != "" {
-			return beConfig.DefaultOrg, nil
-		}
-	}
-
-	return "", nil
-}


### PR DESCRIPTION
In preparation for moving `workspace.GetCurrentCloudURL` to the package workspace we need to move `GetBackendConfigDefaultOrg` first.

(N.B. this also uses `workspace.GetPulumiConfig` which we also want to move, but will take a bit longer)