### PR TITLE
Revert #17338 and #17127

### DIFF
--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -16,7 +16,6 @@ package httpstate
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -181,11 +180,6 @@ func (b *cloudBackend) newUpdate(ctx context.Context, stackRef backend.StackRefe
 			tok, err := b.Client().RenewUpdateLease(
 				ctx, update, currentToken, duration)
 			if err != nil {
-				// Translate 403 status codes to expired token errors to stop the token refresh loop.
-				var apierr apitype.ErrorResponse
-				if errors.As(err, &apierr) && apierr.Code == 403 {
-					return "", time.Time{}, expiredTokenError{err}
-				}
 				return "", time.Time{}, err
 			}
 			return tok, assumedExpires(), err


### PR DESCRIPTION
This reverts commit f3a8271fd02364d9a7af8b406245d041e26f5688 and 89bb75fe2c066e697e3412ae26da1c3670a36e4d.

These seem to have causes a massive increase in 403 traffic against the service. Reverting until we investigate and fix.