### PR TITLE
run NodeJS tests in parallel

### DIFF
--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -60,14 +60,14 @@ install_plugin:: build
 install:: install_package install_plugin
 
 unit_tests:: $(TEST_ALL_DEPS)
-	yarn run nyc -s mocha --timeout 120000 \
+	yarn run nyc -s mocha --parallel --timeout 120000 \
 		--exclude 'bin/tests/automation/**/*.spec.js' \
 		--exclude 'bin/tests/runtime/closure-integration-tests.js' \
 		'bin/tests/**/*.spec.js'
-	yarn run nyc -s mocha 'bin/tests_with_mocks/**/*.spec.js'
+	yarn run nyc -s mocha --parallel 'bin/tests_with_mocks/**/*.spec.js'
 
 test_auto:: $(TEST_ALL_DEPS)
-	yarn run nyc -s mocha --timeout 300000 'bin/tests/automation/**/*.spec.js'
+	yarn run nyc -s mocha --parallel --timeout 300000 'bin/tests/automation/**/*.spec.js'
 
 test_integration:: $(TEST_ALL_DEPS)
 	node 'bin/tests/runtime/closure-integration-tests.js'


### PR DESCRIPTION
Inspired by https://github.com/pulumi/pulumi/pull/17334#discussion_r1779274727 mentioning that adding more tests would slow down the automation test suite significantly, I realized that we currently run the NodeJS sequentially, and was wondering if we could run them in parallel, which would cut down the pain here a lot, since the tests spend a long time just waiting around.

Mocha conveniently provides an option for this since v8.0.0 (https://mochajs.org/#parallel-tests).  We're currently running v9.0.0, so this should just work.

Hopefully this will just work, but we'll see in CI if any of the tests interfere with eachother.