### PR TITLE
improve the usage string for the config env add/rm commands

### DIFF
--- a/changelog/pending/20240927--cli-config--improve-usage-string-for-config-env-add-rm-commands.yaml
+++ b/changelog/pending/20240927--cli-config--improve-usage-string-for-config-env-add-rm-commands.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/config
+  description: Improve usage string for config env add/rm commands

--- a/pkg/cmd/pulumi/config_env_add.go
+++ b/pkg/cmd/pulumi/config_env_add.go
@@ -26,7 +26,7 @@ func newConfigEnvAddCmd(parent *configEnvCmd) *cobra.Command {
 	impl := configEnvAddCmd{parent: parent}
 
 	cmd := &cobra.Command{
-		Use:   "add",
+		Use:   "add <environment-name>...",
 		Short: "Add environments to a stack",
 		Long: "Adds environments to the end of a stack's import list. Imported environments are merged in order\n" +
 			"per the ESC merge rules. The list of stacks behaves as if it were the import list in an anonymous\n" +

--- a/pkg/cmd/pulumi/config_env_rm.go
+++ b/pkg/cmd/pulumi/config_env_rm.go
@@ -26,8 +26,8 @@ func newConfigEnvRmCmd(parent *configEnvCmd) *cobra.Command {
 	impl := configEnvRmCmd{parent: parent}
 
 	cmd := &cobra.Command{
-		Use:   "rm",
-		Short: "Remove environments from a stack",
+		Use:   "rm <environment-name>",
+		Short: "Remove environment from a stack",
 		Long:  "Removes an environment from a stack's import list.",
 		Args:  cmdutil.ExactArgs(1),
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Make it clear which arguments are required for these commands, and that add takes multiple environments as argument.

Output before:
```
$ pulumi config env add
Adds environments to the end of a stack's import list. Imported environments are merged in order
per the ESC merge rules. The list of stacks behaves as if it were the import list in an anonymous
environment.

Usage:
  pulumi config env add [flags]

[...]
error: requires at least 1 arg(s), only received 0
```

Output after:
```
$ pulumi config env add
Adds environments to the end of a stack's import list. Imported environments are merged in order
per the ESC merge rules. The list of stacks behaves as if it were the import list in an anonymous
environment.

Usage:
  pulumi config env add <environment-name>... [flags]
[...]
error: requires at least 1 arg(s), only received 0
```

The former left me puzzled what argument I need to add, I think the second one helps the users a lot more to understand what they need to provide.