### PR TITLE
Document that 'diffs' only supports top level keys

### DIFF
--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -18,7 +18,7 @@
 3421371250 793 proto/pulumi/errors.proto
 1271651547 11993 proto/pulumi/language.proto
 2893249402 1992 proto/pulumi/plugin.proto
-4103487931 27133 proto/pulumi/provider.proto
+3116791592 27259 proto/pulumi/provider.proto
 1190662922 17848 proto/pulumi/resource.proto
 607478140 1008 proto/pulumi/source.proto
 1507248916 2314 proto/pulumi/testing/language.proto

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -292,7 +292,10 @@ message DiffResponse {
     repeated string stables = 2;  // an optional list of properties that will not ever change.
     bool deleteBeforeReplace = 3; // if true, this resource must be deleted before replacing it.
     DiffChanges changes = 4;      // if true, this diff represents an actual difference and thus requires an update.
-    repeated string diffs = 5;    // a list of the properties that changed.
+
+    // a list of the properties that changed. This should only contain top level property names, it does not
+    // support nested properties. For that use detailedDiff.
+    repeated string diffs = 5;
 
     // detailedDiff is an optional field that contains map from each changed property to the type of the change.
     //

--- a/sdk/proto/go/provider.pb.go
+++ b/sdk/proto/go/provider.pb.go
@@ -1251,7 +1251,9 @@ type DiffResponse struct {
 	Stables             []string                 `protobuf:"bytes,2,rep,name=stables,proto3" json:"stables,omitempty"`                                          // an optional list of properties that will not ever change.
 	DeleteBeforeReplace bool                     `protobuf:"varint,3,opt,name=deleteBeforeReplace,proto3" json:"deleteBeforeReplace,omitempty"`                 // if true, this resource must be deleted before replacing it.
 	Changes             DiffResponse_DiffChanges `protobuf:"varint,4,opt,name=changes,proto3,enum=pulumirpc.DiffResponse_DiffChanges" json:"changes,omitempty"` // if true, this diff represents an actual difference and thus requires an update.
-	Diffs               []string                 `protobuf:"bytes,5,rep,name=diffs,proto3" json:"diffs,omitempty"`                                              // a list of the properties that changed.
+	// a list of the properties that changed. This should only contain top level property names, it does not
+	// support nested properties. For that use detailedDiff.
+	Diffs []string `protobuf:"bytes,5,rep,name=diffs,proto3" json:"diffs,omitempty"`
 	// detailedDiff is an optional field that contains map from each changed property to the type of the change.
 	//
 	// The keys of this map are property paths. These paths are essentially Javascript property access expressions

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
@@ -729,7 +729,9 @@ class DiffResponse(google.protobuf.message.Message):
     """if true, this diff represents an actual difference and thus requires an update."""
     @property
     def diffs(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """a list of the properties that changed."""
+        """a list of the properties that changed. This should only contain top level property names, it does not
+        support nested properties. For that use detailedDiff.
+        """
     @property
     def detailedDiff(self) -> google.protobuf.internal.containers.MessageMap[builtins.str, global___PropertyDiff]:
         """detailedDiff is an optional field that contains map from each changed property to the type of the change.


### PR DESCRIPTION
Prompted by https://github.com/pulumi/pulumi-azure-native/issues/3546. This documents that the `diffs` key in the diff response only supports top level property keys, not paths.