### PR TITLE
snapshot prune: check that the elements match instead of equals

### DIFF
--- a/pkg/resource/deploy/snapshot_test.go
+++ b/pkg/resource/deploy/snapshot_test.go
@@ -656,7 +656,7 @@ func TestSnapshotPrune_FixesDanglingReferences(t *testing.T) {
 
 			// Assert.
 			assert.Equal(t, c.want, snap.Resources)
-			assert.Equal(t, c.results, actual)
+			assert.ElementsMatch(t, c.results, actual)
 			assert.NoError(t, snap.VerifyIntegrity())
 		})
 	}


### PR DESCRIPTION
The property map in the results list is not necessarily ordered. Instead of making sure that we have an equal object for the prune, let's just check if the elements match, since that's what we care about.  This fixes some flakyness because of map ordering.

Note that we don't need to do the same for snap.Resources, and it's better that way, because we care about the ordering of the resources in the snapshot.

Fixes https://github.com/pulumi/pulumi/issues/17476

cc @lunaris 