### PR TITLE
[schema] Validate version is provided when package supports packing

### DIFF
--- a/changelog/pending/20240928--sdkgen--validate-schema-version-is-provided-when-package-supports-packing.yaml
+++ b/changelog/pending/20240928--sdkgen--validate-schema-version-is-provided-when-package-supports-packing.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdkgen
+  description: Validate schema version is provided when package supports packing

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -230,6 +230,9 @@ func newBinder(info PackageInfoSpec, spec specSource, loader Loader,
 			version = &v
 		}
 	}
+	if info.Meta != nil && info.Meta.SupportPack && info.Version == "" {
+		diags = diags.Append(errorf("#/version", "version must be provided when package supports packing"))
+	}
 
 	// Parse the module format, if any.
 	moduleFormat := "(.*)"

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -751,6 +751,23 @@ func TestUsingIdInResourcePropertiesEmitsWarning(t *testing.T) {
 	assert.Contains(t, diags[0].Summary, "id is a reserved property name")
 }
 
+func TestOmittingVersionWhenSupportsPackEnabledGivesError(t *testing.T) {
+	t.Parallel()
+	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	pkgSpec := PackageSpec{
+		Name: "test",
+		Meta: &MetadataSpec{
+			SupportPack: true,
+		},
+		Resources: map[string]ResourceSpec{},
+	}
+
+	_, diags, _ := BindSpec(pkgSpec, loader)
+	assert.Len(t, diags, 1)
+	assert.Equal(t, diags[0].Severity, hcl.DiagError)
+	assert.Contains(t, diags[0].Summary, "version must be provided when package supports packing")
+}
+
 func TestUsingIdInComponentResourcePropertiesEmitsNoWarning(t *testing.T) {
 	t.Parallel()
 	loader := NewPluginLoader(utils.NewHost(testdataPath))


### PR DESCRIPTION
### Description

When a schema has `SupportsPack` enabled, then it must embed a version. This test adds a validation that returns an error diagnostic when that requirement is not met. 

Follow up for (but not depending upon) #17409 