### PR TITLE
Fix GetPluginInfo with shimless project plugins

### DIFF
--- a/pkg/cmd/pulumi/plugin.go
+++ b/pkg/cmd/pulumi/plugin.go
@@ -105,10 +105,6 @@ func resolvePlugins(plugins []workspace.PluginSpec) ([]workspace.PluginInfo, err
 	for _, plugin := range plugins {
 		info, err := workspace.GetPluginInfo(d, plugin.Kind, plugin.Name, plugin.Version, ctx.Host.GetProjectPlugins())
 		if err != nil {
-			err = info.SetFileMetadata(info.Path)
-			if err != nil {
-				return nil, err
-			}
 			contract.IgnoreError(err)
 		}
 		if info != nil {


### PR DESCRIPTION
Before this fix GetPluginInfo would error because stat on the expected `pulumi-resource-exe` file would fail (because it didn't exist). This fixes it to fallback to looking at the folder instead.