### PR TITLE
[sdk/python] Always unwrap value from InvokeResult in invoke_async

### DIFF
--- a/changelog/pending/20240924--sdk-python--always-unwrap-value-from-invokeresult-in-invoke_async.yaml
+++ b/changelog/pending/20240924--sdk-python--always-unwrap-value-from-invokeresult-in-invoke_async.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Always unwrap value from InvokeResult in invoke_async

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -146,7 +146,7 @@ def invoke_output(
 
     async def do_invoke_output() -> None:
         try:
-            invoke_result = await invoke_async(
+            invoke_result = await _invoke(
                 tok, props, opts, typ, package_ref=package_ref
             )
 
@@ -174,13 +174,14 @@ async def invoke_async(
     opts: Optional[InvokeOptions] = None,
     typ: Optional[type] = None,
     package_ref: Optional[Awaitable[Optional[str]]] = None,
-) -> InvokeResult:
+) -> Any:
     """
     invoke_async dynamically asynchronously invokes the function, tok, which is offered by a provider plugin.
     the inputs can be a bag of computed values (Ts or Awaitable[T]s), and the result is a Awaitable[Any] that
     resolves when the invoke finishes.
     """
-    return await _invoke(tok, props, opts, typ, package_ref=package_ref)
+    invokeResult = await _invoke(tok, props, opts, typ, package_ref=package_ref)
+    return invokeResult.value
 
 
 def _invoke(

--- a/sdk/python/lib/test/langhost/invoke/__main__.py
+++ b/sdk/python/lib/test/langhost/invoke/__main__.py
@@ -56,10 +56,10 @@ async def await_invoke():
 
 
 async def await_invoke_async():
-    invokeResult = await invoke_async(
+    value = await invoke_async(
         "test:index:MyFunction", props={"value": 41, "value2": get_value2()}
     )
-    return invokeResult.value["value"]
+    return value["value"]
 
 
 res = MyResource("resourceA", do_invoke())


### PR DESCRIPTION
In #17275 I changed `invoke_async` to return `InvokeResult`, however this variant of the invoke should always unwrap `value` from the `InvokeResult`. 

Reverted a changed test in #17275 thinking it was syntactic, however it was not since it unwrapped the value in the test whereas the unwrapping should have happened in the function implementation of `invoke_async`
```diff
async def await_invoke_async():
   value = await invoke_async(
        "test:index:MyFunction", props={"value": 41, "value2": get_value2()}
   )
   return value["value"]
```

Fixes #17347
