### PR TITLE
fix help text for pulumi config set

### DIFF
--- a/changelog/pending/20240920--cli-config--fix-help-text-for-config-set-command.yaml
+++ b/changelog/pending/20240920--cli-config--fix-help-text-for-config-set-command.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/config
+  description: Fix help text for `config set` command

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -586,7 +586,7 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 			"will set the value to a list with the first item `a`.\n" +
 			"  - `pulumi config set --path parent.nested value` " +
 			"will set the value of `parent` to a map `nested: value`.\n" +
-			"  - `pulumi config set --path '[\"parent.name\"].[\"nested.name\"]' value` will set the value of \n" +
+			"  - `pulumi config set --path '[\"parent.name\"][\"nested.name\"]' value` will set the value of \n" +
 			"    `parent.name` to a map `nested.name: value`.",
 		Args: cmdutil.RangeArgs(1, 2),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
For the nested config we currently have an extra `.`, which makes the command fail.  Removing the dot will make the command work as documented.

Fixes https://github.com/pulumi/pulumi/issues/17313