### PR TITLE
Rename `createSecretsManager` to `createSecretsManagerForExistingStack`

### DIFF
--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -140,7 +140,7 @@ func (cmd *stackChangeSecretsProviderCmd) Run(ctx context.Context, args []string
 		// the current secrets provider is empty
 		((secretsProvider == "passphrase") && (currentProjectStack.SecretsProvider == ""))
 	// Create the new secrets provider and set to the currentStack
-	if err := createSecretsManager(ctx, ws, currentStack, secretsProvider, rotateProvider,
+	if err := createSecretsManagerForExistingStack(ctx, ws, currentStack, secretsProvider, rotateProvider,
 		false /*creatingStack*/); err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -173,7 +173,7 @@ func (cmd *stateMoveCmd) Run(
 		}
 
 		// The user is in the right directory.  If we fail below we will return the error of that failure.
-		err = createSecretsManager(ctx, cmd.ws, dest, "", false, true)
+		err = createSecretsManagerForExistingStack(ctx, cmd.ws, dest, "", false, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -206,7 +206,7 @@ func currentBackend(
 	return lm.Login(ctx, ws, cmdutil.Diag(), url, project, url == "", opts.Color)
 }
 
-func createSecretsManager(
+func createSecretsManagerForExistingStack(
 	ctx context.Context, ws pkgWorkspace.Context, stack backend.Stack, secretsProvider string,
 	rotateSecretsProvider, creatingStack bool,
 ) error {
@@ -277,7 +277,7 @@ func createStack(ctx context.Context, ws pkgWorkspace.Context,
 		return nil, fmt.Errorf("could not create stack: %w", err)
 	}
 
-	if err := createSecretsManager(ctx, ws, stack, secretsProvider,
+	if err := createSecretsManagerForExistingStack(ctx, ws, stack, secretsProvider,
 		false /*rotateSecretsManager*/, true /*creatingStack*/); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit is in preparation for creating secrets managers as part of state initialisation.