### PR TITLE
Document secrets configure behavior

### DIFF
--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -18,7 +18,7 @@
 3421371250 793 proto/pulumi/errors.proto
 4059640985 11994 proto/pulumi/language.proto
 2893249402 1992 proto/pulumi/plugin.proto
-1987331868 27969 proto/pulumi/provider.proto
+1529552991 28224 proto/pulumi/provider.proto
 1190662922 17848 proto/pulumi/resource.proto
 607478140 1008 proto/pulumi/source.proto
 3670315643 2603 proto/pulumi/testing/language.proto

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -48,7 +48,14 @@ service ResourceProvider {
     rpc CheckConfig(CheckRequest) returns (CheckResponse) {}
     // DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
     rpc DiffConfig(DiffRequest) returns (DiffResponse) {}
+
     // Configure configures the resource provider with "globals" that control its behavior.
+    //
+    // :::{warning}
+    // ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
+    // ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
+    // ConfigureRequest.args.
+    // :::
     rpc Configure(ConfigureRequest) returns (ConfigureResponse) {}
 
     // Invoke dynamically executes a built-in function in the provider.

--- a/sdk/nodejs/proto/provider_grpc_pb.js
+++ b/sdk/nodejs/proto/provider_grpc_pb.js
@@ -417,6 +417,12 @@ diffConfig: {
     responseDeserialize: deserialize_pulumirpc_DiffResponse,
   },
   // Configure configures the resource provider with "globals" that control its behavior.
+//
+// :::{warning}
+// ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
+// ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
+// ConfigureRequest.args.
+// :::
 configure: {
     path: '/pulumirpc.ResourceProvider/Configure',
     requestStream: false,

--- a/sdk/proto/go/provider_grpc.pb.go
+++ b/sdk/proto/go/provider_grpc.pb.go
@@ -44,6 +44,12 @@ type ResourceProviderClient interface {
 	// DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
 	DiffConfig(ctx context.Context, in *DiffRequest, opts ...grpc.CallOption) (*DiffResponse, error)
 	// Configure configures the resource provider with "globals" that control its behavior.
+	//
+	// :::{warning}
+	// ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
+	// ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
+	// ConfigureRequest.args.
+	// :::
 	Configure(ctx context.Context, in *ConfigureRequest, opts ...grpc.CallOption) (*ConfigureResponse, error)
 	// Invoke dynamically executes a built-in function in the provider.
 	Invoke(ctx context.Context, in *InvokeRequest, opts ...grpc.CallOption) (*InvokeResponse, error)
@@ -327,6 +333,12 @@ type ResourceProviderServer interface {
 	// DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
 	DiffConfig(context.Context, *DiffRequest) (*DiffResponse, error)
 	// Configure configures the resource provider with "globals" that control its behavior.
+	//
+	// :::{warning}
+	// ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
+	// ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
+	// ConfigureRequest.args.
+	// :::
 	Configure(context.Context, *ConfigureRequest) (*ConfigureResponse, error)
 	// Invoke dynamically executes a built-in function in the provider.
 	Invoke(context.Context, *InvokeRequest) (*InvokeResponse, error)

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
@@ -167,6 +167,12 @@ class ResourceProviderServicer(object):
 
     def Configure(self, request, context):
         """Configure configures the resource provider with "globals" that control its behavior.
+
+        :::{warning}
+        ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
+        ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
+        ConfigureRequest.args.
+        :::
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
@@ -67,7 +67,14 @@ class ResourceProviderStub:
         pulumi.provider_pb2.ConfigureRequest,
         pulumi.provider_pb2.ConfigureResponse,
     ]
-    """Configure configures the resource provider with "globals" that control its behavior."""
+    """Configure configures the resource provider with "globals" that control its behavior.
+
+    :::{warning}
+    ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
+    ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
+    ConfigureRequest.args.
+    :::
+    """
     Invoke: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.InvokeRequest,
         pulumi.provider_pb2.InvokeResponse,
@@ -217,7 +224,14 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         request: pulumi.provider_pb2.ConfigureRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.ConfigureResponse:
-        """Configure configures the resource provider with "globals" that control its behavior."""
+        """Configure configures the resource provider with "globals" that control its behavior.
+
+        :::{warning}
+        ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
+        ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
+        ConfigureRequest.args.
+        :::
+        """
     
     def Invoke(
         self,


### PR DESCRIPTION
Following up on https://github.com/pulumi/pulumi-gcp/issues/2405, this PR adds a comment to Configure explaining that ConfigureRequest.args may contain secrets.