### PR TITLE
add debugging events to automation API

### DIFF
--- a/changelog/pending/20240910--auto-nodejs-python--add-startdebuggingevent-to-the-automation-api.yaml
+++ b/changelog/pending/20240910--auto-nodejs-python--add-startdebuggingevent-to-the-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/nodejs,python
+  description: Add StartDebuggingEvent to the automation API

--- a/sdk/nodejs/automation/events.ts
+++ b/sdk/nodejs/automation/events.ts
@@ -317,6 +317,14 @@ export interface ResOpFailedEvent {
 }
 
 /**
+ * An event emitted when a debugger has been started and is waiting for the user
+ * to attach to it using the DAP protocol.
+ */
+export interface StartDebuggingEvent {
+    config: Record<string, any>;
+}
+
+/**
  * A Pulumi engine event, such as a change to a resource or diagnostic message.
  * This is intended to capture a discriminated union -- exactly one event field
  * will be non-nil.
@@ -387,4 +395,9 @@ export interface EngineEvent {
      * A policy event, if this engine event represents a policy violation.
      */
     policyEvent?: PolicyEvent;
+
+    /**
+     * A debugging event, if the engine event represents a debugging message.
+     */
+    startDebuggingEvent?: StartDebuggingEvent;
 }

--- a/sdk/python/lib/pulumi/automation/events.py
+++ b/sdk/python/lib/pulumi/automation/events.py
@@ -514,6 +514,20 @@ class ResOpFailedEvent(BaseEvent):
         )
 
 
+class StartDebuggingEvent(BaseEvent):
+    """
+    StartDebuggingEvent is emitted when a debugger has been started and is waiting for the user
+    to attach to it using the DAP protocol.
+    """
+
+    def __init__(self, config: Mapping[str, Any]):
+        self.config = config
+
+    @classmethod
+    def from_json(cls, data: dict) -> "StartDebuggingEvent":
+        return cls(data.get("config", {}))
+
+
 class EngineEvent(BaseEvent):
     """
     EngineEvent describes a Pulumi engine event, such as a change to a resource or diagnostic
@@ -546,6 +560,7 @@ class EngineEvent(BaseEvent):
         res_outputs_event: Optional[ResOutputsEvent] = None,
         res_op_failed_event: Optional[ResOpFailedEvent] = None,
         policy_event: Optional[PolicyEvent] = None,
+        start_debugging_event: Optional[StartDebuggingEvent] = None,
     ):
         self.sequence = sequence
         self.timestamp = timestamp
@@ -558,6 +573,7 @@ class EngineEvent(BaseEvent):
         self.res_outputs_event = res_outputs_event
         self.res_op_failed_event = res_op_failed_event
         self.policy_event = policy_event
+        self.start_debugging_event = start_debugging_event
 
     @classmethod
     def from_json(cls, data: dict) -> "EngineEvent":
@@ -569,6 +585,7 @@ class EngineEvent(BaseEvent):
         res_outputs_event = data.get("resOutputsEvent")
         res_op_failed_event = data.get("resOpFailedEvent")
         policy_event = data.get("policyEvent")
+        start_debugging_event = data.get("startDebuggingEvent")
 
         return cls(
             sequence=data.get("sequence", 0),
@@ -604,4 +621,9 @@ class EngineEvent(BaseEvent):
                 else None
             ),
             policy_event=PolicyEvent.from_json(policy_event) if policy_event else None,
+            start_debugging_event=(
+                StartDebuggingEvent.from_json(start_debugging_event)
+                if start_debugging_event
+                else None
+            ),
         )


### PR DESCRIPTION
To allow users of the automation API use debugging events, add them as types.

I couldn't find an easy way to add tests for this, without running things under a debugger, which is tricky in tests.  If anyone has a good idea please lmk.

Fixes https://github.com/pulumi/pulumi/issues/17210