### PR TITLE
Flesh out architecture documentation

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,5 @@
 .ensure.phony
 _build
+_generated
+_tools
 venv/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build ensure ensure-python watch
+.PHONY: build ensure ensure-proto ensure-python generate generate-proto watch
 
 VENV = venv
 
@@ -9,13 +9,23 @@ ensure-python:: .ensure-python.phony
 	. $(VENV)/*/activate && python -m pip install -r requirements.txt
 	@touch .ensure-python.phony
 
-ensure:: ensure-python
+ensure-proto:: .ensure-proto.phony
+.ensure-proto.phony: ensure-python
+	. $(VENV)/*/activate && python make.py ensure-proto
+	@touch .ensure-proto.phony
+
+ensure:: ensure-proto ensure-python
+
+generate-proto: ensure
+	. $(VENV)/*/activate && python make.py generate-proto
+
+generate:: generate-proto
 
 # This target is intended to be called by Read the Docs as part of deployment,
 # whereby the READTHEDOCS_OUTPUT environment variable will be set to a
 # destination that Read the Docs expects to be populated with the generated
 # documentation.
-build: ensure
+build: ensure generate
 	mkdir -p $$READTHEDOCS_OUTPUT/html
 	. $(VENV)/*/activate && python -m sphinx \
 		-T \
@@ -27,7 +37,7 @@ build: ensure
 		$$READTHEDOCS_OUTPUT/html
 	cp sphinx/index.html.template $$READTHEDOCS_OUTPUT/html/index.html
 
-watch: ensure
+watch: ensure generate
 	. $(VENV)/*/activate && sphinx-autobuild \
 		-c sphinx \
 		-b html \

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,4 +10,5 @@ complete documentation for maintainers of and contributors to Pulumi.
 self
 /docs/documentation
 /docs/architecture/README
+/docs/references/README
 :::

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -112,3 +112,14 @@ follows:[^side-node-exhaustive]
   a similar pattern when it comes to several of the core components -- e.g. most
   providers will have an `sdk/` directory exposing provider SDKs for each
   supported language.
+
+The remainder of this section covers many of these components in more detail, as
+well as discussing how they are verified and tested.
+
+:::{toctree}
+:maxdepth: 1
+:titlesonly:
+
+/docs/architecture/deployment-execution/README
+/docs/architecture/mlcs
+:::

--- a/docs/architecture/deployment-execution/README.md
+++ b/docs/architecture/deployment-execution/README.md
@@ -1,0 +1,91 @@
+(deployments)=
+# Deployment execution
+
+The Pulumi engine is responsible for orchestrating *deployments*. A deployment
+typically comprises a single *operation*, such as an update or destroy, though
+it may conceptually execute more than one (if `--refresh` is passed to an
+`up`, for example). Internally, a deployment is an event-driven process whose
+lifecycle looks roughly as follows:
+
+* The engine starts and collects necessary configuration values to construct a
+  deployment (the stack to operate on, whether it should continue when it
+  encounters errors, and so on).
+* As part of this process, the engine decides upon a *source* that will provide
+  events to drive the deployment. Events represent things like resources that
+  need to be managed ("I want to declare an S3 bucket"), or functions that need
+  to be called ("I want to look up the EC2 instance with this ID").
+* Once the deployment has been instantiated and configured with a source, the
+  engine *iterates* over the source and the events it provides in order to drive
+  the deployment.
+* [Resource events](resource-registration) result in [steps](step-generation), which
+  correspond to actions that must be taken in order to arrive at the desired
+  state for a given resource -- e.g. by calling a [provider](providers)
+  [](pulumirpc.ResourceProvider.Create) method in order to create a new
+  resource.
+* When all steps have been executed, the (hopefully desired)
+  [state](state-snapshots) of the infrastructure is persisted to the configured
+  backend and the deployment is completed.
+
+The choice of source depends on the operation.
+
+## Operations that do not execute the program
+
+`refresh` and `destroy` operations do not currently result in program execution.
+Whether or not this is desirable/useful arguably depends on the context, but as
+far as the implementation is concerned at present, these operations are driven
+as follows:
+
+* `destroy` uses a *null source*
+  (<gh-file:pulumi#pkg/resource/deploy/source_null.go>), which simply returns no
+  events. This effectively simulates an empty program, which is exactly what
+  we'd write if we wanted to destroy all our resources.
+* `refresh` uses an *error source*
+  (<gh-file:pulumi#pkg/resource/deploy/source_error.go>), which returns an error
+  event if it is iterated. This is to capture the invariant that a `refresh`
+  operation should not consult its source, since it is only concerned with
+  changes in the various providers, and not the program.
+
+## Operations that execute the program
+
+For `preview` and `update` operations, the Pulumi program specifies the desired
+state of a user's infrastructure in a manner idiomatic to the language in which
+the program is written, e.g. `new Resource(...)` in TypeScript, or
+`Resource(...)` in Python. When performing these operations, the engine
+instantiates an *evaluation source*
+(<gh-file:pulumi#pkg/resource/deploy/source_eval.go>) that boots up a language
+host to run the program. The classes, function calls, and so on exposed by the
+particular language SDK are implemented using gRPC calls under the hood that
+enable communication between the language host and the engine. Specifically:
+
+* [](pulumirpc.ResourceMonitor) is the primary interface used to manage
+  resources. A resource monitor supports [registering
+  resources](pulumirpc.ResourceMonitor.RegisterResource), [reading
+  resources](pulumirpc.ResourceMonitor.ReadResource), [invoking
+  functions](pulumirpc.ResourceMonitor.Invoke), and many more operations key to
+  the operation of a Pulumi program. An evaluation source contains a
+  `ResourceMonitor` instance that enqueues events to be returned when it is
+  iterated over, so the deployment ends up being driven by the program
+  evaluation.
+* [](codegen.Loader) provides methods for loading schemata.
+* [](pulumirpc.Engine) exposes auxilliary operations that are not specific to a
+  particular resource, such as [logging](pulumirpc.Engine.Log) and [state
+  management](pulumirpc.Engine.SetRootResource).
+* [](pulumirpc.Callbacks) allows callers to [execute
+  functions](pulumirpc.Callbacks.Invoke) in the language host, such as
+  [transforms](https://www.pulumi.com/docs/concepts/options/transforms/), which
+  are specified as part of the program but whose execution is driven by the
+  engine.
+
+The engine hosts services implementing `ResourceMonitor`, `Loader`, and
+`Engine`, while language hosts implement `Callbacks`. All of these come together
+in a number of processes to execute a Pulumi program, as elucidated in the
+following pages.
+
+:::{toctree}
+:maxdepth: 1
+:titlesonly:
+
+/docs/architecture/deployment-execution/resource-registration
+/docs/architecture/deployment-execution/providers
+/docs/architecture/deployment-execution/state
+:::

--- a/docs/architecture/deployment-execution/providers.md
+++ b/docs/architecture/deployment-execution/providers.md
@@ -1,0 +1,72 @@
+(providers)=
+# Providers
+
+(default-providers)=
+## Default providers
+
+A *default provider* for a package and version is the provider instance that
+Pulumi will use to manage resources that do not have a provider explicitly
+specified (either directly as a resource option or indirectly via a parent, for
+instance). Consider for example the following TypeScript program that creates
+an S3 bucket in AWS:
+
+```typescript
+import * as aws from "@pulumi/aws"
+
+new aws.s3.Bucket("my-bucket")
+```
+
+The `Bucket` constructor will yield a [](pulumirpc.RegisterResourceRequest) such
+as the following:
+
+```
+RegisterResourceRequest{
+	type: "aws:s3/bucket:Bucket",
+	name: "my-bucket",
+	parent: "urn:pulumi:dev::project::pulumi:pulumi:Stack::project",
+	custom: true,
+	object: {},
+	version: "4.16.0",
+}
+```
+
+The absence of a `provider` field in this request will cause the engine to use a
+default provider for the `aws` package at version 4.16.0. The engine's
+[](pulumirpc.ResourceMonitor) implementation ensures that only a single default
+provider instance exists for each package version, and only creates default
+provider instances on demand (that is, when a resource that requires one is
+registered). Default provider instances are created by synthesizing appropriate
+`RegisterResourceEvent`s with inputs sourced from the stack's configuration
+values for the relevant provider package. In the example above, the default AWS
+provider would be configured using any stack configuration values whose keys
+begin with `aws:` (e.g. `aws:region`).
+
+Changing the above example to use an explicit provider will prevent a default
+provider from being used:
+
+```typescript
+import * as aws from "@pulumi/aws"
+
+const usWest2 = new aws.Provider("us-west-2", { region: "us-west-2" })
+
+new aws.s3.Bucket("my-bucket", {}, { provider: usWest2 })
+```
+
+This will yield a `RegisterResourceRequest` whose `provider` field references
+the explicitly constructed entity:
+
+```
+RegisterResourceRequest{
+	type: "aws:s3/bucket:Bucket",
+	name: "my-bucket",
+	parent: "urn:pulumi:dev::project::pulumi:pulumi:Stack::project",
+	custom: true,
+	object: {},
+	provider: "urn:pulumi:dev::project::pulumi:providers:aws::us-west-2::308b79ee-8249-40fb-a203-de190cb8faa8",
+	version: "4.16.0",
+}
+```
+
+Note that the explicit provider *itself* is registered as a resource, and its
+constructor will emit its own `RegisterResourceRequest` with the appropriate
+name, type, parent, and so on.

--- a/docs/architecture/deployment-execution/resource-registration.md
+++ b/docs/architecture/deployment-execution/resource-registration.md
@@ -1,0 +1,418 @@
+(resource-registration)=
+# Resource registration
+
+As a Pulumi program is executed by the language host, it will make
+[](pulumirpc.ResourceMonitor.RegisterResource) calls to the engine in order to
+declare resources and their desired state. Each
+[](pulumirpc.RegisterResourceRequest) contains:
+
+* The resource's type and name.
+* The resource's [parent](https://www.pulumi.com/docs/concepts/options/parent/),
+  if it has one.
+* A reference to the
+  [provider](https://www.pulumi.com/docs/concepts/resources/providers/) that
+  manages the resource, if an explicit one has been specified. If no reference
+  has been specified, Pulumi will use a [default provider](#default-providers)
+  instance for the resource's package and version.
+* Values for the resource's input properties.
+* Any [resource options](https://www.pulumi.com/docs/concepts/options/) that
+  have been specified for the resource.
+
+In order to determine what actions to take in order to arrive at the desired,
+the engine *diffs* the desired state of the resource against the current state
+as recorded in the [state snapshot](state-snapshots):
+
+* If there is no current state, the engine will call the provider's
+  [](pulumirpc.ResourceProvider.Create) method to create a new resource.
+* If there is a current state, the engine will call the provider's
+  [](pulumirpc.ResourceProvider.Diff) method to determine whether the resource
+  is unchanged, requires updating, or must be replaced in some manner.
+
+When the appropriate actions have been determined, the engine will invoke the
+relevant provider methods to carry them out. After the actions complete, the
+engine returns the new state of the resource to the program.
+
+Although all of the above happens "in the engine", in practice these concerns
+are separated into a number of subsystems: the [resource
+monitor](resource-monitor), the [step generator](step-generation), and the [step
+executor](step-execution).
+
+(resource-monitor)=
+## Resource monitor
+
+The *resource monitor* (largely represented by `resmon` in the codebase; see
+<gh-file:pulumi#pkg/resource/deploy/source_eval.go>) implements the
+[](pulumirpc.ResourceMonitor) interface, which is the primary communication
+channel between language hosts and the engine. There is a single resource
+monitor per deployment. Aside from being a marshalling and unmarshalling layer
+between the engine and its gRPC boundary, the resource monitor is also
+responsible for resolving [default providers](default-providers) and
+[multi-language components](mlcs), responding to
+[](pulumirpc.RegisterResourceRequest)s as follows:
+
+* The request is unmarshalled from the gRPC wire format into an engine-internal
+  representation.
+* If the request lacks a `provider` reference, the resource monitor will resolve
+  a [default provider](default-providers) for the resource's package and
+  version.
+* If the request registers a [multi-language component (MLC)](mlcs), the
+  resource monitor will dispatch an appropriate
+  [](pulumirpc.ResourceProvider.Construct) call to the MLC's provider and await
+  the result.
+* If the request does *not* register an MLC, the resource monitor will emit a
+  `RegisterResourceEvent` and await a response.
+* When a result is received (either in response to a
+  [](pulumirpc.ResourceProvider.Construct) call or a `RegisterResourceEvent`),
+  the resource monitor will marshal the result back into the gRPC wire format
+  and return it to the language host.
+
+(step-generation)=
+## Step generation
+
+The *step generator* (<gh-file:pulumi#pkg/resource/deploy/step_generator.go>) is
+responsible for processing `RegisterResourceEvent`s emitted by the resource
+monitor. When an event is received, the step generator proceeds as follows:
+
+1. A URN is generated for the resource, using the type, name and parent fields
+   from the event.
+2. The URN is used to look up the resource's existing state, if it has any. If
+   the event contains aliases, state under those aliases will also be looked up.
+   It is an error if multiple pieces of existing state are found due to
+   aliasing.
+3. Input properties are pre-processed to implement the `ignoreChanges` resource
+   option, by resetting the values of any properties which should be ignored to
+   their previous values.
+4. If the event indicates that the resource should be imported, the step
+   generator will emit an `ImportStep` and return.
+5. If the resource is not being imported, the step generator will continue by
+   calling the provider's [](pulumirpc.ResourceProvider.Check) method with both
+   the event's input properties and the resource's existing
+   inputs.[^existing-inputs] `Check` will return a validated bag of input values
+   that may be used in later calls to [](pulumirpc.ResourceProvider.Diff),
+   [](pulumirpc.ResourceProvider.Create), and
+   [](pulumirpc.ResourceProvider.Update).
+6. At this point, the step generator will invoke any *analyzers* that have been
+   configured in the stack to perform additional validation on the resource's
+   input properties.
+7. If the resource has no existing state, it must be created. Issue a
+   `CreateStep` and return.
+8. [Diff](step-generation-diff) the resource in order to determine whether it
+   must be updated, replaced, or left as-is.
+9. If there are no changes, issue a `SameStep` and return.
+10. If the resource is not being replaced, issue an `UpdateStep` and return.
+11. If the resource is being replaced, call the resource provider's
+    [](pulumirpc.ResourceProvider.Check) method again, this time sending no
+    existing inputs. This call ensures that the input properties used to create
+    the replacement will not reuse generated defaults that should be unique to
+    the existing resource.
+12. If the replacement should be created before the original is deleted (a
+    normal replacement, also "create-replace" or "create-before-replace"), issue
+    an appropriate `CreateStep` and `DeleteStep` pair and return.
+13. If the replacement should be created after the original has been deleted
+    ("delete-replace", "delete-before-replace", "DBR"), calculate the list of
+    resources that will have to be deleted in response to the deletion of the
+    original (see the sections on [deletions](step-generation-deletions) and
+    [dependent replacements](step-generation-dependent-replacements) later on
+    for more details). Then, issue a `DeleteStep` and `CreateStep` pair for the
+    replacement and return.
+
+[^existing-inputs]:
+    Existing inputs inputs may be used to repopulate default values for input
+    properties that are automatically generated when the resource is created but
+    that are not changed on subsequent updates (e.g. automatically generated
+    names).
+
+:::{note}
+Presently, step generation is a *serial* process (that is, steps are processed
+one at a time, in turn). This means that step generation is on the critical path
+for a deployment, so any significant blocking operations could slow down
+deployments considerably. In the case of an update, step generator latency is
+generally insignificant compared to the time spend performing provider
+operations (e.g. cloud updates), but in the case of a large preview operation,
+or an update where most resources are unchanged, the step generator could become
+a bottleneck.
+:::
+
+Step generation is a fire-and-forget process. Once a step has been generated,
+the step generator immediately moves on to the next `RegisterResourceEvent`. It
+is the responsibility of the [step executor](step-execution) to communicate the
+results of each step back to the [resource monitor](resource-monitor).
+
+(step-generation-diff)=
+### Diffing
+
+While in most cases diffing boils down to calling a provider's
+[](pulumirpc.ResourceProvider.Diff) method, there are a number of cases where
+this might not happen. The full algorithm that the engine currently implements
+is as follows:
+
+1. If the resource has been marked for replacement out-of-band (e.g. by the use
+   of the `--target-replace` command-line option), the resource must be
+   replaced.
+2. If the resource's provider has changed, the resource must be replaced.
+   [Default providers](default-providers) are allowed to change without
+   triggering a replacement if and only if the provider's configuration allows
+   the new default provider to continue to manage existing resources. This is
+   intended to allow default providers to be upgraded without causing all
+   resources they manage to be replaced.
+3. If the engine is configured to use legacy (pre-1.0) diffs, the engine will
+   compare old and new inputs itself (without consulting the provider). If these
+   differ, the resource must be updated.
+4. In all other cases, the engine will call the provider's
+   [](pulumirpc.ResourceProvider.Diff) method to determine whether the resource
+   must be updated, replaced, or left as-is.
+
+(step-generation-deletions)=
+### Deletions
+
+Once the Pulumi program has exited, the step generator determines the set of
+resources that must be deleted by computing the difference between the set of
+registered resources and the set of resources that were present in the previous
+state snapshot. This set is sorted topologically by reverse dependencies (that
+is, resources that depend on other resources are deleted first). This sorted
+list is then decomposed into a list of lists where the sublists must be
+processed serially but the contents of each sublist can be processed in
+parallel.
+
+(step-generation-dependent-replacements)=
+### Dependent replacements
+
+By default, Pulumi will replace resources by first creating the replacement and
+then deleting the original (create-before-replace). There are cases however
+where Pulumi will delete the original first (a delete-before-replace):
+
+* If the resource's provider specifies that the resource must be deleted before
+  it can be replaced as using a [](pulumirpc.DiffResponse)'s
+  `deleteBeforeReplace` field.
+* If the program specifies the [`deleteBeforeReplace` resource
+  option](https://www.pulumi.com/docs/concepts/options/deletebeforereplace/) for
+  the resource.
+
+In such cases, it may be necessary to first delete resources that depend on that
+being replaced, since there will be a moment between the delete and create steps
+where no version of the resource exists (and thus dependent resources will have
+broken dependencies). The step generator does this as follows:
+
+1. Compute the full set of resources that transitively depend on the resource
+   being replaced.
+2. Remove from this set any resources that would *not themselves be replaced* by
+   changes to their dependencies. This is determined by substituting unknown
+   values for any inputs that stem from a dependency and calling the provider's
+   [](pulumirpc.ResourceProvider.Diff) method.
+3. Process the replacements in reverse topological order.
+
+To better illustrate this, consider the following example (written in
+pseudo-TypeScript):
+
+```typescript
+const a = new Resource("a", {})
+const b = new Resource("b", {}, { dependsOn: a })
+const c = new Resource("c", { input: a.output })
+const d = new Resource("d", { input: b.output })
+```
+
+The dependency graph for this program is as follows:
+
+```{mermaid}
+flowchart TD
+    b --> a
+    c --> a
+    d --> b
+```
+
+We see that the transitive set of resources that depend on `a` is `{b, c, d}`.
+In the event that `a` is subject to a delete-before-replace, then each of `b`,
+`c`, and `d` must also be considered. Since `b`'s relationship is only due to
+[`dependsOn`](https://www.pulumi.com/docs/concepts/options/dependson/), its
+inputs will not be affected by the deletion of `a`, so it does not need to be
+replaced. `c`'s inputs are affected by the deletion of `a`, so we must call
+`Diff` to see whether it needs to be replaced or not. `d`'s dependency on `a` is
+through `b`, which we have established does not need to be replaced, so `d` does
+not need to be replaced either.
+
+(step-execution)=
+## Step execution
+
+The *step executor* is responsible for executing steps yielded by the [step
+generator](step-generation). Steps are processed in sequences called *chains*.
+While the steps within a chain must be processed serially, chains may be
+processed in parallel. The step executor uses a pool of workers to execute
+steps. Once a step completes, the executor communicates its results to the
+[resource monitor](resource-monitor). If a step fails, the executor notes its
+failure and cancels the deployment. Once the Pulumi program has exited and the
+step generator has issued all required deletions, the step executor waits for
+all outstanding steps to complete and then returns.
+
+(resource-registration-examples)=
+## Examples
+
+The following subsections give some example sequence diagrams for the processes
+described in this document. Use your mouse to zoom in/out and move around as
+necessary.
+
+### Creating a resource
+
+```{mermaid}
+:zoom:
+
+sequenceDiagram
+    participant LH as Language host
+    box Engine
+        participant RM as Resource monitor
+        participant SG as Step generator
+        participant SE as Step executor
+    end
+    participant P as Provider
+
+    LH->>+RM: RegisterResourceRequest(type, name, inputs, options)
+    RM->>+SG: RegisterResourceEvent(type, name, inputs, options)
+    SG->>+P: CheckRequest(type, inputs)
+    P->>-SG: CheckResponse(inputs', failures)
+    SG->>+SE: CreateStep(inputs', options)
+    SE->>+P: CreateRequest(type, inputs')
+    P->>-SE: CreateResponse(new state)
+    SE->>-RM: Done(new state)
+    RM->>-LH: RegisterResourceResponse(URN, ID, new state)
+```
+
+### Updating a resource
+
+```{mermaid}
+:zoom:
+
+sequenceDiagram
+    participant LH as Language host
+    box Engine
+        participant RM as Resource monitor
+        participant SG as Step generator
+        participant SE as Step executor
+    end
+    participant P as Provider
+
+    LH->>+RM: RegisterResourceRequest(type, name, inputs, options)
+    RM->>+SG: RegisterResourceEvent(type, name, inputs, options)
+    SG->>+P: CheckRequest(type, inputs, old inputs)
+    P->>-SG: CheckResponse(inputs', failures)
+    SG->>+P: DiffRequest(type, inputs', old state, options)
+    P->>-SG: DiffResponse(diff)
+    SG->>+SE: UpdateStep(inputs', old state, options)
+    SE->>+P: UpdateRequest(type, inputs', old state)
+    P->>-SE: UpdateResponse(new state)
+    SE->>-RM: Done(new state)
+    RM->>-LH: RegisterResourceResponse(URN, ID, new state)
+```
+
+### Replacing a resource (create-before-replace)
+
+```{mermaid}
+:zoom:
+
+sequenceDiagram
+    participant LH as Language host
+    box Engine
+        participant RM as Resource monitor
+        participant SG as Step generator
+        participant SE as Step executor
+    end
+    participant P as Provider
+
+    LH->>+RM: RegisterResourceRequest(type, name, inputs, options)
+    RM->>+SG: RegisterResourceEvent(type, name, inputs, options)
+    SG->>+P: CheckRequest(type, inputs, old inputs)
+    P->>-SG: CheckResponse(inputs', failures)
+    SG->>+P: DiffRequest(type, inputs', old state, options)
+    P->>-SG: DiffResponse(diff)
+    SG->>+SE: CreateStep(inputs', old state, options)
+    SE->>+P: CreateRequest(type, inputs', old state)
+    P->>-SE: CreateResponse(new state)
+    SE->>-RM: Done(new state)
+    RM->>-LH: RegisterResourceResponse(URN, ID, new state)
+
+    Note over SG: Pulumi program exits
+
+    SG->>SG: Generate delete steps
+    SG->>+SE: DeleteStep(old state)
+    SE->>+P: DeleteRequest(type, old state)
+    P->>-SE: DeleteResponse()
+```
+
+### Replacing a resource (delete-before-replace)
+
+```{mermaid}
+:zoom:
+
+sequenceDiagram
+    participant LH as Language host
+    box Engine
+        participant RM as Resource monitor
+        participant SG as Step generator
+        participant SE as Step executor
+    end
+    participant P as Provider
+
+    LH->>+RM: RegisterResourceRequest(type, name, inputs, options)
+    RM->>+SG: RegisterResourceEvent(type, name, inputs, options)
+    SG->>+P: CheckRequest(type, inputs, old inputs)
+    P->>-SG: CheckResponse(inputs', failures)
+    SG->>+P: DiffRequest(type, inputs', old state, options)
+    P->>-SG: DiffResponse(diff)
+    SG->>+SE: DeleteStep(old state), CreateStep(inputs', options)
+    SE->>+P: DeleteRequest(type, old state)
+    P->>-SE: DeleteResponse()
+    SE->>+P: CreateRequest(type, inputs', old state)
+    P->>-SE: CreateResponse(new state)
+    SE->>-RM: Done(new state)
+    RM->>-LH: RegisterResourceResponse(URN, ID, new state)
+```
+
+### Importing a resource
+
+```{mermaid}
+:zoom:
+
+sequenceDiagram
+    participant LH as Language host
+    box Engine
+        participant RM as Resource monitor
+        participant SG as Step generator
+        participant SE as Step executor
+    end
+    participant P as Provider
+
+    LH->>+RM: RegisterResourceRequest(type, name, inputs, options)
+    RM->>+SG: RegisterResourceEvent(type, name, inputs, options)
+    SG->>+SE: ImportStep(inputs, options)
+    SE->>+P: ReadRequest(type, id)
+    P->>-SE: ReadResponse(current inputs, current state)
+    SE->>+P: CheckRequest(type, inputs, current inputs)
+    P->>-SE: CheckResponse(inputs', failures)
+    SE->>+P: DiffRequest(type, inputs', current state, options)
+    P->>-SE: DiffResponse(diff)
+    SE->>-RM: Done(current state)
+    RM->>-LH: RegisterResourceResponse(URN, ID, current state)
+```
+
+### Leaving a resource unchanged
+
+```{mermaid}
+:zoom:
+
+sequenceDiagram
+    participant LH as Language host
+    box Engine
+        participant RM as Resource monitor
+        participant SG as Step generator
+        participant SE as Step executor
+    end
+    participant P as Provider
+
+    LH->>+RM: RegisterResourceRequest(type, name, inputs, options)
+    RM->>+SG: RegisterResourceEvent(type, name, inputs, options)
+    SG->>+P: CheckRequest(type, inputs, old inputs)
+    P->>-SG: CheckResponse(inputs', failures)
+    SG->>+P: DiffRequest(type, inputs', old state, options)
+    P->>-SG: DiffResponse(diff)
+    SG->>+SE: SameStep(inputs', old state, options)
+    SE->>-RM: Done(old state)
+    RM->>-LH: RegisterResourceResponse(URN, ID, old state)
+```

--- a/docs/architecture/deployment-execution/state.md
+++ b/docs/architecture/deployment-execution/state.md
@@ -1,0 +1,2 @@
+(state-snapshots)=
+# State management and snapshots

--- a/docs/architecture/mlcs.md
+++ b/docs/architecture/mlcs.md
@@ -1,0 +1,2 @@
+(mlcs)=
+# Multi-language components

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -18,19 +18,43 @@ make -C docs watch
 ```
 
 which will watch for changes and rebuild the documentation as needed, serving
-the results at http://localhost:8000. If you want to build the documentation
-without watching for changes, you can use the `build` target instead:
+the results at <http://localhost:8000/docs/README.html>.
+
+### Deployment
+
+This documentation is deployed to [Read the Docs](https://readthedocs.org) as
+part of our CI/CD pipelines. The `build` target in the `Makefile` is used to
+build an HTML version of the documentation that Read the Docs then deploys. See
+the <gh-file:pulumi#.readthedocs.yaml> configuration in the root of the
+repository for more information.
+
+#### Previewing changes
+
+If you want to preview the documentation as it will appear on Read the Docs,
+simply raise a PR with your changes. Read the Docs will build your PR and
+generate a preview site for you to review. The link to the preview site will
+appear in the list of checks on your PR. See [Read the Docs' documentation on
+preview builds](https://docs.readthedocs.io/en/stable/pull-requests.html) for
+more.
+
+#### Local builds
+
+If you want to build the documentation without watching for changes, you can use
+the `build` target yourself locally, too. Set the `READTHEDOCS_OUTPUT`
+environment variable to the location you'd like the documentation to be built to
+and then run the build:
 
 ```sh
+export READTHEDOCS_OUTPUT=/path/to/output
 make -C docs build
 ```
 
-`build` will compile documentation to a static HTML website in the `docs/_build`
-directory; you can open the `README.html` file in your browser to view the built
-files from there:
+`build` will compile documentation to a static HTML website in the
+`/path/to/output/html` directory; you can open the `index.html` file in your
+browser to view the built files from there:
 
 ```sh
-open docs/_build/docs/README.html
+open /path/to/output/html/index.html
 ```
 
 :::{toctree}

--- a/docs/make.py
+++ b/docs/make.py
@@ -1,0 +1,218 @@
+import io
+import os
+import pathlib
+import platform
+import requests
+import sys
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from typing import Callable, Optional
+import zipfile
+
+
+class Config:
+    """Config collects configuration information necessary to execute build
+    tasks."""
+
+    def __init__(
+        self,
+        generated_dir: str,
+        tools_dir: str,
+        protoc_version: str,
+        protoc_platforms: dict[str, str],
+        protoc_gen_doc_version: str,
+        protoc_gen_doc_platforms: dict[str, str],
+        proto_path: str,
+        proto_files: dict[str, str],
+        proto_template: str,
+    ) -> None:
+        """Constructs a new configuration object.
+
+        :param generated_dir:
+            The directory where generated files should be written. This
+            directory should not be checked into source control.
+        :param tools_dir:
+            The directory where build tools should be installed. This directory
+            should not be checked into source control.
+        :param protoc_version:
+            The version of `protoc`, the Protobuf compiler, to use for build
+            tasks that require it.
+        :param protoc_platforms:
+            A mapping from platform keys to archive keys for `protoc` releases.
+        :param protoc_gen_doc_version:
+            The version of `protoc-gen-doc`, the Protobuf documentation generator,
+            to use for build tasks that require it.
+        :param protoc_gen_doc_platforms:
+            A mapping from platform keys to archive keys for `protoc-gen-doc`
+            releases.
+        :param proto_path:
+            The path to the directory containing Protobuf files.
+        :param proto_files:
+            A mapping from human-readable file titles to Protobuf file names.
+            Each Protobuf file will yield a separate Markdown file containing
+            the contents of running `protoc-gen-doc` on the file. The file's
+            H1 title will be the human-readable title provided.
+        :param proto_template:
+            A path to a template file that will be passed to `protoc-gen-doc` in
+            order to generate Markdown for each Protobuf file. The template file
+            may contain a single `{{ .TitleFromPython }}` token that will be
+            replaced with the human-readable title for the Protobuf file, as
+            well as the standard `protoc-gen-doc` template tokens.
+        """
+        self.generated_dir = pathlib.Path(generated_dir).resolve()
+        self.tools_dir = pathlib.Path(tools_dir).resolve()
+
+        platform_key = get_platform_key()
+
+        self.protoc_version = protoc_version
+        self.protoc_platforms = protoc_platforms
+        self.protoc_url = f"https://github.com/protocolbuffers/protobuf/releases/download/v{self.protoc_version}/protoc-{self.protoc_version}-{self.protoc_platforms[platform_key]}.zip"
+
+        self.protoc_gen_doc_version = protoc_gen_doc_version
+        self.protoc_gen_doc_platforms = protoc_gen_doc_platforms
+        self.protoc_gen_doc_url = f"https://github.com/pseudomuto/protoc-gen-doc/releases/download/v{self.protoc_gen_doc_version}/protoc-gen-doc_{self.protoc_gen_doc_version}_{self.protoc_gen_doc_platforms[platform_key]}.tar.gz"
+
+        self.proto_path = pathlib.Path(proto_path).resolve()
+        self.proto_files = {
+            title: self.proto_path / file for title, file in proto_files.items()
+        }
+        self.proto_template = pathlib.Path(proto_template).resolve()
+
+        self.proto_generated_dir = self.generated_dir / "proto"
+        self.proto_tools_dir = self.tools_dir / "proto"
+        self.protoc = self.proto_tools_dir / "protoc"
+        self.protoc_gen_doc = self.proto_tools_dir / "protoc-gen-doc"
+
+
+def get_platform_key() -> str:
+    """Returns a key representing the current platform for use in configuration."""
+
+    uname = platform.uname()
+    platform_key = f"{uname.system}_{uname.machine}"
+    return platform_key
+
+
+def ensure_proto(config: Config) -> None:
+    """Ensures that Protobuf tools such as `protoc` and `protoc-gen-doc` are
+    installed."""
+
+    shutil.rmtree(config.proto_tools_dir, ignore_errors=True)
+    os.makedirs(config.proto_tools_dir, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with requests.get(
+            config.protoc_url, stream=True
+        ) as protoc_response, zipfile.ZipFile(
+            io.BytesIO(protoc_response.content)
+        ) as protoc_zip:
+            protoc_zip.extractall(path=tmpdir)
+
+        shutil.move(f"{tmpdir}/bin/protoc", config.protoc)
+        shutil.move(f"{tmpdir}/include", config.proto_tools_dir)
+        os.chmod(config.protoc, 0o755)
+
+        with requests.get(
+            config.protoc_gen_doc_url, stream=True
+        ) as protoc_gen_doc_response, tarfile.open(
+            fileobj=protoc_gen_doc_response.raw, mode="r:gz"
+        ) as protoc_gen_doc_tar:
+            protoc_gen_doc_tar.extractall(path=tmpdir)
+
+        shutil.move(f"{tmpdir}/protoc-gen-doc", config.protoc_gen_doc)
+        os.chmod(config.protoc_gen_doc, 0o755)
+
+
+def generate_proto(config: Config) -> None:
+    """Generates Markdown documentation for each configured Protobuf file."""
+
+    shutil.rmtree(config.proto_generated_dir, ignore_errors=True)
+    os.makedirs(config.proto_generated_dir, exist_ok=True)
+
+    template = config.proto_template.read_text(encoding="utf-8")
+    for title, file in config.proto_files.items():
+        with tempfile.NamedTemporaryFile() as tmpfile:
+            tmpfile.write(
+                template.replace("{{ .TitleFromPython }}", title).encode("utf-8")
+            )
+            tmpfile.flush()
+
+            args = [
+                config.protoc,
+                f"--plugin=protoc-gen-doc={config.protoc_gen_doc}",
+                f"--doc_out={config.proto_generated_dir}",
+                f"--doc_opt={tmpfile.name},{file.stem}.md",
+                f"--proto_path={config.proto_path}",
+                f"{config.proto_path/file}",
+            ]
+            subprocess.run(args, check=True)
+
+
+TARGETS: dict[str, Callable[[Config], None]] = {
+    "ensure-proto": ensure_proto,
+    "generate-proto": generate_proto,
+}
+
+
+def main():
+    """The main program entry point."""
+
+    if len(sys.argv) < 2:
+        usage()
+
+    target = sys.argv[1]
+    if target not in TARGETS:
+        usage(f"unknown target '{target}'")
+
+    config = Config(
+        generated_dir="_generated",
+        tools_dir="_tools",
+        protoc_version="25.1",
+        protoc_platforms={
+            "Linux_x86_64": "linux-x86_64",
+            "Darwin_arm64": "osx-aarch_64",
+        },
+        protoc_gen_doc_version="1.5.1",
+        protoc_gen_doc_platforms={
+            "Linux_x86_64": "linux_amd64",
+            "Darwin_arm64": "darwin_arm64",
+        },
+        proto_path="../proto",
+        proto_files={
+            "Aliasing": "pulumi/alias.proto",
+            "Analysis": "pulumi/analyzer.proto",
+            "Callbacks": "pulumi/callback.proto",
+            "Engine services": "pulumi/engine.proto",
+            "Errors": "pulumi/errors.proto",
+            "Language hosts": "pulumi/language.proto",
+            "Plugins": "pulumi/plugin.proto",
+            "Program conversion": "pulumi/converter.proto",
+            "Providers": "pulumi/provider.proto",
+            "Resource registration": "pulumi/resource.proto",
+            "Schema loading": "pulumi/codegen/loader.proto",
+            "Source positions": "pulumi/source.proto",
+        },
+        proto_template="references/proto.md.tmpl",
+    )
+
+    TARGETS[target](config)
+
+
+def usage(error: Optional[str] = None):
+    """Prints usage information and exits with a non-zero status."""
+
+    if error:
+        print(f"Error: {error}")
+
+    print("Usage: python make.py [target]")
+    print()
+    print("Targets:")
+    for target in sorted(TARGETS):
+        print(f"  {target}")
+
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/references/README.md
+++ b/docs/references/README.md
@@ -1,0 +1,12 @@
+# References
+
+This section of the documentation is intended to serve as an index for various
+pieces of machine-generated documentation (e.g. docstrings from Protobuf files,
+TypeDocs from the NodeJS/TypeScript SDK, and so on).
+
+:::{toctree}
+:maxdepth: 2
+:titlesonly:
+
+/proto/README
+:::

--- a/docs/references/proto.md.tmpl
+++ b/docs/references/proto.md.tmpl
@@ -1,0 +1,51 @@
+{{- range .Files -}}
+# {{ .TitleFromPython }}
+<gh-file:pulumi#proto/{{ .Name }}>
+
+{{ if .Services -}}
+## Services
+{{- range .Services -}}
+{{- $ServiceName := .FullName }}
+
+({{ .FullName }})=
+### 🔌 {{ .Name }}
+{{ .Description }}
+
+{{ range .Methods }}
+({{ $ServiceName }}.{{ .Name }})=
+#### 📞 {{ .Name }}
+
+⤵️ [{{ .RequestLongType }}](#{{ .RequestFullType }}) ⤴️ [{{ .ResponseLongType }}](#{{ .ResponseFullType }})
+
+{{ .Description }}
+
+{{ end }}{{- /* range .Methods */ -}}
+
+{{ end }}{{- /* range .Services */ -}}
+
+{{ end }}{{- /* if .Services */ -}}
+
+{{ if .Messages -}}
+## Messages
+{{ range .Messages -}}
+{{- $MessageName := .FullName -}}
+
+({{ .FullName }})=
+### 📨 {{ .Name }}
+{{ .Description }}
+
+{{ range .Fields }}
+`{{ .Name }}` [{{ .LongType }}](#{{ .FullType }})
+: {{ if .Description -}}
+    {{ .Description | indent 2 }}
+  {{- else -}}
+    &lt;No description&gt;
+  {{- end }}
+
+{{ end }}{{- /* range .Fields */ -}}
+
+{{ end }}{{- /* range .Messages */ -}}
+
+{{ end }}{{- /* if .Messages */ -}}
+
+{{ end }}{{- /* range .Files */ -}}

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -126,8 +126,14 @@ html_title = "Pulumi developer documentation"
 html_logo = "https://www.pulumi.com/images/logo/logo-on-white-box.svg"
 
 html_theme_options = {
-    # Show all headings up to level 2 in the sidebar table of contents.
-    "show_toc_levels": 2,
+    # Expand all headings up to level 2 by default in the left sidebar (global)
+    # table of contents.
+    "show_navbar_depth": 2,
+    # Show all headings up to level 2 in the right sidebar (in-page) table of
+    # contents.
+    "show_toc_level": 2,
+    # Expand all headings up to level 2 by default in the sidebar table of
+    # contents.
     # Enable margin notes
     # (https://sphinx-book-theme.readthedocs.io/en/stable/content/content-blocks.html#sidenotes-and-marginnotes).
     "use_sidenotes": True,

--- a/proto/README.md
+++ b/proto/README.md
@@ -1,0 +1,51 @@
+# Protobuf and gRPC interfaces
+
+This package contains [Protobuf definitions](https://protobuf.dev) for the
+various types, messages and interfaces that Pulumi components use to
+communicate. These definitions serve as the source of truth for several parts of
+the wider codebase.
+
+## Code generation
+
+:::{note}
+Code generated from Protobuf files is committed to the repository. If you change
+one or more `.proto` files, you should run `make build_proto` to regenerate the
+necessary stubs and commit the changes as part of the same piece of work.
+:::
+
+The <gh-file:pulumi#proto/generate.sh> script in this directory (called by the
+`build_proto` target in the top-level <gh-file:pulumi#Makefile>) generates types
+and gRPC clients for the languages supported in this repository (Go,
+NodeJS/TypeScript and Python). Generated code is committed to the repository,
+typically in `proto` directories at the relevant use sites (e.g.
+<gh-file:pulumi#sdk/nodejs/proto>).
+
+## Documentation
+
+We use the [`protoc-gen-doc`
+plugin](https://github.com/pseudomuto/protoc-gen-doc) to `protoc` to generate
+Markdown documentation from the Protobuf files. This process is handled by the
+<gh-file:pulumi#docs/Makefile> in the `docs` directory and uses the
+<gh-file:pulumi#docs/references/proto.md.tmpl> template. Generated documentation ends
+up in the `docs/_generated` directory (which is `.gitignore`d), so e.g. this
+index links to files in this folder.
+
+## Index
+
+:::{toctree}
+:maxdepth: 1
+:titlesonly:
+
+/docs/_generated/proto/resource
+/docs/_generated/proto/provider
+/docs/_generated/proto/plugin
+/docs/_generated/proto/language
+/docs/_generated/proto/callback
+/docs/_generated/proto/loader
+/docs/_generated/proto/converter
+/docs/_generated/proto/analyzer
+/docs/_generated/proto/alias
+/docs/_generated/proto/engine
+/docs/_generated/proto/errors
+/docs/_generated/proto/source
+:::


### PR DESCRIPTION
This commit ports over some of the old content from `developer-docs`. While there we flesh out some bits, freshen up others by linking to our newly-generated Protobuf documentation, and migrate the various diagrams to Mermaid so that they can e.g. support zooming in the browser with D3.