### PR TITLE
run acceptance tests for windows on PR rather than on merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,7 +381,8 @@ jobs:
     # appearing in the rendered title of the job name. See: unit test.
     name: Acceptance Test${{ matrix.platform && '' }}
     needs: [matrix, build-binaries, build-sdks]
-    # alow jobs to fail if the platform contains windows
+    if: ${{ needs.matrix.outputs.acceptance-test-matrix-win != '{}' }}
+    # allow jobs to fail if the platform contains windows
     strategy:
       matrix: ${{ fromJson(needs.matrix.outputs.acceptance-test-matrix-win) }}
     uses: ./.github/workflows/ci-run-test.yml
@@ -407,7 +408,7 @@ jobs:
     name: Acceptance Test${{ matrix.platform && '' }}
     needs: [matrix, build-binaries, build-sdks]
     if: ${{ needs.matrix.outputs.acceptance-test-matrix-macos != '{}' }}
-    # alow jobs to fail if the platform contains windows
+    # allow jobs to fail if the platform contains windows
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
       matrix: ${{ fromJson(needs.matrix.outputs.acceptance-test-matrix-macos) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,7 +381,6 @@ jobs:
     # appearing in the rendered title of the job name. See: unit test.
     name: Acceptance Test${{ matrix.platform && '' }}
     needs: [matrix, build-binaries, build-sdks]
-    if: ${{ needs.matrix.outputs.acceptance-test-matrix-win != '{}' }}
     # alow jobs to fail if the platform contains windows
     strategy:
       matrix: ${{ fromJson(needs.matrix.outputs.acceptance-test-matrix-win) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ on:
         type: string
       acceptance-test-platforms:
         required: false
-        default: windows-latest macos-latest
+        default: macos-latest
         description: Platforms on which to run integration tests, as a space delimited list
         type: string
       enable-coverage:
@@ -428,7 +428,7 @@ jobs:
     secrets: inherit
 
   test-collect-reports:
-    needs: [unit-test, integration-test, acceptance-test-win, acceptance-test-macos]
+    needs: [unit-test, integration-test, acceptance-test-macos]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -449,7 +449,7 @@ jobs:
           ls -lhR test-results
           find test-results -mindepth 1 -name '*.json' -mtime +7 -delete
   test-collect-coverage:
-    needs: [unit-test, integration-test, acceptance-test-win, acceptance-test-macos]
+    needs: [unit-test, integration-test, acceptance-test-macos]
     if: ${{ inputs.enable-coverage }}
     runs-on: ubuntu-latest
     steps:
@@ -484,7 +484,7 @@ jobs:
   build-release-binaries:
     # This overwrites the previously built testing binaries with versions without coverage.
     name: Rebuild binaries
-    needs: [matrix, unit-test, integration-test, acceptance-test-win, acceptance-test-macos]
+    needs: [matrix, unit-test, integration-test, acceptance-test-macos]
     if: ${{ inputs.enable-coverage }}
     strategy:
       fail-fast: ${{ inputs.fail-fast }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -44,6 +44,7 @@ jobs:
       enable-coverage: true
       fail-fast: true
       test-retries: 2
+      acceptance-test-platforms: 'macos-latest'
     secrets: inherit
 
   prepare-release:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -89,7 +89,7 @@ jobs:
         ${{
           contains(github.event.pull_request.labels.*.name, 'ci/test')
           && 'macos-latest windows-latest'
-          || ''
+          || 'windows-latest'
         }}
       # We'll only upload coverage artifacts with the periodic-coverage cron workflow.
       enable-coverage: false

--- a/.github/workflows/pr-test-acceptance-on-dispatch.yml
+++ b/.github/workflows/pr-test-acceptance-on-dispatch.yml
@@ -63,7 +63,7 @@ jobs:
       lint: true
       test-version-sets: current
       integration-test-platforms: ubuntu-latest
-      acceptance-test-platforms: ''
+      acceptance-test-platforms: 'windows-latest'
       # We'll only upload coverage artifacts with the periodic-coverage cron workflow.
       enable-coverage: false
     secrets:


### PR DESCRIPTION
Acceptance tests on Windows sometimes fail for mysterious reasons. It's unclear to me whether this is because the tests sometimes genuinely take too many resources, and break the windows host, or whether it's instability of the windows CI runners in general (it could also be both).

This is very annoying during merges, because for any failed test we need to re-do the merge, which means re-running all tests, which is both expensive and slow.

Instead, run the acceptance tests on windows during PRs always, but don't run them during merge.

I think this is okay to do because if there is a mismerge, I don't expect exclusively windows tests to fail, but I expect that to also affect Linux and MacOS runners.  It seems very unlikely for a Windows specific problem to pop up only when multiple PRs are merged together.

It is also convenient to run the windows tests during PRs in the first place, because those are tests developers usually don't run on their own machine, so it's not super unlikely they fail.  We used to not run these tests on PRs because it's kind of expensive to run them, but we have more headroom now, so running them during PRs should no longer be a big issue.