### PR TITLE
Update tests to run on Go 1.22 and 1.23

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GOLANGCI_LINT_VERSION: v1.57.2
+  GOLANGCI_LINT_VERSION: v1.60.3
 
 jobs:
   golangci:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ You'll want to install the following on your machine:
 You can get all required dependencies with brew and npm
 
 ```bash
-brew install node python@3 typescript yarn go@1.21 golangci/tap/golangci-lint gofumpt pulumi/tap/pulumictl coreutils jq
+brew install node python@3 typescript yarn go@1.23 golangci/tap/golangci-lint gofumpt pulumi/tap/pulumictl coreutils jq
 curl https://raw.githubusercontent.com/Homebrew/homebrew-cask/339862f79e/Casks/dotnet-sdk.rb > dotnet-sdk.rb
 brew install --HEAD -s dotnet-sdk.rb
 rm dotnet-sdk.rb

--- a/changelog/pending/20240903--ci--run-ci-with-go-1-22-and-1-23.yaml
+++ b/changelog/pending/20240903--ci--run-ci-with-go-1-22-and-1-23.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: ci
+  description: Run CI with Go 1.22 and 1.23

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -120,7 +120,7 @@ ALL_PLATFORMS = ["ubuntu-latest", "windows-latest", "macos-latest"]
 MINIMUM_SUPPORTED_VERSION_SET = {
     "name": "minimum",
     "dotnet": "6",
-    "go": "1.21.x",
+    "go": "1.22.x",
     "nodejs": "18.x",
     "python": "3.8.x",
 }
@@ -128,7 +128,7 @@ MINIMUM_SUPPORTED_VERSION_SET = {
 CURRENT_VERSION_SET = {
     "name": "current",
     "dotnet": "8",
-    "go": "1.22.x",
+    "go": "1.23.x",
     "nodejs": "22.x",
     "python": "3.12.x",
 }


### PR DESCRIPTION
Go 1.23 was released a couple weeks ago https://go.dev/blog/go1.23, update CI to use the 2 latest versions.
