### PR TITLE
Add StringMapMapMap to Go SDK

### DIFF
--- a/changelog/pending/20240928--sdkgen-go--fix-nested-string-map-map-map-properties.yaml
+++ b/changelog/pending/20240928--sdkgen-go--fix-nested-string-map-map-map-properties.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/go
+  description: Fix nested string map map map properties

--- a/sdk/go/pulumi/generate/main.go
+++ b/sdk/go/pulumi/generate/main.go
@@ -273,7 +273,7 @@ func makeBuiltins(primitives []*builtin) []*builtin {
 			Example:       fmt.Sprintf("%sMapArray{%sMap{\"baz\": %s}}", name, name, p.Example),
 			RegisterInput: true,
 		})
-		builtins = append(builtins, &builtin{
+		mapMapType := &builtin{
 			Name:          name + "MapMap",
 			Type:          "map[string]" + name + "MapInput",
 			ItemType:      name + "MapInput",
@@ -281,7 +281,8 @@ func makeBuiltins(primitives []*builtin) []*builtin {
 			item:          mapType,
 			Example:       fmt.Sprintf("%sMapMap{\"baz\": %sMap{\"baz\": %s}}", name, name, p.Example),
 			RegisterInput: true,
-		})
+		}
+		builtins = append(builtins, mapMapType)
 		arrayArrayType := &builtin{
 			Name:          name + "ArrayArray",
 			Type:          "[]" + name + "ArrayInput",
@@ -302,6 +303,19 @@ func makeBuiltins(primitives []*builtin) []*builtin {
 				elementType:   "map[string][][]" + p.Type,
 				item:          arrayArrayType,
 				Example:       fmt.Sprintf("%sArrayArrayMap{\"baz\": %sArrayArray{Array{%s}}}", name, name, p.Example),
+				RegisterInput: true,
+			})
+		}
+
+		// Unblock https://github.com/pulumi/pulumi/issues/17415
+		if name == "String" {
+			builtins = append(builtins, &builtin{
+				Name:          name + "MapMapMap",
+				Type:          "map[string]" + name + "MapMapInput",
+				ItemType:      name + "MapMapInput",
+				elementType:   "map[string]map[string]map[string]" + p.Type,
+				item:          mapMapType,
+				Example:       fmt.Sprintf("%sMapMap{\"baz\": %sMap{\"baz\": %sMap{\"baz\": %s}}}", name, name, name, p.Example),
 				RegisterInput: true,
 			})
 		}

--- a/sdk/go/pulumi/generate/main.go
+++ b/sdk/go/pulumi/generate/main.go
@@ -315,7 +315,7 @@ func makeBuiltins(primitives []*builtin) []*builtin {
 				ItemType:      name + "MapMapInput",
 				elementType:   "map[string]map[string]map[string]" + p.Type,
 				item:          mapMapType,
-				Example:       fmt.Sprintf("%sMapMap{\"baz\": %sMap{\"baz\": %sMap{\"baz\": %s}}}", name, name, name, p.Example),
+				Example:       fmt.Sprintf("%sMapMapMap{\"baz\": %sMapMap{\"baz\": %sMap{\"baz\": %s}}}", name, name, name, p.Example),
 				RegisterInput: true,
 			})
 		}

--- a/sdk/go/pulumi/types_builtins.go
+++ b/sdk/go/pulumi/types_builtins.go
@@ -5566,6 +5566,87 @@ func ToStringArrayArrayOutput(in []StringArrayOutput) StringArrayArrayOutput {
 	return a.ToStringArrayArrayOutput()
 }
 
+var stringMapMapMapType = reflect.TypeOf((*map[string]map[string]map[string]string)(nil)).Elem()
+
+// StringMapMapMapInput is an input type that accepts StringMapMapMap and StringMapMapMapOutput values.
+type StringMapMapMapInput interface {
+	Input
+
+	ToStringMapMapMapOutput() StringMapMapMapOutput
+	ToStringMapMapMapOutputWithContext(ctx context.Context) StringMapMapMapOutput
+}
+
+// StringMapMapMap is an input type for map[string]StringMapMapInput values.
+type StringMapMapMap map[string]StringMapMapInput
+
+// ElementType returns the element type of this Input (map[string]map[string]map[string]string).
+func (StringMapMapMap) ElementType() reflect.Type {
+	return stringMapMapMapType
+}
+
+func (in StringMapMapMap) ToOutput(ctx context.Context) pulumix.Output[map[string]map[string]map[string]string] {
+	return pulumix.Output[map[string]map[string]map[string]string]{
+		OutputState: internal.GetOutputState(ToOutputWithContext(ctx, in)),
+	}
+}
+
+func (in StringMapMapMap) ToStringMapMapMapOutput() StringMapMapMapOutput {
+	return ToOutput(in).(StringMapMapMapOutput)
+}
+
+func (in StringMapMapMap) ToStringMapMapMapOutputWithContext(ctx context.Context) StringMapMapMapOutput {
+	return ToOutputWithContext(ctx, in).(StringMapMapMapOutput)
+}
+
+// StringMapMapMapOutput is an Output that returns map[string]map[string]map[string]string values.
+type StringMapMapMapOutput struct{ *OutputState }
+
+func (StringMapMapMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("Outputs can not be marshaled to JSON")
+}
+
+func (o StringMapMapMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]map[string]map[string]string] {
+	return pulumix.Output[map[string]map[string]map[string]string]{
+		OutputState: o.OutputState,
+	}
+}
+
+// ElementType returns the element type of this Output (map[string]map[string]map[string]string).
+func (StringMapMapMapOutput) ElementType() reflect.Type {
+	return stringMapMapMapType
+}
+
+func (o StringMapMapMapOutput) ToStringMapMapMapOutput() StringMapMapMapOutput {
+	return o
+}
+
+func (o StringMapMapMapOutput) ToStringMapMapMapOutputWithContext(ctx context.Context) StringMapMapMapOutput {
+	return o
+}
+
+// MapIndex looks up the key k in the map.
+func (o StringMapMapMapOutput) MapIndex(k StringInput) StringMapMapOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) map[string]map[string]string {
+		return vs[0].(map[string]map[string]map[string]string)[vs[1].(string)]
+	}).(StringMapMapOutput)
+}
+
+func ToStringMapMapMap(in map[string]map[string]map[string]string) StringMapMapMap {
+	m := make(StringMapMapMap)
+	for k, v := range in {
+		m[k] = ToStringMapMap(v)
+	}
+	return m
+}
+
+func ToStringMapMapMapOutput(in map[string]StringMapMapOutput) StringMapMapMapOutput {
+	m := make(StringMapMapMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToStringMapMapMapOutput()
+}
+
 var urnType = reflect.TypeOf((*URN)(nil)).Elem()
 
 // URNInput is an input type that accepts URN and URNOutput values.
@@ -7104,6 +7185,19 @@ func (a AnyOutput) AsStringArrayArrayOutput() StringArrayArrayOutput {
 	}).(StringArrayArrayOutput)
 }
 
+// AsStringMapMapMapOutput asserts that the type of the AnyOutput's underlying interface{} value is
+// map[string]map[string]map[string]string or a compatible type and returns a `StringMapMapMapOutput` with that value.
+// AsStringMapMapMapOutput panics if the value was not the expected type or a compatible type.
+func (a AnyOutput) AsStringMapMapMapOutput() StringMapMapMapOutput {
+	return a.ApplyT(func(i interface{}) (map[string]map[string]map[string]string, error) {
+		v, err := coerceTypeConversion(i, reflect.TypeOf((*map[string]map[string]map[string]string)(nil)).Elem())
+		if err != nil {
+			return nil, err
+		}
+		return v.(map[string]map[string]map[string]string), nil
+	}).(StringMapMapMapOutput)
+}
+
 // AsURNOutput asserts that the type of the AnyOutput's underlying interface{} value is
 // URN and returns a `URNOutput` with that value. AsURNOutput panics if the value
 // was not the expected type.
@@ -7270,6 +7364,7 @@ func init() {
 	RegisterInputType(reflect.TypeOf((*StringMapArrayInput)(nil)).Elem(), StringMapArray{})
 	RegisterInputType(reflect.TypeOf((*StringMapMapInput)(nil)).Elem(), StringMapMap{})
 	RegisterInputType(reflect.TypeOf((*StringArrayArrayInput)(nil)).Elem(), StringArrayArray{})
+	RegisterInputType(reflect.TypeOf((*StringMapMapMapInput)(nil)).Elem(), StringMapMapMap{})
 	RegisterInputType(reflect.TypeOf((*URNInput)(nil)).Elem(), URN(""))
 	RegisterInputType(reflect.TypeOf((*URNPtrInput)(nil)).Elem(), URN(""))
 	RegisterInputType(reflect.TypeOf((*URNArrayInput)(nil)).Elem(), URNArray{})
@@ -7346,6 +7441,7 @@ func init() {
 	RegisterOutputType(StringMapArrayOutput{})
 	RegisterOutputType(StringMapMapOutput{})
 	RegisterOutputType(StringArrayArrayOutput{})
+	RegisterOutputType(StringMapMapMapOutput{})
 	RegisterOutputType(URNOutput{})
 	RegisterOutputType(URNPtrOutput{})
 	RegisterOutputType(URNArrayOutput{})

--- a/sdk/go/pulumi/types_builtins_test.go
+++ b/sdk/go/pulumi/types_builtins_test.go
@@ -2075,7 +2075,7 @@ func TestToOutputStringArrayArray(t *testing.T) {
 func TestToOutputStringMapMapMap(t *testing.T) {
 	t.Parallel()
 
-	out := ToOutput(StringMapMap{"baz": StringMap{"baz": StringMap{"baz": String("foo")}}})
+	out := ToOutput(StringMapMapMap{"baz": StringMapMap{"baz": StringMap{"baz": String("foo")}}})
 	_, ok := out.(StringMapMapMapInput)
 	assert.True(t, ok)
 
@@ -4297,7 +4297,7 @@ func TestToStringArrayArrayOutput(t *testing.T) {
 func TestToStringMapMapMapOutput(t *testing.T) {
 	t.Parallel()
 
-	in := StringMapMapMapInput(StringMapMap{"baz": StringMap{"baz": StringMap{"baz": String("foo")}}})
+	in := StringMapMapMapInput(StringMapMapMap{"baz": StringMapMap{"baz": StringMap{"baz": String("foo")}}})
 
 	out := in.ToStringMapMapMapOutput()
 
@@ -7554,7 +7554,7 @@ func TestTopLevelToStringMapMapOutput(t *testing.T) {
 func TestStringMapMapMapIndex(t *testing.T) {
 	t.Parallel()
 
-	out := (StringMapMap{"baz": StringMap{"baz": StringMap{"baz": String("foo")}}}).ToStringMapMapMapOutput()
+	out := (StringMapMapMap{"baz": StringMapMap{"baz": StringMap{"baz": String("foo")}}}).ToStringMapMapMapOutput()
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -8920,7 +8920,7 @@ func TestAnyOutputAsStringArrayArrayOutput(t *testing.T) {
 func TestAnyOutputAsStringMapMapMapOutput(t *testing.T) {
 	t.Parallel()
 
-	anyout := Any(StringMapMap{"baz": StringMap{"baz": StringMap{"baz": String("foo")}}})
+	anyout := Any(StringMapMapMap{"baz": StringMapMap{"baz": StringMap{"baz": String("foo")}}})
 	out := anyout.AsStringMapMapMapOutput()
 
 	ev, known, _, _, err := await(anyout)

--- a/sdk/go/pulumi/types_builtins_test.go
+++ b/sdk/go/pulumi/types_builtins_test.go
@@ -545,6 +545,14 @@ func TestOutputApply(t *testing.T) {
 		})
 
 		//nolint:paralleltest // uses shared state with parent
+		t.Run("ApplyT::StringMapMapMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string]map[string]map[string]string {
+				return *new(map[string]map[string]map[string]string)
+			}).(StringMapMapMapOutput)
+			assert.True(t, ok)
+		})
+
+		//nolint:paralleltest // uses shared state with parent
 		t.Run("ApplyT::URNOutput", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) URN { return *new(URN) }).(URNOutput)
 			assert.True(t, ok)
@@ -2057,6 +2065,26 @@ func TestToOutputStringArrayArray(t *testing.T) {
 
 	out = ToOutput(out)
 	_, ok = out.(StringArrayArrayInput)
+	assert.True(t, ok)
+
+	_, known, _, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToOutputStringMapMapMap(t *testing.T) {
+	t.Parallel()
+
+	out := ToOutput(StringMapMap{"baz": StringMap{"baz": StringMap{"baz": String("foo")}}})
+	_, ok := out.(StringMapMapMapInput)
+	assert.True(t, ok)
+
+	_, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(StringMapMapMapInput)
 	assert.True(t, ok)
 
 	_, known, _, _, err = await(out)
@@ -4260,6 +4288,36 @@ func TestToStringArrayArrayOutput(t *testing.T) {
 	assert.NoError(t, err)
 
 	out = out.ToStringArrayArrayOutputWithContext(context.Background())
+
+	_, known, _, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToStringMapMapMapOutput(t *testing.T) {
+	t.Parallel()
+
+	in := StringMapMapMapInput(StringMapMap{"baz": StringMap{"baz": StringMap{"baz": String("foo")}}})
+
+	out := in.ToStringMapMapMapOutput()
+
+	_, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToStringMapMapMapOutput()
+
+	_, known, _, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToStringMapMapMapOutputWithContext(context.Background())
+
+	_, known, _, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToStringMapMapMapOutputWithContext(context.Background())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7493,6 +7551,58 @@ func TestTopLevelToStringMapMapOutput(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]map[string]string)["baz"], iv)
 }
 
+func TestStringMapMapMapIndex(t *testing.T) {
+	t.Parallel()
+
+	out := (StringMapMap{"baz": StringMap{"baz": StringMap{"baz": String("foo")}}}).ToStringMapMapMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+	assert.EqualValues(t, av.(map[string]map[string]map[string]string)["baz"], iv)
+
+	iv, known, _, _, err = await(out.MapIndex(String("notfound")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+	assert.Zero(t, iv)
+}
+
+func TestToStringMapMapMap(t *testing.T) {
+	t.Parallel()
+
+	out := ToStringMapMapMap(map[string]map[string]map[string]string{"baz": {"baz": {"baz": "foo"}}}).ToStringMapMapMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]map[string]string)["baz"], iv)
+}
+
+func TestTopLevelToStringMapMapMapOutput(t *testing.T) {
+	t.Parallel()
+
+	out := ToStringMapMapMapOutput(map[string]StringMapMapOutput{"baz": ToOutput(StringMapMap{"baz": StringMap{"baz": String("foo")}}).(StringMapMapOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]map[string]string)["baz"], iv)
+}
+
 func TestURNMapIndex(t *testing.T) {
 	t.Parallel()
 
@@ -8795,6 +8905,23 @@ func TestAnyOutputAsStringArrayArrayOutput(t *testing.T) {
 
 	anyout := Any(StringArrayArray{StringArray{String("foo")}})
 	out := anyout.AsStringArrayArrayOutput()
+
+	ev, known, _, _, err := await(anyout)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, ev, av)
+}
+
+func TestAnyOutputAsStringMapMapMapOutput(t *testing.T) {
+	t.Parallel()
+
+	anyout := Any(StringMapMap{"baz": StringMap{"baz": StringMap{"baz": String("foo")}}})
+	out := anyout.AsStringMapMapMapOutput()
 
 	ev, known, _, _, err := await(anyout)
 	assert.True(t, known)

--- a/tests/testdata/codegen/go-nested-collections/go/repro/foo.go
+++ b/tests/testdata/codegen/go-nested-collections/go/repro/foo.go
@@ -14,7 +14,8 @@ import (
 type Foo struct {
 	pulumi.CustomResourceState
 
-	ConditionSets BarArrayArrayArrayOutput `pulumi:"conditionSets"`
+	ConditionSets   BarArrayArrayArrayOutput     `pulumi:"conditionSets"`
+	PrivateEndpoint pulumi.StringMapMapMapOutput `pulumi:"privateEndpoint"`
 }
 
 // NewFoo registers a new resource with the given unique name, arguments, and options.
@@ -152,6 +153,10 @@ func (o FooOutput) ToFooOutputWithContext(ctx context.Context) FooOutput {
 
 func (o FooOutput) ConditionSets() BarArrayArrayArrayOutput {
 	return o.ApplyT(func(v *Foo) BarArrayArrayArrayOutput { return v.ConditionSets }).(BarArrayArrayArrayOutput)
+}
+
+func (o FooOutput) PrivateEndpoint() pulumi.StringMapMapMapOutput {
+	return o.ApplyT(func(v *Foo) pulumi.StringMapMapMapOutput { return v.PrivateEndpoint }).(pulumi.StringMapMapMapOutput)
 }
 
 type FooArrayOutput struct{ *pulumi.OutputState }

--- a/tests/testdata/codegen/go-nested-collections/schema.json
+++ b/tests/testdata/codegen/go-nested-collections/schema.json
@@ -15,6 +15,18 @@
                             }
                         }
                     }
+                },
+                "privateEndpoint": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
                 }
             }
         },


### PR DESCRIPTION
This is to unblock https://github.com/pulumi/pulumi/issues/17415. We add `StringMapMapMap` to the Go SDK and a test to check that sdk-gen can use that type.

Really this ought to be a conformance test, but to unblock this quickly just added a sanity check in the old codegen tests.