### PR TITLE
Improve invalid credentials error message

### DIFF
--- a/changelog/pending/20241011--sdk-go--improve-error-message-when-credentials-file-invalid.yaml
+++ b/changelog/pending/20241011--sdk-go--improve-error-message-when-credentials-file-invalid.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Improve error message when credentials file invalid

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -184,8 +184,8 @@ func GetStoredCredentials() (Credentials, error) {
 
 	var creds Credentials
 	if err = json.Unmarshal(c, &creds); err != nil {
-		return Credentials{}, fmt.Errorf("failed to read Pulumi credentials file. Please re-run "+
-			"`pulumi login` to reset your credentials file: %w", err)
+		return Credentials{}, fmt.Errorf("failed to read Pulumi credentials file. Please fix "+
+			"or delete invalid credentials file: '%s': %w", credsFile, err)
 	}
 
 	secrets := slice.Prealloc[string](len(creds.AccessTokens))


### PR DESCRIPTION
We're seeing this error from esc ([issue](https://github.com/pulumi/esc/issues/401)) which is confusing because it recommends `pulumi login` when using `esc login`. Additionally, rerunning `pulumi login` (or `esc login`) as the message suggests doesn't actually fix anything. I think a better error message is to suggest fixing or deleting the invalid credentials file - open to suggestions though

Testing:
```
❯ go run ./cmd/pulumi login
error: could not determine current cloud: failed to read Pulumi credentials file. Please fix or delete invalid credentials file: '/Users/sean/.pulumi/credentials.json': invalid character 'a' looking for beginning of value
exit status 255
```