### PR TITLE
Factor out the lifecycle testing framework

### DIFF
--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
-	"github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest"
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
@@ -302,11 +302,11 @@ func generateSnapshots(t testing.TB, r *rand.Rand, resourceCount, resourcePayloa
 	hostF := deploytest.NewPluginHostF(nil, nil, programF)
 
 	var journalEntries engine.JournalEntries
-	p := &lifecycletest.TestPlan{
+	p := &lt.TestPlan{
 		// This test generates big amounts of data so the event streams that would need to be
 		// checked in get too big.  Skip them instead.
-		Options: lifecycletest.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
-		Steps: []lifecycletest.TestStep{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
+		Steps: []lt.TestStep{
 			{
 				Op:          engine.Update,
 				SkipPreview: true,

--- a/pkg/engine/lifecycletest/alias_test.go
+++ b/pkg/engine/lifecycletest/alias_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -184,9 +185,9 @@ func createUpdateProgramWithResourceFuncForAliasTests(
 			return err
 		})
 		hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
-		p := &TestPlan{
-			Options: TestUpdateOptions{T: t, HostF: hostF},
-			Steps: []TestStep{
+		p := &lt.TestPlan{
+			Options: lt.TestUpdateOptions{T: t, HostF: hostF},
+			Steps: []lt.TestStep{
 				{
 					Op:            Update,
 					ExpectFailure: expectFailure,
@@ -1294,14 +1295,14 @@ func TestDuplicatesDueToAliases(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
 
 	project := p.GetProject()
 
 	// Run an update to create the starting A resource
-	snap, err := TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Len(t, snap.Resources, 2)
@@ -1309,7 +1310,7 @@ func TestDuplicatesDueToAliases(t *testing.T) {
 
 	// Set mode to try and create A then a B that aliases to it, this should fail
 	mode = 1
-	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	assert.Error(t, err)
 	assert.NotNil(t, snap)
 	assert.Len(t, snap.Resources, 2)
@@ -1317,7 +1318,7 @@ func TestDuplicatesDueToAliases(t *testing.T) {
 
 	// Set mode to try and create B first then a A, this should fail
 	mode = 2
-	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
+	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
 	assert.Error(t, err)
 	assert.NotNil(t, snap)
 	assert.Len(t, snap.Resources, 2)
@@ -1397,14 +1398,14 @@ func TestCorrectResourceChosen(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
 
 	project := p.GetProject()
 
 	// Run an update for initial state with "resA", "resB with resA as its parent", and "resB with no parent".
-	snap, err := TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Nil(t, snap.VerifyIntegrity())
@@ -1415,7 +1416,7 @@ func TestCorrectResourceChosen(t *testing.T) {
 
 	// Run the next case, with "resA" and "resB with no parent and alias to have resA as its parent".
 	mode = 1
-	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Nil(t, snap.VerifyIntegrity())
@@ -1472,14 +1473,14 @@ func TestComponentToCustomUpdate(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
 
 	project := p.GetProject()
 
 	// Run an update to create the resources
-	snap, err := TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Len(t, snap.Resources, 1)
@@ -1496,7 +1497,7 @@ func TestComponentToCustomUpdate(t *testing.T) {
 		})
 		assert.NoError(t, err)
 	}
-	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	// Assert that A is now a custom
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -1515,7 +1516,7 @@ func TestComponentToCustomUpdate(t *testing.T) {
 		})
 		assert.NoError(t, err)
 	}
-	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
+	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
 	// Assert that A is now a custom
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -1584,21 +1585,21 @@ func TestParentAlias(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
 
 	project := p.GetProject()
 
 	// Run an update to create the resources
-	snap, err := TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Len(t, snap.Resources, 4)
 
 	// Now run again with the rearranged parents, we don't expect to see any replaces
 	firstRun = false
-	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient,
+	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient,
 		func(project workspace.Project, target deploy.Target,
 			entries JournalEntries, events []Event, err error,
 		) error {
@@ -1660,21 +1661,21 @@ func TestEmptyParentAlias(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
 
 	project := p.GetProject()
 
 	// Run an update to create the resources
-	snap, err := TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Len(t, snap.Resources, 2)
 
 	// Now run again with the rearranged parents, we don't expect to see any replaces
 	firstRun = false
-	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient,
+	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient,
 		func(project workspace.Project, target deploy.Target,
 			entries JournalEntries, events []Event, err error,
 		) error {
@@ -1782,14 +1783,14 @@ func TestSplitUpdateComponentAliases(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
 
 	project := p.GetProject()
 
 	// Run an update for initial state with "resA", "resB", and "resC".
-	snap, err := TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Nil(t, snap.VerifyIntegrity())
@@ -1806,7 +1807,7 @@ func TestSplitUpdateComponentAliases(t *testing.T) {
 	// tell it needed to delete due to the error), C should have it's old URN but new parent because it wasn't
 	// registered.
 	mode = 1
-	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	assert.Error(t, err)
 	assert.NotNil(t, snap)
 	assert.Nil(t, snap.VerifyIntegrity())
@@ -1819,7 +1820,7 @@ func TestSplitUpdateComponentAliases(t *testing.T) {
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typB::resB"), snap.Resources[3].Parent)
 
 	mode = 2
-	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
+	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Nil(t, snap.VerifyIntegrity())
@@ -1914,14 +1915,14 @@ func TestFailDeleteDuplicateAliases(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
 
 	project := p.GetProject()
 
 	// Run an update for initial state with "resA"
-	snap, err := TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "1")
+	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "1")
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Nil(t, snap.VerifyIntegrity())
@@ -1930,7 +1931,7 @@ func TestFailDeleteDuplicateAliases(t *testing.T) {
 
 	// Run the next case, resA should be aliased
 	mode = 1
-	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
+	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Nil(t, snap.VerifyIntegrity())
@@ -1940,7 +1941,7 @@ func TestFailDeleteDuplicateAliases(t *testing.T) {
 	// Run the last case, resAX should try to delete and resA should be created. We can't possibly know that resA ==
 	// resAX at this point because we're not being sent aliases.
 	mode = 2
-	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "3")
+	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "3")
 	assert.Error(t, err)
 	assert.NotNil(t, snap)
 	assert.Nil(t, snap.VerifyIntegrity())

--- a/pkg/engine/lifecycletest/analyzer_test.go
+++ b/pkg/engine/lifecycletest/analyzer_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/blang/semver"
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -80,8 +81,8 @@ func TestSimpleAnalyzer(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
 			T: t,
 			UpdateOptions: UpdateOptions{
 				RequiredPolicies: []RequiredPolicy{NewRequiredPolicy("analyzerA", "", nil)},
@@ -91,7 +92,7 @@ func TestSimpleAnalyzer(t *testing.T) {
 	}
 
 	project := p.GetProject()
-	_, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	_, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	assert.NoError(t, err)
 }
 
@@ -125,8 +126,8 @@ func TestSimpleAnalyzeResourceFailure(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
 			T: t,
 			UpdateOptions: UpdateOptions{
 				RequiredPolicies: []RequiredPolicy{NewRequiredPolicy("analyzerA", "", nil)},
@@ -136,7 +137,7 @@ func TestSimpleAnalyzeResourceFailure(t *testing.T) {
 	}
 
 	project := p.GetProject()
-	_, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	_, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	assert.Error(t, err)
 }
 
@@ -170,8 +171,8 @@ func TestSimpleAnalyzeStackFailure(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
 			T:                t,
 			SkipDisplayTests: true, // TODO: this seems flaky, could use some more investigation.
 			UpdateOptions: UpdateOptions{
@@ -182,7 +183,7 @@ func TestSimpleAnalyzeStackFailure(t *testing.T) {
 	}
 
 	project := p.GetProject()
-	_, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	_, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	assert.Error(t, err)
 }
 
@@ -234,8 +235,8 @@ func TestResourceRemediation(t *testing.T) {
 	})
 	host := deploytest.NewPluginHostF(nil, nil, program, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
 			T: t,
 			UpdateOptions: UpdateOptions{
 				RequiredPolicies: []RequiredPolicy{NewRequiredPolicy("analyzerA", "", nil)},
@@ -245,7 +246,7 @@ func TestResourceRemediation(t *testing.T) {
 	}
 
 	project := p.GetProject()
-	snap, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 
 	// Expect no error, valid snapshot, two resources:
 	assert.Nil(t, err)
@@ -292,8 +293,8 @@ func TestRemediationDiagnostic(t *testing.T) {
 	})
 	host := deploytest.NewPluginHostF(nil, nil, program, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
 			T: t,
 			UpdateOptions: UpdateOptions{
 				RequiredPolicies: []RequiredPolicy{NewRequiredPolicy("analyzerA", "", nil)},
@@ -303,7 +304,7 @@ func TestRemediationDiagnostic(t *testing.T) {
 	}
 
 	project := p.GetProject()
-	snap, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 
 	// Expect no error, valid snapshot, two resources:
 	assert.NoError(t, err)
@@ -336,8 +337,8 @@ func TestRemediateFailure(t *testing.T) {
 	})
 	host := deploytest.NewPluginHostF(nil, nil, program, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
 			T: t,
 			UpdateOptions: UpdateOptions{
 				RequiredPolicies: []RequiredPolicy{NewRequiredPolicy("analyzerA", "", nil)},
@@ -347,7 +348,7 @@ func TestRemediateFailure(t *testing.T) {
 	}
 
 	project := p.GetProject()
-	snap, res := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	snap, res := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	assert.NotNil(t, res)
 	assert.NotNil(t, snap)
 	assert.Equal(t, 0, len(snap.Resources))
@@ -383,15 +384,15 @@ func TestSimpleAnalyzeResourceFailureRemediateDowngradedToMandatory(t *testing.T
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
 			T: t,
 			UpdateOptions: UpdateOptions{
 				RequiredPolicies: []RequiredPolicy{NewRequiredPolicy("analyzerA", "", nil)},
 			},
 			HostF: hostF,
 		},
-		Steps: []TestStep{
+		Steps: []lt.TestStep{
 			{
 				Op:            Update,
 				SkipPreview:   true,
@@ -448,8 +449,8 @@ func TestSimpleAnalyzeStackFailureRemediateDowngradedToMandatory(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
 			T:                t,
 			SkipDisplayTests: true, // TODO: this seems flaky, could use some more investigation.
 			UpdateOptions: UpdateOptions{
@@ -457,7 +458,7 @@ func TestSimpleAnalyzeStackFailureRemediateDowngradedToMandatory(t *testing.T) {
 			},
 			HostF: hostF,
 		},
-		Steps: []TestStep{
+		Steps: []lt.TestStep{
 			{
 				Op:            Update,
 				SkipPreview:   true,

--- a/pkg/engine/lifecycletest/continue_on_error_test.go
+++ b/pkg/engine/lifecycletest/continue_on_error_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/blang/semver"
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -74,8 +75,8 @@ func TestDestroyContinueOnError(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
 			T: t,
 			// Skip display tests because different ordering makes the colouring different.
 			SkipDisplayTests: true,
@@ -89,13 +90,13 @@ func TestDestroyContinueOnError(t *testing.T) {
 	project := p.GetProject()
 
 	// Run an update to create the resource
-	snap, err := TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Len(t, snap.Resources, 7) // We expect 5 resources + 2 providers
 
 	createResource = false
-	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	assert.ErrorContains(t, err, "intentionally failed delete")
 	assert.NotNil(t, snap)
 	assert.Len(t, snap.Resources, 4) // We expect 2 resources + 2 providers
@@ -196,8 +197,8 @@ func TestUpContinueOnErrorCreate(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
 			T: t,
 			UpdateOptions: UpdateOptions{
 				ContinueOnError: true,
@@ -210,7 +211,7 @@ func TestUpContinueOnErrorCreate(t *testing.T) {
 	project := p.GetProject()
 
 	// Run an update to create the resource
-	snap, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	require.ErrorContains(t, err, "intentionally failed create")
 	require.NotNil(t, snap)
 
@@ -329,8 +330,8 @@ func TestUpContinueOnErrorUpdate(t *testing.T) {
 
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
 			T: t,
 			UpdateOptions: UpdateOptions{
 				ContinueOnError: true,
@@ -343,7 +344,7 @@ func TestUpContinueOnErrorUpdate(t *testing.T) {
 	project := p.GetProject()
 
 	// Run an update to create the resource
-	snap, err := TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Equal(t, 3, len(snap.Resources)) // 2 resources + 1 provider
@@ -353,7 +354,7 @@ func TestUpContinueOnErrorUpdate(t *testing.T) {
 		"foo": "baz",
 	})
 	// Run an update to create the resource
-	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	require.ErrorContains(t, err, "intentionally failed update")
 	assert.NotNil(t, snap)
 	expectedURNs := []string{
@@ -446,8 +447,8 @@ func TestUpContinueOnErrorUpdateWithRefresh(t *testing.T) {
 
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
 			T: t,
 			UpdateOptions: UpdateOptions{
 				ContinueOnError: true,
@@ -460,7 +461,7 @@ func TestUpContinueOnErrorUpdateWithRefresh(t *testing.T) {
 	project := p.GetProject()
 
 	// Run an update to create the resource
-	snap, err := TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Equal(t, 2, len(snap.Resources)) // 1 resource + 1 provider
@@ -470,7 +471,7 @@ func TestUpContinueOnErrorUpdateWithRefresh(t *testing.T) {
 		"foo": "baz",
 	})
 	// Run an update to create the resource
-	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	require.ErrorContains(t, err, "intentionally failed update")
 	assert.NotNil(t, snap)
 	assert.Equal(t, 6, len(snap.Resources)) // 4 resources + 2 providers
@@ -531,8 +532,8 @@ func TestUpContinueOnErrorNoSDKSupport(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
 			T: t,
 			UpdateOptions: UpdateOptions{
 				ContinueOnError: true,
@@ -544,7 +545,7 @@ func TestUpContinueOnErrorNoSDKSupport(t *testing.T) {
 	project := p.GetProject()
 
 	// Run an update to create the resource
-	snap, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	require.ErrorContains(t, err, "intentionally failed create")
 	require.NotNil(t, snap)
 	require.Equal(t, 5, len(snap.Resources)) // 3 resources + 2 providers
@@ -616,8 +617,8 @@ func TestUpContinueOnErrorUpdateNoSDKSupport(t *testing.T) {
 
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
 			T: t,
 			UpdateOptions: UpdateOptions{
 				ContinueOnError: true,
@@ -629,7 +630,7 @@ func TestUpContinueOnErrorUpdateNoSDKSupport(t *testing.T) {
 	project := p.GetProject()
 
 	// Run an update to create the resource
-	snap, err := TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Equal(t, 2, len(snap.Resources)) // 1 resource + 1 provider
@@ -639,7 +640,7 @@ func TestUpContinueOnErrorUpdateNoSDKSupport(t *testing.T) {
 		"foo": "baz",
 	})
 	// Run an update to create the resource
-	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	require.ErrorContains(t, err, "intentionally failed update")
 	assert.NotNil(t, snap)
 	assert.Equal(t, 6, len(snap.Resources)) // 4 resources + 2 providers
@@ -685,8 +686,8 @@ func TestDestroyContinueOnErrorDeleteAfterFailedUp(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
 			T: t,
 			// Skip display tests because different ordering makes the colouring different.
 			SkipDisplayTests: true,
@@ -700,7 +701,7 @@ func TestDestroyContinueOnErrorDeleteAfterFailedUp(t *testing.T) {
 	project := p.GetProject()
 
 	// Run an update to create the resource
-	snap, err := TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Len(t, snap.Resources, 2) // We expect 1 resource + 1 provider
@@ -708,7 +709,7 @@ func TestDestroyContinueOnErrorDeleteAfterFailedUp(t *testing.T) {
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::willBeDeleted"), snap.Resources[1].URN)
 
 	update = true
-	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	assert.ErrorContains(t, err, "intentionally failed create")
 	assert.NotNil(t, snap)
 	assert.Len(t, snap.Resources, 1) // We expect 1 provider
@@ -750,8 +751,8 @@ func TestContinueOnErrorImport(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
 			T: t,
 			UpdateOptions: UpdateOptions{
 				ContinueOnError: true,
@@ -763,7 +764,7 @@ func TestContinueOnErrorImport(t *testing.T) {
 	project := p.GetProject()
 
 	// Run an update to create the resource
-	snap, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	require.ErrorContains(t, err, "inputs to import do not match the existing resource")
 	require.NotNil(t, snap)
 	assert.Equal(t, 1, len(snap.Resources)) // 1 provider
@@ -835,8 +836,8 @@ func TestUpContinueOnErrorFailedDependencies(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
 			T: t,
 			UpdateOptions: UpdateOptions{
 				ContinueOnError: true,
@@ -849,7 +850,7 @@ func TestUpContinueOnErrorFailedDependencies(t *testing.T) {
 	project := p.GetProject()
 
 	// Run an update to create the resource
-	snap, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	require.ErrorContains(t, err, "intentionally failed create")
 	require.NotNil(t, snap)
 
@@ -873,7 +874,7 @@ func TestUpContinueOnErrorFailedDependencies(t *testing.T) {
 func TestContinueOnErrorWithChangingProviderOnCreate(t *testing.T) {
 	t.Parallel()
 
-	p := &TestPlan{}
+	p := &lt.TestPlan{}
 	project := p.GetProject()
 
 	upLoaders := []*deploytest.ProviderLoader{
@@ -903,13 +904,13 @@ func TestContinueOnErrorWithChangingProviderOnCreate(t *testing.T) {
 	})
 
 	upHostF := deploytest.NewPluginHostF(nil, nil, programF, upLoaders...)
-	upOptions := TestUpdateOptions{
+	upOptions := lt.TestUpdateOptions{
 		T: t, HostF: upHostF, UpdateOptions: UpdateOptions{
 			ContinueOnError: true,
 		},
 	}
 
-	snap, err := TestOp(Update).
+	snap, err := lt.TestOp(Update).
 		RunStep(project, p.GetTarget(t, nil), upOptions, false, p.BackendClient, nil, "0")
 	assert.NoError(t, err)
 
@@ -951,14 +952,14 @@ func TestContinueOnErrorWithChangingProviderOnCreate(t *testing.T) {
 		return nil
 	})
 	replaceHostF := deploytest.NewPluginHostF(nil, nil, programF, replaceLoaders...)
-	replaceOptions := TestUpdateOptions{
+	replaceOptions := lt.TestUpdateOptions{
 		T: t, HostF: replaceHostF,
 		UpdateOptions: UpdateOptions{
 			ContinueOnError: true,
 		},
 	}
 
-	snap, err = TestOp(Update).
+	snap, err = lt.TestOp(Update).
 		RunStep(project, p.GetTarget(t, snap), replaceOptions, false, p.BackendClient, nil, "1")
 	assert.ErrorContains(t, err, "interrupt replace")
 

--- a/pkg/engine/lifecycletest/golang_sdk_test.go
+++ b/pkg/engine/lifecycletest/golang_sdk_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
@@ -114,10 +115,10 @@ func TestSingleResourceDefaultProviderGolangLifecycle(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
+	p := &lt.TestPlan{
 		// Skip display tests because different ordering makes the colouring different.
-		Options: TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
-		Steps:   MakeBasicLifecycleSteps(t, 4),
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
+		Steps:   lt.MakeBasicLifecycleSteps(t, 4),
 	}
 	p.Run(t, nil)
 }
@@ -181,9 +182,9 @@ func TestIgnoreChangesGolangLifecycle(t *testing.T) {
 		})
 
 		hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
-		p := &TestPlan{
-			Options: TestUpdateOptions{T: t, HostF: hostF},
-			Steps: []TestStep{
+		p := &lt.TestPlan{
+			Options: lt.TestUpdateOptions{T: t, HostF: hostF},
+			Steps: []lt.TestStep{
 				{
 					Op: Update,
 					Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
@@ -215,7 +216,7 @@ func TestIgnoreChangesGolangLifecycle(t *testing.T) {
 func TestExplicitDeleteBeforeReplaceGoSDK(t *testing.T) {
 	t.Parallel()
 
-	p := &TestPlan{}
+	p := &lt.TestPlan{}
 
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
@@ -284,12 +285,12 @@ func TestExplicitDeleteBeforeReplaceGoSDK(t *testing.T) {
 	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 	p.Options.T = t
 	p.Options.SkipDisplayTests = true
-	p.Steps = []TestStep{{Op: Update}}
+	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
 
 	// Change the value of resA.A. Should create before replace
 	inputsA.Foo = pulumi.String("bar")
-	p.Steps = []TestStep{{
+	p.Steps = []lt.TestStep{{
 		Op: Update,
 
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
@@ -313,7 +314,7 @@ func TestExplicitDeleteBeforeReplaceGoSDK(t *testing.T) {
 	// Change the registration of resA such that it requires delete-before-replace and change the value of resA.A.
 	// replacement should be delete-before-replace.
 	dbrA, inputsA.Foo = &dbrValue, pulumi.String("baz")
-	p.Steps = []TestStep{{
+	p.Steps = []lt.TestStep{{
 		Op: Update,
 
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
@@ -378,9 +379,9 @@ func TestReadResourceGolangLifecycle(t *testing.T) {
 		})
 
 		hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
-		p := &TestPlan{
-			Options: TestUpdateOptions{T: t, HostF: hostF},
-			Steps: []TestStep{
+		p := &lt.TestPlan{
+			Options: lt.TestUpdateOptions{T: t, HostF: hostF},
+			Steps: []lt.TestStep{
 				{
 					Op: Update,
 					Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
@@ -585,9 +586,9 @@ func TestProviderInheritanceGolangLifecycle(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
-		Steps:   []TestStep{{Op: Update}},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
+		Steps:   []lt.TestStep{{Op: Update}},
 	}
 	p.Run(t, nil)
 }
@@ -637,9 +638,9 @@ func TestReplaceOnChangesGolangLifecycle(t *testing.T) {
 	expectedOps := []display.StepOp{deploy.OpCreate}
 
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
-		Steps: []TestStep{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
+		Steps: []lt.TestStep{
 			{
 				Op: Update,
 				Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
@@ -768,9 +769,9 @@ func TestRemoteComponentGolang(t *testing.T) {
 
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
-		Steps:   []TestStep{{Op: Update}},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
+		Steps:   []lt.TestStep{{Op: Update}},
 	}
 	p.Run(t, nil)
 }

--- a/pkg/engine/lifecycletest/loader_test.go
+++ b/pkg/engine/lifecycletest/loader_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -105,9 +106,9 @@ func TestLoader(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
 	}
-	_, err := TestOp(Update).RunStep(p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	_, err := lt.TestOp(Update).RunStep(p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	assert.NoError(t, err)
 }

--- a/pkg/engine/lifecycletest/parameterized_test.go
+++ b/pkg/engine/lifecycletest/parameterized_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
@@ -108,11 +109,12 @@ func TestPackageRef(t *testing.T) {
 	})
 
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
 
-	snap, err := TestOp(Update).RunStep(p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	snap, err := lt.TestOp(Update).
+		RunStep(p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
@@ -336,11 +338,11 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 	})
 
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
 
-	snap, err := TestOp(Update).RunStep(
+	snap, err := lt.TestOp(Update).RunStep(
 		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "up")
 	require.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -362,13 +364,13 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 		},
 	}), prov.Inputs)
 
-	snap, err = TestOp(Refresh).RunStep(
+	snap, err = lt.TestOp(Refresh).RunStep(
 		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "refresh")
 	require.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Len(t, snap.Resources, 7)
 
-	snap, err = TestOp(Destroy).RunStep(
+	snap, err = lt.TestOp(Destroy).RunStep(
 		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "destroy")
 	require.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -460,15 +462,15 @@ func TestReplacementParameterizedProviderConfig(t *testing.T) {
 	})
 
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 		Config: config.Map{
 			config.MustParseKey("pkgA:name"):   config.NewValue("testingBase"),
 			config.MustParseKey("pkgExt:name"): config.NewValue("testingExt"),
 		},
 	}
 
-	snap, err := TestOp(Update).RunStep(
+	snap, err := lt.TestOp(Update).RunStep(
 		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "up")
 	require.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -487,13 +489,13 @@ func TestReplacementParameterizedProviderConfig(t *testing.T) {
 		},
 	}), prov.Inputs)
 
-	snap, err = TestOp(Refresh).RunStep(
+	snap, err = lt.TestOp(Refresh).RunStep(
 		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "refresh")
 	require.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Len(t, snap.Resources, 4)
 
-	snap, err = TestOp(Destroy).RunStep(
+	snap, err = lt.TestOp(Destroy).RunStep(
 		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "destroy")
 	require.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -609,11 +611,11 @@ func TestReplacementParameterizedProviderImport(t *testing.T) {
 	})
 
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
 
-	snap, err := TestOp(Update).RunStep(
+	snap, err := lt.TestOp(Update).RunStep(
 		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "up")
 	require.NoError(t, err)
 	assert.NotNil(t, snap)

--- a/pkg/engine/lifecycletest/pending_delete_test.go
+++ b/pkg/engine/lifecycletest/pending_delete_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -41,9 +42,9 @@ func TestDestroyWithPendingDelete(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
+	p := &lt.TestPlan{
 		// Skip display tests because different ordering makes the colouring different.
-		Options: TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
 	}
 
 	resURN := p.NewURN("pkgA:m:typA", "resA", "")
@@ -72,7 +73,7 @@ func TestDestroyWithPendingDelete(t *testing.T) {
 		},
 	}
 
-	p.Steps = []TestStep{{
+	p.Steps = []lt.TestStep{{
 		Op: Update,
 		Validate: func(_ workspace.Project, _ deploy.Target, entries JournalEntries,
 			_ []Event, err error,
@@ -118,9 +119,9 @@ func TestUpdateWithPendingDelete(t *testing.T) {
 
 	hostF := deploytest.NewPluginHostF(nil, nil, nil, loaders...)
 
-	p := &TestPlan{
+	p := &lt.TestPlan{
 		// Skip display tests because different ordering makes the colouring different.
-		Options: TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
 	}
 
 	resURN := p.NewURN("pkgA:m:typA", "resA", "")
@@ -149,7 +150,7 @@ func TestUpdateWithPendingDelete(t *testing.T) {
 		},
 	}
 
-	p.Steps = []TestStep{{
+	p.Steps = []lt.TestStep{{
 		Op: Destroy,
 		Validate: func(_ workspace.Project, _ deploy.Target, entries JournalEntries,
 			_ []Event, err error,

--- a/pkg/engine/lifecycletest/pending_replace_test.go
+++ b/pkg/engine/lifecycletest/pending_replace_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -42,7 +43,7 @@ func TestPendingReplaceFailureDoesNotViolateSnapshotIntegrity(t *testing.T) {
 	t.Parallel()
 
 	// Arrange.
-	p := &TestPlan{}
+	p := &lt.TestPlan{}
 	project := p.GetProject()
 
 	diffsCalled := make(map[string]bool)
@@ -125,9 +126,9 @@ func TestPendingReplaceFailureDoesNotViolateSnapshotIntegrity(t *testing.T) {
 	})
 
 	upHostF := deploytest.NewPluginHostF(nil, nil, programF, upLoaders...)
-	upOptions := TestUpdateOptions{T: t, HostF: upHostF}
+	upOptions := lt.TestUpdateOptions{T: t, HostF: upHostF}
 
-	upSnap, err := TestOp(Update).
+	upSnap, err := lt.TestOp(Update).
 		RunStep(project, p.GetTarget(t, nil), upOptions, false, p.BackendClient, nil, "0")
 	assert.NoError(t, err)
 
@@ -148,9 +149,9 @@ func TestPendingReplaceFailureDoesNotViolateSnapshotIntegrity(t *testing.T) {
 	}
 
 	replaceHostF := deploytest.NewPluginHostF(nil, nil, programF, replaceLoaders...)
-	replaceOptions := TestUpdateOptions{T: t, HostF: replaceHostF}
+	replaceOptions := lt.TestUpdateOptions{T: t, HostF: replaceHostF}
 
-	replaceSnap, err := TestOp(Update).
+	replaceSnap, err := lt.TestOp(Update).
 		RunStep(project, p.GetTarget(t, upSnap), replaceOptions, false, p.BackendClient, nil, "1")
 	assert.ErrorContains(t, err, "interrupt replace")
 
@@ -185,9 +186,9 @@ func TestPendingReplaceFailureDoesNotViolateSnapshotIntegrity(t *testing.T) {
 	}
 
 	retryHostF := deploytest.NewPluginHostF(nil, nil, programF, retryLoaders...)
-	retryOptions := TestUpdateOptions{T: t, HostF: retryHostF}
+	retryOptions := lt.TestUpdateOptions{T: t, HostF: retryHostF}
 
-	retrySnap, err := TestOp(Update).
+	retrySnap, err := lt.TestOp(Update).
 		RunStep(project, p.GetTarget(t, replaceSnap), retryOptions, false, p.BackendClient, nil, "2")
 	assert.NoError(t, err)
 
@@ -218,7 +219,7 @@ func TestPendingReplaceResumeWithSameGoals(t *testing.T) {
 	t.Parallel()
 
 	// Arrange.
-	p := &TestPlan{}
+	p := &lt.TestPlan{}
 	project := p.GetProject()
 
 	returnReplaceDiff := func(
@@ -286,9 +287,9 @@ func TestPendingReplaceResumeWithSameGoals(t *testing.T) {
 	})
 
 	upHostF := deploytest.NewPluginHostF(nil, nil, programF, upLoaders...)
-	upOptions := TestUpdateOptions{T: t, HostF: upHostF}
+	upOptions := lt.TestUpdateOptions{T: t, HostF: upHostF}
 
-	upSnap, err := TestOp(Update).
+	upSnap, err := lt.TestOp(Update).
 		RunStep(project, p.GetTarget(t, nil), upOptions, false, p.BackendClient, nil, "0")
 	assert.NoError(t, err)
 
@@ -309,9 +310,9 @@ func TestPendingReplaceResumeWithSameGoals(t *testing.T) {
 	}
 
 	replaceHostF := deploytest.NewPluginHostF(nil, nil, programF, replaceLoaders...)
-	replaceOptions := TestUpdateOptions{T: t, HostF: replaceHostF}
+	replaceOptions := lt.TestUpdateOptions{T: t, HostF: replaceHostF}
 
-	replaceSnap, err := TestOp(Update).
+	replaceSnap, err := lt.TestOp(Update).
 		RunStep(project, p.GetTarget(t, upSnap), replaceOptions, false, p.BackendClient, nil, "1")
 	assert.ErrorContains(t, err, "interrupt replace")
 
@@ -336,9 +337,9 @@ func TestPendingReplaceResumeWithSameGoals(t *testing.T) {
 	}
 
 	removeHostF := deploytest.NewPluginHostF(nil, nil, programF, removeLoaders...)
-	removeOptions := TestUpdateOptions{T: t, HostF: removeHostF}
+	removeOptions := lt.TestUpdateOptions{T: t, HostF: removeHostF}
 
-	removeSnap, err := TestOp(Update).
+	removeSnap, err := lt.TestOp(Update).
 		RunStep(project, p.GetTarget(t, replaceSnap), removeOptions, false, p.BackendClient, nil, "2")
 	assert.NoError(t, err)
 
@@ -364,7 +365,7 @@ func TestPendingReplaceResumeWithDeletedGoals(t *testing.T) {
 	t.Parallel()
 
 	// Arrange.
-	p := &TestPlan{}
+	p := &lt.TestPlan{}
 	project := p.GetProject()
 
 	returnReplaceDiff := func(
@@ -432,9 +433,9 @@ func TestPendingReplaceResumeWithDeletedGoals(t *testing.T) {
 	})
 
 	upHostF := deploytest.NewPluginHostF(nil, nil, programF, upLoaders...)
-	upOptions := TestUpdateOptions{T: t, HostF: upHostF}
+	upOptions := lt.TestUpdateOptions{T: t, HostF: upHostF}
 
-	upSnap, err := TestOp(Update).
+	upSnap, err := lt.TestOp(Update).
 		RunStep(project, p.GetTarget(t, nil), upOptions, false, p.BackendClient, nil, "0")
 	assert.NoError(t, err)
 
@@ -455,9 +456,9 @@ func TestPendingReplaceResumeWithDeletedGoals(t *testing.T) {
 	}
 
 	replaceHostF := deploytest.NewPluginHostF(nil, nil, programF, replaceLoaders...)
-	replaceOptions := TestUpdateOptions{T: t, HostF: replaceHostF}
+	replaceOptions := lt.TestUpdateOptions{T: t, HostF: replaceHostF}
 
-	replaceSnap, err := TestOp(Update).
+	replaceSnap, err := lt.TestOp(Update).
 		RunStep(project, p.GetTarget(t, upSnap), replaceOptions, false, p.BackendClient, nil, "1")
 	assert.ErrorContains(t, err, "interrupt replace")
 
@@ -489,9 +490,9 @@ func TestPendingReplaceResumeWithDeletedGoals(t *testing.T) {
 	})
 
 	removeHostF := deploytest.NewPluginHostF(nil, nil, removeProgramF, removeLoaders...)
-	removeOptions := TestUpdateOptions{T: t, HostF: removeHostF}
+	removeOptions := lt.TestUpdateOptions{T: t, HostF: removeHostF}
 
-	removeSnap, err := TestOp(Update).
+	removeSnap, err := lt.TestOp(Update).
 		RunStep(project, p.GetTarget(t, replaceSnap), removeOptions, false, p.BackendClient, nil, "2")
 	assert.NoError(t, err)
 
@@ -520,7 +521,7 @@ func TestPendingReplaceResumeWithUpdatedGoals(t *testing.T) {
 	t.Parallel()
 
 	// Arrange.
-	p := &TestPlan{}
+	p := &lt.TestPlan{}
 	project := p.GetProject()
 
 	returnReplaceDiff := func(
@@ -602,9 +603,9 @@ func TestPendingReplaceResumeWithUpdatedGoals(t *testing.T) {
 	})
 
 	upHostF := deploytest.NewPluginHostF(nil, nil, programF, upLoaders...)
-	upOptions := TestUpdateOptions{T: t, HostF: upHostF}
+	upOptions := lt.TestUpdateOptions{T: t, HostF: upHostF}
 
-	upSnap, err := TestOp(Update).
+	upSnap, err := lt.TestOp(Update).
 		RunStep(project, p.GetTarget(t, nil), upOptions, false, p.BackendClient, nil, "0")
 	assert.NoError(t, err)
 
@@ -625,9 +626,9 @@ func TestPendingReplaceResumeWithUpdatedGoals(t *testing.T) {
 	}
 
 	replaceHostF := deploytest.NewPluginHostF(nil, nil, programF, replaceLoaders...)
-	replaceOptions := TestUpdateOptions{T: t, HostF: replaceHostF}
+	replaceOptions := lt.TestUpdateOptions{T: t, HostF: replaceHostF}
 
-	replaceSnap, err := TestOp(Update).
+	replaceSnap, err := lt.TestOp(Update).
 		RunStep(project, p.GetTarget(t, upSnap), replaceOptions, false, p.BackendClient, nil, "1")
 	assert.ErrorContains(t, err, "interrupt replace")
 
@@ -655,9 +656,9 @@ func TestPendingReplaceResumeWithUpdatedGoals(t *testing.T) {
 	}
 
 	removeHostF := deploytest.NewPluginHostF(nil, nil, programF, removeLoaders...)
-	removeOptions := TestUpdateOptions{T: t, HostF: removeHostF}
+	removeOptions := lt.TestUpdateOptions{T: t, HostF: removeHostF}
 
-	removeSnap, err := TestOp(Update).
+	removeSnap, err := lt.TestOp(Update).
 		RunStep(project, p.GetTarget(t, replaceSnap), removeOptions, false, p.BackendClient, nil, "2")
 	assert.NoError(t, err)
 
@@ -675,7 +676,7 @@ func TestInteruptedPendingReplace(t *testing.T) {
 	t.Parallel()
 
 	// Arrange.
-	p := &TestPlan{}
+	p := &lt.TestPlan{}
 	project := p.GetProject()
 
 	// Act.
@@ -704,9 +705,9 @@ func TestInteruptedPendingReplace(t *testing.T) {
 	})
 
 	upHostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
-	upOptions := TestUpdateOptions{T: t, HostF: upHostF}
+	upOptions := lt.TestUpdateOptions{T: t, HostF: upHostF}
 
-	upSnap, err := TestOp(Update).
+	upSnap, err := lt.TestOp(Update).
 		RunStep(project, p.GetTarget(t, nil), upOptions, false, p.BackendClient, nil, "0")
 	assert.NoError(t, err)
 
@@ -739,7 +740,7 @@ func TestInteruptedPendingReplace(t *testing.T) {
 		}
 	}
 
-	replaceSnap, err := TestOp(Update).
+	replaceSnap, err := lt.TestOp(Update).
 		RunStep(project, p.GetTarget(t, upSnap), upOptions, false, p.BackendClient, nil, "1")
 	assert.ErrorContains(t, err, "interrupt replace")
 
@@ -751,7 +752,7 @@ func TestInteruptedPendingReplace(t *testing.T) {
 
 	// Operation 3 -- try and resume the replacement with the same program, but fail the create again.
 
-	secondReplaceSnap, err := TestOp(Update).
+	secondReplaceSnap, err := lt.TestOp(Update).
 		RunStep(project, p.GetTarget(t, replaceSnap), upOptions, false, p.BackendClient, nil, "2")
 	assert.ErrorContains(t, err, "interrupt replace")
 
@@ -785,7 +786,7 @@ func TestInteruptedPendingReplace(t *testing.T) {
 		}
 	}
 
-	secondUpSnap, err := TestOp(Update).
+	secondUpSnap, err := lt.TestOp(Update).
 		RunStep(project, p.GetTarget(t, secondReplaceSnap), upOptions, false, p.BackendClient, nil, "3")
 	assert.NoError(t, err)
 

--- a/pkg/engine/lifecycletest/refresh_legacy_diff_test.go
+++ b/pkg/engine/lifecycletest/refresh_legacy_diff_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
@@ -57,7 +58,7 @@ func validateRefreshBasicsWithLegacyDiffCombination(
 	targets []string,
 	name string,
 ) {
-	p := &TestPlan{}
+	p := &lt.TestPlan{}
 
 	// NOTE: This is the only difference between this test and TestRefreshBasics.
 	// Setting this flag should trigger old behaviour, where refresh diffs only
@@ -141,7 +142,7 @@ func validateRefreshBasicsWithLegacyDiffCombination(
 	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, nil, loaders...)
 	p.Options.T = t
 
-	p.Steps = []TestStep{{
+	p.Steps = []lt.TestStep{{
 		Op: Refresh,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
 			_ []Event, err error,

--- a/pkg/engine/lifecycletest/resource_reference_test.go
+++ b/pkg/engine/lifecycletest/resource_reference_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -101,10 +102,10 @@ func TestResourceReferences(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
+	p := &lt.TestPlan{
 		// Skip display tests because different ordering makes the colouring different.
-		Options: TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
-		Steps:   MakeBasicLifecycleSteps(t, 4),
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
+		Steps:   lt.MakeBasicLifecycleSteps(t, 4),
 	}
 	p.Run(t, nil)
 }
@@ -182,10 +183,10 @@ func TestResourceReferences_DownlevelSDK(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
+	p := &lt.TestPlan{
 		// Skip display tests because different ordering makes the colouring different.
-		Options: TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
-		Steps:   MakeBasicLifecycleSteps(t, 4),
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
+		Steps:   lt.MakeBasicLifecycleSteps(t, 4),
 	}
 	p.Run(t, nil)
 }
@@ -265,15 +266,15 @@ func TestResourceReferences_DownlevelEngine(t *testing.T) {
 
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
+	p := &lt.TestPlan{
 		// Skip display tests because different ordering makes the colouring different.
-		Options: TestUpdateOptions{
+		Options: lt.TestUpdateOptions{
 			T:                t,
 			HostF:            hostF,
 			UpdateOptions:    UpdateOptions{DisableResourceReferences: true},
 			SkipDisplayTests: true,
 		},
-		Steps: MakeBasicLifecycleSteps(t, 4),
+		Steps: lt.MakeBasicLifecycleSteps(t, 4),
 	}
 	p.Run(t, nil)
 }
@@ -341,10 +342,10 @@ func TestResourceReferences_GetResource(t *testing.T) {
 
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
+	p := &lt.TestPlan{
 		// Skip display tests because different ordering makes the colouring different.
-		Options: TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
-		Steps:   MakeBasicLifecycleSteps(t, 4),
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
+		Steps:   lt.MakeBasicLifecycleSteps(t, 4),
 	}
 	p.Run(t, nil)
 }

--- a/pkg/engine/lifecycletest/retain_on_delete_test.go
+++ b/pkg/engine/lifecycletest/retain_on_delete_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -82,12 +83,12 @@ func TestRetainOnDelete(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{Options: TestUpdateOptions{T: t, HostF: hostF}}
+	p := &lt.TestPlan{Options: lt.TestUpdateOptions{T: t, HostF: hostF}}
 
 	project := p.GetProject()
 
 	// Run an update to create the resource
-	snap, err := TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Len(t, snap.Resources, 2)
@@ -97,7 +98,7 @@ func TestRetainOnDelete(t *testing.T) {
 	ins = resource.NewPropertyMapFromMap(map[string]interface{}{
 		"foo": "baz",
 	})
-	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Len(t, snap.Resources, 2)
@@ -105,7 +106,7 @@ func TestRetainOnDelete(t *testing.T) {
 
 	// Run a new update which will cause a delete, we still shouldn't see a provider delete
 	createResource = false
-	snap, err = TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
+	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Len(t, snap.Resources, 0)

--- a/pkg/engine/lifecycletest/source_query_test.go
+++ b/pkg/engine/lifecycletest/source_query_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/engine/lifecycletest/transformation_test.go
+++ b/pkg/engine/lifecycletest/transformation_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -228,13 +229,13 @@ func TestRemoteTransforms(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
+	p := &lt.TestPlan{
 		// Skip display tests because secrets are serialized with the blinding crypter and can't be restored
-		Options: TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
 	}
 
 	project := p.GetProject()
-	snap, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	assert.NoError(t, err)
 
 	assert.Len(t, snap.Resources, 3)
@@ -296,12 +297,12 @@ func TestRemoteTransformBadResponse(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
 
 	project := p.GetProject()
-	snap, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	assert.ErrorContains(t, err, "unmarshaling response: proto:")
 	assert.ErrorContains(t, err, "cannot parse invalid wire-format data")
 	assert.Len(t, snap.Resources, 0)
@@ -340,12 +341,12 @@ func TestRemoteTransformErrorResponse(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
 
 	project := p.GetProject()
-	snap, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	assert.ErrorContains(t, err, "Unknown desc = bad transform")
 	assert.Len(t, snap.Resources, 0)
 }
@@ -413,12 +414,12 @@ func TestRemoteTransformationsConstruct(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
 
 	project := p.GetProject()
-	snap, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	assert.NoError(t, err)
 
 	assert.Len(t, snap.Resources, 3)
@@ -530,12 +531,12 @@ func TestRemoteTransformsOptions(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
 
 	project := p.GetProject()
-	snap, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	require.NoError(t, err)
 	assert.Len(t, snap.Resources, 5)
 	// Check Resources[4] is the resD resource
@@ -630,12 +631,12 @@ func TestRemoteTransformsDependencies(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
 
 	project := p.GetProject()
-	snap, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	assert.NoError(t, err)
 
 	assert.Len(t, snap.Resources, 4)
@@ -719,12 +720,12 @@ func TestRemoteComponentTransforms(t *testing.T) {
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
 
 	project := p.GetProject()
-	snap, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	assert.NoError(t, err)
 
 	assert.Len(t, snap.Resources, 3)
@@ -818,9 +819,9 @@ func TestTransformsProviderOpt(t *testing.T) {
 		return nil
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
-		Steps: []TestStep{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
+		Steps: []lt.TestStep{
 			{
 				Op: Update,
 			},
@@ -897,9 +898,9 @@ func TestTransformInvoke(t *testing.T) {
 	})
 
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
-		Steps: []TestStep{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
+		Steps: []lt.TestStep{
 			{
 				Op: Update,
 			},
@@ -954,9 +955,9 @@ func TestTransformInvokeTransformProvider(t *testing.T) {
 	})
 
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
-	p := &TestPlan{
-		Options: TestUpdateOptions{T: t, HostF: hostF},
-		Steps: []TestStep{
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
+		Steps: []lt.TestStep{
 			{
 				Op: Update,
 			},


### PR DESCRIPTION
Lifecycle tests exist to test the Pulumi engine, allowing us to mock providers and programs and resource registrations before executing specific operations. We'd like to extend our lifecycle test suite to support fuzzing the engine -- that is, generating test cases to exercise edge cases that we might otherwise struggle to find manually. Presently, the framework underpinning the lifecycle tests is defined in a single `test_plan.go` module that sits alongside the `_test.go` files themselves. This means that it's not really possible to factor out or neatly extend the framework (e.g. by adding a `fuzzing` submodule) without introducing circular imports (since tests in `lifecycletest` will import `fuzzing`, which imports the framework from `lifecycletest`).

This commit therefore pulls out `test_plan.go` into a dedicated `framework` submodule, which is now explicitly imported and used by existing tests. It also adapts the framework slightly to define the subset of `testing.T` functionality it needs more precisely, so that when the time comes for us to fuzz we can e.g. pass a `rapid.T` just as easily. No behavioural changes are made to the tests themselves -- this is purely a structural change to facilitate subsequent work on fuzzing.