### PR TITLE
ci: Bump macos-12 runner to macos-13

### DIFF
--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -11,7 +11,7 @@ defaults:
 jobs:
   macos-homebrew-install:
     name: Install Pulumi with Homebrew on macOS
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       # Workaround for https://github.com/pulumi/pulumi/issues/13938
       - name: Delete default golang installed on the runner
@@ -36,7 +36,7 @@ jobs:
           exit 1
   macOS-direct-install:
     name: Install Pulumi via script on macOS
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - run: curl -fsSL https://get.pulumi.com | sh
       - run: echo "/Users/runner/.pulumi/bin" >> "${GITHUB_PATH}"
@@ -53,7 +53,7 @@ jobs:
           exit 1
   macos-verify-download-link:
     name: Verify Direct Download link on macOS
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Direct Download
         run: curl -L -o pulumi.tar.gz "https://get.pulumi.com/releases/sdk/pulumi-v$(curl -sS https://www.pulumi.com/latest-version)-darwin-x64.tar.gz"
@@ -153,7 +153,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-12"]
+        os: ["ubuntu-latest", "windows-latest", "macos-13"]
     steps:
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1


### PR DESCRIPTION
> The macOS 12 runner image will be removed by December 3rd, 2024. To raise awareness of the upcoming removal, jobs using macOS 12 will temporarily fail during scheduled time periods defined below:
> 
>  • November 4, 9:00 AM - 7:00 PM EST
>  • November 11, 9:00 AM - 7:00 PM EST
>  • November 18, 9:00 AM - 7:00 PM EST
>  • November 25, 9:00 AM - 7:00 PM EST
> What you need to do
> 
> Jobs using the macos-12 YAML workflow label should be updated to macos-15, macos-14, macos-13, or macos-latest. You can always get up-to-date information on our tools by reading about the software in the [runner images](https://github.com/actions/runner-images?elqTrackId=52d12286b0ab49208138b8f06e3af7e9&elq=228d7b34533340db8085b8aaff3b8930&elqaid=4233&elqat=1&elqCampaignId=4442&elqak=8AF539AA690C65F019049E0E1A8B64038152D9CB708D98DFF247D973847D52734FE7) repository. Please contact GitHub [Support](https://support.github.com/contact?form%5Bsubject%5D=Re%3A+GitHub+Actions&tags=dotcom-contact-params&elqTrackId=7a78e8710a0c4d378d4de10f9828752e&elq=228d7b34533340db8085b8aaff3b8930&elqaid=4233&elqat=1&elqCampaignId=4442&elqak=8AF592F31F339E082BFF97F54F17F450F2B0D9CB708D98DFF247D973847D52734FE7) if you run into any problems or need help.