### PR TITLE
[sdk-gen/node/python] Bump minimum valid SDK  to v3.134.1 so that output-invokes work and maintain secrets

### DIFF
--- a/changelog/pending/20240926--sdkgen-nodejs-python--bump-minimum-valid-sdk-version-to-v3-134-1-so-that-output-invokes-work-and-maintain-secrets.yaml
+++ b/changelog/pending/20240926--sdkgen-nodejs-python--bump-minimum-valid-sdk-version-to-v3-134-1-so-that-output-invokes-work-and-maintain-secrets.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdkgen/nodejs,python
+  description: Bump minimum valid SDK version to v3.134.1 so that output-invokes work and maintain secrets

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	// The minimum version of @pulumi/pulumi compatible with the generated SDK.
-	MinimumValidSDKVersion string = "^3.133.0"
+	MinimumValidSDKVersion string = "^3.134.1"
 	// The minimum version of @pulumi/pulumi that supports parameterization.
 	MinimumValidParameterizationSDKVersion string = "^3.133.0"
 	MinimumTypescriptVersion               string = "^4.3.5"

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -3402,7 +3402,7 @@ func setDependencies(schema *PyprojectSchema, pkg *schema.Package) error {
 }
 
 // Require the SDK to fall within the same major version.
-var MinimumValidSDKVersion = ">=3.0.0,<4.0.0"
+var MinimumValidSDKVersion = ">=3.134.1,<4.0.0"
 
 // Require the SDK to fall within the same major version, and be at least 3.134.0 which added support for the
 // package reference feature flag.

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -320,7 +320,7 @@ func TestCalculateDeps(t *testing.T) {
 			// with semver and parver formatted differently from Pulumi.
 			// Pulumi should not have a version.
 			{"parver>=0.2.1", ""},
-			{"pulumi", ">=3.0.0,<4.0.0"},
+			{"pulumi", ">=3.134.1,<4.0.0"},
 			{"semver>=2.8.1"},
 		},
 	}, {
@@ -332,7 +332,7 @@ func TestCalculateDeps(t *testing.T) {
 		expected: [][2]string{
 			{"foobar", "7.10.8"},
 			{"parver>=0.2.1", ""},
-			{"pulumi", ">=3.0.0,<4.0.0"},
+			{"pulumi", ">=3.134.1,<4.0.0"},
 			{"semver>=2.8.1"},
 		},
 	}, {

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_alpha',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_asset_archive',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_config',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_fail_on_create',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_large',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_primitive',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_primitive_ref',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple_invoke',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_alpha',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_asset_archive',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_config',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_fail_on_create',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_large',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_primitive',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_primitive_ref',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple_invoke',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_alpha"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.134.1,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.8"
   version = "3.0.0a1+internal"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_asset_archive"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.134.1,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.8"
   version = "5.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_config"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.134.1,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.8"
   version = "9.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_fail_on_create"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.134.1,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.8"
   version = "4.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_large"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.134.1,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.8"
   version = "4.3.2"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_primitive"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.134.1,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.8"
   version = "7.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_primitive_ref"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.134.1,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.8"
   version = "11.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_simple"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.134.1,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.8"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_simple_invoke"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.134.1,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.8"
   version = "10.0.0"

--- a/tests/testdata/codegen/assets-and-archives/nodejs/package.json
+++ b/tests/testdata/codegen/assets-and-archives/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.133.0"
+        "@pulumi/pulumi": "^3.134.1"
     },
     "devDependencies": {
         "@types/node": "^14",

--- a/tests/testdata/codegen/assets-and-archives/python/setup.py
+++ b/tests/testdata/codegen/assets-and-archives/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/config-variables/nodejs/package.json
+++ b/tests/testdata/codegen/config-variables/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.133.0"
+        "@pulumi/pulumi": "^3.134.1"
     },
     "devDependencies": {
         "@types/node": "^14",

--- a/tests/testdata/codegen/config-variables/python/setup.py
+++ b/tests/testdata/codegen/config-variables/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/cyclic-types/python/setup.py
+++ b/tests/testdata/codegen/cyclic-types/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/dash-named-schema/python/setup.py
+++ b/tests/testdata/codegen/dash-named-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_foo_bar',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/dashed-import-schema/python/setup.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plant',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/different-enum/python/setup.py
+++ b/tests/testdata/codegen/different-enum/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plant',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/embedded-crd-types/nodejs/package.json
+++ b/tests/testdata/codegen/embedded-crd-types/nodejs/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/kubernetes": "^3.0.0",
-        "@pulumi/pulumi": "^3.133.0"
+        "@pulumi/pulumi": "^3.134.1"
     },
     "devDependencies": {
         "@types/node": "^14",

--- a/tests/testdata/codegen/external-node-compatibility/nodejs/package.json
+++ b/tests/testdata/codegen/external-node-compatibility/nodejs/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/google-native": "^0.11.0",
-        "@pulumi/pulumi": "^3.133.0"
+        "@pulumi/pulumi": "^3.134.1"
     },
     "devDependencies": {
         "@types/node": "^14",

--- a/tests/testdata/codegen/external-resource-schema/nodejs/package.json
+++ b/tests/testdata/codegen/external-resource-schema/nodejs/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "@pulumi/aws": "^4.19.0",
         "@pulumi/kubernetes": "^3.7.0",
-        "@pulumi/pulumi": "^3.133.0",
+        "@pulumi/pulumi": "^3.134.1",
         "@pulumi/random": "^4.2.0"
     },
     "devDependencies": {

--- a/tests/testdata/codegen/external-resource-schema/python/setup.py
+++ b/tests/testdata/codegen/external-resource-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/functions-secrets/nodejs/package.json
+++ b/tests/testdata/codegen/functions-secrets/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.133.0"
+        "@pulumi/pulumi": "^3.134.1"
     },
     "devDependencies": {
         "@types/node": "ts4.3",

--- a/tests/testdata/codegen/functions-secrets/python/setup.py
+++ b/tests/testdata/codegen/functions-secrets/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_mypkg',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/hyphenated-symbols/python/setup.py
+++ b/tests/testdata/codegen/hyphenated-symbols/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_repro',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/legacy-names/nodejs/package.json
+++ b/tests/testdata/codegen/legacy-names/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.133.0"
+        "@pulumi/pulumi": "^3.134.1"
     },
     "devDependencies": {
         "@types/node": "^14",

--- a/tests/testdata/codegen/legacy-names/python/setup.py
+++ b/tests/testdata/codegen/legacy-names/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_legacy_names',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/methods-return-plain-resource/nodejs/package.json
+++ b/tests/testdata/codegen/methods-return-plain-resource/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.133.0",
+        "@pulumi/pulumi": "^3.134.1",
         "@pulumi/tls": "4.10"
     },
     "devDependencies": {

--- a/tests/testdata/codegen/methods-return-plain-resource/python/setup.py
+++ b/tests/testdata/codegen/methods-return-plain-resource/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_metaprovider',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/naming-collisions/python/setup.py
+++ b/tests/testdata/codegen/naming-collisions/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/nested-module/python/setup.py
+++ b/tests/testdata/codegen/nested-module/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_foo',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/output-funcs-edgeorder/nodejs/package.json
+++ b/tests/testdata/codegen/output-funcs-edgeorder/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.133.0"
+        "@pulumi/pulumi": "^3.134.1"
     },
     "devDependencies": {
         "@types/node": "ts4.3",

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/setup.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_myedgeorder',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/output-funcs-tfbridge20/nodejs/package.json
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.133.0"
+        "@pulumi/pulumi": "^3.134.1"
     },
     "devDependencies": {
         "@types/mocha": "latest",

--- a/tests/testdata/codegen/output-funcs-tfbridge20/python/setup.py
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_mypkg',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/output-funcs/nodejs/package.json
+++ b/tests/testdata/codegen/output-funcs/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.133.0"
+        "@pulumi/pulumi": "^3.134.1"
     },
     "devDependencies": {
         "@types/mocha": "latest",

--- a/tests/testdata/codegen/output-funcs/python/setup.py
+++ b/tests/testdata/codegen/output-funcs/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_mypkg',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/plain-and-default/python/setup.py
+++ b/tests/testdata/codegen/plain-and-default/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_foobar',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/plain-object-defaults/python/setup.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/setup.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/provider-config-schema/python/setup.py
+++ b/tests/testdata/codegen/provider-config-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_configstation',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/provider-type-schema/python/setup.py
+++ b/tests/testdata/codegen/provider-type-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_providerType',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/regress-8403/python/setup.py
+++ b/tests/testdata/codegen/regress-8403/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_mongodbatlas',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/regress-node-8110/nodejs/package.json
+++ b/tests/testdata/codegen/regress-node-8110/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.133.0"
+        "@pulumi/pulumi": "^3.134.1"
     },
     "devDependencies": {
         "@types/node": "ts4.3",

--- a/tests/testdata/codegen/regress-node-8110/python/setup.py
+++ b/tests/testdata/codegen/regress-node-8110/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_my8110',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/regress-py-12546/python/setup.py
+++ b/tests/testdata/codegen/regress-py-12546/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plant',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/regress-py-12980/python/setup.py
+++ b/tests/testdata/codegen/regress-py-12980/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_myPkg',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/regress-py-14012/python/setup.py
+++ b/tests/testdata/codegen/regress-py-14012/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_foo',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/replace-on-change/python/setup.py
+++ b/tests/testdata/codegen/replace-on-change/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/setup.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/resource-args-python/python/setup.py
+++ b/tests/testdata/codegen/resource-args-python/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/resource-property-overlap/python/setup.py
+++ b/tests/testdata/codegen/resource-property-overlap/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/secrets/nodejs/package.json
+++ b/tests/testdata/codegen/secrets/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.133.0"
+        "@pulumi/pulumi": "^3.134.1"
     },
     "devDependencies": {
         "@types/node": "ts4.3",

--- a/tests/testdata/codegen/secrets/python/setup.py
+++ b/tests/testdata/codegen/secrets/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_mypkg',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/simple-enum-schema/python/setup.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plant',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/nodejs/package.json
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.133.0"
+        "@pulumi/pulumi": "^3.134.1"
     },
     "devDependencies": {
         "@types/node": "ts4.3",

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/setup.py
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/simple-methods-schema/python/setup.py
+++ b/tests/testdata/codegen/simple-methods-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/python/setup.py
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/simple-plain-schema/python/setup.py
+++ b/tests/testdata/codegen/simple-plain-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/setup.py
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/setup.py
@@ -31,7 +31,7 @@ setup(name='custom_py_package',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/simple-resource-schema/nodejs/package.json
+++ b/tests/testdata/codegen/simple-resource-schema/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.133.0"
+        "@pulumi/pulumi": "^3.134.1"
     },
     "devDependencies": {
         "@types/mocha": "latest",

--- a/tests/testdata/codegen/simple-resource-schema/python/setup.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/setup.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/simple-schema-pyproject/python/pyproject.toml
+++ b/tests/testdata/codegen/simple-schema-pyproject/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
   name = "pulumi_example"
   description = "This is a test package for pyproject.toml"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.134.1,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
   keywords = ["Testing", "Pulumipus"]
   readme = "README.md"
   requires-python = ">=3.8"

--- a/tests/testdata/codegen/simple-yaml-schema/python/setup.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/unions-inline/nodejs/package.json
+++ b/tests/testdata/codegen/unions-inline/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.133.0"
+        "@pulumi/pulumi": "^3.134.1"
     },
     "devDependencies": {
         "@types/node": "^14",

--- a/tests/testdata/codegen/unions-inline/python/setup.py
+++ b/tests/testdata/codegen/unions-inline/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/unions-inside-arrays/nodejs/package.json
+++ b/tests/testdata/codegen/unions-inside-arrays/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.133.0"
+        "@pulumi/pulumi": "^3.134.1"
     },
     "devDependencies": {
         "@types/node": "^14",

--- a/tests/testdata/codegen/unions-inside-arrays/python/setup.py
+++ b/tests/testdata/codegen/unions-inside-arrays/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/urn-id-properties/nodejs/package.json
+++ b/tests/testdata/codegen/urn-id-properties/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.133.0"
+        "@pulumi/pulumi": "^3.134.1"
     },
     "devDependencies": {
         "@types/node": "^14",

--- a/tests/testdata/codegen/urn-id-properties/python/setup.py
+++ b/tests/testdata/codegen/urn-id-properties/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_urnid',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/using-shared-types-in-config/nodejs/package.json
+++ b/tests/testdata/codegen/using-shared-types-in-config/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.133.0"
+        "@pulumi/pulumi": "^3.134.1"
     },
     "devDependencies": {
         "@types/node": "^14",

--- a/tests/testdata/codegen/using-shared-types-in-config/python/setup.py
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_credentials',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.134.1,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],


### PR DESCRIPTION
### Description

This PR updates SDK-gen for python and nodejs so that they emit latest published SDK v3.134.1 (at the time of writing) which includes fixes for output-invokes. 

Fixes #12710