### PR TITLE
Add tests to resource/graph to bring up coverage

### DIFF
--- a/pkg/resource/graph/dependency_graph.go
+++ b/pkg/resource/graph/dependency_graph.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
 
 package graph
 
@@ -92,10 +92,10 @@ func (dg *DependencyGraph) DependingOn(res *resource.State,
 	return dependents
 }
 
-// OnlyDependsOn returns a slice containing all resources that directly or indirectly
-// depend upon *only* the given resource.  Resources that also depend on another resource with
-// the same URN will not be included in the returned slice.  The returned slice is guaranteed
-// to be in topological order with respect to the snapshot dependency graph.
+// OnlyDependsOn returns a slice containing all resources that directly or indirectly depend upon *only* the specific ID
+// for the given resources URN. Resources that also depend on another resource with the same URN, but a different ID,
+// will not be included in the returned slice. The returned slice is guaranteed to be in topological order with respect
+// to the snapshot dependency graph.
 //
 // The time complexity of OnlyDependsOn is linear with respect to the number of resources.
 func (dg *DependencyGraph) OnlyDependsOn(res *resource.State) []*resource.State {

--- a/pkg/resource/graph/dependency_graph_test.go
+++ b/pkg/resource/graph/dependency_graph_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
 
 package graph
 
@@ -335,7 +335,28 @@ func TestDependencyGraph(t *testing.T) {
 			name     string
 			res      *resource.State
 			expected []*resource.State
-		}{}
+		}{
+			{
+				name:     "providerA",
+				res:      providerA,
+				expected: []*resource.State{a1, a2, providerB, b1, c1},
+			},
+			{
+				name:     "a1",
+				res:      a1,
+				expected: []*resource.State{a2, providerB, b1, c1},
+			},
+			{
+				name:     "d1",
+				res:      d1,
+				expected: []*resource.State{d2, d3, d4, d5},
+			},
+			{
+				name:     "e1",
+				res:      e1,
+				expected: []*resource.State{e2, e3, e4, e5},
+			},
+		}
 
 		for _, c := range cases {
 			c := c
@@ -754,6 +775,86 @@ func TestDependencyGraph(t *testing.T) {
 
 				// Act.
 				actual := dg.ParentsOf(c.res)
+
+				// Assert.
+				assert.Equal(t, c.expected, actual)
+			})
+		}
+	})
+
+	t.Run("ChildrenOf", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		cases := []struct {
+			name     string
+			res      *resource.State
+			expected []*resource.State
+		}{
+			{
+				name:     "d1",
+				res:      d1,
+				expected: []*resource.State{d2, d4},
+			},
+			{
+				name:     "d2",
+				res:      d2,
+				expected: []*resource.State{d4},
+			},
+			{
+				name:     "d3",
+				res:      d3,
+				expected: []*resource.State{d5},
+			},
+			{
+				name:     "e1",
+				res:      e1,
+				expected: []*resource.State{},
+			},
+		}
+
+		for _, c := range cases {
+			c := c
+			t.Run(c.name, func(t *testing.T) {
+				t.Parallel()
+
+				// Act.
+				actual := dg.ChildrenOf(c.res)
+
+				// Assert.
+				assert.Equal(t, c.expected, actual)
+			})
+		}
+	})
+
+	t.Run("Contains", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		cases := []struct {
+			name     string
+			res      *resource.State
+			expected bool
+		}{
+			{
+				name:     "a1",
+				res:      a1,
+				expected: true,
+			},
+			{
+				name:     "fx1",
+				res:      fx1,
+				expected: false,
+			},
+		}
+
+		for _, c := range cases {
+			c := c
+			t.Run(c.name, func(t *testing.T) {
+				t.Parallel()
+
+				// Act.
+				actual := dg.Contains(c.res)
 
 				// Assert.
 				assert.Equal(t, c.expected, actual)


### PR DESCRIPTION
Was looking at
https://metabase.corp.pulumi.com/dashboard/209-code-coverage-by-repository?repository=pulumi and this package is very nearly at 100% coverage. So adding a few tests to bring it up to 100%.

Also reworded the doc for `OnlyDependsOn` a bit because it took me a hot minute to work out what it was saying.