### PR TITLE
Have `Host.Provider` accept a `PackageDescriptor`

### DIFF
--- a/cmd/pulumi-test-language/test_host.go
+++ b/cmd/pulumi-test-language/test_host.go
@@ -81,13 +81,13 @@ func (h *testHost) ListAnalyzers() []plugin.Analyzer {
 	return nil
 }
 
-func (h *testHost) Provider(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
+func (h *testHost) Provider(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
 	// Look in the providers map for this provider
-	if version == nil {
+	if descriptor.Version == nil {
 		return nil, errors.New("unexpected provider request with no version")
 	}
 
-	key := fmt.Sprintf("%s@%s", pkg, version)
+	key := fmt.Sprintf("%s@%s", descriptor.Name, descriptor.Version)
 	provider, has := h.providers[key]
 	if !has {
 		return nil, fmt.Errorf("unknown provider %s", key)

--- a/pkg/codegen/convert/plugin_mapper.go
+++ b/pkg/codegen/convert/plugin_mapper.go
@@ -76,7 +76,14 @@ func (pc *hostManagedProvider) Close() error {
 // that uses the given plugin host to create providers.
 func ProviderFactoryFromHost(host plugin.Host) ProviderFactory {
 	return func(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
-		provider, err := host.Provider(pkg, version)
+		descriptor := workspace.PackageDescriptor{
+			PluginSpec: workspace.PluginSpec{
+				Name:    string(pkg),
+				Version: version,
+			},
+		}
+
+		provider, err := host.Provider(descriptor)
 		if err != nil {
 			desc := pkg.String()
 			if version != nil {

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -335,7 +335,22 @@ func (l *pluginLoader) loadSchemaBytes(
 func (l *pluginLoader) loadPluginSchemaBytes(
 	ctx context.Context, descriptor *PackageDescriptor,
 ) ([]byte, plugin.Provider, error) {
-	provider, err := l.host.Provider(tokens.Package(descriptor.Name), descriptor.Version)
+	wsDescriptor := workspace.PackageDescriptor{
+		PluginSpec: workspace.PluginSpec{
+			Name:              descriptor.Name,
+			Version:           descriptor.Version,
+			PluginDownloadURL: descriptor.DownloadURL,
+		},
+	}
+	if descriptor.Parameterization != nil {
+		wsDescriptor.Parameterization = &workspace.Parameterization{
+			Name:    descriptor.Parameterization.Name,
+			Version: descriptor.Parameterization.Version,
+			Value:   descriptor.Parameterization.Value,
+		}
+	}
+
+	provider, err := l.host.Provider(wsDescriptor)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/codegen/schema/loader_test.go
+++ b/pkg/codegen/schema/loader_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -160,9 +159,9 @@ func TestLoadParameterized(t *testing.T) {
 	}
 
 	host := &plugin.MockHost{
-		ProviderF: func(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
-			assert.Equal(t, tokens.Package("terraform-provider"), pkg)
-			assert.Equal(t, semver.MustParse("1.0.0"), *version)
+		ProviderF: func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
+			assert.Equal(t, "terraform-provider", descriptor.Name)
+			assert.Equal(t, semver.MustParse("1.0.0"), *descriptor.Version)
 			return mockProvider, nil
 		},
 		ResolvePluginF: func(kind apitype.PluginKind, name string, version *semver.Version) (*workspace.PluginInfo, error) {

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -363,20 +363,20 @@ func (host *pluginHost) plugin(kind apitype.PluginKind, name string, version *se
 	return plug, nil
 }
 
-func (host *pluginHost) Provider(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
+func (host *pluginHost) Provider(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
 	if host.isClosed() {
 		return nil, ErrHostIsClosed
 	}
-	plug, err := host.plugin(apitype.ResourcePlugin, string(pkg), version, nil)
+	plug, err := host.plugin(apitype.ResourcePlugin, descriptor.Name, descriptor.Version, nil)
 	if err != nil {
 		return nil, err
 	}
 	if plug == nil {
 		v := "nil"
-		if version != nil {
-			v = version.String()
+		if descriptor.Version != nil {
+			v = descriptor.Version.String()
 		}
-		return nil, fmt.Errorf("Could not find plugin for (%s, %s)", pkg.String(), v)
+		return nil, fmt.Errorf("Could not find plugin for (%s, %s)", descriptor.Name, v)
 	}
 	return plug.(plugin.Provider), nil
 }

--- a/pkg/resource/deploy/deploytest/pluginhost_test.go
+++ b/pkg/resource/deploy/deploytest/pluginhost_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -123,7 +123,12 @@ func TestPluginHostProvider(t *testing.T) {
 		t.Parallel()
 		expectedVersion := semver.MustParse("1.0.0")
 		host := &pluginHost{}
-		_, err := host.Provider(tokens.Package("pkgA"), &expectedVersion)
+		_, err := host.Provider(workspace.PackageDescriptor{
+			PluginSpec: workspace.PluginSpec{
+				Name:    "pkgA",
+				Version: &expectedVersion,
+			},
+		})
 		assert.ErrorContains(t, err, "Could not find plugin for (pkgA, 1.0.0)")
 	})
 	t.Run("error: plugin host is shutting down", func(t *testing.T) {
@@ -131,7 +136,12 @@ func TestPluginHostProvider(t *testing.T) {
 		t.Run("Provider", func(t *testing.T) {
 			t.Parallel()
 			host := &pluginHost{closed: true}
-			_, err := host.Provider(tokens.Package("pkgA"), &semver.Version{})
+			_, err := host.Provider(workspace.PackageDescriptor{
+				PluginSpec: workspace.PluginSpec{
+					Name:    "pkgA",
+					Version: &semver.Version{},
+				},
+			})
 			assert.ErrorIs(t, err, ErrHostIsClosed)
 		})
 		t.Run("LanguageRuntime", func(t *testing.T) {

--- a/pkg/resource/deploy/import_test.go
+++ b/pkg/resource/deploy/import_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -101,9 +102,9 @@ func TestImporter(t *testing.T) {
 					},
 					source: &nullSource{},
 					providers: providers.NewRegistry(&mockHost{
-						ProviderF: func(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
-							assert.Equal(t, tokens.Package("foo"), pkg)
-							assert.Equal(t, "1.0.0", version.String())
+						ProviderF: func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
+							assert.Equal(t, "foo", descriptor.Name)
+							assert.Equal(t, "1.0.0", descriptor.Version.String())
 							return nil, expectedErr
 						},
 					}, true, nil),

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -37,7 +37,7 @@ import (
 
 type testPluginHost struct {
 	t             *testing.T
-	provider      func(pkg tokens.Package, version *semver.Version) (plugin.Provider, error)
+	provider      func(descriptor workspace.PackageDescriptor) (plugin.Provider, error)
 	closeProvider func(provider plugin.Provider) error
 }
 
@@ -76,8 +76,8 @@ func (host *testPluginHost) ListAnalyzers() []plugin.Analyzer {
 	return nil
 }
 
-func (host *testPluginHost) Provider(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
-	return host.provider(pkg, version)
+func (host *testPluginHost) Provider(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
+	return host.provider(descriptor)
 }
 
 func (host *testPluginHost) CloseProvider(provider plugin.Provider) error {
@@ -185,14 +185,14 @@ type providerLoader struct {
 func newPluginHost(t *testing.T, loaders []*providerLoader) plugin.Host {
 	return &testPluginHost{
 		t: t,
-		provider: func(pkg tokens.Package, ver *semver.Version) (plugin.Provider, error) {
+		provider: func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
 			var best *providerLoader
 			for _, l := range loaders {
-				if l.pkg != pkg {
+				if string(l.pkg) != descriptor.Name {
 					continue
 				}
 
-				if ver != nil && l.version.LT(*ver) {
+				if descriptor.Version != nil && l.version.LT(*descriptor.Version) {
 					continue
 				}
 				if best == nil || l.version.GT(best.version) {

--- a/pkg/resource/deploy/source_query_test.go
+++ b/pkg/resource/deploy/source_query_test.go
@@ -614,7 +614,7 @@ type mockHost struct {
 
 	ListAnalyzersF func() []plugin.Analyzer
 
-	ProviderF func(pkg tokens.Package, version *semver.Version) (plugin.Provider, error)
+	ProviderF func(descriptor workspace.PackageDescriptor) (plugin.Provider, error)
 
 	CloseProviderF func(provider plugin.Provider) error
 
@@ -679,9 +679,9 @@ func (h *mockHost) ListAnalyzers() []plugin.Analyzer {
 	panic("unimplemented")
 }
 
-func (h *mockHost) Provider(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
+func (h *mockHost) Provider(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
 	if h.ProviderF != nil {
-		return h.ProviderF(pkg, version)
+		return h.ProviderF(descriptor)
 	}
 	panic("unimplemented")
 }

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -66,7 +66,7 @@ type Host interface {
 
 	// Provider loads a new copy of the provider for a given package.  If a provider for this package could not be
 	// found, or an error occurs while creating it, a non-nil error is returned.
-	Provider(pkg tokens.Package, version *semver.Version) (Provider, error)
+	Provider(descriptor workspace.PackageDescriptor) (Provider, error)
 	// CloseProvider closes the given provider plugin and deregisters it from this host.
 	CloseProvider(provider Provider) error
 	// LanguageRuntime fetches the language runtime plugin for a given language, lazily allocating if necessary.  If
@@ -375,13 +375,16 @@ func (host *defaultHost) ListAnalyzers() []Analyzer {
 	return analyzers
 }
 
-func (host *defaultHost) Provider(pkg tokens.Package, version *semver.Version) (Provider, error) {
+func (host *defaultHost) Provider(descriptor workspace.PackageDescriptor) (Provider, error) {
 	plugin, err := host.loadPlugin(host.loadRequests, func() (interface{}, error) {
+		pkg := descriptor.Name
+		version := descriptor.Version
+
 		// Try to load and bind to a plugin.
 
 		result := make(map[string]string)
 		for k, v := range host.config {
-			if tokens.Package(k.Namespace()) != pkg {
+			if k.Namespace() != pkg {
 				continue
 			}
 			result[k.Name()] = v
@@ -392,7 +395,7 @@ func (host *defaultHost) Provider(pkg tokens.Package, version *semver.Version) (
 		}
 
 		plug, err := NewProvider(
-			host, host.ctx, pkg, version,
+			host, host.ctx, tokens.Package(pkg), version,
 			host.runtimeOptions, host.disableProviderPreview, string(jsonConfig))
 		if err == nil && plug != nil {
 			info, infoerr := plug.GetPluginInfo(host.ctx.Request())
@@ -503,7 +506,7 @@ func (host *defaultHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds Fla
 			}
 		case apitype.ResourcePlugin:
 			if kinds&ResourcePlugins != 0 {
-				if _, err := host.Provider(tokens.Package(plugin.Name), plugin.Version); err != nil {
+				if _, err := host.Provider(workspace.PackageDescriptor{PluginSpec: plugin}); err != nil {
 					result = multierror.Append(result,
 						fmt.Errorf("failed to load resource plugin %s: %w", plugin.Name, err))
 				}

--- a/sdk/go/common/resource/plugin/mock.go
+++ b/sdk/go/common/resource/plugin/mock.go
@@ -33,7 +33,7 @@ type MockHost struct {
 	AnalyzerF           func(nm tokens.QName) (Analyzer, error)
 	PolicyAnalyzerF     func(name tokens.QName, path string, opts *PolicyAnalyzerOptions) (Analyzer, error)
 	ListAnalyzersF      func() []Analyzer
-	ProviderF           func(pkg tokens.Package, version *semver.Version) (Provider, error)
+	ProviderF           func(descriptor workspace.PackageDescriptor) (Provider, error)
 	CloseProviderF      func(provider Provider) error
 	LanguageRuntimeF    func(runtime string, info ProgramInfo) (LanguageRuntime, error)
 	EnsurePluginsF      func(plugins []workspace.PluginSpec, kinds Flags) error
@@ -86,9 +86,9 @@ func (m *MockHost) ListAnalyzers() []Analyzer {
 	return nil
 }
 
-func (m *MockHost) Provider(pkg tokens.Package, version *semver.Version) (Provider, error) {
+func (m *MockHost) Provider(descriptor workspace.PackageDescriptor) (Provider, error) {
 	if m.ProviderF != nil {
-		return m.ProviderF(pkg, version)
+		return m.ProviderF(descriptor)
 	}
 	return nil, errors.New("Provider not implemented")
 }

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -774,6 +774,28 @@ func (pp ProjectPlugin) Spec() PluginSpec {
 	}
 }
 
+// A PackageDescriptor specifies a package: the source PluginSpec that provides it, and any parameterization
+// that must be applied to that plugin in order to produce the package.
+type PackageDescriptor struct {
+	// A specification for the plugin that provides the package.
+	PluginSpec
+
+	// An optional parameterization to apply to the providing plugin to produce
+	// the package.
+	Parameterization *Parameterization
+}
+
+// A Parameterization may be applied to a supporting plugin to yield a package.
+type Parameterization struct {
+	// The name of the package that will be produced by the parameterization.
+	Name string
+	// The version of the package that will be produced by the parameterization.
+	Version semver.Version
+	// A plugin-dependent bytestring representing the value of the parameter to be
+	// passed to the plugin.
+	Value []byte
+}
+
 // PluginSpec provides basic specification for a plugin.
 type PluginSpec struct {
 	Name              string             // the simple name of the plugin.


### PR DESCRIPTION
Plugins are the core means by which Pulumi may be extended. Language hosts, resource providers, analyzers, and converters, for instance, are all kinds of plugin. Plugins are loaded by a plugin `Host`, which also offers convenience methods for loading specific kinds of plugin such as those mentioned above.

The `Provider` method on `Host` currently accepts a name and version. This is not ideal, since there are several other parameters that may affect the plugin to be loaded, as well as what operations may be run on it when it is loaded:

* Custom download URLs and checksums may be desirable to control where a plugin is retrieved from, and to verify a plugin's integrity.
* Parameterization means that while the `aws` provider is desired, it is actually provided by a dynamically-bridging `terraform` plugin which is to be supplied with a parameter such as `{"name":"aws","version":"..."}`.

This PR begins reworking the `Host` interface so that its `Provider` method accepts a more complete `PackageDescriptor`, consisting of a full `PluginSpec` and an optional `Parameterization`. Presently this PR just replicates existing call sites to use the new data structure -- if this merges successfully then several of these call sites can likely be cleaned up further by moving duplicated logic that handles things like custom download URLs, etc. _into_ the newly capable `Provider` implementation.