### PR TITLE
Allow passing an initial state at stack creation

### DIFF
--- a/sdk/go/common/apitype/stacks.go
+++ b/sdk/go/common/apitype/stacks.go
@@ -58,6 +58,9 @@ type CreateStackRequest struct {
 
 	// An optional set of teams to assign to the stack.
 	Teams []string `json:"teams,omitempty"`
+
+	// An optional state to initialize the stack with.
+	State *UntypedDeployment `json:"state,omitempty"`
 }
 
 // CreateStackResponse is the response from a create Stack request.


### PR DESCRIPTION
When creating a stack, there are cases where it would be valuable to be able to initialise the stack with a known state snapshot (such as one containing a non-default secrets manager, as discussed in #16890, for instance). This commit begins adding support by this by extending the API types for stack creation to take an `UntypedDeployment`. When this is released, changes to relevant backends (DIY and Pulumi Cloud) can be implemented to support the new field, at which point the CLI can then be modified to take advantage of it.