### PR TITLE
Hide `pulumi preview`'s `--show-secrets` with `--save-plan`

### DIFF
--- a/changelog/pending/20241001--cli-display--hide-show-secrets-with-save-plan.yaml
+++ b/changelog/pending/20241001--cli-display--hide-show-secrets-with-save-plan.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Hide --show-secrets with --save-plan

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -556,7 +556,7 @@ func newPreviewCmd() *cobra.Command {
 		contract.AssertNoErrorf(cmd.PersistentFlags().MarkHidden("save-plan"),
 			`Could not mark "save-plan" as hidden`)
 		contract.AssertNoErrorf(cmd.Flags().MarkHidden("show-secrets"),
-			`Could not mark "save-plan" as hidden`)
+			`Could not mark "show-secrets" as hidden`)
 	}
 	cmd.PersistentFlags().StringVar(
 		&importFilePath, "import-file", "",

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -458,6 +458,11 @@ func newPreviewCmd() *cobra.Command {
 				importFilePromise = buildImportFile(events)
 			}
 
+			if planFilePath == "" && showSecrets {
+				cmdutil.Diag().Warningf(diag.RawMessage("", /*urn*/
+					"--show-secrets only applies when --save-plan is set"))
+			}
+
 			plan, changes, res := s.Preview(ctx, backend.UpdateOperation{
 				Proj:               proj,
 				Root:               root,
@@ -543,15 +548,19 @@ func newPreviewCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(
 		&planFilePath, "save-plan", "",
 		"[EXPERIMENTAL] Save the operations proposed by the preview to a plan file at the given path")
+	cmd.Flags().BoolVarP(
+		&showSecrets, "show-secrets", "", false,
+		"[EXPERIMENTAL] Emit secrets in plaintext in the plan file. Defaults to `false`")
+
 	if !hasExperimentalCommands() {
-		contract.AssertNoErrorf(cmd.PersistentFlags().MarkHidden("save-plan"), `Could not mark "save-plan" as hidden`)
+		contract.AssertNoErrorf(cmd.PersistentFlags().MarkHidden("save-plan"),
+			`Could not mark "save-plan" as hidden`)
+		contract.AssertNoErrorf(cmd.Flags().MarkHidden("show-secrets"),
+			`Could not mark "save-plan" as hidden`)
 	}
 	cmd.PersistentFlags().StringVar(
 		&importFilePath, "import-file", "",
 		"Save any creates seen during the preview into an import file to use with 'pulumi import'")
-
-	cmd.Flags().BoolVarP(
-		&showSecrets, "show-secrets", "", false, "Emit secrets in plaintext in the plan file. Defaults to `false`")
 
 	cmd.PersistentFlags().StringVar(
 		&client, "client", "", "The address of an existing language runtime host to connect to")


### PR DESCRIPTION
`--show-secrets` implies that https://github.com/pulumi/pulumi/issues/9830 is implemented for `pulumi preview`, but it has not been. Instead `pulumi preview` only applies to `--save-plan`, which is hidden by default. This PR does 2 things:

1. It hides `--show-secrets` when `--save-plan` is also hidden.
2. It adds a warning when `--show-secrets` is true but `--save-plan` is unset.

This makes the use of `--show-secrets` less confusing.