### PR TITLE
[nodejs] First-class output-versioned invokes

### DIFF
--- a/changelog/pending/20240911--sdkgen-nodejs--first-class-output-versioned-invokes-in-nodejs.yaml
+++ b/changelog/pending/20240911--sdkgen-nodejs--first-class-output-versioned-invokes-in-nodejs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/nodejs
+  description: Add first-class output-versioned invokes for NodeJS

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1283,22 +1283,13 @@ func (mod *modContext) genFunctionDefinition(w io.Writer, fun *schema.Function, 
 			}
 
 			if name := mod.provideDefaultsFuncName(p.Type, true /*input*/); name != "" {
-				if codegen.IsNOptionalInput(p.Type) {
+				if codegen.IsNOptionalInput(p.Type) || !plain {
 					body = fmt.Sprintf("pulumi.output(%s).apply(%s)", body, name)
 				} else {
 					body = fmt.Sprintf("%s(%s)", name, body)
 				}
 
-				var typeCast string
-				if !plain {
-					// if the defaults function return an object, say MyType with default values
-					// it won't be automatically compatible with the non-plain version MyTypeArgs
-					// even though technically MyType is a subset of MyTypeArgs so here we tell the compiler
-					// that it's fine to cast MyType to MyTypeArgs
-					typeCast = "<any>"
-				}
-
-				body = fmt.Sprintf("args.%s ? %s%s : undefined", p.Name, typeCast, body)
+				body = fmt.Sprintf("args.%s ? %s : undefined", p.Name, body)
 			}
 			fmt.Fprintf(w, "        \"%[1]s\": %[2]s,\n", p.Name, body)
 		}

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1218,6 +1218,11 @@ func (mod *modContext) genFunctionDefinition(w io.Writer, fun *schema.Function, 
 
 		argsType := title(name) + suffix
 		argsig = fmt.Sprintf("args%s: %s, ", optFlag, argsType)
+
+		if !plain && len(fun.Inputs.Properties) == 0 {
+			// for empty/unit args on output-versioned invokes, don't generate an empty argument
+			argsig = ""
+		}
 	}
 
 	funReturnType := mod.functionReturnType(fun)
@@ -1260,7 +1265,7 @@ func (mod *modContext) genFunctionDefinition(w io.Writer, fun *schema.Function, 
 	}
 
 	// Zero initialize the args if empty and necessary.
-	if fun.Inputs != nil && argsOptional && !fun.MultiArgumentInputs {
+	if fun.Inputs != nil && argsOptional && !fun.MultiArgumentInputs && argsig != "" {
 		fmt.Fprintf(w, "    args = args || {};\n")
 	}
 

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1288,7 +1288,17 @@ func (mod *modContext) genFunctionDefinition(w io.Writer, fun *schema.Function, 
 				} else {
 					body = fmt.Sprintf("%s(%s)", name, body)
 				}
-				body = fmt.Sprintf("args.%s ? %s : undefined", p.Name, body)
+
+				var typeCast string
+				if !plain {
+					// if the defaults function return an object, say MyType with default values
+					// it won't be automatically compatible with the non-plain version MyTypeArgs
+					// even though technically MyType is a subset of MyTypeArgs so here we tell the compiler
+					// that it's fine to cast MyType to MyTypeArgs
+					typeCast = "<any>"
+				}
+
+				body = fmt.Sprintf("args.%s ? %s%s : undefined", p.Name, typeCast, body)
 			}
 			fmt.Fprintf(w, "        \"%[1]s\": %[2]s,\n", p.Name, body)
 		}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/simple-invoke-10.0.0/myInvoke.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/simple-invoke-10.0.0/myInvoke.ts
@@ -5,7 +5,6 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 export function myInvoke(args: MyInvokeArgs, opts?: pulumi.InvokeOptions): Promise<MyInvokeResult> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("simple-invoke:index:myInvoke", {
         "value": args.value,
@@ -20,7 +19,10 @@ export interface MyInvokeResult {
     readonly result: string;
 }
 export function myInvokeOutput(args: MyInvokeOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<MyInvokeResult> {
-    return pulumi.output(args).apply((a: any) => myInvoke(a, opts))
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("simple-invoke:index:myInvoke", {
+        "value": args.value,
+    }, opts);
 }
 
 export interface MyInvokeOutputArgs {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/simple-invoke-10.0.0/unit.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/simple-invoke-10.0.0/unit.ts
@@ -6,7 +6,6 @@ import * as utilities from "./utilities";
 
 export function unit(args?: UnitArgs, opts?: pulumi.InvokeOptions): Promise<UnitResult> {
     args = args || {};
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("simple-invoke:index:unit", {
     }, opts);
@@ -19,5 +18,8 @@ export interface UnitResult {
     readonly result: string;
 }
 export function unitOutput(opts?: pulumi.InvokeOptions): pulumi.Output<UnitResult> {
-    return pulumi.output(unit(opts))
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("simple-invoke:index:unit", {
+    }, opts);
 }
+

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/simple-invoke-10.0.0/myInvoke.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/simple-invoke-10.0.0/myInvoke.ts
@@ -5,7 +5,6 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 export function myInvoke(args: MyInvokeArgs, opts?: pulumi.InvokeOptions): Promise<MyInvokeResult> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("simple-invoke:index:myInvoke", {
         "value": args.value,
@@ -20,7 +19,10 @@ export interface MyInvokeResult {
     readonly result: string;
 }
 export function myInvokeOutput(args: MyInvokeOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<MyInvokeResult> {
-    return pulumi.output(args).apply((a: any) => myInvoke(a, opts))
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("simple-invoke:index:myInvoke", {
+        "value": args.value,
+    }, opts);
 }
 
 export interface MyInvokeOutputArgs {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/simple-invoke-10.0.0/unit.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/simple-invoke-10.0.0/unit.ts
@@ -6,7 +6,6 @@ import * as utilities from "./utilities";
 
 export function unit(args?: UnitArgs, opts?: pulumi.InvokeOptions): Promise<UnitResult> {
     args = args || {};
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("simple-invoke:index:unit", {
     }, opts);
@@ -19,5 +18,8 @@ export interface UnitResult {
     readonly result: string;
 }
 export function unitOutput(opts?: pulumi.InvokeOptions): pulumi.Output<UnitResult> {
-    return pulumi.output(unit(opts))
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("simple-invoke:index:unit", {
+    }, opts);
 }
+

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -81,7 +81,7 @@ export function invoke(
     opts: InvokeOptions = {},
     packageRef?: Promise<string | undefined>,
 ): Promise<any> {
-    return invokeAsync(tok, props, opts, packageRef).then(response => {
+    return invokeAsync(tok, props, opts, packageRef).then((response) => {
         // ignore secrets for plain invoke
         const { result } = response;
         return result;
@@ -89,9 +89,9 @@ export function invoke(
 }
 
 /**
-* Similar to the plain `invoke` but returns the response as an output, maintaining
-* secrets of the response, if any.
-*/
+ * Similar to the plain `invoke` but returns the response as an output, maintaining
+ * secrets of the response, if any.
+ */
 export function invokeOutput<T>(
     tok: string,
     props: Inputs,
@@ -101,14 +101,16 @@ export function invokeOutput<T>(
     const [output, resolve] = createOutput<T>(`invoke(${tok})`);
     // assume that responses from invoke are always known
     const isKnown = true;
-    invokeAsync(tok, props, opts, packageRef).then(response => {
-        const { result, containsSecrets } = response;
-        resolve(<T>result, isKnown, containsSecrets, [], undefined)
-    }).catch(err => {
-        resolve(<any>undefined, isKnown, false, [], err)
-    });
+    invokeAsync(tok, props, opts, packageRef)
+        .then((response) => {
+            const { result, containsSecrets } = response;
+            resolve(<T>result, isKnown, containsSecrets, [], undefined);
+        })
+        .catch((err) => {
+            resolve(<any>undefined, isKnown, false, [], err);
+        });
 
-    return output
+    return output;
 }
 
 function extractSingleValue(result: Inputs | undefined): any {
@@ -132,7 +134,7 @@ export function invokeSingle(
     opts: InvokeOptions = {},
     packageRef?: Promise<string | undefined>,
 ): Promise<any> {
-    return invokeAsync(tok, props, opts, packageRef).then(response => {
+    return invokeAsync(tok, props, opts, packageRef).then((response) => {
         // ignore secrets for plain invoke
         const { result } = response;
         return extractSingleValue(result);
@@ -152,15 +154,17 @@ export function invokeSingleOutput<T>(
     const [output, resolve] = createOutput<T>(`invokeSingleOutput(${tok})`);
     // assume that responses from invoke are always known
     const isKnown = true;
-    invokeAsync(tok, props, opts, packageRef).then(response => {
-        const { result, containsSecrets } = response;
-        const value = extractSingleValue(result)
-        resolve(<T>value, isKnown, containsSecrets, [], undefined)
-    }).catch(err => {
-        resolve(<any>undefined, isKnown, false, [], err)
-    });
+    invokeAsync(tok, props, opts, packageRef)
+        .then((response) => {
+            const { result, containsSecrets } = response;
+            const value = extractSingleValue(result);
+            resolve(<T>value, isKnown, containsSecrets, [], undefined);
+        })
+        .catch((err) => {
+            resolve(<any>undefined, isKnown, false, [], err);
+        });
 
-    return output
+    return output;
 }
 
 export async function streamInvoke(
@@ -330,9 +334,9 @@ function getProvider(tok: string, opts: InvokeOptions) {
 function deserializeResponse(
     tok: string,
     resp: { getFailuresList(): Array<providerproto.CheckFailure>; getReturn(): gstruct.Struct | undefined },
-): { 
-    result: Inputs | undefined, 
-    containsSecrets: boolean 
+): {
+    result: Inputs | undefined;
+    containsSecrets: boolean;
 } {
     const failures = resp.getFailuresList();
     if (failures?.length) {
@@ -353,11 +357,11 @@ function deserializeResponse(
     if (result === undefined) {
         return {
             result,
-            containsSecrets
+            containsSecrets,
         };
     }
 
-    const properties =  deserializeProperties(result)
+    const properties = deserializeProperties(result);
     // Keep track of whether we need to mark the resulting output a secret.
     // and unwrap each individual value if it is a secret.
     for (const key of Object.keys(properties)) {
@@ -367,7 +371,7 @@ function deserializeResponse(
 
     return {
         result: properties,
-        containsSecrets
+        containsSecrets,
     };
 }
 

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -81,7 +81,44 @@ export function invoke(
     opts: InvokeOptions = {},
     packageRef?: Promise<string | undefined>,
 ): Promise<any> {
-    return invokeAsync(tok, props, opts, packageRef);
+    return invokeAsync(tok, props, opts, packageRef).then(response => {
+        // ignore secrets for plain invoke
+        const { result } = response;
+        return result;
+    });
+}
+
+/**
+* Similar to the plain `invoke` but returns the response as an output, maintaining
+* secrets of the response, if any.
+*/
+export function invokeOutput<T>(
+    tok: string,
+    props: Inputs,
+    opts: InvokeOptions = {},
+    packageRef?: Promise<string | undefined>,
+): Output<T> {
+    const [output, resolve] = createOutput<T>(`invoke(${tok})`);
+    // assume that responses from invoke are always known
+    const isKnown = true;
+    invokeAsync(tok, props, opts, packageRef).then(response => {
+        const { result, containsSecrets } = response;
+        resolve(<T>result, isKnown, containsSecrets, [], undefined)
+    }).catch(err => {
+        resolve(<any>undefined, isKnown, false, [], err)
+    });
+
+    return output
+}
+
+function extractSingleValue(result: Inputs | undefined): any {
+    if (result === undefined) {
+        return result;
+    }
+    // assume outputs has at least one key
+    const keys = Object.keys(result);
+    // return the first key's value from the outputs
+    return result[keys[0]];
 }
 
 /*
@@ -95,12 +132,35 @@ export function invokeSingle(
     opts: InvokeOptions = {},
     packageRef?: Promise<string | undefined>,
 ): Promise<any> {
-    return invokeAsync(tok, props, opts, packageRef).then((outputs) => {
-        // assume outputs have a single key
-        const keys = Object.keys(outputs);
-        // return the first key's value from the outputs
-        return outputs[keys[0]];
+    return invokeAsync(tok, props, opts, packageRef).then(response => {
+        // ignore secrets for plain invoke
+        const { result } = response;
+        return extractSingleValue(result);
     });
+}
+
+/**
+ * Similar to the plain `invokeSingle` but returns the response as an output, maintaining
+ * secrets of the response, if any.
+ */
+export function invokeSingleOutput<T>(
+    tok: string,
+    props: Inputs,
+    opts: InvokeOptions = {},
+    packageRef?: Promise<string | undefined>,
+): Output<T> {
+    const [output, resolve] = createOutput<T>(`invokeSingleOutput(${tok})`);
+    // assume that responses from invoke are always known
+    const isKnown = true;
+    invokeAsync(tok, props, opts, packageRef).then(response => {
+        const { result, containsSecrets } = response;
+        const value = extractSingleValue(result)
+        resolve(<T>value, isKnown, containsSecrets, [], undefined)
+    }).catch(err => {
+        resolve(<any>undefined, isKnown, false, [], err)
+    });
+
+    return output
 }
 
 export async function streamInvoke(
@@ -155,7 +215,10 @@ async function invokeAsync(
     props: Inputs,
     opts: InvokeOptions,
     packageRef?: Promise<string | undefined>,
-): Promise<any> {
+): Promise<{
+    result: Inputs | undefined;
+    containsSecrets: boolean;
+}> {
     const label = `Invoking function: tok=${tok} asynchronously`;
     log.debug(label + (excessiveDebugOutput ? `, props=${JSON.stringify(props)}` : ``));
 
@@ -267,7 +330,10 @@ function getProvider(tok: string, opts: InvokeOptions) {
 function deserializeResponse(
     tok: string,
     resp: { getFailuresList(): Array<providerproto.CheckFailure>; getReturn(): gstruct.Struct | undefined },
-): Inputs | undefined {
+): { 
+    result: Inputs | undefined, 
+    containsSecrets: boolean 
+} {
     const failures = resp.getFailuresList();
     if (failures?.length) {
         let reasons = "";
@@ -282,8 +348,27 @@ function deserializeResponse(
         throw new Error(`Invoke of '${tok}' failed: ${reasons}`);
     }
 
-    const ret = resp.getReturn();
-    return ret === undefined ? ret : deserializeProperties(ret);
+    let containsSecrets = false;
+    const result = resp.getReturn();
+    if (result === undefined) {
+        return {
+            result,
+            containsSecrets
+        };
+    }
+
+    const properties =  deserializeProperties(result)
+    // Keep track of whether we need to mark the resulting output a secret.
+    // and unwrap each individual value if it is a secret.
+    for (const key of Object.keys(properties)) {
+        containsSecrets = containsSecrets || isRpcSecret(properties[key]);
+        properties[key] = unwrapRpcSecret(properties[key]);
+    }
+
+    return {
+        result: properties,
+        containsSecrets
+    };
 }
 
 /**
@@ -368,21 +453,8 @@ export function call<T>(
                 );
 
                 // Deserialize the response and resolve the output.
-                const deserialized = deserializeResponse(tok, resp);
-                let isSecret = false;
+                const { result, containsSecrets } = deserializeResponse(tok, resp);
                 const deps: Resource[] = [];
-
-                // Keep track of whether we need to mark the resulting output a secret.
-                // and unwrap each individual value.
-                if (deserialized !== undefined) {
-                    for (const k of Object.keys(deserialized)) {
-                        const v = deserialized[k];
-                        if (isRpcSecret(v)) {
-                            isSecret = true;
-                            deserialized[k] = unwrapRpcSecret(v);
-                        }
-                    }
-                }
 
                 // Combine the individual dependencies into a single set of dependency resources.
                 const rpcDeps = resp.getReturndependenciesMap();
@@ -401,7 +473,7 @@ export function call<T>(
                 // If the value the engine handed back is or contains an unknown value, the resolver will mark its value as
                 // unknown automatically, so we just pass true for isKnown here. Note that unknown values will only be
                 // present during previews (i.e. isDryRun() will be true).
-                resolver(<any>deserialized, true, isSecret, deps);
+                resolver(<any>result, true, containsSecrets, deps);
             } catch (e) {
                 resolver(<any>undefined, true, false, undefined, e);
             } finally {

--- a/tests/testdata/codegen/assets-and-archives/nodejs/getAssets.ts
+++ b/tests/testdata/codegen/assets-and-archives/nodejs/getAssets.ts
@@ -5,7 +5,6 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 export function getAssets(args: GetAssetsArgs, opts?: pulumi.InvokeOptions): Promise<GetAssetsResult> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("example::GetAssets", {
         "archive": args.archive,
@@ -23,7 +22,11 @@ export interface GetAssetsResult {
     readonly source: pulumi.asset.Asset | pulumi.asset.Archive;
 }
 export function getAssetsOutput(args: GetAssetsOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<GetAssetsResult> {
-    return pulumi.output(args).apply((a: any) => getAssets(a, opts))
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("example::GetAssets", {
+        "archive": args.archive,
+        "source": args.source,
+    }, opts);
 }
 
 export interface GetAssetsOutputArgs {

--- a/tests/testdata/codegen/external-resource-schema/nodejs/argFunction.ts
+++ b/tests/testdata/codegen/external-resource-schema/nodejs/argFunction.ts
@@ -8,7 +8,6 @@ import * as pulumiRandom from "@pulumi/random";
 
 export function argFunction(args?: ArgFunctionArgs, opts?: pulumi.InvokeOptions): Promise<ArgFunctionResult> {
     args = args || {};
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("example::argFunction", {
         "name": args.name,
@@ -23,7 +22,11 @@ export interface ArgFunctionResult {
     readonly age?: number;
 }
 export function argFunctionOutput(args?: ArgFunctionOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<ArgFunctionResult> {
-    return pulumi.output(args).apply((a: any) => argFunction(a, opts))
+    args = args || {};
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("example::argFunction", {
+        "name": args.name,
+    }, opts);
 }
 
 export interface ArgFunctionOutputArgs {

--- a/tests/testdata/codegen/functions-secrets/nodejs/funcWithSecrets.ts
+++ b/tests/testdata/codegen/functions-secrets/nodejs/funcWithSecrets.ts
@@ -5,7 +5,6 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 export function funcWithSecrets(args: FuncWithSecretsArgs, opts?: pulumi.InvokeOptions): Promise<FuncWithSecretsResult> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("mypkg::funcWithSecrets", {
         "cryptoKey": args.cryptoKey,
@@ -25,7 +24,11 @@ export interface FuncWithSecretsResult {
     readonly plaintext: string;
 }
 export function funcWithSecretsOutput(args: FuncWithSecretsOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<FuncWithSecretsResult> {
-    return pulumi.output(args).apply((a: any) => funcWithSecrets(a, opts))
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("mypkg::funcWithSecrets", {
+        "cryptoKey": args.cryptoKey,
+        "plaintext": args.plaintext,
+    }, opts);
 }
 
 export interface FuncWithSecretsOutputArgs {

--- a/tests/testdata/codegen/output-funcs-edgeorder/nodejs/listConfigurations.ts
+++ b/tests/testdata/codegen/output-funcs-edgeorder/nodejs/listConfigurations.ts
@@ -12,7 +12,6 @@ import * as utilities from "./utilities";
  * API Version: 2020-12-01-preview.
  */
 export function listConfigurations(args: ListConfigurationsArgs, opts?: pulumi.InvokeOptions): Promise<ListConfigurationsResult> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("myedgeorder::listConfigurations", {
         "configurationFilters": args.configurationFilters,
@@ -54,7 +53,12 @@ export interface ListConfigurationsResult {
  * API Version: 2020-12-01-preview.
  */
 export function listConfigurationsOutput(args: ListConfigurationsOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<ListConfigurationsResult> {
-    return pulumi.output(args).apply((a: any) => listConfigurations(a, opts))
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("myedgeorder::listConfigurations", {
+        "configurationFilters": args.configurationFilters,
+        "customerSubscriptionDetails": args.customerSubscriptionDetails,
+        "skipToken": args.skipToken,
+    }, opts);
 }
 
 export interface ListConfigurationsOutputArgs {

--- a/tests/testdata/codegen/output-funcs-edgeorder/nodejs/listProductFamilies.ts
+++ b/tests/testdata/codegen/output-funcs-edgeorder/nodejs/listProductFamilies.ts
@@ -12,7 +12,6 @@ import * as utilities from "./utilities";
  * API Version: 2020-12-01-preview.
  */
 export function listProductFamilies(args: ListProductFamiliesArgs, opts?: pulumi.InvokeOptions): Promise<ListProductFamiliesResult> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("myedgeorder::listProductFamilies", {
         "customerSubscriptionDetails": args.customerSubscriptionDetails,
@@ -59,7 +58,13 @@ export interface ListProductFamiliesResult {
  * API Version: 2020-12-01-preview.
  */
 export function listProductFamiliesOutput(args: ListProductFamiliesOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<ListProductFamiliesResult> {
-    return pulumi.output(args).apply((a: any) => listProductFamilies(a, opts))
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("myedgeorder::listProductFamilies", {
+        "customerSubscriptionDetails": args.customerSubscriptionDetails,
+        "expand": args.expand,
+        "filterableProperties": args.filterableProperties,
+        "skipToken": args.skipToken,
+    }, opts);
 }
 
 export interface ListProductFamiliesOutputArgs {

--- a/tests/testdata/codegen/output-funcs-tfbridge20/nodejs/getAmiIds.ts
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/nodejs/getAmiIds.ts
@@ -12,7 +12,6 @@ import * as utilities from "./utilities";
 /** @deprecated aws.getAmiIds has been deprecated in favor of aws.ec2.getAmiIds */
 export function getAmiIds(args: GetAmiIdsArgs, opts?: pulumi.InvokeOptions): Promise<GetAmiIdsResult> {
     pulumi.log.warn("getAmiIds is deprecated: aws.getAmiIds has been deprecated in favor of aws.ec2.getAmiIds")
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("mypkg::getAmiIds", {
         "executableUsers": args.executableUsers,
@@ -76,7 +75,15 @@ export interface GetAmiIdsResult {
  */
 /** @deprecated aws.getAmiIds has been deprecated in favor of aws.ec2.getAmiIds */
 export function getAmiIdsOutput(args: GetAmiIdsOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<GetAmiIdsResult> {
-    return pulumi.output(args).apply((a: any) => getAmiIds(a, opts))
+    pulumi.log.warn("getAmiIds is deprecated: aws.getAmiIds has been deprecated in favor of aws.ec2.getAmiIds")
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("mypkg::getAmiIds", {
+        "executableUsers": args.executableUsers,
+        "filters": args.filters,
+        "nameRegex": args.nameRegex,
+        "owners": args.owners,
+        "sortAscending": args.sortAscending,
+    }, opts);
 }
 
 /**

--- a/tests/testdata/codegen/output-funcs-tfbridge20/nodejs/listStorageAccountKeys.ts
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/nodejs/listStorageAccountKeys.ts
@@ -11,7 +11,6 @@ import * as utilities from "./utilities";
  * API Version: 2021-02-01.
  */
 export function listStorageAccountKeys(args: ListStorageAccountKeysArgs, opts?: pulumi.InvokeOptions): Promise<ListStorageAccountKeysResult> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("mypkg::listStorageAccountKeys", {
         "accountName": args.accountName,
@@ -49,7 +48,12 @@ export interface ListStorageAccountKeysResult {
  * API Version: 2021-02-01.
  */
 export function listStorageAccountKeysOutput(args: ListStorageAccountKeysOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<ListStorageAccountKeysResult> {
-    return pulumi.output(args).apply((a: any) => listStorageAccountKeys(a, opts))
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("mypkg::listStorageAccountKeys", {
+        "accountName": args.accountName,
+        "expand": args.expand,
+        "resourceGroupName": args.resourceGroupName,
+    }, opts);
 }
 
 export interface ListStorageAccountKeysOutputArgs {

--- a/tests/testdata/codegen/output-funcs/nodejs/funcWithAllOptionalInputs.ts
+++ b/tests/testdata/codegen/output-funcs/nodejs/funcWithAllOptionalInputs.ts
@@ -9,7 +9,6 @@ import * as utilities from "./utilities";
  */
 export function funcWithAllOptionalInputs(args?: FuncWithAllOptionalInputsArgs, opts?: pulumi.InvokeOptions): Promise<FuncWithAllOptionalInputsResult> {
     args = args || {};
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("mypkg::funcWithAllOptionalInputs", {
         "a": args.a,
@@ -35,7 +34,12 @@ export interface FuncWithAllOptionalInputsResult {
  * Check codegen of functions with all optional inputs.
  */
 export function funcWithAllOptionalInputsOutput(args?: FuncWithAllOptionalInputsOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<FuncWithAllOptionalInputsResult> {
-    return pulumi.output(args).apply((a: any) => funcWithAllOptionalInputs(a, opts))
+    args = args || {};
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("mypkg::funcWithAllOptionalInputs", {
+        "a": args.a,
+        "b": args.b,
+    }, opts);
 }
 
 export interface FuncWithAllOptionalInputsOutputArgs {

--- a/tests/testdata/codegen/output-funcs/nodejs/funcWithConstInput.ts
+++ b/tests/testdata/codegen/output-funcs/nodejs/funcWithConstInput.ts
@@ -9,7 +9,6 @@ import * as utilities from "./utilities";
  */
 export function funcWithConstInput(args?: FuncWithConstInputArgs, opts?: pulumi.InvokeOptions): Promise<void> {
     args = args || {};
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("mypkg::funcWithConstInput", {
         "plainInput": args.plainInput,

--- a/tests/testdata/codegen/output-funcs/nodejs/funcWithDefaultValue.ts
+++ b/tests/testdata/codegen/output-funcs/nodejs/funcWithDefaultValue.ts
@@ -8,7 +8,6 @@ import * as utilities from "./utilities";
  * Check codegen of functions with default values.
  */
 export function funcWithDefaultValue(args: FuncWithDefaultValueArgs, opts?: pulumi.InvokeOptions): Promise<FuncWithDefaultValueResult> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("mypkg::funcWithDefaultValue", {
         "a": args.a,
@@ -28,7 +27,11 @@ export interface FuncWithDefaultValueResult {
  * Check codegen of functions with default values.
  */
 export function funcWithDefaultValueOutput(args: FuncWithDefaultValueOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<FuncWithDefaultValueResult> {
-    return pulumi.output(args).apply((a: any) => funcWithDefaultValue(a, opts))
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("mypkg::funcWithDefaultValue", {
+        "a": args.a,
+        "b": args.b,
+    }, opts);
 }
 
 export interface FuncWithDefaultValueOutputArgs {

--- a/tests/testdata/codegen/output-funcs/nodejs/funcWithDictParam.ts
+++ b/tests/testdata/codegen/output-funcs/nodejs/funcWithDictParam.ts
@@ -9,7 +9,6 @@ import * as utilities from "./utilities";
  */
 export function funcWithDictParam(args?: FuncWithDictParamArgs, opts?: pulumi.InvokeOptions): Promise<FuncWithDictParamResult> {
     args = args || {};
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("mypkg::funcWithDictParam", {
         "a": args.a,
@@ -29,7 +28,12 @@ export interface FuncWithDictParamResult {
  * Check codegen of functions with a Dict<str,str> parameter.
  */
 export function funcWithDictParamOutput(args?: FuncWithDictParamOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<FuncWithDictParamResult> {
-    return pulumi.output(args).apply((a: any) => funcWithDictParam(a, opts))
+    args = args || {};
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("mypkg::funcWithDictParam", {
+        "a": args.a,
+        "b": args.b,
+    }, opts);
 }
 
 export interface FuncWithDictParamOutputArgs {

--- a/tests/testdata/codegen/output-funcs/nodejs/funcWithEmptyOutputs.ts
+++ b/tests/testdata/codegen/output-funcs/nodejs/funcWithEmptyOutputs.ts
@@ -8,7 +8,6 @@ import * as utilities from "./utilities";
  * n/a
  */
 export function funcWithEmptyOutputs(args: FuncWithEmptyOutputsArgs, opts?: pulumi.InvokeOptions): Promise<void> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("mypkg::funcWithEmptyOutputs", {
         "name": args.name,

--- a/tests/testdata/codegen/output-funcs/nodejs/funcWithListParam.ts
+++ b/tests/testdata/codegen/output-funcs/nodejs/funcWithListParam.ts
@@ -9,7 +9,6 @@ import * as utilities from "./utilities";
  */
 export function funcWithListParam(args?: FuncWithListParamArgs, opts?: pulumi.InvokeOptions): Promise<FuncWithListParamResult> {
     args = args || {};
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("mypkg::funcWithListParam", {
         "a": args.a,
@@ -29,7 +28,12 @@ export interface FuncWithListParamResult {
  * Check codegen of functions with a List parameter.
  */
 export function funcWithListParamOutput(args?: FuncWithListParamOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<FuncWithListParamResult> {
-    return pulumi.output(args).apply((a: any) => funcWithListParam(a, opts))
+    args = args || {};
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("mypkg::funcWithListParam", {
+        "a": args.a,
+        "b": args.b,
+    }, opts);
 }
 
 export interface FuncWithListParamOutputArgs {

--- a/tests/testdata/codegen/output-funcs/nodejs/getBastionShareableLink.ts
+++ b/tests/testdata/codegen/output-funcs/nodejs/getBastionShareableLink.ts
@@ -11,7 +11,6 @@ import * as utilities from "./utilities";
  * API Version: 2020-11-01.
  */
 export function getBastionShareableLink(args: GetBastionShareableLinkArgs, opts?: pulumi.InvokeOptions): Promise<GetBastionShareableLinkResult> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("mypkg::getBastionShareableLink", {
         "bastionHostName": args.bastionHostName,
@@ -49,7 +48,12 @@ export interface GetBastionShareableLinkResult {
  * API Version: 2020-11-01.
  */
 export function getBastionShareableLinkOutput(args: GetBastionShareableLinkOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<GetBastionShareableLinkResult> {
-    return pulumi.output(args).apply((a: any) => getBastionShareableLink(a, opts))
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("mypkg::getBastionShareableLink", {
+        "bastionHostName": args.bastionHostName,
+        "resourceGroupName": args.resourceGroupName,
+        "vms": args.vms,
+    }, opts);
 }
 
 export interface GetBastionShareableLinkOutputArgs {

--- a/tests/testdata/codegen/output-funcs/nodejs/getClientConfig.ts
+++ b/tests/testdata/codegen/output-funcs/nodejs/getClientConfig.ts
@@ -8,7 +8,6 @@ import * as utilities from "./utilities";
  * Failing example taken from azure-native. Original doc: Use this function to access the current configuration of the native Azure provider.
  */
 export function getClientConfig(opts?: pulumi.InvokeOptions): Promise<GetClientConfigResult> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("mypkg::getClientConfig", {
     }, opts);
@@ -39,5 +38,7 @@ export interface GetClientConfigResult {
  * Failing example taken from azure-native. Original doc: Use this function to access the current configuration of the native Azure provider.
  */
 export function getClientConfigOutput(opts?: pulumi.InvokeOptions): pulumi.Output<GetClientConfigResult> {
-    return pulumi.output(getClientConfig(opts))
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("mypkg::getClientConfig", {
+    }, opts);
 }

--- a/tests/testdata/codegen/output-funcs/nodejs/getIntegrationRuntimeObjectMetadatum.ts
+++ b/tests/testdata/codegen/output-funcs/nodejs/getIntegrationRuntimeObjectMetadatum.ts
@@ -11,7 +11,6 @@ import * as utilities from "./utilities";
  * API Version: 2018-06-01.
  */
 export function getIntegrationRuntimeObjectMetadatum(args: GetIntegrationRuntimeObjectMetadatumArgs, opts?: pulumi.InvokeOptions): Promise<GetIntegrationRuntimeObjectMetadatumResult> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("mypkg::getIntegrationRuntimeObjectMetadatum", {
         "factoryName": args.factoryName,
@@ -58,7 +57,13 @@ export interface GetIntegrationRuntimeObjectMetadatumResult {
  * API Version: 2018-06-01.
  */
 export function getIntegrationRuntimeObjectMetadatumOutput(args: GetIntegrationRuntimeObjectMetadatumOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<GetIntegrationRuntimeObjectMetadatumResult> {
-    return pulumi.output(args).apply((a: any) => getIntegrationRuntimeObjectMetadatum(a, opts))
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("mypkg::getIntegrationRuntimeObjectMetadatum", {
+        "factoryName": args.factoryName,
+        "integrationRuntimeName": args.integrationRuntimeName,
+        "metadataPath": args.metadataPath,
+        "resourceGroupName": args.resourceGroupName,
+    }, opts);
 }
 
 export interface GetIntegrationRuntimeObjectMetadatumOutputArgs {

--- a/tests/testdata/codegen/output-funcs/nodejs/listStorageAccountKeys.ts
+++ b/tests/testdata/codegen/output-funcs/nodejs/listStorageAccountKeys.ts
@@ -11,7 +11,6 @@ import * as utilities from "./utilities";
  * API Version: 2021-02-01.
  */
 export function listStorageAccountKeys(args: ListStorageAccountKeysArgs, opts?: pulumi.InvokeOptions): Promise<ListStorageAccountKeysResult> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("mypkg::listStorageAccountKeys", {
         "accountName": args.accountName,
@@ -49,7 +48,12 @@ export interface ListStorageAccountKeysResult {
  * API Version: 2021-02-01.
  */
 export function listStorageAccountKeysOutput(args: ListStorageAccountKeysOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<ListStorageAccountKeysResult> {
-    return pulumi.output(args).apply((a: any) => listStorageAccountKeys(a, opts))
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("mypkg::listStorageAccountKeys", {
+        "accountName": args.accountName,
+        "expand": args.expand,
+        "resourceGroupName": args.resourceGroupName,
+    }, opts);
 }
 
 export interface ListStorageAccountKeysOutputArgs {

--- a/tests/testdata/codegen/plain-object-defaults/nodejs/funcWithAllOptionalInputs.ts
+++ b/tests/testdata/codegen/plain-object-defaults/nodejs/funcWithAllOptionalInputs.ts
@@ -39,7 +39,7 @@ export function funcWithAllOptionalInputsOutput(args?: FuncWithAllOptionalInputs
     args = args || {};
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invokeOutput("example::funcWithAllOptionalInputs", {
-        "a": args.a ? <any>inputs.helmReleaseSettingsProvideDefaults(args.a) : undefined,
+        "a": args.a ? pulumi.output(args.a).apply(inputs.helmReleaseSettingsProvideDefaults) : undefined,
         "b": args.b,
     }, opts);
 }

--- a/tests/testdata/codegen/plain-object-defaults/nodejs/funcWithAllOptionalInputs.ts
+++ b/tests/testdata/codegen/plain-object-defaults/nodejs/funcWithAllOptionalInputs.ts
@@ -39,7 +39,7 @@ export function funcWithAllOptionalInputsOutput(args?: FuncWithAllOptionalInputs
     args = args || {};
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invokeOutput("example::funcWithAllOptionalInputs", {
-        "a": args.a ? inputs.helmReleaseSettingsProvideDefaults(args.a) : undefined,
+        "a": args.a ? <any>inputs.helmReleaseSettingsProvideDefaults(args.a) : undefined,
         "b": args.b,
     }, opts);
 }

--- a/tests/testdata/codegen/plain-object-defaults/nodejs/funcWithAllOptionalInputs.ts
+++ b/tests/testdata/codegen/plain-object-defaults/nodejs/funcWithAllOptionalInputs.ts
@@ -11,7 +11,6 @@ import * as utilities from "./utilities";
  */
 export function funcWithAllOptionalInputs(args?: FuncWithAllOptionalInputsArgs, opts?: pulumi.InvokeOptions): Promise<FuncWithAllOptionalInputsResult> {
     args = args || {};
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("example::funcWithAllOptionalInputs", {
         "a": args.a ? inputs.helmReleaseSettingsProvideDefaults(args.a) : undefined,
@@ -37,7 +36,12 @@ export interface FuncWithAllOptionalInputsResult {
  * Check codegen of functions with all optional inputs.
  */
 export function funcWithAllOptionalInputsOutput(args?: FuncWithAllOptionalInputsOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<FuncWithAllOptionalInputsResult> {
-    return pulumi.output(args).apply((a: any) => funcWithAllOptionalInputs(a, opts))
+    args = args || {};
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("example::funcWithAllOptionalInputs", {
+        "a": args.a ? inputs.helmReleaseSettingsProvideDefaults(args.a) : undefined,
+        "b": args.b,
+    }, opts);
 }
 
 export interface FuncWithAllOptionalInputsOutputArgs {

--- a/tests/testdata/codegen/plain-object-disable-defaults/nodejs/funcWithAllOptionalInputs.ts
+++ b/tests/testdata/codegen/plain-object-disable-defaults/nodejs/funcWithAllOptionalInputs.ts
@@ -11,7 +11,6 @@ import * as utilities from "./utilities";
  */
 export function funcWithAllOptionalInputs(args?: FuncWithAllOptionalInputsArgs, opts?: pulumi.InvokeOptions): Promise<FuncWithAllOptionalInputsResult> {
     args = args || {};
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("mypkg::funcWithAllOptionalInputs", {
         "a": args.a ? inputs.helmReleaseSettingsProvideDefaults(args.a) : undefined,
@@ -37,7 +36,12 @@ export interface FuncWithAllOptionalInputsResult {
  * Check codegen of functions with all optional inputs.
  */
 export function funcWithAllOptionalInputsOutput(args?: FuncWithAllOptionalInputsOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<FuncWithAllOptionalInputsResult> {
-    return pulumi.output(args).apply((a: any) => funcWithAllOptionalInputs(a, opts))
+    args = args || {};
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("mypkg::funcWithAllOptionalInputs", {
+        "a": args.a ? inputs.helmReleaseSettingsProvideDefaults(args.a) : undefined,
+        "b": args.b,
+    }, opts);
 }
 
 export interface FuncWithAllOptionalInputsOutputArgs {

--- a/tests/testdata/codegen/plain-object-disable-defaults/nodejs/funcWithAllOptionalInputs.ts
+++ b/tests/testdata/codegen/plain-object-disable-defaults/nodejs/funcWithAllOptionalInputs.ts
@@ -39,7 +39,7 @@ export function funcWithAllOptionalInputsOutput(args?: FuncWithAllOptionalInputs
     args = args || {};
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invokeOutput("mypkg::funcWithAllOptionalInputs", {
-        "a": args.a ? inputs.helmReleaseSettingsProvideDefaults(args.a) : undefined,
+        "a": args.a ? <any>inputs.helmReleaseSettingsProvideDefaults(args.a) : undefined,
         "b": args.b,
     }, opts);
 }

--- a/tests/testdata/codegen/plain-object-disable-defaults/nodejs/funcWithAllOptionalInputs.ts
+++ b/tests/testdata/codegen/plain-object-disable-defaults/nodejs/funcWithAllOptionalInputs.ts
@@ -39,7 +39,7 @@ export function funcWithAllOptionalInputsOutput(args?: FuncWithAllOptionalInputs
     args = args || {};
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invokeOutput("mypkg::funcWithAllOptionalInputs", {
-        "a": args.a ? <any>inputs.helmReleaseSettingsProvideDefaults(args.a) : undefined,
+        "a": args.a ? pulumi.output(args.a).apply(inputs.helmReleaseSettingsProvideDefaults) : undefined,
         "b": args.b,
     }, opts);
 }

--- a/tests/testdata/codegen/provider-config-schema/nodejs/funcWithAllOptionalInputs.ts
+++ b/tests/testdata/codegen/provider-config-schema/nodejs/funcWithAllOptionalInputs.ts
@@ -9,7 +9,6 @@ import * as utilities from "./utilities";
  */
 export function funcWithAllOptionalInputs(args?: FuncWithAllOptionalInputsArgs, opts?: pulumi.InvokeOptions): Promise<FuncWithAllOptionalInputsResult> {
     args = args || {};
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("configstation::funcWithAllOptionalInputs", {
         "a": args.a,
@@ -35,7 +34,12 @@ export interface FuncWithAllOptionalInputsResult {
  * Check codegen of functions with all optional inputs.
  */
 export function funcWithAllOptionalInputsOutput(args?: FuncWithAllOptionalInputsOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<FuncWithAllOptionalInputsResult> {
-    return pulumi.output(args).apply((a: any) => funcWithAllOptionalInputs(a, opts))
+    args = args || {};
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("configstation::funcWithAllOptionalInputs", {
+        "a": args.a,
+        "b": args.b,
+    }, opts);
 }
 
 export interface FuncWithAllOptionalInputsOutputArgs {

--- a/tests/testdata/codegen/regress-8403/nodejs/getCustomDbRoles.ts
+++ b/tests/testdata/codegen/regress-8403/nodejs/getCustomDbRoles.ts
@@ -8,7 +8,6 @@ import * as utilities from "./utilities";
 
 export function getCustomDbRoles(args?: GetCustomDbRolesArgs, opts?: pulumi.InvokeOptions): Promise<GetCustomDbRolesResult> {
     args = args || {};
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("mongodbatlas::getCustomDbRoles", {
     }, opts);
@@ -20,6 +19,10 @@ export interface GetCustomDbRolesArgs {
 export interface GetCustomDbRolesResult {
     readonly result?: outputs.GetCustomDbRolesResult;
 }
-export function getCustomDbRolesOutput(opts?: pulumi.InvokeOptions): pulumi.Output<GetCustomDbRolesResult> {
-    return pulumi.output(getCustomDbRoles(opts))
+export function getCustomDbRolesOutput(args?: GetCustomDbRolesOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<GetCustomDbRolesResult> {
+    args = args || {};
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("mongodbatlas::getCustomDbRoles", {
+    }, opts);
 }
+

--- a/tests/testdata/codegen/regress-8403/nodejs/getCustomDbRoles.ts
+++ b/tests/testdata/codegen/regress-8403/nodejs/getCustomDbRoles.ts
@@ -19,8 +19,7 @@ export interface GetCustomDbRolesArgs {
 export interface GetCustomDbRolesResult {
     readonly result?: outputs.GetCustomDbRolesResult;
 }
-export function getCustomDbRolesOutput(args?: GetCustomDbRolesOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<GetCustomDbRolesResult> {
-    args = args || {};
+export function getCustomDbRolesOutput(opts?: pulumi.InvokeOptions): pulumi.Output<GetCustomDbRolesResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invokeOutput("mongodbatlas::getCustomDbRoles", {
     }, opts);

--- a/tests/testdata/codegen/regress-node-8110/nodejs/exampleFunc.ts
+++ b/tests/testdata/codegen/regress-node-8110/nodejs/exampleFunc.ts
@@ -9,7 +9,6 @@ import * as utilities from "./utilities";
 
 export function exampleFunc(args?: ExampleFuncArgs, opts?: pulumi.InvokeOptions): Promise<void> {
     args = args || {};
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("my8110::exampleFunc", {
         "enums": args.enums,

--- a/tests/testdata/codegen/simple-plain-schema/nodejs/doFoo.ts
+++ b/tests/testdata/codegen/simple-plain-schema/nodejs/doFoo.ts
@@ -7,7 +7,6 @@ import * as outputs from "./types/output";
 import * as utilities from "./utilities";
 
 export function doFoo(args: DoFooArgs, opts?: pulumi.InvokeOptions): Promise<void> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("example::doFoo", {
         "foo": args.foo,

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/nodejs/argFunction.ts
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/nodejs/argFunction.ts
@@ -8,7 +8,6 @@ import {Resource} from "./index";
 
 export function argFunction(args?: ArgFunctionArgs, opts?: pulumi.InvokeOptions): Promise<ArgFunctionResult> {
     args = args || {};
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("example::argFunction", {
         "arg1": args.arg1,
@@ -23,7 +22,11 @@ export interface ArgFunctionResult {
     readonly result?: Resource;
 }
 export function argFunctionOutput(args?: ArgFunctionOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<ArgFunctionResult> {
-    return pulumi.output(args).apply((a: any) => argFunction(a, opts))
+    args = args || {};
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("example::argFunction", {
+        "arg1": args.arg1,
+    }, opts);
 }
 
 export interface ArgFunctionOutputArgs {

--- a/tests/testdata/codegen/simple-resource-schema/nodejs/argFunction.ts
+++ b/tests/testdata/codegen/simple-resource-schema/nodejs/argFunction.ts
@@ -8,7 +8,6 @@ import {Resource} from "./index";
 
 export function argFunction(args?: ArgFunctionArgs, opts?: pulumi.InvokeOptions): Promise<ArgFunctionResult> {
     args = args || {};
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("example::argFunction", {
         "arg1": args.arg1,
@@ -23,7 +22,11 @@ export interface ArgFunctionResult {
     readonly result?: Resource;
 }
 export function argFunctionOutput(args?: ArgFunctionOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<ArgFunctionResult> {
-    return pulumi.output(args).apply((a: any) => argFunction(a, opts))
+    args = args || {};
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("example::argFunction", {
+        "arg1": args.arg1,
+    }, opts);
 }
 
 export interface ArgFunctionOutputArgs {

--- a/tests/testdata/codegen/simple-yaml-schema/nodejs/argFunction.ts
+++ b/tests/testdata/codegen/simple-yaml-schema/nodejs/argFunction.ts
@@ -8,7 +8,6 @@ import {Resource} from "./index";
 
 export function argFunction(args?: ArgFunctionArgs, opts?: pulumi.InvokeOptions): Promise<ArgFunctionResult> {
     args = args || {};
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("example::argFunction", {
         "arg1": args.arg1,
@@ -23,7 +22,11 @@ export interface ArgFunctionResult {
     readonly result?: Resource;
 }
 export function argFunctionOutput(args?: ArgFunctionOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<ArgFunctionResult> {
-    return pulumi.output(args).apply((a: any) => argFunction(a, opts))
+    args = args || {};
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("example::argFunction", {
+        "arg1": args.arg1,
+    }, opts);
 }
 
 export interface ArgFunctionOutputArgs {

--- a/tests/testdata/codegen/simplified-invokes/nodejs/abs.ts
+++ b/tests/testdata/codegen/simplified-invokes/nodejs/abs.ts
@@ -9,7 +9,6 @@ import * as utilities from "./utilities";
  * Example: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.
  */
 export function abs(args: AbsArgs, opts?: pulumi.InvokeOptions): Promise<AbsResult> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("std:index:Abs", {
         "a": args.a,
@@ -30,7 +29,11 @@ export interface AbsResult {
  * Example: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.
  */
 export function absOutput(args: AbsOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<AbsResult> {
-    return pulumi.output(args).apply((a: any) => abs(a, opts))
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("std:index:Abs", {
+        "a": args.a,
+        "b": args.b,
+    }, opts);
 }
 
 export interface AbsOutputArgs {

--- a/tests/testdata/codegen/simplified-invokes/nodejs/absMultiArgs.ts
+++ b/tests/testdata/codegen/simplified-invokes/nodejs/absMultiArgs.ts
@@ -9,7 +9,6 @@ import * as utilities from "./utilities";
  * Example: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.
  */
 export function absMultiArgs(a: number, b?: number, opts?: pulumi.InvokeOptions): Promise<AbsMultiArgsResult> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("std:index:AbsMultiArgs", {
         "a": a,
@@ -25,9 +24,9 @@ export interface AbsMultiArgsResult {
  * Example: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.
  */
 export function absMultiArgsOutput(a: pulumi.Input<number>, b?: pulumi.Input<number | undefined>, opts?: pulumi.InvokeOptions): pulumi.Output<AbsMultiArgsResult> {
-    var args = {
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("std:index:AbsMultiArgs", {
         "a": a,
         "b": b,
-    };
-    return pulumi.output(args).apply((resolvedArgs: any) => absMultiArgs(resolvedArgs.a, resolvedArgs.b, opts));
+    }, opts);
 }

--- a/tests/testdata/codegen/simplified-invokes/nodejs/absMultiArgsReducedOutput.ts
+++ b/tests/testdata/codegen/simplified-invokes/nodejs/absMultiArgsReducedOutput.ts
@@ -9,7 +9,6 @@ import * as utilities from "./utilities";
  * Example: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.
  */
 export function absMultiArgsReducedOutput(a: number, b?: number, opts?: pulumi.InvokeOptions): Promise<number> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invokeSingle("std:index:AbsMultiArgsReducedOutput", {
         "a": a,
@@ -21,9 +20,9 @@ export function absMultiArgsReducedOutput(a: number, b?: number, opts?: pulumi.I
  * Example: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.
  */
 export function absMultiArgsReducedOutputOutput(a: pulumi.Input<number>, b?: pulumi.Input<number | undefined>, opts?: pulumi.InvokeOptions): pulumi.Output<number> {
-    var args = {
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeSingleOutput("std:index:AbsMultiArgsReducedOutput", {
         "a": a,
         "b": b,
-    };
-    return pulumi.output(args).apply((resolvedArgs: any) => absMultiArgsReducedOutput(resolvedArgs.a, resolvedArgs.b, opts));
+    }, opts);
 }

--- a/tests/testdata/codegen/simplified-invokes/nodejs/absMultiArgsReducedOutputSwapped.ts
+++ b/tests/testdata/codegen/simplified-invokes/nodejs/absMultiArgsReducedOutputSwapped.ts
@@ -9,7 +9,6 @@ import * as utilities from "./utilities";
  * Example: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.
  */
 export function absMultiArgsReducedOutputSwapped(b: number, a: number, opts?: pulumi.InvokeOptions): Promise<number> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invokeSingle("std:index:AbsMultiArgsReducedOutputSwapped", {
         "b": b,
@@ -21,9 +20,9 @@ export function absMultiArgsReducedOutputSwapped(b: number, a: number, opts?: pu
  * Example: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.
  */
 export function absMultiArgsReducedOutputSwappedOutput(b: pulumi.Input<number>, a: pulumi.Input<number>, opts?: pulumi.InvokeOptions): pulumi.Output<number> {
-    var args = {
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeSingleOutput("std:index:AbsMultiArgsReducedOutputSwapped", {
         "b": b,
         "a": a,
-    };
-    return pulumi.output(args).apply((resolvedArgs: any) => absMultiArgsReducedOutputSwapped(resolvedArgs.b, resolvedArgs.a, opts));
+    }, opts);
 }

--- a/tests/testdata/codegen/simplified-invokes/nodejs/absReducedOutput.ts
+++ b/tests/testdata/codegen/simplified-invokes/nodejs/absReducedOutput.ts
@@ -9,7 +9,6 @@ import * as utilities from "./utilities";
  * Example: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.
  */
 export function absReducedOutput(args: AbsReducedOutputArgs, opts?: pulumi.InvokeOptions): Promise<number> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invokeSingle("std:index:AbsReducedOutput", {
         "a": args.a,
@@ -26,7 +25,11 @@ export interface AbsReducedOutputArgs {
  * Example: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.
  */
 export function absReducedOutputOutput(args: AbsReducedOutputOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<number> {
-    return pulumi.output(args).apply((a: any) => absReducedOutput(a, opts))
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeSingleOutput("std:index:AbsReducedOutput", {
+        "a": args.a,
+        "b": args.b,
+    }, opts);
 }
 
 export interface AbsReducedOutputOutputArgs {

--- a/tests/testdata/codegen/simplified-invokes/nodejs/getArchive.ts
+++ b/tests/testdata/codegen/simplified-invokes/nodejs/getArchive.ts
@@ -5,15 +5,14 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 export function getArchive(a?: number, opts?: pulumi.InvokeOptions): Promise<pulumi.asset.Archive> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invokeSingle("std:index:GetArchive", {
         "a": a,
     }, opts);
 }
 export function getArchiveOutput(a?: pulumi.Input<number | undefined>, opts?: pulumi.InvokeOptions): pulumi.Output<pulumi.asset.Archive> {
-    var args = {
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeSingleOutput("std:index:GetArchive", {
         "a": a,
-    };
-    return pulumi.output(args).apply((resolvedArgs: any) => getArchive(resolvedArgs.a, opts));
+    }, opts);
 }

--- a/tests/testdata/codegen/simplified-invokes/nodejs/getArrayCustomResult.ts
+++ b/tests/testdata/codegen/simplified-invokes/nodejs/getArrayCustomResult.ts
@@ -7,15 +7,14 @@ import * as outputs from "./types/output";
 import * as utilities from "./utilities";
 
 export function getArrayCustomResult(a?: number, opts?: pulumi.InvokeOptions): Promise<outputs.CustomResult[]> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invokeSingle("std:index:GetArrayCustomResult", {
         "a": a,
     }, opts);
 }
 export function getArrayCustomResultOutput(a?: pulumi.Input<number | undefined>, opts?: pulumi.InvokeOptions): pulumi.Output<outputs.CustomResult[]> {
-    var args = {
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeSingleOutput("std:index:GetArrayCustomResult", {
         "a": a,
-    };
-    return pulumi.output(args).apply((resolvedArgs: any) => getArrayCustomResult(resolvedArgs.a, opts));
+    }, opts);
 }

--- a/tests/testdata/codegen/simplified-invokes/nodejs/getAsset.ts
+++ b/tests/testdata/codegen/simplified-invokes/nodejs/getAsset.ts
@@ -5,15 +5,14 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 export function getAsset(a?: number, opts?: pulumi.InvokeOptions): Promise<pulumi.asset.Asset | pulumi.asset.Archive> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invokeSingle("std:index:GetAsset", {
         "a": a,
     }, opts);
 }
 export function getAssetOutput(a?: pulumi.Input<number | undefined>, opts?: pulumi.InvokeOptions): pulumi.Output<pulumi.asset.Asset | pulumi.asset.Archive> {
-    var args = {
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeSingleOutput("std:index:GetAsset", {
         "a": a,
-    };
-    return pulumi.output(args).apply((resolvedArgs: any) => getAsset(resolvedArgs.a, opts));
+    }, opts);
 }

--- a/tests/testdata/codegen/simplified-invokes/nodejs/getCustomResult.ts
+++ b/tests/testdata/codegen/simplified-invokes/nodejs/getCustomResult.ts
@@ -7,15 +7,14 @@ import * as outputs from "./types/output";
 import * as utilities from "./utilities";
 
 export function getCustomResult(a?: number, opts?: pulumi.InvokeOptions): Promise<outputs.CustomResult> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("std:index:GetCustomResult", {
         "a": a,
     }, opts);
 }
 export function getCustomResultOutput(a?: pulumi.Input<number | undefined>, opts?: pulumi.InvokeOptions): pulumi.Output<outputs.CustomResult> {
-    var args = {
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("std:index:GetCustomResult", {
         "a": a,
-    };
-    return pulumi.output(args).apply((resolvedArgs: any) => getCustomResult(resolvedArgs.a, opts));
+    }, opts);
 }

--- a/tests/testdata/codegen/simplified-invokes/nodejs/getDictionary.ts
+++ b/tests/testdata/codegen/simplified-invokes/nodejs/getDictionary.ts
@@ -7,15 +7,14 @@ import * as outputs from "./types/output";
 import * as utilities from "./utilities";
 
 export function getDictionary(a?: number, opts?: pulumi.InvokeOptions): Promise<{[key: string]: outputs.AnotherCustomResult}> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("std:index:GetDictionary", {
         "a": a,
     }, opts);
 }
 export function getDictionaryOutput(a?: pulumi.Input<number | undefined>, opts?: pulumi.InvokeOptions): pulumi.Output<{[key: string]: outputs.AnotherCustomResult}> {
-    var args = {
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("std:index:GetDictionary", {
         "a": a,
-    };
-    return pulumi.output(args).apply((resolvedArgs: any) => getDictionary(resolvedArgs.a, opts));
+    }, opts);
 }

--- a/tests/testdata/codegen/urn-id-properties/nodejs/test.ts
+++ b/tests/testdata/codegen/urn-id-properties/nodejs/test.ts
@@ -8,7 +8,6 @@ import * as utilities from "./utilities";
  * It's fine for invokes to use urn and id
  */
 export function test(args: TestArgs, opts?: pulumi.InvokeOptions): Promise<TestResult> {
-
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("urnid:index:Test", {
         "id": args.id,
@@ -29,7 +28,11 @@ export interface TestResult {
  * It's fine for invokes to use urn and id
  */
 export function testOutput(args: TestOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<TestResult> {
-    return pulumi.output(args).apply((a: any) => test(a, opts))
+    opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
+    return pulumi.runtime.invokeOutput("urnid:index:Test", {
+        "id": args.id,
+        "urn": args.urn,
+    }, opts);
 }
 
 export interface TestOutputArgs {


### PR DESCRIPTION
### Description 

Partially addressing https://github.com/pulumi/pulumi/issues/12710

This PR extends the nodejs SDK with functions `invokeOutput` and `invokeSingleOutput` which are the output-versioned equivalent of the plain `invoke` and `invokeSingle`. The underlying implementation doesn't rely on the plain one and properly implements output deserialization such that secrets are maintained from the invoke response.

Then we extend the SDK-gen part of nodejs such that output-versioned invokes use the new primitives `invokeOutput` and `invokeSingleOutput` in their generated function body without wrapping the plain invoke.