### PR TITLE
state move: show full set of delete commands when writing source stack fails

### DIFF
--- a/changelog/pending/20240909--cli-state--show-the-full-set-of-delete-commands-necessary-to-remove-resources-from-the-source-stack-if-writing-to-it-fails.yaml
+++ b/changelog/pending/20240909--cli-state--show-the-full-set-of-delete-commands-necessary-to-remove-resources-from-the-source-stack-if-writing-to-it-fails.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/state
+  description: Show the full set of delete commands necessary to remove resources from the source stack, if writing to it fails

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -88,6 +88,9 @@ type Backend interface {
 
 	// Upgrade to the latest state store version.
 	Upgrade(ctx context.Context, opts *UpgradeOptions) error
+
+	// Lock the specified stack reference in this backend.
+	Lock(ctx context.Context, stackRef backend.StackReference) error
 }
 
 type diyBackend struct {

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -1267,6 +1267,8 @@ Successfully moved resources from organization/test/sourceStack to organization/
 }
 
 func TestMoveLockedBackendShowsDeleteCommands(t *testing.T) {
+	t.Parallel()
+
 	providerURN := resource.NewURN("sourceStack", "test", "", "pulumi:providers:a", "default_1_0_0")
 	sourceResources := []*resource.State{
 		{
@@ -1319,6 +1321,8 @@ func TestMoveLockedBackendShowsDeleteCommands(t *testing.T) {
 	}
 
 	lockingB, err := diy.New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
 	err = lockingB.Lock(ctx, sourceStack.Ref())
 	assert.NoError(t, err)
 

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -1329,6 +1329,6 @@ func TestMoveLockedBackendShowsDeleteCommands(t *testing.T) {
 	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[2].URN)}, mp, mp)
 	//nolint:lll
 	assert.ErrorContains(t, err, "Please remove the resources from the source stack manually the following commands:\n"+
-		"    pulumi state delete --stack organization/test/sourceStack 'urn:pulumi:sourceStack::test::d:e:f$a:b:c::name2'"+
+		"    pulumi state delete --stack organization/test/sourceStack 'urn:pulumi:sourceStack::test::d:e:f$a:b:c::name2'\n"+
 		"    pulumi state delete --stack organization/test/sourceStack 'urn:pulumi:sourceStack::test::d:e:f$a:b:c::name'")
 }

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -1265,3 +1265,66 @@ Successfully moved resources from organization/test/sourceStack to organization/
 	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:pulumi:Stack::test-destStack"),
 		destSnapshot.Resources[2].Parent)
 }
+
+func TestMoveLockedBackendShowsDeleteCommands(t *testing.T) {
+	providerURN := resource.NewURN("sourceStack", "test", "", "pulumi:providers:a", "default_1_0_0")
+	sourceResources := []*resource.State{
+		{
+			URN:  resource.DefaultRootStackURN("sourceStack", "test"),
+			Type: "pulumi:pulumi:Stack",
+		},
+		{
+			URN:    providerURN,
+			Type:   "pulumi:providers:a::default_1_0_0",
+			ID:     "provider_id",
+			Custom: true,
+			Parent: resource.DefaultRootStackURN("sourceStack", "test"),
+		},
+		{
+			URN:      resource.NewURN("sourceStack", "test", "d:e:f", "a:b:c", "name"),
+			Type:     "a:b:c",
+			Provider: string(providerURN) + "::provider_id",
+		},
+		{
+			URN:      resource.NewURN("sourceStack", "test", "d:e:f", "a:b:c", "name2"),
+			Type:     "a:b:c",
+			Provider: string(providerURN) + "::provider_id",
+			Parent:   resource.NewURN("sourceStack", "test", "d:e:f", "a:b:c", "name"),
+		},
+	}
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	b, err := diy.New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	sourceStackName := "organization/test/sourceStack"
+	sourceStack := createStackWithResources(t, b, sourceStackName, sourceResources)
+
+	destStackName := "organization/anotherproject/destStack"
+	destStack := createStackWithResources(t, b, destStackName, []*resource.State{})
+
+	mp := &secrets.MockProvider{}
+	mp = mp.Add("b64", func(_ json.RawMessage) (secrets.Manager, error) {
+		return b64.NewBase64SecretsManager(), nil
+	})
+
+	var stdout bytes.Buffer
+
+	stateMoveCmd := stateMoveCmd{
+		Yes:       true,
+		Stdout:    &stdout,
+		Colorizer: colors.Never,
+	}
+
+	lockingB, err := diy.New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	err = lockingB.Lock(ctx, sourceStack.Ref())
+	assert.NoError(t, err)
+
+	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[2].URN)}, mp, mp)
+	//nolint:lll
+	assert.ErrorContains(t, err, "Please remove the resources from the source stack manually the following commands:\n"+
+		"    pulumi state delete --stack organization/test/sourceStack 'urn:pulumi:sourceStack::test::d:e:f$a:b:c::name2'"+
+		"    pulumi state delete --stack organization/test/sourceStack 'urn:pulumi:sourceStack::test::d:e:f$a:b:c::name'")
+}


### PR DESCRIPTION

Before actually writing the source stack, we have no way of knowing we can write it.  The same is true for writing the destination stack. This means if the one we write later fails to write, we get an incompletely moved state.

We've decided to move the destination stack first, and then the source stack, so resources are always tracked.  The error message also mentions cleaning up the source stack, however it's not completely obvious how to do that.  Since we know the resources that were supposed to be moved (and successfully been written to the destination stack at this point), we can give the user better instructions on how to clean up the resources.

Do that by giving them a full set of `pulumi state delete` commands they can run to clean up the source stack.

Fixes https://github.com/pulumi/pulumi/issues/17187