### PR TITLE
Couple of monitor support code cleanups from review

### DIFF
--- a/sdk/go/internal/cmd.go
+++ b/sdk/go/internal/cmd.go
@@ -1,0 +1,358 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/httputil"
+)
+
+const unknownErrorCode = -2
+
+// PulumiCommand manages the Pulumi CLI and runs operations.
+type PulumiCommand interface {
+	Run(ctx context.Context,
+		workdir string,
+		stdin io.Reader,
+		additionalOutput []io.Writer,
+		additionalErrorOutput []io.Writer,
+		additionalEnv []string,
+		args ...string) (string, string, int, error)
+	Version() semver.Version
+}
+
+type PulumiCommandOptions struct {
+	// Version is the version to install or validate.
+	Version semver.Version
+	// Root sets the directory where the CLI should be installed to, or from
+	// where the CLI should be retrieved.
+	Root string
+	// SkipVersionCheck is used to disable the validation of the found Pulumi
+	// binary.
+	SkipVersionCheck bool
+}
+
+// withDefaults returns a new copy of the options with default values set.
+// Version defaults to the CLI version matching the current SDK release. Root
+// defaults to $HOME/.pulumi/versions/$VERSION.
+func (opts *PulumiCommandOptions) withDefaults() (*PulumiCommandOptions, error) {
+	newOpts := &PulumiCommandOptions{
+		Version:          opts.Version,
+		Root:             opts.Root,
+		SkipVersionCheck: opts.SkipVersionCheck,
+	}
+	if newOpts.Version.EQ(semver.Version{}) {
+		newOpts.Version = sdk.Version
+	}
+
+	if newOpts.Root == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		newOpts.Root = filepath.Join(home, ".pulumi", "versions", newOpts.Version.String())
+	}
+
+	return newOpts, nil
+}
+
+type pulumiCommand struct {
+	version semver.Version
+	command string
+}
+
+// NewPulumiCommand creates a Pulumi instance that uses the installation in
+// `opts.Root`.  Defaults to using the Pulumi binary found in $PATH if no
+// installation root is specified.  If `opts.Version` is specified, it
+// validates that the CLI is compatible with the requested version and throws
+// an error if not. This validation can be skipped by setting the environment
+// variable `PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK` or setting
+// `opts.SkipVersionCheck` to `true`. Note that the environment variable
+// always takes precedence. If it is set it is not possible to re-enable the
+// validation with `opts.SkipVersionCheck`.
+func NewPulumiCommand(opts *PulumiCommandOptions) (PulumiCommand, error) {
+	if opts == nil {
+		opts = &PulumiCommandOptions{}
+	}
+	command := "pulumi"
+	if opts.Root != "" {
+		command = filepath.Join(opts.Root, "bin", "pulumi")
+		if runtime.GOOS == "windows" {
+			command += ".exe"
+		}
+	}
+
+	cmd := exec.Command(command, "version")
+	out, err := cmd.Output()
+	if err != nil {
+		return pulumiCommand{}, fmt.Errorf("failed to run `pulumi version`: %w", err)
+	}
+	currentVersion := strings.TrimSpace(string(out))
+	min, _ := semver.ParseTolerant("3.2.0-alpha")
+	if opts.Version.GT(min) {
+		min = opts.Version
+	}
+	skipVersionCheck := opts.SkipVersionCheck || env.SkipVersionCheck.Value()
+	version, err := parseAndValidatePulumiVersion(min, currentVersion, skipVersionCheck)
+	if err != nil {
+		return pulumiCommand{}, err
+	}
+
+	return pulumiCommand{
+		version: version,
+		command: command,
+	}, nil
+}
+
+// InstallPulumiCommand downloads and installs the Pulumi CLI. By default the
+// CLI version matching the current SDK release is installed in
+// $HOME/.pulumi/versions/$VERSION. Set `opts.Root` to specify a different
+// directory, and `opts.Version` to install a custom version.
+func InstallPulumiCommand(ctx context.Context, opts *PulumiCommandOptions) (
+	PulumiCommand,
+	error,
+) {
+	if opts == nil {
+		opts = &PulumiCommandOptions{}
+	}
+	opts, err := opts.withDefaults()
+	if err != nil {
+		return pulumiCommand{}, err
+	}
+	pulumi, err := NewPulumiCommand(opts)
+	if err == nil {
+		// Found an installation and it satisfies the version requirement
+		return pulumi, nil
+	}
+	if runtime.GOOS == "windows" {
+		if err := installWindows(ctx, opts.Version, opts.Root); err != nil {
+			return pulumiCommand{}, err
+		}
+	} else {
+		if err := installPosix(ctx, opts.Version, opts.Root); err != nil {
+			return pulumiCommand{}, err
+		}
+	}
+	return NewPulumiCommand(opts)
+}
+
+func downloadToTmpFile(ctx context.Context, url, filePattern string) (_ string, err error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := httputil.DoWithRetry(req, http.DefaultClient)
+	if err != nil {
+		return "", fmt.Errorf("failed to download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	scriptData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response from %s: %w", url, err)
+	}
+	tmp, err := os.CreateTemp("", filePattern)
+	if err != nil {
+		return "", err
+	}
+	scriptPath := tmp.Name()
+	defer func() {
+		if err != nil {
+			os.Remove(scriptPath)
+		}
+	}()
+	// The permissions here are ignored because the tmp file already exists.
+	// We need to explicitly call chmod below to set the desired permissions.
+	err = os.WriteFile(scriptPath, scriptData, 0o600)
+	if err != nil {
+		return "", err
+	}
+	if err = tmp.Close(); err != nil {
+		return "", err
+	}
+	err = os.Chmod(scriptPath, 0o700)
+	if err != nil {
+		return "", err
+	}
+	return scriptPath, nil
+}
+
+func installWindows(ctx context.Context, version semver.Version, root string) error {
+	scriptPath, err := downloadToTmpFile(ctx, "https://get.pulumi.com/install.ps1", "install-*.ps1")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(scriptPath)
+	command := "powershell.exe"
+	if os.Getenv("SystemRoot") != "" {
+		command = filepath.Join(os.Getenv("SystemRoot"), "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+	}
+	args := []string{
+		"-NoProfile",
+		"-InputFormat",
+		"None",
+		"-ExecutionPolicy",
+		"Bypass",
+		"-File",
+		scriptPath,
+		"-NoEditPath",
+		"-InstallRoot",
+		root,
+		"-Version",
+		version.String(),
+	}
+	cmd := exec.CommandContext(ctx, command, args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("installation failed with %w: %s", err, out)
+	}
+	return nil
+}
+
+func installPosix(ctx context.Context, version semver.Version, root string) error {
+	scriptPath, err := downloadToTmpFile(ctx, "https://get.pulumi.com/install.sh", "install-*.sh")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(scriptPath)
+	args := []string{
+		"--no-edit-path",
+		"--install-root", root,
+		"--version", version.String(),
+	}
+	cmd := exec.CommandContext(ctx, scriptPath, args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("installation failed with %w: %s", err, out)
+	}
+	return nil
+}
+
+// Run executes a Pulumi CLI command.
+func (p pulumiCommand) Run(ctx context.Context,
+	workdir string,
+	stdin io.Reader,
+	additionalOutput []io.Writer,
+	additionalErrorOutput []io.Writer,
+	additionalEnv []string,
+	args ...string,
+) (string, string, int, error) {
+	// all commands should be run in non-interactive mode.
+	// this causes commands to fail rather than prompting for input (and thus hanging indefinitely)
+	args = withNonInteractiveArg(args)
+	cmd := exec.CommandContext(ctx, p.command, args...) //nolint:gosec
+	cmd.Dir = workdir
+	env := append(os.Environ(), additionalEnv...)
+	if filepath.IsAbs(p.command) {
+		pulumiBin := filepath.Dir(p.command)
+		env = fixupPath(env, pulumiBin)
+	}
+	cmd.Env = env
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	additionalOutput = append(additionalOutput, &stdout)
+	additionalErrorOutput = append(additionalErrorOutput, &stderr)
+	cmd.Stdout = io.MultiWriter(additionalOutput...)
+	cmd.Stderr = io.MultiWriter(additionalErrorOutput...)
+	cmd.Stdin = stdin
+
+	code := unknownErrorCode
+	err := cmd.Run()
+	if exitError, ok := err.(*exec.ExitError); ok {
+		code = exitError.ExitCode()
+	} else if err == nil {
+		// If there was no error then the exit code was 0
+		code = 0
+	}
+	return stdout.String(), stderr.String(), code, err
+}
+
+// The version of the current Pulumi CLI installation.
+func (p pulumiCommand) Version() semver.Version {
+	return p.version
+}
+
+func withNonInteractiveArg(args []string) []string {
+	out := slice.Prealloc[string](len(args))
+	seen := false
+	for _, a := range args {
+		out = append(out, a)
+		if a == "--non-interactive" {
+			seen = true
+		}
+	}
+	if !seen {
+		out = append(out, "--non-interactive")
+	}
+	return out
+}
+
+// fixupPath returns a new copy of `env` where the `PATH` entry contains
+// pulumiBin as the first path.
+func fixupPath(env []string, pulumiBin string) []string {
+	newEnv := make([]string, len(env))
+	copy(newEnv, env)
+	pathIndex := -1
+	for i, e := range env {
+		// Case-insensitive compare, as Windows will normally be "Path", not "PATH".
+		if len(e) >= 5 && strings.EqualFold(e[0:5], "PATH=") {
+			pathIndex = i
+			break
+		}
+	}
+	if pathIndex >= 0 {
+		pathEntry := pulumiBin
+		oldPath := env[pathIndex][5:]
+		if oldPath != "" {
+			pathEntry = pulumiBin + string(os.PathListSeparator) + oldPath
+		}
+		newEnv[pathIndex] = "PATH=" + pathEntry
+	} else {
+		newEnv = append(newEnv, "PATH="+pulumiBin)
+	}
+	return newEnv
+}
+
+//nolint:lll
+func parseAndValidatePulumiVersion(minVersion semver.Version, currentVersion string, optOut bool) (semver.Version, error) {
+	version, err := semver.ParseTolerant(currentVersion)
+	if err != nil && !optOut {
+		return semver.Version{}, fmt.Errorf("Unable to parse Pulumi CLI version (skip with %s=true): %w", env.SkipVersionCheck.Var().Name(), err)
+	}
+	if optOut {
+		return version, nil
+	}
+	if minVersion.Major < version.Major {
+		return semver.Version{}, fmt.Errorf("Major version mismatch. You are using Pulumi CLI version %s with Automation SDK v%v. Please update the SDK.", currentVersion, minVersion.Major) //nolint
+	}
+	if minVersion.GT(version) {
+		return semver.Version{}, fmt.Errorf("Minimum version requirement failed. The minimum CLI version requirement is %s, your current CLI version is %s. Please update the Pulumi CLI.", minVersion, currentVersion) //nolint
+	}
+	return version, nil
+}

--- a/sdk/go/internal/cmd_test.go
+++ b/sdk/go/internal/cmd_test.go
@@ -1,0 +1,240 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstallDefaultRoot(t *testing.T) {
+	t.Parallel()
+
+	requestedVersion := semver.Version{Major: 3, Minor: 98, Patch: 0}
+
+	_, err := InstallPulumiCommand(context.Background(), &PulumiCommandOptions{Version: requestedVersion})
+
+	require.NoError(t, err)
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+	pulumiBin := filepath.Join(homeDir, ".pulumi", "versions", requestedVersion.String(), "bin", "pulumi")
+	if runtime.GOOS == "windows" {
+		pulumiBin += ".exe"
+	}
+	_, err = os.Stat(pulumiBin)
+	require.NoError(t, err, "did not find pulumi binary in the expected path")
+	cmd := exec.Command(pulumiBin, "version")
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	require.Equal(t, "v3.98.0", strings.TrimSpace(string(out)))
+}
+
+func TestOptionDefaults(t *testing.T) {
+	t.Parallel()
+
+	opts := &PulumiCommandOptions{}
+
+	opts, err := opts.withDefaults()
+
+	require.NoError(t, err)
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+	root := filepath.Join(homeDir, ".pulumi", "versions", sdk.Version.String())
+	require.Equal(t, root, opts.Root)
+	require.Equal(t, sdk.Version, opts.Version)
+}
+
+func TestInstallTwice(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "automation-test-")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	version := semver.Version{Major: 3, Minor: 98, Patch: 0}
+
+	_, err = InstallPulumiCommand(context.Background(), &PulumiCommandOptions{Root: dir, Version: version})
+
+	require.NoError(t, err)
+	pulumiPath := filepath.Join(dir, "bin", "pulumi")
+	if runtime.GOOS == "windows" {
+		pulumiPath += ".exe"
+	}
+	stat, err := os.Stat(pulumiPath)
+	require.NoError(t, err, "did not find pulumi binary in the expected path")
+	modTime1 := stat.ModTime()
+
+	_, err = InstallPulumiCommand(context.Background(), &PulumiCommandOptions{Root: dir, Version: version})
+
+	require.NoError(t, err)
+	stat, err = os.Stat(pulumiPath)
+	require.NoError(t, err, "did not find pulumi binary in the expected path")
+	modTime2 := stat.ModTime()
+	require.Equal(t, modTime1, modTime2)
+}
+
+func TestErrorIncompatibleVersion(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "automation-test-")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	installedVersion := semver.Version{Major: 3, Minor: 98, Patch: 0}
+	_, err = InstallPulumiCommand(context.Background(), &PulumiCommandOptions{Root: dir, Version: installedVersion})
+	require.NoError(t, err)
+	requestedVersion := semver.Version{Major: 3, Minor: 101, Patch: 0}
+
+	// Try getting an incompatible version
+	_, err = NewPulumiCommand(&PulumiCommandOptions{Root: dir, Version: requestedVersion})
+
+	require.ErrorContains(t, err, "version requirement failed")
+
+	// Succeeds when disabling version check
+	_, err = NewPulumiCommand(&PulumiCommandOptions{Root: dir, Version: requestedVersion, SkipVersionCheck: true})
+
+	require.NoError(t, err)
+}
+
+func TestFixupPath(t *testing.T) {
+	t.Parallel()
+
+	env := fixupPath([]string{"FOO=bar", "V=1"}, "/pulumi-root/bin")
+
+	require.Contains(t, env, "PATH=/pulumi-root/bin")
+}
+
+func TestFixupPathExistingPath(t *testing.T) {
+	t.Parallel()
+
+	env := fixupPath([]string{"FOO=bar", "PATH=/usr/local/bin"}, "/pulumi-root/bin")
+
+	require.Contains(t, env, "PATH=/pulumi-root/bin"+string(os.PathListSeparator)+"/usr/local/bin")
+}
+
+const (
+	PARSE   = `Unable to parse`
+	MAJOR   = `Major version mismatch.`
+	MINIMUM = `Minimum version requirement failed.`
+)
+
+var minVersionTests = []struct {
+	name           string
+	currentVersion string
+	expectedError  string
+	optOut         bool
+}{
+	{
+		"higher_major",
+		"100.0.0",
+		MAJOR,
+		false,
+	},
+	{
+		"lower_major",
+		"1.0.0",
+		MINIMUM,
+		false,
+	},
+	{
+		"higher_minor",
+		"2.2.0",
+		MINIMUM,
+		false,
+	},
+	{
+		"lower_minor",
+		"2.1.0",
+		MINIMUM,
+		false,
+	},
+	{
+		"equal_minor_higher_patch",
+		"2.2.2",
+		MINIMUM,
+		false,
+	},
+	{
+		"equal_minor_equal_patch",
+		"2.2.1",
+		MINIMUM,
+		false,
+	},
+	{
+		"equal_minor_lower_patch",
+		"2.2.0",
+		MINIMUM,
+		false,
+	},
+	{
+		"equal_minor_equal_patch_prerelease",
+		// Note that prerelease < release so this case will error
+		"2.21.1-alpha.1234",
+		MINIMUM,
+		false,
+	},
+	{
+		"opt_out_of_check_would_fail_otherwise",
+		"2.2.0",
+		"",
+		true,
+	},
+	{
+		"opt_out_of_check_would_succeed_otherwise",
+		"2.2.0",
+		"",
+		true,
+	},
+	{
+		"unparsable_version",
+		"invalid",
+		PARSE,
+		false,
+	},
+	{
+		"opt_out_unparsable_version",
+		"invalid",
+		"",
+		true,
+	},
+}
+
+func TestMinimumVersion(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range minVersionTests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			minVersion := semver.Version{Major: 2, Minor: 21, Patch: 1}
+
+			_, err := parseAndValidatePulumiVersion(minVersion, tt.currentVersion, tt.optOut)
+
+			if tt.expectedError != "" {
+				require.ErrorContains(t, err, tt.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -242,14 +242,27 @@ export async function awaitFeatureSupport(): Promise<void> {
     const monitorRef = getMonitor();
     if (monitorRef !== undefined) {
         const store = getStore();
-        store.supportsSecrets = await monitorSupportsFeature(monitorRef, "secrets");
-        store.supportsResourceReferences = await monitorSupportsFeature(monitorRef, "resourceReferences");
-        store.supportsOutputValues = await monitorSupportsFeature(monitorRef, "outputValues");
-        store.supportsDeletedWith = await monitorSupportsFeature(monitorRef, "deletedWith");
-        store.supportsAliasSpecs = await monitorSupportsFeature(monitorRef, "aliasSpecs");
-        store.supportsTransforms = await monitorSupportsFeature(monitorRef, "transforms");
-        store.supportsInvokeTransforms = await monitorSupportsFeature(monitorRef, "invokeTransforms");
-        store.supportsParameterization = await monitorSupportsFeature(monitorRef, "parameterization");
+        const supports = await Promise.all(
+            [
+                "secrets",
+                "resourceReferences",
+                "outputValues",
+                "deletedWith",
+                "aliasSpecs",
+                "transforms",
+                "invokeTransforms",
+                "parameterization",
+            ].map((feature) => monitorSupportsFeature(monitorRef, feature)),
+        );
+
+        store.supportsSecrets = supports[0];
+        store.supportsResourceReferences = supports[1];
+        store.supportsOutputValues = supports[2];
+        store.supportsDeletedWith = supports[3];
+        store.supportsAliasSpecs = supports[4];
+        store.supportsTransforms = supports[5];
+        store.supportsInvokeTransforms = supports[6];
+        store.supportsParameterization = supports[7];
     }
 }
 

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -243,14 +243,14 @@ export async function awaitFeatureSupport(): Promise<void> {
     if (monitorRef !== undefined) {
         const store = getStore();
         const [
-            supportsSecrets,
-            supportsResourceReferences,
-            supportsOutputValues,
-            supportsDeletedWith,
-            supportsAliasSpecs,
-            supportsTransforms,
-            supportsInvokeTransforms,
-            supportsParameterization,
+            secrets,
+            resourceReferences,
+            outputValues,
+            deletedWith,
+            aliasSpecs,
+            transforms,
+            invokeTransforms,
+            parameterization,
         ] = await Promise.all(
             [
                 "secrets",
@@ -264,14 +264,14 @@ export async function awaitFeatureSupport(): Promise<void> {
             ].map((feature) => monitorSupportsFeature(monitorRef, feature)),
         );
 
-        store.supportsSecrets = supportsSecrets;
-        store.supportsResourceReferences = supportsResourceReferences;
-        store.supportsOutputValues = supportsOutputValues;
-        store.supportsDeletedWith = supportsDeletedWith;
-        store.supportsAliasSpecs = supportsAliasSpecs;
-        store.supportsTransforms = supportsTransforms;
-        store.supportsInvokeTransforms = supportsInvokeTransforms;
-        store.supportsParameterization = supportsParameterization;
+        store.supportsSecrets = secrets;
+        store.supportsResourceReferences = resourceReferences;
+        store.supportsOutputValues = outputValues;
+        store.supportsDeletedWith = deletedWith;
+        store.supportsAliasSpecs = aliasSpecs;
+        store.supportsTransforms = transforms;
+        store.supportsInvokeTransforms = invokeTransforms;
+        store.supportsParameterization = parameterization;
     }
 }
 

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -242,7 +242,16 @@ export async function awaitFeatureSupport(): Promise<void> {
     const monitorRef = getMonitor();
     if (monitorRef !== undefined) {
         const store = getStore();
-        const supports = await Promise.all(
+        const [
+            supportsSecrets,
+            supportsResourceReferences,
+            supportsOutputValues,
+            supportsDeletedWith,
+            supportsAliasSpecs,
+            supportsTransforms,
+            supportsInvokeTransforms,
+            supportsParameterization,
+        ] = await Promise.all(
             [
                 "secrets",
                 "resourceReferences",
@@ -255,14 +264,14 @@ export async function awaitFeatureSupport(): Promise<void> {
             ].map((feature) => monitorSupportsFeature(monitorRef, feature)),
         );
 
-        store.supportsSecrets = supports[0];
-        store.supportsResourceReferences = supports[1];
-        store.supportsOutputValues = supports[2];
-        store.supportsDeletedWith = supports[3];
-        store.supportsAliasSpecs = supports[4];
-        store.supportsTransforms = supports[5];
-        store.supportsInvokeTransforms = supports[6];
-        store.supportsParameterization = supports[7];
+        store.supportsSecrets = supportsSecrets;
+        store.supportsResourceReferences = supportsResourceReferences;
+        store.supportsOutputValues = supportsOutputValues;
+        store.supportsDeletedWith = supportsDeletedWith;
+        store.supportsAliasSpecs = supportsAliasSpecs;
+        store.supportsTransforms = supportsTransforms;
+        store.supportsInvokeTransforms = supportsInvokeTransforms;
+        store.supportsParameterization = supportsParameterization;
     }
 }
 

--- a/sdk/python/lib/pulumi/_utils.py
+++ b/sdk/python/lib/pulumi/_utils.py
@@ -237,6 +237,12 @@ class ContextProperty:
     def __getitem__(self, key):
         return self.fget()[key]
 
+    def get(self, key, default=None):
+        data = self.fget()
+        if not isinstance(data, dict):
+            raise TypeError("Can't get key values on non-dict variables.")
+        return data.get(key, default)
+
     def __contains__(self, element):
         return element in self.fget()
 

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -328,21 +328,15 @@ async def monitor_supports_alias_specs() -> bool:
 
 
 def _sync_monitor_supports_transforms() -> bool:
-    if "transforms" not in SETTINGS.feature_support:
-        return False
-    return SETTINGS.feature_support["transforms"]
+    return SETTINGS.feature_support.get("transforms", False)
 
 
 def _sync_monitor_supports_invoke_transforms() -> bool:
-    if "invokeTransforms" not in SETTINGS.feature_support:
-        return False
-    return SETTINGS.feature_support["invokeTransforms"]
+    return SETTINGS.feature_support.get("invokeTransforms", False)
 
 
 def _sync_monitor_supports_parameterization() -> bool:
-    if "parameterization" not in SETTINGS.feature_support:
-        return False
-    return SETTINGS.feature_support["parameterization"]
+    return SETTINGS.feature_support.get("supportsParameterization", False)
 
 
 def reset_options(


### PR DESCRIPTION
Couple of things pointed out by @lunaris while reviewing https://github.com/pulumi/pulumi/pull/17153.

First use `get` instead of `if` for looking up in python dictionaries: https://github.com/pulumi/pulumi/pull/17153#discussion_r1758413156

Second to use `Promise.all` to collect all feature supports at once: https://github.com/pulumi/pulumi/pull/17153#discussion_r1752320486