### PR TITLE
Mark `pulumi package get-mapping` as a debug command

### DIFF
--- a/changelog/pending/20240910--cli-package--mark-pulumi-package-get-mapping-as-a-debug-command.yaml
+++ b/changelog/pending/20240910--cli-package--mark-pulumi-package-get-mapping-as-a-debug-command.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/package
+  description: Mark `pulumi package get-mapping` as a debug command

--- a/pkg/cmd/pulumi/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/package_extract_mapping.go
@@ -33,6 +33,7 @@ func newExtractMappingCommand() *cobra.Command {
 		Long: `Get the mapping information for a given key from a package.
 
 <schema_source> can be a package name or the path to a plugin binary.`,
+		Hidden: !hasDebugCommands(),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			key := args[0]
 			source := args[1]


### PR DESCRIPTION
`pulumi package get-mapping` was introduced to help provider authors debug mapping commands.[^1] In general, `pulumi convert` should just work as intended. `pulumi package get-mapping` is largely undocumented,[^2] so it's doubtful there is much community use.

[^1]: https://github.com/pulumi/pulumi/pull/13155
[^2]: https://github.com/pulumi/pulumi/issues/15210