### PR TITLE
[sdk/nodejs] Maintain secretness and input dependencies of output invokes

### DIFF
--- a/changelog/pending/20241004--sdk-nodejs--maintain-secretness-and-input-dependencies-of-output-invokes.yaml
+++ b/changelog/pending/20241004--sdk-nodejs--maintain-secretness-and-input-dependencies-of-output-invokes.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Maintain secretness and input dependencies of output invokes

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -232,11 +232,6 @@ func TestLanguage(t *testing.T) {
 
 			for _, tt := range tests.Tests {
 				tt := tt
-				if tt == "l2-invoke-secrets" || tt == "l2-invoke-dependencies" {
-					// TODO: implement secret and dependency tracking for output invokes
-					// https://github.com/pulumi/pulumi/issues/17474
-					t.Skip("skipping " + tt)
-				}
 				t.Run(tt, func(t *testing.T) {
 					t.Parallel()
 

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-dependencies/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-dependencies/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-dependencies/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-dependencies/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: l2-invoke-dependencies
+runtime:
+  name: nodejs
+  options:
+    typescript: false

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-dependencies/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-dependencies/index.ts
@@ -1,0 +1,11 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as simple from "@pulumi/simple";
+import * as simple_invoke from "@pulumi/simple-invoke";
+
+const first = new simple.Resource("first", {value: false});
+// assert that resource second depends on resource first
+// because it uses .secret from the invoke which depends on first
+const second = new simple.Resource("second", {value: simple_invoke.secretInvokeOutput({
+    value: "hello",
+    secretResponse: first.value,
+}).apply(invoke => invoke.secret)});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-dependencies/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-dependencies/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "l2-invoke-dependencies",
+	"devDependencies": {
+		"@types/node": "^14"
+	},
+	"dependencies": {
+		"typescript": "^4.0.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz",
+		"@pulumi/simple-invoke": "ROOT/artifacts/pulumi-simple-invoke-10.0.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-dependencies/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-dependencies/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2016",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-secrets/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-secrets/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-secrets/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-secrets/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: l2-invoke-secrets
+runtime:
+  name: nodejs
+  options:
+    typescript: false

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-secrets/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-secrets/index.ts
@@ -1,0 +1,17 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as simple from "@pulumi/simple";
+import * as simple_invoke from "@pulumi/simple-invoke";
+
+const res = new simple.Resource("res", {value: true});
+export const nonSecret = simple_invoke.secretInvokeOutput({
+    value: "hello",
+    secretResponse: false,
+}).apply(invoke => invoke.response);
+export const firstSecret = simple_invoke.secretInvokeOutput({
+    value: "hello",
+    secretResponse: res.value,
+}).apply(invoke => invoke.response);
+export const secondSecret = simple_invoke.secretInvokeOutput({
+    value: pulumi.secret("goodbye"),
+    secretResponse: false,
+}).apply(invoke => invoke.response);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-secrets/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-secrets/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "l2-invoke-secrets",
+	"devDependencies": {
+		"@types/node": "^14"
+	},
+	"dependencies": {
+		"typescript": "^4.0.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz",
+		"@pulumi/simple-invoke": "ROOT/artifacts/pulumi-simple-invoke-10.0.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-secrets/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-secrets/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2016",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-dependencies/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-dependencies/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-dependencies/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-dependencies/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-invoke-dependencies
+runtime: nodejs

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-dependencies/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-dependencies/index.ts
@@ -1,0 +1,11 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as simple from "@pulumi/simple";
+import * as simple_invoke from "@pulumi/simple-invoke";
+
+const first = new simple.Resource("first", {value: false});
+// assert that resource second depends on resource first
+// because it uses .secret from the invoke which depends on first
+const second = new simple.Resource("second", {value: simple_invoke.secretInvokeOutput({
+    value: "hello",
+    secretResponse: first.value,
+}).apply(invoke => invoke.secret)});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-dependencies/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-dependencies/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "l2-invoke-dependencies",
+	"devDependencies": {
+		"@types/node": "^14"
+	},
+	"dependencies": {
+		"typescript": "^4.0.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz",
+		"@pulumi/simple-invoke": "ROOT/artifacts/pulumi-simple-invoke-10.0.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-dependencies/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-dependencies/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2016",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-secrets/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-secrets/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-secrets/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-secrets/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-invoke-secrets
+runtime: nodejs

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-secrets/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-secrets/index.ts
@@ -1,0 +1,17 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as simple from "@pulumi/simple";
+import * as simple_invoke from "@pulumi/simple-invoke";
+
+const res = new simple.Resource("res", {value: true});
+export const nonSecret = simple_invoke.secretInvokeOutput({
+    value: "hello",
+    secretResponse: false,
+}).apply(invoke => invoke.response);
+export const firstSecret = simple_invoke.secretInvokeOutput({
+    value: "hello",
+    secretResponse: res.value,
+}).apply(invoke => invoke.response);
+export const secondSecret = simple_invoke.secretInvokeOutput({
+    value: pulumi.secret("goodbye"),
+    secretResponse: false,
+}).apply(invoke => invoke.response);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-secrets/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-secrets/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "l2-invoke-secrets",
+	"devDependencies": {
+		"@types/node": "^14"
+	},
+	"dependencies": {
+		"typescript": "^4.0.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz",
+		"@pulumi/simple-invoke": "ROOT/artifacts/pulumi-simple-invoke-10.0.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-secrets/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-secrets/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2016",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -594,8 +594,7 @@ export function unwrapRpcSecret(obj: any): any {
     return obj.value;
 }
 
-/** @internal */
-export function isPrimitive(value: unknown): boolean {
+function isPrimitive(value: unknown): boolean {
     return (
         value === null ||
         value === undefined ||

--- a/sdk/nodejs/tests/runtime/rpc.spec.ts
+++ b/sdk/nodejs/tests/runtime/rpc.spec.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/nodejs/tests/runtime/rpc.spec.ts
+++ b/sdk/nodejs/tests/runtime/rpc.spec.ts
@@ -1,0 +1,72 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "assert";
+import * as rpc from "../../runtime/rpc";
+
+const secretUnwrappingTestData: { original: any; unwrapped: any }[] = [
+    // primitive value wrapped in a secret
+    {
+        original: rpc.serializeSecretValue("secret"),
+        unwrapped: "secret",
+    },
+    // object with a secret value,
+    {
+        original: {
+            first: "first",
+            second: rpc.serializeSecretValue("second"),
+            nested: {
+                first: "first",
+                second: rpc.serializeSecretValue("secret"),
+            },
+        },
+        unwrapped: {
+            first: "first",
+            second: "second",
+            nested: {
+                first: "first",
+                second: "secret",
+            },
+        },
+    },
+    // inside an array
+    {
+        original: ["first", rpc.serializeSecretValue("second")],
+        unwrapped: ["first", "second"],
+    },
+    // inside an array inside an object
+    {
+        original: {
+            first: "first",
+            second: [{ nested: [rpc.serializeSecretValue("nested")] }],
+        },
+        unwrapped: {
+            first: "first",
+            second: [{ nested: ["nested"] }],
+        },
+    },
+];
+
+describe("rpc tests", () => {
+    it("unwrapSecretValues works", () => {
+        for (const { original, unwrapped } of secretUnwrappingTestData) {
+            const [result, containsSecret] = rpc.unwrapSecretValues(original);
+            assert.strictEqual(containsSecret, true);
+            assert.deepStrictEqual(result, unwrapped);
+            const [unwrappedResult, containsSecretAgain] = rpc.unwrapSecretValues(result);
+            assert.strictEqual(containsSecretAgain, false);
+            assert.deepStrictEqual(unwrappedResult, result);
+        }
+    });
+});

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -90,6 +90,7 @@
         "tests/runtime/findWorkspaceRoot.spec.ts",
         "tests/runtime/registrations.spec.ts",
         "tests/runtime/pack.ts",
+        "tests/runtime/rpc.spec.ts",
         "tests/runtime/install-package-tests.ts",
         "tests/runtime/closure-integration-tests.ts",
         "tests/runtime/props.spec.ts",


### PR DESCRIPTION
### Description 

Addresses the nodejs part of #17474, it does the following
 - Keeping track of secretness of inputs
 - Unwraps the inputs such that they are sent as plain values to the engine
 - Marks the invoke result as secret if any of the inputs is a secret
 - Marks the dependencies of the output invoke response being the list of all dependencies of the inputs
 - Enables conformance tests `l2-invoke-secrets` and `l2-invoke-dependencies`
 - Adds unit tests for newly added function `unwrapSecretValues`