### PR TITLE
[pcl] Allow PCL function element to take a dynamic expression as input in non-strict mode

### DIFF
--- a/changelog/pending/20241018--programgen--allow-pcl-function-element-to-take-a-dynamic-expression-as-input-in-non-strict-mode.yaml
+++ b/changelog/pending/20241018--programgen--allow-pcl-function-element-to-take-a-dynamic-expression-as-input-in-non-strict-mode.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Allow PCL function element to take a dynamic expression as input in non-strict mode

--- a/pkg/codegen/pcl/functions.go
+++ b/pkg/codegen/pcl/functions.go
@@ -65,12 +65,15 @@ func pulumiBuiltins(options bindOptions) map[string]*model.Function {
 						_, elementType := model.UnifyTypes(t.ElementTypes...)
 						listType, returnType = args[0].Type(), elementType
 					default:
-						rng := args[0].SyntaxNode().Range()
-						diagnostics = hcl.Diagnostics{&hcl.Diagnostic{
-							Severity: hcl.DiagError,
-							Summary:  "the first argument to 'element' must be a list or tuple",
-							Subject:  &rng,
-						}}
+						if !options.skipRangeTypecheck {
+							// we are in strict mode, so we should error if the type is not a list or tuple
+							rng := args[0].SyntaxNode().Range()
+							diagnostics = hcl.Diagnostics{&hcl.Diagnostic{
+								Severity: hcl.DiagError,
+								Summary:  "the first argument to 'element' must be a list or tuple",
+								Subject:  &rng,
+							}}
+						}
 					}
 				}
 				return model.StaticFunctionSignature{


### PR DESCRIPTION
### Description

Making PCL function `element` more lenient in non-strict mode such that when the input collection isn't a list or tuple, we still allow it instead of erroring out which is what happens today when converting terraform modules such as VPC.

Also added more tests around `element` in combination with splat expressions.

Tested locally and with this change, I am able to convert terraform-aws-vpc to PCL (base typecheck) and to typescript