### PR TITLE
cmdutil/profile: do not defer in loop

### DIFF
--- a/changelog/pending/20241210--sdk-go--fix-a-defer-leak-when-writing-memory-profiles.yaml
+++ b/changelog/pending/20241210--sdk-go--fix-a-defer-leak-when-writing-memory-profiles.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fix a `defer` leak when writing memory profiles

--- a/sdk/go/common/util/cmdutil/profile.go
+++ b/sdk/go/common/util/cmdutil/profile.go
@@ -79,16 +79,18 @@ func memoryProfileWriteLoop(prefix string) {
 
 		mem, err := os.Create(fmt.Sprintf("%s.%v.mem.%d", prefix, os.Getpid(), i))
 		if err != nil {
+			contract.IgnoreClose(mem)
 			fmt.Fprintf(os.Stderr, "could not create memory profile: %s\n", err.Error())
+
 			return
 		}
-		defer mem.Close()
 
 		runtime.GC() // get up-to-date statistics
 		if err = pprof.Lookup("allocs").WriteTo(mem, 0); err != nil {
 			fmt.Fprintf(os.Stderr, "could not create memory profile: %s\n", err.Error())
 		}
 
+		contract.IgnoreClose(mem)
 		os.Remove(fmt.Sprintf("%s.%v.mem.%d", prefix, os.Getpid(), i-1))
 	}
 }


### PR DESCRIPTION
This fixes a defer leak that has been added during the review of #17461.

Calling defer in a loop allocates memory (stack or heap depending on the Go version) and doesn't execute the deferred functions until the loop is over.

In this case, since the loop runs forever, it would be even worse.

This commit proposes as fix to simply remove the defer and move the close to its original place in the first iteration of the PR. This is safe to do since there are no retuns in-between.

We could also refactor the loop to call instead writeMemoryProfile (as was suggested in the PR review). In that case, if the defer is inside writeMemoryProfile, then it can be safely called from the loop.

More info about Go defer: https://victoriametrics.com/blog/defer-in-go/