### PR TITLE
Keep the token source loop going in the face of errors

### DIFF
--- a/changelog/pending/20240922--engine--fix-token-expired-errors-due-to-network-issues.yaml
+++ b/changelog/pending/20240922--engine--fix-token-expired-errors-due-to-network-issues.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix token expired errors due to network issues

--- a/pkg/backend/httpstate/token_source.go
+++ b/pkg/backend/httpstate/token_source.go
@@ -16,6 +16,7 @@ package httpstate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -35,6 +36,18 @@ type tokenSource struct {
 var _ tokenSourceCapability = &tokenSource{}
 
 type tokenRequest chan<- tokenResponse
+
+type expiredTokenError struct {
+	err error
+}
+
+func (e expiredTokenError) Error() string {
+	return fmt.Sprintf("token expired: %v", e.err)
+}
+
+func (e expiredTokenError) Unwrap() error {
+	return e.err
+}
 
 type tokenResponse struct {
 	token string
@@ -96,11 +109,16 @@ func (ts *tokenSource) handleRequests(
 		}
 
 		newToken, newTokenExpires, err := refreshToken(ctx, duration, state.token)
-		// If renew failed, all further GetToken requests will return this error.
-		if err != nil {
+		// Renewing might fail because of network issues, or because the token is no longer valid.
+		// We only care about the latter, if its just a network issue we should retry again.
+		var expired expiredTokenError
+		if errors.As(err, &expired) {
 			logging.V(3).Infof("error renewing lease: %v", err)
 			state.error = fmt.Errorf("renewing lease: %w", err)
 			renewTicker.Stop()
+		} else if err != nil {
+			// If we failed to renew the lease, we will retry in the next cycle.
+			logging.V(3).Infof("error renewing lease: %v", err)
 		} else {
 			state.token = newToken
 			state.expires = newTokenExpires

--- a/pkg/backend/httpstate/token_source_test.go
+++ b/pkg/backend/httpstate/token_source_test.go
@@ -16,8 +16,9 @@ package httpstate
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"runtime"
+	"math/rand"
 	"sync"
 	"testing"
 	"time"
@@ -26,11 +27,6 @@ import (
 )
 
 func TestTokenSource(t *testing.T) {
-	// TODO[pulumi/pulumi#16500] fix flaky test and unskip
-	t.Skip("Skipping flaky test: TODO[pulumi/pulumi#16500] to unskip")
-	if runtime.GOOS == "windows" {
-		t.Skip("Flaky on Windows CI workers due to the use of timer+Sleep")
-	}
 	t.Parallel()
 
 	ctx := context.Background()
@@ -64,11 +60,6 @@ func TestTokenSource(t *testing.T) {
 }
 
 func TestTokenSourceWithQuicklyExpiringInitialToken(t *testing.T) {
-	// TODO[pulumi/pulumi#16500] fix flaky test and unskip
-	t.Skip("Skipping flaky test: TODO[pulumi/pulumi#16500] to unskip")
-	if runtime.GOOS == "windows" {
-		t.Skip("Flaky on Windows CI workers due to the use of timer+Sleep")
-	}
 	t.Parallel()
 
 	ctx := context.Background()
@@ -108,6 +99,12 @@ func (ts *testTokenBackend) Refresh(
 ) (string, time.Time, error) {
 	ts.mu.Lock()
 	defer ts.mu.Unlock()
+
+	// Simulate some network errors
+	if rand.Float32() < 0.1 { //nolint:gosec // test is not security sensitive
+		return "", time.Time{}, errors.New("network error")
+	}
+
 	if err := ts.verifyTokenInner(currentToken); err != nil {
 		return "", time.Time{}, err
 	}
@@ -144,12 +141,12 @@ func (ts *testTokenBackend) verifyTokenInner(token string) error {
 	now := time.Now()
 	expires, gotCurrentToken := ts.tokens[token]
 	if !gotCurrentToken {
-		return fmt.Errorf("Unknown token: %v", token)
+		return expiredTokenError{fmt.Errorf("Unknown token: %v", token)}
 	}
 
 	if now.After(expires) {
-		return fmt.Errorf("Expired token %v (%v past expiration)",
-			token, now.Sub(expires))
+		return expiredTokenError{fmt.Errorf("Expired token %v (%v past expiration)",
+			token, now.Sub(expires))}
 	}
 	return nil
 }


### PR DESCRIPTION
Currently the token source loop will stop if `refreshToken` ever returns an error, regardless of what that error is. While the API call to the service does have some retry logic at it's level it can still potentially return an error just due to transient network/server conditions. In that case the refreh loop will just stop working and the token will eventually expire.

This changes the token source to keep going until it gets a specific `expiredTokenError` error. This should make it more resilient to network issues.

Towards fixing https://github.com/pulumi/pulumi/issues/7094.