### PR TITLE
community-pr tests: don't pass PULUMI_BOT_TOKEN to ci.yml

### DIFF
--- a/.github/workflows/pr-test-acceptance-on-dispatch.yml
+++ b/.github/workflows/pr-test-acceptance-on-dispatch.yml
@@ -68,7 +68,6 @@ jobs:
       enable-coverage: false
     secrets:
       # Scope secrets to the minimum required:
-      PULUMI_BOT_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
       PULUMI_PROD_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/17193 I removed PULUMI_BOT_TOKEN from being used in ci.yml completely.  Unfortunately this broke the dispatching of the acceptance tests in community PRs, as they still pass the PULUMI_BOT_TOKEN through, but GitHub actions is unhappy with the extra secret being passed.

Stop passing this secret through to fix running those tests.