### PR TITLE
allow tests to run in parallel with linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,7 +325,7 @@ jobs:
     # To this:
     #   CI / Unit Test / sdk/dotnet dotnet_test on macos-11/current
     name: Unit Test${{ matrix.platform && '' }}
-    needs: [matrix, lint]
+    needs: [matrix]
     if: ${{ needs.matrix.outputs.unit-test-matrix != '{}' }}
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
@@ -351,7 +351,7 @@ jobs:
     # By putting a variable in the name, we remove GitHub's auto-generated matrix parameters from
     # appearing in the rendered title of the job name. See: unit test.
     name: Integration Test${{ matrix.platform && '' }}
-    needs: [matrix, build-binaries, build-sdks, lint]
+    needs: [matrix, build-binaries, build-sdks]
     if: ${{ needs.matrix.outputs.integration-test-matrix != '{}' }}
     strategy:
       fail-fast: ${{ inputs.fail-fast }}


### PR DESCRIPTION
Currently we make running the tests depend on linting the program. This occasionally saves some GitHub actions runner time, when the lint step detects that the build is failing.  However in many cases it's quite inconvenient, especially if the lint error is really just a lint error (e.g. because of a long line or something).

In that case the submitter of the PR has to fix the lint first, and then push those changes, and wait for CI all over again, which can add a considerable amount of time (especially since CI is kinda slow, so at least I usually end up doing something else and checking back later).

In addition it adds to the time it takes to run all tests in total, as the tests can't be run in parallel with linting (and linting takes more than a minute).

Allow the tests to run in parallel instead.  This means we can get the test results early, as long as the code builds fine.  In some occasions that means some extra time spent on GitHub actions, but that's time well spent imo.