### PR TITLE
Improve snapshot integrity panics depending on operation

### DIFF
--- a/pkg/backend/diy/state.go
+++ b/pkg/backend/diy/state.go
@@ -178,6 +178,10 @@ func (b *diyBackend) getSnapshot(ctx context.Context,
 	// Ensure the snapshot passes verification before returning it, to catch bugs early.
 	if !backend.DisableIntegrityChecking {
 		if err := snapshot.VerifyIntegrity(); err != nil {
+			if sie, ok := deploy.AsSnapshotIntegrityError(err); ok {
+				return nil, fmt.Errorf("snapshot integrity failure; refusing to use it: %w", sie.ForRead())
+			}
+
 			return nil, fmt.Errorf("snapshot integrity failure; refusing to use it: %w", err)
 		}
 	}

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -227,6 +227,10 @@ func (b *cloudBackend) getSnapshot(ctx context.Context,
 	// Ensure the snapshot passes verification before returning it, to catch bugs early.
 	if !backend.DisableIntegrityChecking {
 		if err := snapshot.VerifyIntegrity(); err != nil {
+			if sie, ok := deploy.AsSnapshotIntegrityError(err); ok {
+				return nil, fmt.Errorf("snapshot integrity failure; refusing to use it: %w", sie.ForRead())
+			}
+
 			return nil, fmt.Errorf("snapshot integrity failure; refusing to use it: %w", err)
 		}
 	}

--- a/pkg/cmd/pulumi/errors.go
+++ b/pkg/cmd/pulumi/errors.go
@@ -94,7 +94,7 @@ func printSnapshotIntegrityError(err error, sie deploy.SnapshotIntegrityError) {
 	if sie.Op == deploy.SnapshotIntegrityRead {
 		readOrWrite = `
 NOTE: This error occurred while reading a snaphot. This error was introduced by
-a previous operation when it wrote the snapshot. If you have details of this
+a previous operation when it wrote the snapshot. If you have details about that
 operation, please include them in your report as well.
 `
 	}
@@ -106,7 +106,7 @@ operation, please include them in your report as well.
 ================================================================================
 We would appreciate a report: https://github.com/pulumi/pulumi/issues/
 %s
-Please provide all of the below text in your report.
+Please provide all of the text below in your report.
 ================================================================================
 Pulumi Version:    %s
 Go Version:        %s


### PR DESCRIPTION
Snapshot integrity errors generally happen for one of two reasons:

* We just *wrote* a snapshot with an issue.
* We just attempted to *read* a snapshot with an issue.

As much as possible, we want to capture errors and issues at the point of *writing* the snapshot, since that will generally be where the bug that caused the integrity issue lies. This commit updates snapshot integrity errors to carry awareness of whether they happened during a read or write, and modifies the panic message to nudge users to hunt down the failing write operation if the panic they are seeing relates to a read.

![image](https://github.com/user-attachments/assets/6d91b5ea-95f5-470b-992f-1abfa116c838)