### PR TITLE
[sdk/nodejs] Short-circuit output invokes if inputs contains unknowns

### DIFF
--- a/changelog/pending/20240924--sdk-nodejs--short-circuit-output-invokes-if-inputs-contains-unknowns.yaml
+++ b/changelog/pending/20240924--sdk-nodejs--short-circuit-output-invokes-if-inputs-contains-unknowns.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Short-circuit output invokes if inputs contains unknowns

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -791,7 +791,6 @@ class Unknown {
 /**
  * {@link unknown} is the singleton {@link Unknown} value.
  *
- * @internal
  */
 export const unknown = new Unknown();
 

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -589,15 +589,23 @@ export function unwrapRpcSecret(obj: any): any {
     return obj.value;
 }
 
-export function containsUnknownValues(value: any): boolean {
+/** @internal */
+export function containsUnknownValues(value: unknown): boolean {
     if (value === unknownValue) {
         return true;
-    } else if (value === null || typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
+    } else if (
+        value === null ||
+        value === undefined ||
+        typeof value === "boolean" ||
+        typeof value === "number" ||
+        typeof value === "string"
+    ) {
         return false;
     } else if (value instanceof Array) {
         return value.some(containsUnknownValues);
     } else {
-        return Object.keys(value).some((k) => containsUnknownValues(value[k]));
+        const map = value as Record<string, unknown>;
+        return Object.keys(map).some((key) => containsUnknownValues(map[key]));
     }
 }
 

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -589,6 +589,18 @@ export function unwrapRpcSecret(obj: any): any {
     return obj.value;
 }
 
+export function containsUnknownValues(value: any): boolean {
+    if (value === unknownValue) {
+        return true;
+    } else if (value === null || typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
+        return false;
+    } else if (value instanceof Array) {
+        return value.some(containsUnknownValues);
+    } else {
+        return Object.keys(value).some((k) => containsUnknownValues(value[k]));
+    }
+}
+
 /**
  * Unpacks some special types, reversing the process undertaken by
  * {@link serializeProperty}.

--- a/tests/testdata/codegen/output-funcs/nodejs-extras/tests/codegen.spec.ts
+++ b/tests/testdata/codegen/output-funcs/nodejs-extras/tests/codegen.spec.ts
@@ -144,6 +144,20 @@ describe("output-funcs", () => {
         });
     });
 
+    it("listStorageAccountKeysOutput with unknown inputs returns unknown", (done) => {
+        const output = sut.listStorageAccountKeysOutput({
+            accountName: pulumi.output("my-account-name"),
+            resourceGroupName: pulumi.output("my-resource-group-name"),
+            expand: pulumi.unknown as any,
+        });
+
+        output.apply((res) => {
+            done(new Error("apply should not be called when the result is unknown"));
+        });
+
+        setTimeout(done, 1000);
+    });
+
     it("getIntegrationRuntimeObjectMetadatumOutput", (done) => {
         checkTable(
             done,


### PR DESCRIPTION
### Description

#17237 introduced output invokes that don't rely on plain invokes, however since they now no longer await inputs in the generated provider sdks and instead await them in the core sdk, we should short-circuit the output invoke if it contained any unknown values so that the behaviour matches what was happening before the change. 

Fixes #17363