### PR TITLE
Document `ResourceProvider.CheckConfig`

### DIFF
--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -18,7 +18,7 @@
 1921230328 1269 proto/pulumi/errors.proto
 420991671 12306 proto/pulumi/language.proto
 2893249402 1992 proto/pulumi/plugin.proto
-2293184687 31670 proto/pulumi/provider.proto
+4068219036 35607 proto/pulumi/provider.proto
 1190662922 17848 proto/pulumi/resource.proto
 607478140 1008 proto/pulumi/source.proto
 3670315643 2603 proto/pulumi/testing/language.proto

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -59,7 +59,24 @@ service ResourceProvider {
     // GetSchema fetches the schema for this resource provider.
     rpc GetSchema(GetSchemaRequest) returns (GetSchemaResponse) {}
 
-    // CheckConfig validates the configuration for this resource provider.
+    // `CheckConfig` validates a set of configuration inputs that will be passed to this provider instance.
+    // `CheckConfig` is to provider resources what [](pulumirpc.ResourceProvider.Check) is to individual resources, and
+    // is the first stage in configuring (that is, eventually executing a [](pulumirpc.ResourceProvider.Configure) call)
+    // a provider using user-supplied values. In the case that provider inputs are coming from some source that has been
+    // checked previously (e.g. a Pulumi state), it is not necessary to call `CheckConfig`.
+    //
+    // A `CheckConfig` call returns either a set of checked, known-valid inputs that may subsequently be passed to
+    // [](pulumirpc.ResourceProvider.DiffConfig) and/or [](pulumirpc.ResourceProvider.Configure), or a set of errors
+    // explaining why the inputs are invalid. In the case that a set of inputs are successfully validated and returned,
+    // `CheckConfig` *may also populate default values* for provider configuration, returning them so that they may be
+    // passed to a subsequent [](pulumirpc.ResourceProvider.Configure) call and persisted in the Pulumi state. In the
+    // case that `CheckConfig` fails and returns a set of errors, it is expected that the caller (typically the Pulumi
+    // engine) will fail provider registration.
+    //
+    // As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
+    // the properties as present in the program inputs. Though this rule is not required for correctness, violations
+    // thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+    // rendering diffs.
     rpc CheckConfig(CheckRequest) returns (CheckResponse) {}
     // DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
     rpc DiffConfig(DiffRequest) returns (DiffResponse) {}
@@ -276,37 +293,74 @@ message CallResponse {
     map<string, ReturnDependencies> returnDependencies = 2;
 }
 
+// `CheckRequest` is the type of requests sent as part of [](pulumirpc.ResourceProvider.CheckConfig) and
+// [](pulumirpc.ResourceProvider.Check) calls. A `CheckRequest` primarily captures the URN and inputs of the resource
+// being checked. In the case of [](pulumirpc.ResourceProvider.CheckConfig), the URN will be the URN of the provider
+// resource being constructed, which may or may not be a [default provider](default-providers), and the inputs will be
+// the provider configuration.
 message CheckRequest {
-    string urn = 1;                  // the Pulumi URN for this resource.
-    google.protobuf.Struct olds = 2; // the old Pulumi inputs for this resource, if any.
+    // The URN of the resource whose inputs are being checked. In the case of
+    // [](pulumirpc.ResourceProvider.CheckConfig), this will be the URN of the provider resource being constructed,
+    // which may or may not be a [default provider](default-providers).
+    string urn = 1;
 
-    // the new Pulumi inputs for this resource.
+    // The old input properties or configuration for the resource, if any.
+    google.protobuf.Struct olds = 2;
+
+    // The new input properties or configuration for the resource, if any.
     //
-    // Note that if the user specifies the ignoreChanges resource option, the value of news passed
-    // to the provider here may differ from the values written in the program source. It will be pre-processed by
-    // replacing every ignoreChanges property by a matching value from the old inputs stored in the state.
-    //
-    // See also: https://www.pulumi.com/docs/concepts/options/ignorechanges/
+    // :::{note}
+    // If this resource has been specified with the
+    // [`ignoreChanges`](https://www.pulumi.com/docs/concepts/options/ignorechanges/), then the values in `news` may
+    // differ from those written in the Pulumi program registering this resource. In such cases, the caller (e.g. the
+    // Pulumi engine) is expected to preprocess the `news` value by replacing every property matched by `ignoreChanges`
+    // with its corresponding `olds` value (effectively ignoring the change).
+    // :::
     google.protobuf.Struct news = 3;
 
-    // We used to send sequenceNumber but that has been replaced by randomSeed.
+    // `CheckRequest`s originally contained sequence numbers, but they have since been replaced by random seeds.
     reserved 4;
     reserved "sequenceNumber";
 
-    bytes randomSeed = 5;            // a deterministically random hash, primarily intended for global unique naming.
+    // A random but deterministically computed hash, intended to be used for generating globally unique names.
+    bytes randomSeed = 5;
 
-    string name = 6; // the Pulumi name for this resource.
-    string type = 7; // the Pulumi type for this resource.
+    // The name of the resource being checked. This must match the name specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the name of the resource.
+    string name = 6;
+
+    // The type of the resource being checked. This must match the type specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the type of the resource.
+    string type = 7;
 }
 
+// `CheckResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.CheckConfig) or
+// [](pulumirpc.ResourceProvider.Check) call. A `CheckResponse` may contain either:
+//
+// * a set of checked, known-valid `inputs`. In the case of [](pulumirpc.ResourceProvider.CheckConfig), these may
+//   subsequently be passed to [](pulumirpc.ResourceProvider.DiffConfig) and/or
+//   [](pulumirpc.ResourceProvider.Configure). In the case of [](pulumirpc.ResourceProvider.Check), these may be passed
+//   to any of the supported lifecycle methods that accept provider inputs.
+// * a set of `failures` detailing invalid inputs.
+//
+// In cases where the supplied set of inputs is valid, a `CheckResponse` may contain default values that should
+// persisted to Pulumi state and passed to subsequent calls.
 message CheckResponse {
-    google.protobuf.Struct inputs = 1;  // the provider inputs for this resource.
-    repeated CheckFailure failures = 2; // any validation failures that occurred.
+    // A valid, checked set of inputs. May contain defaults.
+    google.protobuf.Struct inputs = 1;
+
+    // Any validation failures that occurred.
+    repeated CheckFailure failures = 2;
 }
 
+// A `CheckFailure` describes a single validation error that arose as part of a
+// [](pulumirpc.ResourceProvider.CheckConfig) or [](pulumirpc.ResourceProvider.Check) call.
 message CheckFailure {
-    string property = 1; // the property that failed validation.
-    string reason = 2;   // the reason that the property failed validation.
+    // The input property that failed validation.
+    string property = 1;
+
+    // The reason that the named property failed validation.
+    string reason = 2;
 }
 
 message DiffRequest {

--- a/sdk/nodejs/proto/provider_grpc_pb.js
+++ b/sdk/nodejs/proto/provider_grpc_pb.js
@@ -408,7 +408,24 @@ getSchema: {
     responseSerialize: serialize_pulumirpc_GetSchemaResponse,
     responseDeserialize: deserialize_pulumirpc_GetSchemaResponse,
   },
-  // CheckConfig validates the configuration for this resource provider.
+  // `CheckConfig` validates a set of configuration inputs that will be passed to this provider instance.
+// `CheckConfig` is to provider resources what [](pulumirpc.ResourceProvider.Check) is to individual resources, and
+// is the first stage in configuring (that is, eventually executing a [](pulumirpc.ResourceProvider.Configure) call)
+// a provider using user-supplied values. In the case that provider inputs are coming from some source that has been
+// checked previously (e.g. a Pulumi state), it is not necessary to call `CheckConfig`.
+//
+// A `CheckConfig` call returns either a set of checked, known-valid inputs that may subsequently be passed to
+// [](pulumirpc.ResourceProvider.DiffConfig) and/or [](pulumirpc.ResourceProvider.Configure), or a set of errors
+// explaining why the inputs are invalid. In the case that a set of inputs are successfully validated and returned,
+// `CheckConfig` *may also populate default values* for provider configuration, returning them so that they may be
+// passed to a subsequent [](pulumirpc.ResourceProvider.Configure) call and persisted in the Pulumi state. In the
+// case that `CheckConfig` fails and returns a set of errors, it is expected that the caller (typically the Pulumi
+// engine) will fail provider registration.
+//
+// As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
+// the properties as present in the program inputs. Though this rule is not required for correctness, violations
+// thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+// rendering diffs.
 checkConfig: {
     path: '/pulumirpc.ResourceProvider/CheckConfig',
     requestStream: false,

--- a/sdk/proto/go/provider_grpc.pb.go
+++ b/sdk/proto/go/provider_grpc.pb.go
@@ -53,7 +53,24 @@ type ResourceProviderClient interface {
 	Parameterize(ctx context.Context, in *ParameterizeRequest, opts ...grpc.CallOption) (*ParameterizeResponse, error)
 	// GetSchema fetches the schema for this resource provider.
 	GetSchema(ctx context.Context, in *GetSchemaRequest, opts ...grpc.CallOption) (*GetSchemaResponse, error)
-	// CheckConfig validates the configuration for this resource provider.
+	// `CheckConfig` validates a set of configuration inputs that will be passed to this provider instance.
+	// `CheckConfig` is to provider resources what [](pulumirpc.ResourceProvider.Check) is to individual resources, and
+	// is the first stage in configuring (that is, eventually executing a [](pulumirpc.ResourceProvider.Configure) call)
+	// a provider using user-supplied values. In the case that provider inputs are coming from some source that has been
+	// checked previously (e.g. a Pulumi state), it is not necessary to call `CheckConfig`.
+	//
+	// A `CheckConfig` call returns either a set of checked, known-valid inputs that may subsequently be passed to
+	// [](pulumirpc.ResourceProvider.DiffConfig) and/or [](pulumirpc.ResourceProvider.Configure), or a set of errors
+	// explaining why the inputs are invalid. In the case that a set of inputs are successfully validated and returned,
+	// `CheckConfig` *may also populate default values* for provider configuration, returning them so that they may be
+	// passed to a subsequent [](pulumirpc.ResourceProvider.Configure) call and persisted in the Pulumi state. In the
+	// case that `CheckConfig` fails and returns a set of errors, it is expected that the caller (typically the Pulumi
+	// engine) will fail provider registration.
+	//
+	// As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
+	// the properties as present in the program inputs. Though this rule is not required for correctness, violations
+	// thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+	// rendering diffs.
 	CheckConfig(ctx context.Context, in *CheckRequest, opts ...grpc.CallOption) (*CheckResponse, error)
 	// DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
 	DiffConfig(ctx context.Context, in *DiffRequest, opts ...grpc.CallOption) (*DiffResponse, error)
@@ -356,7 +373,24 @@ type ResourceProviderServer interface {
 	Parameterize(context.Context, *ParameterizeRequest) (*ParameterizeResponse, error)
 	// GetSchema fetches the schema for this resource provider.
 	GetSchema(context.Context, *GetSchemaRequest) (*GetSchemaResponse, error)
-	// CheckConfig validates the configuration for this resource provider.
+	// `CheckConfig` validates a set of configuration inputs that will be passed to this provider instance.
+	// `CheckConfig` is to provider resources what [](pulumirpc.ResourceProvider.Check) is to individual resources, and
+	// is the first stage in configuring (that is, eventually executing a [](pulumirpc.ResourceProvider.Configure) call)
+	// a provider using user-supplied values. In the case that provider inputs are coming from some source that has been
+	// checked previously (e.g. a Pulumi state), it is not necessary to call `CheckConfig`.
+	//
+	// A `CheckConfig` call returns either a set of checked, known-valid inputs that may subsequently be passed to
+	// [](pulumirpc.ResourceProvider.DiffConfig) and/or [](pulumirpc.ResourceProvider.Configure), or a set of errors
+	// explaining why the inputs are invalid. In the case that a set of inputs are successfully validated and returned,
+	// `CheckConfig` *may also populate default values* for provider configuration, returning them so that they may be
+	// passed to a subsequent [](pulumirpc.ResourceProvider.Configure) call and persisted in the Pulumi state. In the
+	// case that `CheckConfig` fails and returns a set of errors, it is expected that the caller (typically the Pulumi
+	// engine) will fail provider registration.
+	//
+	// As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
+	// the properties as present in the program inputs. Though this rule is not required for correctness, violations
+	// thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+	// rendering diffs.
 	CheckConfig(context.Context, *CheckRequest) (*CheckResponse, error)
 	// DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
 	DiffConfig(context.Context, *DiffRequest) (*DiffResponse, error)

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
@@ -521,6 +521,13 @@ global___CallResponse = CallResponse
 
 @typing_extensions.final
 class CheckRequest(google.protobuf.message.Message):
+    """`CheckRequest` is the type of requests sent as part of [](pulumirpc.ResourceProvider.CheckConfig) and
+    [](pulumirpc.ResourceProvider.Check) calls. A `CheckRequest` primarily captures the URN and inputs of the resource
+    being checked. In the case of [](pulumirpc.ResourceProvider.CheckConfig), the URN will be the URN of the provider
+    resource being constructed, which may or may not be a [default provider](default-providers), and the inputs will be
+    the provider configuration.
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     URN_FIELD_NUMBER: builtins.int
@@ -530,26 +537,35 @@ class CheckRequest(google.protobuf.message.Message):
     NAME_FIELD_NUMBER: builtins.int
     TYPE_FIELD_NUMBER: builtins.int
     urn: builtins.str
-    """the Pulumi URN for this resource."""
+    """The URN of the resource whose inputs are being checked. In the case of
+    [](pulumirpc.ResourceProvider.CheckConfig), this will be the URN of the provider resource being constructed,
+    which may or may not be a [default provider](default-providers).
+    """
     @property
     def olds(self) -> google.protobuf.struct_pb2.Struct:
-        """the old Pulumi inputs for this resource, if any."""
+        """The old input properties or configuration for the resource, if any."""
     @property
     def news(self) -> google.protobuf.struct_pb2.Struct:
-        """the new Pulumi inputs for this resource.
+        """The new input properties or configuration for the resource, if any.
 
-        Note that if the user specifies the ignoreChanges resource option, the value of news passed
-        to the provider here may differ from the values written in the program source. It will be pre-processed by
-        replacing every ignoreChanges property by a matching value from the old inputs stored in the state.
-
-        See also: https://www.pulumi.com/docs/concepts/options/ignorechanges/
+        :::{note}
+        If this resource has been specified with the
+        [`ignoreChanges`](https://www.pulumi.com/docs/concepts/options/ignorechanges/), then the values in `news` may
+        differ from those written in the Pulumi program registering this resource. In such cases, the caller (e.g. the
+        Pulumi engine) is expected to preprocess the `news` value by replacing every property matched by `ignoreChanges`
+        with its corresponding `olds` value (effectively ignoring the change).
+        :::
         """
     randomSeed: builtins.bytes
-    """a deterministically random hash, primarily intended for global unique naming."""
+    """A random but deterministically computed hash, intended to be used for generating globally unique names."""
     name: builtins.str
-    """the Pulumi name for this resource."""
+    """The name of the resource being checked. This must match the name specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the name of the resource.
+    """
     type: builtins.str
-    """the Pulumi type for this resource."""
+    """The type of the resource being checked. This must match the type specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the type of the resource.
+    """
     def __init__(
         self,
         *,
@@ -567,16 +583,29 @@ global___CheckRequest = CheckRequest
 
 @typing_extensions.final
 class CheckResponse(google.protobuf.message.Message):
+    """`CheckResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.CheckConfig) or
+    [](pulumirpc.ResourceProvider.Check) call. A `CheckResponse` may contain either:
+
+    * a set of checked, known-valid `inputs`. In the case of [](pulumirpc.ResourceProvider.CheckConfig), these may
+      subsequently be passed to [](pulumirpc.ResourceProvider.DiffConfig) and/or
+      [](pulumirpc.ResourceProvider.Configure). In the case of [](pulumirpc.ResourceProvider.Check), these may be passed
+      to any of the supported lifecycle methods that accept provider inputs.
+    * a set of `failures` detailing invalid inputs.
+
+    In cases where the supplied set of inputs is valid, a `CheckResponse` may contain default values that should
+    persisted to Pulumi state and passed to subsequent calls.
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     INPUTS_FIELD_NUMBER: builtins.int
     FAILURES_FIELD_NUMBER: builtins.int
     @property
     def inputs(self) -> google.protobuf.struct_pb2.Struct:
-        """the provider inputs for this resource."""
+        """A valid, checked set of inputs. May contain defaults."""
     @property
     def failures(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___CheckFailure]:
-        """any validation failures that occurred."""
+        """Any validation failures that occurred."""
     def __init__(
         self,
         *,
@@ -590,14 +619,18 @@ global___CheckResponse = CheckResponse
 
 @typing_extensions.final
 class CheckFailure(google.protobuf.message.Message):
+    """A `CheckFailure` describes a single validation error that arose as part of a
+    [](pulumirpc.ResourceProvider.CheckConfig) or [](pulumirpc.ResourceProvider.Check) call.
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     PROPERTY_FIELD_NUMBER: builtins.int
     REASON_FIELD_NUMBER: builtins.int
     property: builtins.str
-    """the property that failed validation."""
+    """The input property that failed validation."""
     reason: builtins.str
-    """the reason that the property failed validation."""
+    """The reason that the named property failed validation."""
     def __init__(
         self,
         *,

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
@@ -170,7 +170,24 @@ class ResourceProviderServicer(object):
         raise NotImplementedError('Method not implemented!')
 
     def CheckConfig(self, request, context):
-        """CheckConfig validates the configuration for this resource provider.
+        """`CheckConfig` validates a set of configuration inputs that will be passed to this provider instance.
+        `CheckConfig` is to provider resources what [](pulumirpc.ResourceProvider.Check) is to individual resources, and
+        is the first stage in configuring (that is, eventually executing a [](pulumirpc.ResourceProvider.Configure) call)
+        a provider using user-supplied values. In the case that provider inputs are coming from some source that has been
+        checked previously (e.g. a Pulumi state), it is not necessary to call `CheckConfig`.
+
+        A `CheckConfig` call returns either a set of checked, known-valid inputs that may subsequently be passed to
+        [](pulumirpc.ResourceProvider.DiffConfig) and/or [](pulumirpc.ResourceProvider.Configure), or a set of errors
+        explaining why the inputs are invalid. In the case that a set of inputs are successfully validated and returned,
+        `CheckConfig` *may also populate default values* for provider configuration, returning them so that they may be
+        passed to a subsequent [](pulumirpc.ResourceProvider.Configure) call and persisted in the Pulumi state. In the
+        case that `CheckConfig` fails and returns a set of errors, it is expected that the caller (typically the Pulumi
+        engine) will fail provider registration.
+
+        As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
+        the properties as present in the program inputs. Though this rule is not required for correctness, violations
+        thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+        rendering diffs.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
@@ -73,7 +73,25 @@ class ResourceProviderStub:
         pulumi.provider_pb2.CheckRequest,
         pulumi.provider_pb2.CheckResponse,
     ]
-    """CheckConfig validates the configuration for this resource provider."""
+    """`CheckConfig` validates a set of configuration inputs that will be passed to this provider instance.
+    `CheckConfig` is to provider resources what [](pulumirpc.ResourceProvider.Check) is to individual resources, and
+    is the first stage in configuring (that is, eventually executing a [](pulumirpc.ResourceProvider.Configure) call)
+    a provider using user-supplied values. In the case that provider inputs are coming from some source that has been
+    checked previously (e.g. a Pulumi state), it is not necessary to call `CheckConfig`.
+
+    A `CheckConfig` call returns either a set of checked, known-valid inputs that may subsequently be passed to
+    [](pulumirpc.ResourceProvider.DiffConfig) and/or [](pulumirpc.ResourceProvider.Configure), or a set of errors
+    explaining why the inputs are invalid. In the case that a set of inputs are successfully validated and returned,
+    `CheckConfig` *may also populate default values* for provider configuration, returning them so that they may be
+    passed to a subsequent [](pulumirpc.ResourceProvider.Configure) call and persisted in the Pulumi state. In the
+    case that `CheckConfig` fails and returns a set of errors, it is expected that the caller (typically the Pulumi
+    engine) will fail provider registration.
+
+    As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
+    the properties as present in the program inputs. Though this rule is not required for correctness, violations
+    thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+    rendering diffs.
+    """
     DiffConfig: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.DiffRequest,
         pulumi.provider_pb2.DiffResponse,
@@ -242,7 +260,25 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         request: pulumi.provider_pb2.CheckRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.CheckResponse:
-        """CheckConfig validates the configuration for this resource provider."""
+        """`CheckConfig` validates a set of configuration inputs that will be passed to this provider instance.
+        `CheckConfig` is to provider resources what [](pulumirpc.ResourceProvider.Check) is to individual resources, and
+        is the first stage in configuring (that is, eventually executing a [](pulumirpc.ResourceProvider.Configure) call)
+        a provider using user-supplied values. In the case that provider inputs are coming from some source that has been
+        checked previously (e.g. a Pulumi state), it is not necessary to call `CheckConfig`.
+
+        A `CheckConfig` call returns either a set of checked, known-valid inputs that may subsequently be passed to
+        [](pulumirpc.ResourceProvider.DiffConfig) and/or [](pulumirpc.ResourceProvider.Configure), or a set of errors
+        explaining why the inputs are invalid. In the case that a set of inputs are successfully validated and returned,
+        `CheckConfig` *may also populate default values* for provider configuration, returning them so that they may be
+        passed to a subsequent [](pulumirpc.ResourceProvider.Configure) call and persisted in the Pulumi state. In the
+        case that `CheckConfig` fails and returns a set of errors, it is expected that the caller (typically the Pulumi
+        engine) will fail provider registration.
+
+        As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
+        the properties as present in the program inputs. Though this rule is not required for correctness, violations
+        thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+        rendering diffs.
+        """
     
     def DiffConfig(
         self,


### PR DESCRIPTION
This commit fleshes out the documentation for the `CheckConfig` method of resource providers.