### PR TITLE
Add LoginManager to backend package

### DIFF
--- a/changelog/pending/20240909--cli--using-pulumi_backend_url-no-longer-updates-credentials-json.yaml
+++ b/changelog/pending/20240909--cli--using-pulumi_backend_url-no-longer-updates-credentials-json.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Using PULUMI_BACKEND_URL no longer updates credentials.json

--- a/pkg/backend/login_manager.go
+++ b/pkg/backend/login_manager.go
@@ -35,7 +35,7 @@ type LoginManager interface {
 		setCurrent bool,
 	) (Backend, error)
 
-	// Login returns the current logged in backend instance for the given url, or starts the login process for that url.
+	// Login starts the login process for the given URL. If there is already a logged-in backend, this is returned as-is.
 	Login(
 		ctx context.Context,
 		ws pkgWorkspace.Context,

--- a/pkg/backend/login_manager.go
+++ b/pkg/backend/login_manager.go
@@ -1,0 +1,48 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"context"
+
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// LoginManager provides a slim wrapper around functions related to backend logins.
+type LoginManager interface {
+	// Current returns the currently logged in backend instance for the given url.
+	Current(
+		ctx context.Context,
+		ws pkgWorkspace.Context,
+		sink diag.Sink,
+		url string,
+		project *workspace.Project,
+		setCurrent bool,
+	) (Backend, error)
+
+	// Login returns the current logged in backend instance for the given url, or starts the login process for that url.
+	Login(
+		ctx context.Context,
+		ws pkgWorkspace.Context,
+		sink diag.Sink,
+		url string,
+		project *workspace.Project,
+		setCurrent bool,
+		color colors.Colorization,
+	) (Backend, error)
+}

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -25,8 +25,10 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -751,6 +753,58 @@ func (mp *MockPolicyPack) Validate(ctx context.Context, op PolicyPackOperation) 
 func (mp *MockPolicyPack) Remove(ctx context.Context, op PolicyPackOperation) error {
 	if mp.RemoveF != nil {
 		return mp.RemoveF(ctx, op)
+	}
+	panic("not implemented")
+}
+
+type MockLoginManager struct {
+	CurrentF func(
+		ctx context.Context,
+		ws pkgWorkspace.Context,
+		sink diag.Sink,
+		url string,
+		project *workspace.Project,
+		setCurrent bool,
+	) (Backend, error)
+
+	LoginF func(
+		ctx context.Context,
+		ws pkgWorkspace.Context,
+		sink diag.Sink,
+		url string,
+		project *workspace.Project,
+		setCurrent bool,
+		color colors.Colorization,
+	) (Backend, error)
+}
+
+var _ LoginManager = (*MockLoginManager)(nil)
+
+func (lm *MockLoginManager) Login(
+	ctx context.Context,
+	ws pkgWorkspace.Context,
+	sink diag.Sink,
+	url string,
+	project *workspace.Project,
+	setCurrent bool,
+	color colors.Colorization,
+) (Backend, error) {
+	if lm.LoginF != nil {
+		return lm.LoginF(ctx, ws, sink, url, project, setCurrent, color)
+	}
+	panic("not implemented")
+}
+
+func (lm *MockLoginManager) Current(
+	ctx context.Context,
+	ws pkgWorkspace.Context,
+	sink diag.Sink,
+	url string,
+	project *workspace.Project,
+	setCurrent bool,
+) (Backend, error) {
+	if lm.CurrentF != nil {
+		return lm.CurrentF(ctx, ws, sink, url, project, setCurrent)
 	}
 	panic("not implemented")
 }

--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -66,7 +66,7 @@ func newAboutCmd() *cobra.Command {
 		Args: cmdutil.MaximumNArgs(0),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			summary := getSummaryAbout(ctx, pkgWorkspace.Instance, transitiveDependencies, stack)
+			summary := getSummaryAbout(ctx, pkgWorkspace.Instance, DefaultLoginManager, transitiveDependencies, stack)
 			if jsonOut {
 				return printJSON(summary)
 			}
@@ -105,7 +105,8 @@ type summaryAbout struct {
 }
 
 func getSummaryAbout(
-	ctx context.Context, ws pkgWorkspace.Context, transitiveDependencies bool, selectedStack string,
+	ctx context.Context, ws pkgWorkspace.Context, lm backend.LoginManager,
+	transitiveDependencies bool, selectedStack string,
 ) summaryAbout {
 	var err error
 	cli := getCLIAbout()
@@ -182,7 +183,7 @@ func getSummaryAbout(
 	}
 
 	var backend backend.Backend
-	backend, err = nonInteractiveCurrentBackend(ctx, ws, proj)
+	backend, err = nonInteractiveCurrentBackend(ctx, ws, lm, proj)
 	if err != nil {
 		addError(err, "Could not access the backend")
 	} else if backend != nil {

--- a/pkg/cmd/pulumi/ai.go
+++ b/pkg/cmd/pulumi/ai.go
@@ -33,7 +33,7 @@ type aiCmd struct {
 	// currentBackend is a reference to the top-level currentBackend function.
 	// This is used to override the default implementation for testing purposes.
 	currentBackend func(
-		context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+		context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 	) (backend.Backend, error)
 }
 

--- a/pkg/cmd/pulumi/ai_web.go
+++ b/pkg/cmd/pulumi/ai_web.go
@@ -82,7 +82,7 @@ type aiWebCmd struct {
 	// currentBackend is a reference to the top-level currentBackend function.
 	// This is used to override the default implementation for testing purposes.
 	currentBackend func(
-		context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+		context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 	) (backend.Backend, error)
 }
 

--- a/pkg/cmd/pulumi/cancel.go
+++ b/pkg/cmd/pulumi/cancel.go
@@ -60,7 +60,7 @@ func newCancelCmd() *cobra.Command {
 
 			ws := pkgWorkspace.Instance
 
-			s, err := requireStack(ctx, ws, stack, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, stack, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -74,7 +74,7 @@ func newConfigCmd() *cobra.Command {
 				return err
 			}
 
-			stack, err := requireStack(ctx, ws, stack, stackOfferNew|stackSetCurrent, opts)
+			stack, err := requireStack(ctx, ws, DefaultLoginManager, stack, stackOfferNew|stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -150,7 +150,7 @@ func newConfigCopyCmd(stack *string) *cobra.Command {
 			}
 
 			// Get current stack and ensure that it is a different stack to the destination stack
-			currentStack, err := requireStack(ctx, ws, *stack, stackSetCurrent, opts)
+			currentStack, err := requireStack(ctx, ws, DefaultLoginManager, *stack, stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -163,7 +163,7 @@ func newConfigCopyCmd(stack *string) *cobra.Command {
 			}
 
 			// Get the destination stack
-			destinationStack, err := requireStack(ctx, ws, destinationStackName, stackLoadOnly, opts)
+			destinationStack, err := requireStack(ctx, ws, DefaultLoginManager, destinationStackName, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}
@@ -325,7 +325,7 @@ func newConfigGetCmd(stack *string) *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(ctx, ws, *stack, stackOfferNew|stackSetCurrent, opts)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, *stack, stackOfferNew|stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -376,7 +376,7 @@ func newConfigRmCmd(stack *string) *cobra.Command {
 				return err
 			}
 
-			stack, err := requireStack(ctx, ws, *stack, stackOfferNew|stackSetCurrent, opts)
+			stack, err := requireStack(ctx, ws, DefaultLoginManager, *stack, stackOfferNew|stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -431,7 +431,7 @@ func newConfigRmAllCmd(stack *string) *cobra.Command {
 				return err
 			}
 
-			stack, err := requireStack(ctx, ws, *stack, stackOfferNew, opts)
+			stack, err := requireStack(ctx, ws, DefaultLoginManager, *stack, stackOfferNew, opts)
 			if err != nil {
 				return err
 			}
@@ -482,7 +482,7 @@ func newConfigRefreshCmd(stk *string) *cobra.Command {
 			}
 
 			// Ensure the stack exists.
-			s, err := requireStack(ctx, ws, *stk, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, *stk, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}
@@ -602,7 +602,7 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 			}
 
 			// Ensure the stack exists.
-			s, err := requireStack(ctx, ws, *stack, stackOfferNew|stackSetCurrent, opts)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, *stack, stackOfferNew|stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -722,7 +722,7 @@ func newConfigSetAllCmd(stack *string) *cobra.Command {
 			}
 
 			// Ensure the stack exists.
-			stack, err := requireStack(ctx, ws, *stack, stackOfferNew, opts)
+			stack, err := requireStack(ctx, ws, DefaultLoginManager, *stack, stackOfferNew, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/config_env.go
+++ b/pkg/cmd/pulumi/config_env.go
@@ -70,6 +70,7 @@ type configEnvCmd struct {
 	requireStack func(
 		ctx context.Context,
 		ws pkgWorkspace.Context,
+		lm backend.LoginManager,
 		stackName string,
 		lopt stackLoadOption,
 		opts display.Options,
@@ -96,7 +97,7 @@ func (cmd *configEnvCmd) loadEnvPreamble(ctx context.Context,
 		return nil, nil, nil, err
 	}
 
-	stack, err := cmd.requireStack(ctx, cmd.ws, *cmd.stackRef, stackOfferNew|stackSetCurrent, opts)
+	stack, err := cmd.requireStack(ctx, cmd.ws, DefaultLoginManager, *cmd.stackRef, stackOfferNew|stackSetCurrent, opts)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/cmd/pulumi/config_env_init.go
+++ b/pkg/cmd/pulumi/config_env_init.go
@@ -104,7 +104,8 @@ func (cmd *configEnvInitCmd) run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	stack, err := cmd.parent.requireStack(ctx, cmd.parent.ws, *cmd.parent.stackRef, stackOfferNew|stackSetCurrent, opts)
+	stack, err := cmd.parent.requireStack(
+		ctx, cmd.parent.ws, DefaultLoginManager, *cmd.parent.stackRef, stackOfferNew|stackSetCurrent, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/config_env_test.go
+++ b/pkg/cmd/pulumi/config_env_test.go
@@ -97,6 +97,7 @@ func newConfigEnvCmdForTestWithCheckYAMLEnvironment(
 		requireStack: func(
 			ctx context.Context,
 			ws pkgWorkspace.Context,
+			lm backend.LoginManager,
 			stackName string,
 			lopt stackLoadOption,
 			opts display.Options,

--- a/pkg/cmd/pulumi/console.go
+++ b/pkg/cmd/pulumi/console.go
@@ -49,7 +49,7 @@ func newConsoleCmd() *cobra.Command {
 				return err
 			}
 
-			currentBackend, err := currentBackend(ctx, ws, project, opts)
+			currentBackend, err := currentBackend(ctx, ws, DefaultLoginManager, project, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/deployment_run.go
+++ b/pkg/cmd/pulumi/deployment_run.go
@@ -67,7 +67,7 @@ func newDeploymentRunCmd() *cobra.Command {
 				return err
 			}
 
-			currentBe, err := currentBackend(ctx, ws, project, display)
+			currentBe, err := currentBackend(ctx, ws, DefaultLoginManager, project, display)
 			if err != nil {
 				return err
 			}
@@ -77,7 +77,7 @@ func newDeploymentRunCmd() *cobra.Command {
 					currentBe.Name())
 			}
 
-			s, err := requireStack(ctx, ws, stack, stackOfferNew|stackSetCurrent, display)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, stack, stackOfferNew|stackSetCurrent, display)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/deployment_settings_config.go
+++ b/pkg/cmd/pulumi/deployment_settings_config.go
@@ -129,7 +129,7 @@ func initializeDeploymentSettingsCmd(
 		return nil, err
 	}
 
-	be, err := currentBackend(ctx, ws, project, displayOpts)
+	be, err := currentBackend(ctx, ws, DefaultLoginManager, project, displayOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func initializeDeploymentSettingsCmd(
 			be.Name())
 	}
 
-	s, err := requireStack(ctx, ws, stack, stackOfferNew|stackSetCurrent, displayOpts)
+	s, err := requireStack(ctx, ws, DefaultLoginManager, stack, stackOfferNew|stackSetCurrent, displayOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -175,7 +175,7 @@ func newDestroyCmd() *cobra.Command {
 				opts.Display.SuppressPermalink = true
 			}
 
-			s, err := requireStack(ctx, ws, stackName, stackLoadOnly, opts.Display)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, stackName, stackLoadOnly, opts.Display)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -838,7 +838,7 @@ func newImportCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack.
-			s, err := requireStack(ctx, ws, stackName, stackLoadOnly, opts.Display)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, stackName, stackLoadOnly, opts.Display)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -68,7 +68,7 @@ func newLogsCmd() *cobra.Command {
 				return err
 			}
 
-			s, err := requireStack(ctx, ws, stackName, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, stackName, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -137,7 +137,7 @@ func runNew(ctx context.Context, args newArgs) error {
 	var b backend.Backend
 	if !args.generateOnly {
 		// There is no current project at this point to pass into currentBackend
-		b, err = currentBackend(ctx, ws, nil, opts)
+		b, err = currentBackend(ctx, ws, DefaultLoginManager, nil, opts)
 		if err != nil {
 			return err
 		}
@@ -164,7 +164,7 @@ func runNew(ctx context.Context, args newArgs) error {
 			return err
 		}
 
-		b, err := currentBackend(ctx, ws, project, opts)
+		b, err := currentBackend(ctx, ws, DefaultLoginManager, project, opts)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/new_acceptance_test.go
@@ -191,7 +191,7 @@ func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 	ctx := context.Background()
 
-	b, err := currentBackend(ctx, pkgWorkspace.Instance, nil, display.Options{})
+	b, err := currentBackend(ctx, pkgWorkspace.Instance, DefaultLoginManager, nil, display.Options{})
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(b.URL(), "https://app.pulumi.com"))
 
@@ -223,7 +223,7 @@ func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 		backendDir, workspace.BookkeepingDir, workspace.StackDir, defaultProjectName, stackName+".json"))
 	assert.NoError(t, err)
 
-	b, err = currentBackend(ctx, pkgWorkspace.Instance, nil, display.Options{})
+	b, err = currentBackend(ctx, pkgWorkspace.Instance, DefaultLoginManager, nil, display.Options{})
 	require.NoError(t, err)
 	assert.Equal(t, backendURL, b.URL())
 }
@@ -259,7 +259,7 @@ func loadProject(t *testing.T, dir string) *workspace.Project {
 
 func currentUser(t *testing.T) string {
 	ctx := context.Background()
-	b, err := currentBackend(ctx, pkgWorkspace.Instance, nil, display.Options{})
+	b, err := currentBackend(ctx, pkgWorkspace.Instance, DefaultLoginManager, nil, display.Options{})
 	assert.NoError(t, err)
 	currentUser, _, _, err := b.CurrentUser()
 	assert.NoError(t, err)
@@ -275,7 +275,7 @@ func loadStackName(t *testing.T) string {
 func removeStack(t *testing.T, dir, name string) {
 	project := loadProject(t, dir)
 	ctx := context.Background()
-	b, err := currentBackend(ctx, pkgWorkspace.Instance, project, display.Options{})
+	b, err := currentBackend(ctx, pkgWorkspace.Instance, DefaultLoginManager, project, display.Options{})
 	assert.NoError(t, err)
 	ref, err := b.ParseStackReference(name)
 	assert.NoError(t, err)

--- a/pkg/cmd/pulumi/org.go
+++ b/pkg/cmd/pulumi/org.go
@@ -102,7 +102,7 @@ func newOrgSetDefaultCmd() *cobra.Command {
 				return err
 			}
 
-			currentBe, err := currentBackend(ctx, ws, project, displayOpts)
+			currentBe, err := currentBackend(ctx, ws, DefaultLoginManager, project, displayOpts)
 			if err != nil {
 				return err
 			}
@@ -146,7 +146,7 @@ func newOrgGetDefaultCmd() *cobra.Command {
 				return err
 			}
 
-			currentBe, err := currentBackend(ctx, ws, project, displayOpts)
+			currentBe, err := currentBackend(ctx, ws, DefaultLoginManager, project, displayOpts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -104,7 +104,7 @@ type searchCmd struct {
 	// currentBackend is a reference to the top-level currentBackend function.
 	// This is used to override the default implementation for testing purposes.
 	currentBackend func(
-		context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+		context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 	) (backend.Backend, error)
 }
 
@@ -142,7 +142,7 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	backend, err := currentBackend(ctx, ws, project, opts.Display)
+	backend, err := currentBackend(ctx, ws, DefaultLoginManager, project, opts.Display)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/org_search_ai.go
+++ b/pkg/cmd/pulumi/org_search_ai.go
@@ -65,7 +65,7 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	backend, err := currentBackend(ctx, ws, project, opts.Display)
+	backend, err := currentBackend(ctx, ws, DefaultLoginManager, project, opts.Display)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/org_search_ai_test.go
+++ b/pkg/cmd/pulumi/org_search_ai_test.go
@@ -66,7 +66,7 @@ func TestSearchAI_cmd(t *testing.T) {
 			orgName: orgName,
 			Stdout:  &buff,
 			currentBackend: func(
-				context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+				context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 			) (backend.Backend, error) {
 				return b, nil
 			},
@@ -98,7 +98,7 @@ func TestAISearchUserOrgFailure_cmd(t *testing.T) {
 			orgName: orgName,
 			Stdout:  &buff,
 			currentBackend: func(
-				context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+				context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 			) (backend.Backend, error) {
 				return &stubHTTPBackend{
 					SearchF: func(context.Context, string, *apitype.PulumiQueryRequest) (*apitype.ResourceSearchResponse, error) {

--- a/pkg/cmd/pulumi/org_search_test.go
+++ b/pkg/cmd/pulumi/org_search_test.go
@@ -48,7 +48,7 @@ func TestSearch_cmd(t *testing.T) {
 			orgName: orgName,
 			Stdout:  &buff,
 			currentBackend: func(
-				context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+				context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 			) (backend.Backend, error) {
 				return &stubHTTPBackend{
 					SearchF: func(context.Context, string, *apitype.PulumiQueryRequest) (*apitype.ResourceSearchResponse, error) {
@@ -102,7 +102,7 @@ func TestSearchNoOrgName_cmd(t *testing.T) {
 		searchCmd: searchCmd{
 			Stdout: &buff,
 			currentBackend: func(
-				context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+				context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 			) (backend.Backend, error) {
 				return &stubHTTPBackend{
 					SearchF: func(context.Context, string, *apitype.PulumiQueryRequest) (*apitype.ResourceSearchResponse, error) {

--- a/pkg/cmd/pulumi/policy_disable.go
+++ b/pkg/cmd/pulumi/policy_disable.go
@@ -37,7 +37,7 @@ func newPolicyDisableCmd() *cobra.Command {
 			ctx := cmd.Context()
 			// Obtain current PolicyPack, tied to the Pulumi Cloud backend.
 			var err error
-			policyPack, err := requirePolicyPack(ctx, cliArgs[0], loginToCloud)
+			policyPack, err := requirePolicyPack(ctx, cliArgs[0], DefaultLoginManager)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/policy_enable.go
+++ b/pkg/cmd/pulumi/policy_enable.go
@@ -43,7 +43,7 @@ func newPolicyEnableCmd() *cobra.Command {
 		Run: runCmdFunc(func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := cmd.Context()
 			// Obtain current PolicyPack, tied to the Pulumi Cloud backend.
-			policyPack, err := requirePolicyPack(ctx, cliArgs[0], loginToCloud)
+			policyPack, err := requirePolicyPack(ctx, cliArgs[0], DefaultLoginManager)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/policy_group_ls.go
+++ b/pkg/cmd/pulumi/policy_group_ls.go
@@ -58,7 +58,9 @@ func newPolicyGroupLsCmd() *cobra.Command {
 			}
 
 			// Get backend.
-			b, err := currentBackend(ctx, ws, project, display.Options{Color: cmdutil.GetGlobalColorization()})
+			b, err := currentBackend(
+				ctx, ws, DefaultLoginManager, project,
+				display.Options{Color: cmdutil.GetGlobalColorization()})
 			if err != nil {
 				return fmt.Errorf("failed to get current backend: %w", err)
 			}

--- a/pkg/cmd/pulumi/policy_ls.go
+++ b/pkg/cmd/pulumi/policy_ls.go
@@ -48,7 +48,9 @@ func newPolicyLsCmd() *cobra.Command {
 			}
 
 			// Get backend.
-			b, err := currentBackend(ctx, ws, project, display.Options{Color: cmdutil.GetGlobalColorization()})
+			b, err := currentBackend(
+				ctx, ws, DefaultLoginManager, project,
+				display.Options{Color: cmdutil.GetGlobalColorization()})
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/policy_publish_test.go
+++ b/pkg/cmd/pulumi/policy_publish_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
-	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,6 +24,25 @@ func TestPolicyPublishCmd_default(t *testing.T) {
 		},
 	}
 
+	lm := &backend.MockLoginManager{
+		LoginF: func(
+			ctx context.Context,
+			ws pkgWorkspace.Context,
+			sink diag.Sink,
+			url string,
+			project *workspace.Project,
+			setCurrent bool,
+			color colors.Colorization,
+		) (backend.Backend, error) {
+			return &backend.MockBackend{
+				GetPolicyPackF: func(ctx context.Context, name string, d diag.Sink) (backend.PolicyPack, error) {
+					assert.Contains(t, name, "org1")
+					return mockPolicyPack, nil
+				},
+			}, nil
+		},
+	}
+
 	cmd := policyPublishCmd{
 		getwd: func() (string, error) {
 			cwd, err := os.Getwd()
@@ -31,20 +51,12 @@ func TestPolicyPublishCmd_default(t *testing.T) {
 			}
 			return filepath.Join(cwd, "testdata/policy"), nil
 		},
-		loginToCloud: func(context.Context, string, *workspace.Project, bool, display.Options) (backend.Backend, error) {
-			return &backend.MockBackend{
-				GetPolicyPackF: func(ctx context.Context, name string, d diag.Sink) (backend.PolicyPack, error) {
-					assert.Contains(t, name, "org1")
-					return mockPolicyPack, nil
-				},
-			}, nil
-		},
 		defaultOrg: func(*workspace.Project) (string, error) {
 			return "org1", nil
 		},
 	}
 
-	err := cmd.Run(context.Background(), []string{})
+	err := cmd.Run(context.Background(), lm, []string{})
 	require.NoError(t, err)
 }
 
@@ -57,15 +69,16 @@ func TestPolicyPublishCmd_orgNamePassedIn(t *testing.T) {
 		},
 	}
 
-	cmd := policyPublishCmd{
-		getwd: func() (string, error) {
-			cwd, err := os.Getwd()
-			if err != nil {
-				return "", err
-			}
-			return filepath.Join(cwd, "testdata/policy"), nil
-		},
-		loginToCloud: func(context.Context, string, *workspace.Project, bool, display.Options) (backend.Backend, error) {
+	lm := &backend.MockLoginManager{
+		LoginF: func(
+			ctx context.Context,
+			ws pkgWorkspace.Context,
+			sink diag.Sink,
+			url string,
+			project *workspace.Project,
+			setCurrent bool,
+			color colors.Colorization,
+		) (backend.Backend, error) {
 			return &backend.MockBackend{
 				GetPolicyPackF: func(ctx context.Context, name string, d diag.Sink) (backend.PolicyPack, error) {
 					assert.Contains(t, name, "org1")
@@ -75,6 +88,16 @@ func TestPolicyPublishCmd_orgNamePassedIn(t *testing.T) {
 		},
 	}
 
-	err := cmd.Run(context.Background(), []string{"org1"})
+	cmd := policyPublishCmd{
+		getwd: func() (string, error) {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return "", err
+			}
+			return filepath.Join(cwd, "testdata/policy"), nil
+		},
+	}
+
+	err := cmd.Run(context.Background(), lm, []string{"org1"})
 	require.NoError(t, err)
 }

--- a/pkg/cmd/pulumi/policy_rm.go
+++ b/pkg/cmd/pulumi/policy_rm.go
@@ -39,7 +39,7 @@ func newPolicyRmCmd() *cobra.Command {
 			ctx := cmd.Context()
 			yes = yes || skipConfirmations()
 			// Obtain current PolicyPack, tied to the Pulumi Cloud backend.
-			policyPack, err := requirePolicyPack(ctx, args[0], loginToCloud)
+			policyPack, err := requirePolicyPack(ctx, args[0], DefaultLoginManager)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/policy_validate.go
+++ b/pkg/cmd/pulumi/policy_validate.go
@@ -34,7 +34,7 @@ func newPolicyValidateCmd() *cobra.Command {
 		Run: runCmdFunc(func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := cmd.Context()
 			// Obtain current PolicyPack, tied to the Pulumi Cloud backend.
-			policyPack, err := requirePolicyPack(ctx, cliArgs[0], loginToCloud)
+			policyPack, err := requirePolicyPack(ctx, cliArgs[0], DefaultLoginManager)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -362,7 +362,7 @@ func newPreviewCmd() *cobra.Command {
 				return err
 			}
 
-			s, err := requireStack(ctx, ws, stackName, stackOfferNew, displayOpts)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, stackName, stackOfferNew, displayOpts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/query.go
+++ b/pkg/cmd/pulumi/query.go
@@ -74,7 +74,7 @@ issue at https://github.com/pulumi/pulumi/issues/16964.
 				return err
 			}
 
-			b, err := currentBackend(ctx, ws, project, opts.Display)
+			b, err := currentBackend(ctx, ws, DefaultLoginManager, project, opts.Display)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -168,7 +168,7 @@ func newRefreshCmd() *cobra.Command {
 				opts.Display.SuppressPermalink = true
 			}
 
-			s, err := requireStack(ctx, ws, stackName, stackOfferNew, opts.Display)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, stackName, stackOfferNew, opts.Display)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -65,7 +65,7 @@ func newStackCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(ctx, ws, stackName, stackOfferNew, opts)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, stackName, stackOfferNew, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -104,7 +104,7 @@ func (cmd *stackChangeSecretsProviderCmd) Run(ctx context.Context, args []string
 	}
 
 	// Get the current stack and its project
-	currentStack, err := requireStack(ctx, ws, cmd.stack, stackLoadOnly, opts)
+	currentStack, err := requireStack(ctx, ws, DefaultLoginManager, cmd.stack, stackLoadOnly, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/stack_export.go
+++ b/pkg/cmd/pulumi/stack_export.go
@@ -53,7 +53,7 @@ func newStackExportCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack and export its deployment
-			s, err := requireStack(ctx, ws, stackName, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, stackName, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_graph.go
+++ b/pkg/cmd/pulumi/stack_graph.go
@@ -72,7 +72,7 @@ func newStackGraphCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(ctx, ws, cmdOpts.stackName, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, cmdOpts.stackName, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -43,7 +43,7 @@ This command displays data about previous updates for a stack.`,
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := requireStack(ctx, ws, stack, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, stack, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_import.go
+++ b/pkg/cmd/pulumi/stack_import.go
@@ -57,7 +57,7 @@ func newStackImportCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack and import a deployment.
-			s, err := requireStack(ctx, ws, stackName, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, stackName, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -98,7 +98,7 @@ type stackInitCmd struct {
 	// currentBackend is a reference to the top-level currentBackend function.
 	// This is used to override the default implementation for testing purposes.
 	currentBackend func(
-		context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+		context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 	) (backend.Backend, error)
 }
 
@@ -123,7 +123,7 @@ func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	b, err := currentBackend(ctx, ws, project, opts)
+	b, err := currentBackend(ctx, ws, DefaultLoginManager, project, opts)
 	if err != nil {
 		return err
 	}
@@ -189,7 +189,7 @@ func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
 		}
 
 		// load the old stack and its project
-		copyStack, err := requireStack(ctx, ws, cmd.stackToCopy, stackLoadOnly, opts)
+		copyStack, err := requireStack(ctx, ws, DefaultLoginManager, cmd.stackToCopy, stackLoadOnly, opts)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/stack_init_test.go
+++ b/pkg/cmd/pulumi/stack_init_test.go
@@ -42,7 +42,7 @@ func TestStackInit_teamsUnsupportedByBackend(t *testing.T) {
 		teams:     []string{"red", "blue"},
 		stackName: "dev",
 		currentBackend: func(
-			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+			context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 		) (backend.Backend, error) {
 			return mockBackend, nil
 		},

--- a/pkg/cmd/pulumi/stack_ls.go
+++ b/pkg/cmd/pulumi/stack_ls.go
@@ -142,7 +142,9 @@ func runStackLS(ctx context.Context, args stackLSArgs) error {
 	}
 
 	// Get the current backend.
-	b, err := currentBackend(ctx, ws, project, display.Options{Color: cmdutil.GetGlobalColorization()})
+	b, err := currentBackend(
+		ctx, ws, DefaultLoginManager, project,
+		display.Options{Color: cmdutil.GetGlobalColorization()})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/stack_output.go
+++ b/pkg/cmd/pulumi/stack_output.go
@@ -77,7 +77,8 @@ type stackOutputCmd struct {
 	// This is a field on stackOutputCmd so that we can replace it
 	// from tests.
 	requireStack func(
-		ctx context.Context, ws pkgWorkspace.Context, name string, lopt stackLoadOption, opts display.Options,
+		ctx context.Context, ws pkgWorkspace.Context, lm backend.LoginManager,
+		name string, lopt stackLoadOption, opts display.Options,
 	) (backend.Stack, error)
 
 	Stdout io.Writer // defaults to os.Stdout
@@ -119,7 +120,7 @@ func (cmd *stackOutputCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	// Fetch the current stack and its output properties.
-	s, err := requireStack(ctx, cmd.ws, cmd.stackName, stackLoadOnly, opts)
+	s, err := requireStack(ctx, cmd.ws, DefaultLoginManager, cmd.stackName, stackLoadOnly, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/stack_output_test.go
+++ b/pkg/cmd/pulumi/stack_output_test.go
@@ -109,7 +109,7 @@ func TestStackOutputCmd_plainText(t *testing.T) {
 					},
 				},
 			}
-			requireStack := func(context.Context, pkgWorkspace.Context,
+			requireStack := func(context.Context, pkgWorkspace.Context, backend.LoginManager,
 				string, stackLoadOption, display.Options,
 			) (backend.Stack, error) {
 				return &backend.MockStack{
@@ -221,7 +221,7 @@ func TestStackOutputCmd_json(t *testing.T) {
 					},
 				},
 			}
-			requireStack := func(context.Context, pkgWorkspace.Context,
+			requireStack := func(context.Context, pkgWorkspace.Context, backend.LoginManager,
 				string, stackLoadOption, display.Options,
 			) (backend.Stack, error) {
 				return &backend.MockStack{
@@ -343,7 +343,7 @@ func TestStackOutputCmd_shell(t *testing.T) {
 					},
 				},
 			}
-			requireStack := func(context.Context, pkgWorkspace.Context,
+			requireStack := func(context.Context, pkgWorkspace.Context, backend.LoginManager,
 				string, stackLoadOption, display.Options,
 			) (backend.Stack, error) {
 				return &backend.MockStack{
@@ -382,7 +382,7 @@ func TestStackOutputCmd_jsonAndShellConflict(t *testing.T) {
 
 	cmd := stackOutputCmd{
 		requireStack: func(
-			context.Context, pkgWorkspace.Context, string, stackLoadOption, display.Options,
+			context.Context, pkgWorkspace.Context, backend.LoginManager, string, stackLoadOption, display.Options,
 		) (backend.Stack, error) {
 			t.Fatal("This function should not be called")
 			return nil, errors.New("should not be called")

--- a/pkg/cmd/pulumi/stack_rename.go
+++ b/pkg/cmd/pulumi/stack_rename.go
@@ -53,7 +53,7 @@ func newStackRenameCmd() *cobra.Command {
 			}
 
 			// Look up the stack to be moved, and find the path to the project file's location.
-			s, err := requireStack(ctx, ws, stack, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, stack, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_rm.go
+++ b/pkg/cmd/pulumi/stack_rm.go
@@ -64,7 +64,7 @@ func newStackRmCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(ctx, ws, stack, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, stack, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_select.go
+++ b/pkg/cmd/pulumi/stack_select.go
@@ -57,7 +57,7 @@ func newStackSelectCmd() *cobra.Command {
 				return err
 			}
 
-			b, err := currentBackend(ctx, ws, project, opts)
+			b, err := currentBackend(ctx, ws, DefaultLoginManager, project, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_tag.go
+++ b/pkg/cmd/pulumi/stack_tag.go
@@ -67,7 +67,7 @@ func newStackTagGetCmd(stack *string) *cobra.Command {
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := requireStack(ctx, ws, *stack, stackLoadOnly, opts)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, *stack, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}
@@ -101,7 +101,7 @@ func newStackTagLsCmd(stack *string) *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(ctx, ws, *stack, stackSetCurrent, opts)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, *stack, stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -159,7 +159,7 @@ func newStackTagRmCmd(stack *string) *cobra.Command {
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := requireStack(ctx, ws, *stack, stackSetCurrent, opts)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, *stack, stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -191,7 +191,7 @@ func newStackTagSetCmd(stack *string) *cobra.Command {
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := requireStack(ctx, ws, *stack, stackSetCurrent, opts)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, *stack, stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -119,10 +119,10 @@ func locateStackResource(opts display.Options, snap *deploy.Snapshot, urn resour
 
 // runStateEdit runs the given state edit function on a resource with the given URN in a given stack.
 func runStateEdit(
-	ctx context.Context, ws pkgWorkspace.Context, stackName string, showPrompt bool,
+	ctx context.Context, ws pkgWorkspace.Context, lm backend.LoginManager, stackName string, showPrompt bool,
 	urn resource.URN, operation edit.OperationFunc,
 ) error {
-	return runTotalStateEdit(ctx, ws, stackName, showPrompt, func(opts display.Options, snap *deploy.Snapshot) error {
+	return runTotalStateEdit(ctx, ws, lm, stackName, showPrompt, func(opts display.Options, snap *deploy.Snapshot) error {
 		res, err := locateStackResource(opts, snap, urn)
 		if err != nil {
 			return err
@@ -135,13 +135,13 @@ func runStateEdit(
 // runTotalStateEdit runs a snapshot-mutating function on the entirety of the given stack's snapshot.
 // Before mutating, the user may be prompted to for confirmation if the current session is interactive.
 func runTotalStateEdit(
-	ctx context.Context, ws pkgWorkspace.Context, stackName string, showPrompt bool,
+	ctx context.Context, ws pkgWorkspace.Context, lm backend.LoginManager, stackName string, showPrompt bool,
 	operation func(opts display.Options, snap *deploy.Snapshot) error,
 ) error {
 	opts := display.Options{
 		Color: cmdutil.GetGlobalColorization(),
 	}
-	s, err := requireStack(ctx, ws, stackName, stackOfferNew, opts)
+	s, err := requireStack(ctx, ws, lm, stackName, stackOfferNew, opts)
 	if err != nil {
 		return err
 	}
@@ -209,7 +209,8 @@ func totalStateEdit(ctx context.Context, s backend.Stack, showPrompt bool, opts 
 //
 // Prompt is displayed to the user when selecting the URN.
 func getURNFromState(
-	ctx context.Context, ws pkgWorkspace.Context, stackName string, snap **deploy.Snapshot, prompt string,
+	ctx context.Context, ws pkgWorkspace.Context, lm backend.LoginManager,
+	stackName string, snap **deploy.Snapshot, prompt string,
 ) (resource.URN, error) {
 	if snap == nil {
 		// This means we won't cache the value.
@@ -220,7 +221,7 @@ func getURNFromState(
 			Color: cmdutil.GetGlobalColorization(),
 		}
 
-		s, err := requireStack(ctx, ws, stackName, stackLoadOnly, opts)
+		s, err := requireStack(ctx, ws, lm, stackName, stackLoadOnly, opts)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/cmd/pulumi/state_edit.go
+++ b/pkg/cmd/pulumi/state_edit.go
@@ -59,7 +59,7 @@ a preview showing a diff of the altered state.`,
 			}
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
-			s, err := requireStack(ctx, ws, stackName, stackLoadOnly, display.Options{
+			s, err := requireStack(ctx, ws, DefaultLoginManager, stackName, stackLoadOnly, display.Options{
 				Color:         cmdutil.GetGlobalColorization(),
 				IsInteractive: true,
 			})

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -73,14 +73,14 @@ splitting a stack into multiple stacks or when merging multiple stacks into one.
 			if sourceStackName == "" && destStackName == "" {
 				return errors.New("at least one of --source or --dest must be provided")
 			}
-			sourceStack, err := requireStack(ctx, ws, sourceStackName, stackLoadOnly, display.Options{
+			sourceStack, err := requireStack(ctx, ws, DefaultLoginManager, sourceStackName, stackLoadOnly, display.Options{
 				Color:         cmdutil.GetGlobalColorization(),
 				IsInteractive: true,
 			})
 			if err != nil {
 				return err
 			}
-			destStack, err := requireStack(ctx, ws, destStackName, stackLoadOnly, display.Options{
+			destStack, err := requireStack(ctx, ws, DefaultLoginManager, destStackName, stackLoadOnly, display.Options{
 				Color:         cmdutil.GetGlobalColorization(),
 				IsInteractive: true,
 			})

--- a/pkg/cmd/pulumi/state_rename.go
+++ b/pkg/cmd/pulumi/state_rename.go
@@ -187,7 +187,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 				var snap *deploy.Snapshot
 				err := surveyStack(
 					func() (err error) {
-						urn, err = getURNFromState(ctx, ws, stack, &snap, "Select a resource to rename:")
+						urn, err = getURNFromState(ctx, ws, DefaultLoginManager, stack, &snap, "Select a resource to rename:")
 						if err != nil {
 							err = fmt.Errorf("failed to select resource: %w", err)
 						}
@@ -227,7 +227,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 			// Show the confirmation prompt if the user didn't pass the --yes parameter to skip it.
 			showPrompt := !yes
 
-			err := runTotalStateEdit(ctx, ws, stack, showPrompt,
+			err := runTotalStateEdit(ctx, ws, DefaultLoginManager, stack, showPrompt,
 				func(opts display.Options, snap *deploy.Snapshot) error {
 					return stateRenameOperation(urn, newResourceName, opts, snap)
 				})

--- a/pkg/cmd/pulumi/state_unprotect.go
+++ b/pkg/cmd/pulumi/state_unprotect.go
@@ -62,7 +62,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 					return missingNonInteractiveArg("resource URN")
 				}
 				var err error
-				urn, err = getURNFromState(ctx, ws, stack, nil, "Select a resource to unprotect:")
+				urn, err = getURNFromState(ctx, ws, DefaultLoginManager, stack, nil, "Select a resource to unprotect:")
 				if err != nil {
 					return fmt.Errorf("failed to select resource: %w", err)
 				}
@@ -83,19 +83,20 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 }
 
 func unprotectAllResources(ctx context.Context, ws pkgWorkspace.Context, stackName string, showPrompt bool) error {
-	err := runTotalStateEdit(ctx, ws, stackName, showPrompt, func(_ display.Options, snap *deploy.Snapshot) error {
-		// Protects against Panic when a user tries to unprotect non-existing resources
-		if snap == nil {
-			return errors.New("no resources found to unprotect")
-		}
+	err := runTotalStateEdit(
+		ctx, ws, DefaultLoginManager, stackName, showPrompt, func(_ display.Options, snap *deploy.Snapshot) error {
+			// Protects against Panic when a user tries to unprotect non-existing resources
+			if snap == nil {
+				return errors.New("no resources found to unprotect")
+			}
 
-		for _, res := range snap.Resources {
-			err := edit.UnprotectResource(snap, res)
-			contract.AssertNoErrorf(err, "Unable to unprotect resource %q", res.URN)
-		}
+			for _, res := range snap.Resources {
+				err := edit.UnprotectResource(snap, res)
+				contract.AssertNoErrorf(err, "Unable to unprotect resource %q", res.URN)
+			}
 
-		return nil
-	})
+			return nil
+		})
 	if err != nil {
 		return err
 	}
@@ -106,7 +107,7 @@ func unprotectAllResources(ctx context.Context, ws pkgWorkspace.Context, stackNa
 func unprotectResource(
 	ctx context.Context, ws pkgWorkspace.Context, stackName string, urn resource.URN, showPrompt bool,
 ) error {
-	err := runStateEdit(ctx, ws, stackName, showPrompt, urn, edit.UnprotectResource)
+	err := runStateEdit(ctx, ws, DefaultLoginManager, stackName, showPrompt, urn, edit.UnprotectResource)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/state_upgrade.go
+++ b/pkg/cmd/pulumi/state_upgrade.go
@@ -66,7 +66,7 @@ type stateUpgradeCmd struct {
 	// Used to mock out the currentBackend function for testing.
 	// Defaults to currentBackend function.
 	currentBackend func(
-		context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+		context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 	) (backend.Backend, error)
 }
 
@@ -92,7 +92,7 @@ func (cmd *stateUpgradeCmd) Run(ctx context.Context) error {
 		Stdout: cmd.Stdout,
 	}
 
-	b, err := currentBackend(ctx, pkgWorkspace.Instance, nil, dopts)
+	b, err := currentBackend(ctx, pkgWorkspace.Instance, DefaultLoginManager, nil, dopts)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/state_upgrade_test.go
+++ b/pkg/cmd/pulumi/state_upgrade_test.go
@@ -95,7 +95,7 @@ func TestStateUpgradeCommand_Run_upgrade(t *testing.T) {
 	var called bool
 	cmd := stateUpgradeCmd{
 		currentBackend: func(
-			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+			context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 		) (backend.Backend, error) {
 			return &stubDIYBackend{
 				UpgradeF: func(context.Context, *diy.UpgradeOptions) error {
@@ -120,7 +120,7 @@ func TestStateUpgradeCommand_Run_upgrade_yes_flag(t *testing.T) {
 	var called bool
 	cmd := stateUpgradeCmd{
 		currentBackend: func(
-			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+			context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 		) (backend.Backend, error) {
 			return &stubDIYBackend{
 				UpgradeF: func(context.Context, *diy.UpgradeOptions) error {
@@ -145,7 +145,7 @@ func TestStateUpgradeCommand_Run_upgradeRejected(t *testing.T) {
 
 	cmd := stateUpgradeCmd{
 		currentBackend: func(
-			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+			context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 		) (backend.Backend, error) {
 			return &stubDIYBackend{
 				UpgradeF: func(context.Context, *diy.UpgradeOptions) error {
@@ -169,7 +169,7 @@ func TestStateUpgradeCommand_Run_unsupportedBackend(t *testing.T) {
 	cmd := stateUpgradeCmd{
 		Stdout: &stdout,
 		currentBackend: func(
-			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+			context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 		) (backend.Backend, error) {
 			return &backend.MockBackend{}, nil
 		},
@@ -187,7 +187,7 @@ func TestStateUpgradeCmd_Run_backendError(t *testing.T) {
 	giveErr := errors.New("great sadness")
 	cmd := stateUpgradeCmd{
 		currentBackend: func(
-			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+			context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 		) (backend.Backend, error) {
 			return nil, giveErr
 		},

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -90,9 +90,9 @@ func newUpCmd() *cobra.Command {
 
 	// up implementation used when the source of the Pulumi program is in the current working directory.
 	upWorkingDirectory := func(
-		ctx context.Context, ws pkgWorkspace.Context, opts backend.UpdateOptions, cmd *cobra.Command,
+		ctx context.Context, ws pkgWorkspace.Context, lm backend.LoginManager, opts backend.UpdateOptions, cmd *cobra.Command,
 	) error {
-		s, err := requireStack(ctx, ws, stackName, stackOfferNew, opts.Display)
+		s, err := requireStack(ctx, ws, lm, stackName, stackOfferNew, opts.Display)
 		if err != nil {
 			return err
 		}
@@ -212,7 +212,7 @@ func newUpCmd() *cobra.Command {
 	}
 
 	// up implementation used when the source of the Pulumi program is a template name or a URL to a template.
-	upTemplateNameOrURL := func(ctx context.Context, ws pkgWorkspace.Context,
+	upTemplateNameOrURL := func(ctx context.Context, ws pkgWorkspace.Context, lm backend.LoginManager,
 		templateNameOrURL string, opts backend.UpdateOptions, cmd *cobra.Command,
 	) error {
 		// Retrieve the template repo.
@@ -261,7 +261,7 @@ func newUpCmd() *cobra.Command {
 		}
 
 		// There is no current project at this point to pass into currentBackend
-		b, err := currentBackend(ctx, ws, nil, opts.Display)
+		b, err := currentBackend(ctx, ws, lm, nil, opts.Display)
 		if err != nil {
 			return err
 		}
@@ -537,10 +537,10 @@ func newUpCmd() *cobra.Command {
 			opts.Display.ShowLinkToCopilot = env.ShowCopilotLink.Value()
 
 			if len(args) > 0 {
-				return upTemplateNameOrURL(ctx, ws, args[0], opts, cmd)
+				return upTemplateNameOrURL(ctx, ws, DefaultLoginManager, args[0], opts, cmd)
 			}
 
-			return upWorkingDirectory(ctx, ws, opts, cmd)
+			return upWorkingDirectory(ctx, ws, DefaultLoginManager, opts, cmd)
 		}),
 	}
 

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -153,6 +153,9 @@ func (f *lm) Login(
 	color colors.Colorization,
 ) (backend.Backend, error) {
 	if diy.IsDIYBackendURL(url) {
+		if setCurrent {
+			return diy.Login(ctx, sink, url, project)
+		}
 		return diy.New(ctx, sink, url, project)
 	}
 

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -185,7 +185,8 @@ func nonInteractiveCurrentBackend(
 		return nil, fmt.Errorf("could not get cloud url: %w", err)
 	}
 
-	return lm.Current(ctx, ws, cmdutil.Diag(), url, project, true /*setCurrent*/)
+	// Only set current if we don't currently have a cloud URL set.
+	return lm.Current(ctx, ws, cmdutil.Diag(), url, project, url == "")
 }
 
 func currentBackend(
@@ -201,7 +202,8 @@ func currentBackend(
 		return nil, fmt.Errorf("could not get cloud url: %w", err)
 	}
 
-	return lm.Login(ctx, ws, cmdutil.Diag(), url, project, true /*setCurrent*/, opts.Color)
+	// Only set current if we don't currently have a cloud URL set.
+	return lm.Login(ctx, ws, cmdutil.Diag(), url, project, url == "", opts.Color)
 }
 
 func createSecretsManager(

--- a/pkg/cmd/pulumi/util_remote.go
+++ b/pkg/cmd/pulumi/util_remote.go
@@ -399,7 +399,7 @@ func runDeployment(ctx context.Context, ws pkgWorkspace.Context, cmd *cobra.Comm
 		return err
 	}
 
-	b, err := currentBackend(ctx, ws, project, opts)
+	b, err := currentBackend(ctx, ws, DefaultLoginManager, project, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -92,7 +92,7 @@ func newWatchCmd() *cobra.Command {
 				return err
 			}
 
-			s, err := requireStack(ctx, ws, stackName, stackOfferNew, opts.Display)
+			s, err := requireStack(ctx, ws, DefaultLoginManager, stackName, stackOfferNew, opts.Display)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/whoami.go
+++ b/pkg/cmd/pulumi/whoami.go
@@ -63,7 +63,7 @@ type whoAmICmd struct {
 	// currentBackend is a reference to the top-level currentBackend function.
 	// This is used to override the default implementation for testing purposes.
 	currentBackend func(
-		context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+		context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 	) (backend.Backend, error)
 }
 
@@ -88,7 +88,7 @@ func (cmd *whoAmICmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	b, err := currentBackend(ctx, ws, project, opts)
+	b, err := currentBackend(ctx, ws, DefaultLoginManager, project, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/whoami_test.go
+++ b/pkg/cmd/pulumi/whoami_test.go
@@ -20,7 +20,7 @@ func TestWhoAmICmd_default(t *testing.T) {
 	cmd := whoAmICmd{
 		Stdout: &buff,
 		currentBackend: func(
-			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+			context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 		) (backend.Backend, error) {
 			return &backend.MockBackend{
 				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
@@ -44,7 +44,7 @@ func TestWhoAmICmd_verbose(t *testing.T) {
 		verbose: true,
 		Stdout:  &buff,
 		currentBackend: func(
-			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+			context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 		) (backend.Backend, error) {
 			return &backend.MockBackend{
 				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
@@ -75,7 +75,7 @@ func TestWhoAmICmd_json(t *testing.T) {
 		jsonOut: true,
 		Stdout:  &buff,
 		currentBackend: func(
-			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+			context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 		) (backend.Backend, error) {
 			return &backend.MockBackend{
 				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
@@ -106,7 +106,7 @@ func TestWhoAmICmd_verbose_teamToken(t *testing.T) {
 		verbose: true,
 		Stdout:  &buff,
 		currentBackend: func(
-			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+			context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 		) (backend.Backend, error) {
 			return &backend.MockBackend{
 				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
@@ -141,7 +141,7 @@ func TestWhoAmICmd_json_teamToken(t *testing.T) {
 		jsonOut: true,
 		Stdout:  &buff,
 		currentBackend: func(
-			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+			context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 		) (backend.Backend, error) {
 			return &backend.MockBackend{
 				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
@@ -176,7 +176,7 @@ func TestWhoAmICmd_verbose_unknownToken(t *testing.T) {
 		verbose: true,
 		Stdout:  &buff,
 		currentBackend: func(
-			context.Context, pkgWorkspace.Context, *workspace.Project, display.Options,
+			context.Context, pkgWorkspace.Context, backend.LoginManager, *workspace.Project, display.Options,
 		) (backend.Backend, error) {
 			return &backend.MockBackend{
 				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {


### PR DESCRIPTION
This abstracts the code from `currentBackend` and
`nonInteractiveCurrentBackend` into a new interface `LoginManager`. This happens to very closely match the `LoginManger` interface defined in the httpstate backend, but this is intended to be used for diy state as well.

There were a few places using `loginToCloud` to specifically login to the cloud backend. I've replaced these with just `DefaultLoginManager.Login` because either they are specifically passing in a cloud URL, or possibly an empty URL which will in Login select the cloud backend.

This lays the path to getting rid of backendInstance, which should allow more tests to run with `t.Parallel()`, and be a more obvious mock point (plus its just nice to have less global variables).