### PR TITLE
Support falling back to snapshot secret managers

### DIFF
--- a/changelog/pending/20240917--cli-state--support-falling-back-to-snapshot-secret-managers-when-pulumi_fallback_to_state_secrets_manager-is-set.yaml
+++ b/changelog/pending/20240917--cli-state--support-falling-back-to-snapshot-secret-managers-when-pulumi_fallback_to_state_secrets_manager-is-set.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/state
+  description: Support falling back to snapshot secret managers when PULUMI_FALLBACK_TO_STATE_SECRETS_MANAGER is set

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -94,7 +94,19 @@ func newConfigCmd() *cobra.Command {
 				openEnvironment = showSecrets
 			}
 
-			return listConfig(ctx, os.Stdout, project, stack, ps, showSecrets, jsonOut, openEnvironment)
+			ssml := newStackSecretsManagerLoaderFromEnv()
+
+			return listConfig(
+				ctx,
+				ssml,
+				os.Stdout,
+				project,
+				stack,
+				ps,
+				showSecrets,
+				jsonOut,
+				openEnvironment,
+			)
 		}),
 	}
 
@@ -172,18 +184,31 @@ func newConfigCopyCmd(stack *string) *cobra.Command {
 				return err
 			}
 
+			ssml := newStackSecretsManagerLoaderFromEnv()
+
 			// Do we need to copy a single value or the entire map
 			if len(args) > 0 {
 				// A single key was specified so we only need to copy that specific value
-				return copySingleConfigKey(args[0], path, currentStack, currentProjectStack, destinationStack,
-					destinationProjectStack)
+				return copySingleConfigKey(
+					ctx,
+					ssml,
+					args[0],
+					path,
+					currentStack,
+					currentProjectStack,
+					destinationStack,
+					destinationProjectStack,
+				)
 			}
 
 			requiresSaving, err := copyEntireConfigMap(
+				ctx,
+				ssml,
 				currentStack,
 				currentProjectStack,
 				destinationStack,
-				destinationProjectStack)
+				destinationProjectStack,
+			)
 			if err != nil {
 				return err
 			}
@@ -211,8 +236,14 @@ func newConfigCopyCmd(stack *string) *cobra.Command {
 	return cpCommand
 }
 
-func copySingleConfigKey(configKey string, path bool, currentStack backend.Stack,
-	currentProjectStack *workspace.ProjectStack, destinationStack backend.Stack,
+func copySingleConfigKey(
+	ctx context.Context,
+	ssml stackSecretsManagerLoader,
+	configKey string,
+	path bool,
+	currentStack backend.Stack,
+	currentProjectStack *workspace.ProjectStack,
+	destinationStack backend.Stack,
 	destinationProjectStack *workspace.ProjectStack,
 ) error {
 	var decrypter config.Decrypter
@@ -230,16 +261,19 @@ func copySingleConfigKey(configKey string, path bool, currentStack backend.Stack
 
 	if v.Secure() {
 		var err error
-		var needsSave bool
-		if decrypter, needsSave, err = getStackDecrypter(currentStack, currentProjectStack); err != nil {
+		var state stackSecretsManagerState
+		if decrypter, state, err = ssml.getDecrypter(ctx, currentStack, currentProjectStack); err != nil {
 			return fmt.Errorf("could not create a decrypter: %w", err)
 		}
-		contract.Assertf(!needsSave, "We're reading a secure value so the encryption information must be present already")
+		contract.Assertf(
+			state == stackSecretsManagerUnchanged,
+			"We're reading a secure value so the encryption information must be present already",
+		)
 	} else {
 		decrypter = config.NewPanicCrypter()
 	}
 
-	encrypter, _, cerr := getStackEncrypter(destinationStack, destinationProjectStack)
+	encrypter, _, cerr := ssml.getEncrypter(ctx, destinationStack, destinationProjectStack)
 	if cerr != nil {
 		return cerr
 	}
@@ -257,8 +291,12 @@ func copySingleConfigKey(configKey string, path bool, currentStack backend.Stack
 	return saveProjectStack(destinationStack, destinationProjectStack)
 }
 
-func copyEntireConfigMap(currentStack backend.Stack,
-	currentProjectStack *workspace.ProjectStack, destinationStack backend.Stack,
+func copyEntireConfigMap(
+	ctx context.Context,
+	ssml stackSecretsManagerLoader,
+	currentStack backend.Stack,
+	currentProjectStack *workspace.ProjectStack,
+	destinationStack backend.Stack,
 	destinationProjectStack *workspace.ProjectStack,
 ) (bool, error) {
 	var decrypter config.Decrypter
@@ -266,17 +304,20 @@ func copyEntireConfigMap(currentStack backend.Stack,
 	currentEnvironments := currentProjectStack.Environment
 
 	if currentConfig.HasSecureValue() {
-		dec, needsSave, decerr := getStackDecrypter(currentStack, currentProjectStack)
+		dec, state, decerr := ssml.getDecrypter(ctx, currentStack, currentProjectStack)
 		if decerr != nil {
 			return false, decerr
 		}
-		contract.Assertf(!needsSave, "We're reading a secure value so the encryption information must be present already")
+		contract.Assertf(
+			state == stackSecretsManagerUnchanged,
+			"We're reading a secure value so the encryption information must be present already",
+		)
 		decrypter = dec
 	} else {
 		decrypter = config.NewPanicCrypter()
 	}
 
-	encrypter, _, cerr := getStackEncrypter(destinationStack, destinationProjectStack)
+	encrypter, _, cerr := ssml.getEncrypter(ctx, destinationStack, destinationProjectStack)
 	if cerr != nil {
 		return false, cerr
 	}
@@ -335,7 +376,8 @@ func newConfigGetCmd(stack *string) *cobra.Command {
 				return fmt.Errorf("invalid configuration key: %w", err)
 			}
 
-			return getConfig(ctx, ws, s, key, path, jsonOut, open)
+			ssml := newStackSecretsManagerLoaderFromEnv()
+			return getConfig(ctx, ssml, ws, s, key, path, jsonOut, open)
 		}),
 	}
 	getCmd.Flags().BoolVarP(
@@ -642,12 +684,14 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 				return err
 			}
 
+			ssml := newStackSecretsManagerLoaderFromEnv()
+
 			// Encrypt the config value if needed.
 			var v config.Value
 			if secret {
 				// We're always going to save, so can ignore the bool for if getStackEncrypter changed the
 				// config data.
-				c, _, cerr := getStackEncrypter(s, ps)
+				c, _, cerr := ssml.getEncrypter(ctx, s, ps)
 				if cerr != nil {
 					return cerr
 				}
@@ -745,6 +789,8 @@ func newConfigSetAllCmd(stack *string) *cobra.Command {
 				}
 			}
 
+			ssml := newStackSecretsManagerLoaderFromEnv()
+
 			for _, sArg := range secretArgs {
 				key, value, err := parseKeyValuePair(sArg)
 				if err != nil {
@@ -752,7 +798,7 @@ func newConfigSetAllCmd(stack *string) *cobra.Command {
 				}
 				// We're always going to save, so can ignore the bool for if getStackEncrypter changed the
 				// config data.
-				c, _, cerr := getStackEncrypter(stack, ps)
+				c, _, cerr := ssml.getEncrypter(ctx, stack, ps)
 				if cerr != nil {
 					return cerr
 				}
@@ -876,6 +922,7 @@ type configValueJSON struct {
 
 func listConfig(
 	ctx context.Context,
+	ssml stackSecretsManagerLoader,
 	stdout io.Writer,
 	project *workspace.Project,
 	stack backend.Stack,
@@ -901,12 +948,12 @@ func listConfig(
 	if env != nil {
 		pulumiEnv = env.Properties["pulumiConfig"]
 
-		stackEncrypter, needsSave, err := getStackEncrypter(stack, ps)
+		stackEncrypter, state, err := ssml.getEncrypter(ctx, stack, ps)
 		if err != nil {
 			return err
 		}
 		// This may have setup the stack's secrets provider, so save the stack if needed.
-		if needsSave {
+		if state != stackSecretsManagerUnchanged {
 			if err = saveProjectStack(stack, ps); err != nil {
 				return fmt.Errorf("save stack config: %w", err)
 			}
@@ -931,12 +978,12 @@ func listConfig(
 	// By default, we will use a blinding decrypter to show "[secret]". If requested, display secrets in plaintext.
 	decrypter := config.NewBlindingDecrypter()
 	if cfg.HasSecureValue() && showSecrets {
-		stackDecrypter, needsSave, err := getStackDecrypter(stack, ps)
+		stackDecrypter, state, err := ssml.getDecrypter(ctx, stack, ps)
 		if err != nil {
 			return err
 		}
 		// This may have setup the stack's secrets provider, so save the stack if needed.
-		if needsSave {
+		if state != stackSecretsManagerUnchanged {
 			if err = saveProjectStack(stack, ps); err != nil {
 				return fmt.Errorf("save stack config: %w", err)
 			}
@@ -1044,7 +1091,13 @@ func listConfig(
 }
 
 func getConfig(
-	ctx context.Context, ws pkgWorkspace.Context, stack backend.Stack, key config.Key, path, jsonOut, openEnvironment bool,
+	ctx context.Context,
+	ssml stackSecretsManagerLoader,
+	ws pkgWorkspace.Context,
+	stack backend.Stack,
+	key config.Key,
+	path, jsonOut,
+	openEnvironment bool,
 ) error {
 	project, _, err := ws.ReadProject()
 	if err != nil {
@@ -1071,12 +1124,12 @@ func getConfig(
 	if env != nil {
 		pulumiEnv = env.Properties["pulumiConfig"]
 
-		stackEncrypter, needsSave, err := getStackEncrypter(stack, ps)
+		stackEncrypter, state, err := ssml.getEncrypter(ctx, stack, ps)
 		if err != nil {
 			return err
 		}
 		// This may have setup the stack's secrets provider, so save the stack if needed.
-		if needsSave {
+		if state != stackSecretsManagerUnchanged {
 			if err = saveProjectStack(stack, ps); err != nil {
 				return fmt.Errorf("save stack config: %w", err)
 			}
@@ -1105,12 +1158,12 @@ func getConfig(
 		var d config.Decrypter
 		if v.Secure() {
 			var err error
-			var needsSave bool
-			if d, needsSave, err = getStackDecrypter(stack, ps); err != nil {
+			var state stackSecretsManagerState
+			if d, state, err = ssml.getDecrypter(ctx, stack, ps); err != nil {
 				return fmt.Errorf("could not create a decrypter: %w", err)
 			}
 			// This may have setup the stack's secrets provider, so save the stack if needed.
-			if needsSave {
+			if state != stackSecretsManagerUnchanged {
 				if err = saveProjectStack(stack, ps); err != nil {
 					return fmt.Errorf("save stack config: %w", err)
 				}
@@ -1193,41 +1246,47 @@ func looksLikeSecret(k config.Key, v string) bool {
 }
 
 func getAndSaveSecretsManager(
-	stack backend.Stack, workspaceStack *workspace.ProjectStack, fallbackManager secrets.Manager,
+	ctx context.Context,
+	ssml stackSecretsManagerLoader,
+	stack backend.Stack,
+	workspaceStack *workspace.ProjectStack,
 ) (secrets.Manager, error) {
-	sm, needsSave, err := getStackSecretsManager(stack, workspaceStack, fallbackManager)
+	sm, state, err := ssml.getSecretsManager(ctx, stack, workspaceStack)
 	if err != nil {
 		return nil, fmt.Errorf("get stack secrets manager: %w", err)
 	}
-	if needsSave {
-		if err = saveProjectStack(stack, workspaceStack); err != nil {
+	if state != stackSecretsManagerUnchanged {
+		if err = saveProjectStack(stack, workspaceStack); err != nil && state == stackSecretsManagerMustSave {
 			return nil, fmt.Errorf("save stack config: %w", err)
 		}
 	}
 	return sm, nil
 }
 
-// getStackConfiguration loads configuration information for a given stack. If stackConfigFile is non empty,
-// it is uses instead of the default configuration file for the stack
+// Attempts to load configuration for the given stack.
 func getStackConfiguration(
 	ctx context.Context,
+	ssml stackSecretsManagerLoader,
 	stack backend.Stack,
 	project *workspace.Project,
-	fallbackSecretsManager secrets.Manager, // optional
 ) (backend.StackConfiguration, secrets.Manager, error) {
-	return getStackConfigurationWithFallback(ctx, stack, project, fallbackSecretsManager, nil)
+	return getStackConfigurationWithFallback(ctx, ssml, stack, project, nil)
 }
 
-// getStackConfigurationOrLatest runs getStackConfiguration and if no Project is found,
-// falls back on the latest stack configuration in the backend.
+// getStackConfigurationOrLatest attempts to load a current stack configuration
+// using getStackConfiguration. If that fails due to not being run within a
+// valid project, the latest configuration from the backend is returned. This is
+// primarily for use in commands like `pulumi destroy`, where it is useful to be
+// able to clean up a stack whose configuration has already been deleted as part
+// of that cleanup.
 func getStackConfigurationOrLatest(
 	ctx context.Context,
+	ssml stackSecretsManagerLoader,
 	stack backend.Stack,
 	project *workspace.Project,
-	fallbackSecretsManager secrets.Manager, // optional
 ) (backend.StackConfiguration, secrets.Manager, error) {
 	return getStackConfigurationWithFallback(
-		ctx, stack, project, fallbackSecretsManager,
+		ctx, ssml, stack, project,
 		func(err error) (config.Map, error) {
 			if errors.Is(err, workspace.ErrProjectNotFound) {
 				// This error indicates that we're not being run in a project directory.
@@ -1312,12 +1371,12 @@ func openStackEnv(
 
 func getStackConfigurationWithFallback(
 	ctx context.Context,
-	stack backend.Stack,
+	ssml stackSecretsManagerLoader,
+	s backend.Stack,
 	project *workspace.Project,
-	fallbackSecretsManager secrets.Manager, // optional
 	fallbackGetConfig func(err error) (config.Map, error), // optional
 ) (backend.StackConfiguration, secrets.Manager, error) {
-	workspaceStack, err := loadProjectStack(project, stack)
+	workspaceStack, err := loadProjectStack(project, s)
 	if err != nil || workspaceStack == nil {
 		if fallbackGetConfig == nil {
 			return backend.StackConfiguration{}, nil, err
@@ -1333,16 +1392,12 @@ func getStackConfigurationWithFallback(
 		}
 	}
 
-	sm, err := getAndSaveSecretsManager(stack, workspaceStack, fallbackSecretsManager)
+	sm, err := getAndSaveSecretsManager(ctx, ssml, s, workspaceStack)
 	if err != nil {
-		if fallbackSecretsManager != nil {
-			sm = fallbackSecretsManager
-		} else {
-			return backend.StackConfiguration{}, nil, err
-		}
+		return backend.StackConfiguration{}, nil, err
 	}
 
-	config, err := getStackConfigurationFromProjectStack(ctx, stack, project, sm, workspaceStack)
+	config, err := getStackConfigurationFromProjectStack(ctx, s, project, sm, workspaceStack)
 	if err != nil {
 		return backend.StackConfiguration{}, nil, err
 	}

--- a/pkg/cmd/pulumi/config_env.go
+++ b/pkg/cmd/pulumi/config_env.go
@@ -65,7 +65,8 @@ type configEnvCmd struct {
 	interactive bool
 	color       colors.Colorization
 
-	ws pkgWorkspace.Context
+	ssml stackSecretsManagerLoader
+	ws   pkgWorkspace.Context
 
 	requireStack func(
 		ctx context.Context,
@@ -86,6 +87,8 @@ type configEnvCmd struct {
 func (cmd *configEnvCmd) initArgs() {
 	cmd.interactive = cmdutil.Interactive()
 	cmd.color = cmdutil.GetGlobalColorization()
+
+	cmd.ssml = newStackSecretsManagerLoaderFromEnv()
 }
 
 func (cmd *configEnvCmd) loadEnvPreamble(ctx context.Context,
@@ -171,7 +174,17 @@ func (cmd *configEnvCmd) editStackEnvironment(
 		return err
 	}
 
-	if err := listConfig(ctx, cmd.stdout, project, *stack, projectStack, showSecrets, false, false); err != nil {
+	if err := listConfig(
+		ctx,
+		cmd.ssml,
+		cmd.stdout,
+		project,
+		*stack,
+		projectStack,
+		showSecrets,
+		false, /*jsonOut*/
+		false, /*openEnvironment*/
+	); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/pulumi/config_env_init.go
+++ b/pkg/cmd/pulumi/config_env_init.go
@@ -200,12 +200,12 @@ func (cmd *configEnvInitCmd) getStackConfig(
 		return nil, nil, err
 	}
 
-	decrypter, needsSave, err := getStackDecrypter(stack, ps)
+	decrypter, state, err := cmd.parent.ssml.getDecrypter(ctx, stack, ps)
 	if err != nil {
 		return nil, nil, err
 	}
 	// This may have setup the stack's secrets provider, so save the stack if needed.
-	if needsSave {
+	if state != stackSecretsManagerUnchanged {
 		if err = cmd.parent.saveProjectStack(stack, ps); err != nil {
 			return nil, nil, fmt.Errorf("saving stack config: %w", err)
 		}

--- a/pkg/cmd/pulumi/config_test.go
+++ b/pkg/cmd/pulumi/config_test.go
@@ -61,6 +61,7 @@ func TestGetStackConfigurationDoesNotGetLatestConfiguration(t *testing.T) {
 	// Don't check return values. Just check that GetLatestConfiguration() is not called.
 	_, _, _ = getStackConfiguration(
 		context.Background(),
+		stackSecretsManagerLoader{},
 		&backend.MockStack{
 			RefF: func() backend.StackReference {
 				return &backend.MockStackReference{
@@ -80,7 +81,6 @@ func TestGetStackConfigurationDoesNotGetLatestConfiguration(t *testing.T) {
 			},
 		},
 		nil,
-		nil,
 	)
 }
 
@@ -90,6 +90,7 @@ func TestGetStackConfigurationOrLatest(t *testing.T) {
 	called := false
 	_, _, _ = getStackConfigurationOrLatest(
 		context.Background(),
+		stackSecretsManagerLoader{},
 		&backend.MockStack{
 			RefF: func() backend.StackReference {
 				return &backend.MockStackReference{
@@ -111,7 +112,6 @@ func TestGetStackConfigurationOrLatest(t *testing.T) {
 				}
 			},
 		},
-		nil,
 		nil,
 	)
 	if !called {
@@ -427,7 +427,13 @@ func TestCopyConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		requiresSaving, err := copyEntireConfigMap(
-			sourceStack, &sourceProjectStack, destinationStack, &destinationProjectStack)
+			context.Background(),
+			stackSecretsManagerLoader{},
+			sourceStack,
+			&sourceProjectStack,
+			destinationStack,
+			&destinationProjectStack,
+		)
 		require.NoError(t, err)
 		assert.True(t, requiresSaving, "expected config file changes requiring saving")
 

--- a/pkg/cmd/pulumi/crypto.go
+++ b/pkg/cmd/pulumi/crypto.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -23,53 +24,130 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/cloud"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/deepcopy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func getStackEncrypter(s backend.Stack, ps *workspace.ProjectStack) (config.Encrypter, bool, error) {
-	sm, needsSave, err := getStackSecretsManager(s, ps, nil)
-	if err != nil {
-		return nil, false, err
-	}
-
-	enc, err := sm.Encrypter()
-	if err != nil {
-		return nil, needsSave, err
-	}
-	return enc, needsSave, nil
+// A stackSecretsManagerLoader provides methods for loading secrets managers and
+// their encrypters and decrypters for a given stack and project stack. A loader
+// encapsulates the logic for determining which secrets manager to use based on
+// a given configuration, such as whether or not to fallback to the stack state
+// if there is no secrets manager configured in the project stack.
+type stackSecretsManagerLoader struct {
+	// True if the loader should fallback to the stack state if there is no
+	// secrets manager configured in the project stack.
+	FallbackToState bool
 }
 
-func getStackDecrypter(s backend.Stack, ps *workspace.ProjectStack) (config.Decrypter, bool, error) {
-	sm, needsSave, err := getStackSecretsManager(s, ps, nil)
+// The state of a stack's secret manager configuration following an operation.
+type stackSecretsManagerState string
+
+const (
+	// The state of the stack's secret manager configuration is unchanged.
+	stackSecretsManagerUnchanged stackSecretsManagerState = "unchanged"
+
+	// The stack's secret manager configuration has changed and should be saved to
+	// the stack configuration file if possible. If saving is not possible, the
+	// configuration can be restored by falling back to the state file.
+	stackSecretsManagerShouldSave stackSecretsManagerState = "should-save"
+
+	// The stack's secret manager configuration has changed and must be saved to the
+	// stack configuration file. Changes have been made that do not align with the
+	// state and so the state file cannot be used to restore the configuration.
+	stackSecretsManagerMustSave stackSecretsManagerState = "must-save"
+)
+
+// Creates a new stack secrets manager loader from the environment.
+func newStackSecretsManagerLoaderFromEnv() stackSecretsManagerLoader {
+	return stackSecretsManagerLoader{
+		FallbackToState: env.FallbackToStateSecretsManager.Value(),
+	}
+}
+
+// Returns a decrypter for the given stack and project stack.
+func (l *stackSecretsManagerLoader) getDecrypter(
+	ctx context.Context,
+	s backend.Stack,
+	ps *workspace.ProjectStack,
+) (config.Decrypter, stackSecretsManagerState, error) {
+	sm, state, err := l.getSecretsManager(ctx, s, ps)
 	if err != nil {
-		return nil, false, err
+		return nil, stackSecretsManagerUnchanged, err
 	}
 
 	dec, err := sm.Decrypter()
 	if err != nil {
-		return nil, needsSave, err
+		return nil, state, err
 	}
-	return dec, needsSave, nil
+	return dec, state, nil
 }
 
-func getStackSecretsManager(
-	s backend.Stack, ps *workspace.ProjectStack, fallbackManager secrets.Manager,
-) (secrets.Manager, bool, error) {
+// Returns an encrypter for the given stack and project stack.
+func (l *stackSecretsManagerLoader) getEncrypter(
+	ctx context.Context,
+	s backend.Stack,
+	ps *workspace.ProjectStack,
+) (config.Encrypter, stackSecretsManagerState, error) {
+	sm, state, err := l.getSecretsManager(ctx, s, ps)
+	if err != nil {
+		return nil, stackSecretsManagerUnchanged, err
+	}
+
+	enc, err := sm.Encrypter()
+	if err != nil {
+		return nil, state, err
+	}
+	return enc, state, nil
+}
+
+// Returns a secrets manager for the given stack and project stack.
+func (l *stackSecretsManagerLoader) getSecretsManager(
+	ctx context.Context,
+	s backend.Stack,
+	ps *workspace.ProjectStack,
+) (secrets.Manager, stackSecretsManagerState, error) {
 	oldConfig := deepcopy.Copy(ps).(*workspace.ProjectStack)
 
 	var sm secrets.Manager
 	var err error
+
+	fellBack := false
 	if ps.SecretsProvider != passphrase.Type && ps.SecretsProvider != "default" && ps.SecretsProvider != "" {
 		sm, err = cloud.NewCloudSecretsManager(
-			ps, ps.SecretsProvider, false /* rotateSecretsProvider */)
+			ps,
+			ps.SecretsProvider,
+			false, /* rotateSecretsProvider */
+		)
 	} else if ps.EncryptionSalt != "" {
 		sm, err = passphrase.NewPromptingPassphraseSecretsManager(
-			ps, false /* rotateSecretsProvider */)
+			ps,
+			false, /* rotateSecretsProvider */
+		)
 	} else {
+		var fallbackManager secrets.Manager
+
+		// If the loader has been configured to fallback to the stack state, we will
+		// attempt to use the current snapshot secrets manager, if there is one.
+		// This ensures that in cases where stack configuration is missing (or is
+		// present but missing secrets provider configuration), we will keep using
+		// what is already specified in the snapshot, rather than creating a new
+		// default secrets manager which differs from what the user has previously
+		// specified.
+		if l.FallbackToState {
+			snap, err := s.Snapshot(ctx, stack.DefaultSecretsProvider)
+			if err != nil {
+				return nil, stackSecretsManagerUnchanged, err
+			}
+
+			if snap != nil {
+				fallbackManager = snap.SecretsManager
+			}
+		}
+
 		if fallbackManager != nil {
-			sm = fallbackManager
+			sm, fellBack = fallbackManager, true
 
 			// We need to ensure the fallback manager picked saves to the stack state. TODO: It would be
 			// really nice if the format of secrets state in the config file matched what managers reported
@@ -90,12 +168,27 @@ func getStackSecretsManager(
 		}
 	}
 	if err != nil {
-		return nil, false, err
+		return nil, stackSecretsManagerUnchanged, err
 	}
 
-	// Handle if the configuration changed any of EncryptedKey, etc
+	// First, work out if the new configuration is different to the old one. If it is, and we fell back
+	// to the state, we will return that the configuration *should* be saved. If the configurations
+	// differ and we didn't fall back to the state (i.e. some brand new configuration was supplied to
+	// us from an unknown source) then we will return that the configuration *must* be saved, lest it
+	// be lost.
 	needsSave := needsSaveProjectStackAfterSecretManger(oldConfig, ps)
-	return stack.NewCachingSecretsManager(sm), needsSave, nil
+	var state stackSecretsManagerState
+	if needsSave {
+		if fellBack {
+			state = stackSecretsManagerShouldSave
+		} else {
+			state = stackSecretsManagerMustSave
+		}
+	} else {
+		state = stackSecretsManagerUnchanged
+	}
+
+	return stack.NewCachingSecretsManager(sm), state, nil
 }
 
 func needsSaveProjectStackAfterSecretManger(

--- a/pkg/cmd/pulumi/crypto_test.go
+++ b/pkg/cmd/pulumi/crypto_test.go
@@ -1,0 +1,272 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+)
+
+//nolint:paralleltest // Modifies the environment
+func TestNewStackSecretsManagerLoaderFromEnv(t *testing.T) {
+	// Arrange.
+	cases := []struct {
+		envValue string
+		expected bool
+	}{
+		{"true", true},
+		{"1", true},
+		{"false", false},
+		{"0", false},
+	}
+
+	for _, c := range cases {
+		t.Setenv("PULUMI_FALLBACK_TO_STATE_SECRETS_MANAGER", c.envValue)
+
+		// Act.
+		loader := newStackSecretsManagerLoaderFromEnv()
+
+		// Assert.
+		assert.Equal(
+			t, c.expected, loader.FallbackToState,
+			"FallbackToState (%v) should be pulled from the environment (%v)", c.envValue,
+		)
+	}
+}
+
+func TestStackSecretsManagerLoaderDecrypterFallsBack(t *testing.T) {
+	t.Parallel()
+
+	// Arrange.
+	fellback := false
+	sm := &secrets.MockSecretsManager{
+		TypeF: func() string { return "mock" },
+		DecrypterF: func() (config.Decrypter, error) {
+			fellback = true
+			return config.NopDecrypter, nil
+		},
+	}
+	snap := &deploy.Snapshot{SecretsManager: sm}
+
+	s := &backend.MockStack{
+		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+			return snap, nil
+		},
+	}
+
+	ps := &workspace.ProjectStack{}
+	ssml := stackSecretsManagerLoader{FallbackToState: true}
+
+	// Act.
+	_, state, err := ssml.getDecrypter(context.Background(), s, ps)
+
+	// Assert.
+	//
+	// We can't assert that the decrypter we get back is the one we returned since
+	// it may be decorated (e.g. with a caching decrypter). We thus assert that
+	// our fallback was called as a proxy.
+	assert.NoError(t, err)
+	assert.Equal(
+		t, stackSecretsManagerUnchanged, state,
+		"A mock decrypter should have no effect on the project stack",
+	)
+	assert.True(t, fellback, "Should have fallen back to the mock decrypter")
+}
+
+func TestStackSecretsManagerLoaderDecrypterUpdatesConfig(t *testing.T) {
+	t.Parallel()
+
+	// Arrange.
+	sm := &secrets.MockSecretsManager{
+		TypeF:      func() string { return passphrase.Type },
+		DecrypterF: func() (config.Decrypter, error) { return config.NopDecrypter, nil },
+		StateF:     func() json.RawMessage { return []byte(`{"salt":"test-salt"}`) },
+	}
+	snap := &deploy.Snapshot{SecretsManager: sm}
+
+	s := &backend.MockStack{
+		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+			return snap, nil
+		},
+	}
+
+	ps := &workspace.ProjectStack{}
+	ssml := stackSecretsManagerLoader{FallbackToState: true}
+
+	// Act.
+	_, state, err := ssml.getDecrypter(context.Background(), s, ps)
+
+	// Assert.
+	assert.NoError(t, err)
+	assert.Equal(
+		t, stackSecretsManagerShouldSave, state,
+		"A fallback passphrase decrypter should be written to the project stack",
+	)
+	assert.Equal(t, "test-salt", ps.EncryptionSalt, "The encryption salt should be set on the project stack")
+}
+
+func TestStackSecretsManagerLoaderDecrypterUsesDefaultSecretsManager(t *testing.T) {
+	t.Parallel()
+
+	// Arrange.
+	defaulted := false
+	sm := &secrets.MockSecretsManager{
+		TypeF: func() string { return "mock" },
+		DecrypterF: func() (config.Decrypter, error) {
+			defaulted = true
+			return config.NopDecrypter, nil
+		},
+	}
+
+	s := &backend.MockStack{
+		DefaultSecretManagerF: func(info *workspace.ProjectStack) (secrets.Manager, error) {
+			return sm, nil
+		},
+		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+			return &deploy.Snapshot{}, nil
+		},
+	}
+
+	ps := &workspace.ProjectStack{}
+	ssml := stackSecretsManagerLoader{FallbackToState: false}
+
+	// Act.
+	_, state, err := ssml.getDecrypter(context.Background(), s, ps)
+
+	// Assert.
+	assert.NoError(t, err)
+	assert.Equal(
+		t, stackSecretsManagerUnchanged, state,
+		"No fallback manager should mean no changes to the project stack",
+	)
+	assert.True(t, defaulted, "Should have loaded the default decrypter")
+}
+
+func TestStackSecretsManagerLoaderEncrypterFallsBack(t *testing.T) {
+	t.Parallel()
+
+	// Arrange.
+	fellback := false
+	sm := &secrets.MockSecretsManager{
+		TypeF: func() string { return "mock" },
+		EncrypterF: func() (config.Encrypter, error) {
+			fellback = true
+			return config.NopEncrypter, nil
+		},
+	}
+	snap := &deploy.Snapshot{SecretsManager: sm}
+
+	s := &backend.MockStack{
+		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+			return snap, nil
+		},
+	}
+
+	ps := &workspace.ProjectStack{}
+	ssml := stackSecretsManagerLoader{FallbackToState: true}
+
+	// Act.
+	_, state, err := ssml.getEncrypter(context.Background(), s, ps)
+
+	// Assert.
+	//
+	// We can't assert that the encrypter we get back is the one we returned since
+	// it may be decorated (e.g. with a caching encrypter). We thus assert that
+	// our fallback was called as a proxy.
+	assert.NoError(t, err)
+	assert.Equal(
+		t, stackSecretsManagerUnchanged, state,
+		"A mock encrypter should have no effect on the project stack",
+	)
+	assert.True(t, fellback, "Should have fallen back to the mock encrypter")
+}
+
+func TestStackSecretsManagerLoaderEncrypterUpdatesConfig(t *testing.T) {
+	t.Parallel()
+
+	// Arrange.
+	sm := &secrets.MockSecretsManager{
+		TypeF:      func() string { return passphrase.Type },
+		EncrypterF: func() (config.Encrypter, error) { return config.NopEncrypter, nil },
+		StateF:     func() json.RawMessage { return []byte(`{"salt":"test-salt"}`) },
+	}
+	snap := &deploy.Snapshot{SecretsManager: sm}
+
+	s := &backend.MockStack{
+		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+			return snap, nil
+		},
+	}
+
+	ps := &workspace.ProjectStack{}
+	ssml := stackSecretsManagerLoader{FallbackToState: true}
+
+	// Act.
+	_, state, err := ssml.getEncrypter(context.Background(), s, ps)
+
+	// Assert.
+	assert.NoError(t, err)
+	assert.Equal(
+		t, stackSecretsManagerShouldSave, state,
+		"A fallback passphrase encrypter should be written to the project stack",
+	)
+	assert.Equal(t, "test-salt", ps.EncryptionSalt, "The encryption salt should be set on the project stack")
+}
+
+func TestStackSecretsManagerLoaderEncrypterUsesDefaultSecretsManager(t *testing.T) {
+	t.Parallel()
+
+	// Arrange.
+	defaulted := false
+	sm := &secrets.MockSecretsManager{
+		TypeF: func() string { return "mock" },
+		EncrypterF: func() (config.Encrypter, error) {
+			defaulted = true
+			return config.NopEncrypter, nil
+		},
+	}
+
+	s := &backend.MockStack{
+		DefaultSecretManagerF: func(info *workspace.ProjectStack) (secrets.Manager, error) {
+			return sm, nil
+		},
+		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+			return &deploy.Snapshot{}, nil
+		},
+	}
+
+	ps := &workspace.ProjectStack{}
+	ssml := stackSecretsManagerLoader{FallbackToState: false}
+
+	// Act.
+	_, state, err := ssml.getEncrypter(context.Background(), s, ps)
+
+	// Assert.
+	assert.NoError(t, err)
+	assert.Equal(
+		t, stackSecretsManagerUnchanged, state,
+		"No fallback manager should mean no changes to the project stack",
+	)
+	assert.True(t, defaulted, "Should have loaded the default encrypter")
+}

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -30,7 +30,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/graph"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
-	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -97,6 +96,11 @@ func newDestroyCmd() *cobra.Command {
 		Args: cmdArgs,
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+
+			// Destroy is always permitted to fall back to looking for secrets providers in state, since we explicitly
+			// want to support use cases where a user is trying to destroy a stack they no longer have configuration for.
+			ssml := stackSecretsManagerLoader{FallbackToState: true}
+
 			ws := pkgWorkspace.Instance
 
 			// Remote implies we're skipping previews.
@@ -203,24 +207,13 @@ func newDestroyCmd() *cobra.Command {
 				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
 
-			snap, err := s.Snapshot(ctx, stack.DefaultSecretsProvider)
-			if err != nil {
-				return err
-			}
-
-			// Use the current snapshot secrets manager, if there is one, as the fallback secrets manager.
-			var defaultSecretsManager secrets.Manager
-			if snap != nil {
-				defaultSecretsManager = snap.SecretsManager
-			}
-
 			getConfig := getStackConfiguration
 			if stackName != "" {
 				// `pulumi destroy --stack <stack>` can be run outside of the project directory.
 				// The config may be missing, fallback on the latest configuration in the backend.
 				getConfig = getStackConfigurationOrLatest
 			}
-			cfg, sm, err := getConfig(ctx, s, proj, defaultSecretsManager)
+			cfg, sm, err := getConfig(ctx, ssml, s, proj)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -652,6 +652,8 @@ func newImportCmd() *cobra.Command {
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
+			ssml := newStackSecretsManagerLoaderFromEnv()
+
 			cwd, err := os.Getwd()
 			if err != nil {
 				return fmt.Errorf("get working directory: %w", err)
@@ -910,7 +912,7 @@ func newImportCmd() *cobra.Command {
 				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
 
-			cfg, sm, err := getStackConfiguration(ctx, s, proj, nil)
+			cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -57,6 +57,7 @@ func newLogsCmd() *cobra.Command {
 		Args: cmdutil.NoArgs,
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ssml := newStackSecretsManagerLoaderFromEnv()
 			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
@@ -73,7 +74,7 @@ func newLogsCmd() *cobra.Command {
 				return err
 			}
 
-			cfg, sm, err := getStackConfiguration(ctx, s, proj, nil)
+			cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -97,6 +97,7 @@ func runNew(ctx context.Context, args newArgs) error {
 		IsInteractive: args.interactive,
 	}
 
+	ssml := newStackSecretsManagerLoaderFromEnv()
 	ws := pkgWorkspace.Instance
 
 	// Validate name (if specified) before further prompts/operations.
@@ -407,9 +408,19 @@ func runNew(ctx context.Context, args newArgs) error {
 	// Prompt for config values (if needed) and save.
 	if !args.generateOnly {
 		err = handleConfig(
-			ctx, ws, args.prompt, proj, s,
-			args.templateNameOrURL, template, args.configArray,
-			args.yes, args.configPath, opts)
+			ctx,
+			ssml,
+			ws,
+			args.prompt,
+			proj,
+			s,
+			args.templateNameOrURL,
+			template,
+			args.configArray,
+			args.yes,
+			args.configPath,
+			opts,
+		)
 		if err != nil {
 			return err
 		}
@@ -1103,6 +1114,7 @@ func parseConfig(configArray []string, path bool) (config.Map, error) {
 // value when prompting instead of the default value specified in templateConfig.
 func promptForConfig(
 	ctx context.Context,
+	ssml stackSecretsManagerLoader,
 	prompt promptForValueFunc,
 	project *workspace.Project,
 	stack backend.Stack,
@@ -1137,11 +1149,11 @@ func promptForConfig(
 		return nil, fmt.Errorf("loading stack config: %w", err)
 	}
 
-	sm, needsSave, err := getStackSecretsManager(stack, ps, nil)
+	sm, state, err := ssml.getSecretsManager(ctx, stack, ps)
 	if err != nil {
 		return nil, err
 	}
-	if needsSave {
+	if state != stackSecretsManagerUnchanged {
 		if err = saveProjectStack(stack, ps); err != nil {
 			return nil, fmt.Errorf("saving stack config: %w", err)
 		}

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -296,6 +296,7 @@ func newPreviewCmd() *cobra.Command {
 		Args: cmdArgs,
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ssml := newStackSecretsManagerLoaderFromEnv()
 			ws := pkgWorkspace.Instance
 			displayType := display.DisplayProgress
 			if diffDisplay {
@@ -382,7 +383,7 @@ func newPreviewCmd() *cobra.Command {
 				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
 
-			cfg, sm, err := getStackConfiguration(ctx, s, proj, nil)
+			cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -90,6 +90,7 @@ func newRefreshCmd() *cobra.Command {
 		Args: cmdArgs,
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ssml := newStackSecretsManagerLoaderFromEnv()
 			ws := pkgWorkspace.Instance
 
 			// Remote implies we're skipping previews.
@@ -183,7 +184,7 @@ func newRefreshCmd() *cobra.Command {
 				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
 
-			cfg, sm, err := getStackConfiguration(ctx, s, proj, nil)
+			cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -53,6 +53,7 @@ func newStackHistoryCmd() *cobra.Command {
 This command displays data about previous updates for a stack.`,
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ssml := newStackSecretsManagerLoaderFromEnv()
 			ws := pkgWorkspace.Instance
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
@@ -76,11 +77,11 @@ This command displays data about previous updates for a stack.`,
 				if err != nil {
 					return fmt.Errorf("getting stack config: %w", err)
 				}
-				crypter, needsSave, err := getStackDecrypter(s, ps)
+				crypter, state, err := ssml.getDecrypter(ctx, s, ps)
 				if err != nil {
 					return fmt.Errorf("decrypting secrets: %w", err)
 				}
-				if needsSave {
+				if state != stackSecretsManagerUnchanged {
 					if err = saveProjectStack(s, ps); err != nil {
 						return fmt.Errorf("saving stack config: %w", err)
 					}

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -115,6 +115,7 @@ func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
 		Color: cmdutil.GetGlobalColorization(),
 	}
 
+	ssml := newStackSecretsManagerLoaderFromEnv()
 	ws := pkgWorkspace.Instance
 
 	// Try to read the current project
@@ -205,7 +206,14 @@ func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
 		}
 
 		// copy the config from the old to the new
-		requiresSaving, err := copyEntireConfigMap(copyStack, copyProjectStack, newStack, newProjectStack)
+		requiresSaving, err := copyEntireConfigMap(
+			ctx,
+			ssml,
+			copyStack,
+			copyProjectStack,
+			newStack,
+			newProjectStack,
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -91,7 +91,12 @@ func newUpCmd() *cobra.Command {
 
 	// up implementation used when the source of the Pulumi program is in the current working directory.
 	upWorkingDirectory := func(
-		ctx context.Context, ws pkgWorkspace.Context, lm backend.LoginManager, opts backend.UpdateOptions, cmd *cobra.Command,
+		ctx context.Context,
+		ssml stackSecretsManagerLoader,
+		ws pkgWorkspace.Context,
+		lm backend.LoginManager,
+		opts backend.UpdateOptions,
+		cmd *cobra.Command,
 	) error {
 		s, err := requireStack(ctx, ws, lm, stackName, stackOfferNew, opts.Display)
 		if err != nil {
@@ -113,7 +118,7 @@ func newUpCmd() *cobra.Command {
 			return fmt.Errorf("gathering environment metadata: %w", err)
 		}
 
-		cfg, sm, err := getStackConfiguration(ctx, s, proj, nil)
+		cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
 		if err != nil {
 			return fmt.Errorf("getting stack configuration: %w", err)
 		}
@@ -213,8 +218,14 @@ func newUpCmd() *cobra.Command {
 	}
 
 	// up implementation used when the source of the Pulumi program is a template name or a URL to a template.
-	upTemplateNameOrURL := func(ctx context.Context, ws pkgWorkspace.Context, lm backend.LoginManager,
-		templateNameOrURL string, opts backend.UpdateOptions, cmd *cobra.Command,
+	upTemplateNameOrURL := func(
+		ctx context.Context,
+		ssml stackSecretsManagerLoader,
+		ws pkgWorkspace.Context,
+		lm backend.LoginManager,
+		templateNameOrURL string,
+		opts backend.UpdateOptions,
+		cmd *cobra.Command,
 	) error {
 		// Retrieve the template repo.
 		repo, err := workspace.RetrieveTemplates(templateNameOrURL, false, workspace.TemplateKindPulumiProject)
@@ -326,9 +337,19 @@ func newUpCmd() *cobra.Command {
 
 		// Prompt for config values (if needed) and save.
 		if err = handleConfig(
-			ctx, ws, promptForValue, proj, s,
-			templateNameOrURL, template, configArray,
-			yes, path, opts.Display); err != nil {
+			ctx,
+			ssml,
+			ws,
+			promptForValue,
+			proj,
+			s,
+			templateNameOrURL,
+			template,
+			configArray,
+			yes,
+			path,
+			opts.Display,
+		); err != nil {
 			return err
 		}
 
@@ -351,7 +372,7 @@ func newUpCmd() *cobra.Command {
 			return fmt.Errorf("gathering environment metadata: %w", err)
 		}
 
-		cfg, sm, err := getStackConfiguration(ctx, s, proj, nil)
+		cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
 		if err != nil {
 			return fmt.Errorf("getting stack configuration: %w", err)
 		}
@@ -446,6 +467,7 @@ func newUpCmd() *cobra.Command {
 		Args: cmdutil.MaximumNArgs(1),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ssml := newStackSecretsManagerLoaderFromEnv()
 			ws := pkgWorkspace.Instance
 
 			// Remote implies we're skipping previews.
@@ -539,10 +561,25 @@ func newUpCmd() *cobra.Command {
 			logging.V(7).Infof("ShowLinkToCopilot=%v", opts.Display.ShowLinkToCopilot)
 
 			if len(args) > 0 {
-				return upTemplateNameOrURL(ctx, ws, DefaultLoginManager, args[0], opts, cmd)
+				return upTemplateNameOrURL(
+					ctx,
+					ssml,
+					ws,
+					DefaultLoginManager,
+					args[0],
+					opts,
+					cmd,
+				)
 			}
 
-			return upWorkingDirectory(ctx, ws, DefaultLoginManager, opts, cmd)
+			return upWorkingDirectory(
+				ctx,
+				ssml,
+				ws,
+				DefaultLoginManager,
+				opts,
+				cmd,
+			)
 		}),
 	}
 
@@ -707,6 +744,7 @@ func validatePolicyPackConfig(policyPackPaths []string, policyPackConfigPaths []
 // handleConfig handles prompting for config values (as needed) and saving config.
 func handleConfig(
 	ctx context.Context,
+	ssml stackSecretsManagerLoader,
 	ws pkgWorkspace.Context,
 	prompt promptForValueFunc,
 	project *workspace.Project,
@@ -748,7 +786,18 @@ func handleConfig(
 		}
 
 		// Prompt for config as needed.
-		c, err = promptForConfig(ctx, prompt, project, s, template.Config, commandLineConfig, stackConfig, yes, opts)
+		c, err = promptForConfig(
+			ctx,
+			ssml,
+			prompt,
+			project,
+			s,
+			template.Config,
+			commandLineConfig,
+			stackConfig,
+			yes,
+			opts,
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -67,6 +67,7 @@ func newWatchCmd() *cobra.Command {
 		Args: cmdutil.MaximumNArgs(1),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ssml := newStackSecretsManagerLoaderFromEnv()
 			ws := pkgWorkspace.Instance
 
 			opts, err := updateFlagsToOptions(false /* interactive */, true /* skipPreview */, true, /* autoApprove */
@@ -112,7 +113,7 @@ func newWatchCmd() *cobra.Command {
 				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
 
-			cfg, sm, err := getStackConfiguration(ctx, s, proj, nil)
+			cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -97,6 +97,9 @@ var BackendURL = env.String("BACKEND_URL",
 var ShowCopilotLink = env.Bool("SHOW_COPILOT_LINK",
 	"Show the 'explainFailure' link to Copilot in the CLI output.")
 
+var FallbackToStateSecretsManager = env.Bool("FALLBACK_TO_STATE_SECRETS_MANAGER",
+	"Use the snapshot secrets manager as a fallback when the stack configuration is missing or incomplete.")
+
 // List of overrides for Plugin Download URLs. The expected format is `regexp=URL`, and multiple pairs can
 // be specified separated by commas, e.g. `regexp1=URL1,regexp2=URL2`
 //

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -24,8 +24,11 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"gopkg.in/yaml.v2"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -531,6 +534,76 @@ func TestInstall(t *testing.T) {
 			assert.Regexp(t, regexp.MustCompile(`resource plugin random.+ installing`), stderr)
 			e.RunCommand("pulumi", "stack", "init", "test")
 			e.RunCommand("pulumi", "up", "--yes")
+			e.RunCommand("pulumi", "destroy", "--yes")
+		})
+	}
+}
+
+// A smoke test to ensure that secrets providers that are persisted to state are
+// used in favour of and to restore stack YAML configuration when it is absent
+// or empty and the PULUMI_FALLBACK_TO_STATE_SECRETS_MANAGER environment variable
+// is set.
+//
+//nolint:paralleltest // pulumi new is not parallel safe, and we set environment variables
+func TestSecretsProvidersSmoke(t *testing.T) {
+	// Make sure we can download needed plugins
+	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
+
+	// Ensure we have a passphrase set for the default secrets provider.
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "test-passphrase")
+
+	// Enable secrets manager fallback.
+	t.Setenv("PULUMI_FALLBACK_TO_STATE_SECRETS_MANAGER", "true")
+
+	operations := [][]string{
+		{"up", "--yes"},
+		{"preview"},
+		{"refresh", "--yes"},
+	}
+
+	for _, runtime := range Runtimes {
+		t.Run(runtime, func(t *testing.T) {
+			//nolint:paralleltest
+
+			e := ptesting.NewEnvironment(t)
+			defer deleteIfNotFailed(e)
+
+			// `new` wants to work in an empty directory but our use of local url means we have a
+			// ".pulumi" directory at root.
+			projectDir := filepath.Join(e.RootPath, "project")
+			err := os.Mkdir(projectDir, 0o700)
+			require.NoError(t, err)
+
+			e.CWD = projectDir
+
+			e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+			e.RunCommand("pulumi", "new", "random-"+Languages[runtime], "--yes")
+			e.RunCommand("pulumi", "up", "--yes")
+
+			stackJSONStr, _ := e.RunCommand("pulumi", "stack", "export")
+			stackJSON := apitype.UntypedDeployment{}
+			err = json.Unmarshal([]byte(stackJSONStr), &stackJSON)
+			require.NoError(t, err)
+
+			deployment := apitype.DeploymentV3{}
+			err = json.Unmarshal(stackJSON.Deployment, &deployment)
+			require.NoError(t, err)
+
+			for _, operation := range operations {
+				os.Remove(filepath.Join(projectDir, "Pulumi.dev.yaml"))
+				e.RunCommand("pulumi", operation...)
+
+				stackYamlStr, err := os.ReadFile(filepath.Join(projectDir, "Pulumi.dev.yaml"))
+				require.NoError(t, err)
+
+				stack := workspace.ProjectStack{}
+				err = yaml.Unmarshal(stackYamlStr, &stack)
+				require.NoError(t, err)
+
+				require.NotEmpty(t, stack.EncryptionSalt)
+				require.Contains(t, string(deployment.SecretsProviders.State), stack.EncryptionSalt)
+			}
+
 			e.RunCommand("pulumi", "destroy", "--yes")
 		})
 	}


### PR DESCRIPTION
Secrets providers are the means by which Pulumi manages the encryption and decryption of secrets. Since secrets may be present in both the state (e.g. sensitive resource outputs) and a stack's configuration (API keys, etc.), so can secrets providers be persisted/specified in both these places.

Currently, if a stack configuration does not exist, or does not specify a secrets provider, a default will be instantiated. This is true even when there is a state snapshot that *does* specify a provider. Consider as an example the following sequence of events:

* A new Pulumi stack, `dev`, is created with a cloud backend and a passphrase secrets provider. The fact that a passphrase provider is in use is persisted to `Pulumi.dev.yaml`.
* `pulumi up -s dev` is run in the new stack. The passphrase provider is written to the state.
* `Pulumi.dev.yaml` is deleted.
* `pulumi up -s dev` is run again. Not finding `Pulumi.dev.yaml`, Pulumi will generate _a new secrets provider_. The default provider for a cloud backend is Pulumi Cloud (which is different to the passphrase provider serialised in state). As part of the operation, the passphrase provider in state will be used to decrypt state secrets. When the operation completes, the secrets will be reencrypted with the new cloud provider in configuration, and the cloud provider will be written back to state. This is despite the fact that the passphrase provider was present in the state prior to the operation taking place.

This might be seen as an edge case -- if `Pulumi.dev.yaml` disappears between operations, we might assume that this would be due to deliberate actions by the user. Unfortunately this is not the case.

The Automation API supports "inline programs", whereby the source code for a Pulumi program can be passed as part of the program using the Automation API, rather than having to have that source code live somewhere on disk (as it would in a "normal" Pulumi program). Under the hood, Pulumi makes things work by emulating a "normal" program, writing out a stack configuration file to a temporary directory. When these directories differ across runs of the program using the Automation API, stack configuration is not persisted between runs, enabling this very scenario (https://github.com/pulumi/pulumi/issues/16890).

This commit adds support for changing this behaviour if an environment variable, `PULUMI_FALLBACK_TO_STATE_SECRETS_MANAGER`, is set to a truthy value. In such cases, a secrets provider persisted to state is always used in the absence of one in configuration. This functionality is gated behind an environment variable for a couple of reasons:

* This is technically a change in behaviour. It is possible that users could be relying on the ability to change their configuration to effect a change of secrets provider. That said, given that this use case is a. hard to understand the full implications of and b. already better served by `pulumi stack change-secrets-provider`, this is not necessarily a huge problem.
* In some cases, we need to load the state snapshot twice -- once in order to retrieve the secrets manager at configuration time, and once again when we actually perform a deployment operation. For large stacks, this could mean a marked difference in performance. An opt-in environment variable thus feels like a safer choice to guard against performance regressions in large numbers of cases.

To avoid sprinkling checks for a global environment variable throughout the codebase, this commit refactors secret manager loading behind a `stackSecretsManagerLoader` struct, whose fallback behaviour can be configured. We then do so using an environment variable at the top level of each command. Tests for the new provider have been added, as well as a smoke test for the high-level scenario.