### PR TITLE
plugins: don't panic when the given path is not clean

### DIFF
--- a/changelog/pending/20240903--engine--fix-panic-with-user-specified-plugin-paths.yaml
+++ b/changelog/pending/20240903--engine--fix-panic-with-user-specified-plugin-paths.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix panic with user specified plugin paths

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1843,7 +1843,7 @@ func getPluginInfoAndPath(
 			Name:    spec.Name,
 			Kind:    spec.Kind,
 			Version: spec.Version,
-			Path:    plugin.Path,
+			Path:    filepath.Clean(plugin.Path),
 		}
 		// computing plugin sizes can be very expensive (nested node_modules)
 		if !skipMetadata {

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1543,3 +1543,39 @@ func TestPluginInfoShimless(t *testing.T) {
 	// schemaPaths are odd, they're one directory up from the plugin directory
 	assert.Equal(t, filepath.Join(filepath.Dir(pluginPath), "schema-mock.json"), info.SchemaPath)
 }
+
+//nolint:paralleltest // modifies environment variables
+func TestProjectPluginsWithUncleanPath(t *testing.T) {
+	tempdir := t.TempDir()
+
+	os.WriteFile(filepath.Join(tempdir, "pulumi-resource-aws"), []byte{}, 0o700)
+	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
+	path, err := GetPluginPath(diagtest.LogSink(t), apitype.ResourcePlugin, "aws", nil, []ProjectPlugin{
+		{
+			Name: "aws",
+			Kind: apitype.ResourcePlugin,
+			Path: tempdir + "/", // path with a trailing slash
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(tempdir, "pulumi-resource-aws"), path)
+}
+
+//nolint:paralleltest // modifies environment variables
+func TestProjectPluginsWithSymlink(t *testing.T) {
+	tempdir := t.TempDir()
+
+	os.Mkdir(filepath.Join(tempdir, "subdir"), 0o700)
+	os.Symlink(filepath.Join(tempdir, "subdir"), filepath.Join(tempdir, "symlink"))
+	os.WriteFile(filepath.Join(tempdir, "subdir", "pulumi-resource-aws"), []byte{}, 0o700)
+	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
+	path, err := GetPluginPath(diagtest.LogSink(t), apitype.ResourcePlugin, "aws", nil, []ProjectPlugin{
+		{
+			Name: "aws",
+			Kind: apitype.ResourcePlugin,
+			Path: filepath.Join(tempdir, "symlink"),
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(tempdir, "symlink", "pulumi-resource-aws"), path)
+}

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1548,7 +1548,9 @@ func TestPluginInfoShimless(t *testing.T) {
 func TestProjectPluginsWithUncleanPath(t *testing.T) {
 	tempdir := t.TempDir()
 
-	os.WriteFile(filepath.Join(tempdir, "pulumi-resource-aws"), []byte{}, 0o700)
+	err := os.WriteFile(filepath.Join(tempdir, "pulumi-resource-aws"), []byte{}, 0o600)
+	require.NoError(t, err)
+
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
 	path, err := GetPluginPath(diagtest.LogSink(t), apitype.ResourcePlugin, "aws", nil, []ProjectPlugin{
 		{
@@ -1565,9 +1567,13 @@ func TestProjectPluginsWithUncleanPath(t *testing.T) {
 func TestProjectPluginsWithSymlink(t *testing.T) {
 	tempdir := t.TempDir()
 
-	os.Mkdir(filepath.Join(tempdir, "subdir"), 0o700)
-	os.Symlink(filepath.Join(tempdir, "subdir"), filepath.Join(tempdir, "symlink"))
-	os.WriteFile(filepath.Join(tempdir, "subdir", "pulumi-resource-aws"), []byte{}, 0o700)
+	err := os.Mkdir(filepath.Join(tempdir, "subdir"), 0o700)
+	require.NoError(t, err)
+	err = os.Symlink(filepath.Join(tempdir, "subdir"), filepath.Join(tempdir, "symlink"))
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tempdir, "subdir", "pulumi-resource-aws"), []byte{}, 0o600)
+	require.NoError(t, err)
+
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
 	path, err := GetPluginPath(diagtest.LogSink(t), apitype.ResourcePlugin, "aws", nil, []ProjectPlugin{
 		{


### PR DESCRIPTION
When the user specifies a provider with a specific path in the `Pulumi.yaml`, we later in the program assert that the path that was passed in also matches with the path where we found the plugin. We do this by using a string comparison, however that doesn't work if the path the user passes is not clean, e.g. has a trailing slash, or has a double slash, or some such.

Fix this by using `filepath.Clean` on the user supplied path, which these things up.

I was also briefly wondering if this works properly if the user passes in a path that is a symlink (it does), and wrote a test for that, checking that behaviour.

Fixes https://github.com/pulumi/pulumi/issues/17130