### PR TITLE
Remove unused deployment option

### DIFF
--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -83,8 +83,6 @@ type Options struct {
 	GeneratePlan bool
 	// true if we should continue with the deployment even if a resource operation fails.
 	ContinueOnError bool
-	// true to debug the program.
-	EnableDebugging bool
 }
 
 // DegreeOfParallelism returns the degree of parallelism that should be used during the


### PR DESCRIPTION
I noticed it isn't used anywhere