### PR TITLE
Add `property.Path` to the `property` library

### DIFF
--- a/changelog/pending/20240925--sdk-go--add-property-path-and-associated-functions.yaml
+++ b/changelog/pending/20240925--sdk-go--add-property-path-and-associated-functions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Add `property.Path` and associated functions.

--- a/sdk/go/property/path.go
+++ b/sdk/go/property/path.go
@@ -39,7 +39,7 @@ func (p Path) Get(v Value) (Value, PathApplyFailure) {
 
 // Set a value.
 //
-// Set does not src in place, rather producing a copy.
+// Set does not change src in place, rather producing a copy.
 func (p Path) Set(src, to Value) (Value, PathApplyFailure) {
 	if len(p) == 0 {
 		return to, nil
@@ -53,10 +53,10 @@ func (p Path) Set(src, to Value) (Value, PathApplyFailure) {
 	case v.IsArray():
 		i, ok := last.(IndexSegment)
 		if !ok {
-			return Value{}, pathErrorf(v, "expected an index step, found %T", last)
+			return Value{}, pathErrorf(v, "expected an IndexSegment, found %T", last)
 		}
 		if i.int < 0 || i.int > len(v.AsArray()) {
-			return Value{}, PathApplyIndexOutOfBounds{found: v.AsArray(), idx: i.int}
+			return Value{}, pathApplyIndexOutOfBoundsError{found: v.AsArray(), idx: i.int}
 		}
 		// We now want to set set v.AsArray()[i]=to, but we don't want to mutate v. We make
 		// a shallow copy of v and then alter that.
@@ -67,7 +67,7 @@ func (p Path) Set(src, to Value) (Value, PathApplyFailure) {
 	case v.IsMap():
 		k, ok := last.(KeySegment)
 		if !ok {
-			return Value{}, pathErrorf(v, "expected a key step, found %T", last)
+			return Value{}, pathErrorf(v, "expected a KeySegment, found %T", last)
 		}
 		// We now want to set set v.AsMap()[k]=to, but we don't want to mutate v. We make
 		// a shallow copy of v and then alter that.
@@ -133,9 +133,9 @@ func (k KeySegment) apply(v Value) (Value, PathApplyFailure) {
 		if ok {
 			return r, nil
 		}
-		return Value{}, PathApplyKeyMissing{found: m, needle: k.string}
+		return Value{}, pathApplyKeyMissingError{found: m, needle: k.string}
 	}
-	return Value{}, PathApplyKeyExpectedMap{found: v}
+	return Value{}, pathApplyKeyExpectedMapError{found: v}
 }
 
 type IndexSegment struct{ int }
@@ -144,72 +144,72 @@ func (k IndexSegment) apply(v Value) (Value, PathApplyFailure) {
 	if v.IsArray() {
 		a := v.AsArray()
 		if k.int < 0 || k.int >= len(a) {
-			return Value{}, PathApplyIndexOutOfBounds{found: a, idx: k.int}
+			return Value{}, pathApplyIndexOutOfBoundsError{found: a, idx: k.int}
 		}
 		return a[k.int], nil
 	}
-	return Value{}, PathApplyIndexExpectedArray{found: v}
+	return Value{}, pathApplyIndexExpectedArrayError{found: v}
 }
 
-type PathApplyKeyExpectedMap struct {
+type pathApplyKeyExpectedMapError struct {
 	found Value
 }
 
-func (err PathApplyKeyExpectedMap) Error() string {
+func (err pathApplyKeyExpectedMapError) Error() string {
 	return "expected a map, found a " + typeString(err.found)
 }
 
-func (err PathApplyKeyExpectedMap) Found() Value {
+func (err pathApplyKeyExpectedMapError) Found() Value {
 	return err.found
 }
 
-type PathApplyKeyMissing struct {
+type pathApplyKeyMissingError struct {
 	found  Map
 	needle string
 }
 
-func (err PathApplyKeyMissing) Error() string {
+func (err pathApplyKeyMissingError) Error() string {
 	return fmt.Sprintf("missing key %q in map", err.needle)
 }
 
-func (err PathApplyKeyMissing) Found() Value {
+func (err pathApplyKeyMissingError) Found() Value {
 	return New(err.found)
 }
 
-type PathApplyIndexExpectedArray struct {
+type pathApplyIndexExpectedArrayError struct {
 	found Value
 }
 
-func (err PathApplyIndexExpectedArray) Error() string {
+func (err pathApplyIndexExpectedArrayError) Error() string {
 	return "expected an array, found a " + typeString(err.found)
 }
 
-func (err PathApplyIndexExpectedArray) Found() Value {
+func (err pathApplyIndexExpectedArrayError) Found() Value {
 	return err.found
 }
 
-type PathApplyIndexOutOfBounds struct {
+type pathApplyIndexOutOfBoundsError struct {
 	found Array
 	idx   int
 }
 
-func (err PathApplyIndexOutOfBounds) Found() Value {
+func (err pathApplyIndexOutOfBoundsError) Found() Value {
 	return New(err.found)
 }
 
-func (err PathApplyIndexOutOfBounds) Error() string {
+func (err pathApplyIndexOutOfBoundsError) Error() string {
 	return fmt.Sprintf("index %d out of bounds of an array of length %d",
 		err.idx, len(err.found))
 }
 
 func pathErrorf(v Value, msg string, a ...any) PathApplyFailure {
-	return pathApplyFailure{found: v, msg: fmt.Sprintf(msg, a...)}
+	return pathApplyError{found: v, msg: fmt.Sprintf(msg, a...)}
 }
 
-type pathApplyFailure struct {
+type pathApplyError struct {
 	found Value
 	msg   string
 }
 
-func (err pathApplyFailure) Error() string { return err.msg }
-func (err pathApplyFailure) Found() Value  { return err.found }
+func (err pathApplyError) Error() string { return err.msg }
+func (err pathApplyError) Found() Value  { return err.found }

--- a/sdk/go/property/path.go
+++ b/sdk/go/property/path.go
@@ -1,0 +1,140 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import "fmt"
+
+// Path provides access and alteration methods on [Value]s.
+//
+// Path does not support glob ("*") expansion. Values are treated as is.
+type Path []PathSegment
+
+func (p Path) Get(v Value) (Value, PathApplyFailure) {
+	for _, segment := range p {
+		var err PathApplyFailure
+		v, err = segment.apply(v)
+		if err != nil {
+			return Value{}, err
+		}
+	}
+	return v, nil
+}
+
+func (p Path) Set(src, dst Value) PathApplyFailure {
+	panic("Unimplemented")
+}
+
+func (p Path) Alter(v Value, f func(v Value) Value) {
+	panic("Unimplemented")
+}
+
+type PathSegment interface {
+	apply(Value) (Value, PathApplyFailure)
+}
+
+func NewSegment[T interface{ string | int }](v T) PathSegment {
+	switch v := any(v).(type) {
+	case string:
+		return KeySegment{v}
+	case int:
+		return IndexSegment{v}
+	default:
+		panic("impossible")
+	}
+}
+
+type PathApplyFailure interface {
+	error
+
+	Found() Value
+}
+
+type KeySegment struct{ string }
+
+func (k KeySegment) apply(v Value) (Value, PathApplyFailure) {
+	if v.IsMap() {
+		m := v.AsMap()
+		r, ok := m[k.string]
+		if ok {
+			return r, nil
+		}
+		return Value{}, PathApplyKeyMissing{found: m, needle: k.string}
+	}
+	return Value{}, PathApplyKeyExpectedMap{found: v}
+}
+
+type IndexSegment struct{ int }
+
+func (k IndexSegment) apply(v Value) (Value, PathApplyFailure) {
+	if v.IsArray() {
+		a := v.AsArray()
+		if k.int < 0 || k.int >= len(a) {
+			return Value{}, PathApplyIndexOutOfBounds{found: a, idx: k.int}
+		}
+		return a[k.int], nil
+	}
+	return Value{}, PathApplyIndexExpectedArray{found: v}
+}
+
+type PathApplyKeyExpectedMap struct {
+	found Value
+}
+
+func (err PathApplyKeyExpectedMap) Error() string {
+	return fmt.Sprintf("expected a map, found a %s", typeString(err.found))
+}
+
+func (err PathApplyKeyExpectedMap) Found() Value {
+	return err.found
+}
+
+type PathApplyKeyMissing struct {
+	found  Map
+	needle string
+}
+
+func (err PathApplyKeyMissing) Error() string {
+	return fmt.Sprintf("missing key %q in map", err.needle)
+}
+
+func (err PathApplyKeyMissing) Found() Value {
+	return New(err.found)
+}
+
+type PathApplyIndexExpectedArray struct {
+	found Value
+}
+
+func (err PathApplyIndexExpectedArray) Error() string {
+	return fmt.Sprintf("expected an array, found a %s", typeString(err.found))
+}
+
+func (err PathApplyIndexExpectedArray) Found() Value {
+	return err.found
+}
+
+type PathApplyIndexOutOfBounds struct {
+	found Array
+	idx   int
+}
+
+func (err PathApplyIndexOutOfBounds) Found() Value {
+	return New(err.found)
+}
+
+func (err PathApplyIndexOutOfBounds) Error() string {
+	return fmt.Sprintf("index %d out of bounds of an array of length %d",
+		err.idx, len(err.found))
+}

--- a/sdk/go/property/path_test.go
+++ b/sdk/go/property/path_test.go
@@ -1,0 +1,183 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGet(t *testing.T) {
+	t.Parallel()
+
+	type pathFailure struct {
+		found property.Value
+		msg   string
+	}
+
+	tests := []struct {
+		name string
+		path property.Path
+
+		from     property.Value
+		expected property.Value
+
+		failure *pathFailure
+	}{
+		{
+			name: "map-key",
+			path: property.Path{
+				property.NewSegment("k"),
+			},
+			from: property.New(property.Map{
+				"k": property.New("v"),
+			}),
+			expected: property.New("v"),
+		},
+		{
+			name: "missing-key",
+			path: property.Path{
+				property.NewSegment("missing"),
+			},
+			from: property.New(property.Map{
+				"k": property.New("v"),
+			}),
+			failure: &pathFailure{
+				found: property.New(property.Map{
+					"k": property.New("v"),
+				}),
+				msg: `missing key "missing" in map`,
+			},
+		},
+		{
+			name: "expected-map",
+			path: property.Path{
+				property.NewSegment("missing"),
+			},
+			from: property.New(property.Array{
+				property.New("v"),
+			}),
+			failure: &pathFailure{
+				found: property.New(property.Array{
+					property.New("v"),
+				}),
+				msg: `expected a map, found a array`,
+			},
+		},
+		{
+			name: "array-idx",
+			path: property.Path{
+				property.NewSegment(1),
+			},
+			from: property.New(property.Array{
+				property.New("0"),
+				property.New("1"),
+			}),
+			expected: property.New("1"),
+		},
+		{
+			name: "expected-array",
+			path: property.Path{
+				property.NewSegment(0),
+			},
+			from: property.New("foo"),
+			failure: &pathFailure{
+				found: property.New("foo"),
+				msg:   `expected an array, found a string`,
+			},
+		},
+		{
+			name: "array-out-of-bounds",
+			path: property.Path{
+				property.NewSegment(1),
+			},
+			from: property.New(property.Array{
+				property.New("0"),
+			}),
+			failure: &pathFailure{
+				found: property.New(property.Array{
+					property.New("0"),
+				}),
+				msg: "index 1 out of bounds of an array of length 1",
+			},
+		},
+		{
+			name: "negative-array-index",
+			path: property.Path{
+				property.NewSegment(-1),
+			},
+			from: property.New(property.Array{
+				property.New("0"),
+			}),
+			failure: &pathFailure{
+				found: property.New(property.Array{
+					property.New("0"),
+				}),
+				msg: "index -1 out of bounds of an array of length 1",
+			},
+		},
+		{
+			name:     "empty-path-map",
+			path:     property.Path{},
+			from:     property.New(property.Map{"k": property.New(true)}),
+			expected: property.New(property.Map{"k": property.New(true)}),
+		},
+		{
+			name:     "empty-path-array",
+			path:     property.Path{},
+			from:     property.New(property.Array{property.New(true)}),
+			expected: property.New(property.Array{property.New(true)}),
+		},
+		{
+			name:     "empty-path-primitive",
+			path:     property.Path{},
+			from:     property.New(true),
+			expected: property.New(true),
+		},
+		{
+			name: "nested-access",
+			path: property.Path{
+				property.NewSegment("l1"),
+				property.NewSegment(0),
+				property.NewSegment("n1"),
+			},
+			from: property.New(property.Map{
+				"l0": property.New("l0-value"),
+				"l1": property.New(property.Array{
+					property.New(property.Map{
+						"n1": property.New("found"),
+					}),
+				}),
+			}),
+			expected: property.New("found"),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.path.Get(tt.from)
+			if tt.failure == nil {
+				assert.Equal(t, tt.expected, got)
+				assert.Nil(t, err)
+			} else {
+				assert.Equal(t, tt.failure.found, err.Found())
+				assert.Equal(t, tt.failure.msg, err.Error())
+			}
+		})
+	}
+}

--- a/sdk/go/property/type.go
+++ b/sdk/go/property/type.go
@@ -1,0 +1,48 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import "fmt"
+
+// typeString provides a type name for v.
+//
+// typeString should be used only to generate error messages. Do not rely on typeString
+// providing stable output.
+func typeString(v Value) string {
+	switch {
+	case v.IsArchive():
+		return "archive"
+	case v.IsArray():
+		return "array"
+	case v.IsAsset():
+		return "asset"
+	case v.IsBool():
+		return "bool"
+	case v.IsComputed():
+		return "computed"
+	case v.IsMap():
+		return "map"
+	case v.IsNull():
+		return "null"
+	case v.IsNumber():
+		return "number"
+	case v.IsResourceReference():
+		return "resource reference"
+	case v.IsString():
+		return "string"
+	default:
+		panic(fmt.Sprintf("unknown type %T", v.v))
+	}
+}

--- a/sdk/go/property/values.go
+++ b/sdk/go/property/values.go
@@ -273,13 +273,14 @@ func (v Value) Copy() Value {
 		dependencies: dependencies,
 		v:            value,
 	}
-
 }
 
 // WithGoValue creates a new Value with the inner value newGoValue.
 //
 // To set to a null or computed value, pass Null or Computed as newGoValue.
 func WithGoValue[T GoValue](value Value, newGoValue T) Value {
-	value.v = New(newGoValue).v
+	value.v = nil                   // Set v to nil so we don't deep copy it.
+	value = value.Copy()            // Copy metadata
+	value.v = normalize(newGoValue) // Set the new value in normalized form
 	return value
 }

--- a/sdk/go/property/values_test.go
+++ b/sdk/go/property/values_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 )
 
 // Calling == does not implement desirable behavior, so we ensure that it is invalid.
@@ -99,4 +100,97 @@ func TestNil(t *testing.T) {
 		assert.False(t, emptyString.IsNull())
 		assert.False(t, emptyString.Equals(nullValue))
 	})
+}
+
+func TestCopy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		value    func() Value
+		mutation func(Value)
+	}{
+		{
+			name: "map-value",
+			value: func() Value {
+				return New(Map{
+					"k": New("value"),
+				})
+			},
+			mutation: func(v Value) {
+				v.AsMap()["k"] = New("changed")
+			},
+		},
+		{
+			name: "map-deleted-key",
+			value: func() Value {
+				return New(Map{
+					"k": New("value"),
+				})
+			},
+			mutation: func(v Value) {
+				delete(v.AsMap(), "k")
+			},
+		},
+		{
+			name: "map-added-key",
+			value: func() Value {
+				return New(Map{
+					"k": New("value"),
+				})
+			},
+			mutation: func(v Value) {
+				v.AsMap()["k2"] = New("added")
+			},
+		},
+		{
+			name: "array-value",
+			value: func() Value {
+				return New(Array{
+					New(true),
+				})
+			},
+			mutation: func(v Value) {
+				v.AsArray()[0] = New(0.0)
+			},
+		},
+		{
+			name: "dependencies",
+			value: func() Value {
+				return New("hi").WithDependencies([]urn.URN{"urn1"})
+			},
+			mutation: func(v Value) {
+				v.Dependencies()[0] = "urn2"
+			},
+		},
+		{
+			name: "nested-value",
+			value: func() Value {
+				return New(Map{
+					"k": New(Array{
+						New(Map{
+							"v": New("nested"),
+						}),
+					}),
+				})
+			},
+			mutation: func(v Value) {
+				v.AsMap()["k"].AsArray()[0].AsMap()["new"] = New(true)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			v := tt.value()
+			cp := v.Copy()
+			tt.mutation(cp)
+
+			assert.Equal(t, v, tt.value())
+			assert.NotEqual(t, v, cp)
+		})
+	}
 }


### PR DESCRIPTION
For `property` to be a `resource.Property*` replacement, it needs to have a concept of paths.