### PR TITLE
Check zipped templates for `Pulumi.yaml` files

### DIFF
--- a/changelog/pending/20241001--cli-new--check-zipped-templates-for-pulumi-yaml-files.yaml
+++ b/changelog/pending/20241001--cli-new--check-zipped-templates-for-pulumi-yaml-files.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Check zipped templates for `Pulumi.yaml` files

--- a/sdk/go/common/workspace/templates_zip.go
+++ b/sdk/go/common/workspace/templates_zip.go
@@ -17,6 +17,7 @@ package workspace
 import (
 	"archive/zip"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -165,6 +166,18 @@ func RetrieveZIPTemplateFolder(templateURL *url.URL, tempDir string) (string, er
 	if err != nil {
 		return "", err
 	}
+
+	hasPulumiYAML := false
+	for _, file := range archive.File {
+		if !file.FileInfo().IsDir() && file.FileInfo().Name() == "Pulumi.yaml" {
+			hasPulumiYAML = true
+			break
+		}
+	}
+	if !hasPulumiYAML {
+		return "", errors.New("template does not contain a Pulumi.yaml file")
+	}
+
 	for _, file := range archive.File {
 		filePath, err := sanitizeArchivePath(tempDir, file.Name)
 		if err != nil {


### PR DESCRIPTION
This commit strengthens the validation of project templates supplied as `.zip` archives, checking them for a `Pulumi.yaml` before copying the contents.

Closes #14824