### PR TITLE
exclude lifecycletest from codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -34,9 +34,10 @@ coverage:
         informational: true
 
 ignore:
-  # Integration tests and codegen test data
+  # Integration tests, lifecycle tests and codegen test data
   # should not count against coverage.
   - "tests/"
+  - "pkg/engine/lifecycletest/"
   - "pkg/codegen/testing/test/testdata"
 
   # Don't count protobuf-generated code against coverage.


### PR DESCRIPTION
Everything in the lifecycletest package is test code, and thus doesn't make a lot of sense to count against code coverage.  Exclude it.