### PR TITLE
Generate reproductions for fuzz failures

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/README.md
+++ b/pkg/engine/lifecycletest/fuzzing/README.md
@@ -53,3 +53,16 @@ on them. The strategy we employ is thus as follows:
   the operation completes successfully or not. If an invalid snapshot is
   produced, the test fails and the reproducing combination of snapshot, program,
   providers and plan is returned for debugging.
+
+In the event that a failing test case is found, the reproducing fixture will be
+pretty printed to the screen and code for a reproducing test case will be
+written to a file to aid in debugging. See
+[fixture.go](gh-file:pulumi#pkg/engine/lifecycletest/fuzzing/fixture.go) and
+[reprogen.go](gh-file:pulumi#pkg/engine/lifecycletest/fuzzing/reprogen.go) for
+more details.
+
+:::{note}
+By default, reproduction test files will be written to a temporary directory. A
+specific directory can be configured using the
+`PULUMI_LIFECYCLE_TEST_FUZZING_REPRO_DIR` environment variable.
+:::

--- a/pkg/engine/lifecycletest/fuzzing/fixture.go
+++ b/pkg/engine/lifecycletest/fuzzing/fixture.go
@@ -15,6 +15,10 @@
 package fuzzing
 
 import (
+	"fmt"
+	"os"
+	"regexp"
+
 	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
@@ -81,20 +85,39 @@ func GeneratedFixture(fo FixtureOptions) func(t *rapid.T) {
 		project := p.GetProject()
 
 		failWithSIE := func(err error) {
+			// Try to generate code for a reproducing test. If we fail, we'll still report the snapshot integrity error and
+			// just inform the user that we couldn't write a reproduction for some reason.
+			reproTest := GenerateReproTest(t, fo.StackSpecOptions, snapSpec, progSpec, provSpec, planSpec)
+			reproFile, reproErr := writeReproTest(reproTest)
+
+			var reproMessage string
+			if reproErr != nil {
+				reproMessage = fmt.Sprintf("Error writing reproduction test case:\n\n%v", reproErr)
+			} else {
+				reproMessage = "Reproduction test case was written to %s" + reproFile
+			}
+
+			// To aid in debugging further, we'll color any URNs in the snapshot integrity error message using a regular
+			// expression. This is probably not perfect, but in practice it's really helpful.
+			coloredErr := urnPattern.ReplaceAllStringFunc(err.Error(), Colored)
+
 			assert.Failf(
 				t,
 				"Encountered a snapshot integrity error",
-				`Error: %v
+				`Error: %s
 %s
 %s
 %s
 %s
-`,
-				err,
+
+%s
+	`,
+				coloredErr,
 				snapSpec.Pretty(""),
 				progSpec.Pretty(""),
 				provSpec.Pretty(""),
 				planSpec.Pretty(""),
+				reproMessage,
 			)
 		}
 
@@ -115,4 +138,38 @@ func GeneratedFixture(fo FixtureOptions) func(t *rapid.T) {
 		// In all other cases, we expect errors to be "expected", or "bails" in our terminology.
 		assert.True(t, err == nil || result.IsBail(err), "unexpected error: %v", err)
 	}
+}
+
+// A regular expression pattern for matching URNs in error messages without slurping characters that might appear after
+// them such as commas, periods, or quotation marks.
+var urnPattern = regexp.MustCompile(`urn:pulumi:[^:]+::[^:]+::[^\s,.'"]+`)
+
+// writeReproTest writes the given string to a file in the directory specified by
+// PULUMI_LIFECYCLE_TEST_FUZZING_REPRO_DIR (which will be created if it does not exist), or to a temporary directory if
+// that environment variable is not set. Returns the path to the file written, or an error if one occurred at any point
+// during directory creation or the write.
+func writeReproTest(reproTest string) (string, error) {
+	reproDir := os.Getenv("PULUMI_LIFECYCLE_TEST_FUZZING_REPRO_DIR")
+	if reproDir != "" {
+		mkdirErr := os.MkdirAll(reproDir, 0o700)
+		if mkdirErr != nil {
+			return "", mkdirErr
+		}
+	}
+
+	reproFile, reproFileErr := os.CreateTemp(reproDir, "fuzzing_repro_test_*.go")
+	if reproFileErr != nil {
+		return "", reproFileErr
+	}
+
+	n, writeErr := reproFile.WriteString(reproTest)
+	if writeErr != nil {
+		return "", writeErr
+	}
+
+	if n != len(reproTest) {
+		return "", fmt.Errorf("wrote %d bytes to %s, expected %d", n, reproFile.Name(), len(reproTest))
+	}
+
+	return reproFile.Name(), nil
 }

--- a/pkg/engine/lifecycletest/fuzzing/reprogen.go
+++ b/pkg/engine/lifecycletest/fuzzing/reprogen.go
@@ -1,0 +1,641 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fuzzing
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+)
+
+// GenerateReproTest generates a string containing Go code for a lifecycle test that reproduces the scenario captured by
+// the given *Specs.
+func GenerateReproTest(
+	t lt.TB,
+	sso StackSpecOptions,
+	snapSpec *SnapshotSpec,
+	progSpec *ProgramSpec,
+	provSpec *ProviderSpec,
+	planSpec *PlanSpec,
+) string {
+	var b strings.Builder
+
+	writeHeader(&b)
+	writePackageImports(&b)
+
+	g := &generator{b: &b}
+	writeTestFunction(t, g, sso, snapSpec, progSpec, provSpec, planSpec)
+
+	return b.String()
+}
+
+// writeHeader writes the standard Pulumi license header to the given strings.Builder.
+func writeHeader(b *strings.Builder) {
+	year := time.Now().Year()
+
+	b.WriteString(fmt.Sprintf(`// Copyright %d, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+`, year))
+}
+
+// writePackageImports writes a superset of the imports that we'll need for a generated lifecycle test.
+func writePackageImports(b *strings.Builder) {
+	b.WriteString(`package lifecycletest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
+)
+`)
+}
+
+// generator encapsulates writing indented Go code to a strings.Builder.
+type generator struct {
+	// The underlying strings.Builder to write to.
+	b *strings.Builder
+	// The current indentation string (which will typically be a possibly empty series of tabs).
+	prefix string
+}
+
+// indent increases the indentation level of the generator.
+func (g *generator) indent() {
+	g.prefix += "\t"
+}
+
+// dedent decreases the indentation level of the generator.
+func (g *generator) dedent() {
+	g.prefix = g.prefix[:len(g.prefix)-1]
+}
+
+// writeLine writes a newline-prefixed line of Go code to the generator's strings.Builder, prefixed by the current
+// indentation level.
+func (g *generator) writeLine(s string) {
+	g.b.WriteString("\n" + g.prefix + s)
+}
+
+// writeBlock writes a newline-prefixed block of Go code to the generator's strings.Builder. The block's prefix and
+// suffix will be indented at the current level, while the block's contents will be indented one level deeper. For
+// example, the call:
+//
+//	writeBlock(
+//	  "func foo() {",
+//	  func(g *generator) {
+//	    g.writeLine("bar := 42")
+//	  },
+//	  "}",
+//	)
+//
+// will yield:
+//
+//	func foo() {
+//	  bar := 42
+//	}
+func (g *generator) writeBlock(
+	prefix string,
+	block func(g *generator),
+	suffix string,
+) {
+	g.writeLine(prefix)
+	g.indent()
+	block(g)
+	g.dedent()
+	g.writeLine(suffix)
+}
+
+// writeTestFunction writes a Go test function that reproduces the scenario captured by the given *Specs.
+func writeTestFunction(
+	t require.TestingT,
+	g *generator,
+	sso StackSpecOptions,
+	snapSpec *SnapshotSpec,
+	progSpec *ProgramSpec,
+	provSpec *ProviderSpec,
+	planSpec *PlanSpec,
+) {
+	g.writeBlock(
+		"func TestRepro(t *testing.T) {",
+		func(g *generator) {
+			g.writeLine("t.Parallel()")
+
+			g.writeLine("")
+			g.writeBlock(
+				"p := &lt.TestPlan{",
+				func(g *generator) {
+					g.writeLine(fmt.Sprintf(`Project: "%s",`, sso.Project))
+					g.writeLine(fmt.Sprintf(`Stack: "%s",`, sso.Stack))
+				},
+				"}",
+			)
+			g.writeLine("project := p.GetProject()")
+
+			g.writeLine("")
+			g.writeLine("// Set up the initial snapshot.")
+			g.writeBlock(
+				"setupLoaders := []*deploytest.ProviderLoader{",
+				writeSetupLoaderElements(provSpec),
+				"}",
+			)
+
+			g.writeLine("")
+			g.writeBlock(
+				"setupProgramF := deploytest.NewLanguageRuntimeF("+
+					"func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {",
+				writeResourceRegistrationStatements(t, snapSpec.Resources),
+				"})",
+			)
+
+			g.writeLine("")
+			g.writeLine("setupHostF := deploytest.NewPluginHostF(nil, nil, setupProgramF, setupLoaders...)")
+			g.writeBlock(
+				"setupOpts := lt.TestUpdateOptions{",
+				func(g *generator) {
+					g.writeLine("T: t,")
+					g.writeLine("HostF: setupHostF,")
+				},
+				"}",
+			)
+
+			g.writeLine("setupSnap, err := lt.TestOp(engine.Update)." +
+				"RunStep(project, p.GetTarget(t, nil), setupOpts, false, p.BackendClient, nil, \"0\")")
+			g.writeLine("require.NoError(t, err)")
+
+			g.writeLine("")
+			g.writeLine("// Set up the reproduction providers and program.")
+			g.writeBlock(
+				"createF := func(ctx context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {",
+				writeCreateFStatements(provSpec),
+				"}",
+			)
+			g.writeBlock(
+				"deleteF := func(ctx context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {",
+				writeDeleteFStatements(provSpec),
+				"}",
+			)
+			g.writeBlock(
+				"diffF := func(ctx context.Context, req plugin.DiffRequest) (plugin.DiffResponse, error) {",
+				writeDiffFStatements(provSpec),
+				"}",
+			)
+			g.writeBlock(
+				"readF := func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {",
+				writeReadFStatements(provSpec),
+				"}",
+			)
+			g.writeBlock(
+				"updateF := func(ctx context.Context, req plugin.UpdateRequest) (plugin.UpdateResponse, error) {",
+				writeUpdateFStatements(provSpec),
+				"}",
+			)
+
+			g.writeLine("")
+			g.writeBlock(
+				"reproLoaders := []*deploytest.ProviderLoader{",
+				writeReproLoaderElements(provSpec),
+				"}",
+			)
+
+			g.writeLine("")
+			g.writeBlock(
+				"reproProgramF := deploytest.NewLanguageRuntimeF("+
+					"func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {",
+				writeResourceRegistrationStatements(t, progSpec.ResourceRegistrations),
+				"})",
+			)
+
+			g.writeLine("")
+			g.writeLine("reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, reproLoaders...)")
+			g.writeBlock(
+				"reproOpts := lt.TestUpdateOptions{",
+				func(g *generator) {
+					g.writeLine("T: t,")
+					g.writeLine("HostF: reproHostF,")
+					g.writeBlock(
+						"UpdateOptions: engine.UpdateOptions{",
+						func(g *generator) {
+							if len(planSpec.TargetURNs) > 0 {
+								g.writeBlock(
+									"Targets: deploy.NewUrnTargets([]string{",
+									func(g *generator) {
+										for _, urn := range planSpec.TargetURNs {
+											g.writeLine(fmt.Sprintf(`"%s",`, urn))
+										}
+									},
+									"}),",
+								)
+							}
+						},
+						"},",
+					)
+				},
+				"}",
+			)
+
+			var operation string
+			switch planSpec.Operation {
+			case PlanOperationUpdate:
+				operation = "engine.Update"
+			case PlanOperationRefresh:
+				operation = "engine.Refresh"
+			case PlanOperationDestroy:
+				operation = "engine.Destroy"
+			}
+
+			g.writeLine("")
+			g.writeLine("// Trigger the reproduction.")
+			g.writeLine(fmt.Sprintf(
+				"reproSnap, err := "+
+					"lt.TestOp(%s).RunStep(project, p.GetTarget(t, setupSnap), reproOpts, false, p.BackendClient, nil, \"1\")",
+				operation,
+			))
+			g.writeLine("require.NoError(t, err)")
+		},
+		"}",
+	)
+}
+
+func writeSetupLoaderElements(provSpec *ProviderSpec) func(g *generator) {
+	return func(g *generator) {
+		pkgs := maps.Keys(provSpec.Packages)
+		slices.Sort(pkgs)
+
+		for _, pkg := range pkgs {
+			g.writeBlock(
+				fmt.Sprintf(
+					"deploytest.NewProviderLoader(\"%s\", semver.MustParse(\"1.0.0\"), func() (plugin.Provider, error) {",
+					pkg,
+				),
+				func(g *generator) {
+					g.writeLine("return &deploytest.Provider{}, nil")
+				},
+				"}),",
+			)
+		}
+	}
+}
+
+func writeResourceRegistrationStatements(t require.TestingT, rs []*ResourceSpec) func(g *generator) {
+	return func(g *generator) {
+		indicesByURN := map[resource.URN]int{}
+		varFor := func(urn resource.URN) string {
+			if i, has := indicesByURN[urn]; has {
+				return fmt.Sprintf("res%d", i)
+			}
+
+			return "resUnknown"
+		}
+
+		for i, r := range rs {
+			indicesByURN[r.URN()] = i
+
+			if r.Provider != "" {
+				ref, err := providers.ParseReference(r.Provider)
+				require.NoError(t, err)
+
+				g.writeLine(fmt.Sprintf(
+					"res%dProvRef, err := providers.NewReference(%[2]s.URN, %[2]s.ID)",
+					i, varFor(ref.URN()),
+				))
+				g.writeLine("require.NoError(t, err)")
+			}
+
+			g.writeBlock(
+				fmt.Sprintf(
+					"res%d, err := monitor.RegisterResource(\"%s\", \"%s\", %v, deploytest.ResourceOptions{",
+					i, r.Type, r.Name, r.Custom,
+				),
+				func(g *generator) {
+					if r.Delete {
+						g.writeLine("// You'll need to set up a means for Delete: true to be set on this resource")
+						g.writeLine("// Delete: true,")
+					}
+					if r.PendingReplacement {
+						g.writeLine("// You'll need to set up a means for PendingReplacement: true to be set on this resource")
+						g.writeLine("// PendingReplacement: true,")
+					}
+
+					if r.Protect {
+						g.writeLine("Protect: true,")
+					}
+					if r.RetainOnDelete {
+						g.writeLine("RetainOnDelete: true,")
+					}
+
+					if r.Provider != "" {
+						g.writeLine(fmt.Sprintf("Provider: res%dProvRef.String(),", i))
+					}
+
+					if r.Parent != "" {
+						g.writeLine(fmt.Sprintf("Parent: %s.URN,", varFor(r.Parent)))
+					}
+
+					if len(r.Dependencies) > 0 {
+						g.writeBlock(
+							"Dependencies: []resource.URN{",
+							func(g *generator) {
+								for _, dep := range r.Dependencies {
+									g.writeLine(varFor(dep) + ".URN,")
+								}
+							},
+							"},",
+						)
+					}
+
+					if len(r.PropertyDependencies) > 0 {
+						g.writeBlock(
+							"PropertyDeps: map[resource.PropertyKey][]resource.URN{",
+							func(g *generator) {
+								for k, deps := range r.PropertyDependencies {
+									g.writeBlock(
+										fmt.Sprintf("\"%s\": {", k),
+										func(g *generator) {
+											for _, dep := range deps {
+												g.writeLine(varFor(dep) + ".URN,")
+											}
+										},
+										"},",
+									)
+								}
+							},
+							"},",
+						)
+					}
+
+					if r.DeletedWith != "" {
+						g.writeLine(fmt.Sprintf("DeletedWith: %s.URN,", varFor(r.DeletedWith)))
+					}
+
+					if len(r.Aliases) > 0 {
+						g.writeBlock(
+							"AliasURNs: []resource.URN{",
+							func(g *generator) {
+								for _, alias := range r.Aliases {
+									g.writeLine(fmt.Sprintf("\"%s\",", alias))
+								}
+							},
+							"},",
+						)
+					}
+				},
+				"})",
+			)
+			g.writeLine("require.NoError(t, err)")
+			g.writeLine("")
+		}
+
+		g.writeLine("return nil")
+	}
+}
+
+func writeCreateFStatements(provSpec *ProviderSpec) func(g *generator) {
+	return func(g *generator) {
+		if len(provSpec.Create) > 0 {
+			g.writeLine("switch req.URN {")
+			for urn := range provSpec.Create {
+				g.writeBlock(
+					fmt.Sprintf("case \"%s\":", urn),
+					func(g *generator) {
+						g.writeBlock(
+							"return plugin.CreateResponse{",
+							func(g *generator) {
+								g.writeLine("Status: resource.StatusUnknown,")
+							},
+							"}, fmt.Errorf(\"create failure for %s\", req.URN)",
+						)
+					},
+					"",
+				)
+			}
+			g.writeLine("}")
+		}
+
+		g.writeBlock(
+			"return plugin.CreateResponse{",
+			func(g *generator) {
+				g.writeLine("Properties: req.Properties,")
+				g.writeLine("Status: resource.StatusOK,")
+			},
+			"}, nil",
+		)
+	}
+}
+
+func writeDeleteFStatements(provSpec *ProviderSpec) func(g *generator) {
+	return func(g *generator) {
+		if len(provSpec.Delete) > 0 {
+			g.writeLine("switch req.URN {")
+			for urn := range provSpec.Delete {
+				g.writeBlock(
+					fmt.Sprintf("case \"%s\":", urn),
+					func(g *generator) {
+						g.writeBlock(
+							"return plugin.DeleteResponse{",
+							func(g *generator) {
+								g.writeLine("Status: resource.StatusUnknown,")
+							},
+							"}, fmt.Errorf(\"delete failure for %s\", req.URN)",
+						)
+					},
+					"",
+				)
+			}
+			g.writeLine("}")
+		}
+
+		g.writeBlock(
+			"return plugin.DeleteResponse{",
+			func(g *generator) {
+				g.writeLine("Status: resource.StatusOK,")
+			},
+			"}, nil",
+		)
+	}
+}
+
+func writeDiffFStatements(provSpec *ProviderSpec) func(g *generator) {
+	return func(g *generator) {
+		if len(provSpec.Diff) > 0 {
+			g.writeLine("switch req.URN {")
+			for urn, action := range provSpec.Diff {
+				g.writeBlock(
+					fmt.Sprintf("case \"%s\":", urn),
+					func(g *generator) {
+						switch action {
+						case ProviderDiffDeleteBeforeReplace:
+							g.writeBlock(
+								"return plugin.DiffResponse{",
+								func(g *generator) {
+									g.writeLine("Changes: plugin.DiffSome,")
+									g.writeLine("ReplaceKeys: []resource.PropertyKey{\"__replace\"},")
+									g.writeLine("DeleteBeforeReplace: true,")
+								},
+								"}, nil",
+							)
+						case ProviderDiffDeleteAfterReplace:
+							g.writeBlock(
+								"return plugin.DiffResponse{",
+								func(g *generator) {
+									g.writeLine("Changes: plugin.DiffSome,")
+									g.writeLine("ReplaceKeys: []resource.PropertyKey{\"__replace\"},")
+									g.writeLine("DeleteBeforeReplace: false,")
+								},
+								"}, nil",
+							)
+						case ProviderDiffChange:
+							g.writeLine("return plugin.DiffResponse{Changes: plugin.DiffSome}, nil")
+						case ProviderDiffFailure:
+							g.writeLine("return plugin.DiffResponse{}, fmt.Errorf(\"diff failure for %s\", req.URN)")
+						}
+					},
+					"",
+				)
+			}
+			g.writeLine("}")
+		}
+
+		g.writeLine("return plugin.DiffResponse{}, nil")
+	}
+}
+
+func writeReadFStatements(provSpec *ProviderSpec) func(g *generator) {
+	return func(g *generator) {
+		if len(provSpec.Read) > 0 {
+			g.writeLine("switch req.URN {")
+			for urn, action := range provSpec.Read {
+				g.writeBlock(
+					fmt.Sprintf("case \"%s\":", urn),
+					func(g *generator) {
+						switch action {
+						case ProviderReadDeleted:
+							g.writeLine("return plugin.ReadResponse{}, nil")
+						case ProviderReadFailure:
+							g.writeBlock(
+								"return plugin.ReadResponse{",
+								func(g *generator) {
+									g.writeLine("Status: resource.StatusUnknown,")
+								},
+								"}, fmt.Errorf(\"read failure for %s\", req.URN)",
+							)
+						}
+					},
+					"",
+				)
+			}
+			g.writeLine("}")
+		}
+
+		g.writeBlock(
+			"return plugin.ReadResponse{",
+			func(g *generator) {
+				g.writeLine("ReadResult: plugin.ReadResult{Outputs: resource.PropertyMap{}},")
+				g.writeLine("Status: resource.StatusOK,")
+			},
+			"}, nil",
+		)
+	}
+}
+
+func writeUpdateFStatements(provSpec *ProviderSpec) func(g *generator) {
+	return func(g *generator) {
+		if len(provSpec.Update) > 0 {
+			g.writeLine("switch req.URN {")
+			for urn := range provSpec.Update {
+				g.writeBlock(
+					fmt.Sprintf("case \"%s\":", urn),
+					func(g *generator) {
+						g.writeBlock(
+							"return plugin.UpdateResponse{",
+							func(g *generator) {
+								g.writeLine("Status: resource.StatusUnknown,")
+							},
+							"}, fmt.Errorf(\"update failure for %s\", req.URN)",
+						)
+					},
+					"",
+				)
+			}
+			g.writeLine("}")
+		}
+
+		g.writeBlock(
+			"return plugin.UpdateResponse{",
+			func(g *generator) {
+				g.writeLine("Properties: req.NewInputs,")
+				g.writeLine("Status: resource.StatusOK,")
+			},
+			"}, nil",
+		)
+	}
+}
+
+func writeReproLoaderElements(provSpec *ProviderSpec) func(g *generator) {
+	return func(g *generator) {
+		pkgs := maps.Keys(provSpec.Packages)
+		slices.Sort(pkgs)
+
+		for _, pkg := range pkgs {
+			g.writeBlock(
+				fmt.Sprintf(
+					"deploytest.NewProviderLoader(\"%s\", semver.MustParse(\"1.0.0\"), func() (plugin.Provider, error) {",
+					pkg,
+				),
+				func(g *generator) {
+					g.writeBlock(
+						"return &deploytest.Provider{",
+						func(g *generator) {
+							g.writeLine("CreateF: createF,")
+							g.writeLine("DeleteF: deleteF,")
+							g.writeLine("DiffF: diffF,")
+							g.writeLine("ReadF: readF,")
+							g.writeLine("UpdateF: updateF,")
+						},
+						"}, nil",
+					)
+				},
+				"}),",
+			)
+		}
+	}
+}


### PR DESCRIPTION
In #17623 and the PRs that followed it, we added fuzz testing capabilities to the engine's lifecycle test suite, with a view to randomly generating test cases in the hopes of proactively finding snapshot integrity bugs in our code. This commit extends the fuzzing library to generate a reproducing lifecycle test case in the event that a snapshot integrity error is found, hopefully aiding in debugging and pinning down the exact cause of the error. Code is written to a file in a temporary directory, which may optionally be overridden using an environment variable. This might be useful in e.g. a GitHub action that fuzzes periodically so that failing cases' reproductions can be made available as artifacts for download.

Part of #17213