### PR TITLE
Keep the token source loop going in the face of errors 

### DIFF
--- a/changelog/pending/20240922--engine--fix-token-expired-errors-due-to-network-issues.yaml
+++ b/changelog/pending/20240922--engine--fix-token-expired-errors-due-to-network-issues.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix token expired errors due to network issues

--- a/pkg/backend/httpstate/token_source.go
+++ b/pkg/backend/httpstate/token_source.go
@@ -111,7 +111,7 @@ func (ts *tokenSource) handleRequests(
 			return
 		}
 
-		logging.V(9).Infof("trying to renew token.  Current token expiring at: %v ", state.expires)
+		logging.V(9).Infof("trying to renew token. Current token expiring at: %v ", state.expires)
 
 		newToken, newTokenExpires, err := refreshToken(ctx, duration, state.token)
 		// Renewing might fail because of network issues, or because the token is no longer valid.

--- a/pkg/backend/httpstate/token_source.go
+++ b/pkg/backend/httpstate/token_source.go
@@ -115,7 +115,7 @@ func (ts *tokenSource) handleRequests(
 
 		newToken, newTokenExpires, err := refreshToken(ctx, duration, state.token)
 		// Renewing might fail because of network issues, or because the token is no longer valid.
-		// We only care about the latter, if its just a network issue we should retry again.
+		// We only care about the latter, if it's just a network issue we should retry again.
 		var expired expiredTokenError
 		if errors.As(err, &expired) {
 			logging.V(3).Infof("error renewing lease: %v", err)

--- a/pkg/backend/httpstate/token_source.go
+++ b/pkg/backend/httpstate/token_source.go
@@ -123,6 +123,7 @@ func (ts *tokenSource) handleRequests(
 			// If we failed to renew the lease, we will retry in the next cycle.
 			logging.V(3).Infof("error renewing lease: %v", err)
 		} else {
+			logging.V(5).Infof("renewed lease.  Next expiry: %v", newTokenExpires)
 			state.token = newToken
 			state.expires = newTokenExpires
 		}

--- a/pkg/backend/httpstate/token_source.go
+++ b/pkg/backend/httpstate/token_source.go
@@ -16,6 +16,7 @@ package httpstate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -37,6 +38,18 @@ type tokenSource struct {
 var _ tokenSourceCapability = &tokenSource{}
 
 type tokenRequest chan<- tokenResponse
+
+type expiredTokenError struct {
+	err error
+}
+
+func (e expiredTokenError) Error() string {
+	return fmt.Sprintf("token expired: %v", e.err)
+}
+
+func (e expiredTokenError) Unwrap() error {
+	return e.err
+}
 
 type tokenResponse struct {
 	token string
@@ -99,11 +112,16 @@ func (ts *tokenSource) handleRequests(
 		}
 
 		newToken, newTokenExpires, err := refreshToken(ctx, duration, state.token)
-		// If renew failed, all further GetToken requests will return this error.
-		if err != nil {
+		// Renewing might fail because of network issues, or because the token is no longer valid.
+		// We only care about the latter, if its just a network issue we should retry again.
+		var expired expiredTokenError
+		if errors.As(err, &expired) {
 			logging.V(3).Infof("error renewing lease: %v", err)
 			state.error = fmt.Errorf("renewing lease: %w", err)
 			renewTicker.Stop()
+		} else if err != nil {
+			// If we failed to renew the lease, we will retry in the next cycle.
+			logging.V(3).Infof("error renewing lease: %v", err)
 		} else {
 			state.token = newToken
 			state.expires = newTokenExpires

--- a/pkg/backend/httpstate/token_source.go
+++ b/pkg/backend/httpstate/token_source.go
@@ -111,6 +111,8 @@ func (ts *tokenSource) handleRequests(
 			return
 		}
 
+		logging.V(9).Infof("trying to renew token.  Current token expiring at: %v ", state.expires)
+
 		newToken, newTokenExpires, err := refreshToken(ctx, duration, state.token)
 		// Renewing might fail because of network issues, or because the token is no longer valid.
 		// We only care about the latter, if its just a network issue we should retry again.

--- a/pkg/backend/httpstate/token_source.go
+++ b/pkg/backend/httpstate/token_source.go
@@ -125,7 +125,7 @@ func (ts *tokenSource) handleRequests(
 			// If we failed to renew the lease, we will retry in the next cycle.
 			logging.V(3).Infof("error renewing lease: %v", err)
 		} else {
-			logging.V(5).Infof("renewed lease.  Next expiry: %v", newTokenExpires)
+			logging.V(5).Infof("renewed lease. Next expiry: %v", newTokenExpires)
 			state.token = newToken
 			state.expires = newTokenExpires
 		}

--- a/pkg/backend/httpstate/token_source_test.go
+++ b/pkg/backend/httpstate/token_source_test.go
@@ -145,7 +145,7 @@ func (ts *testTokenBackend) verifyTokenInner(token string) error {
 	now := ts.clock.Now()
 	expires, gotCurrentToken := ts.tokens[token]
 	if !gotCurrentToken {
-		return expiredTokenError{fmt.Errorf("Unknown token: %v", token)}
+		return expiredTokenError{fmt.Errorf("unknown token: %v", token)}
 	}
 
 	if now.After(expires) {

--- a/pkg/backend/httpstate/token_source_test.go
+++ b/pkg/backend/httpstate/token_source_test.go
@@ -149,7 +149,7 @@ func (ts *testTokenBackend) verifyTokenInner(token string) error {
 	}
 
 	if now.After(expires) {
-		return expiredTokenError{fmt.Errorf("Expired token %v (%v past expiration)",
+		return expiredTokenError{fmt.Errorf("expired token %v (%v past expiration)",
 			token, now.Sub(expires))}
 	}
 	return nil


### PR DESCRIPTION
Currently the token source loop will stop if `refreshToken` ever returns
an error, regardless of what that error is. While the API call to the
service does have some retry logic at it's level it can still
potentially return an error just due to transient network/server
conditions. In that case the refreh loop will just stop working and the
token will eventually expire.

This changes the token source to keep going until it gets a specific
`expiredTokenError` error. This should make it more resilient to network
issues.

Towards fixing https://github.com/pulumi/pulumi/issues/7094.

(This is basically a revert of the revert of https://github.com/pulumi/pulumi/pull/17127, and adds a little bit more logging. We reverted that PR originally because something was causing excessive requests to the service.  However I believe what actually caused the excessive requests was https://github.com/pulumi/pulumi/pull/17338.  Everything in this PR only runs once every (duration / 8), which is roughly every 40 sec, which won't overwhelm the service).  This also adds a little bit of additional logging to shed light on this.