### PR TITLE
add the attach-debugger flag to automation API

### DIFF
--- a/sdk/go/auto/optpreview/optpreview.go
+++ b/sdk/go/auto/optpreview/optpreview.go
@@ -143,6 +143,13 @@ func ImportFile(path string) Option {
 	})
 }
 
+// AttachDebugger will run the process under a debugger, and pause until a debugger is attached
+func AttachDebugger() Option {
+	return optionFunc(func(opts *Options) {
+		opts.AttachDebugger = true
+	})
+}
+
 // Option is a parameter to be applied to a Stack.Preview() operation
 type Option interface {
 	ApplyOption(*Options)
@@ -193,6 +200,8 @@ type Options struct {
 	SuppressOutputs bool
 	// Save any creates seen during the preview into an import file to use with pulumi import
 	ImportFile string
+	// Run the process under a debugger, and pause until a debugger is attached
+	AttachDebugger bool
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/optup/optup.go
+++ b/sdk/go/auto/optup/optup.go
@@ -150,6 +150,13 @@ func ContinueOnError() Option {
 	})
 }
 
+// AttachDebugger will run the process under a debugger, and pause until a debugger is attached
+func AttachDebugger() Option {
+	return optionFunc(func(opts *Options) {
+		opts.AttachDebugger = true
+	})
+}
+
 // Option is a parameter to be applied to a Stack.Up() operation
 type Option interface {
 	ApplyOption(*Options)
@@ -202,6 +209,8 @@ type Options struct {
 	SuppressOutputs bool
 	// ContinueOnError will continue to perform the update operation despite the occurrence of errors.
 	ContinueOnError bool
+	// AttachDebugger will run the process under a debugger, and pause until a debugger is attached
+	AttachDebugger bool
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -280,6 +280,9 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 	if preOpts.ImportFile != "" {
 		sharedArgs = append(sharedArgs, "--import-file="+preOpts.ImportFile)
 	}
+	if preOpts.AttachDebugger {
+		sharedArgs = append(sharedArgs, "--attach-debugger")
+	}
 
 	// Apply the remote args, if needed.
 	sharedArgs = append(sharedArgs, s.remoteArgs()...)
@@ -413,6 +416,9 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 	}
 	if upOpts.ContinueOnError {
 		sharedArgs = append(sharedArgs, "--continue-on-error")
+	}
+	if upOpts.AttachDebugger {
+		sharedArgs = append(sharedArgs, "--attach-debugger")
 	}
 
 	// Apply the remote args, if needed.

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -218,6 +218,9 @@ Event: ${line}\n${e.toString()}`);
             if (opts.continueOnError) {
                 args.push("--continue-on-error");
             }
+            if (opts.attachDebugger) {
+                args.push("--attach-debugger");
+            }
             applyGlobalOpts(opts, args);
         }
 
@@ -353,6 +356,9 @@ Event: ${line}\n${e.toString()}`);
             }
             if (opts.importFile) {
                 args.push("--import-file", opts.importFile);
+            }
+            if (opts.attachDebugger) {
+                args.push("--attach-debugger");
             }
             applyGlobalOpts(opts, args);
         }
@@ -1322,6 +1328,11 @@ export interface UpOptions extends GlobalOpts {
      * Continue the operation to completion even if errors occur.
      */
     continueOnError?: boolean;
+
+    /**
+     * Run the process under a debugger, and pause until a debugger is attached.
+     */
+    attachDebugger?: boolean;
 }
 
 /**
@@ -1402,6 +1413,11 @@ export interface PreviewOptions extends GlobalOpts {
      * Plan specifies the path where the update plan should be saved.
      */
     plan?: string;
+
+    /**
+     * Run the process under a debugger, and pause until a debugger is attached.
+     */
+    attachDebugger?: boolean;
 }
 
 /**

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -284,6 +284,7 @@ class Stack:
         suppress_outputs: Optional[bool] = None,
         suppress_progress: Optional[bool] = None,
         continue_on_error: Optional[bool] = None,
+        attach_debugger: Optional[bool] = None,
     ) -> UpResult:
         """
         Creates or updates the resources in a stack by executing the program in the Workspace.
@@ -313,6 +314,7 @@ class Stack:
         :param suppress_outputs: Suppress display of stack outputs (in case they contain sensitive values)
         :param suppress_progress: Suppress display of periodic progress dots
         :param continue_on_error: Continue to perform the update operation despite the occurrence of errors
+        :param attach_debugger: Run the process under a debugger, and pause until a debugger is attached
         :returns: UpResult
         """
         # Disable unused-argument because pylint doesn't understand we process them in _parse_extra_args
@@ -407,6 +409,7 @@ class Stack:
         suppress_outputs: Optional[bool] = None,
         suppress_progress: Optional[bool] = None,
         import_file: Optional[str] = None,
+        attach_debugger: Optional[bool] = None,
     ) -> PreviewResult:
         """
         Performs a dry-run update to a stack, returning pending changes.
@@ -435,6 +438,7 @@ class Stack:
         :param suppress_outputs: Suppress display of stack outputs (in case they contain sensitive values)
         :param suppress_progress: Suppress display of periodic progress dots
         :param import_file: Save any creates seen during the preview into an import file to use with pulumi import
+        :param attach_debugger: Run the process under a debugger, and pause until a debugger is attached
         :returns: PreviewResult
         """
         # Disable unused-argument because pylint doesn't understand we process them in _parse_extra_args
@@ -686,12 +690,12 @@ class Stack:
     ) -> ImportResult:
         """
         Imports resources into the stack.
-        
+
         :param message: Message to associate with the import operation.
         :param resources: The resources to import.
-        :param nameTable: 
+        :param nameTable:
             The name table maps language names to parent and provider URNs.
-            These names are used in the generated definitions, 
+            These names are used in the generated definitions,
             and should match the corresponding declarations
             in the source program. This table is required if any parents or providers are \
             specified by the resources to import.
@@ -1027,6 +1031,7 @@ def _parse_extra_args(**kwargs) -> List[str]:
     suppress_outputs: Optional[bool] = kwargs.get("suppress_outputs")
     suppress_progress: Optional[bool] = kwargs.get("suppress_progress")
     continue_on_error: Optional[bool] = kwargs.get("continue_on_error")
+    attach_debugger: Optional[bool] = kwargs.get("attach_debugger")
 
     if message:
         extra_args.extend(["--message", message])
@@ -1070,6 +1075,8 @@ def _parse_extra_args(**kwargs) -> List[str]:
         extra_args.extend(["--suppress-progress"])
     if continue_on_error:
         extra_args.extend(["--continue-on-error"])
+    if attach_debugger:
+        extra_args.extend(["--attach-debugger"])
     return extra_args
 
 


### PR DESCRIPTION
The VSCode extension will make use of the automation API, so we'll need to be able to pass the flag through there.  While the VSCode extension will only use the TypeScript API, let's add the flag to every language in case someone finds a use for it.

Fixes https://github.com/pulumi/pulumi/issues/17174