### PR TITLE
Fix python typed dicts to be enabled by default

### DIFF
--- a/changelog/pending/20240920--sdkgen-python--fix-python-defaulting-to-generating-typed-dicts-for-input-types.yaml
+++ b/changelog/pending/20240920--sdkgen-python--fix-python-defaulting-to-generating-typed-dicts-for-input-types.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/python
+  description: Fix python defaulting to generating typed dicts for input types

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -672,13 +672,11 @@ func (g *generator) typedDictEnabled(expr model.Expression, typ model.Type) bool
 	contract.AssertNoErrorf(err, "error loading definition for package %q", objType.PackageReference.Name())
 	if lang, ok := pkg.Language["python"]; ok {
 		if pkgInfo, ok := lang.(PackageInfo); ok {
-			if typedDictEnabled(pkgInfo.InputTypes) {
-				return true
-			}
+			return typedDictEnabled(pkgInfo.InputTypes)
 		}
 	}
 
-	return false
+	return true
 }
 
 // argumentTypeName computes the Python argument class name for the given expression and model type.

--- a/tests/testdata/codegen/assets-and-archives/docs/resourcewithassets/_index.md
+++ b/tests/testdata/codegen/assets-and-archives/docs/resourcewithassets/_index.md
@@ -295,12 +295,12 @@ var resourceWithAssetsResource = new ResourceWithAssets("resourceWithAssetsResou
 resource_with_assets_resource = example.ResourceWithAssets("resourceWithAssetsResource",
     source=pulumi.StringAsset("content"),
     archive=pulumi.FileArchive("./path/to/archive"),
-    nested=example.TypeWithAssetsArgs(
-        asset=pulumi.StringAsset("content"),
-        plain_archive=pulumi.FileArchive("./path/to/archive"),
-        archive=pulumi.FileArchive("./path/to/archive"),
-        plain_asset=pulumi.StringAsset("content"),
-    ))
+    nested={
+        "asset": pulumi.StringAsset("content"),
+        "plain_archive": pulumi.FileArchive("./path/to/archive"),
+        "archive": pulumi.FileArchive("./path/to/archive"),
+        "plain_asset": pulumi.StringAsset("content"),
+    })
 ```
 
 </pulumi-choosable>

--- a/tests/testdata/codegen/basic-unions-pp/python/basic-unions.py
+++ b/tests/testdata/codegen/basic-unions-pp/python/basic-unions.py
@@ -2,12 +2,12 @@ import pulumi
 import pulumi_basic_unions as basic_unions
 
 # properties field is bound to union case ServerPropertiesForReplica
-replica = basic_unions.ExampleServer("replica", properties=basic_unions.ServerPropertiesForReplicaArgs(
-    create_mode="Replica",
-    version="0.1.0-dev",
-))
+replica = basic_unions.ExampleServer("replica", properties={
+    "create_mode": "Replica",
+    "version": "0.1.0-dev",
+})
 # properties field is bound to union case ServerPropertiesForRestore
-restore = basic_unions.ExampleServer("restore", properties=basic_unions.ServerPropertiesForRestoreArgs(
-    create_mode="PointInTimeRestore",
-    restore_point_in_time="example",
-))
+restore = basic_unions.ExampleServer("restore", properties={
+    "create_mode": "PointInTimeRestore",
+    "restore_point_in_time": "example",
+})

--- a/tests/testdata/codegen/legacy-names/docs/example_resource/_index.md
+++ b/tests/testdata/codegen/legacy-names/docs/example_resource/_index.md
@@ -296,10 +296,10 @@ example_resource_resource = legacy_names.Example_resource("example_resourceResou
     map_enum=[{
         "string": legacy_names.Enum_XYZ.PLAIN,
     }],
-    request__http=legacy_names.htt_p_module.RequestArgs(
-        url="string",
-        content_body="string",
-    ))
+    request__http={
+        "url": "string",
+        "content_body": "string",
+    })
 ```
 
 </pulumi-choosable>

--- a/tests/testdata/codegen/overlay-supported-languages/docs/overlayresource/_index.md
+++ b/tests/testdata/codegen/overlay-supported-languages/docs/overlayresource/_index.md
@@ -281,9 +281,9 @@ var overlayResourceResource = new OverlayResource("overlayResourceResource", Ove
 ```python
 overlay_resource_resource = example.OverlayResource("overlayResourceResource",
     bar=example.EnumOverlay.SOME_ENUM_VALUE,
-    foo=example.ConfigMapOverlayArgs(
-        config="string",
-    ))
+    foo={
+        "config": "string",
+    })
 ```
 
 </pulumi-choosable>

--- a/tests/testdata/codegen/overlay-supported-languages/docs/overlayresourceconstrainedlanguages/_index.md
+++ b/tests/testdata/codegen/overlay-supported-languages/docs/overlayresourceconstrainedlanguages/_index.md
@@ -281,9 +281,9 @@ var overlayResourceConstrainedLanguagesResource = new OverlayResourceConstrained
 ```python
 overlay_resource_constrained_languages_resource = example.OverlayResourceConstrainedLanguages("overlayResourceConstrainedLanguagesResource",
     bar=example.EnumOverlay.SOME_ENUM_VALUE,
-    foo=example.ConfigMapOverlayArgs(
-        config="string",
-    ))
+    foo={
+        "config": "string",
+    })
 ```
 
 </pulumi-choosable>

--- a/tests/testdata/codegen/overlay-supported-languages/docs/resource/_index.md
+++ b/tests/testdata/codegen/overlay-supported-languages/docs/resource/_index.md
@@ -281,9 +281,9 @@ var resourceResource = new Resource("resourceResource", ResourceArgs.builder()
 ```python
 resource_resource = example.Resource("resourceResource",
     bar=example.EnumOverlay.SOME_ENUM_VALUE,
-    foo=example.ConfigMapOverlayArgs(
-        config="string",
-    ))
+    foo={
+        "config": "string",
+    })
 ```
 
 </pulumi-choosable>

--- a/tests/testdata/codegen/unions-inline/docs/exampleserver/_index.md
+++ b/tests/testdata/codegen/unions-inline/docs/exampleserver/_index.md
@@ -278,10 +278,10 @@ var exampleServerResource = new ExampleServer("exampleServerResource", ExampleSe
 <pulumi-choosable type="language" values="python">
 
 ```python
-example_server_resource = example.ExampleServer("exampleServerResource", properties=example.ServerPropertiesForReplicaArgs(
-    create_mode="Replica",
-    version="string",
-))
+example_server_resource = example.ExampleServer("exampleServerResource", properties={
+    "create_mode": "Replica",
+    "version": "string",
+})
 ```
 
 </pulumi-choosable>

--- a/tests/testdata/codegen/unions-inside-arrays/docs/exampleserver/_index.md
+++ b/tests/testdata/codegen/unions-inside-arrays/docs/exampleserver/_index.md
@@ -283,10 +283,10 @@ var exampleServerResource = new ExampleServer("exampleServerResource", ExampleSe
 <pulumi-choosable type="language" values="python">
 
 ```python
-example_server_resource = example.ExampleServer("exampleServerResource", properties_collection=[example.ServerPropertiesForReplicaArgs(
-    create_mode="Replica",
-    version="string",
-)])
+example_server_resource = example.ExampleServer("exampleServerResource", properties_collection=[{
+    "create_mode": "Replica",
+    "version": "string",
+}])
 ```
 
 </pulumi-choosable>

--- a/tests/testdata/codegen/using-shared-types-in-config/docs/user/_index.md
+++ b/tests/testdata/codegen/using-shared-types-in-config/docs/user/_index.md
@@ -275,9 +275,9 @@ var userResource = new User("userResource", UserArgs.builder()
 <pulumi-choosable type="language" values="python">
 
 ```python
-user_resource = credentials.User("userResource", shared=credentials.SharedArgs(
-    foo="string",
-))
+user_resource = credentials.User("userResource", shared={
+    "foo": "string",
+})
 ```
 
 </pulumi-choosable>


### PR DESCRIPTION
https://github.com/pulumi/pulumi/pull/16704 correctly defaulted typed dicts to false for external schemas in sdk-gen but incorrectly turned them on for external schemas in program-gen iff the schema had any other python language options.

This fixes the latter to assume that typed dicts can be used in program-gen. This should be fine because even the old class style could be passed dict arguments as well, but we'll use the class style if the schema explicitly says to use it.