### PR TITLE
Fix check for disableEntryCache in newPluginLoaderWithOptions

### DIFF
--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -93,7 +93,7 @@ func newPluginLoaderWithOptions(host plugin.Host, cacheOptions pluginLoaderCache
 
 		cacheOptions: cacheOptions,
 	}
-	if !cacheOptions.disableFileCache {
+	if !cacheOptions.disableEntryCache {
 		l = NewCachedLoader(l)
 	}
 	return l


### PR DESCRIPTION
This was checking disableFileCache to disable the memory cache, rather than disableEntryCache.

This is only used in tests, so probably no real impact.