### PR TITLE
Allow `Backend`s to define `DefaultSecretManager`s

### DIFF
--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -661,7 +661,7 @@ func (eng *languageTestServer) RunLanguageTest(
 			return nil, fmt.Errorf("parse test stack reference: %w", err)
 		}
 
-		s, err := testBackend.CreateStack(ctx, ref, "", nil)
+		s, err := testBackend.CreateStack(ctx, ref, "", nil, nil)
 		if err != nil {
 			return nil, fmt.Errorf("create test stack reference: %w", err)
 		}
@@ -900,7 +900,7 @@ func (eng *languageTestServer) RunLanguageTest(
 		}
 		var s backend.Stack
 		if i == 0 {
-			s, err = testBackend.CreateStack(ctx, stackReference, projectDir, nil)
+			s, err = testBackend.CreateStack(ctx, stackReference, projectDir, nil, nil)
 			if err != nil {
 				return nil, fmt.Errorf("create test stack: %w", err)
 			}

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -236,6 +236,13 @@ type Backend interface {
 
 	// Cancel the current update for the given stack.
 	CancelCurrentUpdate(ctx context.Context, stackRef StackReference) error
+
+	// DefaultSecretManager returns the default secrets manager to use for stacks created against this backend, or nil if
+	// it is not possible to determine a default secrets manager for a stack prior to its creation.
+	//
+	// When a stack has been instantiated, you should favor using the Stack.DefaultSecretManager method to get a default
+	// secrets manager for that stack.
+	DefaultSecretManager() (secrets.Manager, error)
 }
 
 // EnvironmentsBackend is an interface that defines an optional capability for a backend to work with environments.

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -165,8 +165,15 @@ type Backend interface {
 
 	// GetStack returns a stack object tied to this backend with the given name, or nil if it cannot be found.
 	GetStack(ctx context.Context, stackRef StackReference) (Stack, error)
-	// CreateStack creates a new stack with the given name and options that are specific to the backend provider.
-	CreateStack(ctx context.Context, stackRef StackReference, root string, opts *CreateStackOptions) (Stack, error)
+	// CreateStack creates a new stack with the given name, initial state and options that are specific to the
+	// backend provider.
+	CreateStack(
+		ctx context.Context,
+		stackRef StackReference,
+		root string,
+		initialState *apitype.UntypedDeployment,
+		opts *CreateStackOptions,
+	) (Stack, error)
 
 	// RemoveStack removes a stack with the given name.  If force is true, the stack will be removed even if it
 	// still contains resources.  Otherwise, if the stack contains resources, a non-nil error is returned, and the

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -701,8 +701,12 @@ func currentProjectContradictsWorkspace(stack *diyBackendReference) bool {
 	return proj.Name.String() != stack.project.String()
 }
 
-func (b *diyBackend) CreateStack(ctx context.Context, stackRef backend.StackReference,
-	root string, opts *backend.CreateStackOptions,
+func (b *diyBackend) CreateStack(
+	ctx context.Context,
+	stackRef backend.StackReference,
+	root string,
+	initialState *apitype.UntypedDeployment,
+	opts *backend.CreateStackOptions,
 ) (backend.Stack, error) {
 	if opts != nil && len(opts.Teams) > 0 {
 		return nil, backend.ErrTeamsNotSupported

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -49,6 +49,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/edit"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -1412,4 +1413,11 @@ func (b *diyBackend) CancelCurrentUpdate(ctx context.Context, stackRef backend.S
 	}
 
 	return nil
+}
+
+func (b *diyBackend) DefaultSecretManager() (secrets.Manager, error) {
+	// The default secrets manager for stacks against a DIY backend is a
+	// passphrase-based manager.
+	info := &workspace.ProjectStack{}
+	return passphrase.NewPromptingPassphraseSecretsManager(info, false /* rotatePassphraseSecretsProvider */)
 }

--- a/pkg/backend/diy/backend_legacy_test.go
+++ b/pkg/backend/diy/backend_legacy_test.go
@@ -51,7 +51,7 @@ func TestListStacksWithMultiplePassphrases_legacy(t *testing.T) {
 	// Create stack "a" and import a checkpoint with a secret
 	aStackRef, err := b.ParseStackReference("a")
 	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 	defer func() {
@@ -69,7 +69,7 @@ func TestListStacksWithMultiplePassphrases_legacy(t *testing.T) {
 	// Create stack "b" and import a checkpoint with a secret
 	bStackRef, err := b.ParseStackReference("b")
 	assert.NoError(t, err)
-	bStack, err := b.CreateStack(ctx, bStackRef, "", nil)
+	bStack, err := b.CreateStack(ctx, bStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, bStack)
 	defer func() {
@@ -133,7 +133,7 @@ func TestCancel_legacy(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check that trying to cancel a stack that isn't locked doesn't error
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 	err = b.CancelCurrentUpdate(ctx, aStackRef)
@@ -195,7 +195,7 @@ func TestRemoveMakesBackups_legacy(t *testing.T) {
 	// Check that creating a new stack doesn't make a backup file
 	aStackRef, err := lb.parseStackReference("a")
 	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 
@@ -238,7 +238,7 @@ func TestRenameWorks_legacy(t *testing.T) {
 	// Create a new stack
 	aStackRef, err := lb.parseStackReference("a")
 	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 
@@ -332,7 +332,7 @@ func TestHtmlEscaping_legacy(t *testing.T) {
 	// Create stack "a" and import a checkpoint with a secret
 	aStackRef, err := b.ParseStackReference("a")
 	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 	err = b.ImportDeployment(ctx, aStack, udep)
@@ -370,7 +370,7 @@ func TestDIYBackendRejectsStackInitOptions_legacy(t *testing.T) {
 	// • Simulate `pulumi stack init`, passing non-nil init options
 	fakeStackRef, err := diy.ParseStackReference("foobar")
 	assert.NoError(t, err)
-	_, err = diy.CreateStack(ctx, fakeStackRef, "", illegalOptions)
+	_, err = diy.CreateStack(ctx, fakeStackRef, "", nil, illegalOptions)
 	assert.ErrorIs(t, err, backend.ErrTeamsNotSupported)
 }
 

--- a/pkg/backend/diy/backend_test.go
+++ b/pkg/backend/diy/backend_test.go
@@ -67,7 +67,7 @@ func TestEnabledFullyQualifiedStackNames(t *testing.T) {
 	ref, err := b.ParseStackReference(stackName)
 	require.NoError(t, err)
 
-	s, err := b.CreateStack(ctx, ref, "", nil)
+	s, err := b.CreateStack(ctx, ref, "", nil, nil)
 	require.NoError(t, err)
 
 	previous := cmdutil.FullyQualifyStackNames
@@ -105,7 +105,7 @@ func TestDisabledFullyQualifiedStackNames(t *testing.T) {
 	ref, err := b.ParseStackReference(stackName)
 	require.NoError(t, err)
 
-	s, err := b.CreateStack(ctx, ref, "", nil)
+	s, err := b.CreateStack(ctx, ref, "", nil, nil)
 	require.NoError(t, err)
 
 	previous := cmdutil.FullyQualifyStackNames
@@ -280,7 +280,7 @@ func TestListStacksWithMultiplePassphrases(t *testing.T) {
 	// Create stack "a" and import a checkpoint with a secret
 	aStackRef, err := b.ParseStackReference("organization/project/a")
 	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 	defer func() {
@@ -298,7 +298,7 @@ func TestListStacksWithMultiplePassphrases(t *testing.T) {
 	// Create stack "b" and import a checkpoint with a secret
 	bStackRef, err := b.ParseStackReference("organization/project/b")
 	assert.NoError(t, err)
-	bStack, err := b.CreateStack(ctx, bStackRef, "", nil)
+	bStack, err := b.CreateStack(ctx, bStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, bStack)
 	defer func() {
@@ -362,7 +362,7 @@ func TestCancel(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check that trying to cancel a stack that isn't locked doesn't error
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 	err = b.CancelCurrentUpdate(ctx, aStackRef)
@@ -424,7 +424,7 @@ func TestRemoveMakesBackups(t *testing.T) {
 	// Check that creating a new stack doesn't make a backup file
 	aStackRef, err := lb.parseStackReference("organization/project/a")
 	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 
@@ -467,7 +467,7 @@ func TestRenameWorks(t *testing.T) {
 	// Create a new stack
 	aStackRef, err := lb.parseStackReference("organization/project/a")
 	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 
@@ -531,7 +531,7 @@ func TestRenamePreservesIntegrity(t *testing.T) {
 
 	stackRef, err := b.ParseStackReference("organization/project/a")
 	assert.NoError(t, err)
-	stk, err := b.CreateStack(ctx, stackRef, "", nil)
+	stk, err := b.CreateStack(ctx, stackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, stk)
 
@@ -640,7 +640,7 @@ func TestRenameProjectWorks(t *testing.T) {
 	// Create a new stack
 	aStackRef, err := lb.parseStackReference("organization/project/a")
 	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 
@@ -741,7 +741,7 @@ func TestHtmlEscaping(t *testing.T) {
 	// Create stack "a" and import a checkpoint with a secret
 	aStackRef, err := b.ParseStackReference("organization/project/a")
 	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 	err = b.ImportDeployment(ctx, aStack, udep)
@@ -778,7 +778,7 @@ func TestDIYBackendRejectsStackInitOptions(t *testing.T) {
 	// • Simulate `pulumi stack init`, passing non-nil init options
 	fakeStackRef, err := diy.ParseStackReference("organization/b/foobar")
 	assert.NoError(t, err)
-	_, err = diy.CreateStack(ctx, fakeStackRef, "", illegalOptions)
+	_, err = diy.CreateStack(ctx, fakeStackRef, "", nil, illegalOptions)
 	assert.ErrorIs(t, err, backend.ErrTeamsNotSupported)
 }
 
@@ -813,7 +813,7 @@ func TestLegacyFolderStructure(t *testing.T) {
 	bRef, err := b.ParseStackReference("b")
 	assert.NoError(t, err)
 	assert.Equal(t, "b", bRef.String())
-	bStack, err := b.CreateStack(ctx, bRef, "", nil)
+	bStack, err := b.CreateStack(ctx, bRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "b", bStack.Ref().String())
 	assert.FileExists(t, path.Join(tmpDir, ".pulumi", "stacks", "b.json"))
@@ -831,12 +831,12 @@ func TestListStacksFilter(t *testing.T) {
 	// Create two different project stack
 	aRef, err := b.ParseStackReference("organization/proj1/a")
 	assert.NoError(t, err)
-	_, err = b.CreateStack(ctx, aRef, "", nil)
+	_, err = b.CreateStack(ctx, aRef, "", nil, nil)
 	assert.NoError(t, err)
 
 	bRef, err := b.ParseStackReference("organization/proj2/b")
 	assert.NoError(t, err)
-	_, err = b.CreateStack(ctx, bRef, "", nil)
+	_, err = b.CreateStack(ctx, bRef, "", nil, nil)
 	assert.NoError(t, err)
 
 	// Check that list stack with a filter only shows one stack
@@ -866,7 +866,7 @@ func TestOptIntoLegacyFolderStructure(t *testing.T) {
 	foo, err := b.ParseStackReference("foo")
 	require.NoError(t, err)
 
-	_, err = b.CreateStack(ctx, foo, "", nil)
+	_, err = b.CreateStack(ctx, foo, "", nil, nil)
 	require.NoError(t, err)
 	assert.FileExists(t, filepath.Join(tmpDir, ".pulumi", "stacks", "foo.json"))
 }
@@ -1000,7 +1000,7 @@ func TestProjectFolderStructure(t *testing.T) {
 	bRef, err := b.ParseStackReference("organization/testproj/b")
 	assert.NoError(t, err)
 	assert.Equal(t, "organization/testproj/b", bRef.String())
-	bStack, err := b.CreateStack(ctx, bRef, "", nil)
+	bStack, err := b.CreateStack(ctx, bRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "organization/testproj/b", bStack.Ref().String())
 	assert.FileExists(t, path.Join(tmpDir, ".pulumi", "stacks", "testproj", "b.json"))
@@ -1040,7 +1040,7 @@ func TestProjectNameMustMatch(t *testing.T) {
 	aRef, err := b.ParseStackReference("a")
 	assert.NoError(t, err)
 	assert.Equal(t, "a", aRef.String())
-	aStack, err := b.CreateStack(ctx, aRef, "", nil)
+	aStack, err := b.CreateStack(ctx, aRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "a", aStack.Ref().String())
 	assert.FileExists(t, path.Join(tmpDir, ".pulumi", "stacks", "my-project", "a.json"))
@@ -1049,7 +1049,7 @@ func TestProjectNameMustMatch(t *testing.T) {
 	bRef, err := b.ParseStackReference("organization/not-my-project/b")
 	assert.NoError(t, err)
 	assert.Equal(t, "organization/not-my-project/b", bRef.String())
-	bStack, err := b.CreateStack(ctx, bRef, "", nil)
+	bStack, err := b.CreateStack(ctx, bRef, "", nil, nil)
 	assert.Error(t, err)
 	assert.Nil(t, bStack)
 
@@ -1057,7 +1057,7 @@ func TestProjectNameMustMatch(t *testing.T) {
 	cRef, err := b.ParseStackReference("organization/my-project/c")
 	assert.NoError(t, err)
 	assert.Equal(t, "c", cRef.String())
-	cStack, err := b.CreateStack(ctx, cRef, "", nil)
+	cStack, err := b.CreateStack(ctx, cRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "c", cStack.Ref().String())
 	assert.FileExists(t, path.Join(tmpDir, ".pulumi", "stacks", "my-project", "c.json"))
@@ -1506,7 +1506,7 @@ func TestCreateStack_gzip(t *testing.T) {
 	fooRef, err := b.ParseStackReference("foo")
 	require.NoError(t, err)
 
-	_, err = b.CreateStack(ctx, fooRef, "", nil)
+	_, err = b.CreateStack(ctx, fooRef, "", nil, nil)
 	require.NoError(t, err)
 
 	// With PULUMI_DIY_BACKEND_GZIP enabled,
@@ -1534,7 +1534,7 @@ func TestCreateStack_retainCheckpoints(t *testing.T) {
 	fooRef, err := b.ParseStackReference("foo")
 	require.NoError(t, err)
 
-	_, err = b.CreateStack(ctx, fooRef, "", nil)
+	_, err = b.CreateStack(ctx, fooRef, "", nil, nil)
 	require.NoError(t, err)
 
 	// With PULUMI_RETAIN_CHECKPOINTS enabled,
@@ -1568,7 +1568,7 @@ func TestDisableIntegrityChecking(t *testing.T) {
 	ref, err := b.ParseStackReference("stack")
 	require.NoError(t, err)
 
-	s, err := b.CreateStack(ctx, ref, "", nil)
+	s, err := b.CreateStack(ctx, ref, "", nil, nil)
 	require.NoError(t, err)
 
 	// make up a bad stack

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -2163,3 +2163,10 @@ func decodeCapabilities(wireLevel []apitype.APICapabilityConfig) (capabilities, 
 	}
 	return parsed, nil
 }
+
+func (b *cloudBackend) DefaultSecretManager() (secrets.Manager, error) {
+	// The default secrets manager for a cloud-backed stack is a cloud secrets manager, which is inherently
+	// stack-specific. Thus at the backend level we return nil, deferring to Stack.DefaultSecretManager when the stack has
+	// been created.
+	return nil, nil
+}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -940,7 +940,10 @@ func currentProjectContradictsWorkspace(project *workspace.Project, stack client
 }
 
 func (b *cloudBackend) CreateStack(
-	ctx context.Context, stackRef backend.StackReference, root string,
+	ctx context.Context,
+	stackRef backend.StackReference,
+	root string,
+	initialState *apitype.UntypedDeployment,
 	opts *backend.CreateStackOptions,
 ) (
 	backend.Stack, error,
@@ -964,7 +967,7 @@ func (b *cloudBackend) CreateStack(
 		return nil, fmt.Errorf("getting stack tags: %w", err)
 	}
 
-	apistack, err := b.client.CreateStack(ctx, stackID, tags, opts.Teams)
+	apistack, err := b.client.CreateStack(ctx, stackID, tags, opts.Teams, nil)
 	if err != nil {
 		// Wire through well-known error types.
 		if errResp, ok := err.(*apitype.ErrorResponse); ok && errResp.Code == http.StatusConflict {

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -52,7 +52,7 @@ func TestEnabledFullyQualifiedStackNames(t *testing.T) {
 	ref, err := b.ParseStackReference(stackName)
 	require.NoError(t, err)
 
-	s, err := b.CreateStack(ctx, ref, "", nil)
+	s, err := b.CreateStack(ctx, ref, "", nil, nil)
 	require.NoError(t, err)
 
 	previous := cmdutil.FullyQualifyStackNames
@@ -87,7 +87,7 @@ func TestDisabledFullyQualifiedStackNames(t *testing.T) {
 	ref, err := b.ParseStackReference(stackName)
 	require.NoError(t, err)
 
-	s, err := b.CreateStack(ctx, ref, "", nil)
+	s, err := b.CreateStack(ctx, ref, "", nil, nil)
 	require.NoError(t, err)
 
 	previous := cmdutil.FullyQualifyStackNames
@@ -243,7 +243,7 @@ func TestDisableIntegrityChecking(t *testing.T) {
 	ref, err := b.ParseStackReference(stackName)
 	require.NoError(t, err)
 
-	s, err := b.CreateStack(ctx, ref, "", nil)
+	s, err := b.CreateStack(ctx, ref, "", nil, nil)
 	require.NoError(t, err)
 
 	// make up a bad stack

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -414,7 +414,11 @@ func (pc *Client) GetStack(ctx context.Context, stackID StackIdentifier) (apityp
 
 // CreateStack creates a stack with the given cloud and stack name in the scope of the indicated project.
 func (pc *Client) CreateStack(
-	ctx context.Context, stackID StackIdentifier, tags map[apitype.StackTagName]string, teams []string,
+	ctx context.Context,
+	stackID StackIdentifier,
+	tags map[apitype.StackTagName]string,
+	teams []string,
+	state *apitype.UntypedDeployment,
 ) (apitype.Stack, error) {
 	// Validate names and tags.
 	if err := validation.ValidateStackTags(tags); err != nil {
@@ -431,6 +435,7 @@ func (pc *Client) CreateStack(
 		StackName: stackID.Stack.String(),
 		Tags:      tags,
 		Teams:     teams,
+		State:     state,
 	}
 
 	endpoint := fmt.Sprintf("/api/stacks/%s/%s", stackID.Owner, stackID.Project)

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -91,6 +91,8 @@ type MockBackend struct {
 		operations.LogQuery) ([]operations.LogEntry, error)
 
 	CancelCurrentUpdateF func(ctx context.Context, stackRef StackReference) error
+
+	DefaultSecretManagerF func() (secrets.Manager, error)
 }
 
 var _ Backend = (*MockBackend)(nil)
@@ -428,6 +430,13 @@ func (be *MockBackend) GetStackDeploymentSettings(ctx context.Context,
 func (be *MockBackend) DestroyStackDeploymentSettings(ctx context.Context, stack Stack) error {
 	if be.DestroyStackDeploymentSettingsF != nil {
 		return be.DestroyStackDeploymentSettingsF(ctx, stack)
+	}
+	panic("not implemented")
+}
+
+func (be *MockBackend) DefaultSecretManager() (secrets.Manager, error) {
+	if be.DefaultSecretManagerF != nil {
+		return be.DefaultSecretManagerF()
 	}
 	panic("not implemented")
 }

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -51,9 +51,15 @@ type MockBackend struct {
 	ValidateStackNameF     func(s string) error
 	DoesProjectExistF      func(context.Context, string, string) (bool, error)
 	GetStackF              func(context.Context, StackReference) (Stack, error)
-	CreateStackF           func(context.Context, StackReference, string, *CreateStackOptions) (Stack, error)
-	RemoveStackF           func(context.Context, Stack, bool) (bool, error)
-	ListStacksF            func(context.Context, ListStacksFilter, ContinuationToken) (
+	CreateStackF           func(
+		context.Context,
+		StackReference,
+		string,
+		*apitype.UntypedDeployment,
+		*CreateStackOptions,
+	) (Stack, error)
+	RemoveStackF func(context.Context, Stack, bool) (bool, error)
+	ListStacksF  func(context.Context, ListStacksFilter, ContinuationToken) (
 		[]StackSummary, ContinuationToken, error)
 	RenameStackF                          func(context.Context, Stack, tokens.QName) (StackReference, error)
 	GetStackCrypterF                      func(StackReference) (config.Crypter, error)
@@ -214,11 +220,15 @@ func (be *MockBackend) GetStack(ctx context.Context, stackRef StackReference) (S
 	panic("not implemented")
 }
 
-func (be *MockBackend) CreateStack(ctx context.Context, stackRef StackReference,
-	root string, opts *CreateStackOptions,
+func (be *MockBackend) CreateStack(
+	ctx context.Context,
+	stackRef StackReference,
+	root string,
+	initialState *apitype.UntypedDeployment,
+	opts *CreateStackOptions,
 ) (Stack, error) {
 	if be.CreateStackF != nil {
-		return be.CreateStackF(ctx, stackRef, root, opts)
+		return be.CreateStackF(ctx, stackRef, root, initialState, opts)
 	}
 	panic("not implemented")
 }

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -67,7 +67,8 @@ type Stack interface {
 	// ImportDeployment imports the given deployment into this stack.
 	ImportDeployment(ctx context.Context, deployment *apitype.UntypedDeployment) error
 
-	// DefaultSecretManager returns the default secrets manager to use for this stack.
+	// DefaultSecretManager returns the default secrets manager to use for this stack. This may be more specific than
+	// Backend.DefaultSecretManager.
 	DefaultSecretManager(info *workspace.ProjectStack) (secrets.Manager, error)
 }
 

--- a/pkg/cmd/pulumi/stack_init_test.go
+++ b/pkg/cmd/pulumi/stack_init_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,6 +47,7 @@ func TestStackInit_teamsUnsupportedByBackend(t *testing.T) {
 			ctx context.Context,
 			ref backend.StackReference,
 			projectRoot string,
+			initialState *apitype.UntypedDeployment,
 			opts *backend.CreateStackOptions,
 		) (backend.Stack, error) {
 			assert.NotEmpty(t, opts.Teams, "expected teams to be set")

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -61,7 +61,7 @@ func createStackWithResources(
 	ref, err := b.ParseStackReference(stackName)
 	require.NoError(t, err)
 
-	s, err := b.CreateStack(ctx, ref, "", nil)
+	s, err := b.CreateStack(ctx, ref, "", nil, nil)
 	require.NoError(t, err)
 
 	err = b.ImportDeployment(ctx, s, udep)
@@ -534,14 +534,14 @@ func TestEmptySourceStack(t *testing.T) {
 	sourceRef, err := b.ParseStackReference(sourceStackName)
 	require.NoError(t, err)
 
-	sourceStack, err := b.CreateStack(ctx, sourceRef, "", nil)
+	sourceStack, err := b.CreateStack(ctx, sourceRef, "", nil, nil)
 	require.NoError(t, err)
 
 	destStackName := "organization/test/destStack"
 	destRef, err := b.ParseStackReference(destStackName)
 	require.NoError(t, err)
 
-	destStack, err := b.CreateStack(ctx, destRef, "", nil)
+	destStack, err := b.CreateStack(ctx, destRef, "", nil, nil)
 	require.NoError(t, err)
 
 	mp := &secrets.MockProvider{}
@@ -586,7 +586,7 @@ func TestEmptyDestStack(t *testing.T) {
 	destRef, err := b.ParseStackReference(destStackName)
 	require.NoError(t, err)
 
-	destStack, err := b.CreateStack(ctx, destRef, "", nil)
+	destStack, err := b.CreateStack(ctx, destRef, "", nil, nil)
 	require.NoError(t, err)
 
 	mp := &secrets.MockProvider{}
@@ -986,7 +986,7 @@ func TestMoveSecret(t *testing.T) {
 	destRef, err := b.ParseStackReference(destStackName)
 	require.NoError(t, err)
 
-	destStack, err := b.CreateStack(ctx, destRef, "", nil)
+	destStack, err := b.CreateStack(ctx, destRef, "", nil, nil)
 	require.NoError(t, err)
 
 	mp := &secrets.MockProvider{}
@@ -1085,7 +1085,7 @@ func TestMoveSecretOutsideOfProjectDir(t *testing.T) {
 	destRef, err := b.ParseStackReference(destStackName)
 	require.NoError(t, err)
 
-	destStack, err := b.CreateStack(ctx, destRef, "", nil)
+	destStack, err := b.CreateStack(ctx, destRef, "", nil, nil)
 	require.NoError(t, err)
 
 	mp := &secrets.MockProvider{}
@@ -1158,7 +1158,7 @@ func TestMoveSecretNotInDestProjectDir(t *testing.T) {
 	destRef, err := b.ParseStackReference(destStackName)
 	require.NoError(t, err)
 
-	destStack, err := b.CreateStack(ctx, destRef, "", nil)
+	destStack, err := b.CreateStack(ctx, destRef, "", nil, nil)
 	require.NoError(t, err)
 
 	mp := &secrets.MockProvider{}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -265,7 +265,7 @@ func createStack(ctx context.Context, ws pkgWorkspace.Context,
 	root string, opts *backend.CreateStackOptions, setCurrent bool,
 	secretsProvider string,
 ) (backend.Stack, error) {
-	stack, err := b.CreateStack(ctx, stackRef, root, opts)
+	stack, err := b.CreateStack(ctx, stackRef, root, nil, opts)
 	if err != nil {
 		// If it's a well-known error, don't wrap it.
 		if _, ok := err.(*backend.StackAlreadyExistsError); ok {


### PR DESCRIPTION
There are a number of cases where it would be useful to be able to seed a newly-created stack with an initial state. #17037 and its underlying issue, for instance, could be resolved by persisting a non-default secrets manager as part of stack initialisation rather than as a separate subsequent operation. In such cases, we want to be able to create a secrets manager for a stack before it has been created. Presently, the `Stack` interface offers `DefaultSecretManager` for asking what the default secret manager for a *stack* should be, but there is no way to ask a `Backend` what the default manager for *stacks associated with that backend* should be. This commit adds a `DefaultSecretManager` method to the `Backend` interface, along with appropriate implementations for DIY and HTTP backends.