### PR TITLE
Write memory profile occasionally when profiling in case of crash/OOM.

### DIFF
--- a/changelog/pending/20241003--cli--allow-memory-profile-to-be-written-occasionally-in-case-of-crash.yaml
+++ b/changelog/pending/20241003--cli--allow-memory-profile-to-be-written-occasionally-in-case-of-crash.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Allow memory profile to be written in the background, so it's available in case of crash

--- a/sdk/go/common/util/cmdutil/profile.go
+++ b/sdk/go/common/util/cmdutil/profile.go
@@ -20,6 +20,7 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"runtime/trace"
+	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
@@ -43,6 +44,7 @@ func InitProfiling(prefix string, memProfileRate int) error {
 
 	if memProfileRate > 0 {
 		runtime.MemProfileRate = memProfileRate
+		go memoryProfileWriteLoop(prefix)
 	}
 
 	return nil
@@ -52,16 +54,41 @@ func CloseProfiling(prefix string) error {
 	pprof.StopCPUProfile()
 	trace.Stop()
 
+	// get up-to-date statistics
+	return writeMemoryProfile(prefix)
+}
+
+func writeMemoryProfile(prefix string) error {
 	mem, err := os.Create(fmt.Sprintf("%s.%v.mem", prefix, os.Getpid()))
 	if err != nil {
 		return fmt.Errorf("could not create memory profile: %w", err)
 	}
 	defer contract.IgnoreClose(mem)
 
-	runtime.GC() // get up-to-date statistics
+	runtime.GC()
 	if err = pprof.Lookup("allocs").WriteTo(mem, 0); err != nil {
 		return fmt.Errorf("could not write memory profile: %w", err)
 	}
-
 	return nil
+}
+
+func memoryProfileWriteLoop(prefix string) {
+	// Every 5 seconds write a memory profile (in case we crash before we get a chance)
+	for i := 0; ; i++ {
+		time.Sleep(5 * time.Second)
+
+		mem, err := os.Create(fmt.Sprintf("%s.%v.mem.%d", prefix, os.Getpid(), i))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "could not create memory profile: %s\n", err.Error())
+			return
+		}
+		defer mem.Close()
+
+		runtime.GC() // get up-to-date statistics
+		if err = pprof.Lookup("allocs").WriteTo(mem, 0); err != nil {
+			fmt.Fprintf(os.Stderr, "could not create memory profile: %s\n", err.Error())
+		}
+
+		os.Remove(fmt.Sprintf("%s.%v.mem.%d", prefix, os.Getpid(), i-1))
+	}
 }


### PR DESCRIPTION
If you don't do this the memory profile will never be written because
you do not close cleanly.  It will pollute with GC, but memory and cpu
profiles should be taken separately anyways.
