### PR TITLE
Avoid race conditions when providers start up

### DIFF
--- a/pkg/resource/provider/host.go
+++ b/pkg/resource/provider/host.go
@@ -36,11 +36,15 @@ type HostClient struct {
 	client pulumirpc.EngineClient
 }
 
+// Provider client is sensitive to GRPC info logging to stdout, so ensure they are dropped.
+// See https://github.com/pulumi/pulumi/issues/7156
+//
+// grpclog.SetLoggerV2 sets global state, and thus must be called before any gRPC
+// connection is initiated. To avoid race conditions, we call it when the package loads.
+func init() { grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, os.Stderr)) }
+
 // NewHostClient dials the target address, connects over gRPC, and returns a client interface.
 func NewHostClient(addr string) (*HostClient, error) {
-	// Provider client is sensitive to GRPC info logging to stdout, so ensure they are dropped.
-	// See https://github.com/pulumi/pulumi/issues/7156
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, os.Stderr))
 	conn, err := grpc.Dial(
 		addr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),


### PR DESCRIPTION
This allows the bridge to run integration tests with `-race` set:

```
go test -test.run \^TestConfigureSimpleValues/int\$ -race 
==================
WARNING: DATA RACE
Write at 0x000104301860 by goroutine 131:
  google.golang.org/grpc/grpclog.SetLoggerV2()
      /Users/ianwahbe/go/pkg/mod/google.golang.org/grpc@v1.66.2/grpclog/loggerv2.go:39 +0x128
  github.com/pulumi/pulumi/pkg/v3/resource/provider.NewHostClient()
      /Users/ianwahbe/go/pkg/mod/github.com/pulumi/pulumi/pkg/v3@v3.137.0/resource/provider/host.go:43 +0x30
  github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge.(*Provider).Attach()
      /Users/ianwahbe/go/src/github.com/pulumi/pulumi-terraform-bridge/pkg/tfbridge/provider.go:350 +0x58
  github.com/pulumi/pulumi/sdk/v3/proto/go._ResourceProvider_Attach_Handler()
      /Users/ianwahbe/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.137.0/proto/go/provider_grpc.pb.go:782 +0x248
  google.golang.org/grpc.(*Server).processUnaryRPC()
      /Users/ianwahbe/go/pkg/mod/google.golang.org/grpc@v1.66.2/server.go:1394 +0x13d8
  google.golang.org/grpc.(*Server).handleStream()
      /Users/ianwahbe/go/pkg/mod/google.golang.org/grpc@v1.66.2/server.go:1805 +0x11a0
  google.golang.org/grpc.(*Server).serveStreams.func2.1()
      /Users/ianwahbe/go/pkg/mod/google.golang.org/grpc@v1.66.2/server.go:1029 +0xe8

Previous read at 0x000104301860 by goroutine 85:
  google.golang.org/grpc/grpclog.V()
      /Users/ianwahbe/go/pkg/mod/google.golang.org/grpc@v1.66.2/grpclog/grpclog.go:38 +0x2c
  google.golang.org/grpc/grpclog.(*componentData).V()
      /Users/ianwahbe/go/pkg/mod/google.golang.org/grpc@v1.66.2/grpclog/component.go:101 +0x18
  google.golang.org/grpc/internal/grpclog.(*PrefixLogger).V()
      /Users/ianwahbe/go/pkg/mod/google.golang.org/grpc@v1.66.2/internal/grpclog/prefix_logger.go:71 +0xa8
  google.golang.org/grpc/internal/transport.(*http2Server).Close()
      /Users/ianwahbe/go/pkg/mod/google.golang.org/grpc@v1.66.2/internal/transport/http2_server.go:1259 +0x68
  google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams()
      /Users/ianwahbe/go/pkg/mod/google.golang.org/grpc@v1.66.2/internal/transport/http2_server.go:666 +0x790
  google.golang.org/grpc.(*Server).serveStreams()
      /Users/ianwahbe/go/pkg/mod/google.golang.org/grpc@v1.66.2/server.go:1023 +0x4dc
  google.golang.org/grpc.(*Server).handleRawConn.func1()
      /Users/ianwahbe/go/pkg/mod/google.golang.org/grpc@v1.66.2/server.go:958 +0x7c

Goroutine 131 (running) created at:
  google.golang.org/grpc.(*Server).serveStreams.func2()
      /Users/ianwahbe/go/pkg/mod/google.golang.org/grpc@v1.66.2/server.go:1040 +0x1e4
  google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders()
      /Users/ianwahbe/go/pkg/mod/google.golang.org/grpc@v1.66.2/internal/transport/http2_server.go:630 +0x29d0
  google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams()
      /Users/ianwahbe/go/pkg/mod/google.golang.org/grpc@v1.66.2/internal/transport/http2_server.go:671 +0x30c
  google.golang.org/grpc.(*Server).serveStreams()
      /Users/ianwahbe/go/pkg/mod/google.golang.org/grpc@v1.66.2/server.go:1023 +0x4dc
  google.golang.org/grpc.(*Server).handleRawConn.func1()
      /Users/ianwahbe/go/pkg/mod/google.golang.org/grpc@v1.66.2/server.go:958 +0x7c

Goroutine 85 (finished) created at:
  google.golang.org/grpc.(*Server).handleRawConn()
      /Users/ianwahbe/go/pkg/mod/google.golang.org/grpc@v1.66.2/server.go:957 +0x2b0
  google.golang.org/grpc.(*Server).Serve.func3()
      /Users/ianwahbe/go/pkg/mod/google.golang.org/grpc@v1.66.2/server.go:926 +0x78
==================
--- FAIL: TestConfigureSimpleValues (0.00s)
    --- FAIL: TestConfigureSimpleValues/int (1.29s)
        tfcheck.go:118: HCL: 
            provider "crossprovider" {
              f0 = 123456
            }
            resource "crossprovider_test_res" "res" {
            }
            
        exec.go:27: terraform plan -refresh=false -out /var/folders/fg/_1q36r4j6yx0rwz2fbhjd5y40000gn/T/TestConfigureSimpleValuesint4104132823/001/test.tfplan -no-color
        exec.go:36: error from `terraform plan -refresh=false -out /var/folders/fg/_1q36r4j6yx0rwz2fbhjd5y40000gn/T/TestConfigureSimpleValuesint4104132823/001/test.tfplan -no-color`
            
            Stdout:
            
            Terraform used the selected providers to generate the following execution
            plan. Resource actions are indicated with the following symbols:
              + create
            
            Terraform will perform the following actions:
            
              # crossprovider_test_res.res will be created
              + resource "crossprovider_test_res" "res" {
                  + id = (known after apply)
                }
            
            Plan: 1 to add, 0 to change, 0 to destroy.
            
            ─────────────────────────────────────────────────────────────────────────────
            
            Saved the plan to:
            /var/folders/fg/_1q36r4j6yx0rwz2fbhjd5y40000gn/T/TestConfigureSimpleValuesint4104132823/001/test.tfplan
            
            To perform exactly these actions, run the following command to apply:
                terraform apply "/var/folders/fg/_1q36r4j6yx0rwz2fbhjd5y40000gn/T/TestConfigureSimpleValuesint4104132823/001/test.tfplan"
            
            
            Stderr:
            
            
        exec.go:27: terraform show -json /var/folders/fg/_1q36r4j6yx0rwz2fbhjd5y40000gn/T/TestConfigureSimpleValuesint4104132823/001/test.tfplan
        exec.go:36: error from `terraform show -json /var/folders/fg/_1q36r4j6yx0rwz2fbhjd5y40000gn/T/TestConfigureSimpleValuesint4104132823/001/test.tfplan`
            
            Stdout:
            {"format_version":"1.2","terraform_version":"1.9.7","planned_values":{"root_module":{"resources":[{"address":"crossprovider_test_res.res","mode":"managed","type":"crossprovider_test_res","name":"res","provider_name":"registry.terraform.io/hashicorp/crossprovider","schema_version":0,"sensitive_values":{}}]}},"resource_changes":[{"address":"crossprovider_test_res.res","mode":"managed","type":"crossprovider_test_res","name":"res","provider_name":"registry.terraform.io/hashicorp/crossprovider","change":{"actions":["create"],"before":null,"after":{},"after_unknown":{"id":true},"before_sensitive":false,"after_sensitive":{}}}],"configuration":{"provider_config":{"crossprovider":{"name":"crossprovider","full_name":"registry.terraform.io/hashicorp/crossprovider","expressions":{"f0":{"constant_value":123456}}}},"root_module":{"resources":[{"address":"crossprovider_test_res.res","mode":"managed","type":"crossprovider_test_res","name":"res","provider_config_key":"crossprovider","schema_version":0}]}},"timestamp":"2024-10-31T16:48:22Z","applyable":true,"complete":true,"errored":false}
            
            
            Stderr:
            
            
        exec.go:27: terraform apply -auto-approve -refresh=false /var/folders/fg/_1q36r4j6yx0rwz2fbhjd5y40000gn/T/TestConfigureSimpleValuesint4104132823/001/test.tfplan
        exec.go:36: error from `terraform apply -auto-approve -refresh=false /var/folders/fg/_1q36r4j6yx0rwz2fbhjd5y40000gn/T/TestConfigureSimpleValuesint4104132823/001/test.tfplan`
            
            Stdout:
            crossprovider_test_res.res: Creating...
            crossprovider_test_res.res: Creation complete after 0s [id=id]
            
            Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
            
            
            Stderr:
            
            
        configure.go:136: 
            
            backend:
                url: file://./data
            name: project
            resources:
                example:
                    properties:
                        f0: 123456
                    type: pulumi:providers:crossprovider
                res:
                    properties: {}
                    type: crosstests:Res
            runtime: yaml
        pu_driver.go:35: 
            
            backend:
                url: file://./data
            name: project
            resources:
                example:
                    properties:
                        f0: 123456
                    type: pulumi:providers:crossprovider
            runtime: yaml
        pulcheck.go:221: PULUMI_BACKEND_URL=file:///var/folders/fg/_1q36r4j6yx0rwz2fbhjd5y40000gn/T/TestConfigureSimpleValuesint1750830720/001
        pulcheck.go:221: PULUMI_DEBUG_GRPC=/var/folders/fg/_1q36r4j6yx0rwz2fbhjd5y40000gn/T/TestConfigureSimpleValuesint1750830720/002/grpc.json
        pulcheck.go:221: starting providers
        pulcheck.go:221: creating stack test
        configure.go:142: deploying
        testing.go:1399: race detected during execution of test
        pulcheck.go:221: refusing to destroy stack at "/var/folders/fg/_1q36r4j6yx0rwz2fbhjd5y40000gn/T/TestConfigureSimpleValuesint4104132823/002" to help debug the failing test
        pulcheck.go:221: TempDir leaving backendDir to help debugging: "/var/folders/fg/_1q36r4j6yx0rwz2fbhjd5y40000gn/T/TestConfigureSimpleValuesint1750830720"
FAIL
exit status 1
FAIL	github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tests	1.909s

Compilation exited abnormally with code 1 at Thu Oct 31 17:48:23, duration 6.92 s
```