### PR TITLE
Mirror destroy and refresh into the state command tree

### DIFF
--- a/changelog/pending/20240909--cli--add-state-destroy-and-state-refresh-to-mirror-the-current-destroy-and-refresh-commands.yaml
+++ b/changelog/pending/20240909--cli--add-state-destroy-and-state-refresh-to-mirror-the-current-destroy-and-refresh-commands.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `state destroy` and `state refresh` to mirror the current `destroy` and `refresh` commands

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -58,6 +58,8 @@ troubleshooting a stack or when performing specific edits that otherwise would r
 	cmd.AddCommand(newStateRenameCommand())
 	cmd.AddCommand(newStateUpgradeCommand())
 	cmd.AddCommand(newStateMoveCommand())
+	cmd.AddCommand(newDestroyCmd())
+	cmd.AddCommand(newRefreshCmd())
 	return cmd
 }
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -534,7 +534,9 @@ func testDestroyStackRef(e *ptesting.Environment, organization string) {
 		stackRef = organization + "/large_resource_js/" + stackName
 	}
 
-	e.RunCommand("pulumi", "destroy", "--skip-preview", "--yes", "-s", stackRef)
+	// This used to test just "destroy" but that is now mirrored to "state destroy" which will be maintained
+	// going forward to not require the project. Just "destroy" might one day error if Pulumi.yaml is missing.
+	e.RunCommand("pulumi", "state", "destroy", "--skip-preview", "--yes", "-s", stackRef)
 	e.RunCommand("pulumi", "stack", "rm", "--yes", "-s", stackRef)
 }
 


### PR DESCRIPTION
As part of https://github.com/pulumi/pulumi/issues/16600 we will be making changes to "refresh" and "destroy" to start running user programs. 

We'll be doing this as backwards compatible as we can but the behavior of these commands will change to support the new features from running the program (such as updating provider versions, running life cycle hooks). Further we may eventually want to take a break change to say that destroy and refresh _must_ run the program (although initially in the spirit of backwards compatibility we'll be minimizing that requirement as much as possible).

To allow a smooth path for users dealing with the above we're adding "state refresh" and "state destroy". We will maintain these new commands with the current behavior, i.e. operating entirely on state and not using the program.

To start with this is just a mirror of the existing commands.