### PR TITLE
Make `property.Value` immutable

### DIFF
--- a/changelog/pending/20240925--sdk-go--add-property-path-and-associated-functions.yaml
+++ b/changelog/pending/20240925--sdk-go--add-property-path-and-associated-functions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Add `property.Path` and associated functions.

--- a/changelog/pending/20241007--sdk-go--make-property-value-immutable.yaml
+++ b/changelog/pending/20241007--sdk-go--make-property-value-immutable.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Make `property.Value` immutable

--- a/sdk/go/common/resource/property_compatibility.go
+++ b/sdk/go/common/resource/property_compatibility.go
@@ -34,14 +34,14 @@ func ToResourcePropertyValue(v property.Value) PropertyValue {
 	case v.IsString():
 		r = NewStringProperty(v.AsString())
 	case v.IsArray():
-		vArr := v.AsArray()
+		vArr := v.AsArray().AsSlice()
 		arr := make([]PropertyValue, len(vArr))
 		for i, vElem := range vArr {
 			arr[i] = ToResourcePropertyValue(vElem)
 		}
 		r = NewArrayProperty(arr)
 	case v.IsMap():
-		vMap := v.AsMap()
+		vMap := v.AsMap().AsMap()
 		rMap := make(PropertyMap, len(vMap))
 		for k, vElem := range vMap {
 			rMap[PropertyKey(k)] = ToResourcePropertyValue(vElem)
@@ -96,14 +96,14 @@ func FromResourcePropertyValue(v PropertyValue) property.Value {
 		return property.New(v.StringValue())
 	case v.IsArray():
 		vArr := v.ArrayValue()
-		arr := make(property.Array, len(vArr))
+		arr := make([]property.Value, len(vArr))
 		for i, v := range vArr {
 			arr[i] = FromResourcePropertyValue(v)
 		}
 		return property.New(arr)
 	case v.IsObject():
 		vMap := v.ObjectValue()
-		rMap := make(property.Map, len(vMap))
+		rMap := make(map[string]property.Value, len(vMap))
 		for k, v := range vMap {
 			rMap[string(k)] = FromResourcePropertyValue(v)
 		}

--- a/sdk/go/property/array.go
+++ b/sdk/go/property/array.go
@@ -1,0 +1,53 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+// An immutable Array of [Value]s.
+type Array struct{ arr []Value }
+
+// AsSlice copies the [Array] into a slice.
+func (a Array) AsSlice() []Value { return copyArray(a.arr) }
+
+func (a Array) All(yield func(int, Value) bool) {
+	for k, v := range a.arr {
+		if !yield(k, v) {
+			return
+		}
+	}
+}
+
+func (a Array) Get(idx int) Value {
+	return a.arr[idx]
+}
+
+func (a Array) Len() int {
+	return len(a.arr)
+}
+
+// Append a new value to the end of the current array.
+func (a Array) Append(v Value) Array {
+	// We need to copy a.arr since append may mutate the backing array, which may be
+	// shared.
+	return Array{append(copyArray(a.arr), v)}
+}
+
+func NewArray(slice []Value) Array { return Array{copyArray(slice)} }
+
+func copyArray(a []Value) []Value {
+	// Perform a shallow copy on v.
+	cp := make([]Value, len(a))
+	copy(cp, a)
+	return cp
+}

--- a/sdk/go/property/array_test.go
+++ b/sdk/go/property/array_test.go
@@ -1,0 +1,151 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArrayAppend(t *testing.T) {
+	t.Parallel()
+	t.Run("basic functionality", func(t *testing.T) {
+		t.Parallel()
+		arr := NewArray([]Value{
+			New("a"),
+			New("b"),
+			New("c"),
+		})
+
+		cp := arr.Append(New("d"), New("e"))
+
+		assert.Equal(t, NewArray([]Value{
+			New("a"),
+			New("b"),
+			New("c"),
+		}), arr)
+
+		assert.Equal(t, NewArray([]Value{
+			New("a"),
+			New("b"),
+			New("c"),
+			New("d"),
+			New("e"),
+		}), cp)
+	})
+
+	t.Run("appends do not conflict", func(t *testing.T) {
+		t.Parallel()
+		arr := NewArray([]Value{New(1.0)})
+
+		arr2 := arr.Append(New(2.0))
+		arr3 := arr.Append(New(3.0))
+
+		assert.Equal(t, NewArray([]Value{
+			New(1.0),
+		}), arr)
+
+		assert.Equal(t, NewArray([]Value{
+			New(1.0),
+			New(2.0),
+		}), arr2)
+
+		assert.Equal(t, NewArray([]Value{
+			New(1.0),
+			New(3.0),
+		}), arr3)
+	})
+}
+
+func TestArraySlice(t *testing.T) {
+	t.Parallel()
+
+	t.Run("from slice", func(t *testing.T) {
+		t.Parallel()
+		s := []Value{
+			New(1.0),
+			New(2.0),
+		}
+
+		arr := NewArray(s)
+
+		s[1] = New(3.0) // Ensure that the mutation of s does not allow a mutation of arr.
+
+		assert.Equal(t, NewArray([]Value{
+			New(1.0),
+			New(2.0),
+		}), arr)
+	})
+
+	t.Run("to slice", func(t *testing.T) {
+		t.Parallel()
+		arr := NewArray([]Value{
+			New(1.0),
+			New(2.0),
+		})
+
+		s := arr.AsSlice()
+
+		s[1] = New(3.0) // Ensure that the mutation of s does not allow a mutation of arr.
+
+		assert.Equal(t, NewArray([]Value{
+			New(1.0),
+			New(2.0),
+		}), arr)
+	})
+}
+
+func TestArrayLen(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 2, NewArray([]Value{
+		New(1.0),
+		New(2.0),
+	}).Len())
+
+	assert.Equal(t, 0, NewArray(nil).Len())
+}
+
+func TestArrayIndex(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		arr := NewArray([]Value{
+			New(1.0),
+			New(2.0),
+		})
+		assert.Equal(t, New(2.0), arr.Get(1))
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		t.Parallel()
+		arr := NewArray([]Value{
+			New(1.0),
+			New(2.0),
+		})
+		assert.Panics(t, func() { arr.Get(-1) })
+	})
+
+	t.Run("too big", func(t *testing.T) {
+		t.Parallel()
+		arr := NewArray([]Value{
+			New(1.0),
+			New(2.0),
+		})
+		assert.Panics(t, func() { arr.Get(2) })
+	})
+}

--- a/sdk/go/property/equal.go
+++ b/sdk/go/property/equal.go
@@ -41,7 +41,7 @@ type eqOpts struct {
 //     equality: a.IsComputed() => (a.Equals(b) <=> b.IsComputed()) (up to secrets and
 //     dependencies).
 //
-//     If EqualRelaxComputed is passed, then computed values are considered equal to all
+//     If [EqualRelaxComputed] is passed, then computed values are considered equal to all
 //     other values. (up to secrets and dependencies)
 func (v Value) Equals(other Value, opts ...EqualOption) bool {
 	var eqOpts eqOpts

--- a/sdk/go/property/equal.go
+++ b/sdk/go/property/equal.go
@@ -77,23 +77,23 @@ func (v Value) equals(other Value, opts eqOpts) bool {
 	case v.IsString() && other.IsString():
 		return v.AsString() == other.AsString()
 	case v.IsArray() && other.IsArray():
-		a1, a2 := v.asArrayMut(), other.asArrayMut()
-		if len(a1) != len(a2) {
+		a1, a2 := v.AsArray(), other.AsArray()
+		if a1.Len() != a2.Len() {
 			return false
 		}
-		for i := range a1 {
-			if !a1[i].equals(a2[i], opts) {
+		for i := range a1.arr {
+			if !a1.arr[i].equals(a2.arr[i], opts) {
 				return false
 			}
 		}
 		return true
 	case v.IsMap() && other.IsMap():
-		m1, m2 := v.asMapMut(), other.asMapMut()
-		if len(m1) != len(m2) {
+		m1, m2 := v.AsMap(), other.AsMap()
+		if m1.Len() != m2.Len() {
 			return false
 		}
-		for k, v1 := range m1 {
-			v2, ok := m2[k]
+		for k, v1 := range m1.m {
+			v2, ok := m2.m[k]
 			if !ok || !v1.equals(v2, opts) {
 				return false
 			}

--- a/sdk/go/property/equal.go
+++ b/sdk/go/property/equal.go
@@ -77,7 +77,7 @@ func (v Value) equals(other Value, opts eqOpts) bool {
 	case v.IsString() && other.IsString():
 		return v.AsString() == other.AsString()
 	case v.IsArray() && other.IsArray():
-		a1, a2 := v.AsArray(), other.AsArray()
+		a1, a2 := v.asArrayMut(), other.asArrayMut()
 		if len(a1) != len(a2) {
 			return false
 		}
@@ -88,7 +88,7 @@ func (v Value) equals(other Value, opts eqOpts) bool {
 		}
 		return true
 	case v.IsMap() && other.IsMap():
-		m1, m2 := v.AsMap(), other.AsMap()
+		m1, m2 := v.asMapMut(), other.asMapMut()
 		if len(m1) != len(m2) {
 			return false
 		}
@@ -100,10 +100,10 @@ func (v Value) equals(other Value, opts eqOpts) bool {
 		}
 		return true
 	case v.IsAsset() && other.IsAsset():
-		a1, a2 := v.AsAsset(), other.AsAsset()
+		a1, a2 := v.asAssetMut(), other.asAssetMut()
 		return a1.Equals(a2)
 	case v.IsArchive() && other.IsArchive():
-		a1, a2 := v.AsArchive(), other.AsArchive()
+		a1, a2 := v.asArchiveMut(), other.asArchiveMut()
 		return a1.Equals(a2)
 	case v.IsResourceReference() && other.IsResourceReference():
 		r1, r2 := v.AsResourceReference(), other.AsResourceReference()

--- a/sdk/go/property/map.go
+++ b/sdk/go/property/map.go
@@ -14,27 +14,44 @@
 
 package property
 
-// Visit each Value in the within v.
-//
-// Parents are visited before their children.
-func (v Value) visit(f func(Value) (continueWalking bool)) bool {
-	cont := f(v)
-	if !cont {
-		return false
-	}
-	switch {
-	case v.IsArray():
-		for _, v := range v.AsArray() {
-			if !v.visit(f) {
-				return false
-			}
-		}
-	case v.IsMap():
-		for _, v := range v.AsArray() {
-			if !v.visit(f) {
-				return false
-			}
+// An immutable Map of [Value]s.
+type Map struct{ m map[string]Value }
+
+func (m Map) AsMap() map[string]Value { return copyMap(m.m) }
+
+func (m Map) All(yield func(string, Value) bool) {
+	for k, v := range m.m {
+		if !yield(k, v) {
+			continue
 		}
 	}
-	return true
+}
+
+func (m Map) Get(key string) Value {
+	return m.m[key]
+}
+
+func (m Map) GetOk(key string) (Value, bool) {
+	v, ok := m.m[key]
+	return v, ok
+}
+
+func (m Map) Len() int {
+	return len(m.m)
+}
+
+func (m Map) Set(key string, value Value) Map {
+	cp := copyMap(m.m)
+	cp[key] = value
+	return Map{cp}
+}
+
+func NewMap(m map[string]Value) Map { return Map{copyMap(m)} }
+
+func copyMap(m map[string]Value) map[string]Value {
+	cp := make(map[string]Value, len(m))
+	for k, v := range m {
+		cp[k] = v
+	}
+	return cp
 }

--- a/sdk/go/property/map.go
+++ b/sdk/go/property/map.go
@@ -14,19 +14,65 @@
 
 package property
 
+import (
+	"slices"
+)
+
 // An immutable Map of [Value]s.
 type Map struct{ m map[string]Value }
 
+// AsMap converts the [Map] into a native Go map from strings to [Values].
 func (m Map) AsMap() map[string]Value { return copyMap(m.m) }
 
+// All calls yield for each key value pair in the Map. All iterates in random order, just
+// like Go's native maps. For stable iteration order, use [Map.AllStable].
+//
+// If yield returns false, then the iteration terminates.
+//
+//	m := property.NewMap(map[]property.Value{
+//		"one": property.New(1),
+//		"two": property.New(2),
+//		"three": property.New(3),
+//	})
+//
+//	m.All(func(k string, v Value) bool {
+//		fmt.Printf("Key: %s, value: %s\n", k, v)
+//		return true
+//	})
+//
+// With Go 1.23, you can use iterator syntax to access each element:
+//
+//	for k, v := range arr.All {
+//		fmt.Printf("Index: %s, value: %s\n", k, v)
+//	}
 func (m Map) All(yield func(string, Value) bool) {
 	for k, v := range m.m {
 		if !yield(k, v) {
-			continue
+			return
 		}
 	}
 }
 
+// AllStable calls yield for each key value pair in the Map in sorted key order.
+//
+// For usage, see [Map.All].
+func (m Map) AllStable(yield func(string, Value) bool) {
+	keys := make([]string, 0, len(m.m))
+	for k := range m.m {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	for _, k := range keys {
+		if !yield(k, m.m[k]) {
+			return
+		}
+	}
+}
+
+// Get retrieves the [Value] associated with key in the [Map]. If key is not in [Map],
+// then a [Null] value is returned.
+//
+// To distinguish between a zero value and no value, use [Map.GetOk].
 func (m Map) Get(key string) Value {
 	return m.m[key]
 }
@@ -36,16 +82,21 @@ func (m Map) GetOk(key string) (Value, bool) {
 	return v, ok
 }
 
+// The number of elements in the [Map].
 func (m Map) Len() int {
 	return len(m.m)
 }
 
+// Set produces a new map identical to the receiver with key mapped to value.
+//
+// Set does not mutate it's receiver.
 func (m Map) Set(key string, value Value) Map {
 	cp := copyMap(m.m)
 	cp[key] = value
 	return Map{cp}
 }
 
+// NewMap creates a new map from m.
 func NewMap(m map[string]Value) Map { return Map{copyMap(m)} }
 
 func copyMap(m map[string]Value) map[string]Value {

--- a/sdk/go/property/map_test.go
+++ b/sdk/go/property/map_test.go
@@ -1,0 +1,280 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapSet(t *testing.T) {
+	t.Parallel()
+	t.Run("basic functionality", func(t *testing.T) {
+		t.Parallel()
+		m := NewMap(map[string]Value{
+			"a": New("alpha"),
+			"b": New("beta"),
+			"c": New("gamma"),
+		})
+
+		cp := m.Set("d", New("delta")).Set("e", New("epsilon"))
+
+		assert.Equal(t, NewMap(map[string]Value{
+			"a": New("alpha"),
+			"b": New("beta"),
+			"c": New("gamma"),
+		}), m)
+
+		assert.Equal(t, NewMap(map[string]Value{
+			"a": New("alpha"),
+			"b": New("beta"),
+			"c": New("gamma"),
+			"d": New("delta"),
+			"e": New("epsilon"),
+		}), cp)
+	})
+
+	t.Run("sets do not conflict", func(t *testing.T) {
+		t.Parallel()
+		m := NewMap(map[string]Value{"key1": New(1.0)})
+
+		m2 := m.Set("key2", New(2.0))
+		m3 := m.Set("key3", New(3.0))
+
+		assert.Equal(t, NewMap(map[string]Value{
+			"key1": New(1.0),
+		}), m)
+
+		assert.Equal(t, NewMap(map[string]Value{
+			"key1": New(1.0),
+			"key2": New(2.0),
+		}), m2)
+
+		assert.Equal(t, NewMap(map[string]Value{
+			"key1": New(1.0),
+			"key3": New(3.0),
+		}), m3)
+	})
+}
+
+func TestMapLen(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 3, NewMap(map[string]Value{
+		"one":   New(1.0),
+		"two":   New(2.0),
+		"three": New(3.0),
+	}).Len())
+
+	assert.Equal(t, 0, NewMap(nil).Len())
+}
+
+func TestMapGet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		m := NewMap(map[string]Value{
+			"key1": New(1.0),
+			"key2": New(2.0),
+		})
+		assert.Equal(t, New(2.0), m.Get("key2"))
+	})
+
+	t.Run("non-existent", func(t *testing.T) {
+		t.Parallel()
+		m := NewMap(map[string]Value{
+			"key1": New(1.0),
+		})
+		assert.Equal(t, New(Null), m.Get("key2")) // Assuming 'New(nil)' represents a null value.
+	})
+}
+
+func TestMapAll(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		m := NewMap(nil)
+		m.All(func(string, Value) bool {
+			assert.Fail(t, "An empty map should never call its iterator")
+			return true
+		})
+	})
+
+	t.Run("single element", func(t *testing.T) {
+		t.Parallel()
+		m := NewMap(map[string]Value{"key1": New("v1")})
+		var wasCalled bool
+		m.All(func(k string, v Value) bool {
+			if wasCalled {
+				assert.Fail(t, "A map with only 1 element should only be called once")
+			}
+			wasCalled = true
+			assert.Equal(t, "key1", k)
+			assert.Equal(t, New("v1"), v)
+			return true
+		})
+	})
+
+	t.Run("multiple elements", func(t *testing.T) {
+		t.Parallel()
+		m := NewMap(map[string]Value{"key1": New("v1"), "key2": New("v2"), "key3": New("v3")})
+		var callCount int
+		m.All(func(k string, v Value) bool {
+			callCount++
+			switch k {
+			case "key1":
+				assert.Equal(t, New("v1"), v)
+			case "key2":
+				assert.Equal(t, New("v2"), v)
+			case "key3":
+				assert.Equal(t, New("v3"), v)
+			default:
+				assert.Fail(t, "unexpected call")
+			}
+			return true
+		})
+		assert.Equal(t, 3, callCount)
+	})
+
+	t.Run("early exit", func(t *testing.T) {
+		t.Parallel()
+		m := NewMap(map[string]Value{"key1": New("v1"), "key2": New("v2")})
+		var wasCalled bool
+		m.All(func(k string, v Value) bool {
+			if wasCalled {
+				assert.Fail(t, "A map iteration with early exit should only be called once")
+			}
+			wasCalled = true
+			switch k {
+			case "key1":
+				assert.Equal(t, New("v1"), v)
+			case "key2":
+				assert.Equal(t, New("v2"), v)
+			default:
+				assert.Fail(t, "unexpected call")
+			}
+
+			return false
+		})
+	})
+}
+
+func TestMapAllStable(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		m := NewMap(nil)
+		m.AllStable(func(string, Value) bool {
+			assert.Fail(t, "An empty map should never call its iterator")
+			return true
+		})
+	})
+
+	t.Run("single element", func(t *testing.T) {
+		t.Parallel()
+		m := NewMap(map[string]Value{"key1": New("v1")})
+		var wasCalled bool
+		m.AllStable(func(k string, v Value) bool {
+			if wasCalled {
+				assert.Fail(t, "A map with only 1 element should only be called once")
+			}
+			wasCalled = true
+			assert.Equal(t, "key1", k)
+			assert.Equal(t, New("v1"), v)
+			return true
+		})
+	})
+
+	t.Run("multiple elements", func(t *testing.T) {
+		t.Parallel()
+		m := NewMap(map[string]Value{
+			"key3": New("v3"),
+			"key1": New("v1"),
+			"key2": New("v2"),
+		})
+
+		expectedKeys := []string{"key1", "key2", "key3"}
+		var index int
+		m.AllStable(func(k string, v Value) bool {
+			if index >= len(expectedKeys) {
+				assert.Fail(t, "unexpected call")
+			}
+			assert.Equal(t, expectedKeys[index], k)
+			assert.Equal(t, New("v"+string(expectedKeys[index][3])), v) // Matches "v1", "v2", "v3"
+			index++
+			return true
+		})
+		assert.Equal(t, len(expectedKeys), index)
+	})
+
+	t.Run("early exit", func(t *testing.T) {
+		t.Parallel()
+		m := NewMap(map[string]Value{
+			"key1": New("v1"),
+			"key2": New("v2"),
+		})
+		var callCount int
+		m.AllStable(func(k string, v Value) bool {
+			callCount++
+			if k == "key1" {
+				assert.Equal(t, New("v1"), v)
+				return false
+			}
+			assert.Fail(t, "The iteration should have been terminated early")
+			return true
+		})
+		assert.Equal(t, 1, callCount)
+	})
+}
+
+func TestMapGetOk(t *testing.T) {
+	t.Parallel()
+
+	t.Run("existing key", func(t *testing.T) {
+		t.Parallel()
+		m := NewMap(map[string]Value{
+			"key1": New(1.0),
+			"key2": New(2.0),
+		})
+
+		value, ok := m.GetOk("key1")
+		assert.True(t, ok, "Expected key to be present")
+		assert.Equal(t, New(1.0), value)
+	})
+
+	t.Run("non-existent key", func(t *testing.T) {
+		t.Parallel()
+		m := NewMap(map[string]Value{
+			"key1": New(1.0),
+		})
+
+		value, ok := m.GetOk("key3")
+		assert.False(t, ok, "Expected key to be absent")
+		assert.Equal(t, New(Null), value) // Assuming 'New(nil)' represents a null or zero value
+	})
+
+	t.Run("empty map", func(t *testing.T) {
+		t.Parallel()
+		m := NewMap(nil)
+
+		value, ok := m.GetOk("key1")
+		assert.False(t, ok, "Expected key not to be found in an empty map")
+		assert.Equal(t, New(Null), value) // Assuming 'New(nil)' represents a null or zero value
+	})
+}

--- a/sdk/go/property/path.go
+++ b/sdk/go/property/path.go
@@ -39,7 +39,7 @@ func (p Path) Get(v Value) (Value, PathApplyFailure) {
 
 // Set a value.
 //
-// Set does not src in place, rather producing a copy.
+// Set does not change src in place, rather producing a copy.
 func (p Path) Set(src, to Value) (Value, PathApplyFailure) {
 	if len(p) == 0 {
 		return to, nil
@@ -53,10 +53,10 @@ func (p Path) Set(src, to Value) (Value, PathApplyFailure) {
 	case v.IsArray():
 		i, ok := last.(IndexSegment)
 		if !ok {
-			return Value{}, pathErrorf(v, "expected an index step, found %T", last)
+			return Value{}, pathErrorf(v, "expected an IndexSegment, found %T", last)
 		}
 		if i.int < 0 || i.int > len(v.AsArray()) {
-			return Value{}, PathApplyIndexOutOfBounds{found: v.AsArray(), idx: i.int}
+			return Value{}, pathApplyIndexOutOfBoundsError{found: v.AsArray(), idx: i.int}
 		}
 		// We now want to set set v.AsArray()[i]=to, but we don't want to mutate v. We make
 		// a shallow copy of v and then alter that.
@@ -67,7 +67,7 @@ func (p Path) Set(src, to Value) (Value, PathApplyFailure) {
 	case v.IsMap():
 		k, ok := last.(KeySegment)
 		if !ok {
-			return Value{}, pathErrorf(v, "expected a key step, found %T", last)
+			return Value{}, pathErrorf(v, "expected a KeySegment, found %T", last)
 		}
 		// We now want to set set v.AsMap()[k]=to, but we don't want to mutate v. We make
 		// a shallow copy of v and then alter that.
@@ -133,9 +133,9 @@ func (k KeySegment) apply(v Value) (Value, PathApplyFailure) {
 		if ok {
 			return r, nil
 		}
-		return Value{}, PathApplyKeyMissing{found: m, needle: k.string}
+		return Value{}, pathApplyKeyMissingError{found: m, needle: k.string}
 	}
-	return Value{}, PathApplyKeyExpectedMap{found: v}
+	return Value{}, pathApplyKeyExpectedMapError{found: v}
 }
 
 type IndexSegment struct{ int }
@@ -144,72 +144,72 @@ func (k IndexSegment) apply(v Value) (Value, PathApplyFailure) {
 	if v.IsArray() {
 		a := v.AsArray()
 		if k.int < 0 || k.int >= len(a) {
-			return Value{}, PathApplyIndexOutOfBounds{found: a, idx: k.int}
+			return Value{}, pathApplyIndexOutOfBoundsError{found: a, idx: k.int}
 		}
 		return a[k.int], nil
 	}
-	return Value{}, PathApplyIndexExpectedArray{found: v}
+	return Value{}, pathApplyIndexExpectedArrayError{found: v}
 }
 
-type PathApplyKeyExpectedMap struct {
+type pathApplyKeyExpectedMapError struct {
 	found Value
 }
 
-func (err PathApplyKeyExpectedMap) Error() string {
+func (err pathApplyKeyExpectedMapError) Error() string {
 	return "expected a map, found a " + typeString(err.found)
 }
 
-func (err PathApplyKeyExpectedMap) Found() Value {
+func (err pathApplyKeyExpectedMapError) Found() Value {
 	return err.found
 }
 
-type PathApplyKeyMissing struct {
+type pathApplyKeyMissingError struct {
 	found  Map
 	needle string
 }
 
-func (err PathApplyKeyMissing) Error() string {
+func (err pathApplyKeyMissingError) Error() string {
 	return fmt.Sprintf("missing key %q in map", err.needle)
 }
 
-func (err PathApplyKeyMissing) Found() Value {
+func (err pathApplyKeyMissingError) Found() Value {
 	return New(err.found)
 }
 
-type PathApplyIndexExpectedArray struct {
+type pathApplyIndexExpectedArrayError struct {
 	found Value
 }
 
-func (err PathApplyIndexExpectedArray) Error() string {
+func (err pathApplyIndexExpectedArrayError) Error() string {
 	return "expected an array, found a " + typeString(err.found)
 }
 
-func (err PathApplyIndexExpectedArray) Found() Value {
+func (err pathApplyIndexExpectedArrayError) Found() Value {
 	return err.found
 }
 
-type PathApplyIndexOutOfBounds struct {
+type pathApplyIndexOutOfBoundsError struct {
 	found Array
 	idx   int
 }
 
-func (err PathApplyIndexOutOfBounds) Found() Value {
+func (err pathApplyIndexOutOfBoundsError) Found() Value {
 	return New(err.found)
 }
 
-func (err PathApplyIndexOutOfBounds) Error() string {
+func (err pathApplyIndexOutOfBoundsError) Error() string {
 	return fmt.Sprintf("index %d out of bounds of an array of length %d",
 		err.idx, len(err.found))
 }
 
 func pathErrorf(v Value, msg string, a ...any) PathApplyFailure {
-	return pathApplyFailure{found: v, msg: fmt.Sprintf(msg, a...)}
+	return pathApplyError{found: v, msg: fmt.Sprintf(msg, a...)}
 }
 
-type pathApplyFailure struct {
+type pathApplyError struct {
 	found Value
 	msg   string
 }
 
-func (err pathApplyFailure) Error() string { return err.msg }
-func (err pathApplyFailure) Found() Value  { return err.found }
+func (err pathApplyError) Error() string { return err.msg }
+func (err pathApplyError) Found() Value  { return err.found }

--- a/sdk/go/property/path.go
+++ b/sdk/go/property/path.go
@@ -55,28 +55,20 @@ func (p Path) Set(src, to Value) (Value, PathApplyFailure) {
 		if !ok {
 			return Value{}, pathErrorf(v, "expected an IndexSegment, found %T", last)
 		}
-		if i.int < 0 || i.int > len(v.AsArray()) {
-			return Value{}, pathApplyIndexOutOfBoundsError{found: v.AsArray(), idx: i.int}
+		arr := v.AsArray()
+		if i.int < 0 || i.int > len(arr) {
+			return Value{}, pathApplyIndexOutOfBounds{found: arr, idx: i.int}
 		}
-		// We now want to set set v.AsArray()[i]=to, but we don't want to mutate v. We make
-		// a shallow copy of v and then alter that.
-		cp := make(Array, len(v.AsArray()))
-		copy(cp, v.AsArray())
-		cp[i.int] = to
-		return butLast.Set(src, New(cp)) // Finally, propagate the shallow change back up.
+		arr[i.int] = to
+		return butLast.Set(src, New(arr))
 	case v.IsMap():
 		k, ok := last.(KeySegment)
 		if !ok {
 			return Value{}, pathErrorf(v, "expected a KeySegment, found %T", last)
 		}
-		// We now want to set set v.AsMap()[k]=to, but we don't want to mutate v. We make
-		// a shallow copy of v and then alter that.
-		cp := make(Map, len(v.AsMap()))
-		for k, e := range v.AsMap() {
-			cp[k] = e
-		}
-		cp[k.string] = to                // Assign to the new map
-		return butLast.Set(src, New(cp)) // Finally, propagate the shallow change back up.
+		m := v.AsMap()
+		m[k.string] = to
+		return butLast.Set(src, New(m))
 	default:
 		return Value{}, pathErrorf(v, "expected a map or array, found %s", typeString(v))
 	}

--- a/sdk/go/property/path.go
+++ b/sdk/go/property/path.go
@@ -1,0 +1,140 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import "fmt"
+
+// Path provides access and alteration methods on [Value]s.
+//
+// Path does not support glob ("*") expansion. Values are treated as is.
+type Path []PathSegment
+
+func (p Path) Get(v Value) (Value, PathApplyFailure) {
+	for _, segment := range p {
+		var err PathApplyFailure
+		v, err = segment.apply(v)
+		if err != nil {
+			return Value{}, err
+		}
+	}
+	return v, nil
+}
+
+func (p Path) Set(src, dst Value) PathApplyFailure {
+	panic("Unimplemented")
+}
+
+func (p Path) Alter(v Value, f func(v Value) Value) {
+	panic("Unimplemented")
+}
+
+type PathSegment interface {
+	apply(Value) (Value, PathApplyFailure)
+}
+
+func NewSegment[T interface{ string | int }](v T) PathSegment {
+	switch v := any(v).(type) {
+	case string:
+		return KeySegment{v}
+	case int:
+		return IndexSegment{v}
+	default:
+		panic("impossible")
+	}
+}
+
+type PathApplyFailure interface {
+	error
+
+	Found() Value
+}
+
+type KeySegment struct{ string }
+
+func (k KeySegment) apply(v Value) (Value, PathApplyFailure) {
+	if v.IsMap() {
+		m := v.AsMap()
+		r, ok := m[k.string]
+		if ok {
+			return r, nil
+		}
+		return Value{}, PathApplyKeyMissing{found: m, needle: k.string}
+	}
+	return Value{}, PathApplyKeyExpectedMap{found: v}
+}
+
+type IndexSegment struct{ int }
+
+func (k IndexSegment) apply(v Value) (Value, PathApplyFailure) {
+	if v.IsArray() {
+		a := v.AsArray()
+		if k.int < 0 || k.int >= len(a) {
+			return Value{}, PathApplyIndexOutOfBounds{found: a, idx: k.int}
+		}
+		return a[k.int], nil
+	}
+	return Value{}, PathApplyIndexExpectedArray{found: v}
+}
+
+type PathApplyKeyExpectedMap struct {
+	found Value
+}
+
+func (err PathApplyKeyExpectedMap) Error() string {
+	return fmt.Sprintf("expected a map, found a %s", typeString(err.found))
+}
+
+func (err PathApplyKeyExpectedMap) Found() Value {
+	return err.found
+}
+
+type PathApplyKeyMissing struct {
+	found  Map
+	needle string
+}
+
+func (err PathApplyKeyMissing) Error() string {
+	return fmt.Sprintf("missing key %q in map", err.needle)
+}
+
+func (err PathApplyKeyMissing) Found() Value {
+	return New(err.found)
+}
+
+type PathApplyIndexExpectedArray struct {
+	found Value
+}
+
+func (err PathApplyIndexExpectedArray) Error() string {
+	return fmt.Sprintf("expected an array, found a %s", typeString(err.found))
+}
+
+func (err PathApplyIndexExpectedArray) Found() Value {
+	return err.found
+}
+
+type PathApplyIndexOutOfBounds struct {
+	found Array
+	idx   int
+}
+
+func (err PathApplyIndexOutOfBounds) Found() Value {
+	return New(err.found)
+}
+
+func (err PathApplyIndexOutOfBounds) Error() string {
+	return fmt.Sprintf("index %d out of bounds of an array of length %d",
+		err.idx, len(err.found))
+}

--- a/sdk/go/property/path_test.go
+++ b/sdk/go/property/path_test.go
@@ -44,7 +44,7 @@ func TestGet(t *testing.T) {
 			path: property.Path{
 				property.NewSegment("k"),
 			},
-			from: property.New(property.Map{
+			from: property.New(map[string]property.Value{
 				"k": property.New("v"),
 			}),
 			expected: property.New("v"),
@@ -54,11 +54,11 @@ func TestGet(t *testing.T) {
 			path: property.Path{
 				property.NewSegment("missing"),
 			},
-			from: property.New(property.Map{
+			from: property.New(map[string]property.Value{
 				"k": property.New("v"),
 			}),
 			failure: &pathFailure{
-				found: property.New(property.Map{
+				found: property.New(map[string]property.Value{
 					"k": property.New("v"),
 				}),
 				msg: `missing key "missing" in map`,
@@ -69,11 +69,11 @@ func TestGet(t *testing.T) {
 			path: property.Path{
 				property.NewSegment("missing"),
 			},
-			from: property.New(property.Array{
+			from: property.New([]property.Value{
 				property.New("v"),
 			}),
 			failure: &pathFailure{
-				found: property.New(property.Array{
+				found: property.New([]property.Value{
 					property.New("v"),
 				}),
 				msg: `expected a map, found a array`,
@@ -84,7 +84,7 @@ func TestGet(t *testing.T) {
 			path: property.Path{
 				property.NewSegment(1),
 			},
-			from: property.New(property.Array{
+			from: property.New([]property.Value{
 				property.New("0"),
 				property.New("1"),
 			}),
@@ -106,11 +106,11 @@ func TestGet(t *testing.T) {
 			path: property.Path{
 				property.NewSegment(1),
 			},
-			from: property.New(property.Array{
+			from: property.New([]property.Value{
 				property.New("0"),
 			}),
 			failure: &pathFailure{
-				found: property.New(property.Array{
+				found: property.New([]property.Value{
 					property.New("0"),
 				}),
 				msg: "index 1 out of bounds of an array of length 1",
@@ -121,11 +121,11 @@ func TestGet(t *testing.T) {
 			path: property.Path{
 				property.NewSegment(-1),
 			},
-			from: property.New(property.Array{
+			from: property.New([]property.Value{
 				property.New("0"),
 			}),
 			failure: &pathFailure{
-				found: property.New(property.Array{
+				found: property.New([]property.Value{
 					property.New("0"),
 				}),
 				msg: "index -1 out of bounds of an array of length 1",
@@ -134,14 +134,14 @@ func TestGet(t *testing.T) {
 		{
 			name:     "empty-path-map",
 			path:     property.Path{},
-			from:     property.New(property.Map{"k": property.New(true)}),
-			expected: property.New(property.Map{"k": property.New(true)}),
+			from:     property.New(map[string]property.Value{"k": property.New(true)}),
+			expected: property.New(map[string]property.Value{"k": property.New(true)}),
 		},
 		{
 			name:     "empty-path-array",
 			path:     property.Path{},
-			from:     property.New(property.Array{property.New(true)}),
-			expected: property.New(property.Array{property.New(true)}),
+			from:     property.New([]property.Value{property.New(true)}),
+			expected: property.New([]property.Value{property.New(true)}),
 		},
 		{
 			name:     "empty-path-primitive",
@@ -156,10 +156,10 @@ func TestGet(t *testing.T) {
 				property.NewSegment(0),
 				property.NewSegment("n1"),
 			},
-			from: property.New(property.Map{
+			from: property.New(map[string]property.Value{
 				"l0": property.New("l0-value"),
-				"l1": property.New(property.Array{
-					property.New(property.Map{
+				"l1": property.New([]property.Value{
+					property.New(map[string]property.Value{
 						"n1": property.New("found"),
 					}),
 				}),
@@ -199,11 +199,11 @@ func TestSet(t *testing.T) {
 		{
 			name: "inside map",
 			path: property.Path{property.NewSegment("k2")},
-			src: property.New(property.Map{
+			src: property.New(map[string]property.Value{
 				"k1": property.New("v1"),
 			}),
 			to: property.New("v2"),
-			expected: property.New(property.Map{
+			expected: property.New(map[string]property.Value{
 				"k1": property.New("v1"),
 				"k2": property.New("v2"),
 			}),
@@ -211,12 +211,12 @@ func TestSet(t *testing.T) {
 		{
 			name: "inside array",
 			path: property.Path{property.NewSegment(1)},
-			src: property.New(property.Array{
+			src: property.New([]property.Value{
 				property.New("o1"),
 				property.New("o2"),
 			}),
 			to: property.New("v2"),
-			expected: property.New(property.Array{
+			expected: property.New([]property.Value{
 				property.New("o1"),
 				property.New("v2"),
 			}),
@@ -235,19 +235,19 @@ func TestSet(t *testing.T) {
 				property.NewSegment(0),
 				property.NewSegment("n1"),
 			},
-			src: property.New(property.Map{
+			src: property.New(map[string]property.Value{
 				"l0": property.New("l0-value"),
-				"l1": property.New(property.Array{
-					property.New(property.Map{
+				"l1": property.New([]property.Value{
+					property.New(map[string]property.Value{
 						"n1": property.New("old-value"),
 					}),
 				}),
 			}),
 			to: property.New(property.Null),
-			expected: property.New(property.Map{
+			expected: property.New(map[string]property.Value{
 				"l0": property.New("l0-value"),
-				"l1": property.New(property.Array{
-					property.New(property.Map{
+				"l1": property.New([]property.Value{
+					property.New(map[string]property.Value{
 						"n1": property.New(property.Null),
 					}),
 				}),
@@ -260,11 +260,8 @@ func TestSet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cp := tt.src.Copy()
 			result, err := tt.path.Set(tt.src, tt.to)
 			require.NoError(t, err)
-
-			assert.Equal(t, cp, tt.src, ".Set should not mutate what it's called on")
 
 			assert.Equal(t, tt.expected, result)
 		})
@@ -292,11 +289,11 @@ func TestAlter(t *testing.T) {
 				}
 				return property.WithGoValue(v, "yes")
 			},
-			v: property.New(property.Map{
+			v: property.New(map[string]property.Value{
 				"k": property.New(true),
 			}),
 			path: property.Path{property.NewSegment("k")},
-			expected: property.New(property.Map{
+			expected: property.New(map[string]property.Value{
 				"k": property.New("yes"),
 			}),
 		},
@@ -305,7 +302,7 @@ func TestAlter(t *testing.T) {
 			f: func(v property.Value) property.Value {
 				panic("v")
 			},
-			v: property.New(property.Map{
+			v: property.New(map[string]property.Value{
 				"k": property.New(true),
 			}),
 			path:      property.Path{property.NewSegment("invalid")},

--- a/sdk/go/property/path_test.go
+++ b/sdk/go/property/path_test.go
@@ -1,0 +1,183 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGet(t *testing.T) {
+	t.Parallel()
+
+	type pathFailure struct {
+		found property.Value
+		msg   string
+	}
+
+	tests := []struct {
+		name string
+		path property.Path
+
+		from     property.Value
+		expected property.Value
+
+		failure *pathFailure
+	}{
+		{
+			name: "map-key",
+			path: property.Path{
+				property.NewSegment("k"),
+			},
+			from: property.New(property.Map{
+				"k": property.New("v"),
+			}),
+			expected: property.New("v"),
+		},
+		{
+			name: "missing-key",
+			path: property.Path{
+				property.NewSegment("missing"),
+			},
+			from: property.New(property.Map{
+				"k": property.New("v"),
+			}),
+			failure: &pathFailure{
+				found: property.New(property.Map{
+					"k": property.New("v"),
+				}),
+				msg: `missing key "missing" in map`,
+			},
+		},
+		{
+			name: "expected-map",
+			path: property.Path{
+				property.NewSegment("missing"),
+			},
+			from: property.New(property.Array{
+				property.New("v"),
+			}),
+			failure: &pathFailure{
+				found: property.New(property.Array{
+					property.New("v"),
+				}),
+				msg: `expected a map, found a array`,
+			},
+		},
+		{
+			name: "array-idx",
+			path: property.Path{
+				property.NewSegment(1),
+			},
+			from: property.New(property.Array{
+				property.New("0"),
+				property.New("1"),
+			}),
+			expected: property.New("1"),
+		},
+		{
+			name: "expected-array",
+			path: property.Path{
+				property.NewSegment(0),
+			},
+			from: property.New("foo"),
+			failure: &pathFailure{
+				found: property.New("foo"),
+				msg:   `expected an array, found a string`,
+			},
+		},
+		{
+			name: "array-out-of-bounds",
+			path: property.Path{
+				property.NewSegment(1),
+			},
+			from: property.New(property.Array{
+				property.New("0"),
+			}),
+			failure: &pathFailure{
+				found: property.New(property.Array{
+					property.New("0"),
+				}),
+				msg: "index 1 out of bounds of an array of length 1",
+			},
+		},
+		{
+			name: "negative-array-index",
+			path: property.Path{
+				property.NewSegment(-1),
+			},
+			from: property.New(property.Array{
+				property.New("0"),
+			}),
+			failure: &pathFailure{
+				found: property.New(property.Array{
+					property.New("0"),
+				}),
+				msg: "index -1 out of bounds of an array of length 1",
+			},
+		},
+		{
+			name:     "empty-path-map",
+			path:     property.Path{},
+			from:     property.New(property.Map{"k": property.New(true)}),
+			expected: property.New(property.Map{"k": property.New(true)}),
+		},
+		{
+			name:     "empty-path-array",
+			path:     property.Path{},
+			from:     property.New(property.Array{property.New(true)}),
+			expected: property.New(property.Array{property.New(true)}),
+		},
+		{
+			name:     "empty-path-primitive",
+			path:     property.Path{},
+			from:     property.New(true),
+			expected: property.New(true),
+		},
+		{
+			name: "nested-access",
+			path: property.Path{
+				property.NewSegment("l1"),
+				property.NewSegment(0),
+				property.NewSegment("n1"),
+			},
+			from: property.New(property.Map{
+				"l0": property.New("l0-value"),
+				"l1": property.New(property.Array{
+					property.New(property.Map{
+						"n1": property.New("found"),
+					}),
+				}),
+			}),
+			expected: property.New("found"),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.path.Get(tt.from)
+			if tt.failure == nil {
+				assert.Equal(t, tt.expected, got)
+				assert.Nil(t, err)
+			} else {
+				assert.Equal(t, tt.failure.found, err.Found())
+				assert.Equal(t, tt.failure.msg, err.Error())
+			}
+		})
+	}
+}

--- a/sdk/go/property/path_test.go
+++ b/sdk/go/property/path_test.go
@@ -178,7 +178,7 @@ func TestGet(t *testing.T) {
 				assert.Equal(t, tt.expected, got)
 				assert.Nil(t, err)
 			} else {
-				assert.Equal(t, tt.failure.found, err.Found())
+				assert.Equal(t, tt.failure.found, err.(property.PathApplyFailure).Found())
 				assert.Equal(t, tt.failure.msg, err.Error())
 			}
 		})

--- a/sdk/go/property/type.go
+++ b/sdk/go/property/type.go
@@ -1,0 +1,48 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import "fmt"
+
+// typeString provides a type name for v.
+//
+// typeString should be used only to generate error messages. Do not rely on typeString
+// providing stable output.
+func typeString(v Value) string {
+	switch {
+	case v.IsArchive():
+		return "archive"
+	case v.IsArray():
+		return "array"
+	case v.IsAsset():
+		return "asset"
+	case v.IsBool():
+		return "bool"
+	case v.IsComputed():
+		return "computed"
+	case v.IsMap():
+		return "map"
+	case v.IsNull():
+		return "null"
+	case v.IsNumber():
+		return "number"
+	case v.IsResourceReference():
+		return "resource reference"
+	case v.IsString():
+		return "string"
+	default:
+		panic(fmt.Sprintf("unknown type %T", v.v))
+	}
+}

--- a/sdk/go/property/values.go
+++ b/sdk/go/property/values.go
@@ -207,12 +207,17 @@ func copyAsset(a Asset) Asset {
 func copyArchive(a Archive) Archive {
 	assets := make(map[string]any, len(a.Assets))
 	for k, v := range a.Assets {
-		// TODO: These values are not actually of any type, and need to be copied
-		// correctly.
-		//
-		// values are of the any type, and thus cannot be reliably deep
-		// copied.
-		assets[k] = v
+		switch v := v.(type) {
+		case Asset:
+			assets[k] = copyAsset(v)
+		case Archive:
+			assets[k] = copyArchive(v)
+		case nil:
+			assets[k] = v
+		default:
+			msg := "Unknown type within property.Archive, expected either property.Asset or property.Archive, found %T"
+			panic(fmt.Sprintf(msg, v))
+		}
 	}
 	return &archive.Archive{
 		Sig:    a.Sig,

--- a/sdk/go/property/values.go
+++ b/sdk/go/property/values.go
@@ -273,13 +273,14 @@ func (v Value) Copy() Value {
 		dependencies: dependencies,
 		v:            value,
 	}
-
 }
 
 // WithGoValue creates a new Value with the inner value newGoValue.
 //
 // To set to a null or computed value, pass Null or Computed as newGoValue.
 func WithGoValue[T GoValue](value Value, newGoValue T) Value {
-	value.v = New(newGoValue).v
+	value.v = nil                   // Set v to nil so we don't deep copy it.
+	value = value.Copy()            // Copy metadata
+	value.v = normalize(newGoValue) // Set the new value in normalized form
 	return value
 }

--- a/sdk/go/property/values_test.go
+++ b/sdk/go/property/values_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 )
 
 // Calling == does not implement desirable behavior, so we ensure that it is invalid.
@@ -99,4 +100,97 @@ func TestNil(t *testing.T) {
 		assert.False(t, emptyString.IsNull())
 		assert.False(t, emptyString.Equals(nullValue))
 	})
+}
+
+func TestCopy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		value    func() Value
+		mutation func(Value)
+	}{
+		{
+			name: "map-value",
+			value: func() Value {
+				return New(Map{
+					"k": New("value"),
+				})
+			},
+			mutation: func(v Value) {
+				v.AsMap()["k"] = New("changed")
+			},
+		},
+		{
+			name: "map-deleted-key",
+			value: func() Value {
+				return New(Map{
+					"k": New("value"),
+				})
+			},
+			mutation: func(v Value) {
+				delete(v.AsMap(), "k")
+			},
+		},
+		{
+			name: "map-added-key",
+			value: func() Value {
+				return New(Map{
+					"k": New("value"),
+				})
+			},
+			mutation: func(v Value) {
+				v.AsMap()["k2"] = New("added")
+			},
+		},
+		{
+			name: "array-value",
+			value: func() Value {
+				return New(Array{
+					New(true),
+				})
+			},
+			mutation: func(v Value) {
+				v.AsArray()[0] = New(0.0)
+			},
+		},
+		{
+			name: "dependencies",
+			value: func() Value {
+				return New("hi").WithDependencies([]urn.URN{"urn1"})
+			},
+			mutation: func(v Value) {
+				v.Dependencies()[0] = "urn2"
+			},
+		},
+		{
+			name: "nested-value",
+			value: func() Value {
+				return New(Map{
+					"k": New(Array{
+						New(Map{
+							"v": New("nested"),
+						}),
+					}),
+				})
+			},
+			mutation: func(v Value) {
+				v.AsMap()["k"].AsArray()[0].AsMap()["new"] = New(true)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			v := tt.value()
+			cp := v.Copy()
+			tt.mutation(cp)
+
+			assert.Equal(t, v, tt.value())
+			assert.NotEqual(t, v, cp)
+		})
+	}
 }

--- a/sdk/go/property/values_test.go
+++ b/sdk/go/property/values_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2024, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,12 +15,14 @@
 package property
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 )
 
@@ -104,10 +106,293 @@ func TestNil(t *testing.T) {
 	// string based type, zero value is ""
 	t.Run("string", func(t *testing.T) {
 		t.Parallel()
-		emptyString := New[string]("")
+		emptyString := New("")
 
 		assert.True(t, emptyString.IsString())
 		assert.False(t, emptyString.IsNull())
 		assert.False(t, emptyString.Equals(nullValue))
 	})
+}
+
+func TestAny(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		input       any
+		expected    Value
+		expectedErr string
+	}{
+		{
+			input:    true,
+			expected: New(true),
+		},
+		{
+			input:    3.14,
+			expected: New(3.14),
+		},
+		{
+			input:    "example",
+			expected: New("example"),
+		},
+		{
+			input:    []Value{New(1.0), New("two")},
+			expected: New([]Value{New(1.0), New("two")}),
+		},
+		{
+			input:    NewArray([]Value{New(1.0), New("two")}),
+			expected: New([]Value{New(1.0), New("two")}),
+		},
+		{
+			input:    map[string]Value{"key": New("value")},
+			expected: New(map[string]Value{"key": New("value")}),
+		},
+		{
+			input:    NewMap(map[string]Value{"key": New("value")}),
+			expected: New(map[string]Value{"key": New("value")}),
+		},
+		{
+			input:    &asset.Asset{Text: "example"},
+			expected: New(&asset.Asset{Text: "example"}),
+		},
+		{
+			input:    &archive.Archive{},
+			expected: New(&archive.Archive{}),
+		},
+		{
+			input:    Computed,
+			expected: New(Computed),
+		},
+		{
+			input:    Null,
+			expected: Value{}, // or New(Null)
+		},
+		{
+			input:    ResourceReference{ID: New("123")},
+			expected: New(ResourceReference{ID: New("123")}),
+		},
+		{
+			input:       struct{ A string }{"A"},
+			expectedErr: "invalid type: {A} of type struct { A string }",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(fmt.Sprintf("%T", tt.input), func(t *testing.T) {
+			t.Parallel()
+			result, err := Any(tt.input)
+			if tt.expectedErr != "" {
+				assert.ErrorContains(t, err, tt.expectedErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestAsset(t *testing.T) {
+	t.Parallel()
+
+	originalText := "original text"
+	a, err := asset.FromText(originalText)
+	assert.NoError(t, err)
+
+	v := New(a)
+
+	assert.True(t, v.IsAsset())
+	assert.Equal(t, a, v.AsAsset())
+
+	a.Text = "other text"
+
+	assert.NotEqual(t, a, v.AsAsset())
+	assert.Equal(t, originalText, v.AsAsset().Text)
+
+	v.AsAsset().Text = "other test"
+	assert.Equal(t, originalText, v.AsAsset().Text)
+}
+
+func TestArchive(t *testing.T) {
+	t.Parallel()
+
+	mkArchive := func(t *testing.T) Archive {
+		archive, err := archive.FromAssets(map[string]any{
+			"f1": must(asset.FromText("some text")),
+			"f2": must(asset.FromText("more text")),
+			"d1": must(archive.FromAssets(map[string]any{
+				"f3": must(asset.FromText("nested text")),
+			})),
+		})
+		assert.NoError(t, err)
+		return archive
+	}
+
+	// Create an initial archive from path
+	archive := mkArchive(t)
+	v := New(archive)
+
+	assert.True(t, v.IsArchive())
+	assert.Equal(t, archive, v.AsArchive())
+
+	// Attempt to mutate the original archive
+	archive.Assets["f1"] = must(asset.FromText("different text"))
+	archive.Assets["d1"].(Archive).Assets["f3"] = must(asset.FromText("different text"))
+	assert.Equal(t, mkArchive(t), v.AsArchive())
+
+	// Attempt to mutate the returned archive
+	archive = v.AsArchive()
+	archive.Assets["f1"] = must(asset.FromText("different text"))
+	archive.Assets["d1"].(Archive).Assets["f3"] = must(asset.FromText("different text"))
+	assert.Equal(t, mkArchive(t), v.AsArchive())
+}
+
+func must[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func TestWithGoValue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("set-computed", func(t *testing.T) {
+		t.Parallel()
+		initialValue := New("initial")
+		newValue := WithGoValue(initialValue, Computed)
+		expectedValue := New(Computed)
+		assert.Equal(t, expectedValue, newValue)
+	})
+
+	t.Run("flag-secret", func(t *testing.T) {
+		t.Parallel()
+		initialValue := New("initial").WithSecret(true)
+		newGoValue := "newSecretValue"
+		newValue := WithGoValue(initialValue, newGoValue)
+		expectedValue := New(newGoValue).WithSecret(true)
+		assert.Equal(t, expectedValue, newValue)
+	})
+
+	t.Run("set-null", func(t *testing.T) {
+		t.Parallel()
+		initialValue := New("initial")
+		newValue := WithGoValue(initialValue, Null)
+		expectedValue := New(Null)
+		assert.Equal(t, expectedValue, newValue)
+	})
+
+	t.Run("set", func(t *testing.T) {
+		t.Parallel()
+		initialValue := New("initial")
+		newGoValue := "newValue"
+		newValue := WithGoValue(initialValue, newGoValue)
+		expectedValue := New(newGoValue)
+		assert.Equal(t, expectedValue, newValue)
+	})
+}
+
+func TestResourceReference(t *testing.T) {
+	t.Parallel()
+
+	mkRef := func() ResourceReference {
+		return ResourceReference{
+			URN: "some-urn",
+			ID:  New(Computed),
+		}
+	}
+
+	v := New(mkRef())
+
+	assert.True(t, v.IsResourceReference())
+	assert.Equal(t, mkRef(), v.AsResourceReference())
+}
+
+func TestHasSecrets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		v         Value
+		hasSecret bool
+	}{
+		{
+			name:      "plain value is not secret",
+			v:         New("noSecret"),
+			hasSecret: false,
+		},
+		{
+			name:      "plain value is secret",
+			v:         New("secret").WithSecret(true),
+			hasSecret: true,
+		},
+		{
+			name:      "array contains secret",
+			v:         New([]Value{New("secret").WithSecret(true)}),
+			hasSecret: true,
+		},
+		{
+			name:      "array is secret",
+			v:         New([]Value{New("secret")}).WithSecret(true),
+			hasSecret: true,
+		},
+		{
+			name:      "map contains a secret",
+			v:         New(map[string]Value{"key": New("secret").WithSecret(true)}),
+			hasSecret: true,
+		},
+		{
+			name:      "map is a secret",
+			v:         New(map[string]Value{"key": New("secret")}).WithSecret(true),
+			hasSecret: true,
+		},
+		{
+			name:      "ComputedNoSecret",
+			v:         New(Computed),
+			hasSecret: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.hasSecret, tt.v.HasSecrets())
+		})
+	}
+}
+
+func TestHasComputed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		v           Value
+		hasComputed bool
+	}{
+		{
+			name:        "plain value is not computed",
+			v:           New("noComputed"),
+			hasComputed: false,
+		},
+		{
+			name:        "is computed",
+			v:           New(Computed),
+			hasComputed: true,
+		},
+		{
+			name:        "array contains computed",
+			v:           New([]Value{New(Computed)}),
+			hasComputed: true,
+		},
+		{
+			name:        "map contains a computed",
+			v:           New(map[string]Value{"key": New(Computed)}),
+			hasComputed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.hasComputed, tt.v.HasComputed())
+		})
+	}
 }

--- a/sdk/go/property/visit.go
+++ b/sdk/go/property/visit.go
@@ -1,0 +1,40 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+// Visit each Value in the within v.
+//
+// Parents are visited before their children.
+func (v Value) visit(f func(Value) (continueWalking bool)) bool {
+	cont := f(v)
+	if !cont {
+		return false
+	}
+	switch {
+	case v.IsArray():
+		for _, v := range v.AsArray().arr {
+			if !v.visit(f) {
+				return false
+			}
+		}
+	case v.IsMap():
+		for _, v := range v.AsMap().m {
+			if !v.visit(f) {
+				return false
+			}
+		}
+	}
+	return true
+}


### PR DESCRIPTION
tldr: making all `property.Value`s immutable will make the API less idiomatic, but it will make API design and usage of `property.Value` clearer and less bug prone. We can do it without sacrificing too much performance.

This change is stacked on top of https://github.com/pulumi/pulumi/pull/17374.

There are two major concerns to address with this PR:

- The API is unidiomatic. ☝️ explains why I think the change is worth it from that perspective.
- The change is not performant.

## API Usage

Regardless of this PR, all APIs that manipulate `property.Value` *must* be of the shape:

```go
func alterValue(startingValue property.Value) (mutatedValue property.Value, _ error)
```

This is because you cannot reliably mutate `startingValue`. You can only mutate `startingValue` if it is a map or an array.[^1] APIs of this shape essentially must discard `startingValue` after `alterValue` is called, since they cannot be sure what value it holds, or what relation it has with `mutatedValue`.

Other languages can express this as an inout (C++) value, or as passing an owned value in and requiring an owned value out (Rust). In Go, we could express this with an in-out `*property.Value`, but that is highly unidiomatic:

```go
func alterValue(value *property.Value) error
```

By making `property.Value` immutable, we side-step this entire conversation. The idiomatic Go function is correct:

```go
func alterValue(property.Value) (property.Value, _ error)
```

The calling API is now free to reuse the value it passed in. The immutable nature of the API makes APIs like `func(property.Value)` clearly wrong, as opposed to flakey.

## Performance

As long as we keep all values immutable, we only need shallow copies on `.AsMap/.AsArray`, and *never* need to make deep copies. `property.Value.Equals` can depend on internals to make target deep mutations as efficient as possible. A full manual traversal of a nested datastructure has the same cost as copying.

I believe that we can afford the additional cost of copying to prevent bugs. TF's underlying data value is immutable (implemented the same way) and TF does not suffer on performance. IMO, the immutability of `cty.Value` makes it much easier to work with.

[^1]: If you're sure that the func will only accept an array or a map, it should encode that in the type system.