### PR TITLE
Add a test for #14254

### DIFF
--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -3448,7 +3448,7 @@ func TestUntargetedProviderChange(t *testing.T) {
 			if provID == "" {
 				provID = providers.UnknownID
 			}
-			provider, err = providers.NewReference(resp.URN, resp.ID)
+			provider, err = providers.NewReference(resp.URN, provID)
 			assert.NoError(t, err)
 		}
 

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -3406,10 +3406,15 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 	})
 }
 
+// This test is a regression test for https://github.com/pulumi/pulumi/issues/14254. This was "fixed" by
+// https://github.com/pulumi/pulumi/pull/15716 but we didn't notice. This test is to ensure that the issue stays fixed
+// because we _almost_ regressed it in https://github.com/pulumi/pulumi/pull/17245.
+//
+// The test checks that if a resource has an explicit provider and we then run an update that changes the resource to
+// use the default provider _but DON'T_ target it that we preserve its explicit provider reference in state. We do NOT
+// want to change state to refer to the default provider as that can then cause provider replace diffs in a later
+// update.
 func TestUntargetedProviderChange(t *testing.T) {
-	// This test is a regression test for https://github.com/pulumi/pulumi/issues/14254. This was "fixed" by
-	// https://github.com/pulumi/pulumi/pull/15716 but we didn't notice. This test is to ensure that the issue
-	// stays fixed because we _almost_ regressed it in https://github.com/pulumi/pulumi/pull/17245.
 	t.Parallel()
 
 	loaders := []*deploytest.ProviderLoader{
@@ -3486,7 +3491,7 @@ func TestUntargetedProviderChange(t *testing.T) {
 		"for resource urn:pulumi:test::test::pkgB:index:typA::unrelated has not been registered yet")
 	// 6 because we have the stack, provider A, target, provider B, unrelated, and the new provider B
 	assert.Equal(t, 6, len(snap.Resources))
-	// unrelated shouldn't have had it's provider changed
+	// unrelated shouldn't have had its provider changed
 	unrelated = snap.Resources[5]
 	assert.Equal(t, "unrelated", unrelated.URN.Name())
 	assert.Equal(t, providerRef, unrelated.Provider)

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -3405,3 +3405,89 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 		})
 	})
 }
+
+func TestUntargetedProviderChange(t *testing.T) {
+	// This test is a regression test for https://github.com/pulumi/pulumi/issues/14254. This was "fixed" by
+	// https://github.com/pulumi/pulumi/pull/15716 but we didn't notice. This test is to ensure that the issue
+	// stays fixed because we _almost_ regressed it in https://github.com/pulumi/pulumi/pull/17245.
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+		deploytest.NewProviderLoader("pkgB", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	inputs := resource.PropertyMap{}
+
+	explicitProvider := true
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		_, err := monitor.RegisterResource("pulumi:pulumi:Stack", "test", false)
+		assert.NoError(t, err)
+
+		_, err = monitor.RegisterResource("pkgA:index:typA", "target", true, deploytest.ResourceOptions{
+			Inputs: inputs,
+		})
+		assert.NoError(t, err)
+
+		var provider providers.Reference
+		if explicitProvider {
+			resp, err := monitor.RegisterResource("pulumi:providers:pkgB", "explicit", true)
+			assert.NoError(t, err)
+
+			provID := resp.ID
+
+			if provID == "" {
+				provID = providers.UnknownID
+			}
+			provider, err = providers.NewReference(resp.URN, resp.ID)
+			assert.NoError(t, err)
+		}
+
+		_, err = monitor.RegisterResource("pkgB:index:typA", "unrelated", true, deploytest.ResourceOptions{
+			Inputs:   inputs,
+			Provider: provider.String(),
+		})
+		assert.NoError(t, err)
+
+		return nil
+	})
+
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	options := TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true}
+	p := &TestPlan{}
+
+	project := p.GetProject()
+
+	// Create all resources.
+	snap, err := TestOp(Update).RunStep(project, p.GetTarget(t, nil), options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+	// Check we have 5 resources in the stack (stack, provider A, target, provider B, unrelated)
+	require.Equal(t, 5, len(snap.Resources))
+	unrelated := snap.Resources[4]
+	assert.Equal(t, "unrelated", unrelated.URN.Name())
+	providerRef := unrelated.Provider
+
+	// Run an update to target the target, that also happens to change the unrelated provider.
+	explicitProvider = false
+	inputs = resource.PropertyMap{
+		"foo": resource.NewStringProperty("bar"),
+	}
+	options.UpdateOptions = UpdateOptions{
+		Targets: deploy.NewUrnTargets([]string{
+			"**target**",
+		}),
+	}
+	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), options, false, p.BackendClient, nil, "1")
+	assert.ErrorContains(t, err,
+		"for resource urn:pulumi:test::test::pkgB:index:typA::unrelated has not been registered yet")
+	// 6 because we have the stack, provider A, target, provider B, unrelated, and the new provider B
+	assert.Equal(t, 6, len(snap.Resources))
+	// unrelated shouldn't have had it's provider changed
+	unrelated = snap.Resources[5]
+	assert.Equal(t, "unrelated", unrelated.URN.Name())
+	assert.Equal(t, providerRef, unrelated.Provider)
+}


### PR DESCRIPTION
Add a test for https://github.com/pulumi/pulumi/issues/14254, which happened to have been "fixed" in https://github.com/pulumi/pulumi/pull/15716. We didn't notice this at the time, and almost regressed this fix in https://github.com/pulumi/pulumi/pull/17245.

Adding a test to ensure we don't regress this.

Fixes https://github.com/pulumi/pulumi/issues/14254.