### PR TITLE
Preserve ordering when editing stack config.

### DIFF
--- a/changelog/pending/20241002--sdk-yaml--fix-pulumi-config-set-behaviour-to-append-to-end-of-file.yaml
+++ b/changelog/pending/20241002--sdk-yaml--fix-pulumi-config-set-behaviour-to-append-to-end-of-file.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/yaml
+  description: Fix pulumi config set behaviour to append to end of file

--- a/sdk/go/common/util/yamlutil/edit.go
+++ b/sdk/go/common/util/yamlutil/edit.go
@@ -26,7 +26,7 @@ type HasRawValue interface {
 
 // Edit does a deep comparison on original and new and returns a YAML document that modifies only
 // the nodes changed between original and new.
-func Edit(original []byte, new interface{}) ([]byte, error) {
+func Edit(original []byte, newValue interface{}) ([]byte, error) {
 	var err error
 	var oldDoc yaml.Node
 	err = yaml.Unmarshal(original, &oldDoc)
@@ -34,97 +34,123 @@ func Edit(original []byte, new interface{}) ([]byte, error) {
 		return nil, err
 	}
 
-	newBytes, err := yaml.Marshal(new)
+	newBytes, err := yaml.Marshal(newValue)
 	if err != nil {
 		return nil, err
 	}
-	var newValue yaml.Node
-	err = yaml.Unmarshal(newBytes, &newValue)
-	if err != nil {
-		return nil, err
-	}
-
-	newValue, err = editNodes(&oldDoc, &newValue)
+	var newNode yaml.Node
+	err = yaml.Unmarshal(newBytes, &newNode)
 	if err != nil {
 		return nil, err
 	}
 
-	return YamlEncode(&newValue)
+	newNode, err = editNodes(&oldDoc, &newNode)
+	if err != nil {
+		return nil, err
+	}
+
+	return YamlEncode(&newNode)
 }
 
-func editNodes(original, new *yaml.Node) (yaml.Node, error) {
-	if original.Kind != new.Kind {
-		return *new, nil
+func editNodes(original, newNode *yaml.Node) (yaml.Node, error) {
+	if original.Kind != newNode.Kind {
+		return *newNode, nil
 	}
 
 	ret := *original
-	ret.Tag = new.Tag
-	ret.Value = new.Value
+	ret.Tag = newNode.Tag
+	ret.Value = newNode.Value
 
 	switch original.Kind {
 	case yaml.DocumentNode, yaml.SequenceNode:
 		var minLen int
 		var content []*yaml.Node
-		if len(new.Content) < len(original.Content) {
-			minLen = len(new.Content)
-		} else {
-			minLen = len(original.Content)
-		}
+		minLen = min(len(newNode.Content), len(original.Content))
 
 		for i := 0; i < minLen; i++ {
-			item, err := editNodes(original.Content[i], new.Content[i])
+			item, err := editNodes(original.Content[i], newNode.Content[i])
 			if err != nil {
 				return ret, err
 			}
 			content = append(content, &item)
 		}
 		// Any excess nodes in the new value are copied verbatim
-		content = append(content, new.Content[minLen:]...)
+		content = append(content, newNode.Content[minLen:]...)
 
 		ret.Content = content
 		return ret, nil
 	case yaml.MappingNode:
-		origKeys := make(map[string]int)
-		newKeys := make(map[string]int)
-		var newKeyList []string
-
-		var content []*yaml.Node
-		for i := 0; i < len(original.Content); i += 2 {
-			origKeys[original.Content[i].Value] = i
-		}
-		for i := 0; i < len(new.Content); i += 2 {
-			value := new.Content[i].Value
-			newKeys[value] = i
-			newKeyList = append(newKeyList, value)
-		}
-		for _, k := range newKeyList {
-			newIdx := newKeys[k]
-			origIdx, has := origKeys[k]
-			var err error
-			var key yaml.Node
-			var value yaml.Node
-			if has {
-				key, err = editNodes(original.Content[origIdx], new.Content[newIdx])
-				if err != nil {
-					return ret, err
-				}
-				value, err = editNodes(original.Content[origIdx+1], new.Content[newIdx+1])
-				if err != nil {
-					return ret, err
-				}
-			} else {
-				key = *new.Content[newIdx]
-				value = *new.Content[newIdx+1]
-			}
-			content = append(content, &key)
-			content = append(content, &value)
+		content, err := handleMappingNode(original, newNode)
+		if err != nil {
+			return ret, err
 		}
 
 		ret.Content = content
 		return ret, nil
 	case yaml.ScalarNode, yaml.AliasNode:
-		ret.Content = new.Content
+		ret.Content = newNode.Content
 		return ret, nil
 	}
 	return yaml.Node{}, errors.New("unknown node type")
+}
+
+func handleMappingNode(original, newNode *yaml.Node) ([]*yaml.Node, error) {
+	origKeys := make(map[string]int)
+	newKeys := make(map[string]int)
+	var origKeyList, newKeyList []string
+
+	content := make([]*yaml.Node, 0, len(newNode.Content))
+	// In each of the Content slices, the keys are at even indices and the values
+	// are at odd indices, so we iterate by 2 each time.
+	for i := 0; i < len(original.Content); i += 2 {
+		origKeys[original.Content[i].Value] = i
+		origKeyList = append(origKeyList, original.Content[i].Value)
+	}
+	for i := 0; i < len(newNode.Content); i += 2 {
+		newKey := newNode.Content[i].Value
+		_, inOriginal := origKeys[newNode.Content[i].Value]
+		newKeys[newKey] = i
+
+		// Keep a list of all the keys that are not in the original to add them to
+		// the end, (see pulumi/pulumi#14860).
+		if !inOriginal {
+			newKeyList = append(newKeyList, newKey)
+		}
+	}
+
+	// Process in original key order, so that we preserve the order of keys in
+	// the file. Add and modify all the keys in the original first, then new
+	// add keys.
+	for _, k := range origKeyList {
+		origIdx := origKeys[k]
+		newIdx, stillPresent := newKeys[k]
+		if !stillPresent {
+			// Key was in the original but not in the new value, so we skip it.
+			continue
+		}
+
+		key, err := editNodes(original.Content[origIdx], newNode.Content[newIdx])
+		if err != nil {
+			return nil, err
+		}
+		value, err := editNodes(original.Content[origIdx+1], newNode.Content[newIdx+1])
+		if err != nil {
+			return nil, err
+		}
+
+		content = append(content, &key)
+		content = append(content, &value)
+	}
+
+	// Apply keys that were not in the original at the end.
+	for _, k := range newKeyList {
+		newIdx := newKeys[k]
+		key := *newNode.Content[newIdx]
+		value := *newNode.Content[newIdx+1]
+
+		content = append(content, &key)
+		content = append(content, &value)
+	}
+
+	return content, nil
 }

--- a/sdk/go/common/util/yamlutil/edit_test.go
+++ b/sdk/go/common/util/yamlutil/edit_test.go
@@ -70,7 +70,6 @@ listFoo:
 	}, `
 # header
 foo: 1
-baz: quux
 list: ["1", "two", "pi", # test3
   e*2] #test4
 listFoo:
@@ -79,6 +78,7 @@ listFoo:
   - bar: "barTwo" # nestedComment1
     list: ["a", "bee", cee] # nestedComment2
     # trailer
+baz: quux
 
 # footer
 `)

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -1530,11 +1530,11 @@ runtime: yaml`
 		require.NoError(t, err)
 
 		expected := `environment:
-  imports:
-    - env
   values:
     pulumiConfig:
       aws:region: us-west-2
+  imports:
+    - env
 `
 
 		stack.Environment = stack.Environment.Append("env")
@@ -1543,12 +1543,12 @@ runtime: yaml`
 		assert.Equal(t, expected, string(marshaled))
 
 		expected = `environment:
-  imports:
-    - env
-    - env2
   values:
     pulumiConfig:
       aws:region: us-west-2
+  imports:
+    - env
+    - env2
 `
 
 		stack.Environment = stack.Environment.Append("env2")

--- a/tests/roundtrip_test.go
+++ b/tests/roundtrip_test.go
@@ -84,9 +84,6 @@ config:
   first-value:
     type: string
     default: first
-  new-value:
-    type: string
-    description: "\U0001F49C a new value added to config, expect unicode to be escaped"
   second-value:
     type: string
   third-value:
@@ -94,14 +91,17 @@ config:
     items:
       type: string
     default: [third] # 🟠 comment after array
+  new-value:
+    type: string
+    description: "\U0001F49C a new value added to config, expect unicode to be escaped"
 # 🟡 comment before resources
 resources:
   my-bucket:
+    type: aws:s3:bucket
     # 🟢 comment before props, note the indentation is excessive, will change to 2 spaces
     properties:
       # 🔵 comment before prop
       bucket: test-123 # 🟣 comment after prop
-    type: aws:s3:bucket
 # 🟥 footer comment
 `)
 	want.Equal(t, string(projData))


### PR DESCRIPTION
This fix does not append new nodes when encountered but instead adds them to the end after all nodes are processed.

I also took to opportunity to rename new to newNode to not shadow the keyword.  Suprising that go even allows this.

Fixes: #14860