### PR TITLE
Persist initial states in DIY backend

### DIFF
--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -737,9 +737,21 @@ func (b *diyBackend) CreateStack(
 		return nil, &backend.StackAlreadyExistsError{StackName: string(stackName)}
 	}
 
-	_, err = b.saveStack(ctx, diyStackRef, nil, nil)
+	_, err = b.saveStack(ctx, diyStackRef, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if initialState != nil {
+		chk, err := stack.MarshalUntypedDeploymentToVersionedCheckpoint(stackName, initialState)
+		if err != nil {
+			return nil, err
+		}
+
+		_, _, err = b.saveCheckpoint(ctx, diyStackRef, chk)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	stack := newStack(diyStackRef, b)

--- a/pkg/backend/diy/snapshot.go
+++ b/pkg/backend/diy/snapshot.go
@@ -32,7 +32,7 @@ type diySnapshotPersister struct {
 }
 
 func (sp *diySnapshotPersister) Save(snapshot *deploy.Snapshot) error {
-	_, err := sp.backend.saveStack(sp.ctx, sp.ref, snapshot, snapshot.SecretsManager)
+	_, err := sp.backend.saveStack(sp.ctx, sp.ref, snapshot)
 	return err
 }
 

--- a/pkg/backend/diy/state.go
+++ b/pkg/backend/diy/state.go
@@ -297,7 +297,6 @@ func (b *diyBackend) saveCheckpoint(
 func (b *diyBackend) saveStack(
 	ctx context.Context,
 	ref *diyBackendReference, snap *deploy.Snapshot,
-	sm secrets.Manager,
 ) (string, error) {
 	contract.Requiref(ref != nil, "ref", "ref was nil")
 	chk, err := stack.SerializeCheckpoint(ref.FullyQualifiedName(), snap, false /* showSecrets */)

--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -140,7 +140,7 @@ func (cmd *stackChangeSecretsProviderCmd) Run(ctx context.Context, args []string
 		// the current secrets provider is empty
 		((secretsProvider == "passphrase") && (currentProjectStack.SecretsProvider == ""))
 	// Create the new secrets provider and set to the currentStack
-	if err := createSecretsManager(ctx, ws, currentStack, secretsProvider, rotateProvider,
+	if err := createSecretsManagerForExistingStack(ctx, ws, currentStack, secretsProvider, rotateProvider,
 		false /*creatingStack*/); err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -173,7 +173,7 @@ func (cmd *stateMoveCmd) Run(
 		}
 
 		// The user is in the right directory.  If we fail below we will return the error of that failure.
-		err = createSecretsManager(ctx, cmd.ws, dest, "", false, true)
+		err = createSecretsManagerForExistingStack(ctx, cmd.ws, dest, "", false, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -206,7 +206,7 @@ func currentBackend(
 	return lm.Login(ctx, ws, cmdutil.Diag(), url, project, url == "", opts.Color)
 }
 
-func createSecretsManager(
+func createSecretsManagerForExistingStack(
 	ctx context.Context, ws pkgWorkspace.Context, stack backend.Stack, secretsProvider string,
 	rotateSecretsProvider, creatingStack bool,
 ) error {
@@ -277,7 +277,7 @@ func createStack(ctx context.Context, ws pkgWorkspace.Context,
 		return nil, fmt.Errorf("could not create stack: %w", err)
 	}
 
-	if err := createSecretsManager(ctx, ws, stack, secretsProvider,
+	if err := createSecretsManagerForExistingStack(ctx, ws, stack, secretsProvider,
 		false /*rotateSecretsManager*/, true /*creatingStack*/); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There are a number of cases where it would be useful to be able to seed a newly-created stack with an initial state. #17037 and its underlying issue, for instance, could be resolved by persisting a non-default secrets manager as part of stack initialisation rather than as a separate subsequent operation. Now that `Backend.CreateStack` accepts an initial state, we can modify implementations to actually persist the new parameter. This commit does so for the DIY backend.