### PR TITLE
Support generating random fixtures in lifecycle tests

### DIFF
--- a/pkg/engine/lifecycletest/README.md
+++ b/pkg/engine/lifecycletest/README.md
@@ -1,5 +1,5 @@
 (lifecycle-tests)=
-## Lifecycle tests
+# Lifecycle tests
 
 *Lifecycle tests* exercise the Pulumi engine and serve as a specification for
 the behaviours and interactions of the various features that define the
@@ -11,4 +11,7 @@ lifecycle of a Pulumi program. This includes, but is not limited to:
   options that might be associated with them (`parent`, `retainOnDelete`, etc.).
 * The state of the program before and after operations are executed.
 
-### How and when to use
+## How and when to use
+
+```{include} /pkg/engine/lifecycletest/fuzzing/README.md
+```

--- a/pkg/engine/lifecycletest/fuzzing/README.md
+++ b/pkg/engine/lifecycletest/fuzzing/README.md
@@ -1,0 +1,55 @@
+(lifecycle-fuzzing)=
+## Fuzzing
+
+[Snapshot integrity errors](snapshot-integrity) are very problematic when they
+occur and can be hard to spot and prevent. To this end, a subset of the
+lifecycle test suite uses a combination of
+[fuzzing](https://en.wikipedia.org/wiki/Fuzzing) and [property-based
+testing](https://en.wikipedia.org/wiki/Property_testing) via the
+[Rapid](https://pkg.go.dev/pgregory.net/rapid) Go library to randomly generate
+snapshots and programs to see whether or not it is possible to trigger a
+snapshot integrity error.
+
+While snapshot integrity issues often happen as part of a chain of snapshot
+operations (e.g. the execution of multiple steps in a deployment), the precursor
+to any error state will always be a valid snapshot. Thus, rather than having to
+generate random chains of operations, we can instead simplify the problem to
+generating valid starting snapshots and then executing a single random operation
+on them. The strategy we employ is thus as follows:
+
+* Generate a [snapshot](state-snapshots)
+  ([snapshot.go](gh-file:pulumi#pkg/engine/lifecycletest/fuzzing/snapshot.go))
+  consisting of a random set of resources
+  ([resource.go](gh-file:pulumi#pkg/engine/lifecycletest/fuzzing/resource.go)),
+  including appropriate [providers](providers).
+  Resources may randomly depend on each other, and may have random properties,
+  such as whether they are [custom resources or components](custom-resources),
+  [pending replacement](step-generation-dependent-replacements), and so on.
+
+* Generate a program
+  ([program.go](gh-file:pulumi#pkg/engine/lifecycletest/fuzzing/program.go))
+  from the previously generated snapshot. The program may choose to
+  [register](resource-registration) any subset (including none) of the
+  resources in the snapshot, as well as any set of new resources before, in
+  between and after those specified in the snapshot. Resources from the snapshot
+  that are registered may be copied as-is or registered with different
+  properties.
+
+* Generate a set of provider implementations for the program
+  ([provider.go](gh-file:pulumi#pkg/engine/lifecycletest/fuzzing/provider.go)).
+  Provider operations such as [](pulumirpc.ResourceProvider.Create),
+  [](pulumirpc.ResourceProvider.Diff), etc. may be configured to fail randomly,
+  or return one of a set of random results (e.g. an update vs a replace for
+  `Diff`), on a per-resource basis.
+
+* Generate an operation (one of `preview`, `up`, `refresh` and `destroy`) and
+  associated configuration (such as a list of `--target`s), known in the test
+  suite as a *plan* to execute
+  ([plan.go](gh-file:pulumi#pkg/engine/lifecycletest/fuzzing/plan.go)).
+
+* Combine the snapshot, program, providers and plan to form a *fixture*
+  ([fixture.go](gh-file:pulumi#pkg/engine/lifecycletest/fuzzing/fixture.go)) and
+  execute it. If the operation yields a valid snapshot, the test passes, whether
+  the operation completes successfully or not. If an invalid snapshot is
+  produced, the test fails and the reproducing combination of snapshot, program,
+  providers and plan is returned for debugging.

--- a/pkg/engine/lifecycletest/fuzzing/fixture.go
+++ b/pkg/engine/lifecycletest/fuzzing/fixture.go
@@ -1,0 +1,118 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fuzzing
+
+import (
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// A set of options for configuring the generation of a fuzzing lifecycle test fixture. A fixture comprises a stack, an
+// initial snapshot, a program to execute against that snapshot, a set of providers to use when executing the program,
+// and a plan to execute and observe the results of.
+type FixtureOptions struct {
+	StackSpecOptions    StackSpecOptions
+	SnapshotSpecOptions SnapshotSpecOptions
+	ProgramSpecOptions  ProgramSpecOptions
+	ProviderSpecOptions ProviderSpecOptions
+	PlanSpecOptions     PlanSpecOptions
+}
+
+// Returns a copy of the FixtureOptions with the given overrides applied.
+func (fo FixtureOptions) With(overrides FixtureOptions) FixtureOptions {
+	fo.StackSpecOptions = fo.StackSpecOptions.With(overrides.StackSpecOptions)
+	fo.SnapshotSpecOptions = fo.SnapshotSpecOptions.With(overrides.SnapshotSpecOptions)
+	fo.ProgramSpecOptions = fo.ProgramSpecOptions.With(overrides.ProgramSpecOptions)
+	fo.ProviderSpecOptions = fo.ProviderSpecOptions.With(overrides.ProviderSpecOptions)
+	fo.PlanSpecOptions = fo.PlanSpecOptions.With(overrides.PlanSpecOptions)
+
+	return fo
+}
+
+// A default set of FixtureOptions.
+var defaultFixtureOptions = FixtureOptions{
+	StackSpecOptions:    defaultStackSpecOptions,
+	SnapshotSpecOptions: defaultSnapshotSpecOptions,
+	ProgramSpecOptions:  defaultProgramSpecOptions,
+	ProviderSpecOptions: defaultProviderSpecOptions,
+	PlanSpecOptions:     defaultPlanSpecOptions,
+}
+
+// Given a set of options, returns a Rapid property test function that generates and tests fixtures according to that
+// configuration.
+func GeneratedFixture(fo FixtureOptions) func(t *rapid.T) {
+	fo = defaultFixtureOptions.With(fo)
+
+	return func(t *rapid.T) {
+		snapSpec := GeneratedSnapshotSpec(fo.StackSpecOptions, fo.SnapshotSpecOptions).Draw(t, "SnapshotSpec")
+		progSpec := GeneratedProgramSpec(snapSpec, fo.StackSpecOptions, fo.ProgramSpecOptions).Draw(t, "ProgramSpec")
+		provSpec := GeneratedProviderSpec(progSpec, fo.ProviderSpecOptions).Draw(t, "ProviderSpec")
+		planSpec := GeneratedPlanSpec(snapSpec, fo.PlanSpecOptions).Draw(t, "PlanSpec")
+
+		inSnap := snapSpec.AsSnapshot()
+		require.NoError(t, inSnap.VerifyIntegrity(), "initial snapshot is not valid")
+
+		hostF := deploytest.NewPluginHostF(nil, nil, progSpec.AsLanguageRuntimeF(t), provSpec.AsProviderLoaders()...)
+
+		opOpts, op := planSpec.Executors(t, hostF)
+		opOpts.SkipDisplayTests = true
+
+		p := &lt.TestPlan{
+			Project: fo.StackSpecOptions.Project,
+			Stack:   fo.StackSpecOptions.Stack,
+		}
+		project := p.GetProject()
+
+		failWithSIE := func(err error) {
+			assert.Failf(
+				t,
+				"Encountered a snapshot integrity error",
+				`Error: %v
+%s
+%s
+%s
+%s
+`,
+				err,
+				snapSpec.Pretty(""),
+				progSpec.Pretty(""),
+				provSpec.Pretty(""),
+				planSpec.Pretty(""),
+			)
+		}
+
+		// Operations may fail for legitimate reasons -- e.g. we have configured a provider operation to fail, aborting
+		// execution. We thus only fail if we encounter an actual snapshot integrity error.
+		outSnap, err := op.RunStep(project, p.GetTarget(t, inSnap), opOpts, false, p.BackendClient, nil, "0")
+		if _, isSIE := deploy.AsSnapshotIntegrityError(err); isSIE {
+			failWithSIE(err)
+		}
+
+		// If for some reason the operation does not return an error, but the resulting snapshot is invalid, we'll fail in
+		// the same manner.
+		outSnapErr := outSnap.VerifyIntegrity()
+		if _, isSIE := deploy.AsSnapshotIntegrityError(outSnapErr); isSIE {
+			failWithSIE(outSnapErr)
+		}
+
+		// In all other cases, we expect errors to be "expected", or "bails" in our terminology.
+		assert.True(t, err == nil || result.IsBail(err), "unexpected error: %v", err)
+	}
+}

--- a/pkg/engine/lifecycletest/fuzzing/plan.go
+++ b/pkg/engine/lifecycletest/fuzzing/plan.go
@@ -1,0 +1,153 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fuzzing
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"pgregory.net/rapid"
+)
+
+// A PlanSpec specifies a lifecycle test operation that executes some program against an initial snapshot using a
+// configured set of providers.
+type PlanSpec struct {
+	// The operation that will be executed (e.g. update, refresh, destroy).
+	Operation OperationSpec
+	// The set of target URNs that will be passed to the operation, if any.
+	TargetURNs []resource.URN
+}
+
+// The type of operations that may be executed as part of a PlanSpec.
+type OperationSpec string
+
+const (
+	// An update operation.
+	PlanOperationUpdate OperationSpec = "plan.update"
+	// A refresh operation.
+	PlanOperationRefresh OperationSpec = "plan.refresh"
+	// A destroy operation.
+	PlanOperationDestroy OperationSpec = "plan.destroy"
+)
+
+// Returns a set of test options and a test operation that can be used to execute this PlanSpec as part of a lifecycle
+// test.
+func (ps *PlanSpec) Executors(t lt.TB, hostF deploytest.PluginHostFactory) (lt.TestUpdateOptions, lt.TestOp) {
+	opts := lt.TestUpdateOptions{
+		T:     t,
+		HostF: hostF,
+	}
+
+	if len(ps.TargetURNs) > 0 {
+		opts.UpdateOptions = engine.UpdateOptions{
+			Targets: deploy.NewUrnTargetsFromUrns(ps.TargetURNs),
+		}
+	}
+
+	var op lt.TestOp
+	switch ps.Operation {
+	case PlanOperationUpdate:
+		op = lt.TestOp(engine.Update)
+	case PlanOperationRefresh:
+		op = lt.TestOp(engine.Refresh)
+	case PlanOperationDestroy:
+		op = lt.TestOp(engine.Destroy)
+	}
+
+	return opts, op
+}
+
+// Implements PrettySpec.Pretty. Returns a human-readable string representation of this PlanSpec, suitable for use in
+// debugging output and error messages.
+func (ps *PlanSpec) Pretty(indent string) string {
+	rendered := fmt.Sprintf("%sPlan %p", indent, ps)
+	rendered += fmt.Sprintf("\n%s  Operation: %s", indent, ps.Operation)
+	if len(ps.TargetURNs) > 0 {
+		rendered += fmt.Sprintf("\n%s  Targets:", indent)
+		for _, urn := range ps.TargetURNs {
+			rendered += fmt.Sprintf("\n%s    %s", indent, Colored(urn))
+		}
+	} else {
+		rendered += fmt.Sprintf("\n%s  No targets", indent)
+	}
+
+	return rendered
+}
+
+// A set of options for configuring the generation of a PlanSpec.
+type PlanSpecOptions struct {
+	Operation   *rapid.Generator[OperationSpec]
+	TargetCount *rapid.Generator[int]
+}
+
+// Returns a copy of the given PlanSpecOptions with the given overrides applied.
+func (pso PlanSpecOptions) With(overrides PlanSpecOptions) PlanSpecOptions {
+	if overrides.Operation != nil {
+		pso.Operation = overrides.Operation
+	}
+	if overrides.TargetCount != nil {
+		pso.TargetCount = overrides.TargetCount
+	}
+
+	return pso
+}
+
+// A default set of PlanSpecOptions. By default, a PlanSpec will have a random operation and between 0 and 5 target
+// URNs.
+var defaultPlanSpecOptions = PlanSpecOptions{
+	Operation:   rapid.SampledFrom(operationSpecs),
+	TargetCount: rapid.IntRange(0, 5),
+}
+
+var operationSpecs = []OperationSpec{
+	PlanOperationUpdate,
+	PlanOperationRefresh,
+	PlanOperationDestroy,
+}
+
+// Given a SnapshotSpec and a set of options, returns a rapid.Generator that will produce PlanSpecs that can be executed
+// against the specified snapshot.
+func GeneratedPlanSpec(ss *SnapshotSpec, pso PlanSpecOptions) *rapid.Generator[*PlanSpec] {
+	pso = defaultPlanSpecOptions.With(pso)
+
+	return rapid.Custom(func(t *rapid.T) *PlanSpec {
+		op := pso.Operation.Draw(t, "PlanSpec.Operation")
+
+		seen := map[resource.URN]bool{}
+		targetURNs := []resource.URN{}
+
+		targetCount := pso.TargetCount.Draw(t, "PlanSpec.TargetCount")
+		for i := 0; i < targetCount; i++ {
+			candidate := rapid.SampledFrom(ss.Resources).Draw(t, fmt.Sprintf("PlanSpec.TargetResource[%d]", i))
+			if seen[candidate.URN()] {
+				continue
+			}
+
+			seen[candidate.URN()] = true
+			targetURNs = append(targetURNs, candidate.URN())
+		}
+
+		ps := &PlanSpec{
+			Operation:  op,
+			TargetURNs: targetURNs,
+		}
+
+		return ps
+	})
+}


### PR DESCRIPTION
Snapshot integrity errors are very problematic when they occur and can be hard to spot and prevent. To this end, #17213 outlines a plan to introduce [fuzzing](https://en.wikipedia.org/wiki/Fuzzing) to our suite of lifecycle tests in order to find cases and executions which might violate snapshot integrity. This commit extends the `fuzzing` package of the suite to support generating random fixtures and adds documentation for the tactics employed when doing so.

A fixture comprises an initial snapshot, a program to run against that initial snapshot, a set of providers to use during that program's execution, and an operation to run. Fixtures can then be generated as part of a Rapid property test, allowing us to fuzz random combinations in order to hunt down snapshot integrity issues.

Part of #17213