### PR TITLE
Replace asyncio.ensure_future with create_task

### DIFF
--- a/changelog/pending/20240927--sdk-python--replace-asyncio-ensure_future-with-create_task.yaml
+++ b/changelog/pending/20240927--sdk-python--replace-asyncio-ensure_future-with-create_task.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/python
+  description: Replace asyncio.ensure_future with create_task

--- a/pkg/codegen/python/utilities.py
+++ b/pkg/codegen/python/utilities.py
@@ -260,7 +260,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal/pulumi_alpha/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal/pulumi_alpha/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/pulumi_large/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/pulumi_large/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/pulumi_simple/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal/pulumi_alpha/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal/pulumi_alpha/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/pulumi_large/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/pulumi_large/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/pulumi_simple/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal/pulumi_alpha/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal/pulumi_alpha/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pulumi_large/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pulumi_large/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pulumi_simple/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/assets-and-archives/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/assets-and-archives/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/_utilities.py
+++ b/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/config-variables/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/config-variables/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/cyclic-types/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/cyclic-types/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/_utilities.py
+++ b/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/_utilities.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/different-enum/python/pulumi_plant/_utilities.py
+++ b/tests/testdata/codegen/different-enum/python/pulumi_plant/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/_utilities.py
+++ b/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/enum-reference-python/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/enum-reference-python/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/enum-reference/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/enum-reference/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/external-enum/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/external-enum/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/external-resource-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/external-resource-schema/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/functions-secrets/python/pulumi_mypkg/_utilities.py
+++ b/tests/testdata/codegen/functions-secrets/python/pulumi_mypkg/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/_utilities.py
+++ b/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/_utilities.py
+++ b/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/_utilities.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/_utilities.py
+++ b/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/_utilities.py
+++ b/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/_utilities.py
+++ b/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/nested-module/python/pulumi_foo/_utilities.py
+++ b/tests/testdata/codegen/nested-module/python/pulumi_foo/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/_utilities.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/_utilities.py
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/_utilities.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/_utilities.py
+++ b/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/_utilities.py
+++ b/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/_utilities.py
+++ b/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/_utilities.py
+++ b/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/_utilities.py
+++ b/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/_utilities.py
+++ b/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/_utilities.py
+++ b/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/regress-8403/python/pulumi_mongodbatlas/_utilities.py
+++ b/tests/testdata/codegen/regress-8403/python/pulumi_mongodbatlas/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/regress-node-8110/python/pulumi_my8110/_utilities.py
+++ b/tests/testdata/codegen/regress-node-8110/python/pulumi_my8110/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/_utilities.py
+++ b/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/_utilities.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/regress-py-14012/python/pulumi_foo/_utilities.py
+++ b/tests/testdata/codegen/regress-py-14012/python/pulumi_foo/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/_utilities.py
+++ b/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/_utilities.py
+++ b/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/_utilities.py
+++ b/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/resource-args-python/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/resource-args-python/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/secrets/python/pulumi_mypkg/_utilities.py
+++ b/tests/testdata/codegen/secrets/python/pulumi_mypkg/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/_utilities.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/_utilities.py
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/simple-schema-pyproject/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-schema-pyproject/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/unions-inline/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/unions-inline/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/_utilities.py
+++ b/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:

--- a/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/_utilities.py
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/_utilities.py
@@ -264,7 +264,7 @@ def call_plain(
     output = pulumi.runtime.call(tok, props, res, typ)
 
     # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
-    result, known, secret, _ = _sync_await(asyncio.ensure_future(_await_output(output)))
+    result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None
     if not known:


### PR DESCRIPTION
`ensure_future` was deprecated in Python 3.10 https://docs.python.org/3/library/asyncio-future.html#asyncio.ensure_future

The preferred way to convert a coroutine into a future is to use `create_task` instead, which was introduced in Python 3.7, so safe for us to use everywhere.

Ref https://github.com/pulumi/pulumi/issues/11827
