### PR TITLE
Nit: Use slice.Prealloc in slice.Map and slice.MapError

### DIFF
--- a/sdk/go/common/slice/slice.go
+++ b/sdk/go/common/slice/slice.go
@@ -26,9 +26,9 @@ func Prealloc[T any](capacity int) []T {
 
 // Map applies the given function to each element of the given slice and returns a new slice with the results.
 func Map[T, U any](s []T, f func(T) U) []U {
-	r := make([]U, len(s))
-	for i, v := range s {
-		r[i] = f(v)
+	r := Prealloc[U](len(s))
+	for _, v := range s {
+		r = append(r, f(v))
 	}
 	return r
 }
@@ -36,7 +36,7 @@ func Map[T, U any](s []T, f func(T) U) []U {
 // MapError applies the given function to each element of the given slice and returns a new slice with the
 // results. If any element returns an error that error is returned, as well as the slice of results so far.
 func MapError[T, U any](s []T, f func(T) (U, error)) ([]U, error) {
-	r := make([]U, 0, len(s))
+	r := Prealloc[U](len(s))
 	for _, v := range s {
 		var err error
 		u, err := f(v)


### PR DESCRIPTION
This handles the pathological case where the length of an input to Map or MapError is 0.