### PR TITLE
Exclude tests from the nodejs npm package

### DIFF
--- a/changelog/pending/20241006--sdk-nodejs--exclude-tests-from-the-nodejs-npm-package.yaml
+++ b/changelog/pending/20241006--sdk-nodejs--exclude-tests-from-the-nodejs-npm-package.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/nodejs
+  description: Exclude tests from the nodejs npm package

--- a/sdk/nodejs/.npmignore
+++ b/sdk/nodejs/.npmignore
@@ -1,0 +1,3 @@
+npm/testdata
+tests
+tests_with_mocks

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -34,7 +34,7 @@ build_package:: ensure
 	yarn run tsc
 	mkdir -p bin/tests/automation/data/
 	cp -R tests/automation/data/. bin/tests/automation/data/
-	cp README.md ../../LICENSE ./dist/* bin/
+	cp .npmignore README.md ../../LICENSE ./dist/* bin/
 	cp -R ./vendor/ ./bin/vendor/
 	node ../../scripts/reversion.js bin/package.json ${VERSION}
 	node ../../scripts/reversion.js bin/version.js ${VERSION}


### PR DESCRIPTION
Add an .npmignore file to exclude tests from the npm package.

Fixes https://github.com/pulumi/pulumi/issues/17471