### PR TITLE
Respect existing stack configuration when initialising secret managers

### DIFF
--- a/changelog/pending/20241003--cli-new--respect-existing-stack-configuration-when-initialising-secret-managers.yaml
+++ b/changelog/pending/20241003--cli-new--respect-existing-stack-configuration-when-initialising-secret-managers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Respect existing stack configuration when initialising secret managers

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -239,12 +239,19 @@ type Backend interface {
 	// Cancel the current update for the given stack.
 	CancelCurrentUpdate(ctx context.Context, stackRef StackReference) error
 
-	// DefaultSecretManager returns the default secrets manager to use for stacks created against this backend, or nil if
-	// it is not possible to determine a default secrets manager for a stack prior to its creation.
+	// DefaultSecretManager accepts a project stack configuration (which may be empty, but not nil) and populates it with
+	// the default secrets manager configuration for stacks created against this backend, returning a secrets manager
+	// corresponding to that configuration.
+	//
+	// If the project stack configuration contains configuration for the same type of secrets manager as the backend
+	// default, this should be respected.
+	//
+	// If it is not possible to determine a default secrets manager for a stack prior to its creation, this method should
+	// return nil and make no changes to the supplied project stack configuration.
 	//
 	// When a stack has been instantiated, you should favor using the Stack.DefaultSecretManager method to get a default
 	// secrets manager for that stack.
-	DefaultSecretManager() (secrets.Manager, error)
+	DefaultSecretManager(ps *workspace.ProjectStack) (secrets.Manager, error)
 }
 
 // EnvironmentsBackend is an interface that defines an optional capability for a backend to work with environments.

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1434,9 +1434,8 @@ func (b *diyBackend) CancelCurrentUpdate(ctx context.Context, stackRef backend.S
 	return nil
 }
 
-func (b *diyBackend) DefaultSecretManager() (secrets.Manager, error) {
+func (b *diyBackend) DefaultSecretManager(ps *workspace.ProjectStack) (secrets.Manager, error) {
 	// The default secrets manager for stacks against a DIY backend is a
 	// passphrase-based manager.
-	info := &workspace.ProjectStack{}
-	return passphrase.NewPromptingPassphraseSecretsManager(info, false /* rotatePassphraseSecretsProvider */)
+	return passphrase.NewPromptingPassphraseSecretsManager(ps, false /* rotateSecretsProvider */)
 }

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -2173,7 +2173,7 @@ func decodeCapabilities(wireLevel []apitype.APICapabilityConfig) (capabilities, 
 	return parsed, nil
 }
 
-func (b *cloudBackend) DefaultSecretManager() (secrets.Manager, error) {
+func (b *cloudBackend) DefaultSecretManager(*workspace.ProjectStack) (secrets.Manager, error) {
 	// The default secrets manager for a cloud-backed stack is a cloud secrets manager, which is inherently
 	// stack-specific. Thus at the backend level we return nil, deferring to Stack.DefaultSecretManager when the stack has
 	// been created.

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -93,7 +93,7 @@ type MockBackend struct {
 
 	CancelCurrentUpdateF func(ctx context.Context, stackRef StackReference) error
 
-	DefaultSecretManagerF func() (secrets.Manager, error)
+	DefaultSecretManagerF func(ps *workspace.ProjectStack) (secrets.Manager, error)
 }
 
 var _ Backend = (*MockBackend)(nil)
@@ -442,9 +442,9 @@ func (be *MockBackend) GetGHAppIntegration(ctx context.Context, stack Stack) (*a
 	panic("not implemented")
 }
 
-func (be *MockBackend) DefaultSecretManager() (secrets.Manager, error) {
+func (be *MockBackend) DefaultSecretManager(ps *workspace.ProjectStack) (secrets.Manager, error) {
 	if be.DefaultSecretManagerF != nil {
-		return be.DefaultSecretManagerF()
+		return be.DefaultSecretManagerF(ps)
 	}
 	panic("not implemented")
 }

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -865,8 +865,15 @@ func getProjectStackPath(stack backend.Stack) (string, error) {
 }
 
 func loadProjectStack(project *workspace.Project, stack backend.Stack) (*workspace.ProjectStack, error) {
+	return loadProjectStackByReference(project, stack.Ref())
+}
+
+func loadProjectStackByReference(
+	project *workspace.Project,
+	stackRef backend.StackReference,
+) (*workspace.ProjectStack, error) {
 	if stackConfigFile == "" {
-		return workspace.DetectProjectStack(stack.Ref().Name().Q())
+		return workspace.DetectProjectStack(stackRef.Name().Q())
 	}
 	return workspace.LoadProjectStack(project, stackConfigFile)
 }

--- a/pkg/cmd/pulumi/stack_init_test.go
+++ b/pkg/cmd/pulumi/stack_init_test.go
@@ -54,7 +54,7 @@ func TestStackInit_teamsUnsupportedByBackend(t *testing.T) {
 			assert.NotEmpty(t, opts.Teams, "expected teams to be set")
 			return nil, backend.ErrTeamsNotSupported
 		},
-		DefaultSecretManagerF: func() (secrets.Manager, error) {
+		DefaultSecretManagerF: func(*workspace.ProjectStack) (secrets.Manager, error) {
 			return nil, nil
 		},
 	}

--- a/pkg/cmd/pulumi/util_test.go
+++ b/pkg/cmd/pulumi/util_test.go
@@ -500,7 +500,7 @@ func TestCreateStack_InitialisesStateWithSecretsManager(t *testing.T) {
 			assert.NoError(t, err)
 			return nil, nil
 		},
-		DefaultSecretManagerF: func() (secrets.Manager, error) {
+		DefaultSecretManagerF: func(*workspace.ProjectStack) (secrets.Manager, error) {
 			return expectedSm, nil
 		},
 	}


### PR DESCRIPTION
In #17387 we modified `stack init` to persist an initial secrets manager as part of stack creation (in contrast to only persisting it on subsequent updates as needed). As part of this change, we made it possible to create secrets managers without an existing stack. In doing so, we assumed that the absence of a stack also implied the absence of stack configuration. Consequently, we introduced a bug -- if a user had supplied a stack configuration (e.g. `Pulumi.<stack>.yaml`) *prior* to creating a stack (`dev` in this case) in the backend, we would ignore that configuration and potentially clobber it with a fresh (and likely useless) secrets provider. This was flagged in #17457.

In this commit, we refine the new pre-creation secrets manager initialisation code so that it will attempt to load a configuration even in the absence of a stack. If one is found, and configuration *for the type of secrets provider supplied to `stack init`* is found, it will be respected and we won't clobber existing values.

Fixes #17457