### PR TITLE
Allow accessing configuration in Python dynamic providers

### DIFF
--- a/changelog/pending/20241104--sdk-python--allow-accessing-configuration-in-python-dynamic-providers.yaml
+++ b/changelog/pending/20241104--sdk-python--allow-accessing-configuration-in-python-dynamic-providers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Allow accessing configuration in Python dynamic providers

--- a/pkg/cmd/pulumi/package.go
+++ b/pkg/cmd/pulumi/package.go
@@ -176,7 +176,7 @@ func providerFromSource(packageSource string) (plugin.Provider, error) {
 	// No file separators, so we try to look up the schema
 	// On unix, these checks are identical. On windows, filepath.Separator is '\\'
 	if !strings.ContainsRune(descriptor.Name, filepath.Separator) && !strings.ContainsRune(descriptor.Name, '/') {
-		host, err := plugin.NewDefaultHost(pCtx, nil, false, nil, nil, nil)
+		host, err := plugin.NewDefaultHost(pCtx, nil, false, nil, nil, nil, "")
 		if err != nil {
 			return nil, err
 		}
@@ -232,7 +232,7 @@ func providerFromSource(packageSource string) (plugin.Provider, error) {
 		}
 	}
 
-	host, err := plugin.NewDefaultHost(pCtx, nil, false, nil, nil, nil)
+	host, err := plugin.NewDefaultHost(pCtx, nil, false, nil, nil, nil, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/deploy/target.go
+++ b/pkg/resource/deploy/target.go
@@ -30,10 +30,13 @@ type Target struct {
 }
 
 const (
+	// The package name for the NodeJS dynamic provider.
 	nodejsDynamicProviderPackage = "pulumi-nodejs"
+	// The package name for the Python dynamic provider.
 	pythonDynamicProviderPackage = "pulumi-python"
 )
 
+// Returns true if the given package refers to a dynamic provider.
 func isDynamicProvider(pkg tokens.Package) bool {
 	return pkg == tokens.Package(nodejsDynamicProviderPackage) || pkg == tokens.Package(pythonDynamicProviderPackage)
 }

--- a/pkg/resource/deploy/target.go
+++ b/pkg/resource/deploy/target.go
@@ -29,6 +29,15 @@ type Target struct {
 	Snapshot     *Snapshot        // the last snapshot deployed to the target.
 }
 
+const (
+	nodejsDynamicProviderPackage = "pulumi-nodejs"
+	pythonDynamicProviderPackage = "pulumi-python"
+)
+
+func isDynamicProvider(pkg tokens.Package) bool {
+	return pkg == tokens.Package(nodejsDynamicProviderPackage) || pkg == tokens.Package(pythonDynamicProviderPackage)
+}
+
 // GetPackageConfig returns the set of configuration parameters for the indicated package, if any.
 func (t *Target) GetPackageConfig(pkg tokens.Package) (resource.PropertyMap, error) {
 	result := resource.PropertyMap{}
@@ -37,7 +46,8 @@ func (t *Target) GetPackageConfig(pkg tokens.Package) (resource.PropertyMap, err
 	}
 
 	for k, c := range t.Config {
-		if tokens.Package(k.Namespace()) != pkg {
+		// For dynamic providers, we always pass the full configuration.
+		if !isDynamicProvider(pkg) && tokens.Package(k.Namespace()) != pkg {
 			continue
 		}
 
@@ -50,7 +60,12 @@ func (t *Target) GetPackageConfig(pkg tokens.Package) (resource.PropertyMap, err
 		if c.Secure() {
 			propertyValue = resource.MakeSecret(propertyValue)
 		}
-		result[resource.PropertyKey(k.Name())] = propertyValue
+		if isDynamicProvider(pkg) {
+			// For dynamic providers, we want to maintain the namespace.
+			result[resource.PropertyKey(k.String())] = propertyValue
+		} else {
+			result[resource.PropertyKey(k.Name())] = propertyValue
+		}
 	}
 	return result, nil
 }

--- a/sdk/go/common/resource/plugin/context.go
+++ b/sdk/go/common/resource/plugin/context.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -103,6 +104,15 @@ func NewContextWithContext(
 		statusD = diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
 	}
 
+	var projectName tokens.PackageName
+	projPath, err := workspace.DetectProjectPath()
+	if err == nil && projPath != "" {
+		project, err := workspace.LoadProject(projPath)
+		if err == nil {
+			projectName = project.Name
+		}
+	}
+
 	pctx := &Context{
 		Diag:            d,
 		StatusDiag:      statusD,
@@ -115,7 +125,7 @@ func NewContextWithContext(
 		baseContext:     ctx,
 	}
 	if host == nil {
-		h, err := NewDefaultHost(pctx, runtimeOptions, disableProviderPreview, plugins, config, debugging)
+		h, err := NewDefaultHost(pctx, runtimeOptions, disableProviderPreview, plugins, config, debugging, projectName)
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -99,7 +99,7 @@ type Host interface {
 // NewDefaultHost implements the standard plugin logic, using the standard installation root to find them.
 func NewDefaultHost(ctx *Context, runtimeOptions map[string]interface{},
 	disableProviderPreview bool, plugins *workspace.Plugins, config map[config.Key]string,
-	debugging DebugEventEmitter,
+	debugging DebugEventEmitter, projectName tokens.PackageName,
 ) (Host, error) {
 	// Create plugin info from providers
 	projectPlugins := make([]workspace.ProjectPlugin, 0)
@@ -141,6 +141,7 @@ func NewDefaultHost(ctx *Context, runtimeOptions map[string]interface{},
 		closer:                  new(sync.Once),
 		projectPlugins:          projectPlugins,
 		debugging:               debugging,
+		projectName:             projectName,
 	}
 
 	// Fire up a gRPC server to listen for requests.  This acts as a RPC interface that plugins can use
@@ -243,6 +244,7 @@ type defaultHost struct {
 	server                  *hostServer                      // the server's RPC machinery.
 	disableProviderPreview  bool                             // true if provider plugins should disable provider preview
 	config                  map[config.Key]string            // the configuration map for the stack, if any.
+	projectName             tokens.PackageName               // name of the project
 	debugging               DebugEventEmitter
 
 	// Used to synchronize shutdown with in-progress plugin loads.
@@ -396,7 +398,7 @@ func (host *defaultHost) Provider(descriptor workspace.PackageDescriptor) (Provi
 
 		plug, err := NewProvider(
 			host, host.ctx, tokens.Package(pkg), version,
-			host.runtimeOptions, host.disableProviderPreview, string(jsonConfig))
+			host.runtimeOptions, host.disableProviderPreview, string(jsonConfig), host.projectName)
 		if err == nil && plug != nil {
 			info, infoerr := plug.GetPluginInfo(host.ctx.Request())
 			if infoerr != nil {

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -166,12 +166,6 @@ func NewProvider(host Host, ctx *Context, pkg tokens.Package, version *semver.Ve
 			env = append(env, fmt.Sprintf("PULUMI_RUNTIME_%s=%v", strings.ToUpper(k), v))
 		}
 		if projectName != "" {
-			if pkg == tokens.Package(nodejsDynamicProviderType) {
-				// The Node.js SDK uses PULUMI_NODEJS_PROJECT to set the project name.
-				// Eventually, we should standardize on PULUMI_PROJECT for all SDKs.
-				// Also see `constructEnv` in sdk/go/common/resource/plugin/analyzer_plugin.go
-				env = append(env, fmt.Sprintf("PULUMI_NODEJS_PROJECT=%s", projectName))
-			}
 			env = append(env, fmt.Sprintf("PULUMI_PROJECT=%s", projectName))
 		}
 		if jsonConfig != "" {

--- a/sdk/python/lib/pulumi/dynamic/__init__.py
+++ b/sdk/python/lib/pulumi/dynamic/__init__.py
@@ -18,6 +18,7 @@ Dynamic Providers for Python.
 
 # Make all module members inside of this package available as package members.
 from .dynamic import (
+    ConfigureRequest,
     CheckResult,
     CheckFailure,
     DiffResult,
@@ -28,7 +29,12 @@ from .dynamic import (
     ResourceProvider,
 )
 
+from .config import (
+    Config,
+)
+
 __all__ = [
+    "ConfigureRequest",
     "CheckResult",
     "CheckFailure",
     "DiffResult",
@@ -37,4 +43,5 @@ __all__ = [
     "UpdateResult",
     "Resource",
     "ResourceProvider",
+    "Config",
 ]

--- a/sdk/python/lib/pulumi/dynamic/__main__.py
+++ b/sdk/python/lib/pulumi/dynamic/__main__.py
@@ -197,7 +197,7 @@ class DynamicResourceProviderServicer(ResourceProviderServicer):
 
     def Configure(self, request, context):
         # Get the configuration from the request and store it. When
-        # deserializing dynamic providers, we will call the providers
+        # deserializing dynamic providers, we will call the provider's
         # `configure` method with this configuration.
         config = rpc.deserialize_properties(request.args)
         config = {k: rpc.unwrap_rpc_secret(v) for k, v in config.items()}

--- a/sdk/python/lib/pulumi/dynamic/__main__.py
+++ b/sdk/python/lib/pulumi/dynamic/__main__.py
@@ -16,6 +16,8 @@ import asyncio
 import base64
 from concurrent import futures
 from threading import Event, Lock
+from typing import Any, Dict, Optional
+import os
 import sys
 import time
 
@@ -23,10 +25,11 @@ import typing
 import dill
 import grpc
 from google.protobuf import empty_pb2
+from pulumi.metadata import get_project
 from pulumi.runtime._serialization import _deserialize
-from pulumi.runtime import proto, rpc
+from pulumi.runtime import configure, proto, rpc, Settings
 from pulumi.runtime.proto import provider_pb2_grpc, ResourceProviderServicer
-from pulumi.dynamic import ResourceProvider
+from pulumi.dynamic import ResourceProvider, ConfigureRequest, Config
 
 _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 PROVIDER_KEY = "__provider"
@@ -36,13 +39,23 @@ _MAX_RPC_MESSAGE_SIZE = 1024 * 1024 * 400
 _GRPC_CHANNEL_OPTIONS = [("grpc.max_receive_message_length", _MAX_RPC_MESSAGE_SIZE)]
 
 
-_PROVIDER_CACHE: typing.Dict[str, ResourceProvider] = {}
+_PROVIDER_CACHE: Dict[str, ResourceProvider] = {}
 _PROVIDER_LOCK = Lock()
 
 
-def get_provider(props) -> ResourceProvider:
+def get_provider(props: Dict[str, Any], config: Dict[str, Any]) -> ResourceProvider:
+    # Ensure Settings are configured in the thread that calls get_provider
+    configure(
+        Settings(
+            project=os.environ.get("PULUMI_PROJECT", "project"),
+            # `stack` and `organization` are the default values for Settings.
+            # Ideally we'd like to get the actual values here and set them.
+            stack="stack",
+            organization="organization",
+        )
+    )
     providerStr = props[PROVIDER_KEY]
-    provider = _PROVIDER_CACHE.get(providerStr)
+    provider: Optional[ResourceProvider] = _PROVIDER_CACHE.get(providerStr)
     if provider is None:
         # This is pesimistic locking, because if two different providers try to fetch at the same time they
         # serialise. But it means we don't create two instances of the same provider. Also looking at issues
@@ -52,17 +65,22 @@ def get_provider(props) -> ResourceProvider:
             provider = _PROVIDER_CACHE.get(providerStr)
             if provider is None:
 
-                def deserialize():
+                def deserialize() -> ResourceProvider:
                     byts = base64.b64decode(providerStr)
                     return dill.loads(byts)
 
                 provider = _deserialize(deserialize)
+                dyn_config = Config(raw_config=config, project_name=get_project())
+                req = ConfigureRequest(config=dyn_config)
+                provider.configure(req)
                 _PROVIDER_CACHE[providerStr] = provider
 
     return provider
 
 
 class DynamicResourceProviderServicer(ResourceProviderServicer):
+    _config: Dict[str, Any] = {}
+
     def CheckConfig(self, request, context):
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("CheckConfig is not implemented by the dynamic provider")
@@ -86,9 +104,9 @@ class DynamicResourceProviderServicer(ResourceProviderServicer):
         olds = rpc.deserialize_properties(request.olds, True)
         news = rpc.deserialize_properties(request.news, True)
         if news[PROVIDER_KEY] == rpc.UNKNOWN:
-            provider = get_provider(olds)
+            provider = get_provider(olds, self._config)
         else:
-            provider = get_provider(news)
+            provider = get_provider(news, self._config)
         result = provider.diff(request.id, olds, news)  # pylint: disable=no-member
         fields = {}
         if result.changes is not None:
@@ -113,7 +131,7 @@ class DynamicResourceProviderServicer(ResourceProviderServicer):
     def Update(self, request, context):
         olds = rpc.deserialize_properties(request.olds)
         news = rpc.deserialize_properties(request.news)
-        provider = get_provider(news)
+        provider = get_provider(news, self._config)
 
         result = provider.update(request.id, olds, news)  # pylint: disable=no-member
         outs = {}
@@ -131,7 +149,7 @@ class DynamicResourceProviderServicer(ResourceProviderServicer):
     def Delete(self, request, context):
         id_ = request.id
         props = rpc.deserialize_properties(request.properties)
-        provider = get_provider(props)
+        provider = get_provider(props, self._config)
         provider.delete(id_, props)  # pylint: disable=no-member
         return empty_pb2.Empty()
 
@@ -140,8 +158,8 @@ class DynamicResourceProviderServicer(ResourceProviderServicer):
 
     def Create(self, request, context):
         props = rpc.deserialize_properties(request.properties)
-        provider = get_provider(props)
-        result = provider.create(props)  # pylint: disable=no-member
+        provider = get_provider(props, self._config)
+        result = provider.create(props)
         outs = result.outs if result.outs is not None else {}
         outs[PROVIDER_KEY] = props[PROVIDER_KEY]
 
@@ -156,9 +174,9 @@ class DynamicResourceProviderServicer(ResourceProviderServicer):
         olds = rpc.deserialize_properties(request.olds, True)
         news = rpc.deserialize_properties(request.news, True)
         if news[PROVIDER_KEY] == rpc.UNKNOWN:
-            provider = get_provider(olds)
+            provider = get_provider(olds, self._config)
         else:
-            provider = get_provider(news)
+            provider = get_provider(news, self._config)
 
         result = provider.check(olds, news)  # pylint: disable=no-member
         inputs = result.inputs
@@ -178,6 +196,12 @@ class DynamicResourceProviderServicer(ResourceProviderServicer):
         return proto.CheckResponse(**fields)
 
     def Configure(self, request, context):
+        # Get the configuration from the request and store it. When
+        # deserializing dynamic providers, we will call the providers
+        # `configure` method with this configuration.
+        config = rpc.deserialize_properties(request.args)
+        config = {k: rpc.unwrap_rpc_secret(v) for k, v in config.items()}
+        self._config = config
         fields = {"acceptSecrets": False}
         return proto.ConfigureResponse(**fields)
 
@@ -195,7 +219,7 @@ class DynamicResourceProviderServicer(ResourceProviderServicer):
     def Read(self, request, context):
         id_ = request.id
         props = rpc.deserialize_properties(request.properties)
-        provider = get_provider(props)
+        provider = get_provider(props, self._config)
         result = provider.read(id_, props)  # pylint: disable=no-member
         outs = result.outs
         outs[PROVIDER_KEY] = props[PROVIDER_KEY]

--- a/sdk/python/lib/pulumi/dynamic/__main__.py
+++ b/sdk/python/lib/pulumi/dynamic/__main__.py
@@ -43,6 +43,11 @@ _PROVIDER_CACHE: Dict[str, ResourceProvider] = {}
 _PROVIDER_LOCK = Lock()
 
 
+# get_provider deserializes the provider from the string found in
+# `props[PROVIDER_KEY]` and calls `provider.configure` with the config. The
+# deserialized and configured provider is stored in `_PROVIDER_CACHE`. This
+# guarantees that the provider is only deserialized and configured once per
+# process.
 def get_provider(props: Dict[str, Any], config: Dict[str, Any]) -> ResourceProvider:
     # Ensure Settings are configured in the thread that calls get_provider
     configure(

--- a/sdk/python/lib/pulumi/dynamic/config.py
+++ b/sdk/python/lib/pulumi/dynamic/config.py
@@ -13,7 +13,7 @@ class Config:
     _props: Dict[str, Any]
     _project_name: str
 
-    def __init__(self, raw_config, project_name):
+    def __init__(self, raw_config: Dict[str, Any], project_name: str) -> None:
         self._props = raw_config
         self._project_name = project_name
 

--- a/sdk/python/lib/pulumi/dynamic/config.py
+++ b/sdk/python/lib/pulumi/dynamic/config.py
@@ -1,0 +1,37 @@
+from typing import Any, Dict
+
+_config_separator = ":"
+
+
+class Config:
+    """
+    Config is a bag of configuration values that can be passed to a provider's configure method.
+
+    Use the Config.get and Config.require methods to retrieve a configuration value by key.
+    """
+
+    _props: Dict[str, Any]
+    _project_name: str
+
+    def __init__(self, raw_config, project_name):
+        self._props = raw_config
+        self._project_name = project_name
+
+    def get(self, key: str) -> Any:
+        """
+        get retrieves a configuration value by key. Returns None if the key is not present.
+        If no namespace is provided in the key, the project name will be used as the namespace.
+        """
+        if _config_separator not in key:
+            key = self._project_name + _config_separator + key
+        return self._props.get(key)
+
+    def require(self, key: str) -> Any:
+        """
+        require retrieves a configuration value by key. Returns an error if the key is not present.
+        If no namespace is provided in the key, the project name will be used as the namespace.
+        """
+        val = self.get(key)
+        if val is None:
+            raise ValueError(f"missing required configuration key: {key}")
+        return val

--- a/sdk/python/lib/pulumi/dynamic/dynamic.py
+++ b/sdk/python/lib/pulumi/dynamic/dynamic.py
@@ -32,11 +32,24 @@ import pulumi
 
 from .. import CustomResource, ResourceOptions
 from ..runtime._serialization import _serialize
+from .config import Config
 
 if TYPE_CHECKING:
     from ..output import Inputs, Output
 
 PROVIDER_KEY = "__provider"
+
+
+class ConfigureRequest:
+    """
+    ConfigureRequest is the shape of the configuration data passed to a
+    provider's configure method.
+    """
+
+    config: Config
+
+    def __init__(self, config: Config):
+        self.config = config
 
 
 class CheckResult:
@@ -238,6 +251,12 @@ class ResourceProvider:
         """
         Delete tears down an existing resource with the given ID.  If it fails, the resource is
         assumed to still exist.
+        """
+
+    def configure(self, req: ConfigureRequest) -> None:
+        """
+        Configure sets up the resource provider. Use this to initialize the
+        provider and store configuration.
         """
 
     def __init__(self) -> None:

--- a/sdk/python/lib/pulumi/dynamic/dynamic.py
+++ b/sdk/python/lib/pulumi/dynamic/dynamic.py
@@ -256,7 +256,7 @@ class ResourceProvider:
         assumed to still exist.
         """
 
-    def configure(self, req: ConfigureRequest)
+    def configure(self, req: ConfigureRequest) -> None:
         """
         Configure sets up the resource provider. Use this to initialize the
         provider and store configuration.

--- a/sdk/python/lib/pulumi/dynamic/dynamic.py
+++ b/sdk/python/lib/pulumi/dynamic/dynamic.py
@@ -47,6 +47,9 @@ class ConfigureRequest:
     """
 
     config: Config
+    """
+    The stack's configuration.
+    """
 
     def __init__(self, config: Config):
         self.config = config

--- a/sdk/python/lib/pulumi/dynamic/dynamic.py
+++ b/sdk/python/lib/pulumi/dynamic/dynamic.py
@@ -256,7 +256,7 @@ class ResourceProvider:
         assumed to still exist.
         """
 
-    def configure(self, req: ConfigureRequest) -> None:
+    def configure(self, req: ConfigureRequest)
         """
         Configure sets up the resource provider. Use this to initialize the
         provider and store configuration.

--- a/sdk/python/lib/test/dynamic/test_config.py
+++ b/sdk/python/lib/test/dynamic/test_config.py
@@ -1,0 +1,23 @@
+from pulumi.dynamic import Config
+
+
+def test_config_get():
+    c = Config({"my-project:a": "A", "namespace:b": "B"}, "my-project")
+
+    assert c.get("my-project:a") == "A"
+    assert c.get("a") == "A"
+    assert c.get("namespace:b") == "B"
+    assert c.get("b") == None
+
+
+def test_config_require():
+    c = Config({"my-project:a": "A", "namespace:b": "B"}, "my-project")
+
+    assert c.require("my-project:a") == "A"
+    assert c.require("a") == "A"
+    assert c.require("namespace:b") == "B"
+    try:
+        c.require("b")
+        assert False
+    except ValueError as e:
+        assert str(e) == "missing required configuration key: b"

--- a/tests/integration/dynamic/python-config-separate-module/Pulumi.yaml
+++ b/tests/integration/dynamic/python-config-separate-module/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: dynamic-provider-config-main-py
+description: test for dynamic provider configuration in a separate module from __main__
+runtime: python

--- a/tests/integration/dynamic/python-config-separate-module/__main__.py
+++ b/tests/integration/dynamic/python-config-separate-module/__main__.py
@@ -1,0 +1,19 @@
+# Copyright 2024, Pulumi Corporation.  All rights reserved.
+
+import pulumi
+from pulumi.dynamic import Resource
+
+from provider import SimpleProvider
+
+
+class SimpleResource(Resource):
+    authenticated: pulumi.Output[str]
+    color: pulumi.Output[str]
+
+    def __init__(self, name):
+        super().__init__(SimpleProvider(), name, {"authenticated": None, "color": None})
+
+
+r = SimpleResource("foo")
+pulumi.export("authenticated", r.authenticated)
+pulumi.export("color", r.color)

--- a/tests/integration/dynamic/python-config-separate-module/provider.py
+++ b/tests/integration/dynamic/python-config-separate-module/provider.py
@@ -1,0 +1,23 @@
+# Copyright 2024, Pulumi Corporation.  All rights reserved.
+
+import pulumi
+from pulumi.dynamic import CreateResult, ResourceProvider, ConfigureRequest, Config
+
+
+class SimpleProvider(ResourceProvider):
+    password: str
+    color: str
+
+    def configure(self, req: ConfigureRequest):
+        self.password = req.config.get("password")
+        self.color = req.config.get("colors:banana")
+
+    def create(self, props):
+        # This simulates using this as a credential to talk to an external system.
+        return CreateResult(
+            "0",
+            {
+                "authenticated": "200" if self.password == "s3cret" else "401",
+                "color": self.color,
+            },
+        )

--- a/tests/integration/dynamic/python-config/Pulumi.yaml
+++ b/tests/integration/dynamic/python-config/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: dynamic-provider-config-main-py
+description: test for dynamic provider configuration within __main__
+runtime: python

--- a/tests/integration/dynamic/python-config/__main__.py
+++ b/tests/integration/dynamic/python-config/__main__.py
@@ -1,0 +1,42 @@
+# Copyright 2024, Pulumi Corporation.  All rights reserved.
+
+import pulumi
+from pulumi.dynamic import (
+    CreateResult,
+    ResourceProvider,
+    ConfigureRequest,
+    Config,
+    Resource,
+)
+
+
+class SimpleProvider(ResourceProvider):
+    password: str
+    color: str
+
+    def configure(self, req: ConfigureRequest):
+        self.password = req.config.get("password")
+        self.color = req.config.get("colors:banana")
+
+    def create(self, props):
+        # This simulates using this as a credential to talk to an external system.
+        return CreateResult(
+            "0",
+            {
+                "authenticated": "200" if self.password == "s3cret" else "401",
+                "color": self.color,
+            },
+        )
+
+
+class SimpleResource(Resource):
+    authenticated: pulumi.Output[str]
+    color: pulumi.Output[str]
+
+    def __init__(self, name):
+        super().__init__(SimpleProvider(), name, {"authenticated": None, "color": None})
+
+
+r = SimpleResource("foo")
+pulumi.export("authenticated", r.authenticated)
+pulumi.export("color", r.color)

--- a/tests/integration/dynamic/python-secrets/__main__.py
+++ b/tests/integration/dynamic/python-secrets/__main__.py
@@ -10,7 +10,10 @@ password = config.require_secret("password")
 
 class SimpleProvider(ResourceProvider):
     def create(self, props):
-        # Need to use `password.get()` to get the underlying value of the secret from within the serialized code.
+        # Need to use `password.get()` to get the underlying value of the secret
+        # from within the serialized code. This configuration value is captured
+        # during serialization, and not retrieved at runtime.
+        #
         # This simulates using this as a credential to talk to an external system.
         return CreateResult("0", { "authenticated": "200" if password.get() == "s3cret" else "401" })
 

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -566,6 +566,41 @@ func TestDynamicProviderSecretsPython(t *testing.T) {
 	})
 }
 
+// Tests configuration for dynamic providers
+//
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestDynamicProviderConfig(t *testing.T) {
+	tests := []string{
+		"python-config",
+		"python-config-separate-module",
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test, func(t *testing.T) {
+			integration.ProgramTest(t, &integration.ProgramTestOptions{
+				Dir: filepath.Join("dynamic", test),
+				Dependencies: []string{
+					filepath.Join("..", "..", "sdk", "python", "env", "src"),
+				},
+				Secrets: map[string]string{
+					"password":      "s3cret",
+					"colors:banana": "yellow",
+				},
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					// Ensure the resulting output had the expected value
+					code, ok := stackInfo.Outputs["authenticated"].(string)
+					assert.True(t, ok)
+					assert.Equal(t, "200", code)
+
+					color, ok := stackInfo.Outputs["color"].(string)
+					assert.True(t, ok)
+					assert.Equal(t, "yellow", color)
+				},
+			})
+		})
+	}
+}
+
 //nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestPartialValuesPython(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{


### PR DESCRIPTION
Python dynamic providers get serialised and deserialised, and run in the `pulumi-python` plugin process. This causes issues when trying to use `pulumi.config.Config` in a dynamic provider:

* Using `Config` at runtime fails because the process is not setup with the current configuration
* When the dynamic provider implementation is in the `__main__` module, the dynamic provider serialization attempts to serialize the global `SETTINGS` object, which pulls in protobuf definitions, which are not serializable by `dill`.

To provide a stable API to access configuration in dynamic providers, the provider classes  (ResourceProvider) can now implement a `configure` method which is called during provider initialization.
```python
class SimpleProvider(ResourceProvider):
    password: str

    def configure(self, req: ConfigureRequest):
        self.password = req.config.get("password")

    def create(self, props):
        # Use `self.password`.
        ...
```

The `configure` method is called when a provider is deserialized. Since we cache the deserialization result, we guarantee that this is only called once per program, and this process level cache serves as a plugin registry.

Fixes https://github.com/pulumi/pulumi/issues/17050