### PR TITLE
Add GetStoredCredentials to pkg workspace

### DIFF
--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
@@ -105,15 +106,33 @@ func TestDisabledFullyQualifiedStackNames(t *testing.T) {
 //nolint:paralleltest // mutates environment variables
 func TestValueOrDefaultURL(t *testing.T) {
 	t.Run("TestValueOrDefault", func(t *testing.T) {
+		current := ""
+		mock := &pkgWorkspace.MockContext{
+			GetStoredCredentialsF: func() (workspace.Credentials, error) {
+				return workspace.Credentials{
+					Current: current,
+				}, nil
+			},
+		}
+
 		// Validate trailing slash gets cut
-		assert.Equal(t, "https://api-test1.pulumi.com", ValueOrDefaultURL("https://api-test1.pulumi.com/"))
+		assert.Equal(t, "https://api-test1.pulumi.com", ValueOrDefaultURL(mock, "https://api-test1.pulumi.com/"))
 
 		// Validate no-op case
-		assert.Equal(t, "https://api-test2.pulumi.com", ValueOrDefaultURL("https://api-test2.pulumi.com"))
+		assert.Equal(t, "https://api-test2.pulumi.com", ValueOrDefaultURL(mock, "https://api-test2.pulumi.com"))
 
 		// Validate trailing slash in pre-set env var is unchanged
 		t.Setenv("PULUMI_API", "https://api-test3.pulumi.com/")
-		assert.Equal(t, "https://api-test3.pulumi.com/", ValueOrDefaultURL(""))
+		assert.Equal(t, "https://api-test3.pulumi.com/", ValueOrDefaultURL(mock, ""))
+		t.Setenv("PULUMI_API", "")
+
+		// Validate current credentials URL is used
+		current = "https://api-test4.pulumi.com"
+		assert.Equal(t, "https://api-test4.pulumi.com", ValueOrDefaultURL(mock, ""))
+
+		// Unless the current credentials URL is a filestate url
+		current = "s3://test"
+		assert.Equal(t, "https://api.pulumi.com", ValueOrDefaultURL(mock, ""))
 	})
 }
 

--- a/pkg/cmd/pulumi/logout.go
+++ b/pkg/cmd/pulumi/logout.go
@@ -69,7 +69,8 @@ func newLogoutCmd() *cobra.Command {
 			} else {
 				if cloudURL == "" {
 					// Try to read the current project
-					project, _, err := pkgWorkspace.Instance.ReadProject()
+					ws := pkgWorkspace.Instance
+					project, _, err := ws.ReadProject()
 					if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 						return err
 					}
@@ -81,7 +82,7 @@ func newLogoutCmd() *cobra.Command {
 
 					// Default to the default cloud URL. This means a `pulumi logout` will delete the
 					// credentials for pulumi.com if there's no "current" user set in the credentials file.
-					cloudURL = httpstate.ValueOrDefaultURL(cloudURL)
+					cloudURL = httpstate.ValueOrDefaultURL(ws, cloudURL)
 				}
 
 				err = workspace.DeleteAccount(cloudURL)

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -48,6 +48,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/util/tracing"
 	"github.com/pulumi/pulumi/pkg/v3/version"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -514,7 +515,7 @@ func checkForUpdate(ctx context.Context) *diag.Diag {
 // getCLIVersionInfo returns information about the latest version of the CLI and the oldest version that should be
 // allowed without warning. It caches data from the server for a day.
 func getCLIVersionInfo(ctx context.Context) (semver.Version, semver.Version, semver.Version, error) {
-	client := client.NewClient(httpstate.DefaultURL(), "", false, cmdutil.Diag())
+	client := client.NewClient(httpstate.DefaultURL(pkgWorkspace.Instance), "", false, cmdutil.Diag())
 	latest, oldest, dev, err := client.GetCLIVersionInfo(ctx)
 	if err != nil {
 		return semver.Version{}, semver.Version{}, semver.Version{}, err

--- a/pkg/workspace/context.go
+++ b/pkg/workspace/context.go
@@ -27,6 +27,9 @@ type Context interface {
 	// project is successfully detected and read, it is returned along with the path to its containing
 	// directory, which will be used as the root of the project's Pulumi program.
 	ReadProject() (*workspace.Project, string, error)
+
+	// GetStoredCredentials returns any credentials stored on the local machine.
+	GetStoredCredentials() (workspace.Credentials, error)
 }
 
 var Instance Context = &context{}
@@ -40,4 +43,8 @@ func (c *context) ReadProject() (*workspace.Project, string, error) {
 	}
 
 	return proj, filepath.Dir(path), nil
+}
+
+func (c *context) GetStoredCredentials() (workspace.Credentials, error) {
+	return workspace.GetStoredCredentials()
 }

--- a/pkg/workspace/mock.go
+++ b/pkg/workspace/mock.go
@@ -21,7 +21,8 @@ import (
 )
 
 type MockContext struct {
-	ReadProjectF func() (*workspace.Project, string, error)
+	ReadProjectF          func() (*workspace.Project, string, error)
+	GetStoredCredentialsF func() (workspace.Credentials, error)
 }
 
 func (c *MockContext) ReadProject() (*workspace.Project, string, error) {
@@ -29,4 +30,11 @@ func (c *MockContext) ReadProject() (*workspace.Project, string, error) {
 		return c.ReadProjectF()
 	}
 	return nil, "", errors.New("ReadProject function is not implemented")
+}
+
+func (c *MockContext) GetStoredCredentials() (workspace.Credentials, error) {
+	if c.GetStoredCredentialsF != nil {
+		return c.GetStoredCredentialsF()
+	}
+	return workspace.Credentials{}, errors.New("GetStoredCredentials function is not implemented")
 }


### PR DESCRIPTION
Add GetStoredCredentials to the package workspace interface. We can't remove the old copy of the code in sdk/go/common, but everywhere in pkg has been updated to use the interface call instead. 

This also allowed the writing of a few more test cases for the `ValueOrDefaultURL` method in the httpstate package.