### PR TITLE
Generate reference documentation from Protobufs

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,5 @@
 .ensure.phony
 _build
+_generated
+_tools
 venv/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build ensure ensure-python watch
+.PHONY: build ensure ensure-proto ensure-python generate generate-proto watch
 
 VENV = venv
 
@@ -9,13 +9,23 @@ ensure-python:: .ensure-python.phony
 	. $(VENV)/*/activate && python -m pip install -r requirements.txt
 	@touch .ensure-python.phony
 
-ensure:: ensure-python
+ensure-proto:: .ensure-proto.phony
+.ensure-proto.phony: ensure-python
+	. $(VENV)/*/activate && python make.py ensure-proto
+	@touch .ensure-proto.phony
+
+ensure:: ensure-proto ensure-python
+
+generate-proto: ensure
+	. $(VENV)/*/activate && python make.py generate-proto
+
+generate:: generate-proto
 
 # This target is intended to be called by Read the Docs as part of deployment,
 # whereby the READTHEDOCS_OUTPUT environment variable will be set to a
 # destination that Read the Docs expects to be populated with the generated
 # documentation.
-build: ensure
+build: ensure generate
 	mkdir -p $$READTHEDOCS_OUTPUT/html
 	. $(VENV)/*/activate && python -m sphinx \
 		-T \
@@ -27,7 +37,7 @@ build: ensure
 		$$READTHEDOCS_OUTPUT/html
 	cp sphinx/index.html.template $$READTHEDOCS_OUTPUT/html/index.html
 
-watch: ensure
+watch: ensure generate
 	. $(VENV)/*/activate && sphinx-autobuild \
 		-c sphinx \
 		-b html \

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,4 +10,5 @@ complete documentation for maintainers of and contributors to Pulumi.
 self
 /docs/documentation
 /docs/architecture/README
+/docs/references/README
 :::

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -18,19 +18,43 @@ make -C docs watch
 ```
 
 which will watch for changes and rebuild the documentation as needed, serving
-the results at http://localhost:8000. If you want to build the documentation
-without watching for changes, you can use the `build` target instead:
+the results at <http://localhost:8000/docs/README.html>.
+
+### Deployment
+
+This documentation is deployed to [Read the Docs](https://readthedocs.org) as
+part of our CI/CD pipelines. The `build` target in the `Makefile` is used to
+build an HTML version of the documentation that Read the Docs then deploys. See
+the <gh-file:pulumi#.readthedocs.yaml> configuration in the root of the
+repository for more information.
+
+#### Previewing changes
+
+If you want to preview the documentation as it will appear on Read the Docs,
+simply raise a PR with your changes. Read the Docs will build your PR and
+generate a preview site for you to review. The link to the preview site will
+appear in the list of checks on your PR. See [Read the Docs' documentation on
+preview builds](https://docs.readthedocs.io/en/stable/pull-requests.html) for
+more.
+
+#### Local builds
+
+If you want to build the documentation without watching for changes, you can use
+the `build` target yourself locally, too. Set the `READTHEDOCS_OUTPUT`
+environment variable to the location you'd like the documentation to be built to
+and then run the build:
 
 ```sh
+export READTHEDOCS_OUTPUT=/path/to/output
 make -C docs build
 ```
 
-`build` will compile documentation to a static HTML website in the `docs/_build`
-directory; you can open the `README.html` file in your browser to view the built
-files from there:
+`build` will compile documentation to a static HTML website in the
+`/path/to/output/html` directory; you can open the `index.html` file in your
+browser to view the built files from there:
 
 ```sh
-open docs/_build/docs/README.html
+open /path/to/output/html/index.html
 ```
 
 :::{toctree}

--- a/docs/make.py
+++ b/docs/make.py
@@ -1,0 +1,218 @@
+import io
+import os
+import pathlib
+import platform
+import requests
+import sys
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from typing import Callable, Optional
+import zipfile
+
+
+class Config:
+    """Config collects configuration information necessary to execute build
+    tasks."""
+
+    def __init__(
+        self,
+        generated_dir: str,
+        tools_dir: str,
+        protoc_version: str,
+        protoc_platforms: dict[str, str],
+        protoc_gen_doc_version: str,
+        protoc_gen_doc_platforms: dict[str, str],
+        proto_path: str,
+        proto_files: dict[str, str],
+        proto_template: str,
+    ) -> None:
+        """Constructs a new configuration object.
+
+        :param generated_dir:
+            The directory where generated files should be written. This
+            directory should not be checked into source control.
+        :param tools_dir:
+            The directory where build tools should be installed. This directory
+            should not be checked into source control.
+        :param protoc_version:
+            The version of `protoc`, the Protobuf compiler, to use for build
+            tasks that require it.
+        :param protoc_platforms:
+            A mapping from platform keys to archive keys for `protoc` releases.
+        :param protoc_gen_doc_version:
+            The version of `protoc-gen-doc`, the Protobuf documentation generator,
+            to use for build tasks that require it.
+        :param protoc_gen_doc_platforms:
+            A mapping from platform keys to archive keys for `protoc-gen-doc`
+            releases.
+        :param proto_path:
+            The path to the directory containing Protobuf files.
+        :param proto_files:
+            A mapping from human-readable file titles to Protobuf file names.
+            Each Protobuf file will yield a separate Markdown file containing
+            the contents of running `protoc-gen-doc` on the file. The file's
+            H1 title will be the human-readable title provided.
+        :param proto_template:
+            A path to a template file that will be passed to `protoc-gen-doc` in
+            order to generate Markdown for each Protobuf file. The template file
+            may contain a single `{{ .TitleFromPython }}` token that will be
+            replaced with the human-readable title for the Protobuf file, as
+            well as the standard `protoc-gen-doc` template tokens.
+        """
+        self.generated_dir = pathlib.Path(generated_dir).resolve()
+        self.tools_dir = pathlib.Path(tools_dir).resolve()
+
+        platform_key = get_platform_key()
+
+        self.protoc_version = protoc_version
+        self.protoc_platforms = protoc_platforms
+        self.protoc_url = f"https://github.com/protocolbuffers/protobuf/releases/download/v{self.protoc_version}/protoc-{self.protoc_version}-{self.protoc_platforms[platform_key]}.zip"
+
+        self.protoc_gen_doc_version = protoc_gen_doc_version
+        self.protoc_gen_doc_platforms = protoc_gen_doc_platforms
+        self.protoc_gen_doc_url = f"https://github.com/pseudomuto/protoc-gen-doc/releases/download/v{self.protoc_gen_doc_version}/protoc-gen-doc_{self.protoc_gen_doc_version}_{self.protoc_gen_doc_platforms[platform_key]}.tar.gz"
+
+        self.proto_path = pathlib.Path(proto_path).resolve()
+        self.proto_files = {
+            title: self.proto_path / file for title, file in proto_files.items()
+        }
+        self.proto_template = pathlib.Path(proto_template).resolve()
+
+        self.proto_generated_dir = self.generated_dir / "proto"
+        self.proto_tools_dir = self.tools_dir / "proto"
+        self.protoc = self.proto_tools_dir / "protoc"
+        self.protoc_gen_doc = self.proto_tools_dir / "protoc-gen-doc"
+
+
+def get_platform_key() -> str:
+    """Returns a key representing the current platform for use in configuration."""
+
+    uname = platform.uname()
+    platform_key = f"{uname.system}_{uname.machine}"
+    return platform_key
+
+
+def ensure_proto(config: Config) -> None:
+    """Ensures that Protobuf tools such as `protoc` and `protoc-gen-doc` are
+    installed."""
+
+    shutil.rmtree(config.proto_tools_dir, ignore_errors=True)
+    os.makedirs(config.proto_tools_dir, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with requests.get(
+            config.protoc_url, stream=True
+        ) as protoc_response, zipfile.ZipFile(
+            io.BytesIO(protoc_response.content)
+        ) as protoc_zip:
+            protoc_zip.extractall(path=tmpdir)
+
+        shutil.move(f"{tmpdir}/bin/protoc", config.protoc)
+        shutil.move(f"{tmpdir}/include", config.proto_tools_dir)
+        os.chmod(config.protoc, 0o755)
+
+        with requests.get(
+            config.protoc_gen_doc_url, stream=True
+        ) as protoc_gen_doc_response, tarfile.open(
+            fileobj=protoc_gen_doc_response.raw, mode="r:gz"
+        ) as protoc_gen_doc_tar:
+            protoc_gen_doc_tar.extractall(path=tmpdir)
+
+        shutil.move(f"{tmpdir}/protoc-gen-doc", config.protoc_gen_doc)
+        os.chmod(config.protoc_gen_doc, 0o755)
+
+
+def generate_proto(config: Config) -> None:
+    """Generates Markdown documentation for each configured Protobuf file."""
+
+    shutil.rmtree(config.proto_generated_dir, ignore_errors=True)
+    os.makedirs(config.proto_generated_dir, exist_ok=True)
+
+    template = config.proto_template.read_text(encoding="utf-8")
+    for title, file in config.proto_files.items():
+        with tempfile.NamedTemporaryFile() as tmpfile:
+            tmpfile.write(
+                template.replace("{{ .TitleFromPython }}", title).encode("utf-8")
+            )
+            tmpfile.flush()
+
+            args = [
+                config.protoc,
+                f"--plugin=protoc-gen-doc={config.protoc_gen_doc}",
+                f"--doc_out={config.proto_generated_dir}",
+                f"--doc_opt={tmpfile.name},{file.stem}.md",
+                f"--proto_path={config.proto_path}",
+                f"{config.proto_path/file}",
+            ]
+            subprocess.run(args, check=True)
+
+
+TARGETS: dict[str, Callable[[Config], None]] = {
+    "ensure-proto": ensure_proto,
+    "generate-proto": generate_proto,
+}
+
+
+def main():
+    """The main program entry point."""
+
+    if len(sys.argv) < 2:
+        usage()
+
+    target = sys.argv[1]
+    if target not in TARGETS:
+        usage(f"unknown target '{target}'")
+
+    config = Config(
+        generated_dir="_generated",
+        tools_dir="_tools",
+        protoc_version="25.1",
+        protoc_platforms={
+            "Linux_x86_64": "linux-x86_64",
+            "Darwin_arm64": "osx-aarch_64",
+        },
+        protoc_gen_doc_version="1.5.1",
+        protoc_gen_doc_platforms={
+            "Linux_x86_64": "linux_amd64",
+            "Darwin_arm64": "darwin_arm64",
+        },
+        proto_path="../proto",
+        proto_files={
+            "Aliasing": "pulumi/alias.proto",
+            "Analysis": "pulumi/analyzer.proto",
+            "Callbacks": "pulumi/callback.proto",
+            "Engine services": "pulumi/engine.proto",
+            "Errors": "pulumi/errors.proto",
+            "Language hosts": "pulumi/language.proto",
+            "Plugins": "pulumi/plugin.proto",
+            "Program conversion": "pulumi/converter.proto",
+            "Providers": "pulumi/provider.proto",
+            "Resource registration": "pulumi/resource.proto",
+            "Schema loading": "pulumi/codegen/loader.proto",
+            "Source positions": "pulumi/source.proto",
+        },
+        proto_template="references/proto.md.tmpl",
+    )
+
+    TARGETS[target](config)
+
+
+def usage(error: Optional[str] = None):
+    """Prints usage information and exits with a non-zero status."""
+
+    if error:
+        print(f"Error: {error}")
+
+    print("Usage: python make.py [target]")
+    print()
+    print("Targets:")
+    for target in sorted(TARGETS):
+        print(f"  {target}")
+
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/references/README.md
+++ b/docs/references/README.md
@@ -1,0 +1,12 @@
+# References
+
+This section of the documentation is intended to serve as an index for various
+pieces of machine-generated documentation (e.g. docstrings from Protobuf files,
+TypeDocs from the NodeJS/TypeScript SDK, and so on).
+
+:::{toctree}
+:maxdepth: 2
+:titlesonly:
+
+/proto/README
+:::

--- a/docs/references/proto.md.tmpl
+++ b/docs/references/proto.md.tmpl
@@ -1,0 +1,51 @@
+{{- range .Files -}}
+# {{ .TitleFromPython }}
+<gh-file:pulumi#proto/{{ .Name }}>
+
+{{ if .Services -}}
+## Services
+{{- range .Services -}}
+{{- $ServiceName := .FullName }}
+
+({{ .FullName }})=
+### 🔌 {{ .Name }}
+{{ .Description }}
+
+{{ range .Methods }}
+({{ $ServiceName }}.{{ .Name }})=
+#### 📞 {{ .Name }}
+
+⤵️ [{{ .RequestLongType }}](#{{ .RequestFullType }}) ⤴️ [{{ .ResponseLongType }}](#{{ .ResponseFullType }})
+
+{{ .Description }}
+
+{{ end }}{{- /* range .Methods */ -}}
+
+{{ end }}{{- /* range .Services */ -}}
+
+{{ end }}{{- /* if .Services */ -}}
+
+{{ if .Messages -}}
+## Messages
+{{ range .Messages -}}
+{{- $MessageName := .FullName -}}
+
+({{ .FullName }})=
+### 📨 {{ .Name }}
+{{ .Description }}
+
+{{ range .Fields }}
+`{{ .Name }}` [{{ .LongType }}](#{{ .FullType }})
+: {{ if .Description -}}
+    {{ .Description | indent 2 }}
+  {{- else -}}
+    &lt;No description&gt;
+  {{- end }}
+
+{{ end }}{{- /* range .Fields */ -}}
+
+{{ end }}{{- /* range .Messages */ -}}
+
+{{ end }}{{- /* if .Messages */ -}}
+
+{{ end }}{{- /* range .Files */ -}}

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -126,8 +126,14 @@ html_title = "Pulumi developer documentation"
 html_logo = "https://www.pulumi.com/images/logo/logo-on-white-box.svg"
 
 html_theme_options = {
-    # Show all headings up to level 2 in the sidebar table of contents.
-    "show_toc_levels": 2,
+    # Expand all headings up to level 2 by default in the left sidebar (global)
+    # table of contents.
+    "show_navbar_depth": 2,
+    # Show all headings up to level 2 in the right sidebar (in-page) table of
+    # contents.
+    "show_toc_level": 2,
+    # Expand all headings up to level 2 by default in the sidebar table of
+    # contents.
     # Enable margin notes
     # (https://sphinx-book-theme.readthedocs.io/en/stable/content/content-blocks.html#sidenotes-and-marginnotes).
     "use_sidenotes": True,

--- a/proto/README.md
+++ b/proto/README.md
@@ -1,0 +1,51 @@
+# Protobuf and gRPC interfaces
+
+This package contains [Protobuf definitions](https://protobuf.dev) for the
+various types, messages and interfaces that Pulumi components use to
+communicate. These definitions serve as the source of truth for several parts of
+the wider codebase.
+
+## Code generation
+
+:::{note}
+Code generated from Protobuf files is committed to the repository. If you change
+one or more `.proto` files, you should run `make build_proto` to regenerate the
+necessary stubs and commit the changes as part of the same piece of work.
+:::
+
+The <gh-file:pulumi#proto/generate.sh> script in this directory (called by the
+`build_proto` target in the top-level <gh-file:pulumi#Makefile>) generates types
+and gRPC clients for the languages supported in this repository (Go,
+NodeJS/TypeScript and Python). Generated code is committed to the repository,
+typically in `proto` directories at the relevant use sites (e.g.
+<gh-file:pulumi#sdk/nodejs/proto>).
+
+## Documentation
+
+We use the [`protoc-gen-doc`
+plugin](https://github.com/pseudomuto/protoc-gen-doc) to `protoc` to generate
+Markdown documentation from the Protobuf files. This process is handled by the
+<gh-file:pulumi#docs/Makefile> in the `docs` directory and uses the
+<gh-file:pulumi#docs/references/proto.md.tmpl> template. Generated documentation ends
+up in the `docs/_generated` directory (which is `.gitignore`d), so e.g. this
+index links to files in this folder.
+
+## Index
+
+:::{toctree}
+:maxdepth: 1
+:titlesonly:
+
+/docs/_generated/proto/resource
+/docs/_generated/proto/provider
+/docs/_generated/proto/plugin
+/docs/_generated/proto/language
+/docs/_generated/proto/callback
+/docs/_generated/proto/loader
+/docs/_generated/proto/converter
+/docs/_generated/proto/analyzer
+/docs/_generated/proto/alias
+/docs/_generated/proto/engine
+/docs/_generated/proto/errors
+/docs/_generated/proto/source
+:::


### PR DESCRIPTION
Protocol buffer (Protobuf) definitions are the source of truth for many of the types and interfaces used across Pulumi products. Documentation written in Protobuf files is already used to generate commented code e.g. when producing gRPC stubs and clients. This commit extends this to generate reference developer documentation from our Protobuf files using the `protoc-gen-doc` plugin for `protoc`, which exports Protobuf documentation as Markdown. This is then incorporated into the build process for our developer documentation so that we can refer to Protobuf types and gRPC services and messages across our documentation.

In order to provide a degree of portability, and also not to require developers (or the Read the Docs build process) to download and manage the `protoc` / `protoc-gen-doc` toolchains required, this commit introduces a `make.py` Python script that encapsulates the more complicated steps of the build without having to resort to reams of shell scripts. This script is still invoked from the `Makefile` and Make is still responsible for dependency tracking (e.g. recognising that generating Protobuf documentation must happen before running the Sphinx build, and so on).