### PR TITLE
Persist metadata about snapshot integrity errors

### DIFF
--- a/changelog/pending/20240918--engine--persist-metadata-about-snapshot-integrity-errors.yaml
+++ b/changelog/pending/20240918--engine--persist-metadata-about-snapshot-integrity-errors.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Persist metadata about snapshot integrity errors

--- a/pkg/backend/diy/state.go
+++ b/pkg/backend/diy/state.go
@@ -179,7 +179,7 @@ func (b *diyBackend) getSnapshot(ctx context.Context,
 	if !backend.DisableIntegrityChecking {
 		if err := snapshot.VerifyIntegrity(); err != nil {
 			if sie, ok := deploy.AsSnapshotIntegrityError(err); ok {
-				return nil, fmt.Errorf("snapshot integrity failure; refusing to use it: %w", sie.ForRead())
+				return nil, fmt.Errorf("snapshot integrity failure; refusing to use it: %w", sie.ForRead(snapshot))
 			}
 
 			return nil, fmt.Errorf("snapshot integrity failure; refusing to use it: %w", err)

--- a/pkg/backend/httpstate/diffs_post_1.20.go
+++ b/pkg/backend/httpstate/diffs_post_1.20.go
@@ -83,7 +83,7 @@ func (s *spanner) finish() ([]byte, spans) {
 }
 
 func marshalSpannedDeployment(b *bytes.Buffer, d *apitype.DeploymentV3) (spans, error) {
-	// one span for {"manifest":...,"secrets_providers":...,"resources":[
+	// one span for {"manifest":...,"secrets_providers":...,"metadata":...,"resources":[
 	// len(resources) spans for resources,
 	// one span for ],"pendingOperations":[
 	// len(operations) spans for operations
@@ -101,6 +101,10 @@ func marshalSpannedDeployment(b *bytes.Buffer, d *apitype.DeploymentV3) (spans, 
 		if err := encoder.Encode(d.SecretsProviders); err != nil {
 			return spans{}, err
 		}
+	}
+	spanner.WriteString(`,"metadata":`)
+	if err := encoder.Encode(d.Metadata); err != nil {
+		return spans{}, err
 	}
 
 	if len(d.Resources) > 0 {

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -235,7 +235,7 @@ func (b *cloudBackend) getSnapshot(ctx context.Context,
 	if !backend.DisableIntegrityChecking {
 		if err := snapshot.VerifyIntegrity(); err != nil {
 			if sie, ok := deploy.AsSnapshotIntegrityError(err); ok {
-				return nil, fmt.Errorf("snapshot integrity failure; refusing to use it: %w", sie.ForRead())
+				return nil, fmt.Errorf("snapshot integrity failure; refusing to use it: %w", sie.ForRead(snapshot))
 			}
 
 			return nil, fmt.Errorf("snapshot integrity failure; refusing to use it: %w", err)

--- a/pkg/backend/httpstate/testdata/snapshot_test.json
+++ b/pkg/backend/httpstate/testdata/snapshot_test.json
@@ -1,7 +1,7 @@
 {
-  "req1": "{\"version\":3,\"deployment\":{\"manifest\":{\"time\":\"0001-01-01T00:00:00Z\",\"magic\":\"\",\"version\":\"\"},\"resources\":[{\"urn\":\"urn-1\",\"custom\":false,\"type\":\"\"}]}}",
-  "req2": "[{\"Span\":{\"uri\":\"\",\"start\":{\"line\":1,\"column\":1,\"offset\":107},\"end\":{\"line\":1,\"column\":1,\"offset\":147}},\"NewText\":\"{\\\"urn\\\":\\\"urn-1\\\",\\\"custom\\\":false,\\\"type\\\":\\\"\\\"},{\\\"urn\\\":\\\"urn-2\\\",\\\"custom\\\":false,\\\"type\\\":\\\"\\\"}\"}]",
-  "req2.hash": "6aa1c22cdac057539b978e88ecce984f7018905e3da8a5b376d8952112a9e792",
-  "req3": "[{\"Span\":{\"uri\":\"\",\"start\":{\"line\":1,\"column\":1,\"offset\":107},\"end\":{\"line\":1,\"column\":1,\"offset\":188}},\"NewText\":\"{\\\"urn\\\":\\\"urn-1\\\",\\\"custom\\\":false,\\\"type\\\":\\\"\\\"}\"}]",
-  "req3.hash": "fbd734bd352631342b9130bc4d76173c9fe1963adac37f6a76b783f097baf5f4"
+  "req1": "{\"version\":3,\"deployment\":{\"manifest\":{\"time\":\"0001-01-01T00:00:00Z\",\"magic\":\"\",\"version\":\"\"},\"metadata\":{},\"resources\":[{\"urn\":\"urn-1\",\"custom\":false,\"type\":\"\"}]}}",
+  "req2": "[{\"Span\":{\"uri\":\"\",\"start\":{\"line\":1,\"column\":1,\"offset\":121},\"end\":{\"line\":1,\"column\":1,\"offset\":161}},\"NewText\":\"{\\\"urn\\\":\\\"urn-1\\\",\\\"custom\\\":false,\\\"type\\\":\\\"\\\"},{\\\"urn\\\":\\\"urn-2\\\",\\\"custom\\\":false,\\\"type\\\":\\\"\\\"}\"}]",
+  "req2.hash": "5ffa59a4628983b155933e87fd91ef1f5e76cb2dfdd413eefc3bedb52a7ce1c4",
+  "req3": "[{\"Span\":{\"uri\":\"\",\"start\":{\"line\":1,\"column\":1,\"offset\":121},\"end\":{\"line\":1,\"column\":1,\"offset\":202}},\"NewText\":\"{\\\"urn\\\":\\\"urn-1\\\",\\\"custom\\\":false,\\\"type\\\":\\\"\\\"}\"}]",
+  "req3.hash": "fa39495cd65a25d850d69388092ae6efcdb5e999ca72b378384236bc77e098a4"
 }

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -589,6 +589,9 @@ type SnapshotIntegrityError struct {
 
 	// The stack trace at the point the error was raised.
 	Stack []byte
+
+	// Metadata about the operation that caused the error, if available.
+	Metadata *SnapshotIntegrityErrorMetadata
 }
 
 // The set of operations alongside which snapshot integrity checks can be
@@ -628,12 +631,14 @@ func (s *SnapshotIntegrityError) Unwrap() error {
 }
 
 // Returns a copy of the given snapshot integrity error with the operation set to
-// SnapshotIntegrityRead.
-func (s *SnapshotIntegrityError) ForRead() *SnapshotIntegrityError {
+// SnapshotIntegrityRead and metadata set to the given snapshot's integrity error
+// metadata.
+func (s *SnapshotIntegrityError) ForRead(snap *Snapshot) *SnapshotIntegrityError {
 	return &SnapshotIntegrityError{
-		Err:   s.Err,
-		Op:    SnapshotIntegrityRead,
-		Stack: s.Stack,
+		Err:      s.Err,
+		Op:       SnapshotIntegrityRead,
+		Stack:    s.Stack,
+		Metadata: snap.Metadata.IntegrityErrorMetadata,
 	}
 }
 


### PR DESCRIPTION
In #17047, we introduced a panic-like error banner for snapshot integrity issues. In #17144, we improved this to prompt users to provide information about the operation that *wrote* an invalid snapshot, should the error be encountered on a later *read*. In this commit, we take things one step further, persisting the writing command to the snapshot as metadata in the event that we are about to write an invalid snapshot. Should an error be encountered on a later read, we are now able to pluck the metadata out of the snapshot and include it in the error banner ourselves. This should hopefully further improve the situation when it comes to tracking down bugs in the engine.

Note that, like all changes to snapshot persistence, new snapshot fields (in this case, the metadata we now collect) may be clobbered by older versions of the CLI. That is, if a latest-version CLI writes metadata, a version older than this commit may erase it, by virtue of ignoring data it does not understand during deserialization. While unfortunate, this is also useful information in the event a user raises an issue, since it (in theory) tells us that a version older than that containing this commit was involved in the process, which may help diagnosis.