### PR TITLE
ci: Free disk space on Ubuntu

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -95,6 +95,13 @@ jobs:
     timeout-minutes: 60
     continue-on-error: ${{ inputs.continue-on-error }}
     steps:
+      - if: contains(inputs.platform, 'ubuntu')
+        name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          swap-storage: false
+
       # Create a coverage file to register a testing job was started.
       # This artifact will be overwritten with "OK" at the end of the job.
       - name: Write test started file

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -101,6 +101,7 @@ jobs:
         with:
           tool-cache: false
           swap-storage: false
+          large-packages: false
 
       # Create a coverage file to register a testing job was started.
       # This artifact will be overwritten with "OK" at the end of the job.

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -102,6 +102,7 @@ jobs:
           tool-cache: false
           swap-storage: false
           large-packages: false
+          dotnet: false
 
       # Create a coverage file to register a testing job was started.
       # This artifact will be overwritten with "OK" at the end of the job.


### PR DESCRIPTION
Some jobs on Ubuntu are failing during merge because they're running out of disk space. Use the `jlumbroso/free-disk-space` to free up some space.

https://github.com/pulumi/pulumi/actions/runs/11168927953/job/31048549192

<img width="1022" alt="Screenshot 2024-10-03 at 2 12 59 PM" src="https://github.com/user-attachments/assets/66178bd8-fbc4-42b9-950a-f8d760f07e17">
