### PR TITLE
Fix Python min parameterization version

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -3389,9 +3389,9 @@ func setDependencies(schema *PyprojectSchema, pkg *schema.Package) error {
 // Require the SDK to fall within the same major version.
 var MinimumValidSDKVersion = ">=3.0.0,<4.0.0"
 
-// Require the SDK to fall within the same major version, and be at least 3.134.1 which added support for the
+// Require the SDK to fall within the same major version, and be at least 3.134.0 which added support for the
 // package reference feature flag.
-var MinimumValidParameterizationSDKVersion = ">=3.134.1,<4.0.0"
+var MinimumValidParameterizationSDKVersion = ">=3.134.0,<4.0.0"
 
 // ensureValidPulumiVersion ensures that the Pulumi SDK has an entry.
 // It accepts a list of dependencies

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1408,10 +1408,10 @@ func TestFailsOnImplicitDependencyCyclesPython(t *testing.T) {
 //
 //nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestParameterizedPython(t *testing.T) {
-	// TODO: Unskip this test after 3.134.1 is released. Python codegen for parameterized providers will try to
-	// refer to release 3.134.1, but until we actually release that version pip will fail that this constraint
+	// TODO: Unskip this test after 3.134.0 is released. Python codegen for parameterized providers will try to
+	// refer to release 3.134.0, but until we actually release that version pip will fail that this constraint
 	// can't be met.
-	t.Skip("This needs to skip until 3.134.1 is released due to how pip resoloution works")
+	t.Skip("This needs to skip until 3.134.0 is released due to how pip resoloution works")
 
 	e := ptesting.NewEnvironment(t)
 

--- a/tests/integration/python/parameterized/sdk/python/setup.py
+++ b/tests/integration/python/parameterized/sdk/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_pkg',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.134.1,<4.0.0',
+          'pulumi>=3.134.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)


### PR DESCRIPTION
We haven't shipped 3.134.0 yet, so this can be 3.134.0 rather than 3.134.1.