### PR TITLE
[sdk/python] Handle nested structures properly when unwrapping secrets from invoke inputs

### DIFF
--- a/changelog/pending/20241005--sdk-python--handle-nested-structures-properly-when-unwrapping-secrets-from-invoke-inputs.yaml
+++ b/changelog/pending/20241005--sdk-python--handle-nested-structures-properly-when-unwrapping-secrets-from-invoke-inputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Handle nested structures properly when unwrapping secrets from invoke inputs

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -815,6 +815,7 @@ def _unwrap_rpc_secret_struct_properties(value: Any) -> Tuple[Any, bool]:
             contains_secrets = contains_secrets or secret_element
             list_values.append(unwrapped)
         return list_values, contains_secrets
+    # pylint: disable=no-member
     if isinstance(value, struct_pb2.Value):
         if value.WhichOneof("kind") == "struct_value":
             unwrapped, secret_element = _unwrap_rpc_secret_struct_properties(

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -814,7 +814,26 @@ def _unwrap_rpc_secret_struct_properties(value: Any) -> Tuple[Any, bool]:
             unwrapped, secret_element = _unwrap_rpc_secret_struct_properties(list_value)
             contains_secrets = contains_secrets or secret_element
             list_values.append(unwrapped)
-        return struct_pb2.ListValue(values=list_values), contains_secrets
+        return list_values, contains_secrets
+    if isinstance(value, struct_pb2.Value):
+        if value.WhichOneof("kind") == "struct_value":
+            unwrapped, secret_element = _unwrap_rpc_secret_struct_properties(
+                value.struct_value
+            )
+            return unwrapped, secret_element
+        if value.WhichOneof("kind") == "list_value":
+            unwrapped, secret_element = _unwrap_rpc_secret_struct_properties(
+                value.list_value
+            )
+            return unwrapped, secret_element
+        if value.WhichOneof("kind") == "string_value":
+            return value.string_value, False
+        if value.WhichOneof("kind") == "number_value":
+            return value.number_value, False
+        if value.WhichOneof("kind") == "bool_value":
+            return value.bool_value, False
+        if value.WhichOneof("kind") == "null_value":
+            return None, False
     return (value, False)
 
 


### PR DESCRIPTION
### Description

Follow up for https://github.com/pulumi/pulumi/pull/17460 including tests. We needed to handle values of type `struct_pb2.Value` when unwrapping secrets from invoke inputs. 

> Linting is failing locally using pylint (missing `Module 'google.protobuf.struct_pb2' has no 'Value' member (no-member)` but mypy reports no issues. Maybe CI is fine though