### PR TITLE
Update function comments to remove outdated DIY backend note

### DIFF
--- a/changelog/pending/20241016--docs--update-function-comments-to-remove-outdated-diy-backend-note.yaml
+++ b/changelog/pending/20241016--docs--update-function-comments-to-remove-outdated-diy-backend-note.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: docs
+  description: Update function comments to remove outdated DIY backend note

--- a/sdk/go/auto/remote_stack.go
+++ b/sdk/go/auto/remote_stack.go
@@ -146,7 +146,6 @@ func (s *RemoteStack) History(ctx context.Context, pageSize, page int) ([]Update
 // Cancel stops a stack's currently running update. It returns an error if no update is currently running.
 // Note that this operation is _very dangerous_, and may leave the stack in an inconsistent state
 // if a resource operation was pending when the update was canceled.
-// This command is not supported for diy backends.
 func (s *RemoteStack) Cancel(ctx context.Context) error {
 	return s.stack.Cancel(ctx)
 }

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -1117,7 +1117,6 @@ func (s *Stack) Info(ctx context.Context) (StackSummary, error) {
 // Cancel stops a stack's currently running update. It returns an error if no update is currently running.
 // Note that this operation is _very dangerous_, and may leave the stack in an inconsistent state
 // if a resource operation was pending when the update was canceled.
-// This command is not supported for diy backends.
 func (s *Stack) Cancel(ctx context.Context) error {
 	stdout, stderr, errCode, err := s.runPulumiCmdSync(
 		ctx,

--- a/sdk/nodejs/automation/remoteStack.ts
+++ b/sdk/nodejs/automation/remoteStack.ts
@@ -112,8 +112,7 @@ export class RemoteStack {
      * Stops a stack's currently running update. It returns an error if no
      * update is currently running. Note that this operation is _very
      * dangerous_, and may leave the stack in an inconsistent state if a
-     * resource operation was pending when the update was canceled. This command
-     * is not supported for DIY backends.
+     * resource operation was pending when the update was canceled.
      */
     cancel(): Promise<void> {
         return this.stack.cancel();

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -862,8 +862,7 @@ Event: ${line}\n${e.toString()}`);
      * Stops a stack's currently running update. It returns an error if no
      * update is currently running. Note that this operation is _very
      * dangerous_, and may leave the stack in an inconsistent state if a
-     * resource operation was pending when the update was canceled. This command
-     * is not supported for DIY backends.
+     * resource operation was pending when the update was canceled.
      */
     async cancel(): Promise<void> {
         await this.runPulumiCmd(["cancel", "--yes"]);

--- a/sdk/python/lib/pulumi/automation/_remote_stack.py
+++ b/sdk/python/lib/pulumi/automation/_remote_stack.py
@@ -133,7 +133,6 @@ class RemoteStack:
         Cancel stops a stack's currently running update. It returns an error if no update is currently running.
         Note that this operation is _very dangerous_, and may leave the stack in an inconsistent state
         if a resource operation was pending when the update was canceled.
-        This command is not supported for diy backends.
         """
         self.__stack.cancel()
 

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -952,7 +952,6 @@ class Stack:
         Cancel stops a stack's currently running update. It returns an error if no update is currently running.
         Note that this operation is _very dangerous_, and may leave the stack in an inconsistent state
         if a resource operation was pending when the update was canceled.
-        This command is not supported for diy backends.
         """
         self._run_pulumi_cmd_sync(["cancel", "--yes"])
 


### PR DESCRIPTION
As per https://github.com/pulumi/pulumi/pull/9100, `pulumi cancel` is supported for filestate/DIY/self-managed backends. 