### PR TITLE
Just use errors.Is instead of As and Is

### DIFF
--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -134,11 +134,8 @@ func DetectProjectPathFrom(dir string) (string, error) {
 	})
 	// We special case permission errors to cause ErrProjectNotFound to return from this function. This is so
 	// users can run pulumi with unreadable root directories.
-	var perr *fs.PathError
-	if errors.As(err, &perr) {
-		if errors.Is(perr.Err, fs.ErrPermission) {
-			err = nil
-		}
+	if errors.Is(err, fs.ErrPermission) {
+		err = nil
 	}
 
 	if err != nil {


### PR DESCRIPTION
Pointed out in https://github.com/pulumi/pulumi/pull/17239#discussion_r1756396738. We can just use `Is` here we don't need to unwrap with `As` first.