### PR TITLE
Fix dependency installation for nodejs projects with a main property

### DIFF
--- a/changelog/pending/20240926--sdk-nodejs--fix-dependency-installation-for-nodejs-projects-with-a-main-property.yaml
+++ b/changelog/pending/20240926--sdk-nodejs--fix-dependency-installation-for-nodejs-projects-with-a-main-property.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix dependency installation for nodejs projects with a main property

--- a/tests/integration/nodejs/pulumi-main/Pulumi.yaml
+++ b/tests/integration/nodejs/pulumi-main/Pulumi.yaml
@@ -1,0 +1,4 @@
+name: pulumi-main
+runtime: nodejs
+description: Set the program directory using the main property
+main: src

--- a/tests/integration/nodejs/pulumi-main/package.json
+++ b/tests/integration/nodejs/pulumi-main/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "pulumi-main",
+  "dependencies": {
+    "@pulumi/pulumi": "latest"
+  }
+}

--- a/tests/integration/nodejs/pulumi-main/src/index.ts
+++ b/tests/integration/nodejs/pulumi-main/src/index.ts
@@ -1,0 +1,3 @@
+// Copyright 2024, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";


### PR DESCRIPTION
After running the package manager installation, we check that a `node_modules` directory exists. This check was done relative to the "Program Directory", however the `node_modules` directory is created next to `package.json`, which itself is often in the "Project Directory". When `Pulumi.yaml` specifies a `main` property, these two directories are different, and the check fails.

We probably did not run into this earlier, because for nodejs you often don't use Pulumi's `main`, but instead use the nodejs `main` in `package.json`.

Fixes https://github.com/pulumi/pulumi/issues/17292
