### PR TITLE
[pcl] Detect and error on binding component nodes that self-reference their source

### DIFF
--- a/changelog/pending/20241010--programgen--detect-and-error-on-binding-component-nodes-in-pcl-programs-that-self-reference-their-source.yaml
+++ b/changelog/pending/20241010--programgen--detect-and-error-on-binding-component-nodes-in-pcl-programs-that-self-reference-their-source.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Detect and error on binding component nodes in PCL programs that self-reference their source

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -602,3 +602,17 @@ resource randomPet "random:index/randomPet:RandomPet" {
 	assert.False(t, diags.HasErrors(), "There are no error diagnostics")
 	assert.NotNil(t, program)
 }
+
+func TestBindingComponentFailsWhenReferencingParentParentAsSource(t *testing.T) {
+	t.Parallel()
+	source := `component example "." {}`
+	program, diags, err := ParseAndBindProgram(t, source, "program.pp",
+		pcl.DirPath("."),
+		pcl.AllowMissingVariables,
+		pcl.ComponentBinder(pcl.ComponentProgramBinderFromFileSystem()))
+
+	require.Nil(t, program)
+	require.NotNil(t, err)
+	require.True(t, diags.HasErrors(), "There are error diagnostics")
+	require.Contains(t, diags.Error(), "cannot bind component example from the same directory as the parent program")
+}

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -603,7 +603,7 @@ resource randomPet "random:index/randomPet:RandomPet" {
 	assert.NotNil(t, program)
 }
 
-func TestBindingComponentFailsWhenReferencingParentParentAsSource(t *testing.T) {
+func TestBindingComponentFailsWhenReferencingParentAsSource(t *testing.T) {
 	t.Parallel()
 	source := `component example "." {}`
 	program, diags, err := ParseAndBindProgram(t, source, "program.pp",


### PR DESCRIPTION
### Description

Recently we have been encountering out of memory errors when trying to convert terraform modules. Found out that the problem is two-fold:
 - pulumi-terraform-converter rewriting `module example "../../"` (tf) into `component example "./."` (pcl) 
 - we try to bind component `example` but it reads its source from the same directory as the program of the component, causing an infinite recursion.

This PR fixes part 2 of the issue, erroring out if the component's source is the same as the current binder directory path. 

Partially addresses https://github.com/pulumi/pulumi-converter-terraform/issues/194 we still need to fix part 1 on the converter side of things