### PR TITLE
Fix language conformance tests for TMPDIR with //

### DIFF
--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -198,7 +199,8 @@ func TestLanguage(t *testing.T) {
 			require.NoError(t, err)
 
 			// Create a temp project dir for the test to run in
-			rootDir := t.TempDir()
+			rootDir, err := filepath.Abs(t.TempDir())
+			require.NoError(t, err)
 
 			snapshotDir := "./testdata/"
 			if forceTsc {


### PR DESCRIPTION
For some obscure reason in my environment on a Mac "$TMPDIR" contains two slashes. I suspect this has to do with starting Emacs from Shortcuts.

    echo "$TMPDIR"
    /var/folders/gd/3ncjb1lj5ljgk8xl5ssn_gvc0000gn/T/com.apple.shortcuts.mac-helper//

This breaks conformance tests for me though. The workaround added to the tests is taking filepath.Abs that normalizes the TMPDIR.