### PR TITLE
Retry token errors immediately

### DIFF
--- a/changelog/pending/20240923--engine--retry-token-refresh-errors-immediately.yaml
+++ b/changelog/pending/20240923--engine--retry-token-refresh-errors-immediately.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Retry token refresh errors immediately


### PR DESCRIPTION
If we hit an error trying to refresh the token source (and it's not an expired token error) then retry right away. This stops two error cases.
Firstly in GetToken where we may return the state token, and secondly on the timer where the duration between now and the next refresh tick might push us over the time limit before the token expires.