### PR TITLE
Remove unused id-token: write permission ci-build-binaries

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -58,9 +58,6 @@ jobs:
     name: ${{ inputs.os }}-${{ inputs.arch }}
     runs-on: ${{ inputs.build-platform }}
 
-    permissions:
-      id-token: write
-
     steps:
       - name: "Windows cache workaround"
         # https://github.com/actions/cache/issues/752#issuecomment-1222415717


### PR DESCRIPTION
While working on https://github.com/pulumi/pulumi/pull/17364 I ran into this, and this permission seems unused.