### PR TITLE
Add python dynamic provider test

### DIFF
--- a/tests/integration/dynamic/python-secrets-separate-module/Pulumi.yaml
+++ b/tests/integration/dynamic/python-secrets-separate-module/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: dynamic-provider-secret-separate-module-py
+description: test for dynamic provider secret capture in a separate module
+runtime: python

--- a/tests/integration/dynamic/python-secrets-separate-module/__main__.py
+++ b/tests/integration/dynamic/python-secrets-separate-module/__main__.py
@@ -1,0 +1,9 @@
+# Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+
+import pulumi
+
+from simple_provider import SimpleResource
+
+
+r = SimpleResource("foo")
+pulumi.export("out", r.authenticated)

--- a/tests/integration/dynamic/python-secrets-separate-module/simple_provider.py
+++ b/tests/integration/dynamic/python-secrets-separate-module/simple_provider.py
@@ -1,0 +1,22 @@
+# Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+
+import pulumi
+from pulumi.dynamic import CreateResult, Resource, ResourceProvider
+
+
+config = pulumi.Config()
+password = config.require_secret("password")
+
+
+class SimpleProvider(ResourceProvider):
+    def create(self, props):
+        # Need to use `password.get()` to get the underlying value of the secret from within the serialized code.
+        # This simulates using this as a credential to talk to an external system.
+        return CreateResult("0", { "authenticated": "200" if password.get() == "s3cret" else "401" })
+
+
+class SimpleResource(Resource):
+    authenticated: pulumi.Output[str]
+
+    def __init__(self, name):
+        super().__init__(SimpleProvider(), name, { "authenticated": None })

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -527,35 +527,44 @@ func TestDynamicPythonDisableSerializationAsSecret(t *testing.T) {
 	})
 }
 
-// Tests custom resource type name of dynamic provider in Python.
+// Tests capturing a secret from config in a dynamic provider.
 //
 //nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestDynamicProviderSecretsPython(t *testing.T) {
-	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		Dir: filepath.Join("dynamic", "python-secrets"),
-		Dependencies: []string{
-			filepath.Join("..", "..", "sdk", "python", "env", "src"),
-		},
-		Secrets: map[string]string{
-			"password": "s3cret",
-		},
-		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-			// Ensure the __provider input (and corresponding output) was marked secret
-			dynRes := stackInfo.Deployment.Resources[2]
-			for _, providerVal := range []interface{}{dynRes.Inputs["__provider"], dynRes.Outputs["__provider"]} {
-				switch v := providerVal.(type) {
-				case string:
-					assert.Fail(t, "__provider was not a secret")
-				case map[string]interface{}:
-					assert.Equal(t, resource.SecretSig, v[resource.SigKey])
-				}
-			}
-			// Ensure the resulting output had the expected value
-			code, ok := stackInfo.Outputs["out"].(string)
-			assert.True(t, ok)
-			assert.Equal(t, "200", code)
-		},
-	})
+	tests := []string{
+		"python-secrets",
+		"python-secrets-separate-module",
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test, func(t *testing.T) {
+			integration.ProgramTest(t, &integration.ProgramTestOptions{
+				Dir: filepath.Join("dynamic", test),
+				Dependencies: []string{
+					filepath.Join("..", "..", "sdk", "python", "env", "src"),
+				},
+				Secrets: map[string]string{
+					"password": "s3cret",
+				},
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					// Ensure the __provider input (and corresponding output) was marked secret
+					dynRes := stackInfo.Deployment.Resources[2]
+					for _, providerVal := range []any{dynRes.Inputs["__provider"], dynRes.Outputs["__provider"]} {
+						switch v := providerVal.(type) {
+						case string:
+							assert.Fail(t, "__provider was not a secret")
+						case map[string]any:
+							assert.Equal(t, resource.SecretSig, v[resource.SigKey])
+						}
+					}
+					// Ensure the resulting output had the expected value
+					code, ok := stackInfo.Outputs["out"].(string)
+					assert.True(t, ok)
+					assert.Equal(t, "200", code)
+				},
+			})
+		})
+	}
 }
 
 //nolint:paralleltest // ProgramTest calls t.Parallel()


### PR DESCRIPTION
Adds a test for the scenario where a Python dynamic provider is capturing secret config in a separate module.

(This test currently fails)