### PR TITLE
Add a `test_lifecycle` target to `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,9 @@ test_fast:: build get_schemas
 
 test_all:: test_pkg test_integration
 
+test_lifecycle:
+	@cd pkg && $(GO_TEST) github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest
+
 lang=$(subst test_codegen_,,$(word 1,$(subst !, ,$@)))
 test_codegen_%: get_schemas
 	@cd pkg && $(GO_TEST) ${PKG_CODEGEN}/${lang}/...


### PR DESCRIPTION
Lifecycle tests (located in `pkg/engine/lifecycletest`) allow us to exercise the various engine code paths controlling the resource lifecycle -- step generation, step execution, and so on. It's often useful when working in the engine (e.g. hunting down a snapshot integrity issue) to just run the lifecycle tests. This commit adds a target to the `Makefile` to do just that.