### PR TITLE
auto: support refresh consistently in up/preview/destroy

### DIFF
--- a/changelog/pending/20240909--auto-nodejs-python--support-refresh-consistently-in-up-preview-destroy.yaml
+++ b/changelog/pending/20240909--auto-nodejs-python--support-refresh-consistently-in-up-preview-destroy.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/nodejs,python
+  description: Support refresh consistently in up/preview/destroy

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -535,6 +535,9 @@ Event: ${line}\n${e.toString()}`);
             if (opts.userAgent) {
                 args.push("--exec-agent", opts.userAgent);
             }
+            if (opts.refresh) {
+                args.push("--refresh");
+            }
             applyGlobalOpts(opts, args);
         }
 

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -1480,6 +1480,11 @@ export interface DestroyOptions extends GlobalOpts {
     message?: string;
 
     /**
+     * Refresh the state of the stack's resources against the cloud provider before running destroy.
+     */
+    refresh?: boolean;
+
+    /**
      * Specify a set of resource URNs to operate on. Other resources will not be updated.
      */
     target?: string[];

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -691,7 +691,7 @@ describe("LocalWorkspace", () => {
         // Assert.
         await assert.rejects(stack.workspace.selectStack(stackName));
     });
-    it(`refreshes before preview`, async () => {
+    it(`refreshes with refresh option`, async () => {
         // We create a simple program, and scan the output for an indication
         // that adding refresh: true will perfrom a refresh operation.
         const program = async () => {
@@ -709,6 +709,12 @@ describe("LocalWorkspace", () => {
         const previewRes = await stack.preview({ userAgent, refresh });
         assert.match(previewRes.stdout, /refreshing/);
         assert.strictEqual(previewRes.changeSummary.same, 1, "preview expected 1 same (the stack)");
+
+        const upRes = await stack.up({ userAgent, refresh });
+        assert.match(upRes.stdout, /refreshing/);
+
+        const destroyRes = await stack.destroy({ userAgent, refresh });
+        assert.match(destroyRes.stdout, /refreshing/);
     });
     it(`destroys an inline program with excludeProtected`, async () => {
         const program = async () => {

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -285,6 +285,7 @@ class Stack:
         suppress_progress: Optional[bool] = None,
         continue_on_error: Optional[bool] = None,
         attach_debugger: Optional[bool] = None,
+        refresh: Optional[bool] = None,
     ) -> UpResult:
         """
         Creates or updates the resources in a stack by executing the program in the Workspace.
@@ -315,6 +316,7 @@ class Stack:
         :param suppress_progress: Suppress display of periodic progress dots
         :param continue_on_error: Continue to perform the update operation despite the occurrence of errors
         :param attach_debugger: Run the process under a debugger, and pause until a debugger is attached
+        :param refresh: Refresh the state of the stack's resources against the cloud provider before running up.
         :returns: UpResult
         """
         # Disable unused-argument because pylint doesn't understand we process them in _parse_extra_args
@@ -410,6 +412,7 @@ class Stack:
         suppress_progress: Optional[bool] = None,
         import_file: Optional[str] = None,
         attach_debugger: Optional[bool] = None,
+        refresh: Optional[bool] = None,
     ) -> PreviewResult:
         """
         Performs a dry-run update to a stack, returning pending changes.
@@ -439,6 +442,7 @@ class Stack:
         :param suppress_progress: Suppress display of periodic progress dots
         :param import_file: Save any creates seen during the preview into an import file to use with pulumi import
         :param attach_debugger: Run the process under a debugger, and pause until a debugger is attached
+        :param refresh: Refresh the state of the stack's resources against the cloud provider before running preview.
         :returns: PreviewResult
         """
         # Disable unused-argument because pylint doesn't understand we process them in _parse_extra_args
@@ -609,6 +613,7 @@ class Stack:
         suppress_progress: Optional[bool] = None,
         continue_on_error: Optional[bool] = None,
         remove: Optional[bool] = None,
+        refresh: Optional[bool] = None,
     ) -> DestroyResult:
         """
         Destroy deletes all resources in a stack, leaving all history and configuration intact.
@@ -632,6 +637,7 @@ class Stack:
         :param suppress_progress: Suppress display of periodic progress dots
         :param continue_on_error: Continue to perform the destroy operation despite the occurrence of errors
         :param remove: Remove the stack and its configuration after all resources in the stack have been deleted.
+        :param refresh: Refresh the state of the stack's resources against the cloud provider before running destroy.
         :returns: DestroyResult
         """
         # Disable unused-argument because pylint doesn't understand we process them in _parse_extra_args
@@ -1032,6 +1038,7 @@ def _parse_extra_args(**kwargs) -> List[str]:
     suppress_progress: Optional[bool] = kwargs.get("suppress_progress")
     continue_on_error: Optional[bool] = kwargs.get("continue_on_error")
     attach_debugger: Optional[bool] = kwargs.get("attach_debugger")
+    refresh: Optional[bool] = kwargs.get("refresh")
 
     if message:
         extra_args.extend(["--message", message])
@@ -1077,6 +1084,8 @@ def _parse_extra_args(**kwargs) -> List[str]:
         extra_args.extend(["--continue-on-error"])
     if attach_debugger:
         extra_args.extend(["--attach-debugger"])
+    if refresh:
+        extra_args.extend(["--refresh"])
     return extra_args
 
 

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -978,22 +978,24 @@ class TestLocalWorkspace(unittest.TestCase):
 
         project_name = "testrefresh"
         stack_name = stack_namer(project_name)
-        stack = create_stack(stack_name, program=pulumi_program)
+        stack = create_stack(
+            stack_name, program=pulumi_program, project_name=project_name
+        )
 
         # pulumi up
         stack.up()
 
         # preview with refresh
         pre_res = stack.preview(refresh=True)
-        self.assertRegexpMatches(pre_res.stdout, "refereshing")
+        self.assertRegex(pre_res.stdout, r".*refreshing.*")
 
         # up with refresh
         up_res = stack.up(refresh=True)
-        self.assertRegexpMatches(up_res.stdout, "refreshing")
+        self.assertRegex(up_res.stdout, r".*refreshing.*")
 
         # destroy with refresh
         destroy_res = stack.destroy(refresh=True)
-        self.assertRegexpMatches(destroy_res.stdout, "refreshing")
+        self.assertRegex(destroy_res.stdout, r".*refreshing.*")
 
     def test_pulumi_command(self):
         p = PulumiCommand()

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -973,6 +973,28 @@ class TestLocalWorkspace(unittest.TestCase):
         self.assertIsNotNone(ws.pulumi_version)
         self.assertRegex(ws.pulumi_version, r"(\d+\.)(\d+\.)(\d+)(-.*)?")
 
+    def test_refresh(self):
+        ws = LocalWorkspace()
+
+        project_name = "testrefresh"
+        stack_name = stack_namer(project_name)
+        stack = create_stack(stack_name, program=pulumi_program)
+
+        # pulumi up
+        stack.up()
+
+        # preview with refresh
+        pre_res = stack.preview(refresh=True)
+        self.assertRegexpMatches(pre_res.stdout, "refereshing")
+
+        # up with refresh
+        up_res = stack.up(refresh=True)
+        self.assertRegexpMatches(up_res.stdout, "refreshing")
+
+        # destroy with refresh
+        destroy_res = stack.destroy(refresh=True)
+        self.assertRegexpMatches(destroy_res.stdout, "refreshing")
+
     def test_pulumi_command(self):
         p = PulumiCommand()
         ws = LocalWorkspace(pulumi_command=p)


### PR DESCRIPTION
Currently refresh support is inconsistent in automation API.  Go supports it for up, preview and destroy, NodeJS only supports it for up and preview, and Python doesn't support it at all.  Support it for all three in up, preview and destroy.

The important bit is supporting it for NodeJS (see https://github.com/pulumi/actions/pull/1278#pullrequestreview-2290185113), but it's best to support it consistently when we can.