### PR TITLE
add interactive account selection to pulumi login

### DIFF
--- a/changelog/pending/20241026--cli--add-interactive-account-selection-to-pulumi-login-command.yaml
+++ b/changelog/pending/20241026--cli--add-interactive-account-selection-to-pulumi-login-command.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add interactive account selection to pulumi login command

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -193,7 +193,8 @@ func newLoginCmd() *cobra.Command {
 		"Please note, currently, only the managed and self-hosted backends support organizations")
 	cmd.PersistentFlags().BoolVarP(&localMode, "local", "l", false, "Use Pulumi in local-only mode")
 	cmd.PersistentFlags().BoolVar(&insecure, "insecure", false, "Allow insecure server connections when using SSL")
-	cmd.PersistentFlags().BoolVar(&interactive, "interactive", false, "Show interactive login options based on known accounts")
+	cmd.PersistentFlags().BoolVar(&interactive, "interactive", false,
+		"Show interactive login options based on known accounts")
 
 	return cmd
 }


### PR DESCRIPTION
Add ability to interactively select account to login to using previously authenticated accounts.

https://github.com/user-attachments/assets/c9e1458d-441b-4e08-86d0-37f20908b076

