### PR TITLE
unhide --attach-debugger flag

### DIFF
--- a/changelog/pending/20240916--cli--add-an-attach-debugger-flag-for-pulumi-preview-and-pulumi-up-that-makes-pulumi-attach-a-debugger-to-the-running-program-and-allows-attaching-to-it.yaml
+++ b/changelog/pending/20240916--cli--add-an-attach-debugger-flag-for-pulumi-preview-and-pulumi-up-that-makes-pulumi-attach-a-debugger-to-the-running-program-and-allows-attaching-to-it.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add an `--attach-debugger` flag for pulumi preview and pulumi up, that makes pulumi attach a debugger to the running program and allows attaching to it

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -624,7 +624,6 @@ func newPreviewCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&attachDebugger, "attach-debugger", false,
 		"Enable the ability to attach a debugger to the program being executed")
-	cmd.Flag("attach-debugger").Hidden = true
 
 	// Remote flags
 	remoteArgs.applyFlags(cmd)

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -657,7 +657,6 @@ func newUpCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&attachDebugger, "attach-debugger", false,
 		"Enable the ability to attach a debugger to the program being executed")
-	cmd.Flag("attach-debugger").Hidden = true
 
 	cmd.PersistentFlags().StringVar(
 		&planFilePath, "plan", "",


### PR DESCRIPTION
Now that all the SDKs support attaching a debugger, we no longer need to hide this flag from the command line options, and can release it to everyone.