### PR TITLE
remove PULUMI_BOT_TOKEN secret from being used by ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,6 @@ on:
         description: "Retry tests n times if there are failures"
         type: number
     secrets:
-      PULUMI_BOT_TOKEN:
-        required: true
-        description: "GitHub access token, required to mitigate GitHub rate limits"
       PULUMI_PROD_ACCESS_TOKEN:
         required: false
         description: "Pulumi access token, required to run tests against the service"


### PR DESCRIPTION
PULUMI_BOT_TOKEN is a company wide resource that we shouldn't use in CI.  Before upgrading to GitHub enterprise it used to be that bots had a higher rate limit than tokens for CI runs, however that is no longer the case since we upgraded the GitHub subscription.

This seemingly has not been used in this workflow for a while in the first place.  Remove it to make sure it isn't accidentally used in the future, and to avoid confusion from the comment that still mentions increasing the rate limit.