### PR TITLE
Test pyright and mypy in python conformance tests

### DIFF
--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -306,6 +306,7 @@ func (g *generator) genComponentDefinition(w io.Writer, component *pcl.Component
 func GenerateProject(
 	directory string, project workspace.Project,
 	program *pcl.Program, localDependencies map[string]string,
+	typechecker string,
 ) error {
 	files, diagnostics, err := GenerateProgram(program)
 	if err != nil {
@@ -331,6 +332,13 @@ func GenerateProject(
 		options = map[string]interface{}{
 			"virtualenv": "venv",
 		}
+	}
+
+	if typechecker != "" {
+		if options == nil {
+			options = map[string]interface{}{}
+		}
+		options["typechecker"] = typechecker
 	}
 
 	// Set the runtime to "python" then marshal to Pulumi.yaml
@@ -378,6 +386,11 @@ func GenerateProject(
 				requirementsTxtLines = append(requirementsTxtLines, packageName)
 			}
 		}
+	}
+
+	// If a typechecker is given we need to list that in the requirements.txt as well
+	if typechecker != "" {
+		requirementsTxtLines = append(requirementsTxtLines, typechecker)
 	}
 
 	// We want the requirements.txt files we generate to be stable, so we sort the

--- a/pkg/codegen/python/gen_program_test.go
+++ b/pkg/codegen/python/gen_program_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
@@ -84,8 +85,13 @@ func TestGenerateProgramVersionSelection(t *testing.T) {
 				},
 			},
 
-			IsGenProject:    true,
-			GenProject:      GenerateProject,
+			IsGenProject: true,
+			GenProject: func(
+				directory string, project workspace.Project,
+				program *pcl.Program, localDependencies map[string]string,
+			) error {
+				return GenerateProject(directory, project, program, localDependencies, "")
+			},
 			ExpectedVersion: expectedVersion,
 			DependencyFile:  "requirements.txt",
 		},

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-builtin-info/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-builtin-info/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-builtin-info
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-builtin-info/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-builtin-info/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-empty/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-empty/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-empty
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-empty/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-empty/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-main/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-main/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-main
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv
 main: subdir

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-main/subdir/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-main/subdir/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-array/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-array/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-output-array
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-array/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-array/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-bool/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-bool/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-output-bool
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-bool/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-bool/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-map/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-map/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-output-map
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-map/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-map/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-number/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-number/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-output-number
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-number/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-number/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-string/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-string/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-output-string
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-string/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-string/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-stack-reference/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-stack-reference/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-stack-reference
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-stack-reference/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-stack-reference/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-destroy/0/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-destroy/0/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-destroy
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-destroy/0/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-destroy/0/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-destroy/1/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-destroy/1/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-destroy
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-destroy/1/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-destroy/1/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-engine-update-options/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-engine-update-options/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-engine-update-options
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-engine-update-options/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-engine-update-options/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-explicit-provider/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-explicit-provider/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-explicit-provider
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-explicit-provider/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-explicit-provider/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-failed-create-continue-on-error/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-failed-create-continue-on-error/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-failed-create-continue-on-error
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-failed-create-continue-on-error/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-failed-create-continue-on-error/requirements.txt
@@ -1,3 +1,4 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_fail_on_create-4.0.0-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-simple/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-simple/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-invoke-simple
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-simple/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-simple/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple_invoke-10.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-variants/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-variants/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-invoke-variants
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-variants/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-variants/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple_invoke-10.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-large-string/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-large-string/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-large-string
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-large-string/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-large-string/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_large-4.3.2-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-plain/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-plain/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-plain
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-plain/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-plain/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_plain-13.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-primitive-ref/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-primitive-ref/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-primitive-ref
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-primitive-ref/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-primitive-ref/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_primitive_ref-11.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-ref-ref/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-ref-ref/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-ref-ref
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-ref-ref/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-ref-ref/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_ref_ref-12.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-alpha/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-alpha/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-resource-alpha
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-alpha/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-alpha/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_alpha-3.0.0a1+internal-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-asset-archive/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-asset-archive/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-asset-archive
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv
 main: subdir

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-asset-archive/subdir/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-asset-archive/subdir/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_asset_archive-5.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-config/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-config/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-resource-config
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-config/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-config/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_config-9.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-primitives/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-primitives/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-resource-primitives
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-primitives/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-primitives/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_primitive-7.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-simple/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-simple/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-resource-simple
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-simple/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-simple/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-target-up-with-new-dependency/0/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-target-up-with-new-dependency/0/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-target-up-with-new-dependency
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-target-up-with-new-dependency/0/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-target-up-with-new-dependency/0/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-target-up-with-new-dependency/1/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-target-up-with-new-dependency/1/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-target-up-with-new-dependency
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-target-up-with-new-dependency/1/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-target-up-with-new-dependency/1/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-builtin-info/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-builtin-info/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-builtin-info
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-builtin-info/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-builtin-info/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-empty/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-empty/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-empty
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-empty/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-empty/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-main/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-main/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-main
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv
 main: subdir

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-main/subdir/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-main/subdir/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-array/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-array/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-output-array
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-array/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-array/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-bool/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-bool/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-output-bool
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-bool/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-bool/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-map/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-map/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-output-map
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-map/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-map/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-number/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-number/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-output-number
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-number/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-number/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-string/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-string/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-output-string
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-string/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-string/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-stack-reference/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-stack-reference/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-stack-reference
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-stack-reference/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-stack-reference/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-destroy/0/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-destroy/0/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-destroy
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-destroy/0/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-destroy/0/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-destroy/1/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-destroy/1/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-destroy
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-destroy/1/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-destroy/1/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-engine-update-options/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-engine-update-options/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-engine-update-options
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-engine-update-options/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-engine-update-options/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-explicit-provider/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-explicit-provider/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-explicit-provider
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-explicit-provider/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-explicit-provider/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-failed-create-continue-on-error/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-failed-create-continue-on-error/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-failed-create-continue-on-error
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-failed-create-continue-on-error/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-failed-create-continue-on-error/requirements.txt
@@ -1,3 +1,4 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_fail_on_create-4.0.0-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-simple/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-simple/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-invoke-simple
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-simple/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-simple/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple_invoke-10.0.0-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-variants/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-variants/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-invoke-variants
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-variants/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-variants/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple_invoke-10.0.0-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-large-string/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-large-string/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-large-string
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-large-string/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-large-string/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_large-4.3.2-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-plain/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-plain/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-plain
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-plain/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-plain/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_plain-13.0.0-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-primitive-ref/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-primitive-ref/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-primitive-ref
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-primitive-ref/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-primitive-ref/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_primitive_ref-11.0.0-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-ref-ref/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-ref-ref/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-ref-ref
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-ref-ref/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-ref-ref/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_ref_ref-12.0.0-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-alpha/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-alpha/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-resource-alpha
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-alpha/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-alpha/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_alpha-3.0.0a1+internal-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-asset-archive/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-asset-archive/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-asset-archive
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv
 main: subdir

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-asset-archive/subdir/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-asset-archive/subdir/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_asset_archive-5.0.0-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-config/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-config/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-resource-config
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-config/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-config/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_config-9.0.0-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-primitives/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-primitives/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-resource-primitives
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-primitives/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-primitives/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_primitive-7.0.0-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-simple/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-simple/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-resource-simple
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-simple/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-simple/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-target-up-with-new-dependency/0/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-target-up-with-new-dependency/0/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-target-up-with-new-dependency
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-target-up-with-new-dependency/0/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-target-up-with-new-dependency/0/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-target-up-with-new-dependency/1/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-target-up-with-new-dependency/1/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-target-up-with-new-dependency
 runtime:
   name: python
   options:
+    typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-target-up-with-new-dependency/1/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-target-up-with-new-dependency/1/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+mypy

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-builtin-info/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-builtin-info/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-builtin-info
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-builtin-info/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-builtin-info/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-empty/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-empty/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-empty
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-empty/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-empty/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-main/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-main/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-main
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv
 main: subdir

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-main/subdir/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-main/subdir/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-array/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-array/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-output-array
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-array/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-array/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-bool/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-bool/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-output-bool
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-bool/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-bool/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-map/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-map/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-output-map
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-map/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-map/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-number/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-number/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-output-number
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-number/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-number/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-string/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-string/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-output-string
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-string/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-string/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-stack-reference/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-stack-reference/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l1-stack-reference
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-stack-reference/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-stack-reference/requirements.txt
@@ -1,1 +1,2 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-destroy/0/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-destroy/0/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-destroy
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-destroy/0/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-destroy/0/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-destroy/1/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-destroy/1/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-destroy
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-destroy/1/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-destroy/1/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-engine-update-options/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-engine-update-options/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-engine-update-options
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-engine-update-options/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-engine-update-options/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-explicit-provider/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-explicit-provider/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-explicit-provider
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-explicit-provider/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-explicit-provider/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-failed-create-continue-on-error/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-failed-create-continue-on-error/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-failed-create-continue-on-error
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-failed-create-continue-on-error/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-failed-create-continue-on-error/requirements.txt
@@ -1,3 +1,4 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_fail_on_create-4.0.0-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-simple/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-simple/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-invoke-simple
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-simple/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-simple/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple_invoke-10.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-variants/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-variants/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-invoke-variants
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-variants/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-variants/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple_invoke-10.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-large-string/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-large-string/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-large-string
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-large-string/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-large-string/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_large-4.3.2-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-plain/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-plain/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-plain
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-plain/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-plain/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_plain-13.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-primitive-ref/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-primitive-ref/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-primitive-ref
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-primitive-ref/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-primitive-ref/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_primitive_ref-11.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-ref-ref/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-ref-ref/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-ref-ref
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-ref-ref/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-ref-ref/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_ref_ref-12.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-alpha/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-alpha/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-resource-alpha
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-alpha/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-alpha/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_alpha-3.0.0a1+internal-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-asset-archive/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-asset-archive/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-asset-archive
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv
 main: subdir

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-asset-archive/subdir/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-asset-archive/subdir/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_asset_archive-5.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-config/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-config/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-resource-config
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-config/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-config/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_config-9.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-primitives/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-primitives/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-resource-primitives
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-primitives/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-primitives/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_primitive-7.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-simple/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-simple/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-resource-simple
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-simple/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-simple/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-target-up-with-new-dependency/0/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-target-up-with-new-dependency/0/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-target-up-with-new-dependency
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-target-up-with-new-dependency/0/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-target-up-with-new-dependency/0/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+pyright

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-target-up-with-new-dependency/1/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-target-up-with-new-dependency/1/Pulumi.yaml
@@ -2,4 +2,5 @@ name: l2-target-up-with-new-dependency
 runtime:
   name: python
   options:
+    typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-target-up-with-new-dependency/1/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-target-up-with-new-dependency/1/requirements.txt
@@ -1,2 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
 ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+pyright


### PR DESCRIPTION
This adds an option to the python language host to emit the typechecker option during program gen. We set this to mypy and pyright in the conformance test to ensure our typing annotations are checked during conformance testing.

Might be there's some way to fit this into `new` and `convert` as well so people can set they want type checking.