### PR TITLE
state move: revert dest changes if source can't be saved

### DIFF
--- a/changelog/pending/20240909--cli-state--try-to-revert-changes-to-destination-stack-if-we-are-unable-to-save-the-source-stack-in-state-move.yaml
+++ b/changelog/pending/20240909--cli-state--try-to-revert-changes-to-destination-stack-if-we-are-unable-to-save-the-source-stack-in-state-move.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/state
+  description: Try to revert changes to destination stack if we are unable to save the source stack in state move

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -281,6 +281,9 @@ func (cmd *stateMoveCmd) Run(
 	}
 	sourceSnapshot.Resources = sourceSnapshot.Resources[:i]
 
+	// Save a copy of the destination snapshot so we can restore it if saving the source snapshot with the deleted resources fails.
+	originalDestResources := destSnapshot.Resources
+
 	// Create a root stack if there is none
 	rootStack, err := stack.GetRootStackResource(destSnapshot)
 	if err != nil {
@@ -441,19 +444,28 @@ None of the resources have been moved, it is safe to try again`, err)
 
 	err = saveSnapshot(ctx, source, sourceSnapshot, false)
 	if err != nil {
-		var deleteCommands string
-		// Iterate over the resources in reverse order, so resources with no dependencies will be deleted first.
-		for i := len(resourcesToMoveOrdered) - 1; i >= 0; i-- {
-			deleteCommands += fmt.Sprintf(
-				"\n    pulumi state delete --stack %s '%s'",
-				source.Ref().FullyQualifiedName(),
-				resourcesToMoveOrdered[i].URN)
-		}
-		return fmt.Errorf(`failed to save source snapshot: %w
+		// Try to restore the destination snapshot to its original state
+		destSnapshot.Resources = originalDestResources
+		errDest := saveSnapshot(ctx, dest, destSnapshot, false)
+		if errDest != nil {
+			var deleteCommands string
+			// Iterate over the resources in reverse order, so resources with no dependencies will be deleted first.
+			for i := len(resourcesToMoveOrdered) - 1; i >= 0; i-- {
+				deleteCommands += fmt.Sprintf(
+					"\n    pulumi state delete --stack %s '%s'",
+					source.Ref().FullyQualifiedName(),
+					resourcesToMoveOrdered[i].URN)
+			}
+			return fmt.Errorf(`failed to save source snapshot: %w
 
 The resources being moved have already been appended to the destination stack, but will still also be in the
 source stack.  Please remove the resources from the source stack manually the following commands:%v
 '`, err, deleteCommands)
+		} else {
+			return fmt.Errorf(`failed to save source snapshot: %w
+
+None of the resources have been moved.  Please fix the error and try again`, err)
+		}
 	}
 
 	fmt.Fprintf(cmd.Stdout, cmd.Colorizer.Colorize(

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -281,7 +281,8 @@ func (cmd *stateMoveCmd) Run(
 	}
 	sourceSnapshot.Resources = sourceSnapshot.Resources[:i]
 
-	// Save a copy of the destination snapshot so we can restore it if saving the source snapshot with the deleted resources fails.
+	// Save a copy of the destination snapshot so we can restore it if saving the source snapshot with the
+	// deleted resources fails.
 	originalDestResources := destSnapshot.Resources
 
 	// Create a root stack if there is none
@@ -461,11 +462,10 @@ None of the resources have been moved, it is safe to try again`, err)
 The resources being moved have already been appended to the destination stack, but will still also be in the
 source stack.  Please remove the resources from the source stack manually the following commands:%v
 '`, err, deleteCommands)
-		} else {
-			return fmt.Errorf(`failed to save source snapshot: %w
+		}
+		return fmt.Errorf(`failed to save source snapshot: %w
 
 None of the resources have been moved.  Please fix the error and try again`, err)
-		}
 	}
 
 	fmt.Fprintf(cmd.Stdout, cmd.Colorizer.Colorize(

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -460,7 +460,7 @@ None of the resources have been moved, it is safe to try again`, err)
 			return fmt.Errorf(`failed to save source snapshot: %w
 
 The resources being moved have already been appended to the destination stack, but will still also be in the
-source stack.  Please remove the resources from the source stack manually the following commands:%v
+source stack.  Please remove the resources from the source stack manually using the following commands:%v
 '`, err, deleteCommands)
 		}
 		return fmt.Errorf(`failed to save source snapshot: %w

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -1268,6 +1268,8 @@ Successfully moved resources from organization/test/sourceStack to organization/
 
 // TODO: Add a test checking the error text for when the reverting to the original destination state fails.
 // See https://github.com/pulumi/pulumi/pull/17208/files#diff-cbb48e4e8470d1946c5073f9d6ece05f454b340cc66ca4d9fbf7901e0a8b5c47L1330
+//
+//nolint:lll // The link is too long
 func TestMoveLockedBackendRevertsDestination(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -1266,6 +1266,8 @@ Successfully moved resources from organization/test/sourceStack to organization/
 		destSnapshot.Resources[2].Parent)
 }
 
+// TODO: Add a test checking the error text for when the reverting to the original destination state fails.
+// See https://github.com/pulumi/pulumi/pull/17208/files#diff-cbb48e4e8470d1946c5073f9d6ece05f454b340cc66ca4d9fbf7901e0a8b5c47L1330
 func TestMoveLockedBackendRevertsDestination(t *testing.T) {
 	t.Parallel()
 
@@ -1327,7 +1329,6 @@ func TestMoveLockedBackendRevertsDestination(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[2].URN)}, mp, mp)
-	//nolint:lll
 	assert.ErrorContains(t, err, "None of the resources have been moved.  Please fix the error and try again")
 
 	sourceStack, err = b.GetStack(ctx, sourceStack.Ref())


### PR DESCRIPTION
As explained in https://github.com/pulumi/pulumi/pull/17205, we need to save one stack after another when doing a state move.  The mentioned PR introduces a better error output, so the user can get themselves out of the broken situation.

However we can do a bit better.  If we fail to save the source stack for any reason, we can still try to revert the changes from the destination stack, bringing us back to the original situation, without the user having to intervene manually, which is usually preferable for users.  If we fail to do *that*, we still display the list of commands the user can use to get themselves out of the situation.

Unfortunately this makes that latter output very hard to test, since we'd have to first succeed in saving the destination stack and on the next attempt fail, and our test infrastructure is not quite set up for that.

This is based on https://github.com/pulumi/pulumi/pull/17205, and should be another improvement to the user experience in that case.