### PR TITLE
always run multiple stacks concurrently test locally

### DIFF
--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -1436,19 +1436,17 @@ describe("LocalWorkspace", () => {
         const dones = [];
         const stacks = ["dev", "dev2", "dev3", "dev4", "dev5"];
         const workDir = upath.joinSafe(__dirname, "data", "tcfg");
-        const ws = await LocalWorkspace.create(
-            withTestBackend({
-                workDir,
-                projectSettings: {
-                    name: "concurrent-config",
-                    runtime: "nodejs",
-                    backend: { url: "file://~" },
-                },
-                envVars: {
-                    PULUMI_CONFIG_PASSPHRASE: "test",
-                },
-            }),
-        );
+        const ws = await LocalWorkspace.create({
+            workDir,
+            projectSettings: {
+                name: "concurrent-config",
+                runtime: "nodejs",
+                backend: { url: "file://~" },
+            },
+            envVars: {
+                PULUMI_CONFIG_PASSPHRASE: "test",
+            },
+        });
         for (let i = 0; i < stacks.length; i++) {
             await Stack.create(stacks[i], ws);
         }


### PR DESCRIPTION
This test was always meant to be run locally.  When I introduced the withTestBackend function I missed that, and made it run with the cloud backend accidentally, which results in stackname conflicts.  Revert that part and make it always run locally again.