### PR TITLE
Fix bug in param loader

### DIFF
--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -350,7 +350,9 @@ func (l *pluginLoader) loadPluginSchemaBytes(
 	if descriptor.Parameterization != nil {
 		parameterization := plugin.ParameterizeRequest{
 			Parameters: &plugin.ParameterizeValue{
-				Value: descriptor.Parameterization.Value,
+				Name:    descriptor.Parameterization.Name,
+				Version: descriptor.Parameterization.Version,
+				Value:   descriptor.Parameterization.Value,
 			},
 		}
 		resp, err := provider.Parameterize(ctx, parameterization)

--- a/pkg/codegen/schema/loader_test.go
+++ b/pkg/codegen/schema/loader_test.go
@@ -117,7 +117,9 @@ func TestLoadParameterized(t *testing.T) {
 	mockProvider := &plugin.MockProvider{
 		ParameterizeF: func(_ context.Context, req plugin.ParameterizeRequest) (plugin.ParameterizeResponse, error) {
 			assert.Equal(t, &plugin.ParameterizeValue{
-				Value: []byte("testdata"),
+				Name:    "aws",
+				Version: semver.MustParse("3.0.0"),
+				Value:   []byte("testdata"),
 			}, req.Parameters)
 
 			return plugin.ParameterizeResponse{


### PR DESCRIPTION
We weren't passing Name and Version to `plugin.ParameterizeValue` when called in the schema loader. This information is supposed to be passed to `Parameterize` as its very common and saves the provider having to encode it into the byte value.