### PR TITLE
Fix golangci-lint output format in CI

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run golangci-lint
         # Print GitHub Actions-friendly output so that errors get marked
         # in the pull request.
-        run: make lint_golang GOLANGCI_LINT_ARGS=--out-format=colored-line-number
+        run: make lint_golang GOLANGCI_LINT_ARGS=--out-format=github-actions
 
   tidy:
     name: go mod tidy


### PR DESCRIPTION
This change snuck through in https://github.com/pulumi/pulumi/pull/15473. IIRC this was for debugging locally only, and we should keep the `github-actions` output format in CI.