### PR TITLE
[sdk/python] Add dependency on `debugpy`

### DIFF
--- a/changelog/pending/20240912--sdk-python--add-debugpy-as-a-dependency-to-improve-the-debugging-experience.yaml
+++ b/changelog/pending/20240912--sdk-python--add-debugpy-as-a-dependency-to-improve-the-debugging-experience.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Add `debugpy` as a dependency to improve the debugging experience

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -48,6 +48,7 @@ setup(name='pulumi',
           'dill~=0.3',
           'six~=1.12',
           'semver~=2.13',
-          'pyyaml~=6.0'
+          'pyyaml~=6.0',
+          'debugpy~=1.8.5'
       ],
       zip_safe=False)

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -6,6 +6,7 @@ dill~=0.3
 six~=1.12
 semver~=2.13
 pyyaml~=6.0
+debugpy~=1.8.5
 
 # Dev packages only needed during development.
 pylint==3.1.0


### PR DESCRIPTION
To improve the E2E experience of debugging Python Pulumi programs, add `debugpy` as a dependency of the Pulumi Python SDK so that it will be available for use without the user having to install it manually.