### PR TITLE
Move GetCurrentCloudURL to pkg workspace

### DIFF
--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -182,7 +182,7 @@ func getSummaryAbout(
 	}
 
 	var backend backend.Backend
-	backend, err = nonInteractiveCurrentBackend(ctx, proj)
+	backend, err = nonInteractiveCurrentBackend(ctx, ws, proj)
 	if err != nil {
 		addError(err, "Could not access the backend")
 	} else if backend != nil {

--- a/pkg/cmd/pulumi/ai.go
+++ b/pkg/cmd/pulumi/ai.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
@@ -31,7 +32,9 @@ type aiCmd struct {
 
 	// currentBackend is a reference to the top-level currentBackend function.
 	// This is used to override the default implementation for testing purposes.
-	currentBackend func(context.Context, *workspace.Project, display.Options) (backend.Backend, error)
+	currentBackend func(
+		context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+	) (backend.Backend, error)
 }
 
 func (cmd *aiCmd) Run(ctx context.Context, args []string) error {

--- a/pkg/cmd/pulumi/ai_web.go
+++ b/pkg/cmd/pulumi/ai_web.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/browser"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -80,7 +81,9 @@ type aiWebCmd struct {
 
 	// currentBackend is a reference to the top-level currentBackend function.
 	// This is used to override the default implementation for testing purposes.
-	currentBackend func(context.Context, *workspace.Project, display.Options) (backend.Backend, error)
+	currentBackend func(
+		context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+	) (backend.Backend, error)
 }
 
 func (cmd *aiWebCmd) Run(ctx context.Context, args []string) error {

--- a/pkg/cmd/pulumi/console.go
+++ b/pkg/cmd/pulumi/console.go
@@ -43,12 +43,13 @@ func newConsoleCmd() *cobra.Command {
 			}
 
 			// Try to read the current project
-			project, _, err := pkgWorkspace.Instance.ReadProject()
+			ws := pkgWorkspace.Instance
+			project, _, err := ws.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
 
-			currentBackend, err := currentBackend(ctx, project, opts)
+			currentBackend, err := currentBackend(ctx, ws, project, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/deployment_run.go
+++ b/pkg/cmd/pulumi/deployment_run.go
@@ -67,7 +67,7 @@ func newDeploymentRunCmd() *cobra.Command {
 				return err
 			}
 
-			currentBe, err := currentBackend(ctx, project, display)
+			currentBe, err := currentBackend(ctx, ws, project, display)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/deployment_settings_config.go
+++ b/pkg/cmd/pulumi/deployment_settings_config.go
@@ -129,7 +129,7 @@ func initializeDeploymentSettingsCmd(
 		return nil, err
 	}
 
-	be, err := currentBackend(ctx, project, displayOpts)
+	be, err := currentBackend(ctx, ws, project, displayOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/diy"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -117,14 +118,15 @@ func newLoginCmd() *cobra.Command {
 			}
 
 			// Try to read the current project
-			project, _, err := pkgWorkspace.Instance.ReadProject()
+			ws := pkgWorkspace.Instance
+			project, _, err := ws.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
 
 			if cloudURL == "" {
 				var err error
-				cloudURL, err = workspace.GetCurrentCloudURL(project)
+				cloudURL, err = pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), project)
 				if err != nil {
 					return fmt.Errorf("could not determine current cloud: %w", err)
 				}
@@ -150,7 +152,7 @@ func newLoginCmd() *cobra.Command {
 				be, err = loginToCloud(ctx, cloudURL, project, insecure, displayOptions)
 				// if the user has specified a default org to associate with the backend
 				if defaultOrg != "" {
-					cloudURL, err := workspace.GetCurrentCloudURL(project)
+					cloudURL, err := pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), project)
 					if err != nil {
 						return err
 					}

--- a/pkg/cmd/pulumi/logout.go
+++ b/pkg/cmd/pulumi/logout.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -75,7 +76,7 @@ func newLogoutCmd() *cobra.Command {
 						return err
 					}
 
-					cloudURL, err = workspace.GetCurrentCloudURL(project)
+					cloudURL, err = pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), project)
 					if err != nil {
 						return fmt.Errorf("could not determine current cloud: %w", err)
 					}

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -137,7 +137,7 @@ func runNew(ctx context.Context, args newArgs) error {
 	var b backend.Backend
 	if !args.generateOnly {
 		// There is no current project at this point to pass into currentBackend
-		b, err = currentBackend(ctx, nil, opts)
+		b, err = currentBackend(ctx, ws, nil, opts)
 		if err != nil {
 			return err
 		}
@@ -164,7 +164,7 @@ func runNew(ctx context.Context, args newArgs) error {
 			return err
 		}
 
-		b, err := currentBackend(ctx, project, opts)
+		b, err := currentBackend(ctx, ws, project, opts)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/new_acceptance_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
@@ -190,7 +191,7 @@ func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 	ctx := context.Background()
 
-	b, err := currentBackend(ctx, nil, display.Options{})
+	b, err := currentBackend(ctx, pkgWorkspace.Instance, nil, display.Options{})
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(b.URL(), "https://app.pulumi.com"))
 
@@ -222,7 +223,7 @@ func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 		backendDir, workspace.BookkeepingDir, workspace.StackDir, defaultProjectName, stackName+".json"))
 	assert.NoError(t, err)
 
-	b, err = currentBackend(ctx, nil, display.Options{})
+	b, err = currentBackend(ctx, pkgWorkspace.Instance, nil, display.Options{})
 	require.NoError(t, err)
 	assert.Equal(t, backendURL, b.URL())
 }
@@ -258,7 +259,7 @@ func loadProject(t *testing.T, dir string) *workspace.Project {
 
 func currentUser(t *testing.T) string {
 	ctx := context.Background()
-	b, err := currentBackend(ctx, nil, display.Options{})
+	b, err := currentBackend(ctx, pkgWorkspace.Instance, nil, display.Options{})
 	assert.NoError(t, err)
 	currentUser, _, _, err := b.CurrentUser()
 	assert.NoError(t, err)
@@ -274,7 +275,7 @@ func loadStackName(t *testing.T) string {
 func removeStack(t *testing.T, dir, name string) {
 	project := loadProject(t, dir)
 	ctx := context.Background()
-	b, err := currentBackend(ctx, project, display.Options{})
+	b, err := currentBackend(ctx, pkgWorkspace.Instance, project, display.Options{})
 	assert.NoError(t, err)
 	ref, err := b.ParseStackReference(name)
 	assert.NoError(t, err)

--- a/pkg/cmd/pulumi/org.go
+++ b/pkg/cmd/pulumi/org.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -37,12 +38,13 @@ func newOrgCmd() *cobra.Command {
 		Args: cmdutil.NoArgs,
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			// Try to read the current project
-			project, _, err := pkgWorkspace.Instance.ReadProject()
+			ws := pkgWorkspace.Instance
+			project, _, err := ws.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
 
-			cloudURL, err := workspace.GetCurrentCloudURL(project)
+			cloudURL, err := pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), project)
 			if err != nil {
 				return err
 			}
@@ -94,12 +96,13 @@ func newOrgSetDefaultCmd() *cobra.Command {
 			orgName = args[0]
 
 			// Try to read the current project
-			project, _, err := pkgWorkspace.Instance.ReadProject()
+			ws := pkgWorkspace.Instance
+			project, _, err := ws.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
 
-			currentBe, err := currentBackend(ctx, project, displayOpts)
+			currentBe, err := currentBackend(ctx, ws, project, displayOpts)
 			if err != nil {
 				return err
 			}
@@ -108,7 +111,7 @@ func newOrgSetDefaultCmd() *cobra.Command {
 					currentBe.Name())
 			}
 
-			cloudURL, err := workspace.GetCurrentCloudURL(project)
+			cloudURL, err := pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), project)
 			if err != nil {
 				return err
 			}
@@ -137,12 +140,13 @@ func newOrgGetDefaultCmd() *cobra.Command {
 			}
 
 			// Try to read the current project
-			project, _, err := pkgWorkspace.Instance.ReadProject()
+			ws := pkgWorkspace.Instance
+			project, _, err := ws.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
 
-			currentBe, err := currentBackend(ctx, project, displayOpts)
+			currentBe, err := currentBackend(ctx, ws, project, displayOpts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -103,7 +103,9 @@ type searchCmd struct {
 
 	// currentBackend is a reference to the top-level currentBackend function.
 	// This is used to override the default implementation for testing purposes.
-	currentBackend func(context.Context, *workspace.Project, display.Options) (backend.Backend, error)
+	currentBackend func(
+		context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+	) (backend.Backend, error)
 }
 
 type orgSearchCmd struct {
@@ -134,12 +136,13 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 		Type:          display.DisplayQuery,
 	}
 	// Try to read the current project
-	project, _, err := pkgWorkspace.Instance.ReadProject()
+	ws := pkgWorkspace.Instance
+	project, _, err := ws.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}
 
-	backend, err := currentBackend(ctx, project, opts.Display)
+	backend, err := currentBackend(ctx, ws, project, opts.Display)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/org_search_ai.go
+++ b/pkg/cmd/pulumi/org_search_ai.go
@@ -59,12 +59,13 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 		Type:          display.DisplayQuery,
 	}
 	// Try to read the current project
-	project, _, err := pkgWorkspace.Instance.ReadProject()
+	ws := pkgWorkspace.Instance
+	project, _, err := ws.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}
 
-	backend, err := currentBackend(ctx, project, opts.Display)
+	backend, err := currentBackend(ctx, ws, project, opts.Display)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/org_search_ai_test.go
+++ b/pkg/cmd/pulumi/org_search_ai_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
@@ -64,7 +65,9 @@ func TestSearchAI_cmd(t *testing.T) {
 		searchCmd: searchCmd{
 			orgName: orgName,
 			Stdout:  &buff,
-			currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+			currentBackend: func(
+				context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+			) (backend.Backend, error) {
 				return b, nil
 			},
 			outputFormat: outputFormatTable,
@@ -94,7 +97,9 @@ func TestAISearchUserOrgFailure_cmd(t *testing.T) {
 		searchCmd: searchCmd{
 			orgName: orgName,
 			Stdout:  &buff,
-			currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+			currentBackend: func(
+				context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+			) (backend.Backend, error) {
 				return &stubHTTPBackend{
 					SearchF: func(context.Context, string, *apitype.PulumiQueryRequest) (*apitype.ResourceSearchResponse, error) {
 						return &apitype.ResourceSearchResponse{

--- a/pkg/cmd/pulumi/org_search_test.go
+++ b/pkg/cmd/pulumi/org_search_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
@@ -46,7 +47,9 @@ func TestSearch_cmd(t *testing.T) {
 		searchCmd: searchCmd{
 			orgName: orgName,
 			Stdout:  &buff,
-			currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+			currentBackend: func(
+				context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+			) (backend.Backend, error) {
 				return &stubHTTPBackend{
 					SearchF: func(context.Context, string, *apitype.PulumiQueryRequest) (*apitype.ResourceSearchResponse, error) {
 						return &apitype.ResourceSearchResponse{
@@ -98,7 +101,9 @@ func TestSearchNoOrgName_cmd(t *testing.T) {
 	cmd := orgSearchCmd{
 		searchCmd: searchCmd{
 			Stdout: &buff,
-			currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+			currentBackend: func(
+				context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+			) (backend.Backend, error) {
 				return &stubHTTPBackend{
 					SearchF: func(context.Context, string, *apitype.PulumiQueryRequest) (*apitype.ResourceSearchResponse, error) {
 						return &apitype.ResourceSearchResponse{

--- a/pkg/cmd/pulumi/policy_group_ls.go
+++ b/pkg/cmd/pulumi/policy_group_ls.go
@@ -51,13 +51,14 @@ func newPolicyGroupLsCmd() *cobra.Command {
 			ctx := cmd.Context()
 
 			// Try to read the current project
-			project, _, err := pkgWorkspace.Instance.ReadProject()
+			ws := pkgWorkspace.Instance
+			project, _, err := ws.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
 
 			// Get backend.
-			b, err := currentBackend(ctx, project, display.Options{Color: cmdutil.GetGlobalColorization()})
+			b, err := currentBackend(ctx, ws, project, display.Options{Color: cmdutil.GetGlobalColorization()})
 			if err != nil {
 				return fmt.Errorf("failed to get current backend: %w", err)
 			}

--- a/pkg/cmd/pulumi/policy_ls.go
+++ b/pkg/cmd/pulumi/policy_ls.go
@@ -41,13 +41,14 @@ func newPolicyLsCmd() *cobra.Command {
 			ctx := cmd.Context()
 
 			// Try to read the current project
-			project, _, err := pkgWorkspace.Instance.ReadProject()
+			ws := pkgWorkspace.Instance
+			project, _, err := ws.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
 
 			// Get backend.
-			b, err := currentBackend(ctx, project, display.Options{Color: cmdutil.GetGlobalColorization()})
+			b, err := currentBackend(ctx, ws, project, display.Options{Color: cmdutil.GetGlobalColorization()})
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/policy_publish.go
+++ b/pkg/cmd/pulumi/policy_publish.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -150,12 +151,13 @@ func requirePolicyPack(
 	//
 
 	// Try to read the current project
-	project, _, err := pkgWorkspace.Instance.ReadProject()
+	ws := pkgWorkspace.Instance
+	project, _, err := ws.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return nil, err
 	}
 
-	cloudURL, err := workspace.GetCurrentCloudURL(project)
+	cloudURL, err := pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), project)
 	if err != nil {
 		return nil, fmt.Errorf("`pulumi policy` command requires the user to be logged into the Pulumi Cloud: %w", err)
 	}

--- a/pkg/cmd/pulumi/query.go
+++ b/pkg/cmd/pulumi/query.go
@@ -68,12 +68,13 @@ issue at https://github.com/pulumi/pulumi/issues/16964.
 			}
 
 			// Try to read the current project
-			project, root, err := pkgWorkspace.Instance.ReadProject()
+			ws := pkgWorkspace.Instance
+			project, root, err := ws.ReadProject()
 			if err != nil {
 				return err
 			}
 
-			b, err := currentBackend(ctx, project, opts.Display)
+			b, err := currentBackend(ctx, ws, project, opts.Display)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -97,7 +97,9 @@ type stackInitCmd struct {
 
 	// currentBackend is a reference to the top-level currentBackend function.
 	// This is used to override the default implementation for testing purposes.
-	currentBackend func(context.Context, *workspace.Project, display.Options) (backend.Backend, error)
+	currentBackend func(
+		context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+	) (backend.Backend, error)
 }
 
 func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
@@ -116,12 +118,12 @@ func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
 	ws := pkgWorkspace.Instance
 
 	// Try to read the current project
-	project, _, err := pkgWorkspace.Instance.ReadProject()
+	project, _, err := ws.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}
 
-	b, err := currentBackend(ctx, project, opts)
+	b, err := currentBackend(ctx, ws, project, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/stack_init_test.go
+++ b/pkg/cmd/pulumi/stack_init_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,7 +41,9 @@ func TestStackInit_teamsUnsupportedByBackend(t *testing.T) {
 	cmd := &stackInitCmd{
 		teams:     []string{"red", "blue"},
 		stackName: "dev",
-		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+		currentBackend: func(
+			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+		) (backend.Backend, error) {
 			return mockBackend, nil
 		},
 	}

--- a/pkg/cmd/pulumi/stack_ls.go
+++ b/pkg/cmd/pulumi/stack_ls.go
@@ -135,13 +135,14 @@ func runStackLS(ctx context.Context, args stackLSArgs) error {
 	}
 
 	// Try to read the current project
-	project, _, err := pkgWorkspace.Instance.ReadProject()
+	ws := pkgWorkspace.Instance
+	project, _, err := ws.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}
 
 	// Get the current backend.
-	b, err := currentBackend(ctx, project, display.Options{Color: cmdutil.GetGlobalColorization()})
+	b, err := currentBackend(ctx, ws, project, display.Options{Color: cmdutil.GetGlobalColorization()})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/stack_select.go
+++ b/pkg/cmd/pulumi/stack_select.go
@@ -57,7 +57,7 @@ func newStackSelectCmd() *cobra.Command {
 				return err
 			}
 
-			b, err := currentBackend(ctx, project, opts)
+			b, err := currentBackend(ctx, ws, project, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/state_upgrade.go
+++ b/pkg/cmd/pulumi/state_upgrade.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/diy"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -64,7 +65,9 @@ type stateUpgradeCmd struct {
 
 	// Used to mock out the currentBackend function for testing.
 	// Defaults to currentBackend function.
-	currentBackend func(context.Context, *workspace.Project, display.Options) (backend.Backend, error)
+	currentBackend func(
+		context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+	) (backend.Backend, error)
 }
 
 func (cmd *stateUpgradeCmd) Run(ctx context.Context) error {
@@ -89,7 +92,7 @@ func (cmd *stateUpgradeCmd) Run(ctx context.Context) error {
 		Stdout: cmd.Stdout,
 	}
 
-	b, err := currentBackend(ctx, nil, dopts)
+	b, err := currentBackend(ctx, pkgWorkspace.Instance, nil, dopts)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/state_upgrade_test.go
+++ b/pkg/cmd/pulumi/state_upgrade_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/diy"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -93,7 +94,9 @@ func TestStateUpgradeCommand_Run_upgrade(t *testing.T) {
 
 	var called bool
 	cmd := stateUpgradeCmd{
-		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+		currentBackend: func(
+			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+		) (backend.Backend, error) {
 			return &stubDIYBackend{
 				UpgradeF: func(context.Context, *diy.UpgradeOptions) error {
 					called = true
@@ -116,7 +119,9 @@ func TestStateUpgradeCommand_Run_upgrade_yes_flag(t *testing.T) {
 
 	var called bool
 	cmd := stateUpgradeCmd{
-		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+		currentBackend: func(
+			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+		) (backend.Backend, error) {
 			return &stubDIYBackend{
 				UpgradeF: func(context.Context, *diy.UpgradeOptions) error {
 					called = true
@@ -139,7 +144,9 @@ func TestStateUpgradeCommand_Run_upgradeRejected(t *testing.T) {
 	t.Parallel()
 
 	cmd := stateUpgradeCmd{
-		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+		currentBackend: func(
+			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+		) (backend.Backend, error) {
 			return &stubDIYBackend{
 				UpgradeF: func(context.Context, *diy.UpgradeOptions) error {
 					t.Fatal("Upgrade should not be called")
@@ -161,7 +168,9 @@ func TestStateUpgradeCommand_Run_unsupportedBackend(t *testing.T) {
 	var stdout bytes.Buffer
 	cmd := stateUpgradeCmd{
 		Stdout: &stdout,
-		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+		currentBackend: func(
+			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+		) (backend.Backend, error) {
 			return &backend.MockBackend{}, nil
 		},
 	}
@@ -177,7 +186,9 @@ func TestStateUpgradeCmd_Run_backendError(t *testing.T) {
 
 	giveErr := errors.New("great sadness")
 	cmd := stateUpgradeCmd{
-		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+		currentBackend: func(
+			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+		) (backend.Backend, error) {
 			return nil, giveErr
 		},
 	}

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -210,7 +210,7 @@ func newUpCmd() *cobra.Command {
 	}
 
 	// up implementation used when the source of the Pulumi program is a template name or a URL to a template.
-	upTemplateNameOrURL := func(ctx context.Context,
+	upTemplateNameOrURL := func(ctx context.Context, ws pkgWorkspace.Context,
 		templateNameOrURL string, opts backend.UpdateOptions, cmd *cobra.Command,
 	) error {
 		// Retrieve the template repo.
@@ -259,7 +259,7 @@ func newUpCmd() *cobra.Command {
 		}
 
 		// There is no current project at this point to pass into currentBackend
-		b, err := currentBackend(ctx, nil, opts.Display)
+		b, err := currentBackend(ctx, ws, nil, opts.Display)
 		if err != nil {
 			return err
 		}
@@ -301,7 +301,6 @@ func newUpCmd() *cobra.Command {
 		}
 
 		// Load the project, update the name & description, remove the template section, and save it.
-		ws := pkgWorkspace.Instance
 		proj, root, err := ws.ReadProject()
 		if err != nil {
 			return err
@@ -530,7 +529,7 @@ func newUpCmd() *cobra.Command {
 			}
 
 			if len(args) > 0 {
-				return upTemplateNameOrURL(ctx, args[0], opts, cmd)
+				return upTemplateNameOrURL(ctx, ws, args[0], opts, cmd)
 			}
 
 			return upWorkingDirectory(ctx, ws, opts, cmd)

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -119,7 +119,7 @@ func isDIYBackend(ws pkgWorkspace.Context, opts display.Options) (bool, error) {
 		return false, err
 	}
 
-	url, err := workspace.GetCurrentCloudURL(project)
+	url, err := pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), project)
 	if err != nil {
 		return false, fmt.Errorf("could not get cloud url: %w", err)
 	}
@@ -142,12 +142,14 @@ func loginToCloud(
 	return httpstate.New(cmdutil.Diag(), cloudURL, project, insecure)
 }
 
-func nonInteractiveCurrentBackend(ctx context.Context, project *workspace.Project) (backend.Backend, error) {
+func nonInteractiveCurrentBackend(
+	ctx context.Context, ws pkgWorkspace.Context, project *workspace.Project,
+) (backend.Backend, error) {
 	if backendInstance != nil {
 		return backendInstance, nil
 	}
 
-	url, err := workspace.GetCurrentCloudURL(project)
+	url, err := pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), project)
 	if err != nil {
 		return nil, fmt.Errorf("could not get cloud url: %w", err)
 	}
@@ -164,12 +166,14 @@ func nonInteractiveCurrentBackend(ctx context.Context, project *workspace.Projec
 	return httpstate.New(cmdutil.Diag(), url, project, insecure)
 }
 
-func currentBackend(ctx context.Context, project *workspace.Project, opts display.Options) (backend.Backend, error) {
+func currentBackend(
+	ctx context.Context, ws pkgWorkspace.Context, project *workspace.Project, opts display.Options,
+) (backend.Backend, error) {
 	if backendInstance != nil {
 		return backendInstance, nil
 	}
 
-	url, err := workspace.GetCurrentCloudURL(project)
+	url, err := pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), project)
 	if err != nil {
 		return nil, fmt.Errorf("could not get cloud url: %w", err)
 	}
@@ -307,7 +311,7 @@ func requireStack(ctx context.Context, ws pkgWorkspace.Context,
 		return nil, err
 	}
 
-	b, err := currentBackend(ctx, project, opts)
+	b, err := currentBackend(ctx, ws, project, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +355,7 @@ func requireCurrentStack(
 	}
 
 	// Search for the current stack.
-	b, err := currentBackend(ctx, project, opts)
+	b, err := currentBackend(ctx, ws, project, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/util_remote.go
+++ b/pkg/cmd/pulumi/util_remote.go
@@ -399,7 +399,7 @@ func runDeployment(ctx context.Context, ws pkgWorkspace.Context, cmd *cobra.Comm
 		return err
 	}
 
-	b, err := currentBackend(ctx, project, opts)
+	b, err := currentBackend(ctx, ws, project, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/whoami.go
+++ b/pkg/cmd/pulumi/whoami.go
@@ -62,7 +62,9 @@ type whoAmICmd struct {
 
 	// currentBackend is a reference to the top-level currentBackend function.
 	// This is used to override the default implementation for testing purposes.
-	currentBackend func(context.Context, *workspace.Project, display.Options) (backend.Backend, error)
+	currentBackend func(
+		context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+	) (backend.Backend, error)
 }
 
 func (cmd *whoAmICmd) Run(ctx context.Context) error {
@@ -80,12 +82,13 @@ func (cmd *whoAmICmd) Run(ctx context.Context) error {
 	}
 
 	// Try to read the current project
-	project, _, err := pkgWorkspace.Instance.ReadProject()
+	ws := pkgWorkspace.Instance
+	project, _, err := ws.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}
 
-	b, err := currentBackend(ctx, project, opts)
+	b, err := currentBackend(ctx, ws, project, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/whoami_test.go
+++ b/pkg/cmd/pulumi/whoami_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,7 +19,9 @@ func TestWhoAmICmd_default(t *testing.T) {
 	var buff bytes.Buffer
 	cmd := whoAmICmd{
 		Stdout: &buff,
-		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+		currentBackend: func(
+			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+		) (backend.Backend, error) {
 			return &backend.MockBackend{
 				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
 					return "user1", []string{"org1", "org2"}, nil, nil
@@ -40,7 +43,9 @@ func TestWhoAmICmd_verbose(t *testing.T) {
 	cmd := whoAmICmd{
 		verbose: true,
 		Stdout:  &buff,
-		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+		currentBackend: func(
+			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+		) (backend.Backend, error) {
 			return &backend.MockBackend{
 				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
 					return "user2", []string{"org1", "org2"}, nil, nil
@@ -69,7 +74,9 @@ func TestWhoAmICmd_json(t *testing.T) {
 	cmd := whoAmICmd{
 		jsonOut: true,
 		Stdout:  &buff,
-		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+		currentBackend: func(
+			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+		) (backend.Backend, error) {
 			return &backend.MockBackend{
 				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
 					return "user3", []string{"org1", "org2"}, nil, nil
@@ -98,7 +105,9 @@ func TestWhoAmICmd_verbose_teamToken(t *testing.T) {
 	cmd := whoAmICmd{
 		verbose: true,
 		Stdout:  &buff,
-		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+		currentBackend: func(
+			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+		) (backend.Backend, error) {
 			return &backend.MockBackend{
 				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
 					return "user2", []string{"org1", "org2"}, &workspace.TokenInformation{
@@ -131,7 +140,9 @@ func TestWhoAmICmd_json_teamToken(t *testing.T) {
 	cmd := whoAmICmd{
 		jsonOut: true,
 		Stdout:  &buff,
-		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+		currentBackend: func(
+			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+		) (backend.Backend, error) {
 			return &backend.MockBackend{
 				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
 					return "user3", []string{"org1", "org2"}, &workspace.TokenInformation{
@@ -164,7 +175,9 @@ func TestWhoAmICmd_verbose_unknownToken(t *testing.T) {
 	cmd := whoAmICmd{
 		verbose: true,
 		Stdout:  &buff,
-		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+		currentBackend: func(
+			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+		) (backend.Backend, error) {
 			return &backend.MockBackend{
 				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
 					return "user2", []string{"org1", "org2"}, &workspace.TokenInformation{

--- a/pkg/workspace/creds.go
+++ b/pkg/workspace/creds.go
@@ -3,8 +3,36 @@ package workspace
 import (
 	"os"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
+
+// GetCurrentCloudURL returns the URL of the cloud we are currently connected to. This may be empty if we
+// have not logged in. Note if PULUMI_BACKEND_URL is set, the corresponding value is returned
+// instead irrespective of the backend for current project or stored credentials.
+func GetCurrentCloudURL(ws Context, e env.Env, project *workspace.Project) (string, error) {
+	// Allow PULUMI_BACKEND_URL to override the current cloud URL selection
+	if backend := e.GetString(env.BackendURL); backend != "" {
+		return backend, nil
+	}
+
+	var url string
+	if project != nil {
+		if project.Backend != nil {
+			url = project.Backend.URL
+		}
+	}
+
+	if url == "" {
+		creds, err := ws.GetStoredCredentials()
+		if err != nil {
+			return "", err
+		}
+		url = creds.Current
+	}
+
+	return url, nil
+}
 
 func GetBackendConfigDefaultOrg(project *workspace.Project) (string, error) {
 	config, err := workspace.GetPulumiConfig()
@@ -12,7 +40,8 @@ func GetBackendConfigDefaultOrg(project *workspace.Project) (string, error) {
 		return "", err
 	}
 
-	backendURL, err := workspace.GetCurrentCloudURL(project)
+	// TODO: This should use injected interfaces, not the global instances.
+	backendURL, err := GetCurrentCloudURL(Instance, env.Global(), project)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/workspace/creds_test.go
+++ b/pkg/workspace/creds_test.go
@@ -1,0 +1,82 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCurrentCloudURL(t *testing.T) {
+	t.Parallel()
+
+	credsF := func() (workspace.Credentials, error) {
+		return workspace.Credentials{Current: "https://credentials.com"}, nil
+	}
+
+	tests := []struct {
+		name           string
+		ws             Context
+		e              env.Env
+		project        *workspace.Project
+		expectedString string
+		expectedError  error
+	}{
+		{
+			name:           "no project, env, or credentials",
+			ws:             &MockContext{},
+			e:              env.NewEnv(env.MapStore{}),
+			expectedString: "",
+		},
+		{
+			name: "stored credentials",
+			ws: &MockContext{
+				GetStoredCredentialsF: credsF,
+			},
+			e:              env.NewEnv(env.MapStore{}),
+			expectedString: "https://credentials.com",
+		},
+		{
+			name: "project setting takes precedence",
+			ws: &MockContext{
+				GetStoredCredentialsF: credsF,
+			},
+			e:              env.NewEnv(env.MapStore{}),
+			project:        &workspace.Project{Backend: &workspace.ProjectBackend{URL: "https://project.com"}},
+			expectedString: "https://project.com",
+		},
+		{
+			name: "envvar takes precedence",
+			ws: &MockContext{
+				GetStoredCredentialsF: credsF,
+			},
+			e: env.NewEnv(env.MapStore{
+				env.BackendURL.Var().Name(): "https://env.com",
+			}),
+			project:        &workspace.Project{Backend: &workspace.ProjectBackend{URL: "https://project.com"}},
+			expectedString: "https://env.com",
+		},
+		{
+			name: "report error from stored credentials",
+			ws: &MockContext{
+				GetStoredCredentialsF: func() (workspace.Credentials, error) {
+					return workspace.Credentials{}, assert.AnError
+				},
+			},
+			e:             env.NewEnv(env.MapStore{}),
+			expectedError: assert.AnError,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			str, err := GetCurrentCloudURL(tt.ws, tt.e, tt.project)
+			assert.Equal(t, tt.expectedError, err)
+			assert.Equal(t, tt.expectedString, str)
+		})
+	}
+}

--- a/pkg/workspace/mock.go
+++ b/pkg/workspace/mock.go
@@ -15,8 +15,6 @@
 package workspace
 
 import (
-	"errors"
-
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -29,12 +27,12 @@ func (c *MockContext) ReadProject() (*workspace.Project, string, error) {
 	if c.ReadProjectF != nil {
 		return c.ReadProjectF()
 	}
-	return nil, "", errors.New("ReadProject function is not implemented")
+	return nil, "", workspace.ErrProjectNotFound
 }
 
 func (c *MockContext) GetStoredCredentials() (workspace.Credentials, error) {
 	if c.GetStoredCredentialsF != nil {
 		return c.GetStoredCredentialsF()
 	}
-	return workspace.Credentials{}, errors.New("GetStoredCredentials function is not implemented")
+	return workspace.Credentials{}, nil
 }

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/rogpeppe/go-internal/lockedfile"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -158,33 +157,6 @@ func getCredsFilePath() (string, error) {
 	}
 
 	return filepath.Join(pulumiFolder, "credentials.json"), nil
-}
-
-// GetCurrentCloudURL returns the URL of the cloud we are currently connected to. This may be empty if we
-// have not logged in. Note if PULUMI_BACKEND_URL is set, the corresponding value is returned
-// instead irrespective of the backend for current project or stored credentials.
-func GetCurrentCloudURL(project *Project) (string, error) {
-	// Allow PULUMI_BACKEND_URL to override the current cloud URL selection
-	if backend := env.BackendURL.Value(); backend != "" {
-		return backend, nil
-	}
-
-	var url string
-	if project != nil {
-		if project.Backend != nil {
-			url = project.Backend.URL
-		}
-	}
-
-	if url == "" {
-		creds, err := GetStoredCredentials()
-		if err != nil {
-			return "", err
-		}
-		url = creds.Current
-	}
-
-	return url, nil
 }
 
 // GetCloudInsecure returns if this cloud url is saved as one that should use insecure transport.


### PR DESCRIPTION
This moves GetCurrentCloudURL to the pkg workspace, and updates all calls in pkg to use the interface method.

This allowed the writing of some unit test for GetCurrentCloudURL.