### PR TITLE
try to choose a consistent port for debugging

### DIFF
--- a/sdk/go/pulumi-internal/netutil/netutil.go
+++ b/sdk/go/pulumi-internal/netutil/netutil.go
@@ -21,7 +21,7 @@ import (
 )
 
 func isPortAvailable(port int) bool {
-	if l, err := net.Listen("tcp", fmt.Sprintf(":%d", port)); err == nil {
+	if l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port)); err == nil {
 		l.Close()
 		return true
 	}

--- a/sdk/go/pulumi-internal/netutil/netutil.go
+++ b/sdk/go/pulumi-internal/netutil/netutil.go
@@ -1,0 +1,38 @@
+// Copyright 2024-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netutil
+
+import (
+	"errors"
+	"fmt"
+	"net"
+)
+
+func isPortAvailable(port int) bool {
+	if l, err := net.Listen("tcp", fmt.Sprintf(":%d", port)); err == nil {
+		l.Close()
+		return true
+	}
+	return false
+}
+
+func FindNextAvailablePort(startPort int) (int, error) {
+	for port := startPort; port < 65535; port++ {
+		if isPortAvailable(port) {
+			return port, nil
+		}
+	}
+	return 0, errors.New("no open ports found")
+}

--- a/sdk/go/pulumi-internal/netutil/netutil_test.go
+++ b/sdk/go/pulumi-internal/netutil/netutil_test.go
@@ -25,6 +25,7 @@ import (
 func TestReturnsPortIfOpen(t *testing.T) {
 	t.Parallel()
 
+	// "random" port for testing
 	port := 57134
 	if !isPortAvailable(port) {
 		t.Skip("port 57134 is not available")
@@ -45,6 +46,7 @@ func TestReturnsErrorIfPortNumberTooHigh(t *testing.T) {
 func TestReturnsNextPortIfNotAvailable(t *testing.T) {
 	t.Parallel()
 
+	// "random" port for testing
 	port := 58943
 	if !isPortAvailable(port + 1) {
 		t.Skip("port 58944 is not available")

--- a/sdk/go/pulumi-internal/netutil/netutil_test.go
+++ b/sdk/go/pulumi-internal/netutil/netutil_test.go
@@ -1,0 +1,59 @@
+// Copyright 2024-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netutil
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReturnsPortIfOpen(t *testing.T) {
+	t.Parallel()
+
+	port := 57134
+	if !isPortAvailable(port) {
+		t.Skip("port 8080 is not available")
+	}
+	p, err := FindNextAvailablePort(port)
+	require.NoError(t, err)
+	require.Equal(t, port, p)
+}
+
+func TestReturnsErrorIfPortNumberTooHigh(t *testing.T) {
+	t.Parallel()
+
+	port := 65535
+	_, err := FindNextAvailablePort(port)
+	require.ErrorContains(t, err, "no open ports found")
+}
+
+func TestReturnsNextPortIfNotAvailable(t *testing.T) {
+	t.Parallel()
+
+	port := 58943
+	if !isPortAvailable(port + 1) {
+		t.Skip("port 58944 is not available")
+	}
+	// Open a listener on the port to make it unavailable.
+	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	require.NoError(t, err)
+	defer l.Close()
+	availablePort, err := FindNextAvailablePort(port)
+	require.NoError(t, err)
+	require.Equal(t, port+1, availablePort)
+}

--- a/sdk/go/pulumi-internal/netutil/netutil_test.go
+++ b/sdk/go/pulumi-internal/netutil/netutil_test.go
@@ -27,7 +27,7 @@ func TestReturnsPortIfOpen(t *testing.T) {
 
 	port := 57134
 	if !isPortAvailable(port) {
-		t.Skip("port 8080 is not available")
+		t.Skip("port 57134 is not available")
 	}
 	p, err := FindNextAvailablePort(port)
 	require.NoError(t, err)
@@ -50,8 +50,8 @@ func TestReturnsNextPortIfNotAvailable(t *testing.T) {
 		t.Skip("port 58944 is not available")
 	}
 	// Open a listener on the port to make it unavailable.
-	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
-	require.NoError(t, err)
+	// Ignore the error.  If the port is already open that's also fine.
+	l, _ := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	defer l.Close()
 	availablePort, err := FindNextAvailablePort(port)
 	require.NoError(t, err)

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -64,6 +64,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
+// The preferred debug port.  Chosen arbitrarily.
 const preferredDebugPort = 57134
 
 // This function takes a file target to specify where to compile to.

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -64,6 +64,8 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
+const preferredDebugPort = 57134
+
 // This function takes a file target to specify where to compile to.
 // If `outfile` is "", the binary is compiled to a new temporary file.
 // This function returns the path of the file that was produced.
@@ -812,7 +814,7 @@ func debugCommand(bin string) (*exec.Cmd, *debugger, error) {
 	contract.IgnoreClose(logFile)
 	args := []string{"--headless=true", "--api-version=2"}
 	args = append(args, "--log", "--log-dest", logFile.Name())
-	port, err := netutil.FindNextAvailablePort(57134)
+	port, err := netutil.FindNextAvailablePort(preferredDebugPort)
 	if err == nil {
 		args = append(args, "--listen=127.0.0.1:"+strconv.Itoa(port))
 	}

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -55,6 +55,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi-internal/netutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
@@ -811,6 +812,10 @@ func debugCommand(bin string) (*exec.Cmd, *debugger, error) {
 	contract.IgnoreClose(logFile)
 	args := []string{"--headless=true", "--api-version=2"}
 	args = append(args, "--log", "--log-dest", logFile.Name())
+	port, err := netutil.FindNextAvailablePort(57134)
+	if err == nil {
+		args = append(args, "--listen=127.0.0.1:"+strconv.Itoa(port))
+	}
 	args = append(args, "exec", bin)
 	dlvCmd := exec.Command(godlv, args...)
 	return dlvCmd, &debugger{Host: "127.0.0.1", LogDest: logFile.Name()}, nil

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -84,6 +84,9 @@ const (
 	// need for us to print any additional error messages since the user already got a a good
 	// one they can handle.
 	pythonProcessExitedAfterShowingUserActionableMessage = 32
+
+	// The preferred debug port.
+	preferredDebugPort = 58791
 )
 
 var (
@@ -707,7 +710,7 @@ func debugCommand(ctx context.Context, opts toolchain.PythonOptions) ([]string, 
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to allocate tmp dir: %w", err)
 	}
-	port, err := netutil.FindNextAvailablePort(58791)
+	port, err := netutil.FindNextAvailablePort(preferredDebugPort)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to select a debug port: %w", err)
 	}

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -85,7 +85,7 @@ const (
 	// one they can handle.
 	pythonProcessExitedAfterShowingUserActionableMessage = 32
 
-	// The preferred debug port.
+	// The preferred debug port.  Chosen arbitrarily.
 	preferredDebugPort = 58791
 )
 


### PR DESCRIPTION
In languages where we need to attach the debugger to a port, we have some choice which port we can give the user.  For using the debugging feature on the command line, it is convenient to have the port always be the same.  Let's try to do that, but go to higher ports if the port we chose is already in use for some reason.

The ports chosen here are "randomly" chosen high ports that are unlikely to be used already.

Thanks @mikhailshilkov for the suggestion of this.