### PR TITLE
Recover from zero-byte `credentials.json` files

### DIFF
--- a/changelog/pending/20240906--cli--recover-from-zero-byte-credentials-json-files.yaml
+++ b/changelog/pending/20240906--cli--recover-from-zero-byte-credentials-json-files.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Recover from zero-byte `credentials.json` files

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -174,6 +174,14 @@ func GetStoredCredentials() (Credentials, error) {
 		return Credentials{}, fmt.Errorf("reading '%s': %w", credsFile, err)
 	}
 
+	// If the file is empty, we can act as if it doesn't exist rather than trying
+	// (and failing) to deserialize its contents. This allows us to recover from
+	// situations where a write to the file was interrupted or it was otherwise
+	// clobbered.
+	if len(c) == 0 {
+		return Credentials{}, nil
+	}
+
 	var creds Credentials
 	if err = json.Unmarshal(c, &creds); err != nil {
 		return Credentials{}, fmt.Errorf("failed to read Pulumi credentials file. Please re-run "+


### PR DESCRIPTION
Pulumi stores credentials in a `credentials.json`. If a non-atomic operation that writes this file is interrupted, we may end up with a zero-byte `credentials.json` file. Presently, this will create a situation where the user has to manually remove the file before e.g. `pulumi login` will work and retrieve new credentials again (see #11017 for an example). This commit changes this behaviour, spotting empty credentials files and returning an empty set of credentials instead of throwing an error.

Fixes #11017