### PR TITLE
Update golangci-lint

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GOLANGCI_LINT_VERSION: v1.57.2
+  GOLANGCI_LINT_VERSION: v1.60.3
 
 jobs:
   golangci:


### PR DESCRIPTION
Update to the latest version, so we can update the Go version used in CI. Our current golangci-lint version crashes on Go 1.23.

https://github.com/pulumi/pulumi/pull/17068 & https://github.com/pulumi/pulumi/pull/17065 resolved issues surfaced by the latest golangci-lint.