### PR TITLE
Unskip TestEngineEventPerf

### DIFF
--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -56,12 +56,9 @@ func TestPrintfNodeJS(t *testing.T) {
 //
 //nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestEngineEventPerf(t *testing.T) {
-	t.Skip() // TODO[pulumi/pulumi#7883]
-
 	// Prior to pulumi/pulumi#2303, a preview or update would take ~40s.
 	// Since then, it should now be down to ~4s, with additional padding,
-	// since some Travis machines (especially the macOS ones) seem quite slow
-	// to begin with.
+	// to account for the fact that the test is running in CI.
 	benchmarkEnforcer := &assertPerfBenchmark{
 		T:                  t,
 		MaxPreviewDuration: 8 * time.Second,


### PR DESCRIPTION
It looks like this performance test was disabled in https://github.com/pulumi/pulumi/pull/8420 for being flaky, see https://github.com/pulumi/pulumi/issues/7883