### PR TITLE
Fix language conformance tests

### DIFF
--- a/cmd/pulumi-test-language/interface_test.go
+++ b/cmd/pulumi-test-language/interface_test.go
@@ -138,6 +138,11 @@ func TestProviderSchemas(t *testing.T) {
 		loader := &providerLoader{providers: test.providers}
 
 		for _, provider := range test.providers {
+			if provider.Pkg() == "parameterized" {
+				// We don't currently support testing the schemas of parameterized providers.
+				continue
+			}
+
 			resp, err := provider.GetSchema(context.Background(), plugin.GetSchemaRequest{})
 			require.NoError(t, err)
 


### PR DESCRIPTION
In #17589 we added the `package` block to PCL in order to support parameterized providers. As part of this work, we added an initial set of language conformance tests for parameterized providers. Presently there are some workarounds involved in doing so as historically we have only tested non-parameterized providers. This commit introduces one that we missed, without which some assertions currently fail since they are unaware of parameterized providers.