### PR TITLE
upgrade pulumi-dotnet to 3.67.0

### DIFF
--- a/changelog/pending/20240910--sdk-dotnet--update-dotnet-to-3-67-0.yaml
+++ b/changelog/pending/20240910--sdk-dotnet--update-dotnet-to-3-67-0.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/dotnet
+  description: Update dotnet to 3.67.0

--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -378,4 +378,4 @@ const (
 )
 
 // PulumiDotnetSDKVersion is the version of the Pulumi .NET SDK to use in program-gen tests
-const PulumiDotnetSDKVersion = "3.66.2"
+const PulumiDotnetSDKVersion = "3.67.0"

--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -32,7 +32,7 @@ download_release() {
 }
 
 # shellcheck disable=SC2043
-for i in "github.com/pulumi/pulumi-java java" "github.com/pulumi/pulumi-yaml yaml" "github.com/pulumi/pulumi-dotnet dotnet v3.66.2"; do
+for i in "github.com/pulumi/pulumi-java java" "github.com/pulumi/pulumi-yaml yaml" "github.com/pulumi/pulumi-dotnet dotnet v3.67.0"; do
   set -- $i # treat strings in loop as args
   REPO="$1"
   PULUMI_LANG="$2"


### PR DESCRIPTION
To be merged after https://github.com/pulumi/pulumi-dotnet/pull/342 has been merged and the release has been built.