### PR TITLE
Fix Typo in preview.go Description

### DIFF
--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -282,7 +282,7 @@ func newPreviewCmd() *cobra.Command {
 		Aliases:    []string{"pre"},
 		SuggestFor: []string{"build", "plan"},
 		Short:      "Show a preview of updates to a stack's resources",
-		Long: "Show a preview of updates a stack's resources.\n" +
+		Long: "Show a preview of updates to a stack's resources.\n" +
 			"\n" +
 			"This command displays a preview of the updates to an existing stack whose state is\n" +
 			"represented by an existing state file. The new desired state is computed by running\n" +


### PR DESCRIPTION
Added the word "to" in order to fix a typo and ensure both long and short description formats are consistent.