### PR TITLE
Clean up stack init command's long doc

### DIFF
--- a/changelog/pending/20241022--docs--fix-spacing-and-formatting-of-stack-init-commands-long-doc.yaml
+++ b/changelog/pending/20241022--docs--fix-spacing-and-formatting-of-stack-init-commands-long-doc.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: docs
+  description: Fix spacing and formatting of `stack init` command's long doc

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -63,10 +63,11 @@ func newStackInitCmd() *cobra.Command {
 			"* `pulumi stack init --secrets-provider=\"awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-east-1\"`\n" +
 			"* `pulumi stack init --secrets-provider=\"azurekeyvault://mykeyvaultname.vault.azure.net/keys/mykeyname\"`\n" +
 			"* `pulumi stack init --secrets-provider=\"gcpkms://projects/<p>/locations/<l>/keyRings/<r>/cryptoKeys/<k>\"`\n" +
-			"* `pulumi stack init --secrets-provider=\"hashivault://mykey\"\n`" +
+			"* `pulumi stack init --secrets-provider=\"hashivault://mykey\"`\n" +
 			"\n" +
 			"A stack can be created based on the configuration of an existing stack by passing the\n" +
-			"`--copy-config-from` flag.\n" +
+			"`--copy-config-from` flag:\n" +
+			"\n" +
 			"* `pulumi stack init --copy-config-from dev`",
 		Run: runCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()


### PR DESCRIPTION
This PR makes the spacing/formatting of the last two examples match the rest of the `stack init` command's long doc.

This'll fix the [markdown generated][1], which is currently rendered [like so][2]:

![image](https://github.com/user-attachments/assets/b156ad8a-92da-49f7-af90-6677ac6475cd)

[1]: https://github.com/pulumi/docs/blob/master/content/docs/iac/cli/commands/pulumi_stack_init.md
[2]: https://www.pulumi.com/docs/iac/cli/commands/pulumi_stack_init/