### PR TITLE
Document developer documentation deployments

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -18,19 +18,43 @@ make -C docs watch
 ```
 
 which will watch for changes and rebuild the documentation as needed, serving
-the results at http://localhost:8000. If you want to build the documentation
-without watching for changes, you can use the `build` target instead:
+the results at <http://localhost:8000/docs/README.html>.
+
+### Deployment
+
+This documentation is deployed to [Read the Docs](https://readthedocs.org) as
+part of our CI/CD pipelines. The `build` target in the `Makefile` is used to
+build an HTML version of the documentation that Read the Docs then deploys. See
+the <gh-file:pulumi#.readthedocs.yaml> configuration in the root of the
+repository for more information.
+
+#### Previewing changes
+
+If you want to preview the documentation as it will appear on Read the Docs,
+simply raise a PR with your changes. Read the Docs will build your PR and
+generate a preview site for you to review. The link to the preview site will
+appear in the list of checks on your PR. See [Read the Docs' documentation on
+preview builds](https://docs.readthedocs.io/en/stable/pull-requests.html) for
+more.
+
+#### Local builds
+
+If you want to build the documentation without watching for changes, you can use
+the `build` target yourself locally, too. Set the `READTHEDOCS_OUTPUT`
+environment variable to the location you'd like the documentation to be built to
+and then run the build:
 
 ```sh
+export READTHEDOCS_OUTPUT=/path/to/output
 make -C docs build
 ```
 
-`build` will compile documentation to a static HTML website in the `docs/_build`
-directory; you can open the `README.html` file in your browser to view the built
-files from there:
+`build` will compile documentation to a static HTML website in the
+`/path/to/output/html` directory; you can open the `index.html` file in your
+browser to view the built files from there:
 
 ```sh
-open docs/_build/docs/README.html
+open /path/to/output/html/index.html
 ```
 
 :::{toctree}

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -126,8 +126,14 @@ html_title = "Pulumi developer documentation"
 html_logo = "https://www.pulumi.com/images/logo/logo-on-white-box.svg"
 
 html_theme_options = {
-    # Show all headings up to level 2 in the sidebar table of contents.
-    "show_toc_levels": 2,
+    # Expand all headings up to level 2 by default in the left sidebar (global)
+    # table of contents.
+    "show_navbar_depth": 2,
+    # Show all headings up to level 2 in the right sidebar (in-page) table of
+    # contents.
+    "show_toc_level": 2,
+    # Expand all headings up to level 2 by default in the sidebar table of
+    # contents.
     # Enable margin notes
     # (https://sphinx-book-theme.readthedocs.io/en/stable/content/content-blocks.html#sidenotes-and-marginnotes).
     "use_sidenotes": True,


### PR DESCRIPTION
This commit documents how developer documentation is deployed to Read the Docs. It also fixes up some configuration options for displaying and expanding the sidebar tables of contents.