### PR TITLE
Correctly case Python package names in `package add` link instructions

### DIFF
--- a/changelog/pending/20240905--sdkgen-python--correctly-case-python-package-names-in-package-add-link-instructions.yaml
+++ b/changelog/pending/20240905--sdkgen-python--correctly-case-python-package-names-in-package-add-link-instructions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/python
+  description: Correctly case Python package names in `package add` link instructions

--- a/pkg/cmd/pulumi/package_add.go
+++ b/pkg/cmd/pulumi/package_add.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	go_gen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/python"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -228,10 +229,19 @@ func printPythonLinkInstructions(ws pkgWorkspace.Context, root string, pkg *sche
 		// Assume pip if no packagemanager is specified
 		pipInstructions()
 	}
+
+	pyInfo, ok := pkg.Language["python"].(python.PackageInfo)
+	var importName string
+	if ok && pyInfo.PackageName != "" {
+		importName = pyInfo.PackageName
+	} else {
+		importName = strings.ReplaceAll(pkg.Name, "-", "_")
+	}
+
 	fmt.Println()
 	fmt.Println("You can then import the SDK in your Python code with:")
 	fmt.Println()
-	fmt.Printf("  import pulumi_%s as %s\n", pkg.Name, pkg.Name)
+	fmt.Printf("  import pulumi_%s as %s\n", importName, importName)
 	fmt.Println()
 	return nil
 }


### PR DESCRIPTION
When we print out instructions for linking a local Python SDK in response to running `package add`, we incorrectly use the Pulumi package name, which may not be a valid Python package name. This commit fixes this to use the specified Python package name override if provided, or the correctly-cased Pulumi package name if not.

Fixes #17149