### PR TITLE
Use AI settings from CreateUpdate to determine if Copilot is enabled

### DIFF
--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -715,6 +715,7 @@ func (display *ProgressDisplay) printDiagnostics() bool {
 			colors.SpecCreateReplacement + "[Pulumi Copilot]" + colors.Reset + " Would you like help with these diagnostics?")
 		display.println("    " +
 			colors.Underline + colors.Blue + display.permalink + "?explainFailure" + colors.Reset)
+		display.println("")
 	}
 
 	return hasError

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1289,7 +1289,8 @@ func (b *cloudBackend) createAndStartUpdate(
 			if err != nil {
 				userName = "unknown"
 			}
-			logging.V(7).Infof("Copilot in org '%s' is not enabled for user '%s', link to Copilot in diagnostics will not be shown",
+			logging.V(7).Infof(
+				"Copilot in org '%s' is not enabled for user '%s', link to Copilot in diagnostics will not be shown",
 				stackID.Owner, userName)
 		}
 		op.Opts.Display.ShowLinkToCopilot = false

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -50,6 +50,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
@@ -1276,6 +1277,22 @@ func (b *cloudBackend) createAndStartUpdate(
 	// Any non-preview update will be considered part of the stack's update history.
 	if action != apitype.PreviewUpdate {
 		logging.V(7).Infof("Stack %s being updated to version %d", stackRef, version)
+	}
+
+	// Check if the user's org (stack's owner) has Copilot enabled. If not, we don't show the link to Copilot.
+	isCopilotEnabled, err := b.Client().IsCopilotEnabledForOrg(ctx, stackID.Owner)
+	if !isCopilotEnabled || err != nil {
+		// This overrides the user's preference stated by PULUMI_SHOW_COPILOT_LINK, so issue a
+		// verbosity level 7 warning to ease diagnosing why the link isn't showing up.
+		if env.ShowCopilotLink.Value() {
+			userName, _, _, err := b.CurrentUser()
+			if err != nil {
+				userName = "unknown"
+			}
+			logging.V(7).Infof("Copilot in org '%s' is not enabled for user '%s', link to Copilot in diagnostics will not be shown",
+				stackID.Owner, userName)
+		}
+		op.Opts.Display.ShowLinkToCopilot = false
 	}
 
 	return update, updateMetadata{

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1280,9 +1280,9 @@ func (b *cloudBackend) createAndStartUpdate(
 	}
 
 	// Check if the user's org (stack's owner) has Copilot enabled. If not, we don't show the link to Copilot.
-	isCopilotEnabled, err := b.Client().IsCopilotEnabledForOrg(ctx, stackID.Owner)
-	if !isCopilotEnabled || err != nil {
-		// This overrides the user's preference stated by PULUMI_SHOW_COPILOT_LINK, so issue a
+	isCopilotEnabled := updateDetails.IsCopilotIntegrationEnabled
+	if !isCopilotEnabled {
+		// If this overrides user's preference stated by PULUMI_SHOW_COPILOT_LINK, issue a
 		// verbosity level 7 warning to ease diagnosing why the link isn't showing up.
 		if env.ShowCopilotLink.Value() {
 			userName, _, _, err := b.CurrentUser()

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -589,8 +589,9 @@ func (pc *Client) ImportStackDeployment(ctx context.Context, stack StackIdentifi
 }
 
 type CreateUpdateDetails struct {
-	Messages         []apitype.Message
-	RequiredPolicies []apitype.RequiredPolicy
+	Messages                    []apitype.Message
+	RequiredPolicies            []apitype.RequiredPolicy
+	IsCopilotIntegrationEnabled bool
 }
 
 // CreateUpdate creates a new update for the indicated stack with the given kind and assorted options. If the update
@@ -665,8 +666,9 @@ func (pc *Client) CreateUpdate(
 			UpdateKind:      kind,
 			UpdateID:        updateResponse.UpdateID,
 		}, CreateUpdateDetails{
-			Messages:         updateResponse.Messages,
-			RequiredPolicies: updateResponse.RequiredPolicies,
+			Messages:                    updateResponse.Messages,
+			RequiredPolicies:            updateResponse.RequiredPolicies,
+			IsCopilotIntegrationEnabled: updateResponse.AISettings.CopilotIsEnabled,
 		}, nil
 }
 
@@ -1238,10 +1240,6 @@ func getPulumiOrgSearchPath(baseURL string, orgName string) string {
 	return fmt.Sprintf("%s/%s/resources", baseURL, url.PathEscape(orgName))
 }
 
-func getOrgAISettingsPath(orgName string) string {
-	return fmt.Sprintf("/api/orgs/%s/aisettings", url.PathEscape(orgName))
-}
-
 // Pulumi Cloud Search Functions
 func (pc *Client) GetSearchQueryResults(
 	ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest, baseURL string,
@@ -1267,17 +1265,6 @@ func (pc *Client) GetNaturalLanguageQueryResults(
 		return nil, fmt.Errorf("querying search failed: %w", err)
 	}
 	return &resp, nil
-}
-
-func (pc *Client) IsCopilotEnabledForOrg(
-	ctx context.Context, orgName string,
-) (bool, error) {
-	var resp apitype.OrganizationAISettings
-	err := pc.restCall(ctx, http.MethodGet, getOrgAISettingsPath(orgName), nil, nil, &resp)
-	if err != nil {
-		return false, fmt.Errorf("unable to query service if Copilot is enabled: %w", err)
-	}
-	return resp.CopilotIsEnabled, nil
 }
 
 func is404(err error) bool {

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1238,6 +1238,10 @@ func getPulumiOrgSearchPath(baseURL string, orgName string) string {
 	return fmt.Sprintf("%s/%s/resources", baseURL, url.PathEscape(orgName))
 }
 
+func getOrgAISettingsPath(orgName string) string {
+	return fmt.Sprintf("/api/orgs/%s/aisettings", url.PathEscape(orgName))
+}
+
 // Pulumi Cloud Search Functions
 func (pc *Client) GetSearchQueryResults(
 	ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest, baseURL string,
@@ -1263,6 +1267,17 @@ func (pc *Client) GetNaturalLanguageQueryResults(
 		return nil, fmt.Errorf("querying search failed: %w", err)
 	}
 	return &resp, nil
+}
+
+func (pc *Client) IsCopilotEnabledForOrg(
+	ctx context.Context, orgName string,
+) (bool, error) {
+	var resp apitype.OrganizationAISettings
+	err := pc.restCall(ctx, http.MethodGet, getOrgAISettingsPath(orgName), nil, nil, &resp)
+	if err != nil {
+		return false, fmt.Errorf("unable to query service if Copilot is enabled: %w", err)
+	}
+	return resp.CopilotIsEnabled, nil
 }
 
 func is404(err error) bool {

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -535,6 +536,7 @@ func newUpCmd() *cobra.Command {
 			// For now, 'explainFailure' link to Copilot in the CLI output
 			// requires env var PULUMI_SHOW_COPILOT_LINK to be set to true
 			opts.Display.ShowLinkToCopilot = env.ShowCopilotLink.Value()
+			logging.V(7).Infof("ShowLinkToCopilot=%v", opts.Display.ShowLinkToCopilot)
 
 			if len(args) > 0 {
 				return upTemplateNameOrURL(ctx, ws, DefaultLoginManager, args[0], opts, cmd)

--- a/sdk/go/common/apitype/deployments.go
+++ b/sdk/go/common/apitype/deployments.go
@@ -356,10 +356,6 @@ type secretWorkflowValue struct {
 	Ciphertext string `json:"ciphertext,omitempty" yaml:"ciphertext,omitempty"`
 }
 
-type OrganizationAISettings struct {
-	CopilotIsEnabled bool `json:"copilotIsEnabled"`
-}
-
 func (v SecretValue) MarshalJSON() ([]byte, error) {
 	switch {
 	case len(v.Ciphertext) != 0:

--- a/sdk/go/common/apitype/deployments.go
+++ b/sdk/go/common/apitype/deployments.go
@@ -356,6 +356,10 @@ type secretWorkflowValue struct {
 	Ciphertext string `json:"ciphertext,omitempty" yaml:"ciphertext,omitempty"`
 }
 
+type OrganizationAISettings struct {
+	CopilotIsEnabled bool `json:"copilotIsEnabled"`
+}
+
 func (v SecretValue) MarshalJSON() ([]byte, error) {
 	switch {
 	case len(v.Ciphertext) != 0:

--- a/sdk/go/common/apitype/updates.go
+++ b/sdk/go/common/apitype/updates.go
@@ -86,6 +86,10 @@ type Message struct {
 	Message string `json:"message"`
 }
 
+type AISettingsForUpdate struct {
+	CopilotIsEnabled bool `json:"copilotIsEnabled"`
+}
+
 // UpdateProgramResponse is the result of an update program request.
 type UpdateProgramResponse struct {
 	// UpdateID is the opaque identifier of the requested update. This value is needed to begin an update, as
@@ -98,7 +102,7 @@ type UpdateProgramResponse struct {
 	// Messages is a list of messages that should be displayed to the user.
 	Messages []Message `json:"messages,omitempty"`
 
-	AISettings OrganizationAISettings `json:"aiSettings,omitempty"`
+	AISettings AISettingsForUpdate `json:"aiSettings,omitempty"`
 }
 
 // StartUpdateRequest requests that an update starts getting applied to a stack.

--- a/sdk/go/common/apitype/updates.go
+++ b/sdk/go/common/apitype/updates.go
@@ -97,6 +97,8 @@ type UpdateProgramResponse struct {
 
 	// Messages is a list of messages that should be displayed to the user.
 	Messages []Message `json:"messages,omitempty"`
+
+	AISettings OrganizationAISettings `json:"aiSettings,omitempty"`
 }
 
 // StartUpdateRequest requests that an update starts getting applied to a stack.


### PR DESCRIPTION
Link to Copilot ("why did this fail") will not be offered to users for whom Copilot is not enabled in the org of the project.
The new API is being introduced in https://github.com/pulumi/pulumi-service/pull/22202.

Fixes https://github.com/pulumi/pulumi.ai/issues/1238