### PR TITLE
Enable Copilot link by default

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1291,13 +1291,15 @@ func (b *cloudBackend) createAndStartUpdate(
 		if env.SuppressCopilotLink.Value() {
 			// Copilot is enabled in user's org, but the environment variable to suppress the link to Copilot is set.
 			op.Opts.Display.ShowLinkToCopilot = false
-			continuationString = " but the environment variable PULUMI_SUPPRESS_COPILOT_LINK suppresses the link to Copilot in diagnostics"
+			continuationString = " but the environment variable PULUMI_SUPPRESS_COPILOT_LINK" +
+				" suppresses the link to Copilot in diagnostics"
 		}
 	} else {
 		op.Opts.Display.ShowLinkToCopilot = false
 		copilotEnabledValueString = "is not"
 	}
-	logging.V(7).Infof("Copilot in org '%s' %s enabled for user '%s'%s", stackID.Owner, copilotEnabledValueString, userName, continuationString)
+	logging.V(7).Infof("Copilot in org '%s' %s enabled for user '%s'%s",
+		stackID.Owner, copilotEnabledValueString, userName, continuationString)
 
 	return update, updateMetadata{
 		version:    version,

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1279,22 +1279,25 @@ func (b *cloudBackend) createAndStartUpdate(
 		logging.V(7).Infof("Stack %s being updated to version %d", stackRef, version)
 	}
 
+	userName, _, _, err := b.CurrentUser()
+	if err != nil {
+		userName = "unknown"
+	}
 	// Check if the user's org (stack's owner) has Copilot enabled. If not, we don't show the link to Copilot.
 	isCopilotEnabled := updateDetails.IsCopilotIntegrationEnabled
-	if !isCopilotEnabled {
-		// If this overrides user's preference stated by PULUMI_SHOW_COPILOT_LINK, issue a
-		// verbosity level 7 warning to ease diagnosing why the link isn't showing up.
-		if env.ShowCopilotLink.Value() {
-			userName, _, _, err := b.CurrentUser()
-			if err != nil {
-				userName = "unknown"
-			}
-			logging.V(7).Infof(
-				"Copilot in org '%s' is not enabled for user '%s', link to Copilot in diagnostics will not be shown",
-				stackID.Owner, userName)
+	copilotEnabledValueString := "is"
+	continuationString := ""
+	if isCopilotEnabled {
+		if env.SuppressCopilotLink.Value() {
+			// Copilot is enabled in user's org, but the environment variable to suppress the link to Copilot is set.
+			op.Opts.Display.ShowLinkToCopilot = false
+			continuationString = " but the environment variable PULUMI_SUPPRESS_COPILOT_LINK suppresses the link to Copilot in diagnostics"
 		}
+	} else {
 		op.Opts.Display.ShowLinkToCopilot = false
+		copilotEnabledValueString = "is not"
 	}
+	logging.V(7).Infof("Copilot in org '%s' %s enabled for user '%s'%s", stackID.Owner, copilotEnabledValueString, userName, continuationString)
 
 	return update, updateMetadata{
 		version:    version,

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -555,10 +555,9 @@ func newUpCmd() *cobra.Command {
 				opts.Display.SuppressPermalink = true
 			}
 
-			// For now, 'explainFailure' link to Copilot in the CLI output
-			// requires env var PULUMI_SHOW_COPILOT_LINK to be set to true
-			opts.Display.ShowLinkToCopilot = env.ShowCopilotLink.Value()
-			logging.V(7).Infof("ShowLinkToCopilot=%v", opts.Display.ShowLinkToCopilot)
+			// Link to Copilot will be shown for orgs that have Copilot enabled, unless the user explicitly suppressed it.
+			logging.V(7).Infof("PULUMI_SUPPRESS_COPILOT_LINK=%v", env.SuppressCopilotLink.Value())
+			opts.Display.ShowLinkToCopilot = !env.SuppressCopilotLink.Value()
 
 			if len(args) > 0 {
 				return upTemplateNameOrURL(

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -95,7 +95,7 @@ var BackendURL = env.String("BACKEND_URL",
 	"Set the backend that will be used instead of the currently logged in backend or the current project's backend.")
 
 var SuppressCopilotLink = env.Bool("SUPPRESS_COPILOT_LINK",
-	"Show the 'explainFailure' link to Copilot in the CLI output.")
+	"Suppress showing the 'explainFailure' link to Copilot in the CLI output.")
 
 var FallbackToStateSecretsManager = env.Bool("FALLBACK_TO_STATE_SECRETS_MANAGER",
 	"Use the snapshot secrets manager as a fallback when the stack configuration is missing or incomplete.")

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -94,7 +94,7 @@ var ContinueOnError = env.Bool("CONTINUE_ON_ERROR",
 var BackendURL = env.String("BACKEND_URL",
 	"Set the backend that will be used instead of the currently logged in backend or the current project's backend.")
 
-var ShowCopilotLink = env.Bool("SHOW_COPILOT_LINK",
+var SuppressCopilotLink = env.Bool("SUPPRESS_COPILOT_LINK",
 	"Show the 'explainFailure' link to Copilot in the CLI output.")
 
 var FallbackToStateSecretsManager = env.Bool("FALLBACK_TO_STATE_SECRETS_MANAGER",


### PR DESCRIPTION
- `PULUMI_SHOW_COPILOT_LINK` env var is no longer recognized. Instead, off-by-default `PULUMI_SUPPRESS_COPILOT_LINK` can be used to suppress the link generation

- Since we changed the logic a few times, I added more level 7 logging to ease troubleshooting. The log will look like this:

```
Copilot in org 'pulumi' is enabled for user 'artur-pulumi-corp' but the environment variable PULUMI_SUPPRESS_COPILOT_LINK suppresses the link to Copilot in diagnostics
```