### PR TITLE
send a value to the abortchan instead of closing it

### DIFF
--- a/changelog/pending/20241001--engine--fix-a-panic-when-multiple-component-provider-construct-calls-fail.yaml
+++ b/changelog/pending/20241001--engine--fix-a-panic-when-multiple-component-provider-construct-calls-fail.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix a panic when multiple component provider construct calls fail

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -196,6 +196,7 @@ type evalSourceIterator struct {
 	regReadChan  chan *readResourceEvent            // the channel that contains read resource requests.
 	finChan      chan error                         // the channel that communicates completion.
 	done         bool                               // set to true when the evaluation is done.
+	aborted      bool                               // set to true when the iterator is aborted.
 }
 
 func (iter *evalSourceIterator) Close() error {
@@ -208,6 +209,10 @@ func (iter *evalSourceIterator) ResourceMonitor() SourceResourceMonitor {
 }
 
 func (iter *evalSourceIterator) Next() (SourceEvent, error) {
+	// if the iterator is aborted, return an error.
+	if iter.aborted {
+		return nil, result.BailErrorf("EvalSourceIterator aborted")
+	}
 	// If we are done, quit.
 	if iter.done {
 		return nil, nil
@@ -216,6 +221,7 @@ func (iter *evalSourceIterator) Next() (SourceEvent, error) {
 	// Await the program to compute some more state and then inspect what it has to say.
 	select {
 	case <-iter.mon.AbortChan():
+		iter.aborted = true
 		return nil, result.BailErrorf("EvalSourceIterator aborted")
 	case reg := <-iter.regChan:
 		contract.Assertf(reg != nil, "received a nil registerResourceEvent")
@@ -2246,7 +2252,7 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 				rm.diagnostics.Errorf(diag.GetResourceInvalidError(constructResult.URN), t, name, err)
 			}
 
-			close(rm.abortChan)
+			rm.abortChan <- true
 			<-rm.cancel
 			return nil, rpcerror.New(codes.Unknown, "resource monitor shut down")
 		}

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -1967,6 +1967,25 @@ func TestEvalSourceIterator(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	})
+	t.Run("Abort", func(t *testing.T) {
+		t.Parallel()
+		abortChan := make(chan bool)
+		iter := &evalSourceIterator{
+			mon: &resmon{
+				abortChan: abortChan,
+			},
+		}
+		go func() {
+			abortChan <- true
+		}()
+		evt, err := iter.Next()
+		assert.ErrorContains(t, err, "EvalSourceIterator aborted")
+		assert.Nil(t, evt)
+
+		evt, err = iter.Next()
+		assert.ErrorContains(t, err, "EvalSourceIterator aborted")
+		assert.Nil(t, evt)
+	})
 }
 
 func TestParseSourcePosition(t *testing.T) {
@@ -3369,9 +3388,11 @@ func TestValidationFailures(t *testing.T) {
 		cancel := make(chan bool)
 		abortChan := make(chan bool)
 		go func() {
-			// the resource monitor should close the abort channel to poison the iterator.
-			_, ok := <-abortChan
-			assert.False(t, ok)
+			// the resource monitor should send a true value to the abort channel to indicate that the
+			// iterator should shut down.
+			val, ok := <-abortChan
+			assert.True(t, ok)
+			assert.True(t, val)
 			close(cancel)
 		}()
 		requests := make(chan defaultProviderRequest, 1)


### PR DESCRIPTION
When we're getting an error, we want to abort the source iterator by closing the abort channel.  However, multiple RegisterResource requests can already be in progress at that time, since they are bbeing run in parallel.  When two of those result in an error, we try to close the channel twice, which in turn results in a panic because Go doesn't allow that.

Instead what we should do here is send a value to the abort channel, which will then poison the iterator, similar to how closing the channel would poison it.

Fixes https://github.com/pulumi/pulumi/issues/17438