### PR TITLE
Centralize resource state dependency traversal

### DIFF
--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -89,7 +89,8 @@ func (sg *stepGenerator) isTargetedForUpdate(res *resource.State) bool {
 		return false
 	}
 
-	if ref := res.Provider; ref != "" {
+	ref, allDeps := res.GetAllDependencies()
+	if ref != "" {
 		proivderRef, err := providers.ParseReference(ref)
 		contract.AssertNoErrorf(err, "failed to parse provider reference: %v", ref)
 		providerURN := proivderRef.URN()
@@ -98,27 +99,10 @@ func (sg *stepGenerator) isTargetedForUpdate(res *resource.State) bool {
 		}
 	}
 
-	if res.Parent != "" {
-		if sg.targetsActual.Contains(res.Parent) {
+	for _, dep := range allDeps {
+		if sg.targetsActual.Contains(dep.URN) {
 			return true
 		}
-	}
-	for _, dep := range res.Dependencies {
-		if dep != "" && sg.targetsActual.Contains(dep) {
-			return true
-		}
-	}
-
-	for _, deps := range res.PropertyDependencies {
-		for _, dep := range deps {
-			if dep != "" && sg.targetsActual.Contains(dep) {
-				return true
-			}
-		}
-	}
-
-	if res.DeletedWith != "" && sg.targetsActual.Contains(res.DeletedWith) {
-		return true
 	}
 
 	return false
@@ -1020,82 +1004,32 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, err
 
 				var steps []Step
 
-				if old.Parent != "" {
-					generatedParent := sg.hasGeneratedStep(old.Parent)
-					if !generatedParent {
-						parentOld, has := sg.deployment.Olds()[old.Parent]
-						if !has {
-							return nil, result.BailErrorf(
-								"parent %s of untargeted resource %s has no old state",
-								old.Parent,
-								urn,
-							)
-						}
-
-						parentSteps, err := getDependencySteps(parentOld, nil)
-						if err != nil {
-							return nil, err
-						}
-
-						steps = append(steps, parentSteps...)
-					}
-				}
-
-				for _, dep := range old.Dependencies {
-					generatedDep := sg.hasGeneratedStep(dep)
+				_, allDeps := old.GetAllDependencies()
+				for _, dep := range allDeps {
+					generatedDep := sg.hasGeneratedStep(dep.URN)
 					if !generatedDep {
-						depOld, has := sg.deployment.Olds()[dep]
+						depOld, has := sg.deployment.Olds()[dep.URN]
 						if !has {
-							return nil, result.BailErrorf(
-								"dependency %s of untargeted resource %s has no old state",
-								dep,
-								urn,
-							)
-						}
-
-						depSteps, err := getDependencySteps(depOld, nil)
-						if err != nil {
-							return nil, err
-						}
-
-						steps = append(steps, depSteps...)
-					}
-				}
-
-				for p, deps := range old.PropertyDependencies {
-					for _, dep := range deps {
-						generatedDep := sg.hasGeneratedStep(dep)
-						if !generatedDep {
-							depOld, has := sg.deployment.Olds()[dep]
-							if !has {
-								return nil, result.BailErrorf(
+							var message string
+							switch dep.Type {
+							case resource.ResourceParent:
+								message = fmt.Sprintf("parent %s of untargeted resource %s has no old state", dep.URN, urn)
+							case resource.ResourceDependency:
+								message = fmt.Sprintf("dependency %s of untargeted resource %s has no old state", dep.URN, urn)
+							case resource.ResourcePropertyDependency:
+								message = fmt.Sprintf(
 									"property dependency %s of untargeted resource %s's property %s has no old state",
-									dep,
-									urn,
-									p,
+									dep.URN, urn, dep.Key,
+								)
+							case resource.ResourceDeletedWith:
+								message = fmt.Sprintf(
+									"deleted with dependency %s of untargeted resource %s has no old state",
+									dep.URN, urn,
 								)
 							}
 
-							depSteps, err := getDependencySteps(depOld, nil)
-							if err != nil {
-								return nil, err
-							}
-
-							steps = append(steps, depSteps...)
-						}
-					}
-				}
-
-				if old.DeletedWith != "" {
-					generatedDep := sg.hasGeneratedStep(old.DeletedWith)
-					if !generatedDep {
-						depOld, has := sg.deployment.Olds()[old.DeletedWith]
-						if !has {
-							return nil, result.BailErrorf(
-								"deleted with dependency %s of untargeted resource %s has no old state",
-								old.DeletedWith,
-								urn,
-							)
+							//nolint:govet
+							return nil, result.BailErrorf(message)
 						}
 
 						depSteps, err := getDependencySteps(depOld, nil)

--- a/pkg/resource/graph/dependency_graph.go
+++ b/pkg/resource/graph/dependency_graph.go
@@ -52,31 +52,29 @@ func (dg *DependencyGraph) DependingOn(res *resource.State,
 		if ignore[candidate.URN] {
 			return false
 		}
-		if includeChildren && dependentSet[candidate.Parent] {
-			return true
-		}
-		for _, dependency := range candidate.Dependencies {
-			if dependentSet[dependency] {
-				return true
-			}
-		}
-		for _, deps := range candidate.PropertyDependencies {
-			for _, dep := range deps {
-				if dependentSet[dep] {
+
+		provider, allDeps := candidate.GetAllDependencies()
+		for _, dep := range allDeps {
+			switch dep.Type {
+			case resource.ResourceParent:
+				if includeChildren && dependentSet[dep.URN] {
+					return true
+				}
+			case resource.ResourceDependency, resource.ResourcePropertyDependency, resource.ResourceDeletedWith:
+				if dependentSet[dep.URN] {
 					return true
 				}
 			}
 		}
-		if candidate.DeletedWith != "" && dependentSet[candidate.DeletedWith] {
-			return true
-		}
-		if candidate.Provider != "" {
-			ref, err := providers.ParseReference(candidate.Provider)
-			contract.AssertNoErrorf(err, "cannot parse provider reference %q", candidate.Provider)
+
+		if provider != "" {
+			ref, err := providers.ParseReference(provider)
+			contract.AssertNoErrorf(err, "cannot parse provider reference %q", provider)
 			if dependentSet[ref.URN()] {
 				return true
 			}
 		}
+
 		return false
 	}
 
@@ -124,35 +122,31 @@ func (dg *DependencyGraph) OnlyDependsOn(res *resource.State) []*resource.State 
 		if res.URN == candidate.URN && res.ID == candidate.ID {
 			return false
 		}
-		if len(dependentSet[candidate.Parent]) > 0 && len(nonDependentSet[candidate.Parent]) == 0 {
-			return true
-		}
-		for _, dependency := range candidate.Dependencies {
-			if len(dependentSet[dependency]) == 1 && len(nonDependentSet[dependency]) == 0 {
-				return true
-			}
-		}
-		for _, deps := range candidate.PropertyDependencies {
-			for _, dep := range deps {
-				if len(dependentSet[dep]) == 1 && len(nonDependentSet[dep]) == 0 {
+
+		provider, allDeps := candidate.GetAllDependencies()
+		for _, dep := range allDeps {
+			switch dep.Type {
+			case resource.ResourceParent:
+				if len(dependentSet[dep.URN]) > 0 && len(nonDependentSet[dep.URN]) == 0 {
+					return true
+				}
+			case resource.ResourceDependency, resource.ResourcePropertyDependency, resource.ResourceDeletedWith:
+				if len(dependentSet[dep.URN]) == 1 && len(nonDependentSet[dep.URN]) == 0 {
 					return true
 				}
 			}
 		}
-		if candidate.DeletedWith != "" {
-			if len(dependentSet[candidate.DeletedWith]) == 1 && len(nonDependentSet[candidate.DeletedWith]) == 0 {
-				return true
-			}
-		}
-		if candidate.Provider != "" {
-			ref, err := providers.ParseReference(candidate.Provider)
-			contract.AssertNoErrorf(err, "cannot parse provider reference %q", candidate.Provider)
+
+		if provider != "" {
+			ref, err := providers.ParseReference(provider)
+			contract.AssertNoErrorf(err, "cannot parse provider reference %q", provider)
 			for _, id := range dependentSet[ref.URN()] {
 				if id == ref.ID() {
 					return true
 				}
 			}
 		}
+
 		return false
 	}
 
@@ -198,23 +192,19 @@ func (dg *DependencyGraph) DependenciesOf(res *resource.State) mapset.Set[*resou
 	set := mapset.NewSet[*resource.State]()
 
 	dependentUrns := make(map[resource.URN]bool)
-	for _, dep := range res.Dependencies {
-		dependentUrns[dep] = true
-	}
-
-	for _, deps := range res.PropertyDependencies {
-		for _, dep := range deps {
-			dependentUrns[dep] = true
+	provider, allDeps := res.GetAllDependencies()
+	for _, dep := range allDeps {
+		if dep.Type == resource.ResourceParent {
+			// We handle parents later on, so we won't include them here.
+			continue
 		}
+
+		dependentUrns[dep.URN] = true
 	}
 
-	if res.DeletedWith != "" {
-		dependentUrns[res.DeletedWith] = true
-	}
-
-	if res.Provider != "" {
-		ref, err := providers.ParseReference(res.Provider)
-		contract.AssertNoErrorf(err, "cannot parse provider reference %q", res.Provider)
+	if provider != "" {
+		ref, err := providers.ParseReference(provider)
+		contract.AssertNoErrorf(err, "cannot parse provider reference %q", provider)
 		dependentUrns[ref.URN()] = true
 	}
 
@@ -322,21 +312,20 @@ func markAsDependency(urn resource.URN, urns map[resource.URN]*node, dependedPro
 	r := urns[urn]
 	for {
 		r.marked = true
-		if r.resource.Provider != "" {
-			ref, err := providers.ParseReference(r.resource.Provider)
-			contract.AssertNoErrorf(err, "cannot parse provider reference %q", r.resource.Provider)
+		provider, allDeps := r.resource.GetAllDependencies()
+		if provider != "" {
+			ref, err := providers.ParseReference(provider)
+			contract.AssertNoErrorf(err, "cannot parse provider reference %q", provider)
 			dependedProviders[ref.URN()] = struct{}{}
 		}
-		for _, dep := range r.resource.Dependencies {
-			markAsDependency(dep, urns, dependedProviders)
-		}
-		for _, deps := range r.resource.PropertyDependencies {
-			for _, dep := range deps {
-				markAsDependency(dep, urns, dependedProviders)
+
+		for _, dep := range allDeps {
+			if dep.Type == resource.ResourceParent {
+				// We handle parents later on, so we won't include them here.
+				continue
 			}
-		}
-		if r.resource.DeletedWith != "" {
-			markAsDependency(r.resource.DeletedWith, urns, dependedProviders)
+
+			markAsDependency(dep.URN, urns, dependedProviders)
 		}
 
 		// If the resource's parent is already marked, we don't need to continue to

--- a/sdk/go/common/resource/resource_state_test.go
+++ b/sdk/go/common/resource/resource_state_test.go
@@ -1,0 +1,219 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAllDependencies(t *testing.T) {
+	t.Parallel()
+
+	// Arrange.
+	cases := []struct {
+		name                string
+		given               *State
+		wantProvider        string
+		wantAllDependencies []StateDependency
+	}{
+		{
+			name:                "no provider, no dependencies",
+			given:               &State{},
+			wantProvider:        "",
+			wantAllDependencies: nil,
+		},
+		{
+			name:                "provider, no dependencies",
+			given:               &State{Provider: "provider"},
+			wantProvider:        "provider",
+			wantAllDependencies: nil,
+		},
+		{
+			name:         "no provider, parent",
+			given:        &State{Parent: "urn"},
+			wantProvider: "",
+			wantAllDependencies: []StateDependency{
+				{Type: ResourceParent, URN: "urn"},
+			},
+		},
+		{
+			name:         "provider, parent (non-empty)",
+			given:        &State{Provider: "provider", Parent: "urn"},
+			wantProvider: "provider",
+			wantAllDependencies: []StateDependency{
+				{Type: ResourceParent, URN: "urn"},
+			},
+		},
+		{
+			name:                "provider, parent (empty)",
+			given:               &State{Provider: "provider", Parent: ""},
+			wantProvider:        "provider",
+			wantAllDependencies: nil,
+		},
+		{
+			name:         "no provider, dependencies",
+			given:        &State{Dependencies: []URN{"urn1", "urn2"}},
+			wantProvider: "",
+			wantAllDependencies: []StateDependency{
+				{Type: ResourceDependency, URN: "urn1"},
+				{Type: ResourceDependency, URN: "urn2"},
+			},
+		},
+		{
+			name:         "provider, dependencies (no empty)",
+			given:        &State{Provider: "provider", Dependencies: []URN{"urn1", "urn2"}},
+			wantProvider: "provider",
+			wantAllDependencies: []StateDependency{
+				{Type: ResourceDependency, URN: "urn1"},
+				{Type: ResourceDependency, URN: "urn2"},
+			},
+		},
+		{
+			name:         "provider, dependencies (some empty)",
+			given:        &State{Provider: "provider", Dependencies: []URN{"urn1", ""}},
+			wantProvider: "provider",
+			wantAllDependencies: []StateDependency{
+				{Type: ResourceDependency, URN: "urn1"},
+			},
+		},
+		{
+			name: "no provider, property dependencies",
+			given: &State{PropertyDependencies: map[PropertyKey][]URN{
+				"key1": {"urn1", "urn2"},
+				"key2": {"urn3"},
+			}},
+			wantProvider: "",
+			wantAllDependencies: []StateDependency{
+				{Type: ResourcePropertyDependency, Key: "key1", URN: "urn1"},
+				{Type: ResourcePropertyDependency, Key: "key1", URN: "urn2"},
+				{Type: ResourcePropertyDependency, Key: "key2", URN: "urn3"},
+			},
+		},
+		{
+			name: "provider, property dependencies (no empty)",
+			given: &State{
+				Provider: "provider",
+				PropertyDependencies: map[PropertyKey][]URN{
+					"key1": {"urn1", "urn2"},
+					"key2": {"urn3"},
+				},
+			},
+			wantProvider: "provider",
+			wantAllDependencies: []StateDependency{
+				{Type: ResourcePropertyDependency, Key: "key1", URN: "urn1"},
+				{Type: ResourcePropertyDependency, Key: "key1", URN: "urn2"},
+				{Type: ResourcePropertyDependency, Key: "key2", URN: "urn3"},
+			},
+		},
+		{
+			name: "provider, property dependencies (some empty)",
+			given: &State{
+				Provider: "provider",
+				PropertyDependencies: map[PropertyKey][]URN{
+					"key1": {"urn1", ""},
+					"key2": {"urn2"},
+					"key3": {},
+				},
+			},
+			wantProvider: "provider",
+			wantAllDependencies: []StateDependency{
+				{Type: ResourcePropertyDependency, Key: "key1", URN: "urn1"},
+				{Type: ResourcePropertyDependency, Key: "key2", URN: "urn2"},
+			},
+		},
+		{
+			name:         "no provider, deleted with",
+			given:        &State{DeletedWith: "urn"},
+			wantProvider: "",
+			wantAllDependencies: []StateDependency{
+				{Type: ResourceDeletedWith, URN: "urn"},
+			},
+		},
+		{
+			name:         "provider, deleted with (non-empty)",
+			given:        &State{Provider: "provider", DeletedWith: "urn"},
+			wantProvider: "provider",
+			wantAllDependencies: []StateDependency{
+				{Type: ResourceDeletedWith, URN: "urn"},
+			},
+		},
+		{
+			name:                "provider, deleted with (empty)",
+			given:               &State{Provider: "provider", DeletedWith: ""},
+			wantProvider:        "provider",
+			wantAllDependencies: nil,
+		},
+		{
+			name: "all dependencies (no empty)",
+			given: &State{
+				Provider:     "provider",
+				Parent:       "urn1",
+				Dependencies: []URN{"urn2", "urn3"},
+				PropertyDependencies: map[PropertyKey][]URN{
+					"key1": {"urn4", "urn5"},
+					"key2": {"urn6"},
+				},
+				DeletedWith: "urn7",
+			},
+			wantProvider: "provider",
+			wantAllDependencies: []StateDependency{
+				{Type: ResourceParent, URN: "urn1"},
+				{Type: ResourceDependency, URN: "urn2"},
+				{Type: ResourceDependency, URN: "urn3"},
+				{Type: ResourcePropertyDependency, Key: "key1", URN: "urn4"},
+				{Type: ResourcePropertyDependency, Key: "key1", URN: "urn5"},
+				{Type: ResourcePropertyDependency, Key: "key2", URN: "urn6"},
+				{Type: ResourceDeletedWith, URN: "urn7"},
+			},
+		},
+		{
+			name: "all dependencies (some empty)",
+			given: &State{
+				Provider:     "provider",
+				Parent:       "urn1",
+				Dependencies: []URN{"urn2", ""},
+				PropertyDependencies: map[PropertyKey][]URN{
+					"key1": {"", "urn3"},
+					"key2": {"urn4"},
+				},
+				DeletedWith: "",
+			},
+			wantProvider: "provider",
+			wantAllDependencies: []StateDependency{
+				{Type: ResourceParent, URN: "urn1"},
+				{Type: ResourceDependency, URN: "urn2"},
+				{Type: ResourcePropertyDependency, Key: "key1", URN: "urn3"},
+				{Type: ResourcePropertyDependency, Key: "key2", URN: "urn4"},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act.
+			actualProvider, actualAllDeps := c.given.GetAllDependencies()
+
+			// Assert.
+			assert.Equal(t, c.wantProvider, actualProvider)
+			assert.ElementsMatch(t, c.wantAllDependencies, actualAllDeps)
+		})
+	}
+}


### PR DESCRIPTION
Resources can depend on others in a number of ways -- provider references, parent-child relationships, dependencies and property dependencies, and deleted-with relationships. With all these linkages to keep track of, it's easy for one to be missed and bugs to be introduced, and indeed this has happened on numerous occasions. This commit attempts to make it harder to introduce bugs where dependencies are missed by adding a new `GetAllDependencies` method to `resource.State`. The idea is not that this will make all traversals of dependencies shorter and neater (though in many cases it does), but that it will force iterations over a resource's dependency set to account for all possible relations appropriately, and discard any that are not important explicitly.

> [!NOTE]
> In some cases the use of `GetAllDependencies` means that algorithms
> which previously mutated an existing set of properties are
> easier/cleaner to express by building up a new set of dependencies and
> mutating after the loop's completion. This does mean a change of
> performance characteristics in some places but I don't think these are
> significant and for the most part they are off hot paths -- `state move`
> and `state rename` are the most obvious examples.

Fixes #16746