### PR TITLE
use passed in fail-fast strategy for windows tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,6 +384,7 @@ jobs:
     if: ${{ needs.matrix.outputs.acceptance-test-matrix-win != '{}' }}
     # allow jobs to fail if the platform contains windows
     strategy:
+      fail-fast: ${{ inputs.fail-fast }}
       matrix: ${{ fromJson(needs.matrix.outputs.acceptance-test-matrix-win) }}
     uses: ./.github/workflows/ci-run-test.yml
     with:


### PR DESCRIPTION
For some reason that is unclear to me we currently set the fail-fast strategy to `inputs.fail-fast` for all types of tests apart from the windows tests.  This means we will also fail-fast these tests when running the PR tests (where we recently started to run the windows tests).

However on PRs it's convenient to not fail-fast, as it's useful to have the test results for all tests, *and* for flakes not having fail-fast enabled means fewer tests to re-run.  Setting this means we'll fail-fast wherever we fail fast for other tests (currently just in the merge queue I believe, where we don't run the windows tests anymore), but we'll keep running tests on PR.