### PR TITLE
Document that args should be read from in preference to variables

### DIFF
--- a/developer-docs/providers/implementers-guide.md
+++ b/developer-docs/providers/implementers-guide.md
@@ -629,3 +629,10 @@ None.
 - TODO:
 	- feature negotiation
 	- data representation
+
+#### Configure
+
+For newer providers it is recommended to ignore `variables` and instead consult `args` for recovering the inputs to the
+provider configuration. This allows for a natural encoding of nested property values that have to be JSON-encoded to
+satisfy the `map<string, string> variables` type constraint. `variables` are retained for backwards-compatibility with
+the older providers only.

--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -18,7 +18,7 @@
 1921230328 1269 proto/pulumi/errors.proto
 420991671 12306 proto/pulumi/language.proto
 2893249402 1992 proto/pulumi/plugin.proto
-1529552991 28224 proto/pulumi/provider.proto
+248318385 28258 proto/pulumi/provider.proto
 1190662922 17848 proto/pulumi/resource.proto
 607478140 1008 proto/pulumi/source.proto
 3670315643 2603 proto/pulumi/testing/language.proto

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -153,8 +153,10 @@ message GetSchemaResponse {
 }
 
 message ConfigureRequest {
-    map<string, string> variables = 1; // a map of configuration keys to values.
-    google.protobuf.Struct args = 2;   // the input properties for the provider. Only filled in for newer providers.
+    // the input properties for the provider, with nested values JSON-encoded; please read from `args` instead.
+    map<string, string> variables = 1;
+
+    google.protobuf.Struct args = 2;   // the input properties for the provider
     bool acceptSecrets  = 3;           // when true, operations should return secrets as strongly typed.
     bool acceptResources = 4;          // when true, operations should return resources as strongly typed values to the provider.
     bool sends_old_inputs = 5;         // when true, diff and update will be called with the old outputs and the old inputs.

--- a/sdk/proto/go/provider.pb.go
+++ b/sdk/proto/go/provider.pb.go
@@ -398,12 +398,13 @@ type ConfigureRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Variables              map[string]string `protobuf:"bytes,1,rep,name=variables,proto3" json:"variables,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"` // a map of configuration keys to values.
-	Args                   *structpb.Struct  `protobuf:"bytes,2,opt,name=args,proto3" json:"args,omitempty"`                                                                                                   // the input properties for the provider. Only filled in for newer providers.
-	AcceptSecrets          bool              `protobuf:"varint,3,opt,name=acceptSecrets,proto3" json:"acceptSecrets,omitempty"`                                                                                // when true, operations should return secrets as strongly typed.
-	AcceptResources        bool              `protobuf:"varint,4,opt,name=acceptResources,proto3" json:"acceptResources,omitempty"`                                                                            // when true, operations should return resources as strongly typed values to the provider.
-	SendsOldInputs         bool              `protobuf:"varint,5,opt,name=sends_old_inputs,json=sendsOldInputs,proto3" json:"sends_old_inputs,omitempty"`                                                      // when true, diff and update will be called with the old outputs and the old inputs.
-	SendsOldInputsToDelete bool              `protobuf:"varint,6,opt,name=sends_old_inputs_to_delete,json=sendsOldInputsToDelete,proto3" json:"sends_old_inputs_to_delete,omitempty"`                          // when true, delete will be called with the old outputs and the old inputs.
+	// the input properties for the provider, with nested values JSON-encoded; please read from `args` instead.
+	Variables              map[string]string `protobuf:"bytes,1,rep,name=variables,proto3" json:"variables,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	Args                   *structpb.Struct  `protobuf:"bytes,2,opt,name=args,proto3" json:"args,omitempty"`                                                                          // the input properties for the provider
+	AcceptSecrets          bool              `protobuf:"varint,3,opt,name=acceptSecrets,proto3" json:"acceptSecrets,omitempty"`                                                       // when true, operations should return secrets as strongly typed.
+	AcceptResources        bool              `protobuf:"varint,4,opt,name=acceptResources,proto3" json:"acceptResources,omitempty"`                                                   // when true, operations should return resources as strongly typed values to the provider.
+	SendsOldInputs         bool              `protobuf:"varint,5,opt,name=sends_old_inputs,json=sendsOldInputs,proto3" json:"sends_old_inputs,omitempty"`                             // when true, diff and update will be called with the old outputs and the old inputs.
+	SendsOldInputsToDelete bool              `protobuf:"varint,6,opt,name=sends_old_inputs_to_delete,json=sendsOldInputsToDelete,proto3" json:"sends_old_inputs_to_delete,omitempty"` // when true, delete will be called with the old outputs and the old inputs.
 }
 
 func (x *ConfigureRequest) Reset() {

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
@@ -180,10 +180,10 @@ class ConfigureRequest(google.protobuf.message.Message):
     SENDS_OLD_INPUTS_TO_DELETE_FIELD_NUMBER: builtins.int
     @property
     def variables(self) -> google.protobuf.internal.containers.ScalarMap[builtins.str, builtins.str]:
-        """a map of configuration keys to values."""
+        """the input properties for the provider, with nested values JSON-encoded; please read from `args` instead."""
     @property
     def args(self) -> google.protobuf.struct_pb2.Struct:
-        """the input properties for the provider. Only filled in for newer providers."""
+        """the input properties for the provider"""
     acceptSecrets: builtins.bool
     """when true, operations should return secrets as strongly typed."""
     acceptResources: builtins.bool


### PR DESCRIPTION
Recommend newer providers read Configure data from `args` instead of `variables`. There still are providers notably `azure-native` and `kubernetes` that rely on `variables`.

Context: https://docs.google.com/document/d/1cnBJzAGWMnjjj2Q5fDdVcq0DcrWd-OqvPPlSxQV50R4/edit?usp=sharing