### PR TITLE
Enable some more linting rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
     - unconvert
     - unused
     - wastedassign
+    - whitespace
 
 linters-settings:
   nakedret:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,7 @@ linters:
     - perfsprint
     - prealloc
     - revive
+    - tenv
     - unconvert
     - unused
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,7 @@ linters:
     - tenv
     - unconvert
     - unused
+    - wastedassign
 
 linters-settings:
   nakedret:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - exhaustive
     - gofumpt
     - goheader
+    - goprintffuncname
     - gosec
     - govet
     - importas

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,25 +6,26 @@ run:
 linters:
   enable-all: false
   enable:
+    - durationcheck
+    - depguard
     - errcheck
     - exhaustive
-    - prealloc
     - gofumpt
-    - revive
+    - goheader
     - gosec
     - govet
+    - importas
     - ineffassign
     - lll
     - misspell
-    - nolintlint
     - nakedret
-    - unconvert
-    - unused
+    - nolintlint
     - paralleltest
     - perfsprint
-    - depguard
-    - importas
-    - goheader
+    - prealloc
+    - revive
+    - unconvert
+    - unused
 
 linters-settings:
   nakedret:

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -362,7 +362,8 @@ func renderPreludeEvent(event engine.PreludeEventPayload, opts Options) string {
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		fprintfIgnoreError(out, "    %v: %v\n", key, event.Config[key])
+		_, err := fmt.Fprintf(out, "    %v: %v\n", key, event.Config[key])
+		contract.IgnoreError(err)
 	}
 
 	return out.String()

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -247,11 +247,7 @@ func renderSummaryEvent(event engine.SummaryEventPayload, hasError bool, diffSty
 		// Ignore anything that didn't change, or is related to 'reads'.  'reads' are just an
 		// indication of the operations we were performing, and are not indicative of any sort of
 		// change to the system.
-		if op != deploy.OpSame &&
-			op != deploy.OpRead &&
-			op != deploy.OpReadDiscard &&
-			op != deploy.OpReadReplacement {
-
+		if op != deploy.OpSame && op != deploy.OpRead && op != deploy.OpReadDiscard && op != deploy.OpReadReplacement {
 			if c := changes[op]; c > 0 {
 				opDescription := string(op)
 				if !event.IsPreview {
@@ -439,7 +435,6 @@ func renderDiffResourceOutputsEvent(
 ) string {
 	out := &bytes.Buffer{}
 	if shouldShow(payload.Metadata, opts) || isRootStack(payload.Metadata) {
-
 		refresh := false // are these outputs from a refresh?
 		if m, has := seen[payload.Metadata.URN]; has && m.Op == deploy.OpRefresh {
 			refresh = true

--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -211,11 +211,6 @@ func shouldShow(step engine.StepEventMetadata, opts Options) bool {
 	return true
 }
 
-func fprintfIgnoreError(w io.Writer, format string, a ...interface{}) {
-	_, err := fmt.Fprintf(w, format, a...)
-	contract.IgnoreError(err)
-}
-
 func fprintIgnoreError(w io.Writer, a ...interface{}) {
 	_, err := fmt.Fprint(w, a...)
 	contract.IgnoreError(err)

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -774,7 +774,6 @@ func (p *propertyPrinter) printPropertyValueDiff(titleFunc func(*propertyPrinter
 		if shouldPrintOld && shouldPrintNew {
 			if diff.Old.IsArchive() &&
 				diff.New.IsArchive() {
-
 				p.printArchiveDiff(titleFunc, diff.Old.ArchiveValue(), diff.New.ArchiveValue())
 				return
 			}
@@ -830,7 +829,6 @@ func (p *propertyPrinter) printPrimitivePropertyValue(v resource.PropertyValue) 
 			// exponents.
 			p.writef("%g", number)
 		}
-
 	} else if v.IsString() {
 		if vv, kind, ok := p.decodeValue(v.StringValue()); ok {
 			p.writef("(%s) ", kind)

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -96,23 +96,23 @@ func writeString(b io.StringWriter, s string) {
 	contract.IgnoreError(err)
 }
 
-func writeWithIndent(b io.StringWriter, indent int, op display.StepOp, prefix bool, format string, a ...interface{}) {
+func writeIndentedf(b io.StringWriter, indent int, op display.StepOp, prefix bool, format string, a ...interface{}) {
 	writeString(b, deploy.Color(op))
 	writeString(b, getIndentationString(indent, op, prefix))
 	writeString(b, fmt.Sprintf(format, a...))
 	writeString(b, colors.Reset)
 }
 
-func writeWithIndentNoPrefix(b io.StringWriter, indent int, op display.StepOp, format string, a ...interface{}) {
-	writeWithIndent(b, indent, op, false, format, a...)
+func writeUnprefixedIndentedf(b io.StringWriter, indent int, op display.StepOp, format string, a ...interface{}) {
+	writeIndentedf(b, indent, op, false, format, a...)
 }
 
-func write(b io.StringWriter, op display.StepOp, format string, a ...interface{}) {
-	writeWithIndentNoPrefix(b, 0, op, format, a...)
+func writef(b io.StringWriter, op display.StepOp, format string, a ...interface{}) {
+	writeUnprefixedIndentedf(b, 0, op, format, a...)
 }
 
 func writeVerbatim(b io.StringWriter, op display.StepOp, value string) {
-	writeWithIndentNoPrefix(b, 0, op, "%s", value)
+	writeUnprefixedIndentedf(b, 0, op, "%s", value)
 }
 
 func getResourcePropertiesSummary(step engine.StepEventMetadata, indent int) string {
@@ -142,10 +142,10 @@ func getResourcePropertiesSummary(step engine.StepEventMetadata, indent int) str
 
 	// Always print the ID, URN, and provider.
 	if id != "" {
-		writeWithIndentNoPrefix(&b, indent+1, simplePropOp, "[id=%s]\n", string(id))
+		writeUnprefixedIndentedf(&b, indent+1, simplePropOp, "[id=%s]\n", string(id))
 	}
 	if urn != "" {
-		writeWithIndentNoPrefix(&b, indent+1, simplePropOp, "[urn=%s]\n", urn)
+		writeUnprefixedIndentedf(&b, indent+1, simplePropOp, "[urn=%s]\n", urn)
 	}
 
 	if step.Provider != "" {
@@ -154,13 +154,13 @@ func getResourcePropertiesSummary(step engine.StepEventMetadata, indent int) str
 			newProv, err := providers.ParseReference(new.Provider)
 			contract.Assertf(err == nil, "invalid provider reference %q: %v", new.Provider, err)
 
-			writeWithIndentNoPrefix(&b, indent+1, deploy.OpUpdate, "[provider: ")
-			write(&b, deploy.OpDelete, "%s", old.Provider)
+			writeUnprefixedIndentedf(&b, indent+1, deploy.OpUpdate, "[provider: ")
+			writef(&b, deploy.OpDelete, "%s", old.Provider)
 			writeVerbatim(&b, deploy.OpUpdate, " => ")
 			if newProv.ID() == providers.UnknownID {
-				write(&b, deploy.OpCreate, "%s", string(newProv.URN())+"::output<string>")
+				writef(&b, deploy.OpCreate, "%s", string(newProv.URN())+"::output<string>")
 			} else {
-				write(&b, deploy.OpCreate, "%s", new.Provider)
+				writef(&b, deploy.OpCreate, "%s", new.Provider)
 			}
 			writeVerbatim(&b, deploy.OpUpdate, "]\n")
 		} else {
@@ -169,7 +169,7 @@ func getResourcePropertiesSummary(step engine.StepEventMetadata, indent int) str
 
 			// Elide references to default providers.
 			if prov.URN().Name() != "default" {
-				writeWithIndentNoPrefix(&b, indent+1, simplePropOp, "[provider=%s]\n", step.Provider)
+				writeUnprefixedIndentedf(&b, indent+1, simplePropOp, "[provider=%s]\n", step.Provider)
 			}
 		}
 	}
@@ -269,11 +269,11 @@ func PrintResourceReference(
 
 func (p *propertyPrinter) printResourceReference(resRef resource.ResourceReference) {
 	p.printPropertyTitle("URN", 3)
-	p.write("%q\n", resRef.URN)
+	p.writef("%q\n", resRef.URN)
 	p.printPropertyTitle("ID", 3)
 	p.printPropertyValue(resRef.ID)
 	p.printPropertyTitle("PackageVersion", 3)
-	p.write("%q\n", resRef.PackageVersion)
+	p.writef("%q\n", resRef.PackageVersion)
 }
 
 func massageStackPreviewAdd(p resource.PropertyValue) resource.PropertyValue {
@@ -530,7 +530,7 @@ func (p *propertyPrinter) writeString(s string) {
 	writeString(p.dest, s)
 }
 
-func (p *propertyPrinter) writeWithIndent(format string, a ...interface{}) {
+func (p *propertyPrinter) writeIndentedf(format string, a ...interface{}) {
 	if p.truncateOutput {
 		for i, item := range a {
 			if item, ok := item.(string); ok {
@@ -538,15 +538,15 @@ func (p *propertyPrinter) writeWithIndent(format string, a ...interface{}) {
 			}
 		}
 	}
-	writeWithIndent(p.dest, p.indent, p.op, p.prefix, format, a...)
+	writeIndentedf(p.dest, p.indent, p.op, p.prefix, format, a...)
 }
 
-func (p *propertyPrinter) writeWithIndentNoPrefix(format string, a ...interface{}) {
-	writeWithIndentNoPrefix(p.dest, p.indent, p.op, format, a...)
+func (p *propertyPrinter) writeUnprefixedIndentedf(format string, a ...interface{}) {
+	writeUnprefixedIndentedf(p.dest, p.indent, p.op, format, a...)
 }
 
-func (p *propertyPrinter) write(format string, a ...interface{}) {
-	write(p.dest, p.op, format, a...)
+func (p *propertyPrinter) writef(format string, a ...interface{}) {
+	writef(p.dest, p.op, format, a...)
 }
 
 func (p *propertyPrinter) writeVerbatim(value string) {
@@ -554,7 +554,7 @@ func (p *propertyPrinter) writeVerbatim(value string) {
 }
 
 func (p *propertyPrinter) printPropertyTitle(name string, align int) {
-	p.writeWithIndent("%-"+strconv.Itoa(align)+"s: ", name)
+	p.writeIndentedf("%-"+strconv.Itoa(align)+"s: ", name)
 }
 
 func propertyTitlePrinter(name string, align int) func(*propertyPrinter) {
@@ -574,15 +574,15 @@ func (p *propertyPrinter) printPropertyValue(v resource.PropertyValue) {
 		} else {
 			p.writeVerbatim("[\n")
 			for i, elem := range arr {
-				p.writeWithIndent("    [%d]: ", i)
+				p.writeIndentedf("    [%d]: ", i)
 				p.indented(1).printPropertyValue(elem)
 			}
-			p.writeWithIndentNoPrefix("]")
+			p.writeUnprefixedIndentedf("]")
 		}
 	case v.IsAsset():
 		a := v.AssetValue()
 		if a.IsText() {
-			p.write("asset(text:%s) {\n", shortHash(a.Hash))
+			p.writef("asset(text:%s) {\n", shortHash(a.Hash))
 
 			a = codeasset.MassageIfUserProgramCodeAsset(a, p.debug)
 
@@ -591,20 +591,20 @@ func (p *propertyPrinter) printPropertyValue(v resource.PropertyValue) {
 			// pretty print the text, line by line, with proper breaks.
 			lines := strings.Split(massaged, "\n")
 			for _, line := range lines {
-				p.writeWithIndentNoPrefix("    %s\n", line)
+				p.writeUnprefixedIndentedf("    %s\n", line)
 			}
-			p.writeWithIndentNoPrefix("}")
+			p.writeUnprefixedIndentedf("}")
 		} else if path, has := a.GetPath(); has {
-			p.write("asset(file:%s) { %s }", shortHash(a.Hash), path)
+			p.writef("asset(file:%s) { %s }", shortHash(a.Hash), path)
 		} else if uri, has := a.GetURI(); has {
-			p.write("asset(uri:%s) { %s }", shortHash(a.Hash), uri)
+			p.writef("asset(uri:%s) { %s }", shortHash(a.Hash), uri)
 		} else {
-			p.write("asset(unknown:%s) { }", shortHash(a.Hash))
+			p.writef("asset(unknown:%s) { }", shortHash(a.Hash))
 		}
 	case v.IsArchive():
 		a := v.ArchiveValue()
 		if assets, has := a.GetAssets(); has {
-			p.write("archive(assets:%s) {\n", shortHash(a.Hash))
+			p.writef("archive(assets:%s) {\n", shortHash(a.Hash))
 			var names []string
 			for name := range assets {
 				names = append(names, name)
@@ -613,13 +613,13 @@ func (p *propertyPrinter) printPropertyValue(v resource.PropertyValue) {
 			for _, name := range names {
 				p.printAssetOrArchive(assets[name], name)
 			}
-			p.writeWithIndentNoPrefix("}")
+			p.writeUnprefixedIndentedf("}")
 		} else if path, has := a.GetPath(); has {
-			p.write("archive(file:%s) { %s }", shortHash(a.Hash), path)
+			p.writef("archive(file:%s) { %s }", shortHash(a.Hash), path)
 		} else if uri, has := a.GetURI(); has {
-			p.write("archive(uri:%s) { %v }", shortHash(a.Hash), uri)
+			p.writef("archive(uri:%s) { %v }", shortHash(a.Hash), uri)
 		} else {
-			p.write("archive(%s) { }", shortHash(a.Hash))
+			p.writef("archive(%s) { }", shortHash(a.Hash))
 		}
 	case v.IsObject():
 		obj := v.ObjectValue()
@@ -628,13 +628,13 @@ func (p *propertyPrinter) printPropertyValue(v resource.PropertyValue) {
 		} else {
 			p.writeVerbatim("{\n")
 			p.indented(1).printObject(obj)
-			p.writeWithIndentNoPrefix("}")
+			p.writeUnprefixedIndentedf("}")
 		}
 	case v.IsResourceReference():
 		resRef := v.ResourceReferenceValue()
 		p.writeVerbatim("{\n")
 		p.indented(1).printResourceReference(resRef)
-		p.writeWithIndentNoPrefix("}")
+		p.writeUnprefixedIndentedf("}")
 	default:
 		contract.Failf("Unknown PropertyValue type %v", v)
 	}
@@ -642,7 +642,7 @@ func (p *propertyPrinter) printPropertyValue(v resource.PropertyValue) {
 }
 
 func (p *propertyPrinter) printAssetOrArchive(v interface{}, name string) {
-	p.writeWithIndent("    \"%v\": ", name)
+	p.writeIndentedf("    \"%v\": ", name)
 	p.indented(1).printPropertyValue(assetOrArchiveToPropertyValue(v))
 }
 
@@ -746,7 +746,7 @@ func (p *propertyPrinter) printPropertyValueDiff(titleFunc func(*propertyPrinter
 		for i := 0; i < a.Len(); i++ {
 			elemPrinter := p.indented(2)
 			elemTitleFunc := func(p *propertyPrinter) {
-				p.indented(-1).writeWithIndent("[%d]: ", i)
+				p.indented(-1).writeIndentedf("[%d]: ", i)
 			}
 
 			if add, isadd := a.Adds[i]; isadd {
@@ -761,12 +761,12 @@ func (p *propertyPrinter) printPropertyValueDiff(titleFunc func(*propertyPrinter
 				elemPrinter.printPropertyValue(same)
 			}
 		}
-		p.writeWithIndentNoPrefix("]\n")
+		p.writeUnprefixedIndentedf("]\n")
 	} else if diff.Object != nil {
 		titleFunc(p)
 		p.writeVerbatim("{\n")
 		p.indented(1).printObjectDiff(*diff.Object, nil)
-		p.writeWithIndentNoPrefix("}\n")
+		p.writeUnprefixedIndentedf("}\n")
 	} else {
 		shouldPrintOld := shouldPrintPropertyValue(diff.Old, false)
 		shouldPrintNew := shouldPrintPropertyValue(diff.New, false)
@@ -816,7 +816,7 @@ func (p *propertyPrinter) printPrimitivePropertyValue(v resource.PropertyValue) 
 	if v.IsNull() {
 		p.writeVerbatim("<null>")
 	} else if v.IsBool() {
-		p.write("%t", v.BoolValue())
+		p.writef("%t", v.BoolValue())
 	} else if v.IsNumber() {
 		// All pulumi numbers are IEEE doubles really (even in languages where we codegen integers the wire
 		// protocol only supports doubles). But by default Go will print them in scientific notation for large
@@ -824,23 +824,23 @@ func (p *propertyPrinter) printPrimitivePropertyValue(v resource.PropertyValue) 
 		// non-fractional). See https://github.com/pulumi/pulumi/issues/13016 for context.
 		number := v.NumberValue()
 		if math.Trunc(number) == number {
-			p.write("%.f", number)
+			p.writef("%.f", number)
 		} else {
 			// For factional values we're fine with Go printing them in scientific notation for large
 			// exponents.
-			p.write("%g", number)
+			p.writef("%g", number)
 		}
 
 	} else if v.IsString() {
 		if vv, kind, ok := p.decodeValue(v.StringValue()); ok {
-			p.write("(%s) ", kind)
+			p.writef("(%s) ", kind)
 			p.printPropertyValue(vv)
 			return
 		}
 		if p.truncateOutput {
-			p.write("%q", p.truncatePropertyString(v.StringValue()))
+			p.writef("%q", p.truncatePropertyString(v.StringValue()))
 		} else {
-			p.write("%q", v.StringValue())
+			p.writef("%q", v.StringValue())
 		}
 	} else if v.IsComputed() || v.IsOutput() {
 		// We render computed and output values differently depending on whether or not we are
@@ -853,10 +853,10 @@ func (p *propertyPrinter) printPrimitivePropertyValue(v resource.PropertyValue) 
 		if p.planning {
 			p.writeVerbatim(v.TypeString())
 		} else {
-			p.write("undefined")
+			p.writef("undefined")
 		}
 	} else if v.IsSecret() {
-		p.write("[secret]")
+		p.writef("[secret]")
 	} else {
 		contract.Failf("Unexpected property value kind '%v'", v)
 	}
@@ -884,21 +884,21 @@ func (p *propertyPrinter) printArchiveDiff(titleFunc func(*propertyPrinter),
 	if oldPath, has := oldArchive.GetPath(); has {
 		if newPath, has := newArchive.GetPath(); has {
 			titleFunc(p)
-			p.write("archive(file:%s) { %s }\n", hashChange, getTextChangeString(oldPath, newPath))
+			p.writef("archive(file:%s) { %s }\n", hashChange, getTextChangeString(oldPath, newPath))
 			return
 		}
 	} else if oldURI, has := oldArchive.GetURI(); has {
 		if newURI, has := newArchive.GetURI(); has {
 			titleFunc(p)
-			p.write("archive(uri:%s) { %s }\n", hashChange, getTextChangeString(oldURI, newURI))
+			p.writef("archive(uri:%s) { %s }\n", hashChange, getTextChangeString(oldURI, newURI))
 			return
 		}
 	} else if oldAssets, has := oldArchive.GetAssets(); has {
 		if newAssets, has := newArchive.GetAssets(); has {
 			titleFunc(p)
-			p.write("archive(assets:%s) {\n", hashChange)
+			p.writef("archive(assets:%s) {\n", hashChange)
 			p.indented(1).printAssetsDiff(oldAssets, newAssets)
-			p.writeWithIndentNoPrefix("}\n")
+			p.writeUnprefixedIndentedf("}\n")
 			return
 		}
 	}
@@ -1021,26 +1021,26 @@ func (p *propertyPrinter) printAssetDiff(titleFunc func(*propertyPrinter), oldAs
 	if oldAsset.IsText() {
 		if newAsset.IsText() {
 			titleFunc(p)
-			p.write("asset(text:%s) {", hashChange)
+			p.writef("asset(text:%s) {", hashChange)
 
 			massagedOldText := codeasset.MassageIfUserProgramCodeAsset(oldAsset, p.debug).Text
 			massagedNewText := codeasset.MassageIfUserProgramCodeAsset(newAsset, p.debug).Text
 
 			p.indented(1).printTextDiff(massagedOldText, massagedNewText)
 
-			p.writeWithIndentNoPrefix("}\n")
+			p.writeUnprefixedIndentedf("}\n")
 			return
 		}
 	} else if oldPath, has := oldAsset.GetPath(); has {
 		if newPath, has := newAsset.GetPath(); has {
 			titleFunc(p)
-			p.write("asset(file:%s) { %s }\n", hashChange, getTextChangeString(oldPath, newPath))
+			p.writef("asset(file:%s) { %s }\n", hashChange, getTextChangeString(oldPath, newPath))
 			return
 		}
 	} else if oldURI, has := oldAsset.GetURI(); has {
 		if newURI, has := newAsset.GetURI(); has {
 			titleFunc(p)
-			p.write("asset(uri:%s) { %s }\n", hashChange, getTextChangeString(oldURI, newURI))
+			p.writef("asset(uri:%s) { %s }\n", hashChange, getTextChangeString(oldURI, newURI))
 			return
 		}
 	}
@@ -1129,7 +1129,7 @@ func (p *propertyPrinter) printLineDiff(diffs []diffmatchpatch.Diff) {
 
 	writeDiff := func(op display.StepOp, text string) {
 		prefix := op == deploy.OpCreate || op == deploy.OpDelete
-		p.withOp(op).withPrefix(prefix).writeWithIndent("%s", text)
+		p.withOp(op).withPrefix(prefix).writeIndentedf("%s", text)
 	}
 
 	for index, diff := range diffs {
@@ -1206,9 +1206,9 @@ func (p *propertyPrinter) printEncodedValueDiff(old, new string) bool {
 	}
 
 	if oldKind == newKind {
-		p.write("(%s) ", oldKind)
+		p.writef("(%s) ", oldKind)
 	} else {
-		p.write("(%s => %s) ", oldKind, newKind)
+		p.writef("(%s => %s) ", oldKind, newKind)
 	}
 
 	diff := oldValue.Diff(newValue, resource.IsInternalPropertyKey)

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -1301,7 +1301,7 @@ func (p *propertyPrinter) translateYAMLValue(v interface{}) (interface{}, bool) 
 	case map[interface{}]interface{}:
 		vv := make(map[string]interface{}, len(v))
 		for k, e := range v {
-			sk := ""
+			var sk string
 			switch k := k.(type) {
 			case string:
 				sk = k

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -1316,7 +1316,7 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 	}
 
 	getDescription := func() string {
-		opText := ""
+		var opText string
 		if failed {
 			switch op {
 			case deploy.OpSame:
@@ -1550,7 +1550,7 @@ func (display *ProgressDisplay) getStepInProgressDescription(step engine.StepEve
 			return display.getPreviewText(step)
 		}
 
-		opText := ""
+		var opText string
 		switch op {
 		case deploy.OpSame:
 			opText = ""

--- a/pkg/backend/display/watch.go
+++ b/pkg/backend/display/watch.go
@@ -63,26 +63,26 @@ func ShowWatchEvents(op string, events <-chan engine.Event, done chan<- bool, op
 			if p.URN != "" {
 				resourceName = p.URN.Name()
 			}
-			PrintfWithWatchPrefix(time.Now(), resourceName,
+			WatchPrefixPrintf(time.Now(), resourceName,
 				"%s", renderDiffDiagEvent(p, opts))
 		case engine.StartDebuggingEvent:
 			continue
 		case engine.ResourcePreEvent:
 			p := e.Payload().(engine.ResourcePreEventPayload)
 			if shouldShow(p.Metadata, opts) {
-				PrintfWithWatchPrefix(time.Now(), p.Metadata.URN.Name(),
+				WatchPrefixPrintf(time.Now(), p.Metadata.URN.Name(),
 					"%s %s\n", p.Metadata.Op, p.Metadata.URN.Type())
 			}
 		case engine.ResourceOutputsEvent:
 			p := e.Payload().(engine.ResourceOutputsEventPayload)
 			if shouldShow(p.Metadata, opts) {
-				PrintfWithWatchPrefix(time.Now(), p.Metadata.URN.Name(),
+				WatchPrefixPrintf(time.Now(), p.Metadata.URN.Name(),
 					"done %s %s\n", p.Metadata.Op, p.Metadata.URN.Type())
 			}
 		case engine.ResourceOperationFailed:
 			p := e.Payload().(engine.ResourceOperationFailedPayload)
 			if shouldShow(p.Metadata, opts) {
-				PrintfWithWatchPrefix(time.Now(), p.Metadata.URN.Name(),
+				WatchPrefixPrintf(time.Now(), p.Metadata.URN.Name(),
 					"failed %s %s\n", p.Metadata.Op, p.Metadata.URN.Type())
 			}
 		case engine.ProgressEvent:
@@ -98,9 +98,9 @@ func ShowWatchEvents(op string, events <-chan engine.Event, done chan<- bool, op
 // the watch output stream as a simple way to avoid garbled output.
 var watchPrintfMutex sync.Mutex
 
-// PrintfWithWatchPrefix wraps fmt.Printf with a watch mode prefixer that adds a timestamp and
+// WatchPrefixPrintf wraps fmt.Printf with a watch mode prefixer that adds a timestamp and
 // resource metadata.
-func PrintfWithWatchPrefix(t time.Time, resourceName string, format string, a ...interface{}) {
+func WatchPrefixPrintf(t time.Time, resourceName string, format string, a ...interface{}) {
 	watchPrintfMutex.Lock()
 	defer watchPrintfMutex.Unlock()
 	prefix := fmt.Sprintf("%12.12s[%20.20s] ", t.Format(timeFormat), resourceName)

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -808,7 +808,6 @@ func (b *diyBackend) ListStacks(
 				continue
 			}
 			return nil, nil, err
-
 		}
 		results = append(results, newDIYStackSummary(stackRef, chk))
 	}

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -275,7 +275,11 @@ func newDIYBackend(
 	gzipCompression := opts.Env.GetBool(env.DIYBackendGzip)
 
 	wbucket := &wrappedBucket{bucket: bucket}
-	bucket = nil // prevent accidental use of unwrapped bucket
+
+	// Prevent accidental use of the unwrapped bucket.
+	//
+	//nolint:wastedassign
+	bucket = nil
 
 	backend := &diyBackend{
 		d:           d,

--- a/pkg/backend/diy/state.go
+++ b/pkg/backend/diy/state.go
@@ -250,7 +250,6 @@ func (b *diyBackend) saveCheckpoint(
 
 	// And now write out the new snapshot file, overwriting that location.
 	if err = b.bucket.WriteAll(ctx, file, byts, nil); err != nil {
-
 		b.mutex.Lock()
 		defer b.mutex.Unlock()
 

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -63,7 +63,6 @@ func (c cloudBackendReference) String() string {
 
 	// If the project names match, we can elide them.
 	if currentProject != nil && c.project == tokens.Name(currentProject.Name) {
-
 		// Elide owner too, if it is the default owner.
 		defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(currentProject)
 		if err == nil && defaultOrg != "" {

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -164,7 +164,6 @@ func (b *cloudBackend) newUpdate(ctx context.Context, stackRef backend.StackRefe
 	// Create a token source for this update if necessary.
 	var tokenSource *tokenSource
 	if token != "" {
-
 		// TODO[pulumi/pulumi#10482] instead of assuming
 		// expiration, consider expiration times returned by
 		// the backend, if any.

--- a/pkg/backend/watch.go
+++ b/pkg/backend/watch.go
@@ -108,7 +108,7 @@ func watchPaths(root string, paths []string) (chan string, func(), error) {
 	args := []string{"--origin", root}
 	for _, p := range paths {
 
-		watchPath := ""
+		var watchPath string
 		if path.IsAbs(p) {
 			watchPath = p
 		} else {

--- a/pkg/backend/watch.go
+++ b/pkg/backend/watch.go
@@ -63,7 +63,7 @@ func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation,
 					eventTime := time.Unix(0, logEntry.Timestamp*1000000)
 
 					message := strings.TrimRight(logEntry.Message, "\n")
-					display.PrintfWithWatchPrefix(eventTime, logEntry.ID, "%s\n", message)
+					display.WatchPrefixPrintf(eventTime, logEntry.ID, "%s\n", message)
 
 					shown[logEntry] = true
 				}
@@ -83,7 +83,7 @@ func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation,
 		colors.SpecHeadline+"Watching (%s):"+colors.Reset+"\n"), stack.Ref())
 
 	for range events {
-		display.PrintfWithWatchPrefix(time.Now(), "", "%s",
+		display.WatchPrefixPrintf(time.Now(), "", "%s",
 			op.Opts.Display.Color.Colorize(colors.SpecImportant+"Updating..."+colors.Reset+"\n"))
 
 		// Perform the update operation
@@ -93,10 +93,10 @@ func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation,
 			if err == context.Canceled {
 				return err
 			}
-			display.PrintfWithWatchPrefix(time.Now(), "", "%s",
+			display.WatchPrefixPrintf(time.Now(), "", "%s",
 				op.Opts.Display.Color.Colorize(colors.SpecImportant+"Update failed."+colors.Reset+"\n"))
 		} else {
-			display.PrintfWithWatchPrefix(time.Now(), "", "%s",
+			display.WatchPrefixPrintf(time.Now(), "", "%s",
 				op.Opts.Display.Color.Colorize(colors.SpecImportant+"Update complete."+colors.Reset+"\n"))
 		}
 	}

--- a/pkg/backend/watch.go
+++ b/pkg/backend/watch.go
@@ -107,7 +107,6 @@ func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation,
 func watchPaths(root string, paths []string) (chan string, func(), error) {
 	args := []string{"--origin", root}
 	for _, p := range paths {
-
 		var watchPath string
 		if path.IsAbs(p) {
 			watchPath = p

--- a/pkg/cmd/pulumi/config_env.go
+++ b/pkg/cmd/pulumi/config_env.go
@@ -149,7 +149,6 @@ func (cmd *configEnvCmd) listStackEnvironments(ctx context.Context, jsonOut bool
 			fprintf(cmd.stdout, "This stack configuration has no environments listed. "+
 				"Try adding one with `pulumi config env add <projectName>/<envName>`.\n")
 		}
-
 	}
 
 	return nil

--- a/pkg/cmd/pulumi/convert-trace.go
+++ b/pkg/cmd/pulumi/convert-trace.go
@@ -237,6 +237,12 @@ func convertTraceToSamples(root *appdash.Trace, start time.Time, quantum time.Du
 	if delta < 0 {
 		delta = 0
 	}
+
+	// We are multiplying a duration by a duration here, which can be buggy (e.g. consider that time.Second * time.Second
+	// is *not* one second, and that in general multiplying durations is not well-defined). However, in this case it's
+	// fine since we are computing the ratio of the delta to the quantum, so we shouldn't be changing scale accidentally.
+	//
+	//nolint:durationcheck
 	when := delta / quantum * quantum
 	if delta%quantum != 0 {
 		when += quantum

--- a/pkg/cmd/pulumi/package_add.go
+++ b/pkg/cmd/pulumi/package_add.go
@@ -149,7 +149,7 @@ func printNodejsLinkInstructions(ws pkgWorkspace.Context, root string, pkg *sche
 		return err
 	}
 	packageSpecifier := fmt.Sprintf("%s@file:%s", pkg.Name, relOut)
-	addCmd := ""
+	var addCmd string
 	options := proj.Runtime.Options()
 	if packagemanager, ok := options["packagemanager"]; ok {
 		if pm, ok := packagemanager.(string); ok {

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -186,7 +186,6 @@ func runStack(ctx context.Context, s backend.Stack, out io.Writer, args stackArg
 		if err == nil {
 			fmt.Fprintf(out, "\n")
 			_ = fprintStackOutputs(os.Stdout, outputs)
-
 		}
 
 		if args.showSecrets {

--- a/pkg/cmd/pulumi/util_remote.go
+++ b/pkg/cmd/pulumi/util_remote.go
@@ -419,7 +419,6 @@ func runDeployment(ctx context.Context, ws pkgWorkspace.Context, cmd *cobra.Comm
 	var gitAuth *apitype.GitAuthConfig
 	if args.gitAuthAccessToken != "" || sshPrivateKey != "" || args.gitAuthPassword != "" ||
 		args.gitAuthUsername != "" {
-
 		gitAuth = &apitype.GitAuthConfig{}
 		switch {
 		case args.gitAuthAccessToken != "":

--- a/pkg/codegen/docs/constructor_syntax_generator.go
+++ b/pkg/codegen/docs/constructor_syntax_generator.go
@@ -51,7 +51,7 @@ func (g *constructorSyntaxGenerator) indent(buffer *bytes.Buffer) {
 	buffer.WriteString(strings.Repeat(" ", g.indentSize))
 }
 
-func (g *constructorSyntaxGenerator) write(buffer *bytes.Buffer, format string, args ...interface{}) {
+func (g *constructorSyntaxGenerator) writef(buffer *bytes.Buffer, format string, args ...interface{}) {
 	buffer.WriteString(fmt.Sprintf(format, args...))
 }
 
@@ -61,7 +61,7 @@ func (g *constructorSyntaxGenerator) writeValue(
 	seenTypes codegen.StringSet,
 ) {
 	write := func(format string, args ...interface{}) {
-		g.write(buffer, format, args...)
+		g.writef(buffer, format, args...)
 	}
 
 	writeValue := func(valueType schema.Type) {
@@ -222,7 +222,7 @@ func (g *constructorSyntaxGenerator) exampleResourceWithName(r *schema.Resource,
 	buffer := bytes.Buffer{}
 	seenTypes := codegen.NewStringSet()
 	resourceName := name(r.Token)
-	g.write(&buffer, "resource \"%s\" %q {\n", resourceName, r.Token)
+	g.writef(&buffer, "resource \"%s\" %q {\n", resourceName, r.Token)
 	g.indented(func() {
 		sortPropertiesByRequiredFirst(r.InputProperties)
 		for _, p := range r.InputProperties {
@@ -235,13 +235,13 @@ func (g *constructorSyntaxGenerator) exampleResourceWithName(r *schema.Resource,
 			}
 
 			g.indent(&buffer)
-			g.write(&buffer, "%s = ", p.Name)
+			g.writef(&buffer, "%s = ", p.Name)
 			g.writeValue(&buffer, codegen.ResolvedType(p.Type), seenTypes)
-			g.write(&buffer, "\n")
+			g.writef(&buffer, "\n")
 		}
 	})
 
-	g.write(&buffer, "}")
+	g.writef(&buffer, "}")
 	return buffer.String()
 }
 
@@ -249,7 +249,7 @@ func (g *constructorSyntaxGenerator) exampleInvokeWithName(function *schema.Func
 	buffer := bytes.Buffer{}
 	seenTypes := codegen.NewStringSet()
 	functionName := name(function.Token)
-	g.write(&buffer, "%s = invoke(\"%s\", {\n", functionName, function.Token)
+	g.writef(&buffer, "%s = invoke(\"%s\", {\n", functionName, function.Token)
 	g.indented(func() {
 		if function.Inputs == nil {
 			return
@@ -266,13 +266,13 @@ func (g *constructorSyntaxGenerator) exampleInvokeWithName(function *schema.Func
 			}
 
 			g.indent(&buffer)
-			g.write(&buffer, "%s = ", p.Name)
+			g.writef(&buffer, "%s = ", p.Name)
 			g.writeValue(&buffer, codegen.ResolvedType(p.Type), seenTypes)
-			g.write(&buffer, "\n")
+			g.writef(&buffer, "\n")
 		}
 	})
 
-	g.write(&buffer, "})")
+	g.writef(&buffer, "})")
 	return buffer.String()
 }
 

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -293,7 +293,6 @@ func (mod *modContext) genFunctionPython(f *schema.Function, resourceName string
 	// Some functions don't have any inputs other than the InvokeOptions.
 	// For example, the `get_billing_service_account` function.
 	if f.Inputs != nil {
-
 		inputs := f.Inputs
 		if outputVersion {
 			inputs = inputs.InputShape
@@ -301,7 +300,6 @@ func (mod *modContext) genFunctionPython(f *schema.Function, resourceName string
 
 		params = slice.Prealloc[formalParam](len(inputs.Properties))
 		for _, prop := range inputs.Properties {
-
 			var schemaType schema.Type
 			if outputVersion {
 				schemaType = codegen.OptionalType(prop)

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -1466,7 +1466,6 @@ func (mod *modContext) genFunction(w io.Writer, fun *schema.Function) error {
 		} else {
 			fmt.Fprintf(w, "(\"%s\", %s, options.WithDefaults());\n", fun.Token, argsParamRef)
 		}
-
 	} else {
 		// multi-argument inputs and output property bag
 		// first generate the function definition
@@ -1547,7 +1546,6 @@ func (mod *modContext) genFunction(w io.Writer, fun *schema.Function) error {
 
 	if fun.ReturnType != nil {
 		if objectType, ok := fun.ReturnType.(*schema.ObjectType); ok && fun.InlineObjectAsReturnType {
-
 			fmt.Fprintf(w, "\n")
 
 			res := &plainType{

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -1300,7 +1300,6 @@ func AnnotateComponentInputs(component *pcl.Component) {
 					}
 				}
 			}
-
 		}
 	}
 }

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -197,7 +197,8 @@ func (g *generator) GenAnonymousFunctionExpression(w io.Writer, expr *model.Anon
 }
 
 func (g *generator) GenBinaryOpExpression(w io.Writer, expr *model.BinaryOpExpression) {
-	opstr, precedence := "", g.GetPrecedence(expr)
+	var opstr string
+	precedence := g.GetPrecedence(expr)
 	switch expr.Operation {
 	case hclsyntax.OpAdd:
 		opstr = "+"

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -1049,7 +1049,6 @@ func (g *generator) GenScopeTraversalExpression(w io.Writer, expr *model.ScopeTr
 
 		// Assume invokes are returning Output<T> instead of Task<T>
 		g.Fgenf(w, ".Apply(%s => %s", lambdaArg, lambdaArg)
-
 	}
 
 	var objType *schema.ObjectType

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -3011,7 +3011,7 @@ func (pkg *pkgContext) genFunctionOutputGenericVersion(w io.Writer, f *schema.Fu
 	originalResultTypeName := pkg.functionResultTypeName(f)
 	resultTypeName := originalResultTypeName + "Output"
 
-	code := ""
+	var code string
 
 	if f.Inputs != nil {
 		code = `
@@ -3137,7 +3137,7 @@ func (pkg *pkgContext) genFunctionOutputVersion(w io.Writer, f *schema.Function,
 	originalResultTypeName := pkg.functionResultTypeName(f)
 	resultTypeName := originalResultTypeName + "Output"
 
-	code := ""
+	var code string
 
 	var inputsVar string
 	if f.Inputs == nil {

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -2205,7 +2205,6 @@ func (pkg *pkgContext) genResource(
 			}
 			fmt.Fprintf(w, "\t}\n")
 		} else if name := pkg.provideDefaultsFuncName(p.Type); name != "" && !pkg.disableObjectDefaults {
-
 			optionalDeref := ""
 			if p.IsRequired() {
 				optionalDeref = "*"
@@ -2682,7 +2681,6 @@ func (pkg *pkgContext) genResource(
 				fmt.Fprintf(w, "}\n")
 			}
 		}
-
 	}
 
 	if !useGenericVariant {
@@ -3659,7 +3657,6 @@ func (pkg *pkgContext) genResourceRegistrations(
 	// Register all output types
 	fmt.Fprintf(w, "\tpulumi.RegisterOutputType(%sOutput{})\n", name)
 	for _, method := range r.Methods {
-
 		var objectReturnType *schema.ObjectType
 		if method.Function.ReturnType != nil {
 			if objectType, ok := method.Function.ReturnType.(*schema.ObjectType); ok && objectType != nil {

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -1220,7 +1220,6 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 		g.Fgen(w, instantiation)
 		g.Fgenf(w, "%[1]s = append(%[1]s, __res)\n", resNameVar)
 		g.Fgenf(w, "}\n")
-
 	} else {
 		resourceName := fmt.Sprintf("%q", resName)
 		if g.isComponent {
@@ -1391,7 +1390,6 @@ func (g *generator) genComponent(w io.Writer, r *pcl.Component) {
 		g.Fgen(w, instantiation)
 		g.Fgenf(w, "%[1]s = append(%[1]s, __res)\n", resNameVar)
 		g.Fgenf(w, "}\n")
-
 	} else {
 		resourceName := fmt.Sprintf("%q", resName)
 		if g.isComponent {
@@ -1463,7 +1461,6 @@ func (g *generator) genTempsMultiReturn(w io.Writer, temps []interface{}, zeroVa
 			// currently only used inside anonymous functions (no scope collisions)
 			g.Fgenf(w, "var _zero %s\n", zeroValueType)
 		}
-
 	}
 
 	for _, t := range temps {
@@ -1594,7 +1591,6 @@ func (g *generator) genLocalVariable(w io.Writer, v *pcl.LocalVariable) {
 		}
 	default:
 		g.Fgenf(w, "%s := %.3v;\n", name, expr)
-
 	}
 }
 

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -127,7 +127,8 @@ func (g *generator) genAnonymousFunctionExpression(
 }
 
 func (g *generator) GenBinaryOpExpression(w io.Writer, expr *model.BinaryOpExpression) {
-	opstr, precedence := "", g.GetPrecedence(expr)
+	var opstr string
+	precedence := g.GetPrecedence(expr)
 	switch expr.Operation {
 	case hclsyntax.OpAdd:
 		opstr = "+"
@@ -341,7 +342,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 			g.Fgenf(w, "%.v", expr.Args[1])
 		}
 
-		optionsBag := ""
+		var optionsBag string
 		var buf bytes.Buffer
 		if len(expr.Args) == 3 {
 			g.Fgenf(&buf, ", %.v", expr.Args[2])
@@ -799,7 +800,8 @@ func (g *generator) genTupleConsExpression(w io.Writer, expr *model.TupleConsExp
 }
 
 func (g *generator) GenUnaryOpExpression(w io.Writer, expr *model.UnaryOpExpression) {
-	opstr, precedence := "", g.GetPrecedence(expr)
+	var opstr string
+	precedence := g.GetPrecedence(expr)
 	switch expr.Operation {
 	case hclsyntax.OpLogicalNot:
 		opstr = "!"
@@ -1204,7 +1206,7 @@ func isInputty(destType model.Type) bool {
 }
 
 func (g *generator) literalKey(x model.Expression) (string, bool) {
-	strKey := ""
+	var strKey string
 	switch x := x.(type) {
 	case *model.LiteralValueExpression:
 		if model.StringType.AssignableFrom(x.Type()) {

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -2856,7 +2856,6 @@ import * as mutex from "async-mutex";
 	}
 
 	if def.Parameterization != nil {
-
 		parameterValue := fmt.Sprintf("Uint8Array.from(atob(%q), c => c.charCodeAt(0))", base64.StdEncoding.EncodeToString(def.Parameterization.Parameter))
 
 		_, err = fmt.Fprintf(w, `

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -127,7 +127,8 @@ func (g *generator) GenAnonymousFunctionExpression(w io.Writer, expr *model.Anon
 }
 
 func (g *generator) GenBinaryOpExpression(w io.Writer, expr *model.BinaryOpExpression) {
-	opstr, precedence := "", g.GetPrecedence(expr)
+	var opstr string
+	precedence := g.GetPrecedence(expr)
 	switch expr.Operation {
 	case hclsyntax.OpAdd:
 		opstr = "+"
@@ -617,7 +618,7 @@ func (g *generator) GenLiteralValueExpression(w io.Writer, expr *model.LiteralVa
 }
 
 func (g *generator) literalKey(x model.Expression) (string, bool) {
-	strKey := ""
+	var strKey string
 	switch x := x.(type) {
 	case *model.LiteralValueExpression:
 		if model.StringType.AssignableFrom(x.Type()) {
@@ -789,7 +790,8 @@ func (g *generator) GenTupleConsExpression(w io.Writer, expr *model.TupleConsExp
 }
 
 func (g *generator) GenUnaryOpExpression(w io.Writer, expr *model.UnaryOpExpression) {
-	opstr, precedence := "", g.GetPrecedence(expr)
+	var opstr string
+	precedence := g.GetPrecedence(expr)
 	switch expr.Operation {
 	case hclsyntax.OpLogicalNot:
 		opstr = "!"

--- a/pkg/codegen/nodejs/test.go
+++ b/pkg/codegen/nodejs/test.go
@@ -117,7 +117,6 @@ func nodejsPackages(t *testing.T, deps codegen.StringSet) map[string]string {
 		default:
 			t.Logf("Unknown package requested: %s", d)
 		}
-
 	}
 	return result
 }

--- a/pkg/codegen/pcl/binder_nodes.go
+++ b/pkg/codegen/pcl/binder_nodes.go
@@ -36,7 +36,6 @@ func (b *binder) bindNode(node Node) hcl.Diagnostics {
 			Summary:  "circular reference",
 			Subject:  &rng,
 		}}
-
 	}
 	node.markBinding()
 

--- a/pkg/codegen/pcl/binder_nodes.go
+++ b/pkg/codegen/pcl/binder_nodes.go
@@ -80,7 +80,7 @@ func (b *binder) getDependencies(node Node) []Node {
 	depSet := codegen.Set{}
 	var deps []Node
 	diags := hclsyntax.VisitAll(node.SyntaxNode(), func(node hclsyntax.Node) hcl.Diagnostics {
-		depName := ""
+		var depName string
 		switch node := node.(type) {
 		case *hclsyntax.FunctionCallExpr:
 			// TODO(pdg): function scope binds tighter than "normal" scope

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1916,8 +1916,8 @@ func (mod *modContext) genFunction(fun *schema.Function) (string, error) {
 	}
 
 	// If there is a return type, emit it.
-	retTypeName := ""
-	retTypeNameOutput := ""
+	var retTypeName string
+	var retTypeNameOutput string
 	var rets []*schema.Property
 	if returnType != nil {
 		retTypeName, rets = mod.genAwaitableType(w, returnType), returnType.Properties

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -822,7 +822,6 @@ func (mod *modContext) genInit(exports []string) string {
 
 	// If there are subpackages, import them with importlib.
 	if mod.submodulesExist() {
-
 		children := make([]*modContext, len(mod.children))
 		copy(children, mod.children)
 

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -109,7 +109,8 @@ func (g *generator) GenAnonymousFunctionExpression(w io.Writer, expr *model.Anon
 }
 
 func (g *generator) GenBinaryOpExpression(w io.Writer, expr *model.BinaryOpExpression) {
-	opstr, precedence := "", g.GetPrecedence(expr)
+	var opstr string
+	precedence := g.GetPrecedence(expr)
 	switch expr.Operation {
 	case hclsyntax.OpAdd:
 		opstr = "+"

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -302,7 +302,6 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 			default:
 				g.Fgenf(w, "%.v", expr.Args[0])
 			}
-
 		}
 	case pcl.IntrinsicApply:
 		g.genApply(w, expr)

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -586,7 +586,7 @@ func (t *types) parseTypeSpecRef(refPath, ref string) (typeSpecRef, hcl.Diagnost
 		fragment = fragment[1:]
 	}
 
-	kind, token := "", ""
+	var kind, token string
 	slash := strings.Index(fragment, "/")
 	if slash == -1 {
 		kind = fragment

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -685,7 +685,6 @@ func TestProgramCodegen(
 				outfilePath := filepath.Join(testDir, testcase.OutputFile)
 				CheckVersion(t, tt.Directory, depFilePath, testcase.ExpectedVersion)
 				GenProjectCleanUp(t, testDir, depFilePath, outfilePath)
-
 			}
 			files, diags, err = testcase.GenProgram(program)
 			assert.NoError(t, err)

--- a/pkg/engine/lifecycletest/continue_on_error_test.go
+++ b/pkg/engine/lifecycletest/continue_on_error_test.go
@@ -68,7 +68,6 @@ func TestDestroyContinueOnError(t *testing.T) {
 
 			_, err = monitor.RegisterResource("pkgA:m:typA", "anotherUnrelatedRes", true, deploytest.ResourceOptions{})
 			assert.NoError(t, err)
-
 		}
 
 		return nil

--- a/pkg/engine/project.go
+++ b/pkg/engine/project.go
@@ -47,7 +47,6 @@ func getPwdMain(root, main string) (string, string, error) {
 	if main == "" {
 		main = "."
 	} else {
-
 		// The path can be relative from the package root.
 		if !filepath.IsAbs(main) {
 			cleanPwd := filepath.Clean(pwd)

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -1373,7 +1373,6 @@ func (s *ImportStep) Apply() (resource.Status, StepCompleteFunc, error) {
 
 		// Print this warning before printing all the check failures to give better context.
 		if len(resp.Failures) != 0 {
-
 			// Based on if the user passed 'properties' or not we want to change the error message here.
 			var errorMessage string
 			if len(inputProperties) == 0 {

--- a/pkg/resource/deploy/step_generator_test.go
+++ b/pkg/resource/deploy/step_generator_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
 package deploy
 
 import (
-	"os"
 	"runtime"
 	"testing"
 
@@ -808,7 +807,6 @@ func TestStepGenerator(t *testing.T) {
 
 		t.Run("fail generateURN", func(t *testing.T) {
 			t.Parallel()
-			os.Setenv("PULUMI_DISABLE_VALIDATION", "true")
 			sg := &stepGenerator{
 				urns: map[resource.URN]bool{
 					"urn:pulumi:stack::::::": true,

--- a/pkg/resource/edit/operations.go
+++ b/pkg/resource/edit/operations.go
@@ -113,7 +113,6 @@ search:
 		}
 
 		newSnapshot = append(newSnapshot, res)
-
 	}
 
 	// If condemnedRes is unique and there exists a resource that is the child of condemnedRes,

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -653,7 +653,6 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter,
 							return resource.PropertyValue{}, fmt.Errorf("encrypting secret value: %w", err)
 						}
 						ciphertext = encryptedText
-
 					} else {
 						unencryptedText, err := dec.DecryptValue(ctx, ciphertext)
 						if err != nil {

--- a/pkg/secrets/passphrase/manager_test.go
+++ b/pkg/secrets/passphrase/manager_test.go
@@ -28,23 +28,16 @@ const (
 	brokenState = `{"salt":"fozI5u6B030=:v1:F+6ZduL:PGMFeIzwobWRKmEAzUdaQHqC5mMRIQ=="}`
 )
 
-func resetPassphraseTestEnvVars() func() {
-	clearCachedSecretsManagers()
-
-	oldPassphrase := os.Getenv("PULUMI_CONFIG_PASSPHRASE")
-	oldPassphraseFile := os.Getenv("PULUMI_CONFIG_PASSPHRASE_FILE")
-	return func() {
-		os.Setenv("PULUMI_CONFIG_PASSPHRASE", oldPassphrase)
-		os.Setenv("PULUMI_CONFIG_PASSPHRASE_FILE", oldPassphraseFile)
-	}
-}
-
 //nolint:paralleltest // mutates environment variables
 func TestPassphraseManagerIncorrectPassphraseReturnsErrorCrypter(t *testing.T) {
-	resetEnv := resetPassphraseTestEnvVars()
-	defer resetEnv()
+	clearCachedSecretsManagers()
 
-	os.Setenv("PULUMI_CONFIG_PASSPHRASE", "password123")
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "password123")
+
+	// There is no t.Unsetenv, so for variables we want to genuinely unset (and not just set to ""), we set the
+	// environment variables to empty strings using t.Setenv and then unset them using os.Unsetenv. In doing do, the
+	// cleanup of t.Setenv takes care of resetting the environment variables when the test has completed.
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE_FILE", "")
 	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE_FILE")
 
 	manager, err := NewPromptingPassphraseSecretsManagerFromState([]byte(state))
@@ -63,10 +56,14 @@ func TestPassphraseManagerIncorrectPassphraseReturnsErrorCrypter(t *testing.T) {
 
 //nolint:paralleltest // mutates environment variables
 func TestPassphraseManagerIncorrectStateReturnsError(t *testing.T) {
-	resetEnv := resetPassphraseTestEnvVars()
-	defer resetEnv()
+	clearCachedSecretsManagers()
 
-	os.Setenv("PULUMI_CONFIG_PASSPHRASE", "password")
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "password")
+
+	// There is no t.Unsetenv, so for variables we want to genuinely unset (and not just set to ""), we set the
+	// environment variables to empty strings using t.Setenv and then unset them using os.Unsetenv. In doing do, the
+	// cleanup of t.Setenv takes care of resetting the environment variables when the test has completed.
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE_FILE", "")
 	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE_FILE")
 
 	_, err := NewPromptingPassphraseSecretsManagerFromState([]byte(brokenState))
@@ -75,10 +72,14 @@ func TestPassphraseManagerIncorrectStateReturnsError(t *testing.T) {
 
 //nolint:paralleltest // mutates environment variables
 func TestPassphraseManagerCorrectPassphraseReturnsSecretsManager(t *testing.T) {
-	resetEnv := resetPassphraseTestEnvVars()
-	defer resetEnv()
+	clearCachedSecretsManagers()
 
-	os.Setenv("PULUMI_CONFIG_PASSPHRASE", "password")
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "password")
+
+	// There is no t.Unsetenv, so for variables we want to genuinely unset (and not just set to ""), we set the
+	// environment variables to empty strings using t.Setenv and then unset them using os.Unsetenv. In doing do, the
+	// cleanup of t.Setenv takes care of resetting the environment variables when the test has completed.
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE_FILE", "")
 	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE_FILE")
 
 	sm, err := NewPromptingPassphraseSecretsManagerFromState([]byte(state))
@@ -88,10 +89,14 @@ func TestPassphraseManagerCorrectPassphraseReturnsSecretsManager(t *testing.T) {
 
 //nolint:paralleltest // mutates environment variables
 func TestPassphraseManagerNoEnvironmentVariablesReturnsError(t *testing.T) {
-	resetEnv := resetPassphraseTestEnvVars()
-	defer resetEnv()
+	clearCachedSecretsManagers()
 
+	// There is no t.Unsetenv, so for variables we want to genuinely unset (and not just set to ""), we set the
+	// environment variables to empty strings using t.Setenv and then unset them using os.Unsetenv. In doing do, the
+	// cleanup of t.Setenv takes care of resetting the environment variables when the test has completed.
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "")
 	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE")
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE_FILE", "")
 	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE_FILE")
 
 	_, err := NewPromptingPassphraseSecretsManagerFromState([]byte(state))
@@ -101,10 +106,14 @@ func TestPassphraseManagerNoEnvironmentVariablesReturnsError(t *testing.T) {
 
 //nolint:paralleltest // mutates environment variables
 func TestPassphraseManagerEmptyPassphraseIsValid(t *testing.T) {
-	resetEnv := resetPassphraseTestEnvVars()
-	defer resetEnv()
+	clearCachedSecretsManagers()
 
-	os.Setenv("PULUMI_CONFIG_PASSPHRASE", "")
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "")
+
+	// There is no t.Unsetenv, so for variables we want to genuinely unset (and not just set to ""), we set the
+	// environment variables to empty strings using t.Setenv and then unset them using os.Unsetenv. In doing do, the
+	// cleanup of t.Setenv takes care of resetting the environment variables when the test has completed.
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE_FILE", "")
 	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE_FILE")
 
 	sm, err := NewPromptingPassphraseSecretsManagerFromState([]byte(state))
@@ -114,8 +123,7 @@ func TestPassphraseManagerEmptyPassphraseIsValid(t *testing.T) {
 
 //nolint:paralleltest // mutates environment variables
 func TestPassphraseManagerCorrectPassfileReturnsSecretsManager(t *testing.T) {
-	resetEnv := resetPassphraseTestEnvVars()
-	defer resetEnv()
+	clearCachedSecretsManagers()
 
 	tmpFile, err := os.CreateTemp("", "pulumi-secret-test")
 	assert.NoError(t, err)
@@ -123,8 +131,13 @@ func TestPassphraseManagerCorrectPassfileReturnsSecretsManager(t *testing.T) {
 	_, err = tmpFile.WriteString("password")
 	assert.NoError(t, err)
 
+	// There is no t.Unsetenv, so for variables we want to genuinely unset (and not just set to ""), we set the
+	// environment variables to empty strings using t.Setenv and then unset them using os.Unsetenv. In doing do, the
+	// cleanup of t.Setenv takes care of resetting the environment variables when the test has completed.
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "")
 	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE")
-	os.Setenv("PULUMI_CONFIG_PASSPHRASE_FILE", tmpFile.Name())
+
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE_FILE", tmpFile.Name())
 
 	sm, err := NewPromptingPassphraseSecretsManagerFromState([]byte(state))
 	assert.NoError(t, err)
@@ -133,11 +146,15 @@ func TestPassphraseManagerCorrectPassfileReturnsSecretsManager(t *testing.T) {
 
 //nolint:paralleltest // mutates environment variables
 func TestPassphraseManagerEmptyPassfileReturnsError(t *testing.T) {
-	resetEnv := resetPassphraseTestEnvVars()
-	defer resetEnv()
+	clearCachedSecretsManagers()
 
+	// There is no t.Unsetenv, so for variables we want to genuinely unset (and not just set to ""), we set the
+	// environment variables to empty strings using t.Setenv and then unset them using os.Unsetenv. In doing do, the
+	// cleanup of t.Setenv takes care of resetting the environment variables when the test has completed.
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "")
 	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE")
-	os.Setenv("PULUMI_CONFIG_PASSPHRASE_FILE", "")
+
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE_FILE", "")
 
 	_, err := NewPromptingPassphraseSecretsManagerFromState([]byte(state))
 	assert.ErrorContains(t, err, "passphrase must be set with "+

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -2196,7 +2196,6 @@ func (pt *ProgramTester) prepareNodeJSProject(projinfo *engine.Projinfo) error {
 					if _, has := entry[packageName]; has {
 						entry[packageName] = packageVersion
 					}
-
 				}
 			}
 
@@ -2628,7 +2627,6 @@ func (pt *ProgramTester) prepareDotNetProject(projinfo *engine.Projinfo) error {
 	}
 
 	for _, dep := range pt.opts.Dependencies {
-
 		// dotnet add package requires a specific version in case of a pre-release, so we have to look it up.
 		globPattern := filepath.Join(localNuget, dep+".?.*.nupkg")
 		matches, err := filepath.Glob(globPattern)

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -401,7 +401,6 @@ func execPlugin(ctx *Context, bin, prefix string, kind apitype.PluginKind,
 			if ok && syscallErr == syscall.ENOENT {
 				return nil, errPluginNotFound
 			}
-
 		}
 		return nil, err
 	}

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -1483,7 +1483,6 @@ func (p *provider) Construct(ctx context.Context, req ConstructRequest) (Constru
 		return ConstructResult{
 			URN: resource.URN(resp.GetUrn()),
 		}, nil
-
 	}
 
 	if !pcfg.acceptSecrets {

--- a/sdk/go/common/resource/resource_id_test.go
+++ b/sdk/go/common/resource/resource_id_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -131,7 +131,6 @@ func TestUniqueNameNonDeterminism(t *testing.T) {
 
 	// if randomSeed is nil or empty we should be nondeterministic
 	for _, randomSeed := range [][]byte{nil, make([]byte, 0)} {
-
 		prefix := "prefix"
 		randlen := 4
 		maxlen := 100

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -321,7 +321,6 @@ func (p *urlAuthParser) Parse(remoteURL string) (string, transport.AuthMethod, e
 		}
 		cacheAuthMethod = true
 		return remoteURL, auth, err
-
 	}
 
 	// For non-SSH URLs, see if there is basic auth info. Strip it from the

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -656,7 +656,6 @@ func (proj *Project) Validate() error {
 						inferredTypeName)
 				}
 			}
-
 		} else {
 			// when not namespaced by project, there shouldn't be a type, only a value
 			if configType.IsExplicitlyTyped() {

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -425,7 +425,6 @@ func RetrieveGitFolder(rawurl string, path string) (string, error) {
 		if cloneErr != nil {
 			return "", fmt.Errorf("failed to clone ref '%s': %w", refAttempts[len(refAttempts)-1], cloneErr)
 		}
-
 	} else {
 		if cloneErr := gitutil.GitCloneAndCheckoutCommit(url, commit, path); cloneErr != nil {
 			return "", fmt.Errorf("failed to clone and checkout %s(%s): %w", url, commit, cloneErr)

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1587,7 +1587,6 @@ func (host *nodeLanguageHost) Pack(ctx context.Context, req *pulumirpc.PackReque
 		if err != nil {
 			return nil, fmt.Errorf("copy vendor: %w", err)
 		}
-
 	} else {
 		// Before we can build the package we need to install it's dependencies.
 		err = writeString("$ npm install\n")

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -629,7 +629,8 @@ func determinePluginVersion(packageVersion string) (string, error) {
 	}
 
 	segments := []string{}
-	num, rest := "", packageVersion
+	var num string
+	rest := packageVersion
 	foundDot := false
 	for {
 		if num, rest = parseNumber(rest); num != "" {

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1894,7 +1894,6 @@ func TestUndefinedStackOutputNode(t *testing.T) {
 				if event.DiagnosticEvent != nil {
 					if event.DiagnosticEvent.Severity == "warning" &&
 						strings.Contains(event.DiagnosticEvent.Message, "will not show as a stack output") {
-
 						assert.Equal(t,
 							"Undefined value (undef) will not show as a stack output.\n",
 							event.DiagnosticEvent.Message)


### PR DESCRIPTION
Issue #10659 lists a number of extra linting checks that we could enable in order to make our Go code more robust. This commit implements as many as seem sensible:

* `durationcheck`, which checks for multiplication of `time.Duration`s, which can lead to unexpected behaviour (e.g. `time.Second * time.Second` is *not* one second)
* `goprintffuncname`, which checks that `Printf`-like functions are appropriately suffixed with `f` to indicate as such
* `tenv`, which checks for `os.Setenv` in tests where `t.Setenv` is generally a better solution
* `wastedassign`, which checks for assignments whose values are never used (such as initial values before an `if` where both branches then overwrite the value)
* `whitespace`, which checks for blank lines at the beginning and end of blocks such as functions, `if`s, `for`s and so on.

This commit does *not* enable the following checks listed in #10659:

* `wrapcheck`, which insists that third-party library errors are always `%w`rapped -- we have a lot of cases where we don't do this and it's probably a bit more involved than "just wrap them" in terms of making sure we don't break anything (maybe)
* `predeclared`, which checks for shadowing of existing Go identifiers -- we use `old` and `new` a lot, especially in step generation, so this is probably a slightly bigger clean-up/one we might want to opt out of
* `mnd` (magic number detection) -- we have a lot of failures on this
* `nilnil` -- we only have a couple of failures on this; these could probably be handled with `//nolint` but for now I've opted not to take this route.