### PR TITLE
Invalidate GITHUB_TOKEN on 401

### DIFF
--- a/changelog/pending/20240924--engine--disable-the-enviromental-github_token-on-401-responses.yaml
+++ b/changelog/pending/20240924--engine--disable-the-enviromental-github_token-on-401-responses.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Disable the enviromental GITHUB_TOKEN on 401 responses

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -474,7 +474,7 @@ func (source *githubSource) getHTTPResponse(
 	addAuth := ""
 	if source.token == "" {
 		if source.tokenDisabled {
-			addAuth = " You can set GITHUB_TOKEN to a different token to make a request with a higher rate limit."
+			addAuth = " Your current GITHUB_TOKEN doesn't allow access to the repository, so we disabled it for this request.  You can set GITHUB_TOKEN to a different token to make a request with a higher rate limit."
 		} else {
 			addAuth = " You can set GITHUB_TOKEN to make an authenticated request with a higher rate limit."
 		}

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -474,7 +474,8 @@ func (source *githubSource) getHTTPResponse(
 	addAuth := ""
 	if source.token == "" {
 		if source.tokenDisabled {
-			addAuth = " Your current GITHUB_TOKEN doesn't allow access to the repository, so we disabled it for this request.  You can set GITHUB_TOKEN to a different token to make a request with a higher rate limit."
+			addAuth = " Your current GITHUB_TOKEN doesn't allow access to the repository, so we disabled it for this request." +
+				" You can set GITHUB_TOKEN to a different token to make a request with a higher rate limit."
 		} else {
 			addAuth = " You can set GITHUB_TOKEN to make an authenticated request with a higher rate limit."
 		}

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -433,8 +433,12 @@ func (source *githubSource) newHTTPRequest(url, accept string) (*http.Request, e
 
 func (source *githubSource) getHTTPResponse(
 	getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error),
-	req *http.Request,
+	url, accept string,
 ) (io.ReadCloser, int64, error) {
+	req, err := source.newHTTPRequest(url, accept)
+	if err != nil {
+		return nil, -1, err
+	}
 	resp, length, err := getHTTPResponse(req)
 	if err == nil {
 		return resp, length, nil
@@ -443,6 +447,11 @@ func (source *githubSource) getHTTPResponse(
 	// Wrap 403 rate limit errors with a more helpful message.
 	var downErr *downloadError
 	if !errors.As(err, &downErr) || downErr.code != 403 {
+		// If we see a 401 error and were using a token we'll disable that token and try again
+		if downErr != nil && downErr.code == 401 && source.token != "" {
+			source.token = ""
+			return source.getHTTPResponse(getHTTPResponse, url, accept)
+		}
 		return nil, -1, err
 	}
 
@@ -474,11 +483,7 @@ func (source *githubSource) GetLatestVersion(
 		"https://%s/repos/%s/%s/releases/latest",
 		source.host, source.organization, source.repository)
 	logging.V(9).Infof("plugin GitHub releases url: %s", releaseURL)
-	req, err := source.newHTTPRequest(releaseURL, "application/json")
-	if err != nil {
-		return nil, err
-	}
-	resp, length, err := source.getHTTPResponse(getHTTPResponse, req)
+	resp, length, err := source.getHTTPResponse(getHTTPResponse, releaseURL, "application/json")
 	if err != nil {
 		return nil, err
 	}
@@ -506,12 +511,7 @@ func (source *githubSource) Download(
 		"https://%s/repos/%s/%s/releases/tags/v%s",
 		source.host, source.organization, source.repository, version)
 	logging.V(9).Infof("plugin GitHub releases url: %s", releaseURL)
-
-	req, err := source.newHTTPRequest(releaseURL, "application/json")
-	if err != nil {
-		return nil, -1, err
-	}
-	resp, length, err := source.getHTTPResponse(getHTTPResponse, req)
+	resp, length, err := source.getHTTPResponse(getHTTPResponse, releaseURL, "application/json")
 	if err != nil {
 		return nil, -1, err
 	}
@@ -541,12 +541,7 @@ func (source *githubSource) Download(
 	}
 
 	logging.V(1).Infof("%s downloading from %s", source.name, assetURL)
-
-	req, err = source.newHTTPRequest(assetURL, "application/octet-stream")
-	if err != nil {
-		return nil, -1, err
-	}
-	return source.getHTTPResponse(getHTTPResponse, req)
+	return source.getHTTPResponse(getHTTPResponse, assetURL, "application/octet-stream")
 }
 
 func (source *githubSource) URL() string {

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -689,6 +689,57 @@ func TestPluginDownload(t *testing.T) {
 		assert.Equal(t, int(l), len(readBytes))
 		assert.Equal(t, expectedBytes, readBytes)
 	})
+	t.Run("GitHub Releases with invalid token", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", token)
+		version := semver.MustParse("4.32.0")
+		spec := PluginSpec{
+			PluginDownloadURL: "",
+			Name:              "mockdl",
+			Version:           &version,
+			Kind:              apitype.PluginKind("resource"),
+		}
+		source, err := spec.GetSource()
+		require.NoError(t, err)
+		attempts := 0
+		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
+			attempts++
+
+			if req.Header.Get("Authorization") == "token "+token {
+				// Fail with a 401 Unauthorized
+				return nil, -1, &downloadError{code: 401}
+			}
+
+			if req.URL.String() == "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/tags/v4.32.0" {
+				assert.Equal(t, "", req.Header.Get("Authorization"))
+				assert.Equal(t, "application/json", req.Header.Get("Accept"))
+				// Minimal JSON from the releases API to get the test to pass
+				return newMockReadCloserString(`{
+					"assets": [
+					  {
+						"url": "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/assets/654321",
+						"name": "pulumi-mockdl_4.32.0_checksums.txt"
+					  },
+					  {
+						"url": "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/assets/123456",
+						"name": "pulumi-resource-mockdl-v4.32.0-darwin-amd64.tar.gz"
+					  }
+					]
+				  }
+				`)
+			}
+
+			assert.Equal(t, "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/assets/123456", req.URL.String())
+			assert.Equal(t, "application/octet-stream", req.Header.Get("Accept"))
+			return newMockReadCloser(expectedBytes)
+		}
+		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
+		require.NoError(t, err)
+		readBytes, err := io.ReadAll(r)
+		require.NoError(t, err)
+		assert.Equal(t, 3, attempts) // Failed attempt, then two successful attempts, first for the tag then the asset.
+		assert.Equal(t, int(l), len(readBytes))
+		assert.Equal(t, expectedBytes, readBytes)
+	})
 }
 
 //nolint:paralleltest // mutates environment variables


### PR DESCRIPTION
Part one of fixing https://github.com/pulumi/pulumi/issues/17217. This disables and retries the plugin http request without GITUHB_TOKEN if we get a 401 error.

This should help with cases where people have tokens that don't have access to public resources. We'll see the 401 and retry without the token set.

This doesn't fix the other part of #17217 to retry 403 error without the token.