### PR TITLE
language.proto: document deprecated fields better

### DIFF
--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -16,7 +16,7 @@
 1027667133 3164 proto/pulumi/converter.proto
 1998652962 3845 proto/pulumi/engine.proto
 3165859981 1276 proto/pulumi/errors.proto
-4059640985 11994 proto/pulumi/language.proto
+420991671 12306 proto/pulumi/language.proto
 2893249402 1992 proto/pulumi/plugin.proto
 1529552991 28224 proto/pulumi/provider.proto
 1190662922 17848 proto/pulumi/resource.proto

--- a/proto/pulumi/language.proto
+++ b/proto/pulumi/language.proto
@@ -91,8 +91,8 @@ message AboutResponse {
 
 message GetProgramDependenciesRequest {
     string project = 1 [deprecated = true]; // the project name, the engine always sets this to "deprecated" now.
-    string pwd = 2 [deprecated = true];     // the program's working directory.
-    string program = 3 [deprecated = true]; // the path to the program.
+    string pwd = 2 [deprecated = true];     // the program's working directory. Deprecated, use info.program_directory instead.
+    string program = 3 [deprecated = true]; // the path to the program. Deprecated, use info.entry_point instead.
     bool transitiveDependencies = 4; // if transitive dependencies should be included in the result.
     ProgramInfo info = 5; // the program info to use to calculate dependencies.
 }
@@ -108,8 +108,8 @@ message GetProgramDependenciesResponse {
 
 message GetRequiredPluginsRequest {
     string project = 1 [deprecated = true]; // the project name, the engine always sets this to "deprecated" now.
-    string pwd = 2 [deprecated = true];     // the program's working directory.
-    string program = 3 [deprecated = true]; // the path to the program.
+    string pwd = 2 [deprecated = true];     // the program's working directory. Deprecated, use info.program_directory instead.
+    string program = 3 [deprecated = true]; // the path to the program. Deprecated, use info.entry_point instead.
     ProgramInfo info = 4; // the program info to use to calculate plugins.
 }
 
@@ -122,7 +122,7 @@ message RunRequest {
     string project = 1;             // the project name.
     string stack = 2;               // the name of the stack being deployed into.
     string pwd = 3;                 // the program's working directory.
-    string program = 4 [deprecated = true];             // the path to the program to execute.
+    string program = 4 [deprecated = true];             // the path to the program to execute. Deprecated, use info.entry_point instead.
     repeated string args = 5;       // any arguments to pass to the program.
     map<string, string> config = 6; // the configuration variables to apply before running.
     bool dryRun = 7;                // true if we're only doing a dryrun (preview).
@@ -150,7 +150,7 @@ message RunResponse {
 }
 
 message InstallDependenciesRequest {
-    string directory = 1 [deprecated = true]; // the program's working directory.
+    string directory = 1 [deprecated = true]; // the program's working directory. Deprecated, use info.program_directory instead.
     bool is_terminal = 2; // if we are running in a terminal and should use ANSI codes
     ProgramInfo info = 3; // the program info to use to execute the plugin.
     bool use_language_version_tools = 4; // if we should use language version tools like pyenv or
@@ -192,7 +192,7 @@ message RuntimeOptionsResponse {
 
 message RunPluginRequest{
     string pwd = 1; // the program's working directory.
-    string program = 2 [deprecated = true]; // the path to the program to execute.
+    string program = 2 [deprecated = true]; // the path to the program to execute. Deprecated, use info.entry_point instead.
     repeated string args = 3; // any arguments to pass to the program.
     repeated string env = 4; // any environment variables to set as part of the program.
     ProgramInfo info = 5; // the program info to use to execute the plugin.

--- a/sdk/proto/go/language.pb.go
+++ b/sdk/proto/go/language.pb.go
@@ -283,9 +283,9 @@ type GetProgramDependenciesRequest struct {
 	// Deprecated: Do not use.
 	Project string `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"` // the project name, the engine always sets this to "deprecated" now.
 	// Deprecated: Do not use.
-	Pwd string `protobuf:"bytes,2,opt,name=pwd,proto3" json:"pwd,omitempty"` // the program's working directory.
+	Pwd string `protobuf:"bytes,2,opt,name=pwd,proto3" json:"pwd,omitempty"` // the program's working directory. Deprecated, use info.program_directory instead.
 	// Deprecated: Do not use.
-	Program                string       `protobuf:"bytes,3,opt,name=program,proto3" json:"program,omitempty"`                                // the path to the program.
+	Program                string       `protobuf:"bytes,3,opt,name=program,proto3" json:"program,omitempty"`                                // the path to the program. Deprecated, use info.entry_point instead.
 	TransitiveDependencies bool         `protobuf:"varint,4,opt,name=transitiveDependencies,proto3" json:"transitiveDependencies,omitempty"` // if transitive dependencies should be included in the result.
 	Info                   *ProgramInfo `protobuf:"bytes,5,opt,name=info,proto3" json:"info,omitempty"`                                      // the program info to use to calculate dependencies.
 }
@@ -470,9 +470,9 @@ type GetRequiredPluginsRequest struct {
 	// Deprecated: Do not use.
 	Project string `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"` // the project name, the engine always sets this to "deprecated" now.
 	// Deprecated: Do not use.
-	Pwd string `protobuf:"bytes,2,opt,name=pwd,proto3" json:"pwd,omitempty"` // the program's working directory.
+	Pwd string `protobuf:"bytes,2,opt,name=pwd,proto3" json:"pwd,omitempty"` // the program's working directory. Deprecated, use info.program_directory instead.
 	// Deprecated: Do not use.
-	Program string       `protobuf:"bytes,3,opt,name=program,proto3" json:"program,omitempty"` // the path to the program.
+	Program string       `protobuf:"bytes,3,opt,name=program,proto3" json:"program,omitempty"` // the path to the program. Deprecated, use info.entry_point instead.
 	Info    *ProgramInfo `protobuf:"bytes,4,opt,name=info,proto3" json:"info,omitempty"`       // the program info to use to calculate plugins.
 }
 
@@ -596,7 +596,7 @@ type RunRequest struct {
 	Stack   string `protobuf:"bytes,2,opt,name=stack,proto3" json:"stack,omitempty"`     // the name of the stack being deployed into.
 	Pwd     string `protobuf:"bytes,3,opt,name=pwd,proto3" json:"pwd,omitempty"`         // the program's working directory.
 	// Deprecated: Do not use.
-	Program           string            `protobuf:"bytes,4,opt,name=program,proto3" json:"program,omitempty"`                                                                                       // the path to the program to execute.
+	Program           string            `protobuf:"bytes,4,opt,name=program,proto3" json:"program,omitempty"`                                                                                       // the path to the program to execute. Deprecated, use info.entry_point instead.
 	Args              []string          `protobuf:"bytes,5,rep,name=args,proto3" json:"args,omitempty"`                                                                                             // any arguments to pass to the program.
 	Config            map[string]string `protobuf:"bytes,6,rep,name=config,proto3" json:"config,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"` // the configuration variables to apply before running.
 	DryRun            bool              `protobuf:"varint,7,opt,name=dryRun,proto3" json:"dryRun,omitempty"`                                                                                        // true if we're only doing a dryrun (preview).
@@ -823,7 +823,7 @@ type InstallDependenciesRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Deprecated: Do not use.
-	Directory               string       `protobuf:"bytes,1,opt,name=directory,proto3" json:"directory,omitempty"`                                                                 // the program's working directory.
+	Directory               string       `protobuf:"bytes,1,opt,name=directory,proto3" json:"directory,omitempty"`                                                                 // the program's working directory. Deprecated, use info.program_directory instead.
 	IsTerminal              bool         `protobuf:"varint,2,opt,name=is_terminal,json=isTerminal,proto3" json:"is_terminal,omitempty"`                                            // if we are running in a terminal and should use ANSI codes
 	Info                    *ProgramInfo `protobuf:"bytes,3,opt,name=info,proto3" json:"info,omitempty"`                                                                           // the program info to use to execute the plugin.
 	UseLanguageVersionTools bool         `protobuf:"varint,4,opt,name=use_language_version_tools,json=useLanguageVersionTools,proto3" json:"use_language_version_tools,omitempty"` // if we should use language version tools like pyenv or
@@ -1125,7 +1125,7 @@ type RunPluginRequest struct {
 
 	Pwd string `protobuf:"bytes,1,opt,name=pwd,proto3" json:"pwd,omitempty"` // the program's working directory.
 	// Deprecated: Do not use.
-	Program string       `protobuf:"bytes,2,opt,name=program,proto3" json:"program,omitempty"` // the path to the program to execute.
+	Program string       `protobuf:"bytes,2,opt,name=program,proto3" json:"program,omitempty"` // the path to the program to execute. Deprecated, use info.entry_point instead.
 	Args    []string     `protobuf:"bytes,3,rep,name=args,proto3" json:"args,omitempty"`       // any arguments to pass to the program.
 	Env     []string     `protobuf:"bytes,4,rep,name=env,proto3" json:"env,omitempty"`         // any environment variables to set as part of the program.
 	Info    *ProgramInfo `protobuf:"bytes,5,opt,name=info,proto3" json:"info,omitempty"`       // the program info to use to execute the plugin.

--- a/sdk/python/lib/pulumi/runtime/proto/language_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/language_pb2.pyi
@@ -147,9 +147,9 @@ class GetProgramDependenciesRequest(google.protobuf.message.Message):
     project: builtins.str
     """the project name, the engine always sets this to "deprecated" now."""
     pwd: builtins.str
-    """the program's working directory."""
+    """the program's working directory. Deprecated, use info.program_directory instead."""
     program: builtins.str
-    """the path to the program."""
+    """the path to the program. Deprecated, use info.entry_point instead."""
     transitiveDependencies: builtins.bool
     """if transitive dependencies should be included in the result."""
     @property
@@ -217,9 +217,9 @@ class GetRequiredPluginsRequest(google.protobuf.message.Message):
     project: builtins.str
     """the project name, the engine always sets this to "deprecated" now."""
     pwd: builtins.str
-    """the program's working directory."""
+    """the program's working directory. Deprecated, use info.program_directory instead."""
     program: builtins.str
-    """the path to the program."""
+    """the path to the program. Deprecated, use info.entry_point instead."""
     @property
     def info(self) -> global___ProgramInfo:
         """the program info to use to calculate plugins."""
@@ -298,7 +298,7 @@ class RunRequest(google.protobuf.message.Message):
     pwd: builtins.str
     """the program's working directory."""
     program: builtins.str
-    """the path to the program to execute."""
+    """the path to the program to execute. Deprecated, use info.entry_point instead."""
     @property
     def args(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
         """any arguments to pass to the program."""
@@ -387,7 +387,7 @@ class InstallDependenciesRequest(google.protobuf.message.Message):
     INFO_FIELD_NUMBER: builtins.int
     USE_LANGUAGE_VERSION_TOOLS_FIELD_NUMBER: builtins.int
     directory: builtins.str
-    """the program's working directory."""
+    """the program's working directory. Deprecated, use info.program_directory instead."""
     is_terminal: builtins.bool
     """if we are running in a terminal and should use ANSI codes"""
     @property
@@ -540,7 +540,7 @@ class RunPluginRequest(google.protobuf.message.Message):
     pwd: builtins.str
     """the program's working directory."""
     program: builtins.str
-    """the path to the program to execute."""
+    """the path to the program to execute. Deprecated, use info.entry_point instead."""
     @property
     def args(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
         """any arguments to pass to the program."""


### PR DESCRIPTION
For the fields that have alternatives, we can document them to save everyone that stumbles upon these some time.  Do that here.