### PR TITLE
plugin download: also invalidate GITHUB_TOKEN on 403

### DIFF
--- a/changelog/pending/20241104--engine--disable-the-enviromental-github_token-on-403-responses.yaml
+++ b/changelog/pending/20241104--engine--disable-the-enviromental-github_token-on-403-responses.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Disable the enviromental GITHUB_TOKEN on 403 responses

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -452,10 +452,12 @@ func (source *githubSource) getHTTPResponse(
 	}
 
 	// We handle error responoses differently here based on the type:
-	// - 403 errors that are also rate limit errors (x-ratelimit-remaining is 0) are wrapped in a more helpful message later.
-	// - If the user has a GITHUB_TOKEN set, 401s and 403s (that are not rate limit errors) are handled by disabling the token
-	//   and trying again.  This can be useful for example if the user has a fine grained token, which when set doesn't allow
-	//   access to public repositories.
+	// - 403 errors that are also rate limit errors (x-ratelimit-remaining is 0) are wrapped in a more helpful message
+	//   later.
+	// - If the user has a GITHUB_TOKEN set, 401s and 403s (that are not rate limit errors) are handled by disabling
+	//   the token
+	//   and trying again.  This can be useful for example if the user has a fine grained token, which when set doesn't
+	//   allow access to public repositories.
 	// All other errors are returned as is.
 	var downErr *downloadError
 	if !errors.As(err, &downErr) || !isRateLimitError(downErr) {

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -453,7 +453,6 @@ func (source *githubSource) getHTTPResponse(
 	var downErr *downloadError
 	if !errors.As(err, &downErr) || downErr.code != 403 || downErr.header.Get("x-ratelimit-remaining") != "0" {
 		// If we see a 401 error and we're using a token we'll disable that token and try again
-		fmt.Println(err, downErr)
 		if downErr != nil && (downErr.code == 401 || downErr.code == 403) && source.token != "" {
 			source.token = ""
 			source.tokenDisabled = true

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -755,16 +755,13 @@ func TestPluginDownload(t *testing.T) {
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			attempts++
 
-			fmt.Println("req.Header.Get(\"Authorization\")", req.Header.Get("Authorization"))
 			if req.Header.Get("Authorization") == "token "+token {
-				fmt.Println("fail forbidden")
 				// Fail with a 403 Forbidden
 				return nil, -1, &downloadError{
 					code:   403,
 					header: http.Header{"x-ratelimit-remaining": []string{"42"}},
 				}
 			}
-			fmt.Println("req.URL.String()", req.URL.String())
 
 			if req.URL.String() == "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/tags/v5.32.0" {
 				assert.Equal(t, "", req.Header.Get("Authorization"))

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -740,6 +740,63 @@ func TestPluginDownload(t *testing.T) {
 		assert.Equal(t, int(l), len(readBytes))
 		assert.Equal(t, expectedBytes, readBytes)
 	})
+	t.Run("GitHub Releases with disallowed", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", token)
+		version := semver.MustParse("5.32.0")
+		spec := PluginSpec{
+			PluginDownloadURL: "",
+			Name:              "mockdl",
+			Version:           &version,
+			Kind:              apitype.PluginKind("resource"),
+		}
+		source, err := spec.GetSource()
+		require.NoError(t, err)
+		attempts := 0
+		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
+			attempts++
+
+			fmt.Println("req.Header.Get(\"Authorization\")", req.Header.Get("Authorization"))
+			if req.Header.Get("Authorization") == "token "+token {
+				fmt.Println("fail forbidden")
+				// Fail with a 403 Forbidden
+				return nil, -1, &downloadError{
+					code:   403,
+					header: http.Header{"x-ratelimit-remaining": []string{"42"}},
+				}
+			}
+			fmt.Println("req.URL.String()", req.URL.String())
+
+			if req.URL.String() == "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/tags/v5.32.0" {
+				assert.Equal(t, "", req.Header.Get("Authorization"))
+				assert.Equal(t, "application/json", req.Header.Get("Accept"))
+				// Minimal JSON from the releases API to get the test to pass
+				return newMockReadCloserString(`{
+					"assets": [
+					  {
+						"url": "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/assets/654321",
+						"name": "pulumi-mockdl_5.32.0_checksums.txt"
+					  },
+					  {
+						"url": "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/assets/123456",
+						"name": "pulumi-resource-mockdl-v5.32.0-darwin-amd64.tar.gz"
+					  }
+					]
+				  }
+				`)
+			}
+
+			assert.Equal(t, "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/assets/123456", req.URL.String())
+			assert.Equal(t, "application/octet-stream", req.Header.Get("Accept"))
+			return newMockReadCloser(expectedBytes)
+		}
+		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
+		require.NoError(t, err)
+		readBytes, err := io.ReadAll(r)
+		require.NoError(t, err)
+		assert.Equal(t, 3, attempts) // Failed attempt, then two successful attempts, first for the tag then the asset.
+		assert.Equal(t, int(l), len(readBytes))
+		assert.Equal(t, expectedBytes, readBytes)
+	})
 }
 
 //nolint:paralleltest // mutates environment variables


### PR DESCRIPTION
Similar to what we did in https://github.com/pulumi/pulumi/pull/17351, we should also invalidate the GITHUB_TOKEN when the GitHub API returns a 403, which can happen in some cases when the token isn't valid.

Fixes https://github.com/pulumi/pulumi/issues/17217