### PR TITLE
[go] Allow output-versioned invokes to resolve and maintain secrets

### DIFF
--- a/changelog/pending/20240901--sdkgen-go--allow-output-versioned-invokes-to-resolve-and-maintain-secrets.yaml
+++ b/changelog/pending/20240901--sdkgen-go--allow-output-versioned-invokes-to-resolve-and-maintain-secrets.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/go
+  description: Allow output-versioned invokes to resolve and maintain secrets

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -659,40 +659,33 @@ func (ctx *Context) Invoke(tok string, args interface{}, result interface{}, opt
 // InvokePackage will invoke a provider's function, identified by its token tok. This function call is synchronous.
 //
 // args and result must be pointers to struct values fields and appropriately tagged and typed for use with Pulumi.
-func (ctx *Context) InvokePackage(
-	tok string, args interface{}, result interface{}, packageRef string, opts ...InvokeOption,
-) (err error) {
+func (ctx *Context) invokePackageRaw(
+	tok string, args interface{}, packageRef string, opts ...InvokeOption,
+) (resource.PropertyMap, error) {
 	if tok == "" {
-		return errors.New("invoke token must not be empty")
-	}
-
-	resultV := reflect.ValueOf(result)
-	if !(resultV.Kind() == reflect.Ptr &&
-		(resultV.Elem().Kind() == reflect.Struct ||
-			(resultV.Elem().Kind() == reflect.Map && resultV.Elem().Type().Key().Kind() == reflect.String))) {
-		return errors.New("result must be a pointer to a struct or map value")
+		return nil, errors.New("invoke token must not be empty")
 	}
 
 	options, err := NewInvokeOptions(opts...)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Note that we're about to make an outstanding RPC request, so that we can rendezvous during shutdown.
 	if err = ctx.beginRPC(); err != nil {
-		return err
+		return nil, err
 	}
 	defer ctx.endRPC(err)
 
 	var providerRef string
 	providers, err := ctx.mergeProviders(tok, options.Parent, options.Provider, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if provider := providers[getPackage(tok)]; provider != nil {
 		pr, err := ctx.resolveProviderReference(provider)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		providerRef = pr
 	}
@@ -703,7 +696,7 @@ func (ctx *Context) InvokePackage(
 	}
 	resolvedArgs, _, err := marshalInput(args, anyType, false)
 	if err != nil {
-		return fmt.Errorf("marshaling arguments: %w", err)
+		return nil, fmt.Errorf("marshaling arguments: %w", err)
 	}
 
 	resolvedArgsMap := resource.PropertyMap{}
@@ -720,7 +713,7 @@ func (ctx *Context) InvokePackage(
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("marshaling arguments: %w", err)
+		return nil, fmt.Errorf("marshaling arguments: %w", err)
 	}
 
 	// Now, invoke the RPC to the provider synchronously.
@@ -736,7 +729,7 @@ func (ctx *Context) InvokePackage(
 	})
 	if err != nil {
 		logging.V(9).Infof("Invoke(%s, ...): error: %v", tok, err)
-		return err
+		return nil, err
 	}
 
 	// If there were any failures from the provider, return them.
@@ -747,32 +740,71 @@ func (ctx *Context) InvokePackage(
 			ferr = multierror.Append(ferr,
 				fmt.Errorf("%s invoke failed: %s (%s)", tok, failure.Reason, failure.Property))
 		}
-		return ferr
+		return nil, ferr
 	}
 
 	// Otherwise, simply unmarshal the output properties and return the result.
-	outProps, err := plugin.UnmarshalProperties(
+	return plugin.UnmarshalProperties(
 		resp.Return,
 		plugin.MarshalOptions{
 			KeepUnknowns:  true,
 			KeepSecrets:   true,
 			KeepResources: true,
-		},
-	)
-	if err != nil {
-		return err
+		})
+}
+
+func validInvokeResult(resultV reflect.Value) bool {
+	isPointer := resultV.Kind() == reflect.Ptr
+	isMap := resultV.Elem().Kind() == reflect.Map && resultV.Elem().Type().Key().Kind() == reflect.String
+	structOrMap := resultV.Elem().Kind() == reflect.Struct || isMap
+	return isPointer && structOrMap
+}
+
+// InvokePackage will invoke a provider's function, identified by its token tok. This function call is synchronous.
+//
+// args and result must be pointers to struct values fields and appropriately tagged and typed for use with Pulumi.
+func (ctx *Context) InvokePackage(
+	tok string, args interface{}, result interface{}, packageRef string, opts ...InvokeOption,
+) error {
+	resultV := reflect.ValueOf(result)
+	if !validInvokeResult(resultV) {
+		return errors.New("result must be a pointer to a struct or map value")
 	}
 
-	// fail if there are secrets returned from the invoke
-	hasSecret, err := unmarshalOutput(ctx, resource.NewObjectProperty(outProps), resultV.Elem())
+	outProps, err := ctx.invokePackageRaw(tok, args, packageRef, opts...)
 	if err != nil {
 		return err
 	}
+	hasSecret, err := unmarshalOutput(ctx, resource.NewObjectProperty(outProps), resultV.Elem())
+
 	if hasSecret {
-		return errors.New("unexpected secret result returned to invoke call")
+		return errors.New("unexpected secret result returned to invoke call, " +
+			"consider using the output-versioned variant of the invoke")
 	}
 	logging.V(9).Infof("Invoke(%s, ...): success: w/ %d outs (err=%v)", tok, len(outProps), err)
 	return nil
+}
+
+// InvokePackageRaw is similar to InvokePackage except that it doesn't error out if the result has secrets.
+// Insread, it returns a boolean indicating if the result has secrets.
+func (ctx *Context) InvokePackageRaw(
+	tok string, args interface{}, result interface{}, packageRef string, opts ...InvokeOption,
+) (isSecret bool, err error) {
+	resultV := reflect.ValueOf(result)
+	if !validInvokeResult(resultV) {
+		return false, errors.New("result must be a pointer to a struct or map value")
+	}
+
+	outProps, err := ctx.invokePackageRaw(tok, args, packageRef, opts...)
+	if err != nil {
+		return false, err
+	}
+	hasSecret, err := unmarshalOutput(ctx, resource.NewObjectProperty(outProps), resultV.Elem())
+	if err != nil {
+		return false, err
+	}
+	logging.V(9).Infof("InvokePackageRaw(%s, ...): success: w/ %d outs (err=%v)", tok, len(outProps), err)
+	return hasSecret, nil
 }
 
 // Call will invoke a provider call function, identified by its token tok.

--- a/tests/testdata/codegen/assets-and-archives/go/example/getAssets.go
+++ b/tests/testdata/codegen/assets-and-archives/go/example/getAssets.go
@@ -33,14 +33,20 @@ type GetAssetsResult struct {
 
 func GetAssetsOutput(ctx *pulumi.Context, args GetAssetsOutputArgs, opts ...pulumi.InvokeOption) GetAssetsResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (GetAssetsResult, error) {
+		ApplyT(func(v interface{}) (GetAssetsResultOutput, error) {
 			args := v.(GetAssetsArgs)
-			r, err := GetAssets(ctx, &args, opts...)
-			var s GetAssetsResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv GetAssetsResult
+			secret, err := ctx.InvokePackageRaw("example::GetAssets", args, &rv, "", opts...)
+			if err != nil {
+				return GetAssetsResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(GetAssetsResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(GetAssetsResultOutput), nil
+			}
+			return output, nil
 		}).(GetAssetsResultOutput)
 }
 

--- a/tests/testdata/codegen/external-resource-schema/go/example/argFunction.go
+++ b/tests/testdata/codegen/external-resource-schema/go/example/argFunction.go
@@ -32,14 +32,20 @@ type ArgFunctionResult struct {
 
 func ArgFunctionOutput(ctx *pulumi.Context, args ArgFunctionOutputArgs, opts ...pulumi.InvokeOption) ArgFunctionResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (ArgFunctionResult, error) {
+		ApplyT(func(v interface{}) (ArgFunctionResultOutput, error) {
 			args := v.(ArgFunctionArgs)
-			r, err := ArgFunction(ctx, &args, opts...)
-			var s ArgFunctionResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv ArgFunctionResult
+			secret, err := ctx.InvokePackageRaw("example::argFunction", args, &rv, "", opts...)
+			if err != nil {
+				return ArgFunctionResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(ArgFunctionResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(ArgFunctionResultOutput), nil
+			}
+			return output, nil
 		}).(ArgFunctionResultOutput)
 }
 

--- a/tests/testdata/codegen/functions-secrets/go/mypkg/funcWithSecrets.go
+++ b/tests/testdata/codegen/functions-secrets/go/mypkg/funcWithSecrets.go
@@ -35,14 +35,20 @@ type FuncWithSecretsResult struct {
 
 func FuncWithSecretsOutput(ctx *pulumi.Context, args FuncWithSecretsOutputArgs, opts ...pulumi.InvokeOption) FuncWithSecretsResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (FuncWithSecretsResult, error) {
+		ApplyT(func(v interface{}) (FuncWithSecretsResultOutput, error) {
 			args := v.(FuncWithSecretsArgs)
-			r, err := FuncWithSecrets(ctx, &args, opts...)
-			var s FuncWithSecretsResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv FuncWithSecretsResult
+			secret, err := ctx.InvokePackageRaw("mypkg::funcWithSecrets", args, &rv, "", opts...)
+			if err != nil {
+				return FuncWithSecretsResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(FuncWithSecretsResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(FuncWithSecretsResultOutput), nil
+			}
+			return output, nil
 		}).(FuncWithSecretsResultOutput)
 }
 

--- a/tests/testdata/codegen/go-overridden-internal-module-name/go/example/argFunction.go
+++ b/tests/testdata/codegen/go-overridden-internal-module-name/go/example/argFunction.go
@@ -31,14 +31,20 @@ type ArgFunctionResult struct {
 
 func ArgFunctionOutput(ctx *pulumi.Context, args ArgFunctionOutputArgs, opts ...pulumi.InvokeOption) ArgFunctionResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (ArgFunctionResult, error) {
+		ApplyT(func(v interface{}) (ArgFunctionResultOutput, error) {
 			args := v.(ArgFunctionArgs)
-			r, err := ArgFunction(ctx, &args, opts...)
-			var s ArgFunctionResult
-			if r != nil {
-				s = *r
+			opts = utilities.PkgInvokeDefaultOpts(opts)
+			var rv ArgFunctionResult
+			secret, err := ctx.InvokePackageRaw("example::argFunction", args, &rv, "", opts...)
+			if err != nil {
+				return ArgFunctionResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(ArgFunctionResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(ArgFunctionResultOutput), nil
+			}
+			return output, nil
 		}).(ArgFunctionResultOutput)
 }
 

--- a/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/listConfigurations.go
+++ b/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/listConfigurations.go
@@ -42,14 +42,20 @@ type ListConfigurationsResult struct {
 
 func ListConfigurationsOutput(ctx *pulumi.Context, args ListConfigurationsOutputArgs, opts ...pulumi.InvokeOption) ListConfigurationsResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (ListConfigurationsResult, error) {
+		ApplyT(func(v interface{}) (ListConfigurationsResultOutput, error) {
 			args := v.(ListConfigurationsArgs)
-			r, err := ListConfigurations(ctx, &args, opts...)
-			var s ListConfigurationsResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv ListConfigurationsResult
+			secret, err := ctx.InvokePackageRaw("myedgeorder::listConfigurations", args, &rv, "", opts...)
+			if err != nil {
+				return ListConfigurationsResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(ListConfigurationsResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(ListConfigurationsResultOutput), nil
+			}
+			return output, nil
 		}).(ListConfigurationsResultOutput)
 }
 

--- a/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/listProductFamilies.go
+++ b/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/listProductFamilies.go
@@ -44,14 +44,20 @@ type ListProductFamiliesResult struct {
 
 func ListProductFamiliesOutput(ctx *pulumi.Context, args ListProductFamiliesOutputArgs, opts ...pulumi.InvokeOption) ListProductFamiliesResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (ListProductFamiliesResult, error) {
+		ApplyT(func(v interface{}) (ListProductFamiliesResultOutput, error) {
 			args := v.(ListProductFamiliesArgs)
-			r, err := ListProductFamilies(ctx, &args, opts...)
-			var s ListProductFamiliesResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv ListProductFamiliesResult
+			secret, err := ctx.InvokePackageRaw("myedgeorder::listProductFamilies", args, &rv, "", opts...)
+			if err != nil {
+				return ListProductFamiliesResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(ListProductFamiliesResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(ListProductFamiliesResultOutput), nil
+			}
+			return output, nil
 		}).(ListProductFamiliesResultOutput)
 }
 

--- a/tests/testdata/codegen/output-funcs-tfbridge20/go/mypkg/getAmiIds.go
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/go/mypkg/getAmiIds.go
@@ -59,14 +59,20 @@ type GetAmiIdsResult struct {
 
 func GetAmiIdsOutput(ctx *pulumi.Context, args GetAmiIdsOutputArgs, opts ...pulumi.InvokeOption) GetAmiIdsResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (GetAmiIdsResult, error) {
+		ApplyT(func(v interface{}) (GetAmiIdsResultOutput, error) {
 			args := v.(GetAmiIdsArgs)
-			r, err := GetAmiIds(ctx, &args, opts...)
-			var s GetAmiIdsResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv GetAmiIdsResult
+			secret, err := ctx.InvokePackageRaw("mypkg::getAmiIds", args, &rv, "", opts...)
+			if err != nil {
+				return GetAmiIdsResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(GetAmiIdsResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(GetAmiIdsResultOutput), nil
+			}
+			return output, nil
 		}).(GetAmiIdsResultOutput)
 }
 

--- a/tests/testdata/codegen/output-funcs-tfbridge20/go/mypkg/listStorageAccountKeys.go
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/go/mypkg/listStorageAccountKeys.go
@@ -40,14 +40,20 @@ type ListStorageAccountKeysResult struct {
 
 func ListStorageAccountKeysOutput(ctx *pulumi.Context, args ListStorageAccountKeysOutputArgs, opts ...pulumi.InvokeOption) ListStorageAccountKeysResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (ListStorageAccountKeysResult, error) {
+		ApplyT(func(v interface{}) (ListStorageAccountKeysResultOutput, error) {
 			args := v.(ListStorageAccountKeysArgs)
-			r, err := ListStorageAccountKeys(ctx, &args, opts...)
-			var s ListStorageAccountKeysResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv ListStorageAccountKeysResult
+			secret, err := ctx.InvokePackageRaw("mypkg::listStorageAccountKeys", args, &rv, "", opts...)
+			if err != nil {
+				return ListStorageAccountKeysResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(ListStorageAccountKeysResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(ListStorageAccountKeysResultOutput), nil
+			}
+			return output, nil
 		}).(ListStorageAccountKeysResultOutput)
 }
 

--- a/tests/testdata/codegen/output-funcs/go-extras/tests/codegen_test.go
+++ b/tests/testdata/codegen/output-funcs/go-extras/tests/codegen_test.go
@@ -70,7 +70,12 @@ func (mocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
 		outputs := map[string]interface{}{
 			"keys": result.Keys,
 		}
-		return resource.NewPropertyMapFromMap(outputs), nil
+		invokeResponse := resource.NewPropertyMapFromMap(outputs)
+		// turn every field into a secret
+		for k, v := range invokeResponse {
+			invokeResponse[k] = resource.MakeSecret(v)
+		}
+		return invokeResponse, nil
 
 	case "mypkg::funcWithDefaultValue",
 		"mypkg::funcWithAllOptionalInputs",

--- a/tests/testdata/codegen/output-funcs/go/mypkg/funcWithAllOptionalInputs.go
+++ b/tests/testdata/codegen/output-funcs/go/mypkg/funcWithAllOptionalInputs.go
@@ -36,14 +36,20 @@ type FuncWithAllOptionalInputsResult struct {
 
 func FuncWithAllOptionalInputsOutput(ctx *pulumi.Context, args FuncWithAllOptionalInputsOutputArgs, opts ...pulumi.InvokeOption) FuncWithAllOptionalInputsResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (FuncWithAllOptionalInputsResult, error) {
+		ApplyT(func(v interface{}) (FuncWithAllOptionalInputsResultOutput, error) {
 			args := v.(FuncWithAllOptionalInputsArgs)
-			r, err := FuncWithAllOptionalInputs(ctx, &args, opts...)
-			var s FuncWithAllOptionalInputsResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv FuncWithAllOptionalInputsResult
+			secret, err := ctx.InvokePackageRaw("mypkg::funcWithAllOptionalInputs", args, &rv, "", opts...)
+			if err != nil {
+				return FuncWithAllOptionalInputsResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(FuncWithAllOptionalInputsResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(FuncWithAllOptionalInputsResultOutput), nil
+			}
+			return output, nil
 		}).(FuncWithAllOptionalInputsResultOutput)
 }
 

--- a/tests/testdata/codegen/output-funcs/go/mypkg/funcWithDefaultValue.go
+++ b/tests/testdata/codegen/output-funcs/go/mypkg/funcWithDefaultValue.go
@@ -47,14 +47,20 @@ type FuncWithDefaultValueResult struct {
 
 func FuncWithDefaultValueOutput(ctx *pulumi.Context, args FuncWithDefaultValueOutputArgs, opts ...pulumi.InvokeOption) FuncWithDefaultValueResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (FuncWithDefaultValueResult, error) {
+		ApplyT(func(v interface{}) (FuncWithDefaultValueResultOutput, error) {
 			args := v.(FuncWithDefaultValueArgs)
-			r, err := FuncWithDefaultValue(ctx, &args, opts...)
-			var s FuncWithDefaultValueResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv FuncWithDefaultValueResult
+			secret, err := ctx.InvokePackageRaw("mypkg::funcWithDefaultValue", args.Defaults(), &rv, "", opts...)
+			if err != nil {
+				return FuncWithDefaultValueResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(FuncWithDefaultValueResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(FuncWithDefaultValueResultOutput), nil
+			}
+			return output, nil
 		}).(FuncWithDefaultValueResultOutput)
 }
 

--- a/tests/testdata/codegen/output-funcs/go/mypkg/funcWithDictParam.go
+++ b/tests/testdata/codegen/output-funcs/go/mypkg/funcWithDictParam.go
@@ -34,14 +34,20 @@ type FuncWithDictParamResult struct {
 
 func FuncWithDictParamOutput(ctx *pulumi.Context, args FuncWithDictParamOutputArgs, opts ...pulumi.InvokeOption) FuncWithDictParamResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (FuncWithDictParamResult, error) {
+		ApplyT(func(v interface{}) (FuncWithDictParamResultOutput, error) {
 			args := v.(FuncWithDictParamArgs)
-			r, err := FuncWithDictParam(ctx, &args, opts...)
-			var s FuncWithDictParamResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv FuncWithDictParamResult
+			secret, err := ctx.InvokePackageRaw("mypkg::funcWithDictParam", args, &rv, "", opts...)
+			if err != nil {
+				return FuncWithDictParamResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(FuncWithDictParamResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(FuncWithDictParamResultOutput), nil
+			}
+			return output, nil
 		}).(FuncWithDictParamResultOutput)
 }
 

--- a/tests/testdata/codegen/output-funcs/go/mypkg/funcWithListParam.go
+++ b/tests/testdata/codegen/output-funcs/go/mypkg/funcWithListParam.go
@@ -34,14 +34,20 @@ type FuncWithListParamResult struct {
 
 func FuncWithListParamOutput(ctx *pulumi.Context, args FuncWithListParamOutputArgs, opts ...pulumi.InvokeOption) FuncWithListParamResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (FuncWithListParamResult, error) {
+		ApplyT(func(v interface{}) (FuncWithListParamResultOutput, error) {
 			args := v.(FuncWithListParamArgs)
-			r, err := FuncWithListParam(ctx, &args, opts...)
-			var s FuncWithListParamResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv FuncWithListParamResult
+			secret, err := ctx.InvokePackageRaw("mypkg::funcWithListParam", args, &rv, "", opts...)
+			if err != nil {
+				return FuncWithListParamResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(FuncWithListParamResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(FuncWithListParamResultOutput), nil
+			}
+			return output, nil
 		}).(FuncWithListParamResultOutput)
 }
 

--- a/tests/testdata/codegen/output-funcs/go/mypkg/getBastionShareableLink.go
+++ b/tests/testdata/codegen/output-funcs/go/mypkg/getBastionShareableLink.go
@@ -41,14 +41,20 @@ type GetBastionShareableLinkResult struct {
 
 func GetBastionShareableLinkOutput(ctx *pulumi.Context, args GetBastionShareableLinkOutputArgs, opts ...pulumi.InvokeOption) GetBastionShareableLinkResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (GetBastionShareableLinkResult, error) {
+		ApplyT(func(v interface{}) (GetBastionShareableLinkResultOutput, error) {
 			args := v.(GetBastionShareableLinkArgs)
-			r, err := GetBastionShareableLink(ctx, &args, opts...)
-			var s GetBastionShareableLinkResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv GetBastionShareableLinkResult
+			secret, err := ctx.InvokePackageRaw("mypkg::getBastionShareableLink", args, &rv, "", opts...)
+			if err != nil {
+				return GetBastionShareableLinkResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(GetBastionShareableLinkResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(GetBastionShareableLinkResultOutput), nil
+			}
+			return output, nil
 		}).(GetBastionShareableLinkResultOutput)
 }
 

--- a/tests/testdata/codegen/output-funcs/go/mypkg/getClientConfig.go
+++ b/tests/testdata/codegen/output-funcs/go/mypkg/getClientConfig.go
@@ -36,13 +36,19 @@ type GetClientConfigResult struct {
 }
 
 func GetClientConfigOutput(ctx *pulumi.Context, opts ...pulumi.InvokeOption) GetClientConfigResultOutput {
-	return pulumi.ToOutput(0).ApplyT(func(int) (GetClientConfigResult, error) {
-		r, err := GetClientConfig(ctx, opts...)
-		var s GetClientConfigResult
-		if r != nil {
-			s = *r
+	return pulumi.ToOutput(0).ApplyT(func(int) (GetClientConfigResultOutput, error) {
+		opts = internal.PkgInvokeDefaultOpts(opts)
+		var rv GetClientConfigResult
+		secret, err := ctx.InvokePackageRaw("mypkg::getClientConfig", nil, &rv, "", opts...)
+		if err != nil {
+			return GetClientConfigResultOutput{}, err
 		}
-		return s, err
+
+		output := pulumi.ToOutput(rv).(GetClientConfigResultOutput)
+		if secret {
+			return pulumi.ToSecret(output).(GetClientConfigResultOutput), nil
+		}
+		return output, nil
 	}).(GetClientConfigResultOutput)
 }
 

--- a/tests/testdata/codegen/output-funcs/go/mypkg/getIntegrationRuntimeObjectMetadatum.go
+++ b/tests/testdata/codegen/output-funcs/go/mypkg/getIntegrationRuntimeObjectMetadatum.go
@@ -45,14 +45,20 @@ type GetIntegrationRuntimeObjectMetadatumResult struct {
 
 func GetIntegrationRuntimeObjectMetadatumOutput(ctx *pulumi.Context, args GetIntegrationRuntimeObjectMetadatumOutputArgs, opts ...pulumi.InvokeOption) GetIntegrationRuntimeObjectMetadatumResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (GetIntegrationRuntimeObjectMetadatumResult, error) {
+		ApplyT(func(v interface{}) (GetIntegrationRuntimeObjectMetadatumResultOutput, error) {
 			args := v.(GetIntegrationRuntimeObjectMetadatumArgs)
-			r, err := GetIntegrationRuntimeObjectMetadatum(ctx, &args, opts...)
-			var s GetIntegrationRuntimeObjectMetadatumResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv GetIntegrationRuntimeObjectMetadatumResult
+			secret, err := ctx.InvokePackageRaw("mypkg::getIntegrationRuntimeObjectMetadatum", args, &rv, "", opts...)
+			if err != nil {
+				return GetIntegrationRuntimeObjectMetadatumResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(GetIntegrationRuntimeObjectMetadatumResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(GetIntegrationRuntimeObjectMetadatumResultOutput), nil
+			}
+			return output, nil
 		}).(GetIntegrationRuntimeObjectMetadatumResultOutput)
 }
 

--- a/tests/testdata/codegen/output-funcs/go/mypkg/listStorageAccountKeys.go
+++ b/tests/testdata/codegen/output-funcs/go/mypkg/listStorageAccountKeys.go
@@ -41,14 +41,20 @@ type ListStorageAccountKeysResult struct {
 
 func ListStorageAccountKeysOutput(ctx *pulumi.Context, args ListStorageAccountKeysOutputArgs, opts ...pulumi.InvokeOption) ListStorageAccountKeysResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (ListStorageAccountKeysResult, error) {
+		ApplyT(func(v interface{}) (ListStorageAccountKeysResultOutput, error) {
 			args := v.(ListStorageAccountKeysArgs)
-			r, err := ListStorageAccountKeys(ctx, &args, opts...)
-			var s ListStorageAccountKeysResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv ListStorageAccountKeysResult
+			secret, err := ctx.InvokePackageRaw("mypkg::listStorageAccountKeys", args, &rv, "", opts...)
+			if err != nil {
+				return ListStorageAccountKeysResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(ListStorageAccountKeysResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(ListStorageAccountKeysResultOutput), nil
+			}
+			return output, nil
 		}).(ListStorageAccountKeysResultOutput)
 }
 

--- a/tests/testdata/codegen/plain-object-defaults/go/example/funcWithAllOptionalInputs.go
+++ b/tests/testdata/codegen/plain-object-defaults/go/example/funcWithAllOptionalInputs.go
@@ -50,14 +50,20 @@ type FuncWithAllOptionalInputsResult struct {
 
 func FuncWithAllOptionalInputsOutput(ctx *pulumi.Context, args FuncWithAllOptionalInputsOutputArgs, opts ...pulumi.InvokeOption) FuncWithAllOptionalInputsResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (FuncWithAllOptionalInputsResult, error) {
+		ApplyT(func(v interface{}) (FuncWithAllOptionalInputsResultOutput, error) {
 			args := v.(FuncWithAllOptionalInputsArgs)
-			r, err := FuncWithAllOptionalInputs(ctx, &args, opts...)
-			var s FuncWithAllOptionalInputsResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv FuncWithAllOptionalInputsResult
+			secret, err := ctx.InvokePackageRaw("example::funcWithAllOptionalInputs", args.Defaults(), &rv, "", opts...)
+			if err != nil {
+				return FuncWithAllOptionalInputsResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(FuncWithAllOptionalInputsResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(FuncWithAllOptionalInputsResultOutput), nil
+			}
+			return output, nil
 		}).(FuncWithAllOptionalInputsResultOutput)
 }
 

--- a/tests/testdata/codegen/plain-object-disable-defaults/go/example/funcWithAllOptionalInputs.go
+++ b/tests/testdata/codegen/plain-object-disable-defaults/go/example/funcWithAllOptionalInputs.go
@@ -35,14 +35,20 @@ type FuncWithAllOptionalInputsResult struct {
 
 func FuncWithAllOptionalInputsOutput(ctx *pulumi.Context, args FuncWithAllOptionalInputsOutputArgs, opts ...pulumi.InvokeOption) FuncWithAllOptionalInputsResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (FuncWithAllOptionalInputsResult, error) {
+		ApplyT(func(v interface{}) (FuncWithAllOptionalInputsResultOutput, error) {
 			args := v.(FuncWithAllOptionalInputsArgs)
-			r, err := FuncWithAllOptionalInputs(ctx, &args, opts...)
-			var s FuncWithAllOptionalInputsResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv FuncWithAllOptionalInputsResult
+			secret, err := ctx.InvokePackageRaw("mypkg::funcWithAllOptionalInputs", args, &rv, "", opts...)
+			if err != nil {
+				return FuncWithAllOptionalInputsResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(FuncWithAllOptionalInputsResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(FuncWithAllOptionalInputsResultOutput), nil
+			}
+			return output, nil
 		}).(FuncWithAllOptionalInputsResultOutput)
 }
 

--- a/tests/testdata/codegen/provider-config-schema/go/configstation/funcWithAllOptionalInputs.go
+++ b/tests/testdata/codegen/provider-config-schema/go/configstation/funcWithAllOptionalInputs.go
@@ -35,14 +35,20 @@ type FuncWithAllOptionalInputsResult struct {
 
 func FuncWithAllOptionalInputsOutput(ctx *pulumi.Context, args FuncWithAllOptionalInputsOutputArgs, opts ...pulumi.InvokeOption) FuncWithAllOptionalInputsResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (FuncWithAllOptionalInputsResult, error) {
+		ApplyT(func(v interface{}) (FuncWithAllOptionalInputsResultOutput, error) {
 			args := v.(FuncWithAllOptionalInputsArgs)
-			r, err := FuncWithAllOptionalInputs(ctx, &args, opts...)
-			var s FuncWithAllOptionalInputsResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv FuncWithAllOptionalInputsResult
+			secret, err := ctx.InvokePackageRaw("configstation::funcWithAllOptionalInputs", args, &rv, "", opts...)
+			if err != nil {
+				return FuncWithAllOptionalInputsResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(FuncWithAllOptionalInputsResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(FuncWithAllOptionalInputsResultOutput), nil
+			}
+			return output, nil
 		}).(FuncWithAllOptionalInputsResultOutput)
 }
 

--- a/tests/testdata/codegen/regress-8403/go/mongodbatlas/getCustomDbRoles.go
+++ b/tests/testdata/codegen/regress-8403/go/mongodbatlas/getCustomDbRoles.go
@@ -30,14 +30,20 @@ type LookupCustomDbRolesResult struct {
 
 func LookupCustomDbRolesOutput(ctx *pulumi.Context, args LookupCustomDbRolesOutputArgs, opts ...pulumi.InvokeOption) LookupCustomDbRolesResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (LookupCustomDbRolesResult, error) {
+		ApplyT(func(v interface{}) (LookupCustomDbRolesResultOutput, error) {
 			args := v.(LookupCustomDbRolesArgs)
-			r, err := LookupCustomDbRoles(ctx, &args, opts...)
-			var s LookupCustomDbRolesResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv LookupCustomDbRolesResult
+			secret, err := ctx.InvokePackageRaw("mongodbatlas::getCustomDbRoles", args, &rv, "", opts...)
+			if err != nil {
+				return LookupCustomDbRolesResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(LookupCustomDbRolesResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(LookupCustomDbRolesResultOutput), nil
+			}
+			return output, nil
 		}).(LookupCustomDbRolesResultOutput)
 }
 

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/go/example/argFunction.go
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/go/example/argFunction.go
@@ -31,14 +31,20 @@ type ArgFunctionResult struct {
 
 func ArgFunctionOutput(ctx *pulumi.Context, args ArgFunctionOutputArgs, opts ...pulumi.InvokeOption) ArgFunctionResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (ArgFunctionResult, error) {
+		ApplyT(func(v interface{}) (ArgFunctionResultOutput, error) {
 			args := v.(ArgFunctionArgs)
-			r, err := ArgFunction(ctx, &args, opts...)
-			var s ArgFunctionResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv ArgFunctionResult
+			secret, err := ctx.InvokePackageRaw("example::argFunction", args, &rv, "", opts...)
+			if err != nil {
+				return ArgFunctionResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(ArgFunctionResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(ArgFunctionResultOutput), nil
+			}
+			return output, nil
 		}).(ArgFunctionResultOutput)
 }
 

--- a/tests/testdata/codegen/simple-resource-schema/go/example/argFunction.go
+++ b/tests/testdata/codegen/simple-resource-schema/go/example/argFunction.go
@@ -31,14 +31,20 @@ type ArgFunctionResult struct {
 
 func ArgFunctionOutput(ctx *pulumi.Context, args ArgFunctionOutputArgs, opts ...pulumi.InvokeOption) ArgFunctionResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (ArgFunctionResult, error) {
+		ApplyT(func(v interface{}) (ArgFunctionResultOutput, error) {
 			args := v.(ArgFunctionArgs)
-			r, err := ArgFunction(ctx, &args, opts...)
-			var s ArgFunctionResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv ArgFunctionResult
+			secret, err := ctx.InvokePackageRaw("example::argFunction", args, &rv, "", opts...)
+			if err != nil {
+				return ArgFunctionResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(ArgFunctionResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(ArgFunctionResultOutput), nil
+			}
+			return output, nil
 		}).(ArgFunctionResultOutput)
 }
 

--- a/tests/testdata/codegen/simple-yaml-schema/go/example/argFunction.go
+++ b/tests/testdata/codegen/simple-yaml-schema/go/example/argFunction.go
@@ -31,14 +31,20 @@ type ArgFunctionResult struct {
 
 func ArgFunctionOutput(ctx *pulumi.Context, args ArgFunctionOutputArgs, opts ...pulumi.InvokeOption) ArgFunctionResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (ArgFunctionResult, error) {
+		ApplyT(func(v interface{}) (ArgFunctionResultOutput, error) {
 			args := v.(ArgFunctionArgs)
-			r, err := ArgFunction(ctx, &args, opts...)
-			var s ArgFunctionResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv ArgFunctionResult
+			secret, err := ctx.InvokePackageRaw("example::argFunction", args, &rv, "", opts...)
+			if err != nil {
+				return ArgFunctionResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(ArgFunctionResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(ArgFunctionResultOutput), nil
+			}
+			return output, nil
 		}).(ArgFunctionResultOutput)
 }
 

--- a/tests/testdata/codegen/urn-id-properties/go/urnid/test.go
+++ b/tests/testdata/codegen/urn-id-properties/go/urnid/test.go
@@ -34,14 +34,20 @@ type TestResult struct {
 
 func TestOutput(ctx *pulumi.Context, args TestOutputArgs, opts ...pulumi.InvokeOption) TestResultOutput {
 	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (TestResult, error) {
+		ApplyT(func(v interface{}) (TestResultOutput, error) {
 			args := v.(TestArgs)
-			r, err := Test(ctx, &args, opts...)
-			var s TestResult
-			if r != nil {
-				s = *r
+			opts = internal.PkgInvokeDefaultOpts(opts)
+			var rv TestResult
+			secret, err := ctx.InvokePackageRaw("urnid:index:Test", args, &rv, "", opts...)
+			if err != nil {
+				return TestResultOutput{}, err
 			}
-			return s, err
+
+			output := pulumi.ToOutput(rv).(TestResultOutput)
+			if secret {
+				return pulumi.ToSecret(output).(TestResultOutput), nil
+			}
+			return output, nil
 		}).(TestResultOutput)
 }
 


### PR DESCRIPTION
Partially addressing #12710

### Description

This PR extends Go SDK-gen, specifically for output-versioned invokes such that they no longer rely on the plain invokes for their function body. 

We do this by implementing and using a sdk function `InvokePackageRaw` which is similar to `InvokePackage` except that it doesn't fail on secrets and actually returns a boolean indicating whether the invoke response contained any secrets. This way, the generated output-versioned invokes can immediately wrap the response as a secret if necessary and more importantly, not failing immediately if the response contained secrets. 

The sdk-gen test `output-funcs` actually do a runtime test for the newly generated function body and it passes. ~~However, I don't think it covers the _if secret then wrap as secret_ path~~ but maybe that's acceptable because it's a simple one liner
```go
// <invoke function body ommited here>
if secret {
  return pulumi.ToSecret(output).(FuncResultOutput), nil
}
```
Follow-up PRs with less priority:
 - [x] A proper test for invokes with secrets in their response
 - [ ] A conformance test
 - [ ] Doing the same for _generic_ output-versioned invokes to let them maintain secretness 

### EDIT
Updated the test in output-funcs such that it now returns a response for an invoke containing secrets

