### PR TITLE
Support topologically sorting snapshots

### DIFF
--- a/pkg/graph/toposort.go
+++ b/pkg/graph/toposort.go
@@ -18,9 +18,9 @@ import (
 	"errors"
 )
 
-// Topsort topologically sorts the graph, yielding an array of nodes that are in dependency order, using a simple
+// Toposort topologically sorts the graph, yielding an array of nodes that are in dependency order, using a simple
 // DFS-based algorithm.  The graph must be acyclic, otherwise this function will return an error.
-func Topsort(g Graph) ([]Vertex, error) {
+func Toposort(g Graph) ([]Vertex, error) {
 	var sorted []Vertex               // will hold the sorted vertices.
 	visiting := make(map[Vertex]bool) // temporary entries to detect cycles.
 	visited := make(map[Vertex]bool)  // entries to avoid visiting the same node twice.
@@ -28,14 +28,14 @@ func Topsort(g Graph) ([]Vertex, error) {
 	// Now enumerate the roots, topologically sorting their dependencies.
 	roots := g.Roots()
 	for _, r := range roots {
-		if err := topvisit(r.To(), &sorted, visiting, visited); err != nil {
+		if err := topovisit(r.To(), &sorted, visiting, visited); err != nil {
 			return sorted, err
 		}
 	}
 	return sorted, nil
 }
 
-func topvisit(n Vertex, sorted *[]Vertex, visiting map[Vertex]bool, visited map[Vertex]bool) error {
+func topovisit(n Vertex, sorted *[]Vertex, visiting map[Vertex]bool, visited map[Vertex]bool) error {
 	if visiting[n] {
 		// This is not a DAG!  Stop sorting right away, and issue an error.
 		// IDEA: return diagnostic information about why this isn't a DAG (e.g., full cycle path).
@@ -44,7 +44,7 @@ func topvisit(n Vertex, sorted *[]Vertex, visiting map[Vertex]bool, visited map[
 	if !visited[n] {
 		visiting[n] = true
 		for _, m := range n.Outs() {
-			if err := topvisit(m.To(), sorted, visiting, visited); err != nil {
+			if err := topovisit(m.To(), sorted, visiting, visited); err != nil {
 				return err
 			}
 		}

--- a/pkg/resource/deploy/snapshot_test.go
+++ b/pkg/resource/deploy/snapshot_test.go
@@ -77,3 +77,454 @@ func TestSnapshotWithUpdatedResources(t *testing.T) {
 	assert.NotSame(t, s, s1)
 	assert.Equal(t, s1.Resources[0].URN+"!", s.Resources[0].URN)
 }
+
+func TestSnapshotToposort_PreservesValidSnapshots(t *testing.T) {
+	t.Parallel()
+
+	// Arrange.
+	cases := []struct {
+		name  string
+		given []*resource.State
+	}{
+		{
+			name:  "empty",
+			given: []*resource.State{},
+		},
+		{
+			name: "a single resource",
+			given: []*resource.State{
+				{URN: "urn:pulumi:stack::project::t::a"},
+			},
+		},
+		{
+			name: "two unrelated resources",
+			given: []*resource.State{
+				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::b"},
+			},
+		},
+		{
+			name: "two resources with a valid provider dependency",
+			given: []*resource.State{
+				{
+					Type: "pulumi:providers:p",
+					URN:  "urn:pulumi:stack::project::pulumi:providers:p::a",
+					ID:   "id",
+				},
+				{
+					URN:      "urn:pulumi:stack::project::t::b",
+					Provider: "urn:pulumi:stack::project::pulumi:providers:p::a::id",
+				},
+			},
+		},
+		{
+			name: "two resources with a valid parent-child relationship",
+			given: []*resource.State{
+				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t$t::b", Parent: "urn:pulumi:stack::project::t::a"},
+			},
+		},
+		{
+			name: "two resources with a valid dependency",
+			given: []*resource.State{
+				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::b", Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"}},
+			},
+		},
+		{
+			name: "two resources with a valid property dependency",
+			given: []*resource.State{
+				{URN: "urn:pulumi:stack::project::t::a"},
+				{
+					URN: "urn:pulumi:stack::project::t::b",
+					PropertyDependencies: map[resource.PropertyKey][]resource.URN{
+						"p": {"urn:pulumi:stack::project::t::a"},
+					},
+				},
+			},
+		},
+		{
+			name: "two resources with a valid deleted-with relationship",
+			given: []*resource.State{
+				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::b", DeletedWith: "urn:pulumi:stack::project::t::a"},
+			},
+		},
+		{
+			name: "duplicate URNs due to deleted/non-deleted",
+			given: []*resource.State{
+				{URN: "urn:pulumi:stack::project::t::a"},
+				{
+					URN:          "urn:pulumi:stack::project::t::b",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+				},
+				{
+					URN:    "urn:pulumi:stack::project::t::a",
+					Delete: true,
+				},
+				{
+					URN:          "urn:pulumi:stack::project::t::b",
+					Delete:       true,
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+				},
+			},
+		},
+		{
+			name: "duplicate URNs due to deleted/non-deleted (false cycle)",
+			given: []*resource.State{
+				{URN: "urn:pulumi:stack::project::t::a"},
+				{
+					URN:          "urn:pulumi:stack::project::t::b",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+				},
+				{
+					URN:          "urn:pulumi:stack::project::t::a",
+					Delete:       true,
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::b"},
+				},
+			},
+		},
+		{
+			name: "multiple duplicate URNs due to multiple deleted",
+			given: []*resource.State{
+				{URN: "urn:pulumi:stack::project::t::a"},
+				{
+					URN:          "urn:pulumi:stack::project::t::b",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+				},
+				{
+					URN:          "urn:pulumi:stack::project::t::a",
+					Delete:       true,
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::b"},
+				},
+				{
+					URN:          "urn:pulumi:stack::project::t::c",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+					Delete:       true,
+				},
+				{
+					URN:          "urn:pulumi:stack::project::t::a",
+					Delete:       true,
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::b"},
+				},
+			},
+		},
+		{
+			name: "multiple sets of dependent resources",
+			given: []*resource.State{
+				{URN: "urn:pulumi:stack::project::t::a"},
+				{
+					URN:          "urn:pulumi:stack::project::t::b",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+				},
+				{
+					URN:          "urn:pulumi:stack::project::t::c",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+				},
+				{
+					URN: "urn:pulumi:stack::project::t::d",
+					PropertyDependencies: map[resource.PropertyKey][]resource.URN{
+						"pa": {"urn:pulumi:stack::project::t::a"},
+						"pb": {"urn:pulumi:stack::project::t::b"},
+					},
+				},
+				{
+					URN: "urn:pulumi:stack::project::t::e",
+					Dependencies: []resource.URN{
+						"urn:pulumi:stack::project::t::c",
+						"urn:pulumi:stack::project::t::d",
+					},
+				},
+				{
+					URN: "urn:pulumi:stack::project::t::f",
+				},
+				{
+					URN:         "urn:pulumi:stack::project::t::g",
+					DeletedWith: "urn:pulumi:stack::project::t::f",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			snap := &Snapshot{Resources: c.given}
+			assert.NoError(t, snap.VerifyIntegrity())
+
+			// Act.
+			err := snap.Toposort()
+
+			// Assert.
+			assert.NoError(t, err)
+			assert.NoError(t, snap.VerifyIntegrity())
+		})
+	}
+}
+
+func TestSnapshotToposort_FixesOrderInvalidSnapshots(t *testing.T) {
+	t.Parallel()
+
+	// Arrange.
+	cases := []struct {
+		name  string
+		given []*resource.State
+	}{
+		{
+			name: "two resources with an out-of-order provider dependency",
+			given: []*resource.State{
+				{
+					URN:      "urn:pulumi:stack::project::t::b",
+					Provider: "urn:pulumi:stack::project::pulumi:providers:p::a::id",
+				},
+				{
+					Type: "pulumi:providers:p",
+					URN:  "urn:pulumi:stack::project::pulumi:providers:p::a",
+					ID:   "id",
+				},
+			},
+		},
+		{
+			name: "two resources with an out-of-order parent-child relationship",
+			given: []*resource.State{
+				{URN: "urn:pulumi:stack::project::t$t::b", Parent: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a"},
+			},
+		},
+		{
+			name: "two resources with an out-of-order dependency",
+			given: []*resource.State{
+				{URN: "urn:pulumi:stack::project::t::b", Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"}},
+				{URN: "urn:pulumi:stack::project::t::a"},
+			},
+		},
+		{
+			name: "two resources with an out-of-order property dependency",
+			given: []*resource.State{
+				{
+					URN: "urn:pulumi:stack::project::t::b",
+					PropertyDependencies: map[resource.PropertyKey][]resource.URN{
+						"p": {"urn:pulumi:stack::project::t::a"},
+					},
+				},
+				{URN: "urn:pulumi:stack::project::t::a"},
+			},
+		},
+		{
+			name: "two resources with an out-of-order deleted-with relationship",
+			given: []*resource.State{
+				{URN: "urn:pulumi:stack::project::t::b", DeletedWith: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a"},
+			},
+		},
+		{
+			name: "duplicate URNs due to deleted/non-deleted",
+			given: []*resource.State{
+				{
+					URN:          "urn:pulumi:stack::project::t::b",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+				},
+				{URN: "urn:pulumi:stack::project::t::a"},
+				{
+					URN:          "urn:pulumi:stack::project::t::b",
+					Delete:       true,
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+				},
+				{
+					URN:    "urn:pulumi:stack::project::t::a",
+					Delete: true,
+				},
+			},
+		},
+		{
+			name: "duplicate URNs due to deleted/non-deleted (false cycle)",
+			given: []*resource.State{
+				{
+					URN:          "urn:pulumi:stack::project::t::b",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+				},
+				{URN: "urn:pulumi:stack::project::t::a"},
+				{
+					URN:          "urn:pulumi:stack::project::t::a",
+					Delete:       true,
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::b"},
+				},
+			},
+		},
+		{
+			name: "multiple duplicate URNs due to multiple deleted",
+			given: []*resource.State{
+				{
+					URN:          "urn:pulumi:stack::project::t::b",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+				},
+				{URN: "urn:pulumi:stack::project::t::a"},
+				{
+					URN:          "urn:pulumi:stack::project::t::c",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+					Delete:       true,
+				},
+				{
+					URN:          "urn:pulumi:stack::project::t::a",
+					Delete:       true,
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::d"},
+				},
+				{
+					URN:          "urn:pulumi:stack::project::t::a",
+					Delete:       true,
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::b"},
+				},
+				{
+					URN:    "urn:pulumi:stack::project::t::d",
+					Delete: true,
+				},
+			},
+		},
+		{
+			name: "multiple sets of out-of-order dependent resources",
+			given: []*resource.State{
+				{
+					URN:          "urn:pulumi:stack::project::t::c",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+				},
+				{URN: "urn:pulumi:stack::project::t::a"},
+				{
+					URN: "urn:pulumi:stack::project::t::e",
+					Dependencies: []resource.URN{
+						"urn:pulumi:stack::project::t::c",
+						"urn:pulumi:stack::project::t::d",
+					},
+				},
+				{
+					URN:          "urn:pulumi:stack::project::t::b",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+				},
+				{
+					URN: "urn:pulumi:stack::project::t::d",
+					PropertyDependencies: map[resource.PropertyKey][]resource.URN{
+						"pa": {"urn:pulumi:stack::project::t::a"},
+						"pb": {"urn:pulumi:stack::project::t::b"},
+					},
+				},
+				{
+					URN:         "urn:pulumi:stack::project::t::g",
+					DeletedWith: "urn:pulumi:stack::project::t::f",
+				},
+				{
+					URN: "urn:pulumi:stack::project::t::f",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			snap := &Snapshot{Resources: c.given}
+			assert.Error(t, snap.VerifyIntegrity())
+
+			// Act.
+			err := snap.Toposort()
+
+			// Assert.
+			assert.NoError(t, err)
+			assert.NoError(t, snap.VerifyIntegrity())
+		})
+	}
+}
+
+func TestSnapshotToposort_DetectsCycles(t *testing.T) {
+	t.Parallel()
+
+	// Arrange.
+	cases := []struct {
+		name  string
+		given []*resource.State
+	}{
+		{
+			name: "direct cycle",
+			given: []*resource.State{
+				{
+					URN:      "urn:pulumi:stack::project::t::b",
+					Provider: "urn:pulumi:stack::project::pulumi:providers:p::a::id",
+				},
+				{
+					Type:         "pulumi:providers:p",
+					URN:          "urn:pulumi:stack::project::pulumi:providers:p::a",
+					ID:           "id",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::b"},
+				},
+			},
+		},
+		{
+			name: "long-chain cycle",
+			given: []*resource.State{
+				{URN: "urn:pulumi:stack::project::t$t::b", Parent: "urn:pulumi:stack::project::t::a"},
+				{
+					URN:          "urn:pulumi:stack::project::t::a",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::c"},
+				},
+				{
+					URN:         "urn:pulumi:stack::project::t::c",
+					DeletedWith: "urn:pulumi:stack::project::t$t::b",
+				},
+			},
+		},
+		{
+			name: "two cycles",
+			given: []*resource.State{
+				{
+					URN:          "urn:pulumi:stack::project::t::b",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+				},
+				{
+					URN:         "urn:pulumi:stack::project::t::a",
+					DeletedWith: "urn:pulumi:stack::project::t::b",
+				},
+				{
+					URN: "urn:pulumi:stack::project::t::d",
+					PropertyDependencies: map[resource.PropertyKey][]resource.URN{
+						"pc": {"urn:pulumi:stack::project::t::c"},
+					},
+				},
+				{
+					URN:          "urn:pulumi:stack::project::t::c",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::d"},
+				},
+			},
+		},
+		{
+			name: "self reference",
+			given: []*resource.State{
+				{
+					URN: "urn:pulumi:stack::project::t::a",
+					PropertyDependencies: map[resource.PropertyKey][]resource.URN{
+						"p": {"urn:pulumi:stack::project::t::a"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			snap := &Snapshot{Resources: c.given}
+
+			// Act.
+			err := snap.Toposort()
+
+			// Assert.
+			assert.ErrorContains(t, err, "snapshot has cyclic dependencies")
+		})
+	}
+}


### PR DESCRIPTION
An important precondition of Pulumi state snapshots is that they are *topologically sorted* with respect to dependencies. That is, each resource in a state snapshot *must* appear *after* those that it depends on (where "depends" here means any kind of dependency relationship -- `Provider`, `Parent`, `DeletedWith`, and so on). The `Snapshot.VerifyIntegrity` method checks this property (among others) and, upon failure, yields a snapshot integrity error.

It turns out that we don't currently have the ability to explicitly sort or re-sort a state snapshot. There are a couple of reasons for this:

* Snapshots are typically built in response to resource registrations from a program, and we require that these registrations are sent in topological order. Indeed, for imperative languages, such as Python, Go, NodeJS, Java and C#, it is not possible to write a program that does *not* send its resource registrations in the appropriate order (at least not using the official SDKs). YAML, being the only currently-supported declarative language, sorts its registrations ahead of sending them to the engine in order to meet this precondition.
* Eagerly sorting snapshots e.g. prior to writes would change the performance characteristics of the CLI on various hot paths, so is probably not something we want to do proactively/optimistically.

However, when it comes to repairing snapshot integrity errors, we *do* want to sort broken states to bring them back to a good state. This commit thus introduces the `Snapshot.Toposort` method to this end, in preparation for integration into e.g. a `state repair` command in a later commit.