### PR TITLE
Update python grpcio to 1.66.2 to support Python 3.13

### DIFF
--- a/changelog/pending/20241005--sdk-python--update-python-grpcio-to-1-66-2.yaml
+++ b/changelog/pending/20241005--sdk-python--update-python-grpcio-to-1-66-2.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/python
+  description: Update python grpcio to 1.66.2

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -44,7 +44,7 @@ setup(name='pulumi',
       # Keep this list in sync with Pipfile
       install_requires=[
           'protobuf~=4.21',
-          'grpcio~=1.60.1',
+          'grpcio~=1.66.2',
           'dill~=0.3',
           'six~=1.12',
           'semver~=2.13',

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -1,7 +1,7 @@
 # Packages needed by the library.
 # Keep this list in sync with setup.py.
 protobuf~=4.21
-grpcio~=1.60.1
+grpcio~=1.66.2
 dill~=0.3
 six~=1.12
 semver~=2.13


### PR DESCRIPTION
To support the upcoming Python 3.13 release, we need to upgrade grpcio to 1.66.2 https://github.com/grpc/grpc/releases/tag/v1.66.2

Update pulumi-policy after this is released https://github.com/pulumi/pulumi-policy/pull/361

Ref https://github.com/pulumi/pulumi/issues/17484
