### PR TITLE
Make the `--out` argument optional for `pulumi package get-mapping`

### DIFF
--- a/changelog/pending/20240910--cli-package--make-out-optional-within-pulumi-package-get-mapping.yaml
+++ b/changelog/pending/20240910--cli-package--make-out-optional-within-pulumi-package-get-mapping.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/package
+  description: Make --out optional within `pulumi package get-mapping`


### PR DESCRIPTION
`--out` should be optional, with the default to pipe to stdout. This mirrors how `pulumi package get-schema` works, allowing intuitive piping like:

```console
$ pulumi package get-mapping terraform aws | jq '<query>'
```

The change is non-breaking.