### PR TITLE
Fix _sync_monitor_supports_parameterization

### DIFF
--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -336,7 +336,7 @@ def _sync_monitor_supports_invoke_transforms() -> bool:
 
 
 def _sync_monitor_supports_parameterization() -> bool:
-    return SETTINGS.feature_support.get("supportsParameterization", False)
+    return SETTINGS.feature_support.get("parameterization", False)
 
 
 def reset_options(

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1408,10 +1408,10 @@ func TestFailsOnImplicitDependencyCyclesPython(t *testing.T) {
 //
 //nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestParameterizedPython(t *testing.T) {
-	// TODO: Unskip this test after 3.133 is released. Python codegen for parameterized providers will try to
-	// refer to release 3.133, but until we actually release that version pip will fail that this constraint
+	// TODO: Unskip this test after 3.134.1 is released. Python codegen for parameterized providers will try to
+	// refer to release 3.134.1, but until we actually release that version pip will fail that this constraint
 	// can't be met.
-	t.Skip("This needs to skip until 3.133.0 is released due to how pip resoloution works")
+	t.Skip("This needs to skip until 3.134.1 is released due to how pip resoloution works")
 
 	e := ptesting.NewEnvironment(t)
 


### PR DESCRIPTION
Trying to split up https://github.com/pulumi/pulumi/pull/17283 as something in it keeps failing CI.

This fixes the `_sync_monitor_supports_parameterization` method (which is currently not being used due to codegen bugs) to refer to the correct flag.

Also update the test that we need to keep skipping till a later version with the codegen fixes is released.