### PR TITLE
Fix TestParameterizedPython

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -540,7 +540,7 @@ _package_ref = ...
 async def get_package():
 	global _package_ref
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_package_references():
+		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
 				if _package_ref is ...:
 					monitor = pulumi.runtime.settings.get_monitor()
@@ -559,7 +559,7 @@ async def get_package():
 					_package_ref = registerPackageResponse.ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
-	if _package_ref is None:
+	if _package_ref is None or _package_ref is ...:
 		raise Exception("The Pulumi CLI does not support parameterization. Please update the Pulumi CLI.")
 	return _package_ref
 	`,
@@ -3389,9 +3389,9 @@ func setDependencies(schema *PyprojectSchema, pkg *schema.Package) error {
 // Require the SDK to fall within the same major version.
 var MinimumValidSDKVersion = ">=3.0.0,<4.0.0"
 
-// Require the SDK to fall within the same major version, and be at least 3.133 which added support for the
+// Require the SDK to fall within the same major version, and be at least 3.133.1 which added support for the
 // package reference feature flag.
-var MinimumValidParameterizationSDKVersion = ">=3.133,<4.0.0"
+var MinimumValidParameterizationSDKVersion = ">=3.133.1,<4.0.0"
 
 // ensureValidPulumiVersion ensures that the Pulumi SDK has an entry.
 // It accepts a list of dependencies

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -336,7 +336,7 @@ def _sync_monitor_supports_invoke_transforms() -> bool:
 
 
 def _sync_monitor_supports_parameterization() -> bool:
-    return SETTINGS.feature_support.get("supportsParameterization", False)
+    return SETTINGS.feature_support.get("parameterization", False)
 
 
 def reset_options(

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1400,11 +1400,6 @@ func TestFailsOnImplicitDependencyCyclesPython(t *testing.T) {
 //
 //nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestParameterizedPython(t *testing.T) {
-	// TODO: Unskip this test after 3.133 is released. Python codegen for parameterized providers will try to
-	// refer to release 3.133, but until we actually release that version pip will fail that this constraint
-	// can't be met.
-	t.Skip("This needs to skip until 3.133.0 is released due to how pip resoloution works")
-
 	e := ptesting.NewEnvironment(t)
 
 	// We can't use ImportDirectory here because we need to run this in the right directory such that the relative paths

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1400,6 +1400,11 @@ func TestFailsOnImplicitDependencyCyclesPython(t *testing.T) {
 //
 //nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestParameterizedPython(t *testing.T) {
+	// TODO: Unskip this test after 3.133.1 is released. Python codegen for parameterized providers will try to
+	// refer to release 3.133.1, but until we actually release that version pip will fail that this constraint
+	// can't be met.
+	t.Skip("This needs to skip until 3.133.1 is released due to how pip resoloution works")
+
 	e := ptesting.NewEnvironment(t)
 
 	// We can't use ImportDirectory here because we need to run this in the right directory such that the relative paths

--- a/tests/integration/python/parameterized/sdk/python/pulumi_pkg/_utilities.py
+++ b/tests/integration/python/parameterized/sdk/python/pulumi_pkg/_utilities.py
@@ -331,7 +331,7 @@ _package_ref = ...
 async def get_package():
 	global _package_ref
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_package_references():
+		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
 				if _package_ref is ...:
 					monitor = pulumi.runtime.settings.get_monitor()
@@ -350,6 +350,7 @@ async def get_package():
 					_package_ref = registerPackageResponse.ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
-	if _package_ref is None:
+	if _package_ref is None or _package_ref is ...:
 		raise Exception("The Pulumi CLI does not support parameterization. Please update the Pulumi CLI.")
 	return _package_ref
+	

--- a/tests/integration/python/parameterized/sdk/python/setup.py
+++ b/tests/integration/python/parameterized/sdk/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_pkg',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.133.0,<4.0.0',
+          'pulumi>=3.133.1,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)


### PR DESCRIPTION
Turns out between skipping this test and releasing 3.133 we broke codegen and utilities. This fixes it and we need to release 1.133.1.