### PR TITLE
Pass ESC Environments on stack update

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -316,6 +316,9 @@ type QueryOperation struct {
 
 // StackConfiguration holds the configuration for a stack and it's associated decrypter.
 type StackConfiguration struct {
+	// List of ESC environments imported by the stack being updated.
+	EnvironmentImports []string
+
 	Environment esc.Value
 	Config      config.Map
 	Decrypter   config.Decrypter

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -1455,9 +1455,10 @@ func getStackConfigurationFromProjectStack(
 	// the correct decrypter for the diy backend would involve prompting for a passphrase)
 	if !needsCrypter(workspaceStack.Config, pulumiEnv) {
 		return backend.StackConfiguration{
-			Environment: pulumiEnv,
-			Config:      workspaceStack.Config,
-			Decrypter:   config.NewPanicCrypter(),
+			EnvironmentImports: workspaceStack.Environment.Imports(),
+			Environment:        pulumiEnv,
+			Config:             workspaceStack.Config,
+			Decrypter:          config.NewPanicCrypter(),
 		}, nil
 	}
 
@@ -1467,9 +1468,10 @@ func getStackConfigurationFromProjectStack(
 	}
 
 	return backend.StackConfiguration{
-		Environment: pulumiEnv,
-		Config:      workspaceStack.Config,
-		Decrypter:   crypter,
+		EnvironmentImports: workspaceStack.Environment.Imports(),
+		Environment:        pulumiEnv,
+		Config:             workspaceStack.Config,
+		Decrypter:          crypter,
 	}, nil
 }
 

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -202,11 +202,6 @@ func newDestroyCmd() *cobra.Command {
 				return err
 			}
 
-			m, err := getUpdateMetadata(message, root, execKind, execAgent, false, cmd.Flags())
-			if err != nil {
-				return fmt.Errorf("gathering environment metadata: %w", err)
-			}
-
 			getConfig := getStackConfiguration
 			if stackName != "" {
 				// `pulumi destroy --stack <stack>` can be run outside of the project directory.
@@ -216,6 +211,11 @@ func newDestroyCmd() *cobra.Command {
 			cfg, sm, err := getConfig(ctx, ssml, s, proj)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
+			}
+
+			m, err := getUpdateMetadata(message, root, execKind, execAgent, false, cfg, cmd.Flags())
+			if err != nil {
+				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
 
 			decrypter, err := sm.Decrypter()

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -904,14 +904,14 @@ func newImportCmd() *cobra.Command {
 				}
 			}
 
-			m, err := getUpdateMetadata(message, root, execKind, execAgent, false, cmd.Flags())
-			if err != nil {
-				return fmt.Errorf("gathering environment metadata: %w", err)
-			}
-
 			cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
+			}
+
+			m, err := getUpdateMetadata(message, root, execKind, execAgent, false, cfg, cmd.Flags())
+			if err != nil {
+				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
 
 			decrypter, err := sm.Decrypter()

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -378,14 +378,14 @@ func newPreviewCmd() *cobra.Command {
 				return err
 			}
 
-			m, err := getUpdateMetadata(message, root, execKind, execAgent, planFilePath != "", cmd.Flags())
-			if err != nil {
-				return fmt.Errorf("gathering environment metadata: %w", err)
-			}
-
 			cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
+			}
+
+			m, err := getUpdateMetadata(message, root, execKind, execAgent, planFilePath != "", cfg, cmd.Flags())
+			if err != nil {
+				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
 
 			decrypter, err := sm.Decrypter()

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -179,14 +179,14 @@ func newRefreshCmd() *cobra.Command {
 				return err
 			}
 
-			m, err := getUpdateMetadata(message, root, execKind, execAgent, false, cmd.Flags())
-			if err != nil {
-				return fmt.Errorf("gathering environment metadata: %w", err)
-			}
-
 			cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
+			}
+
+			m, err := getUpdateMetadata(message, root, execKind, execAgent, false, cfg, cmd.Flags())
+			if err != nil {
+				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
 
 			decrypter, err := sm.Decrypter()

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -113,14 +113,14 @@ func newUpCmd() *cobra.Command {
 			return err
 		}
 
-		m, err := getUpdateMetadata(message, root, execKind, execAgent, planFilePath != "", cmd.Flags())
-		if err != nil {
-			return fmt.Errorf("gathering environment metadata: %w", err)
-		}
-
 		cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
 		if err != nil {
 			return fmt.Errorf("getting stack configuration: %w", err)
+		}
+
+		m, err := getUpdateMetadata(message, root, execKind, execAgent, planFilePath != "", cfg, cmd.Flags())
+		if err != nil {
+			return fmt.Errorf("gathering environment metadata: %w", err)
 		}
 
 		decrypter, err := sm.Decrypter()
@@ -367,14 +367,14 @@ func newUpCmd() *cobra.Command {
 			return err
 		}
 
-		m, err := getUpdateMetadata(message, root, execKind, execAgent, planFilePath != "", cmd.Flags())
-		if err != nil {
-			return fmt.Errorf("gathering environment metadata: %w", err)
-		}
-
 		cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
 		if err != nil {
 			return fmt.Errorf("getting stack configuration: %w", err)
+		}
+
+		m, err := getUpdateMetadata(message, root, execKind, execAgent, planFilePath != "", cfg, cmd.Flags())
+		if err != nil {
+			return fmt.Errorf("gathering environment metadata: %w", err)
 		}
 
 		decrypter, err := sm.Decrypter()

--- a/pkg/cmd/pulumi/util_test.go
+++ b/pkg/cmd/pulumi/util_test.go
@@ -470,6 +470,17 @@ func TestPulumiCLIMetadata(t *testing.T) {
 	}, actualEnv)
 }
 
+func TestAddEscMetadataToEnvironment(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]string{}
+
+	addEscMetadataToEnvironment(env, []string{"proj/env1", "proj/env2@stable"})
+
+	expected := "[{\"name\":\"proj/env1\"},{\"name\":\"proj/env2@stable\"}]"
+	assert.Equal(t, expected, env[backend.StackEnvironments])
+}
+
 // Tests that createStack will send an appropriate initial state when it is asked to create a stack with a non-default
 // secrets manager.
 func TestCreateStack_InitialisesStateWithSecretsManager(t *testing.T) {

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -108,14 +108,14 @@ func newWatchCmd() *cobra.Command {
 				return err
 			}
 
-			m, err := getUpdateMetadata(message, root, execKind, "" /* execAgent */, false, cmd.Flags())
-			if err != nil {
-				return fmt.Errorf("gathering environment metadata: %w", err)
-			}
-
 			cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
+			}
+
+			m, err := getUpdateMetadata(message, root, execKind, "" /* execAgent */, false, cfg, cmd.Flags())
+			if err != nil {
+				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
 
 			decrypter, err := sm.Decrypter()


### PR DESCRIPTION
Related: https://github.com/pulumi/pulumi-service/pull/23672

We want to be able to track which ESC environments are depended on by which stacks on the cloud side, so this passes the list of imported envs as metadata on stack update