### PR TITLE
[sdk-gen/nodejs] Bump valid nodejs version to v3.133 the one that contains invokeOutput and friends

### DIFF
--- a/changelog/pending/20240919--sdkgen-nodejs--bump-valid-nodejs-version-to-v3-133-the-one-that-contains-invokeoutput-and-friends.yaml
+++ b/changelog/pending/20240919--sdkgen-nodejs--bump-valid-nodejs-version-to-v3-133-the-one-that-contains-invokeoutput-and-friends.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdkgen/nodejs
+  description: Bump valid nodejs version to v3.133 the one that contains invokeOutput and friends

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	// The minimum version of @pulumi/pulumi compatible with the generated SDK.
-	MinimumValidSDKVersion string = "^3.42.0"
+	MinimumValidSDKVersion string = "^3.133.0"
 	// The minimum version of @pulumi/pulumi that supports parameterization.
 	MinimumValidParameterizationSDKVersion string = "^3.133.0"
 	MinimumTypescriptVersion               string = "^4.3.5"

--- a/tests/testdata/codegen/assets-and-archives/nodejs/package.json
+++ b/tests/testdata/codegen/assets-and-archives/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.42.0"
+        "@pulumi/pulumi": "^3.133.0"
     },
     "devDependencies": {
         "@types/node": "^14",

--- a/tests/testdata/codegen/config-variables/nodejs/package.json
+++ b/tests/testdata/codegen/config-variables/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.42.0"
+        "@pulumi/pulumi": "^3.133.0"
     },
     "devDependencies": {
         "@types/node": "^14",

--- a/tests/testdata/codegen/embedded-crd-types/nodejs/package.json
+++ b/tests/testdata/codegen/embedded-crd-types/nodejs/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/kubernetes": "^3.0.0",
-        "@pulumi/pulumi": "^3.42.0"
+        "@pulumi/pulumi": "^3.133.0"
     },
     "devDependencies": {
         "@types/node": "^14",

--- a/tests/testdata/codegen/external-node-compatibility/nodejs/package.json
+++ b/tests/testdata/codegen/external-node-compatibility/nodejs/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/google-native": "^0.11.0",
-        "@pulumi/pulumi": "^3.42.0"
+        "@pulumi/pulumi": "^3.133.0"
     },
     "devDependencies": {
         "@types/node": "^14",

--- a/tests/testdata/codegen/external-resource-schema/nodejs/package.json
+++ b/tests/testdata/codegen/external-resource-schema/nodejs/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "@pulumi/aws": "^4.19.0",
         "@pulumi/kubernetes": "^3.7.0",
-        "@pulumi/pulumi": "^3.42.0",
+        "@pulumi/pulumi": "^3.133.0",
         "@pulumi/random": "^4.2.0"
     },
     "devDependencies": {

--- a/tests/testdata/codegen/functions-secrets/nodejs/package.json
+++ b/tests/testdata/codegen/functions-secrets/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.42.0"
+        "@pulumi/pulumi": "^3.133.0"
     },
     "devDependencies": {
         "@types/node": "ts4.3",

--- a/tests/testdata/codegen/legacy-names/nodejs/package.json
+++ b/tests/testdata/codegen/legacy-names/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.42.0"
+        "@pulumi/pulumi": "^3.133.0"
     },
     "devDependencies": {
         "@types/node": "^14",

--- a/tests/testdata/codegen/methods-return-plain-resource/nodejs/package.json
+++ b/tests/testdata/codegen/methods-return-plain-resource/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.42.0",
+        "@pulumi/pulumi": "^3.133.0",
         "@pulumi/tls": "4.10"
     },
     "devDependencies": {

--- a/tests/testdata/codegen/output-funcs-edgeorder/nodejs/package.json
+++ b/tests/testdata/codegen/output-funcs-edgeorder/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.42.0"
+        "@pulumi/pulumi": "^3.133.0"
     },
     "devDependencies": {
         "@types/node": "ts4.3",

--- a/tests/testdata/codegen/output-funcs-tfbridge20/nodejs/package.json
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.42.0"
+        "@pulumi/pulumi": "^3.133.0"
     },
     "devDependencies": {
         "@types/mocha": "latest",

--- a/tests/testdata/codegen/output-funcs/nodejs/package.json
+++ b/tests/testdata/codegen/output-funcs/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.42.0"
+        "@pulumi/pulumi": "^3.133.0"
     },
     "devDependencies": {
         "@types/mocha": "latest",

--- a/tests/testdata/codegen/regress-node-8110/nodejs/package.json
+++ b/tests/testdata/codegen/regress-node-8110/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.42.0"
+        "@pulumi/pulumi": "^3.133.0"
     },
     "devDependencies": {
         "@types/node": "ts4.3",

--- a/tests/testdata/codegen/secrets/nodejs/package.json
+++ b/tests/testdata/codegen/secrets/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.42.0"
+        "@pulumi/pulumi": "^3.133.0"
     },
     "devDependencies": {
         "@types/node": "ts4.3",

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/nodejs/package.json
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.42.0"
+        "@pulumi/pulumi": "^3.133.0"
     },
     "devDependencies": {
         "@types/node": "ts4.3",

--- a/tests/testdata/codegen/simple-resource-schema/nodejs/package.json
+++ b/tests/testdata/codegen/simple-resource-schema/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.42.0"
+        "@pulumi/pulumi": "^3.133.0"
     },
     "devDependencies": {
         "@types/mocha": "latest",

--- a/tests/testdata/codegen/unions-inline/nodejs/package.json
+++ b/tests/testdata/codegen/unions-inline/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.42.0"
+        "@pulumi/pulumi": "^3.133.0"
     },
     "devDependencies": {
         "@types/node": "^14",

--- a/tests/testdata/codegen/unions-inside-arrays/nodejs/package.json
+++ b/tests/testdata/codegen/unions-inside-arrays/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.42.0"
+        "@pulumi/pulumi": "^3.133.0"
     },
     "devDependencies": {
         "@types/node": "^14",

--- a/tests/testdata/codegen/urn-id-properties/nodejs/package.json
+++ b/tests/testdata/codegen/urn-id-properties/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.42.0"
+        "@pulumi/pulumi": "^3.133.0"
     },
     "devDependencies": {
         "@types/node": "^14",

--- a/tests/testdata/codegen/using-shared-types-in-config/nodejs/package.json
+++ b/tests/testdata/codegen/using-shared-types-in-config/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.42.0"
+        "@pulumi/pulumi": "^3.133.0"
     },
     "devDependencies": {
         "@types/node": "^14",


### PR DESCRIPTION
### Description

Version v3.133.0 includes #17237 which adds new SDK functions `invokeOutput` and `invokeSingleOutput`, this PR changes sdk-gen such that the required `@pulumi/pulumi` dependency is that one that contains the former primitives. 