### PR TITLE
don't run tests using poetry in parallel on windows

### DIFF
--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -318,8 +318,11 @@ func TestAutomaticVenvCreation(t *testing.T) {
 	})
 }
 
+//nolint:paralleltest // Poetry causes issues when run in parallel on windows. See pulumi/pulumi#17183
 func TestAutomaticVenvCreationPoetry(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
 
 	e := ptesting.NewEnvironment(t)
 	defer e.DeleteIfNotFailed()
@@ -487,8 +490,11 @@ func TestNewPythonChoosePoetry(t *testing.T) {
 	integration.CheckRuntimeOptions(t, e.RootPath, expected)
 }
 
+//nolint:paralleltest // Poetry causes issues when run in parallel on windows. See pulumi/pulumi#17183
 func TestNewPythonRuntimeOptions(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
 
 	e := ptesting.NewEnvironment(t)
 	defer e.DeleteIfNotFailed()
@@ -508,8 +514,11 @@ func TestNewPythonRuntimeOptions(t *testing.T) {
 	integration.CheckRuntimeOptions(t, e.RootPath, expected)
 }
 
+//nolint:paralleltest // Poetry causes issues when run in parallel on windows. See pulumi/pulumi#17183
 func TestNewPythonConvertRequirementsTxt(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
 
 	e := ptesting.NewEnvironment(t)
 	defer e.DeleteIfNotFailed()


### PR DESCRIPTION
Poetry uses a cache for packages to speed up installation of the venv. It seems like the primitives it uses for that are causing issues when running multiple instances of poetry in parallel that are installing the same packages.  This seems to happen only on Windows.  Make these tests run sequentially on Windows to avoid this test flakyness.

There's an upstream issue for poetry that describes this as well (https://github.com/python-poetry/poetry/issues/7370)

https://github.com/pulumi/pulumi/issues/17183