### PR TITLE
Introduce snapshot metadata

### DIFF
--- a/pkg/backend/diy/backend_legacy_test.go
+++ b/pkg/backend/diy/backend_legacy_test.go
@@ -306,7 +306,7 @@ func TestHtmlEscaping_legacy(t *testing.T) {
 		},
 	}
 
-	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil)
+	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{})
 	ctx := context.Background()
 
 	sdep, err := stack.SerializeDeployment(ctx, snap, false /* showSecrets */)

--- a/pkg/backend/diy/backend_test.go
+++ b/pkg/backend/diy/backend_test.go
@@ -250,7 +250,7 @@ func makeUntypedDeploymentTimestamp(
 		},
 	}
 
-	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil)
+	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{})
 	ctx := context.Background()
 
 	sdep, err := stack.SerializeDeployment(ctx, snap, false /* showSecrets */)
@@ -589,7 +589,7 @@ func TestRenamePreservesIntegrity(t *testing.T) {
 		rParent,
 	}
 
-	snap := deploy.NewSnapshot(deploy.Manifest{}, nil, resources, nil)
+	snap := deploy.NewSnapshot(deploy.Manifest{}, nil, resources, nil, deploy.SnapshotMetadata{})
 	ctx = context.Background()
 
 	sdep, err := stack.SerializeDeployment(ctx, snap, false)
@@ -715,7 +715,7 @@ func TestHtmlEscaping(t *testing.T) {
 		},
 	}
 
-	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil)
+	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{})
 	ctx := context.Background()
 
 	sdep, err := stack.SerializeDeployment(ctx, snap, false /* showSecrets */)

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -662,8 +662,13 @@ func (sm *SnapshotManager) snap() *deploy.Snapshot {
 		secretsManager = sm.baseSnapshot.SecretsManager
 	}
 
+	var metadata deploy.SnapshotMetadata
+	if sm.baseSnapshot != nil {
+		metadata = sm.baseSnapshot.Metadata
+	}
+
 	manifest.Magic = manifest.NewMagic()
-	return deploy.NewSnapshot(manifest, secretsManager, resources, operations)
+	return deploy.NewSnapshot(manifest, secretsManager, resources, operations, metadata)
 }
 
 // saveSnapshot persists the current snapshot and optionally verifies it afterwards.

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -91,7 +91,7 @@ func NewSnapshot(resources []*resource.State) *deploy.Snapshot {
 		Time:    time.Now(),
 		Version: version.Version,
 		Plugins: nil,
-	}, b64.NewBase64SecretsManager(), resources, nil)
+	}, b64.NewBase64SecretsManager(), resources, nil, deploy.SnapshotMetadata{})
 }
 
 var (

--- a/pkg/cmd/pulumi/state_delete_test.go
+++ b/pkg/cmd/pulumi/state_delete_test.go
@@ -108,7 +108,7 @@ func TestStateDeleteURN(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 3, savedDeployment.Version)
 	assert.Equal(t,
-		"{\"manifest\":{\"time\":\"0001-01-01T00:00:00Z\",\"magic\":\"\",\"version\":\"\"}}",
+		`{"manifest":{"time":"0001-01-01T00:00:00Z","magic":"","version":""},"metadata":{}}`,
 		string(savedDeployment.Deployment))
 }
 
@@ -223,6 +223,6 @@ func TestStateDeleteProtected(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 3, savedDeployment.Version)
 	assert.Equal(t,
-		"{\"manifest\":{\"time\":\"0001-01-01T00:00:00Z\",\"magic\":\"\",\"version\":\"\"}}",
+		"{\"manifest\":{\"time\":\"0001-01-01T00:00:00Z\",\"magic\":\"\",\"version\":\"\"},\"metadata\":{}}",
 		string(savedDeployment.Deployment))
 }

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -44,7 +44,7 @@ func createStackWithResources(
 ) backend.Stack {
 	sm := b64.NewBase64SecretsManager()
 
-	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil)
+	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{})
 	ctx := context.Background()
 
 	sdep, err := stack.SerializeDeployment(ctx, snap, false /* showSecrets */)

--- a/pkg/engine/journal.go
+++ b/pkg/engine/journal.go
@@ -146,16 +146,18 @@ func (entries JournalEntries) Snap(base *deploy.Snapshot) (*deploy.Snapshot, err
 		}
 	}
 
-	// If we have a base snapshot, copy over its secrets manager.
+	// If we have a base snapshot, copy over its secrets manager and metadata.
 	var secretsManager secrets.Manager
+	var metadata deploy.SnapshotMetadata
 	if base != nil {
 		secretsManager = base.SecretsManager
+		metadata = base.Metadata
 	}
 
 	manifest := deploy.Manifest{}
 	manifest.Magic = manifest.NewMagic()
 
-	snap := deploy.NewSnapshot(manifest, secretsManager, resources, operations)
+	snap := deploy.NewSnapshot(manifest, secretsManager, resources, operations, metadata)
 	normSnap, err := snap.NormalizeURNReferences()
 	if err != nil {
 		return snap, err

--- a/pkg/resource/deploy/deployment_test.go
+++ b/pkg/resource/deploy/deployment_test.go
@@ -41,7 +41,7 @@ func newSnapshot(resources []*resource.State, ops []resource.Operation) *Snapsho
 		Time:    time.Now(),
 		Version: version.Version,
 		Plugins: nil,
-	}, b64.NewBase64SecretsManager(), resources, ops)
+	}, b64.NewBase64SecretsManager(), resources, ops, SnapshotMetadata{})
 }
 
 func TestPendingOperationsDeployment(t *testing.T) {

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -34,18 +34,38 @@ type Snapshot struct {
 	SecretsManager    secrets.Manager      // the manager to use use when serializing this snapshot.
 	Resources         []*resource.State    // fetches all resources and their associated states.
 	PendingOperations []resource.Operation // all currently pending resource operations.
+	Metadata          SnapshotMetadata     // metadata associated with the snapshot.
+}
+
+// SnapshotMetadata contains metadata about a snapshot.
+type SnapshotMetadata struct {
+	// Metadata associated with any integrity error affecting the snapshot.
+	IntegrityErrorMetadata *SnapshotIntegrityErrorMetadata
+}
+
+// SnapshotIntegrityErrorMetadata contains metadata about a snapshot integrity error, such as the version
+// and invocation of the Pulumi engine that caused it.
+type SnapshotIntegrityErrorMetadata struct {
+	// The version of the Pulumi engine that caused the integrity error.
+	Version string
+	// The command/invocation of the Pulumi engine that caused the integrity error.
+	Command string
+	// The error message associated with the integrity error.
+	Error string
 }
 
 // NewSnapshot creates a snapshot from the given arguments.  The resources must be in topologically sorted order.
 // This property is not checked; for verification, please refer to the VerifyIntegrity function below.
 func NewSnapshot(manifest Manifest, secretsManager secrets.Manager,
 	resources []*resource.State, ops []resource.Operation,
+	metadata SnapshotMetadata,
 ) *Snapshot {
 	return &Snapshot{
 		Manifest:          manifest,
 		SecretsManager:    secretsManager,
 		Resources:         resources,
 		PendingOperations: ops,
+		Metadata:          metadata,
 	}
 }
 

--- a/pkg/resource/edit/operations_test.go
+++ b/pkg/resource/edit/operations_test.go
@@ -69,7 +69,7 @@ func NewSnapshot(resources []*resource.State) *deploy.Snapshot {
 		Time:    time.Now(),
 		Version: version.Version,
 		Plugins: nil,
-	}, b64.NewBase64SecretsManager(), resources, nil)
+	}, b64.NewBase64SecretsManager(), resources, nil, deploy.SnapshotMetadata{})
 }
 
 func TestDeletion(t *testing.T) {

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -146,11 +146,21 @@ func SerializeDeployment(ctx context.Context, snap *deploy.Snapshot, showSecrets
 		}
 	}
 
+	metadata := apitype.SnapshotMetadataV1{}
+	if snap.Metadata.IntegrityErrorMetadata != nil {
+		metadata.IntegrityErrorMetadata = &apitype.SnapshotIntegrityErrorMetadataV1{
+			Version: snap.Metadata.IntegrityErrorMetadata.Version,
+			Command: snap.Metadata.IntegrityErrorMetadata.Command,
+			Error:   snap.Metadata.IntegrityErrorMetadata.Error,
+		}
+	}
+
 	return &apitype.DeploymentV3{
 		Manifest:          manifest,
 		Resources:         resources,
 		SecretsProviders:  secretsProvider,
 		PendingOperations: operations,
+		Metadata:          metadata,
 	}, nil
 }
 
@@ -298,7 +308,16 @@ func DeserializeDeploymentV3(
 		ops = append(ops, desop)
 	}
 
-	return deploy.NewSnapshot(*manifest, secretsManager, resources, ops), nil
+	metadata := deploy.SnapshotMetadata{}
+	if deployment.Metadata.IntegrityErrorMetadata != nil {
+		metadata.IntegrityErrorMetadata = &deploy.SnapshotIntegrityErrorMetadata{
+			Version: deployment.Metadata.IntegrityErrorMetadata.Version,
+			Command: deployment.Metadata.IntegrityErrorMetadata.Command,
+			Error:   deployment.Metadata.IntegrityErrorMetadata.Error,
+		}
+	}
+
+	return deploy.NewSnapshot(*manifest, secretsManager, resources, ops, metadata), nil
 }
 
 // SerializeResource turns a resource into a structure suitable for serialization.

--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -148,11 +148,30 @@ type DeploymentV3 struct {
 	Resources []ResourceV3 `json:"resources,omitempty" yaml:"resources,omitempty"`
 	// PendingOperations are all operations that were known by the engine to be currently executing.
 	PendingOperations []OperationV2 `json:"pending_operations,omitempty" yaml:"pending_operations,omitempty"`
+	// Metadata associated with the snapshot.
+	Metadata SnapshotMetadataV1 `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 }
 
 type SecretsProvidersV1 struct {
 	Type  string          `json:"type"`
 	State json.RawMessage `json:"state,omitempty"`
+}
+
+// SnapshotMetadataV1 contains metadata about a deployment snapshot.
+type SnapshotMetadataV1 struct {
+	// Metadata associated with any integrity error affecting the snapshot.
+	IntegrityErrorMetadata *SnapshotIntegrityErrorMetadataV1 `json:"integrity_error,omitempty" yaml:"integrity_error,omitempty"`
+}
+
+// SnapshotIntegrityErrorMetadataV1 contains metadata about a snapshot integrity error, such as the version
+// and invocation of the Pulumi engine that caused it.
+type SnapshotIntegrityErrorMetadataV1 struct {
+	// The version of the Pulumi engine that caused the integrity error.
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+	// The command/invocation of the Pulumi engine that caused the integrity error.
+	Command string `json:"command,omitempty" yaml:"command,omitempty"`
+	// The error message associated with the integrity error.
+	Error string `json:"error,omitempty" yaml:"error,omitempty"`
 }
 
 // OperationType is the type of an operation initiated by the engine. Its value indicates the type of operation


### PR DESCRIPTION
This commit introduces a `Metadata` field to state snapshots. The initial use case for this field will be tracking snapshot integrity errors, so that better messages can be produced for users and better diagnostic information preserved for contributors. When this commit is merged, support for persisting the field will be added to backends appropriately, before use cases such as the above can be implemented.