### PR TITLE
Introduce the `state repair` command

### DIFF
--- a/changelog/pending/20241001--cli-state--introduce-the-state-repair-command.yaml
+++ b/changelog/pending/20241001--cli-state--introduce-the-state-repair-command.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/state
+  description: Introduce the `state repair` command

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -58,6 +58,7 @@ troubleshooting a stack or when performing specific edits that otherwise would r
 	cmd.AddCommand(newStateRenameCommand())
 	cmd.AddCommand(newStateUpgradeCommand())
 	cmd.AddCommand(newStateMoveCommand())
+	cmd.AddCommand(newStateRepairCommand())
 	return cmd
 }
 

--- a/pkg/cmd/pulumi/state_repair.go
+++ b/pkg/cmd/pulumi/state_repair.go
@@ -1,0 +1,299 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	"github.com/pulumi/pulumi/pkg/v3/version"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type stateRepairCmd struct {
+	// A string containing the set of flags passed to the command, for use in error messages.
+	FlagsString string
+	// Parsed arguments to the command.
+	Args *stateRepairArgs
+
+	// The command's standard input.
+	Stdin terminal.FileReader
+	// The command's standard output.
+	Stdout terminal.FileWriter
+	// The command's standard error.
+	Stderr io.Writer
+
+	// The workspace to operate on.
+	Workspace pkgWorkspace.Context
+	// The login manager to use for authenticating with and loading backends.
+	LoginManager backend.LoginManager
+}
+
+// A set of arguments for the `state repair` command.
+type stateRepairArgs struct {
+	Stack     string
+	Colorizer colors.Colorization
+	Yes       bool
+}
+
+func newStateRepairCommand() *cobra.Command {
+	stateRepair := &stateRepairCmd{
+		Args: &stateRepairArgs{
+			Colorizer: cmdutil.GetGlobalColorization(),
+		},
+		Stdin:        os.Stdin,
+		Stdout:       os.Stdout,
+		Stderr:       os.Stderr,
+		Workspace:    pkgWorkspace.Instance,
+		LoginManager: DefaultLoginManager,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "repair",
+		Short: "Repair an invalid state",
+		Long: `Repair an invalid state,
+
+This command can be used to repair an invalid state file. It will attempt to
+sort resources that appear out of order and remove references to resources that
+are no longer present in the state. If the state is already valid, this command
+will not attempt to make or write any changes. If the state is not already
+valid, and remains invalid after repair has been attempted, this command will
+not write any changes.
+`,
+		Args: cmdutil.NoArgs,
+		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
+			cmd.Flags().Visit(func(f *pflag.Flag) {
+				stateRepair.FlagsString += fmt.Sprintf(" --%s=%q", f.Name, f.Value)
+			})
+
+			ctx := cmd.Context()
+			err := stateRepair.run(ctx)
+
+			return err
+		}),
+	}
+
+	cmd.Flags().StringVarP(&stateRepair.Args.Stack,
+		"stack", "s", "", "The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().BoolVarP(&stateRepair.Args.Yes,
+		"yes", "y", false, "Automatically approve and perform the repair")
+
+	return cmd
+}
+
+func (cmd *stateRepairCmd) run(ctx context.Context) error {
+	// We need to disable integrity checking since this command exists solely to repair invalid states and enabling
+	// integrity checking would prevent us from even loading them in the first place. Currently integrity checking is
+	// controlled by a hacky global variable, so this is the best we can do, but hopefully it and consequently this code
+	// can be refactored.
+	backend.DisableIntegrityChecking = true
+	defer func() { backend.DisableIntegrityChecking = false }()
+
+	displayOpts := display.Options{
+		Color: cmd.Args.Colorizer,
+	}
+	s, err := requireStack(
+		ctx,
+		cmd.Workspace,
+		cmd.LoginManager,
+		cmd.Args.Stack,
+		stackOfferNew,
+		displayOpts,
+	)
+	if err != nil {
+		return err
+	}
+
+	snap, err := s.Snapshot(ctx, stack.DefaultSecretsProvider)
+	if err != nil {
+		return err
+	} else if snap == nil {
+		return nil
+	}
+
+	sink := diag.DefaultSink(cmd.Stdout, cmd.Stderr, diag.FormatOptions{
+		Color: cmd.Args.Colorizer,
+	})
+
+	// If the snapshot is already valid, we won't touch it.
+	initialErr := snap.VerifyIntegrity()
+	if initialErr == nil {
+		sink.Infof(diag.RawMessage("" /*urn*/, "The snapshot is already valid; skipping repair"))
+		return nil
+	}
+
+	beforeSort := snap.Resources
+
+	// Sorting the snapshot could fail due to cycles or e.g. unparseable provider references. In those cases, manual
+	// repair is likely the only option, so we'll print a help banner to guide the user through that and invite them
+	// to file a report so that we can learn about how they ended up with such a state.
+	err = snap.Toposort()
+	if err != nil {
+		sink.Errorf(diag.RawMessage("" /*urn*/, cmd.manualRepairError(initialErr, err)))
+
+		// We've already taken care of printing an error message, so we'll wrap the error we return in a Bail so that
+		// callers higher up the stack don't print anything of their own.
+		return result.BailError(err)
+	}
+
+	afterSort := snap.Resources
+	reorderings := computeStateRepairReorderings(beforeSort, afterSort)
+
+	pruneResults := snap.Prune()
+
+	// In the case that we complete repairs (sorting, pruning and so on) but the snapshot is still invalid, we'll
+	// produce a banner that helps the user conduct a manual repair but also includes both errors, so that if they
+	// file a report we can hopefully diagnose both what caused the invalid snapshot but also why we failed to repair
+	// it (assuming a repair was possible).
+	err = snap.VerifyIntegrity()
+	if err != nil {
+		sink.Errorf(diag.RawMessage("" /*urn*/, cmd.manualRepairError(initialErr, err)))
+
+		// We've already taken care of printing an error message, so we'll wrap the error we return in a Bail so that
+		// callers higher up the stack don't print anything of their own.
+		return result.BailError(initialErr)
+	}
+
+	// We've managed to repair the invalid snapshot. If the user has passed the --yes flag, we'll just write the changes.
+	// If not, we'll render a summary of the operations we've performed and ask for confirmation before writing.
+	if !cmd.Args.Yes {
+		sink.Infof(diag.RawMessage(
+			"", /*urn*/
+			renderStateRepairOperations(cmd.Args.Colorizer, reorderings, pruneResults),
+		))
+
+		yes := "yes"
+		no := "no"
+		msg := "This command will edit your stack's state directly. Confirm?"
+		options := []string{yes, no}
+
+		switch response := promptUser(
+			msg, options, no, cmd.Args.Colorizer,
+			survey.WithStdio(cmd.Stdin, cmd.Stdout, cmd.Stderr),
+		); response {
+		case yes:
+			// Continue.
+		case no:
+			sink.Infof(diag.RawMessage("" /*urn*/, "Confirmation denied, not proceeding with state repair"))
+			return nil
+		}
+	}
+
+	// We've managed to repair the snapshot -- import it back into the backend.
+	sdep, err := stack.SerializeDeployment(ctx, snap, false /*showSecrets*/)
+	if err != nil {
+		return fmt.Errorf("serializing deployment: %w", err)
+	}
+
+	bytes, err := json.Marshal(sdep)
+	if err != nil {
+		return err
+	}
+
+	err = s.ImportDeployment(ctx, &apitype.UntypedDeployment{
+		Version:    apitype.DeploymentSchemaVersionCurrent,
+		Deployment: bytes,
+	})
+	if err != nil {
+		return err
+	}
+
+	sink.Infof(diag.RawMessage("" /*urn*/, "State repaired successfully"))
+	return nil
+}
+
+// Returns a help banner detailing the given error and providing instructions for manual state repair.
+func (cmd *stateRepairCmd) manualRepairError(initialErr error, err error) string {
+	stateFile := "state.json"
+	stateFileBackup := "state.json.backup"
+
+	stateExportCommand := fmt.Sprintf("pulumi stack%s export > %s", cmd.FlagsString, stateFile)
+
+	var copyBinary string
+	if runtime.GOOS == "windows" {
+		copyBinary = "copy"
+	} else {
+		copyBinary = "cp"
+	}
+	copyCommand := fmt.Sprintf("%s %s %s", copyBinary, stateFile, stateFileBackup)
+
+	stateImportCommand := fmt.Sprintf("pulumi stack%s import < %s", cmd.FlagsString, stateFile)
+
+	return fmt.Sprintf(`Failed to repair the snapshot automatically: %[1]v
+
+Pulumi is unable to automatically repair the snapshot. This can happen if the
+snapshot contains cycles or corrupted or unparseable data. You may be able to
+manually repair your stack as follows:
+
+1. Manually export your stack's state to a file named %[2]s:
+
+   %[3]s
+
+2. Make a copy of the exported %[2]s file so that you have a backup:
+
+   %[4]s
+
+3. Edit the exported %[2]s file to fix any issues, such as cyclic
+   dependencies or corrupted data.
+
+4. Import the repaired %[2]s file back into your stack:
+
+   %[5]s
+
+
+================================================================================
+We would appreciate a report: https://github.com/pulumi/pulumi/issues/
+
+Please provide all of the text below in your report.
+================================================================================
+Pulumi Version:    %[6]s
+Go Version:        %[7]s
+Go Compiler:       %[8]s
+Architecture:      %[9]s
+Operating System:  %[10]s
+Command:           %[11]s
+Initial Error:     %[12]s
+`,
+		err,
+		stateFile,
+		stateExportCommand,
+		copyCommand,
+		stateImportCommand,
+		version.Version,
+		runtime.Version(),
+		runtime.Compiler,
+		runtime.GOARCH,
+		runtime.GOOS,
+		strings.Join(os.Args, " "),
+		initialErr,
+	)
+}

--- a/pkg/cmd/pulumi/state_repair_render.go
+++ b/pkg/cmd/pulumi/state_repair_render.go
@@ -1,0 +1,159 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+// Given a list of states before and after a reordering operation (such as a topological sort), computes the set of
+// states which have been moved. This function attempts to only return resources which have been "directly" moved, and
+// not simply shifted in response to another resource changing position. For example, given:
+//
+// Before: 4, 1, 2, 3, 5
+// After:  1, 2, 3, 4, 5
+//
+// We should expect to identify 4 as having been moved, but not 1, 2, or 3, even though their positions have technically
+// changed. We do this by effectively transforming the list of states into a doubly-linked list and only returning
+// elements whose previous *and* next elements changed. This is imperfect in the case where there are exactly two
+// elements in total but otherwise works well. In the example above, we have:
+//
+// Before:
+//
+// 4 { Previous: nil, Next: 1 }
+// 1 { Previous: 4,   Next: 2 }
+// 2 { Previous: 1,   Next: 3 }
+// 3 { Previous: 2,   Next: 5 }
+// 5 { Previous: 3,   Next: nil }
+//
+// After:
+//
+// 1 { Previous: nil, Next: 2 }
+// 2 { Previous: 1,   Next: 3 }
+// 3 { Previous: 2,   Next: 4 }
+// 4 { Previous: 3,   Next: 5 }
+// 5 { Previous: 4,   Next: nil }
+//
+// and so we see that 4 is indeed the sole reordered element.
+func computeStateRepairReorderings(
+	before []*resource.State,
+	after []*resource.State,
+) []*resource.State {
+	prevs := map[resource.URN]*resource.State{}
+	nexts := map[resource.URN]*resource.State{}
+
+	// First run through the list before reordering took place, recording for each state the ones that preceded and
+	// succeeded it.
+	var prev *resource.State
+	for _, state := range before {
+		prevs[state.URN] = prev
+		if prev != nil {
+			nexts[prev.URN] = state
+		}
+
+		prev = state
+	}
+
+	// Now run through the list after reordering. For each element, if *both* its preceding and succeeding states changed,
+	// add it to the list of reorderings.
+	var reorderings []*resource.State
+	prev = nil
+	for i, state := range after {
+		if prev != prevs[state.URN] {
+			var next *resource.State
+			if i < len(after)-1 {
+				next = after[i+1]
+			}
+
+			if next != nexts[state.URN] {
+				reorderings = append(reorderings, state)
+			}
+		}
+
+		prev = state
+	}
+
+	return reorderings
+}
+
+// Renders a set of state repair operations as a human-readable string.
+func renderStateRepairOperations(
+	colorization colors.Colorization,
+	reorderings []*resource.State,
+	pruneResults []deploy.PruneResult,
+) string {
+	var b strings.Builder
+
+	if len(reorderings) > 0 {
+		b.WriteString(`The following resources will be reordered to appear before their dependents:
+
+`)
+
+		for _, state := range reorderings {
+			b.WriteString("* ")
+			b.WriteString(string(state.URN))
+			if state.Delete {
+				b.WriteString(" (deleted)")
+			}
+			b.WriteString("\n")
+		}
+
+		b.WriteString("\n")
+	}
+
+	if len(pruneResults) > 0 {
+		b.WriteString(`The following resources will be modified to remove missing dependencies:
+
+`)
+
+		for _, result := range pruneResults {
+			b.WriteString(colorization.Colorize(colors.SpecUpdate + "~" + colors.Reset + " "))
+			b.WriteString(string(result.OldURN))
+			if result.Delete {
+				b.WriteString(" (deleted)")
+			}
+			b.WriteString("\n")
+
+			if result.NewURN != result.OldURN {
+				b.WriteString("  " + colorization.Colorize(colors.SpecUpdate+"~"+colors.Reset+" "))
+				b.WriteString(string(result.NewURN))
+				b.WriteString(" [urn]\n")
+			}
+
+			for _, d := range result.RemovedDependencies {
+				b.WriteString("  " + colorization.Colorize(colors.SpecDelete+"-"+colors.Reset+" "))
+				b.WriteString(string(d.URN))
+				b.WriteRune(' ')
+				switch d.Type {
+				case resource.ResourceParent:
+					b.WriteString("[parent]")
+				case resource.ResourceDependency:
+					b.WriteString("[dependency]")
+				case resource.ResourcePropertyDependency:
+					b.WriteString("[property dependency: " + string(d.Key) + "]")
+				case resource.ResourceDeletedWith:
+					b.WriteString("[deleted with]")
+				}
+				b.WriteString("\n")
+			}
+		}
+	}
+
+	return b.String()
+}

--- a/pkg/cmd/pulumi/state_repair_test.go
+++ b/pkg/cmd/pulumi/state_repair_test.go
@@ -1,0 +1,377 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"runtime"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+)
+
+//nolint:paralleltest // State repairing modifies the DisableIntegrityChecking global variable
+func TestStateRepair_ExitsIfTheStateIsAlreadyValid(t *testing.T) {
+	// Arrange.
+	cases := []struct {
+		name      string
+		resources []*resource.State
+	}{
+		{
+			name:      "empty",
+			resources: []*resource.State{},
+		},
+		{
+			name: "no dependencies",
+			resources: []*resource.State{
+				{URN: "a"},
+				{URN: "b"},
+				{URN: "c"},
+			},
+		},
+		{
+			name: "valid dependencies",
+			resources: []*resource.State{
+				{URN: "a"},
+				{URN: "b", Dependencies: []resource.URN{"a"}},
+				{URN: "c", Dependencies: []resource.URN{"b"}},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+
+		t.Run(c.name, func(t *testing.T) {
+			fx := newStateRepairCmdFixture(t, []*resource.State{})
+
+			// Act.
+			err := fx.cmd.run(context.Background())
+
+			// Assert.
+			assert.NoError(t, err)
+			assert.Contains(t, fx.stdout.String(), "already valid")
+			assert.Nil(t, fx.imported, "Import should not have proceeded")
+		})
+	}
+}
+
+//nolint:paralleltest // State repairing modifies the DisableIntegrityChecking global variable
+func TestStateRepair_ConfirmationIncludesReorderSummary(t *testing.T) {
+	// Survey (the library we currently use for managing prompt input) does not currently pick up inputs when tested under
+	// Windows. Consequently we skip if the test is running on Windows.
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping: mocking input to Survey is not supported on Windows")
+	}
+
+	// Arrange.
+	fx := newStateRepairCmdFixture(t, []*resource.State{
+		{URN: "b", Dependencies: []resource.URN{"a"}},
+		{URN: "a"},
+	})
+
+	fx.stdin.buf.WriteString("no\r\n")
+
+	// Act.
+	err := fx.cmd.run(context.Background())
+
+	// Assert.
+	assert.NoError(t, err)
+	assert.Contains(t, fx.stdout.String(), "will be reordered")
+	assert.NotContains(t, fx.stdout.String(), "will be modified")
+}
+
+//nolint:paralleltest // State repairing modifies the DisableIntegrityChecking global variable
+func TestStateRepair_ConfirmationIncludesModificationSummary(t *testing.T) {
+	// Survey (the library we currently use for managing prompt input) does not currently pick up inputs when tested under
+	// Windows. Consequently we skip if the test is running on Windows.
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping: mocking input to Survey is not supported on Windows")
+	}
+
+	// Arrange.
+	fx := newStateRepairCmdFixture(t, []*resource.State{
+		{URN: "c", Dependencies: []resource.URN{"d"}},
+	})
+
+	fx.stdin.buf.WriteString("no\r\n")
+
+	// Act.
+	err := fx.cmd.run(context.Background())
+
+	// Assert.
+	assert.NoError(t, err)
+	assert.NotContains(t, fx.stdout.String(), "will be reordered")
+	assert.Contains(t, fx.stdout.String(), "will be modified")
+}
+
+//nolint:paralleltest // State repairing modifies the DisableIntegrityChecking global variable
+func TestStateRepair_ConfirmationIncludesCombinedSummaries(t *testing.T) {
+	// Survey (the library we currently use for managing prompt input) does not currently pick up inputs when tested under
+	// Windows. Consequently we skip if the test is running on Windows.
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping: mocking input to Survey is not supported on Windows")
+	}
+
+	// Arrange.
+	fx := newStateRepairCmdFixture(t, []*resource.State{
+		{URN: "b", Dependencies: []resource.URN{"a"}},
+		{URN: "a"},
+		{URN: "c", Dependencies: []resource.URN{"d"}},
+	})
+
+	fx.stdin.buf.WriteString("no\r\n")
+
+	// Act.
+	err := fx.cmd.run(context.Background())
+
+	// Assert.
+	assert.NoError(t, err)
+	assert.Contains(t, fx.stdout.String(), "will be reordered")
+	assert.Contains(t, fx.stdout.String(), "will be modified")
+}
+
+//nolint:paralleltest // State repairing modifies the DisableIntegrityChecking global variable
+func TestStateRepair_PromptsForConfirmationAndCancels(t *testing.T) {
+	// Survey (the library we currently use for managing prompt input) does not currently pick up inputs when tested under
+	// Windows. Consequently we skip if the test is running on Windows.
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping: mocking input to Survey is not supported on Windows")
+	}
+
+	// Arrange.
+	fx := newStateRepairCmdFixture(t, []*resource.State{
+		{URN: "b", Dependencies: []resource.URN{"a"}},
+		{URN: "a"},
+	})
+
+	fx.stdin.buf.WriteString("no\r\n")
+
+	// Act.
+	err := fx.cmd.run(context.Background())
+
+	// Assert.
+	assert.NoError(t, err)
+	assert.Contains(t, fx.stdout.String(), "Confirm?")
+	assert.Nil(t, fx.imported, "Import should not have proceeded")
+}
+
+//nolint:paralleltest // State repairing modifies the DisableIntegrityChecking global variable
+func TestStateRepair_PromptsForConfirmationAndProceeds(t *testing.T) {
+	// Survey (the library we currently use for managing prompt input) does not currently pick up inputs when tested under
+	// Windows. Consequently we skip if the test is running on Windows.
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping: mocking input to Survey is not supported on Windows")
+	}
+
+	// Arrange.
+	fx := newStateRepairCmdFixture(t, []*resource.State{
+		{URN: "b", Dependencies: []resource.URN{"a"}},
+		{URN: "a"},
+	})
+
+	fx.stdin.buf.WriteString("yes\r\n")
+
+	// Act.
+	err := fx.cmd.run(context.Background())
+
+	// Assert.
+	assert.NoError(t, err)
+	assert.Contains(t, fx.stdout.String(), "Confirm?")
+	assert.NotNil(t, fx.imported, "Import should have proceeded")
+}
+
+//nolint:paralleltest // State repairing modifies the DisableIntegrityChecking global variable
+func TestStateRepair_SkipsConfirmationIfYesFlagIsSet(t *testing.T) {
+	// Arrange.
+	fx := newStateRepairCmdFixture(t, []*resource.State{
+		{URN: "b", Dependencies: []resource.URN{"a"}},
+		{URN: "a"},
+	})
+	fx.cmd.Args.Yes = true
+
+	// Act.
+	err := fx.cmd.run(context.Background())
+
+	// Assert.
+	assert.NoError(t, err)
+	assert.NotContains(t, fx.stdout.String(), "Confirm?")
+	assert.NotNil(t, fx.imported, "Import should have proceeded")
+}
+
+//nolint:paralleltest // State repairing modifies the DisableIntegrityChecking global variable
+func TestStateRepair_DoesNotWriteIfRepairFails(t *testing.T) {
+	// Arrange.
+	//
+	// Dangling provider references can't be fixed, so this snapshot should fail to repair.
+	fx := newStateRepairCmdFixture(t, []*resource.State{
+		{URN: "a", Provider: "urn:pulumi:stack::project::pulumi:providers:p::x::id"},
+	})
+	fx.cmd.Args.Yes = true
+
+	// Act.
+	err := fx.cmd.run(context.Background())
+
+	// Assert.
+	assert.ErrorContains(t, err, "unknown provider")
+	assert.Contains(t, fx.stderr.String(), "Failed to repair")
+	assert.Nil(t, fx.imported, "Import should not have proceeded")
+}
+
+//nolint:paralleltest // State repairing modifies the DisableIntegrityChecking global variable
+func TestStateRepair_RepairsSnapshots(t *testing.T) {
+	// Arrange.
+	fx := newStateRepairCmdFixture(t, []*resource.State{
+		{URN: "b", Dependencies: []resource.URN{"a"}},
+		{URN: "a"},
+	})
+	fx.cmd.Args.Yes = true
+
+	// Act.
+	err := fx.cmd.run(context.Background())
+
+	// Assert.
+	assert.NoError(t, err)
+	assert.Contains(t, fx.stdout.String(), "State repaired successfully")
+	assert.Equal(t, "a", string(fx.imported.Resources[0].URN))
+	assert.Equal(t, "b", string(fx.imported.Resources[1].URN))
+}
+
+type stateRepairCmdFixture struct {
+	cmd *stateRepairCmd
+
+	stdin  *mockFileReader
+	stdout *mockFileWriter
+	stderr *bytes.Buffer
+
+	imported *apitype.DeploymentV3
+}
+
+func newStateRepairCmdFixture(
+	t *testing.T,
+	resources []*resource.State,
+) *stateRepairCmdFixture {
+	fx := &stateRepairCmdFixture{
+		stdin:  &mockFileReader{fd: 0},
+		stdout: &mockFileWriter{fd: 1},
+		stderr: &bytes.Buffer{},
+	}
+
+	s := &backend.MockStack{
+		ImportDeploymentF: func(_ context.Context, d *apitype.UntypedDeployment) error {
+			err := json.Unmarshal(d.Deployment, &fx.imported)
+			assert.NoError(t, err)
+			return nil
+		},
+		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+			sm := b64.NewBase64SecretsManager()
+			return deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{}), nil
+		},
+	}
+
+	b := &backend.MockBackend{
+		GetStackF: func(context.Context, backend.StackReference) (backend.Stack, error) {
+			return s, nil
+		},
+	}
+
+	ws := &pkgWorkspace.MockContext{
+		ReadProjectF: func() (*workspace.Project, string, error) {
+			return &workspace.Project{Backend: &workspace.ProjectBackend{URL: "file://url"}}, "", nil
+		},
+	}
+
+	lm := &backend.MockLoginManager{
+		CurrentF: func(
+			context.Context,
+			pkgWorkspace.Context,
+			diag.Sink,
+			string,
+			*workspace.Project,
+			bool,
+		) (backend.Backend, error) {
+			return b, nil
+		},
+		LoginF: func(
+			context.Context,
+			pkgWorkspace.Context,
+			diag.Sink,
+			string,
+			*workspace.Project,
+			bool,
+			colors.Colorization,
+		) (backend.Backend, error) {
+			return b, nil
+		},
+	}
+
+	fx.cmd = &stateRepairCmd{
+		Args: &stateRepairArgs{
+			Stack:     "organization/project/stack",
+			Colorizer: colors.Never,
+		},
+
+		Stdin:  fx.stdin,
+		Stdout: fx.stdout,
+		Stderr: fx.stderr,
+
+		Workspace:    ws,
+		LoginManager: lm,
+	}
+
+	return fx
+}
+
+type mockFileReader struct {
+	buf bytes.Buffer
+	fd  uintptr
+}
+
+func (m *mockFileReader) Read(p []byte) (n int, err error) {
+	return m.buf.Read(p)
+}
+
+func (m *mockFileReader) Fd() uintptr {
+	return m.fd
+}
+
+type mockFileWriter struct {
+	buf bytes.Buffer
+	fd  uintptr
+}
+
+func (m *mockFileWriter) Write(p []byte) (n int, err error) {
+	return m.buf.Write(p)
+}
+
+func (m *mockFileWriter) Fd() uintptr {
+	return m.fd
+}
+
+func (m *mockFileWriter) String() string {
+	return m.buf.String()
+}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -1261,20 +1261,30 @@ func promptUserSkippable(yes bool, msg string, options []string, defaultOption s
 
 // promptUser prompts the user for a value with a list of options. Hitting enter accepts the
 // default.
-func promptUser(msg string, options []string, defaultOption string, colorization colors.Colorization) string {
+func promptUser(
+	msg string,
+	options []string,
+	defaultOption string,
+	colorization colors.Colorization,
+	surveyAskOpts ...survey.AskOpt,
+) string {
 	prompt := "\b" + colorization.Colorize(colors.SpecPrompt+msg+colors.Reset)
 	surveycore.DisableColor = true
-	surveyIcons := survey.WithIcons(func(icons *survey.IconSet) {
-		icons.Question = survey.Icon{}
-		icons.SelectFocus = survey.Icon{Text: colorization.Colorize(colors.BrightGreen + ">" + colors.Reset)}
-	})
+
+	allSurveyAskOpts := append(
+		surveyAskOpts,
+		survey.WithIcons(func(icons *survey.IconSet) {
+			icons.Question = survey.Icon{}
+			icons.SelectFocus = survey.Icon{Text: colorization.Colorize(colors.BrightGreen + ">" + colors.Reset)}
+		}),
+	)
 
 	var response string
 	if err := survey.AskOne(&survey.Select{
 		Message: prompt,
 		Options: options,
 		Default: defaultOption,
-	}, &response, surveyIcons); err != nil {
+	}, &response, allSurveyAskOpts...); err != nil {
 		return ""
 	}
 	return response


### PR DESCRIPTION
Before performing any operation, Pulumi will by default check that the state it is operating on is well-formed -- that all resources referenced in the state (e.g. as dependencies) actually exist in that state, and that resources are correctly ordered so that states that depend on others appear after those that they require. If these well-formedness checks fail, Pulumi will refuse to continue and report a "snapshot integrity error".

Such errors are both frustrating and scary. Frustrating because it's Pulumi's fault and now something has to be done before we can proceed. Scary because the only options for proceeding are:

* Run another operation with `--disable-integrity-checking`, hoping that the broken state a. won't affect the operation being run negatively and b. that when the operation completes, it will have coincidentally written a well-formed state.
* "State surgery" -- using tools such as `state delete` (likely with `--disable-integrity-checking`) or `state export`/`state import` to manually fix issues in the snapshot.

While `--disable-integrity-checking` offers a slightly better UX, requiring less understanding of the underlying issue in order to fix it, it is riskier, since it combines the act of repairing the state with another operation. State surgery, on the other hand, is safer, but requires a low-level understanding of how Pulumi operates. Moreover, it can be tedious and error-prone, especially when the state is large.

This commit introduces the `state repair` command, which attempts to combine the best bits of these two options. `state repair` automates state surgery that in general we know to be safe -- sorting out-of-order resources (#17403), and pruning dangling references (#17408). While automatic repair may not always be possible, `state repair` should be strictly an improvement: the command will leave valid snapshots untouched and refuse to write snapshots that can't be repaired with these operations.

Fixes #17446