### PR TITLE
Add itime for deterministic time testing

### DIFF
--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/channel"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/itime"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -185,7 +186,7 @@ func (b *cloudBackend) newUpdate(ctx context.Context, stackRef backend.StackRefe
 			return tok, assumedExpires(), err
 		}
 
-		ts, err := newTokenSource(ctx, token, assumedExpires(), duration, renewLease)
+		ts, err := newTokenSource(ctx, itime.NewRealClock(), token, assumedExpires(), duration, renewLease)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/backend/httpstate/token_source.go
+++ b/pkg/backend/httpstate/token_source.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/itime"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
@@ -30,6 +31,7 @@ type tokenSourceCapability interface {
 type tokenSource struct {
 	requests chan tokenRequest
 	done     chan bool
+	clock    itime.Clock
 }
 
 var _ tokenSourceCapability = &tokenSource{}
@@ -43,6 +45,7 @@ type tokenResponse struct {
 
 func newTokenSource(
 	ctx context.Context,
+	clock itime.Clock,
 	initialToken string,
 	initialTokenExpires time.Time,
 	duration time.Duration,
@@ -53,7 +56,7 @@ func newTokenSource(
 	) (string, time.Time, error),
 ) (*tokenSource, error) {
 	requests, done := make(chan tokenRequest), make(chan bool)
-	ts := &tokenSource{requests: requests, done: done}
+	ts := &tokenSource{requests: requests, done: done, clock: clock}
 	go ts.handleRequests(ctx, initialToken, initialTokenExpires, duration, refreshToken)
 	return ts, nil
 }
@@ -69,7 +72,7 @@ func (ts *tokenSource) handleRequests(
 		currentToken string,
 	) (string, time.Time, error),
 ) {
-	renewTicker := time.NewTicker(duration / 8)
+	renewTicker := ts.clock.NewTicker(duration / 8)
 	defer renewTicker.Stop()
 
 	state := struct {
@@ -86,7 +89,7 @@ func (ts *tokenSource) handleRequests(
 			return
 		}
 
-		now := time.Now()
+		now := ts.clock.Now()
 
 		// We will renew the lease after 50% of the duration
 		// has elapsed to allow time for retries.
@@ -109,7 +112,7 @@ func (ts *tokenSource) handleRequests(
 
 	for {
 		select {
-		case <-renewTicker.C:
+		case <-renewTicker.C():
 			renewUpdateLeaseIfStale()
 		case c, ok := <-ts.requests:
 			if !ok {

--- a/sdk/go/common/itime/clock.go
+++ b/sdk/go/common/itime/clock.go
@@ -1,0 +1,58 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package itime
+
+import "time"
+
+// Clock is an interface that abstracts time.Now and time.NewTicker for testing.
+type Clock interface {
+	// Now returns the current time.
+	Now() time.Time
+	// NewTicker returns a new Ticker that will fire every d.
+	NewTicker(d time.Duration) Ticker
+}
+
+// Ticker is an interface that abstracts time.Ticker for testing.
+type Ticker interface {
+	C() <-chan time.Time
+	Stop()
+}
+
+type realTicker struct {
+	t *time.Ticker
+}
+
+func (rt realTicker) C() <-chan time.Time {
+	return rt.t.C
+}
+
+func (rt realTicker) Stop() {
+	rt.t.Stop()
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time {
+	return time.Now()
+}
+
+func (realClock) NewTicker(d time.Duration) Ticker {
+	return realTicker{time.NewTicker(d)}
+}
+
+// NewRealClock returns a Clock that uses the system clock.
+func NewRealClock() Clock {
+	return realClock{}
+}

--- a/sdk/go/common/itime/test_clock.go
+++ b/sdk/go/common/itime/test_clock.go
@@ -1,0 +1,106 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package itime
+
+import (
+	"slices"
+	"sync"
+	"time"
+)
+
+// TestClock is a Clock that can be manually advanced in time for testing. Unlike tickers from the real clock, test
+// tickers do not drop ticks if the channel is not read in time. They are buffered to thousands of ticks to allow easier
+// test writing.
+type TestClock struct {
+	now time.Time
+
+	mu      sync.Mutex
+	tickers []*testTicker
+}
+
+type testTicker struct {
+	c     chan time.Time
+	d     time.Duration
+	t     time.Time
+	clock *TestClock
+}
+
+func (tt *testTicker) C() <-chan time.Time {
+	return tt.c
+}
+
+func (tt *testTicker) Stop() {
+	tt.clock.mu.Lock()
+	defer tt.clock.mu.Unlock()
+	i := slices.Index(tt.clock.tickers, tt)
+	tt.clock.tickers = slices.Delete(tt.clock.tickers, i, i+1)
+}
+
+func (tc *TestClock) Now() time.Time {
+	return tc.now
+}
+
+func (tc *TestClock) NewTicker(d time.Duration) Ticker {
+	ticker := &testTicker{
+		// Buffered channel to avoid blocking in Advance
+		c:     make(chan time.Time, 1000),
+		t:     tc.now,
+		d:     d,
+		clock: tc,
+	}
+	tc.mu.Lock()
+	tc.tickers = append(tc.tickers, ticker)
+	// testTimers need sorting by duration
+	slices.SortFunc(tc.tickers, func(a, b *testTicker) int {
+		if a.d.Nanoseconds() < b.d.Nanoseconds() {
+			return -1
+		}
+		if a.d.Nanoseconds() > b.d.Nanoseconds() {
+			return 1
+		}
+		return 0
+	})
+	tc.mu.Unlock()
+	return ticker
+}
+
+// Advance advances the clock by the given duration, firing any tickers that are due.
+func (tc *TestClock) Advance(d time.Duration) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	tc.now = tc.now.Add(d)
+
+	// keep ticking till everything has caught up
+	anyTicks := true
+	for anyTicks {
+		anyTicks = false
+		for _, ticker := range tc.tickers {
+			next := ticker.t.Add(ticker.d)
+			if !tc.now.Before(next) { // next <= now
+				// Need to fire this ticker at least once
+				ticker.c <- next
+				ticker.t = next
+				anyTicks = true
+			}
+		}
+	}
+}
+
+// NewTestClock returns a new TestClock that starts at the given time.
+func NewTestClock(now time.Time) *TestClock {
+	return &TestClock{
+		now: now,
+	}
+}

--- a/sdk/go/common/itime/test_clock_test.go
+++ b/sdk/go/common/itime/test_clock_test.go
@@ -1,0 +1,111 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package itime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRealClock(t *testing.T) {
+	t.Parallel()
+
+	clock := NewRealClock()
+	cnow := clock.Now()
+	tnow := time.Now()
+
+	if cnow.Sub(tnow) > time.Second {
+		t.Fatalf("RealClock.Now() returned a time that was off by more than a second")
+	}
+}
+
+func TestTestClock(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	clock := NewTestClock(now)
+
+	assert.Equal(t, now, clock.Now())
+
+	clock.Advance(time.Second)
+	assert.Equal(t, now.Add(time.Second), clock.Now())
+}
+
+func TestSingleTicker(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	clock := NewTestClock(now)
+	ticker := clock.NewTicker(time.Second)
+
+	select {
+	case <-ticker.C():
+		t.Fatalf("Expected ticker to not fire immediately")
+	default:
+	}
+
+	clock.Advance(time.Second)
+	select {
+	case <-ticker.C():
+	default:
+		t.Fatalf("Expected ticker to fire after advancing clock")
+	}
+
+	ticker.Stop()
+	clock.Advance(time.Second)
+	select {
+	case <-ticker.C():
+		t.Fatalf("Expected ticker to not fire after stopping")
+	default:
+	}
+}
+
+func TestMultipleTickers(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	clock := NewTestClock(now)
+	ticker1 := clock.NewTicker(time.Second)
+	ticker2 := clock.NewTicker(2 * time.Second)
+
+	wait1 := func() {
+		select {
+		case <-ticker1.C():
+		default:
+			t.Fatal("Expected ticker1 to fire")
+		}
+	}
+	wait2 := func() {
+		select {
+		case <-ticker2.C():
+		default:
+			t.Fatal("Expected ticker2 to fire")
+		}
+	}
+
+	clock.Advance(time.Second)
+	wait1()
+
+	clock.Advance(time.Second)
+	wait1()
+	wait2()
+
+	clock.Advance(time.Second * 2)
+	wait1()
+	wait1()
+	wait2()
+}


### PR DESCRIPTION
This reenables the token source tests as they should now be deteremninistic, no longer relying on `time.Sleep`.