### PR TITLE
needsSaveProjectStackAfterSecretManger doesn't need stack parameter

### DIFF
--- a/pkg/cmd/pulumi/crypto.go
+++ b/pkg/cmd/pulumi/crypto.go
@@ -94,11 +94,11 @@ func getStackSecretsManager(
 	}
 
 	// Handle if the configuration changed any of EncryptedKey, etc
-	needsSave := needsSaveProjectStackAfterSecretManger(s, oldConfig, ps)
+	needsSave := needsSaveProjectStackAfterSecretManger(oldConfig, ps)
 	return stack.NewCachingSecretsManager(sm), needsSave, nil
 }
 
-func needsSaveProjectStackAfterSecretManger(stack backend.Stack,
+func needsSaveProjectStackAfterSecretManger(
 	old *workspace.ProjectStack, new *workspace.ProjectStack,
 ) bool {
 	// We should only save the ProjectStack at this point IF we have changed the

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -250,7 +250,7 @@ func createSecretsManager(
 	}
 
 	// Handle if the configuration changed any of EncryptedKey, etc
-	if needsSaveProjectStackAfterSecretManger(stack, oldConfig, ps) {
+	if needsSaveProjectStackAfterSecretManger(oldConfig, ps) {
 		if err = workspace.SaveProjectStack(stack.Ref().Name().Q(), ps); err != nil {
 			return fmt.Errorf("saving stack config: %w", err)
 		}


### PR DESCRIPTION
Little code cleanup, I noticed this method still took the stack parameter but doesn't use it anymore.