### PR TITLE
[program-gen] Fix PCL bind error "cannot iterate over a value of type number"

### DIFF
--- a/changelog/pending/20241017--programgen--fix-pcl-bind-error-cannot-iterate-over-a-value-of-type-number-when-conditionals-are-used-in-range-expressions.yaml
+++ b/changelog/pending/20241017--programgen--fix-pcl-bind-error-cannot-iterate-over-a-value-of-type-number-when-conditionals-are-used-in-range-expressions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Fix PCL bind error "cannot iterate over a value of type number" when conditionals are used in range expressions 


### PR DESCRIPTION
### Description

Often when converting terraform modules such as tf VPC module, the range expression of resources is a conditional expression of the form `if should_create_resource ? N : 0`. 

These expressions resolve their type to one of `int`, `bool`, `Output[int]` or `Output[bool]`. Any other type we assume we are dealing with a collection that we are trying to iterate over. However if the conditional expression resolves to `optional(int)` then we think it is a collection, try to get it's key-value pair types and error with "cannot iterate over a value of type number"

This PR fixes this problem by unwrapping `int` from `optional(int)` when encountered in these range expressions. 

I was able to isolate a subset of the converted PCL from terraform VPC module where this problem occurs and created a unit test from it. 

Interesting note is that this only occurs in _non-strict_ mode 🤔 in strict mode, the expression type from `range` is not optional. I've not been able to find out why that is the case yet. 