### PR TITLE
build release binaries in parallel with other CI steps

### DIFF
--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -240,6 +240,8 @@ jobs:
           path: artifacts.tmp
       - name: Remove performance test artifacts
         run: rm -rf artifacts.tmp/*-perf
+      - name: Remove integration test artifacts
+        run: rm -rf artifacts.tmp/*-integration
       - name: Flatten artifact directories
         run: |
           find artifacts.tmp

--- a/.github/workflows/ci-prepare-release.yml
+++ b/.github/workflows/ci-prepare-release.yml
@@ -66,6 +66,8 @@ jobs:
           path: artifacts.tmp
       - name: Remove performance test artifacts
         run: rm -rf artifacts.tmp/*-perf
+      - name: Remove integration test artifacts
+        run: rm -rf artifacts.tmp/*-integration
       - name: Rename SDKs
         # This step must match the rename SDKs step in the "sign" job above.
         run: |

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -280,7 +280,7 @@ jobs:
         if: ${{ inputs.is-integration-test }}
         uses: actions/download-artifact@v4
         with:
-          name: artifacts-cli-${{ steps.goenv.outputs.cli-target }}
+          name: artifacts-cli-${{ steps.goenv.outputs.cli-target }}-integration
           path: artifacts/cli
       - name: Download pulumi-${{ steps.goenv.outputs.cli-target }}
         if: ${{ inputs.is-performance-test }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,7 @@ jobs:
       enable-coverage: ${{ inputs.enable-coverage }}
       # Windows and Linux need CGO and cross compile support to support -race. So for now only enable it for darwin and amd64 linux.
       enable-race-detection: ${{ matrix.target.os == 'darwin' || (matrix.target.os == 'linux' && matrix.target.arch == 'amd64') }}
+      artifact-suffix: '-integration'
     secrets: inherit
 
   build-display-wasm-module:
@@ -483,7 +484,7 @@ jobs:
   build-release-binaries:
     # This overwrites the previously built testing binaries with versions without coverage.
     name: Rebuild binaries
-    needs: [matrix, unit-test, integration-test, acceptance-test-macos]
+    needs: [matrix]
     if: ${{ inputs.enable-coverage }}
     strategy:
       fail-fast: ${{ inputs.fail-fast }}

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -40,6 +40,8 @@ jobs:
           path: artifacts.tmp
       - name: Remove performance test artifacts
         run: rm -rf artifacts.tmp/*-perf
+      - name: Remove integration test artifacts
+        run: rm -rf artifacts.tmp/*-integration
       - name: Rename SDKs
         # This step must match the rename SDKs step in the "publish" job below.
         run: |


### PR DESCRIPTION
In CI we want to have binaries that emit coverage and have race detection built in.  However we don't want that in release builds, as neither of these things is useful there, and is just slowing down the binary.  We currently achieve this by rebuilding the binaries after all the tests have run.

However building the binaries takes additional time (~3min currently). Wit the introduction of the artifact-suffix option in `ci-build-binaries` we can now do better, and build the release binaries in parallel with running the tests.  Do that here to save some time when running CI.

(this is a follow up from https://github.com/pulumi/pulumi/pull/17364/files#r1827550113)