### PR TITLE
Use RPC methods for yaml codegen

### DIFF
--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -27,7 +27,6 @@ import (
 	"github.com/spf13/cobra"
 
 	javagen "github.com/pulumi/pulumi-java/pkg/codegen/java"
-	yamlgen "github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
@@ -290,8 +289,6 @@ func runConvert(
 			}, language)
 	case "java":
 		projectGenerator = generatorWrapper(javagen.GenerateProject, language)
-	case "yaml":
-		projectGenerator = generatorWrapper(yamlgen.GenerateProject, language)
 	case "pulumi", "pcl":
 		// No plugin for PCL to install dependencies with
 		generateOnly = true

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -302,7 +302,7 @@ func runConvert(
 		) (hcl.Diagnostics, error) {
 			contract.Requiref(proj != nil, "proj", "must not be nil")
 
-			programInfo := plugin.NewProgramInfo(cwd, cwd, "entry", nil)
+			programInfo := plugin.NewProgramInfo(cwd, cwd, ".", nil)
 			languagePlugin, err := pCtx.Host.LanguageRuntime(language, programInfo)
 			if err != nil {
 				return nil, err

--- a/pkg/cmd/pulumi/convert_test.go
+++ b/pkg/cmd/pulumi/convert_test.go
@@ -48,8 +48,11 @@ func TestYamlConvert(t *testing.T) {
 		t.Fatalf("Pulumi.yaml is a directory, not a file")
 	}
 
+	cwd, err := filepath.Abs("convert_testdata")
+	require.NoError(t, err)
+
 	result := runConvert(
-		pkgWorkspace.Instance, env.Global(), []string{}, "convert_testdata", []string{},
+		pkgWorkspace.Instance, env.Global(), []string{}, cwd, []string{},
 		"yaml", "go", "convert_testdata/go", true, true, "")
 	require.Nil(t, result, "convert failed: %v", result)
 }
@@ -60,8 +63,11 @@ func TestPclConvert(t *testing.T) {
 	// Check that we can run convert from PCL to PCL
 	tmp := t.TempDir()
 
+	cwd, err := filepath.Abs("pcl_convert_testdata")
+	require.NoError(t, err)
+
 	result := runConvert(
-		pkgWorkspace.Instance, env.Global(), []string{}, "pcl_convert_testdata",
+		pkgWorkspace.Instance, env.Global(), []string{}, cwd,
 		[]string{}, "pcl", "pcl", tmp, true, true, "")
 	assert.Nil(t, result)
 
@@ -89,15 +95,18 @@ func TestProjectNameDefaults(t *testing.T) {
 	// Arrange.
 	outDir := t.TempDir()
 
+	cwd, err := filepath.Abs("pcl_convert_testdata")
+	require.NoError(t, err)
+
 	// Act.
-	err := runConvert(
+	err = runConvert(
 		pkgWorkspace.Instance,
 		env.Global(),
-		[]string{},             /*args*/
-		"pcl_convert_testdata", /*cwd*/
-		[]string{},             /*mappings*/
-		"pcl",                  /*from*/
-		"yaml",                 /*language*/
+		[]string{}, /*args*/
+		cwd,        /*cwd*/
+		[]string{}, /*mappings*/
+		"pcl",      /*from*/
+		"yaml",     /*language*/
 		outDir,
 		true, /*generateOnly*/
 		true, /*strict*/
@@ -119,15 +128,18 @@ func TestProjectNameOverrides(t *testing.T) {
 	outDir := t.TempDir()
 	name := "test-project-name"
 
+	cwd, err := filepath.Abs("pcl_convert_testdata")
+	require.NoError(t, err)
+
 	// Act.
-	err := runConvert(
+	err = runConvert(
 		pkgWorkspace.Instance,
 		env.Global(),
-		[]string{},             /*args*/
-		"pcl_convert_testdata", /*cwd*/
-		[]string{},             /*mappings*/
-		"pcl",                  /*from*/
-		"yaml",                 /*language*/
+		[]string{}, /*args*/
+		cwd,        /*cwd*/
+		[]string{}, /*mappings*/
+		"pcl",      /*from*/
+		"yaml",     /*language*/
 		outDir,
 		true, /*generateOnly*/
 		true, /*strict*/

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -876,7 +876,7 @@ func newImportCmd() *cobra.Command {
 						return nil, nil, err
 					}
 					defer contract.IgnoreClose(pCtx.Host)
-					programInfo := plugin.NewProgramInfo(cwd, cwd, "entry", nil)
+					programInfo := plugin.NewProgramInfo(cwd, cwd, ".", nil)
 					languagePlugin, err := ctx.Host.LanguageRuntime(proj.Runtime.Name(), programInfo)
 					if err != nil {
 						return nil, nil, err

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -52,7 +52,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 
 	javagen "github.com/pulumi/pulumi-java/pkg/codegen/java"
-	yamlgen "github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 )
 
@@ -862,8 +861,6 @@ func newImportCmd() *cobra.Command {
 				programGenerator = wrapper(dotnet.GenerateProgram)
 			case "java":
 				programGenerator = wrapper(javagen.GenerateProgram)
-			case "yaml":
-				programGenerator = wrapper(yamlgen.GenerateProgram)
 			default:
 				programGenerator = func(
 					program *pcl.Program, loader schema.ReferenceLoader,

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231
 	github.com/pulumi/esc v0.10.0
 	github.com/pulumi/pulumi-java/pkg v0.16.1
-	github.com/pulumi/pulumi-yaml v1.10.0
+	github.com/pulumi/pulumi-yaml v1.10.1
 	github.com/segmentio/encoding v0.3.5
 	github.com/shirou/gopsutil/v3 v3.22.3
 	github.com/spf13/afero v1.9.5

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -559,8 +559,8 @@ github.com/pulumi/inflector v0.1.1 h1:dvlxlWtXwOJTUUtcYDvwnl6Mpg33prhK+7mzeF+Sob
 github.com/pulumi/inflector v0.1.1/go.mod h1:HUFCjcPTz96YtTuUlwG3i3EZG4WlniBvR9bd+iJxCUY=
 github.com/pulumi/pulumi-java/pkg v0.16.1 h1:orHnDWFbpOERwaBLry9f+6nqPX7x0MsrIkaa5QDGAns=
 github.com/pulumi/pulumi-java/pkg v0.16.1/go.mod h1:QH0DihZkWYle9XFc+LJ76m4hUo+fA3RdyaM90pqOaSM=
-github.com/pulumi/pulumi-yaml v1.10.0 h1:djbgMJCxJBmYMr4kOpAXH5iauxGohYjEuTLfxD3NUUI=
-github.com/pulumi/pulumi-yaml v1.10.0/go.mod h1://lTvwHpgJ+WBKeMGiLrd/jinc4dl3eWV5LZ3G8iCfE=
+github.com/pulumi/pulumi-yaml v1.10.1 h1:BV/Rm57FiBPzb3PjbK4k1mky0vke1IIiaT2s117Ejng=
+github.com/pulumi/pulumi-yaml v1.10.1/go.mod h1:MFMQXkaUP5YQUKVJ6Z/aagZDl2f8hdU9oGaJfTcMf1Y=
 github.com/pulumi/ssh-agent v0.5.1 h1:7DT4FcZNHWBAp9BFI+k0+HeBYGWbJvilJ29ra/4FlRM=
 github.com/pulumi/ssh-agent v0.5.1/go.mod h1:e6cyz/FUcE3PcJZ0tiuygkRsnHnCZcSQoQU+APbnrVA=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -3261,7 +3261,7 @@ github.com/pulumi/esc v0.10.0/go.mod h1:2Bfa+FWj/xl8CKqRTWbWgDX0SOD4opdQgvYSURTG
 github.com/pulumi/inflector v0.1.1 h1:dvlxlWtXwOJTUUtcYDvwnl6Mpg33prhK+7mzeF+SobA=
 github.com/pulumi/inflector v0.1.1/go.mod h1:HUFCjcPTz96YtTuUlwG3i3EZG4WlniBvR9bd+iJxCUY=
 github.com/pulumi/pulumi-java/pkg v0.16.1/go.mod h1:QH0DihZkWYle9XFc+LJ76m4hUo+fA3RdyaM90pqOaSM=
-github.com/pulumi/pulumi-yaml v1.10.0/go.mod h1://lTvwHpgJ+WBKeMGiLrd/jinc4dl3eWV5LZ3G8iCfE=
+github.com/pulumi/pulumi-yaml v1.10.1/go.mod h1:MFMQXkaUP5YQUKVJ6Z/aagZDl2f8hdU9oGaJfTcMf1Y=
 github.com/rakyll/embedmd v0.0.0-20171029212350-c8060a0752a2/go.mod h1:7jOTMgqac46PZcF54q6l2hkLEG8op93fZu61KmxWDV4=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=


### PR DESCRIPTION
Bringing yaml inline with other languages, and removing a couple more dependencies from the yaml<->pulumi cyclic build.

We still depend on the yaml package for docsgen.