### PR TITLE
Lookup language plugin versions by querying the plugin

### DIFF
--- a/changelog/pending/20240910--cli-about--fix-language-plugins-always-having-unknown-version-in-about.yaml
+++ b/changelog/pending/20240910--cli-about--fix-language-plugins-always-having-unknown-version-in-about.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/about
+  description: Fix language plugins always having unknown version in about

--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -301,7 +301,8 @@ func (eng *languageTestServer) PrepareLanguageTests(
 		return nil, fmt.Errorf("dial language plugin: %w", err)
 	}
 
-	languageClient := plugin.NewLanguageRuntimeClient(pctx, req.LanguagePluginName, pulumirpc.NewLanguageRuntimeClient(conn))
+	languageClient := plugin.NewLanguageRuntimeClient(
+		pctx, req.LanguagePluginName, pulumirpc.NewLanguageRuntimeClient(conn))
 
 	// Setup the artifacts directory
 	err = os.MkdirAll(filepath.Join(req.TemporaryDirectory, "artifacts"), 0o755)
@@ -418,7 +419,8 @@ func (eng *languageTestServer) RunLanguageTest(
 		return nil, fmt.Errorf("dial language plugin: %w", err)
 	}
 
-	languageClient := plugin.NewLanguageRuntimeClient(pctx, token.LanguagePluginName, pulumirpc.NewLanguageRuntimeClient(conn))
+	languageClient := plugin.NewLanguageRuntimeClient(
+		pctx, token.LanguagePluginName, pulumirpc.NewLanguageRuntimeClient(conn))
 
 	// And now replace the context host with our own test host
 	providers := make(map[string]plugin.Provider)

--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -301,7 +301,7 @@ func (eng *languageTestServer) PrepareLanguageTests(
 		return nil, fmt.Errorf("dial language plugin: %w", err)
 	}
 
-	languageClient := plugin.NewLanguageRuntimeClient(pctx, "uut", pulumirpc.NewLanguageRuntimeClient(conn))
+	languageClient := plugin.NewLanguageRuntimeClient(pctx, req.LanguagePluginName, pulumirpc.NewLanguageRuntimeClient(conn))
 
 	// Setup the artifacts directory
 	err = os.MkdirAll(filepath.Join(req.TemporaryDirectory, "artifacts"), 0o755)
@@ -418,7 +418,7 @@ func (eng *languageTestServer) RunLanguageTest(
 		return nil, fmt.Errorf("dial language plugin: %w", err)
 	}
 
-	languageClient := plugin.NewLanguageRuntimeClient(pctx, "uut", pulumirpc.NewLanguageRuntimeClient(conn))
+	languageClient := plugin.NewLanguageRuntimeClient(pctx, token.LanguagePluginName, pulumirpc.NewLanguageRuntimeClient(conn))
 
 	// And now replace the context host with our own test host
 	providers := make(map[string]plugin.Provider)
@@ -431,6 +431,7 @@ func (eng *languageTestServer) RunLanguageTest(
 	}
 
 	pctx.Host = &testHost{
+		stderr:      stderr,
 		host:        pctx.Host,
 		runtime:     languageClient,
 		runtimeName: token.LanguagePluginName,

--- a/cmd/pulumi-test-language/test_host.go
+++ b/cmd/pulumi-test-language/test_host.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -37,6 +38,7 @@ import (
 )
 
 type testHost struct {
+	stderr      *bytes.Buffer
 	host        plugin.Host
 	runtime     plugin.LanguageRuntime
 	runtimeName string
@@ -52,7 +54,12 @@ func (h *testHost) ServerAddr() string {
 }
 
 func (h *testHost) Log(sev diag.Severity, urn resource.URN, msg string, streamID int32) {
-	panic("not implemented")
+	prefix := ""
+	if urn != "" {
+		prefix = fmt.Sprintf(" %s: ", urn)
+	}
+	_, err := fmt.Fprintf(h.stderr, "[%s]%s\n", prefix, msg)
+	contract.IgnoreError(err)
 }
 
 func (h *testHost) LogStatus(sev diag.Severity, urn resource.URN, msg string, streamID int32) {

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -626,7 +626,7 @@ func GetRequiredPlugins(
 		if err != nil {
 			return nil, fmt.Errorf("failed to load language plugin %s: %w", runtime, err)
 		}
-		// Query the language runtime plugin for it's version.
+		// Query the language runtime plugin for its version.
 		langInfo, err := lang.GetPluginInfo()
 		if err != nil {
 			// Don't error if this fails, just warn and return the version as unknown.

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -626,10 +626,22 @@ func GetRequiredPlugins(
 		if err != nil {
 			return nil, fmt.Errorf("failed to load language plugin %s: %w", runtime, err)
 		}
-		plugins = append(plugins, workspace.PluginSpec{
-			Name: runtime,
-			Kind: apitype.LanguagePlugin,
-		})
+		// Query the language runtime plugin for it's version.
+		langInfo, err := lang.GetPluginInfo()
+		if err != nil {
+			// Don't error if this fails, just warn and return the version as unknown.
+			host.Log(diag.Warning, "", fmt.Sprintf("failed to get plugin info for language plugin %s: %v", runtime, err), 0)
+			plugins = append(plugins, workspace.PluginSpec{
+				Name: runtime,
+				Kind: apitype.LanguagePlugin,
+			})
+		} else {
+			plugins = append(plugins, workspace.PluginSpec{
+				Name:    langInfo.Name,
+				Kind:    langInfo.Kind,
+				Version: langInfo.Version,
+			})
+		}
 
 		if kinds&ResourcePlugins != 0 {
 			// Use the language plugin to compute this project's set of plugin dependencies.

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -255,7 +255,9 @@ func (h *langhost) GetPluginInfo() (workspace.PluginInfo, error) {
 		Kind: apitype.LanguagePlugin,
 	}
 
-	plugInfo.Path = h.plug.Bin
+	if h.plug != nil {
+		plugInfo.Path = h.plug.Bin
+	}
 
 	resp, err := h.client.GetPluginInfo(h.ctx.Request(), &emptypb.Empty{})
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/17215.

I think every language plugin should respond ok to GetPluginInfo but to be defensive I've made it a warning if the call fails and we just fall back the current behavior of not setting the version.