### PR TITLE
Remove `pulumi package add` error for YAML

### DIFF
--- a/changelog/pending/20241015--yaml--allow-pulumi-package-add-for-yaml-projects.yaml
+++ b/changelog/pending/20241015--yaml--allow-pulumi-package-add-for-yaml-projects.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: yaml
+  description: Allow `pulumi package add` for YAML projects

--- a/pkg/cmd/pulumi/package_add.go
+++ b/pkg/cmd/pulumi/package_add.go
@@ -55,9 +55,6 @@ as in:
 			}
 
 			language := proj.Runtime.Name()
-			if language == "yaml" {
-				return errors.New("pulumi package add does not currently support YAML projects")
-			}
 
 			ctx := cmd.Context()
 


### PR DESCRIPTION
The yaml plugin has support for parameterization, so we no longer need to block it from `pulumi package add`.

I've tested this locally manually. We have a follow-up for this quarter to add conformance tests for parameterization (https://github.com/pulumi/pulumi/issues/17506).