### PR TITLE
Fix gatherPluginsFromSnapshot incorrectly spec'ing parameterized providers

### DIFF
--- a/changelog/pending/20240910--engine--fix-parameterized-providers-not-downloading-correctly-when-found-from-state.yaml
+++ b/changelog/pending/20240910--engine--fix-parameterized-providers-not-downloading-correctly-when-found-from-state.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix parameterized providers not downloading correctly when found from state

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -159,6 +159,11 @@ func gatherPluginsFromSnapshot(plugctx *plugin.Context, target *deploy.Target) (
 			continue
 		}
 		pkg := providers.GetProviderPackage(urn.Type())
+
+		name, err := providers.GetProviderName(pkg, res.Inputs)
+		if err != nil {
+			return set, err
+		}
 		version, err := providers.GetProviderVersion(res.Inputs)
 		if err != nil {
 			return set, err
@@ -171,10 +176,11 @@ func gatherPluginsFromSnapshot(plugctx *plugin.Context, target *deploy.Target) (
 		if err != nil {
 			return set, err
 		}
+
 		logging.V(preparePluginLog).Infof(
-			"gatherPluginsFromSnapshot(): plugin %s %s is required by first-class provider %q", pkg, version, urn)
+			"gatherPluginsFromSnapshot(): plugin %s %s is required by first-class provider %q", name, version, urn)
 		set.Add(workspace.PluginSpec{
-			Name:              pkg.String(),
+			Name:              name.String(),
 			Kind:              apitype.ResourcePlugin,
 			Version:           version,
 			PluginDownloadURL: downloadURL,

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -225,27 +225,6 @@ func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (
 	})
 }
 
-// RunInstallPlugins calls installPlugins and just returns the error (avoids having to export pluginSet).
-func RunInstallPlugins(
-	proj *workspace.Project,
-	pwd string,
-	main string,
-	target *deploy.Target,
-	plugctx *plugin.Context,
-) error {
-	_, _, err := installPlugins(
-		context.Background(),
-		proj,
-		pwd,
-		main,
-		target,
-		nil, /*opts*/
-		plugctx,
-		true, /*returnInstallErrors*/
-	)
-	return err
-}
-
 func installPlugins(
 	ctx context.Context,
 	proj *workspace.Project,


### PR DESCRIPTION
Also deleted `RunInstallPlugins` because nothing was using it.

Without this fix we would report a parameterized plugin in state back as the parameterized package name, e.g. "random" instead of the base plugin "terraform-provider".