### PR TITLE
Target Python 3.8 for linting SDK

### DIFF
--- a/changelog/pending/20241007--sdk-python--target-python-3-8-for-linting-sdk.yaml
+++ b/changelog/pending/20241007--sdk-python--target-python-3-8-for-linting-sdk.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Target Python 3.8 for linting SDK

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -122,6 +122,8 @@ MINIMUM_SUPPORTED_VERSION_SET = {
     "dotnet": "6",
     "go": "1.22.x",
     "nodejs": "18.x",
+    # When updating the minimum Python version here, also update `mypy.ini` and
+    # `.pylintrc` to target this version.
     "python": "3.8.x",
 }
 

--- a/sdk/python/.pylintrc
+++ b/sdk/python/.pylintrc
@@ -1,5 +1,8 @@
 [MASTER]
 
+# The minimum Python version we support
+py-version=3.8
+
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -540,7 +540,7 @@ class Output(Generic[T_co]):
     @staticmethod
     def all(
         *args: Input[Any], **kwargs: Input[Any]
-    ) -> "Output[list[Any] | dict[str, Any]]":
+    ) -> "Output[List[Any] | Dict[str, Any]]":
         """
         Produces an Output of a list (if args i.e a list of inputs are supplied)
         or dict (if kwargs i.e. keyworded arguments are supplied).

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -979,8 +979,8 @@ def register_resource(
                 in {"TRUE", "1"}
             )
 
-            full_aliases_specs: List[alias_pb2.Alias] | None = None
-            alias_urns: List[str] | None = None
+            full_aliases_specs: Optional[List[alias_pb2.Alias]] = None
+            alias_urns: Optional[List[str]] = None
             if resolver.supports_alias_specs:
                 full_aliases_specs = resolver.aliases
             else:

--- a/sdk/python/mypy.ini
+++ b/sdk/python/mypy.ini
@@ -2,6 +2,9 @@
 
 [mypy]
 
+# The minimum Python version we support
+python_version = 3.8
+
 # Per-module options:
 
 [mypy-dill]


### PR DESCRIPTION
We still support Python 3.8 (EOL 2024-10-31). Pylint and MyPy should target this version to ensure the SDK remains compatible with these versions.

This change revaled some issues with our typings, which were not compatible with Python 3.8 or 3.9. Since types are ignored at runtime, this did not cause any issues with using the SDK on these versions. Our test suite runs against the minumum supported verison, and would catch regressions here, however typechecking on these older versions would flag these issues.
