### PR TITLE
Adjust the link path used in generated CLI docs

### DIFF
--- a/pkg/cmd/pulumi/gen_markdown.go
+++ b/pkg/cmd/pulumi/gen_markdown.go
@@ -68,7 +68,7 @@ func newGenMarkdownCmd(root *cobra.Command) *cobra.Command {
 			// linkHandler emits pretty URL links.
 			linkHandler := func(s string) string {
 				link := strings.TrimSuffix(s, ".md")
-				return fmt.Sprintf("/docs/cli/commands/%s/", link)
+				return fmt.Sprintf("/docs/iac/cli/commands/%s/", link)
 			}
 
 			// Generate the .md files.


### PR DESCRIPTION
We recently moved these docs from `/docs/cli/commands` to `/docs/iac/cli/commands`. This PR adjusts the path used to generate links between CLI docs to match the new location.