### PR TITLE
Document more provider methods

### DIFF
--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -18,7 +18,7 @@
 1921230328 1269 proto/pulumi/errors.proto
 420991671 12306 proto/pulumi/language.proto
 2893249402 1992 proto/pulumi/plugin.proto
-4068219036 35607 proto/pulumi/provider.proto
+2562367642 51683 proto/pulumi/provider.proto
 1190662922 17848 proto/pulumi/resource.proto
 607478140 1008 proto/pulumi/source.proto
 3670315643 2603 proto/pulumi/testing/language.proto

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -75,19 +75,34 @@ service ResourceProvider {
     //
     // As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
     // the properties as present in the program inputs. Though this rule is not required for correctness, violations
-    // thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+    // thereof can negatively impact the end-user experience, as the provider inputs are used for detecting and
     // rendering diffs.
     rpc CheckConfig(CheckRequest) returns (CheckResponse) {}
-    // DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
+
+    // `DiffConfig` compares an existing ("old") provider configuration with a new configuration and computes the
+    // difference (if any) between them. `DiffConfig` is to provider resources what [](pulumirpc.ResourceProvider.Diff)
+    // is to individual resources. `DiffConfig` should only be called with values that have at some point been validated
+    // by a [](pulumirpc.ResourceProvider.CheckConfig) call. The [](pulumirpc.DiffResponse) returned by a `DiffConfig`
+    // call is used primarily to determine whether or not the newly configured provider is capable of managing resources
+    // owned by the old provider. If `DiffConfig` indicates that the provider resource needs to be replaced, for
+    // instance, then all resources owned by that provider will *also* need to be replaced. Replacement semantics should
+    // thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
+    // Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
+    // AWS access key, should almost certainly not.
     rpc DiffConfig(DiffRequest) returns (DiffResponse) {}
 
-    // Configure configures the resource provider with "globals" that control its behavior.
+    // `Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
     //
-    // :::{warning}
-    // ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
-    // ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
-    // ConfigureRequest.args.
-    // :::
+    // * Provider-specific configuration, which is the set of inputs that have been validated by a previous
+    //   [](pulumirpc.ResourceProvider.CheckConfig) call.
+    // * Provider-agnostic ("protocol") configuration, such as whether or not the caller supports secrets.
+    //
+    // The provider is expected to return its own set of protocol configuration, indicating which features it supports
+    // in turn so that the caller and the provider can interact appropriately.
+    //
+    // Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
+    // the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
+    // indicate which keys are missing.
     rpc Configure(ConfigureRequest) returns (ConfigureResponse) {}
 
     // Invoke dynamically executes a built-in function in the provider.
@@ -100,26 +115,62 @@ service ResourceProvider {
     // Call dynamically executes a method in the provider associated with a component resource.
     rpc Call(CallRequest) returns (CallResponse) {}
 
-    // Check validates that the given property bag is valid for a resource of the given type and returns the inputs
-    // that should be passed to successive calls to Diff, Create, or Update for this resource. As a rule, the provider
-    // inputs returned by a call to Check should preserve the original representation of the properties as present in
-    // the program inputs. Though this rule is not required for correctness, violations thereof can negatively impact
-    // the end-user experience, as the provider inputs are using for detecting and rendering diffs.
+    // `Check` validates a set of input properties against a given resource type. A `Check` call returns either a set of
+    // checked, known-valid inputs that may subsequently be passed to [](pulumirpc.ResourceProvider.Diff),
+    // [](pulumirpc.ResourceProvider.Create), or [](pulumirpc.ResourceProvider.Update); or a set of errors explaining
+    // why the inputs are invalid. In the case that a set of inputs are successfully validated and returned, `Check`
+    // *may also populate default values* for resource inputs, returning them so that they may be passed to a subsequent
+    // call and persisted in the Pulumi state. In the case that `Check` fails and returns a set of errors, it is
+    // expected that the caller (typically the Pulumi engine) will fail resource registration.
+    //
+    // As a rule, the provider inputs returned by a call to `Check` should preserve the original representation of the
+    // properties as present in the program inputs. Though this rule is not required for correctness, violations thereof
+    // can negatively impact the end-user experience, as the provider inputs are used for detecting and rendering
+    // diffs.
     rpc Check(CheckRequest) returns (CheckResponse) {}
-    // Diff checks what impacts a hypothetical update will have on the resource's properties.
+
+    // `Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
+    // difference (if any) between them. `Diff` should only be called with values that have at some point been validated
+    // by a [](pulumirpc.ResourceProvider.Check) call.
     rpc Diff(DiffRequest) returns (DiffResponse) {}
-    // Create allocates a new instance of the provided resource and returns its unique ID afterwards.  (The input ID
-    // must be blank.)  If this call fails, the resource must not have been created (i.e., it is "transactional").
+
+    // `Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a
+    // provider-assigned ID for the resource as well as the output properties that arose from the creation properties.
+    // Output properties are typically the union of the resource's input properties and any additional values that were
+    // computed or made available during creation.
+    //
+    // If creation fails, `Create` may return an [](pulumirpc.ErrorResourceInitFailed) error detail explaining why.
+    // Moreover, if `Create` does return an error, it must be the case that the resource was *not* created (that is,
+    // `Create` can be thought of as transactional or atomic).
     rpc Create(CreateRequest) returns (CreateResponse) {}
-    // Read the current live state associated with a resource.  Enough state must be include in the inputs to uniquely
-    // identify the resource; this is typically just the resource ID, but may also include some properties.
+
+    // `Read` reads the current live state associated with a resource identified by the supplied state. The given state
+    // must be sufficient to uniquely identify the resource. This is typically just the resource ID, but may also
+    // include other properties.
     rpc Read(ReadRequest) returns (ReadResponse) {}
-    // Update updates an existing resource with new values.
+
+    // `Update` updates an existing resource according to a new set of inputs, returning a new set of output properties.
     rpc Update(UpdateRequest) returns (UpdateResponse) {}
-    // Delete tears down an existing resource with the given ID.  If it fails, the resource is assumed to still exist.
+
+    // `Delete` deprovisions an existing resource as specified by its ID. `Delete` should be transactional/atomic -- if
+    // a call to `Delete` fails, it must be the case that the resource was *not* deleted and can be assumed to still
+    // exist.
     rpc Delete(DeleteRequest) returns (google.protobuf.Empty) {}
 
-    // Construct creates a new instance of the provided component resource and returns its state.
+    // `Construct` provisions a new [component resource](component-resources). Providers that implement `Construct` are
+    // referred to as [component providers](component-providers). `Construct` is to component resources what
+    // [](pulumirpc.ResourceProvider.Create) is to [custom resources](custom-resources). Components do not have any
+    // lifecycle of their own, and instead embody the lifecycles of the resources that they are composed of. As such,
+    // `Construct` is effectively a subprogram whose resources will be persisted in the caller's state. It is
+    // consequently passed enough information to manage fully these resources. At a high level, this comprises:
+    //
+    // * A [](pulumirpc.ResourceMonitor) endpoint which the provider can use to [register](resource-registration) nested
+    //   custom or component resources that belong to the component.
+    //
+    // * A set of input properties.
+    //
+    // * A full set of [resource options](https://www.pulumi.com/docs/iac/concepts/options/) that the component should
+    //   propagate to resources it registers against the supplied resource monitor.
     rpc Construct(ConstructRequest) returns (ConstructResponse) {}
 
     // Cancel signals the provider to gracefully shut down and abort any ongoing resource operations.
@@ -205,32 +256,105 @@ message GetSchemaResponse {
     string schema = 1; // the JSON-encoded schema.
 }
 
+// `ConfigureRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Configure) call. Requests
+// include both provider-specific inputs (`variables` or `args`) and provider-agnostic ("protocol") configuration
+// (`acceptSecrets`, `acceptResources`, and so on).
 message ConfigureRequest {
-    // the input properties for the provider, with nested values JSON-encoded; please read from `args` instead.
+    // :::{warning}
+    // `variables` is deprecated; `args` should be used instead wherever possible.
+    // :::
+    //
+    // A map of input properties for the provider. Compound values, such as nested objects, should be JSON encoded so
+    // that they too can be passed as strings. For instance, the following configuration:
+    //
+    // ```
+    // {
+    //   "a": 42,
+    //   "b": {
+    //     "c": "hello",
+    //     "d": true
+    //   }
+    // }
+    // ```
+    //
+    // should be encoded as:
+    //
+    // ```
+    // {
+    //   "a": "42",
+    //   "b": "{\"c\":\"hello\",\"d\":true}"
+    // }
+    // ```
     map<string, string> variables = 1;
 
-    google.protobuf.Struct args = 2;   // the input properties for the provider
-    bool acceptSecrets  = 3;           // when true, operations should return secrets as strongly typed.
-    bool acceptResources = 4;          // when true, operations should return resources as strongly typed values to the provider.
-    bool sends_old_inputs = 5;         // when true, diff and update will be called with the old outputs and the old inputs.
-    bool sends_old_inputs_to_delete = 6; // when true, delete will be called with the old outputs and the old inputs.
+    // A map of input properties for the provider.
+    //
+    // :::{warning}
+    // `args` may include secrets. Because `ConfigureRequest` is sent before [](pulumirpc.ConfigureResponse) can specify
+    // whether or not the provider accepts secrets in general, providers *must* handle secrets if they appear in `args`.
+    // :::
+    google.protobuf.Struct args = 2;
+
+    // True if and only if the caller supports secrets. If true, operations should return strongly typed secrets if the
+    // provider supports them also.
+    bool acceptSecrets  = 3;
+
+    // True if and only if the caller supports strongly typed resources. If true, operations should return resources as
+    // strongly typed values if the provider supports them also.
+    bool acceptResources = 4;
+
+    // True if and only if the caller supports sending old inputs as part of [](pulumirpc.ResourceProvider.Diff) and
+    // [](pulumirpc.ResourceProvider.Update) calls. If true, the provider should expect these fields to be populated in
+    // these calls.
+    bool sends_old_inputs = 5;
+
+    // True if and only if the caller supports sending old inputs and outputs as part of
+    // [](pulumirpc.ResourceProvider.Delete) calls. If true, the provider should expect these fields to be populated in
+    // these calls.
+    bool sends_old_inputs_to_delete = 6;
 }
 
+// `ConfigureResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Configure) call. Its primary
+// purpose is to communicate features that the provider supports back to the caller.
 message ConfigureResponse {
-    bool acceptSecrets = 1;   // when true, the engine should pass secrets as strongly typed values to the provider.
-    bool supportsPreview = 2; // when true, the engine should invoke create and update with preview=true during previews.
-    bool acceptResources = 3; // when true, the engine should pass resources as strongly typed values to the provider.
-    bool acceptOutputs = 4;   // when true, the engine should pass output values to the provider.
+    // True if and only if the provider supports secrets. If true, the caller should pass secrets as strongly typed
+    // values to the provider.
+    bool acceptSecrets = 1;
+
+    // True if and only if the provider supports the `preview` field on [](pulumirpc.ResourceProvider.Create) and
+    // [](pulumirpc.ResourceProvider.Update) calls. If true, the engine should invoke these calls with `preview` set to
+    // `true` during previews.
+    bool supportsPreview = 2;
+
+    // True if and only if the provider supports strongly typed resources. If true, the caller should pass resources as
+    // strongly typed values to the provider.
+    bool acceptResources = 3;
+
+    // True if and only if the provider supports output values as inputs. If true, the engine should pass output values
+    // to the provider where possible.
+    bool acceptOutputs = 4;
 }
 
-// ConfigureErrorMissingKeys is sent as a Detail on an error returned from `ResourceProvider.Configure`.
+// `ConfigureErrorMissingKeys` is the type of error details that may be sent in response to a
+// [](pulumirpc.ResourceProvider.Configure) call when required configuration keys are missing.
 message ConfigureErrorMissingKeys {
+    // The type of key-value pairs representing keys that are missing from a [](pulumirpc.ResourceProvider.Configure)
+    // call.
     message MissingKey {
-        string name = 1;        // the Pulumi name (not the provider name!) of the missing config key.
-        string description = 2; // a description of the missing config key, as reported by the provider.
+        // The name of the missing configuration key.
+        //
+        // :::{note}
+        // This should be the *Pulumi name* of the missing key, and not any provider-internal or upstream name. Names
+        // that differ between Pulumi and an upstream provider should be translated prior to being returned.
+        // :::
+        string name = 1;
+
+        // A description of the missing config key, as reported by the provider.
+        string description = 2;
     }
 
-    repeated MissingKey missingKeys = 1; // a list of required configuration keys that were not supplied.
+    // A list of required configuration keys that were not supplied.
+    repeated MissingKey missingKeys = 1;
 }
 
 message InvokeRequest {
@@ -363,217 +487,437 @@ message CheckFailure {
     string reason = 2;
 }
 
+// `DiffRequest` is the type of requests sent as part of [](pulumirpc.ResourceProvider.DiffConfig) and
+// [](pulumirpc.ResourceProvider.Diff) calls. A `DiffRequest` primarily captures:
+//
+// * the URN of the resource whose properties are being compared;
+// * the old and new input properties of the resource; and
+// * the old output properties of the resource.
+//
+// In the case of [](pulumirpc.ResourceProvider.DiffConfig), the URN will be the URN of the provider resource being
+// examined, which may or may not be a [default provider](default-providers), and the inputs and outputs will be the
+// provider configuration and state. Inputs supplied to a [](pulumirpc.ResourceProvider.DiffConfig) call should have
+// been previously checked by a call to [](pulumirpc.ResourceProvider.CheckConfig); inputs supplied to a
+// [](pulumirpc.ResourceProvider.Diff) call should have been previously checked by a call to
+// [](pulumirpc.ResourceProvider.Check).
 message DiffRequest {
-    string id = 1;                     // the ID of the resource to diff.
-    string urn = 2;                    // the Pulumi URN for this resource.
-    google.protobuf.Struct olds = 3;   // the old output values of resource to diff.
+    // The ID of the resource being diffed.
+    string id = 1;
 
-    // the new input values of resource to diff, copied from CheckResponse.inputs.
+    // The URN of the resource being diffed.
+    string urn = 2;
+
+    // The old *output* properties of the resource being diffed.
+    google.protobuf.Struct olds = 3;
+
+    // The new *input* properties of the resource being diffed. These should have been validated by an appropriate call
+    // to [](pulumirpc.ResourceProvider.CheckConfig) or [](pulumirpc.ResourceProvider.Check).
     google.protobuf.Struct news = 4;
 
-    repeated string ignoreChanges = 5; // a set of property paths that should be treated as unchanged.
-    google.protobuf.Struct old_inputs = 6;   // the old input values of the resource to diff.
-    string name = 7; // the Pulumi name for this resource.
-    string type = 8; // the Pulumi type for this resource.
+    // A set of [property paths](property-paths) that should be treated as unchanged.
+    repeated string ignoreChanges = 5;
+
+    // The old *input* properties of the resource being diffed.
+    google.protobuf.Struct old_inputs = 6;
+
+    // The name of the resource being diffed. This must match the name specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the name of the resource.
+    string name = 7;
+
+    // The type of the resource being diffed. This must match the type specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the type of the resource.
+    string type = 8;
 }
 
+// `PropertyDiff` describes the kind of change that occurred to a property during a diff operation. A `PropertyDiff` may
+// indicate that a property was added, deleted, or updated, and may further indicate that the change requires a
+// replacement.
 message PropertyDiff {
-    Kind kind = 1; // The kind of diff asdsociated with this property.
-    bool inputDiff = 2; // The difference is between old and new inputs, not old and new state.
+    // The kind of diff associated with this property.
+    Kind kind = 1;
 
+    // True if and only if this difference represents one between a pair of old and new inputs, as opposed to a pair of
+    // old and new states.
+    bool inputDiff = 2;
+
+    // The type of property diff kinds.
     enum Kind {
-        ADD = 0;            // this property was added
-        ADD_REPLACE = 1;    // this property was added, and this change requires a replace
-        DELETE = 2;         // this property was removed
-        DELETE_REPLACE = 3; // this property was removed, and this change requires a replace
-        UPDATE = 4;         // this property's value was changed
-        UPDATE_REPLACE = 5; // this property's value was changed, and this change requires a replace
+        // This property was added.
+        ADD = 0;
+
+        // This property was added, and this change requires a replace.
+        ADD_REPLACE = 1;
+
+        // This property was removed.
+        DELETE = 2;
+
+        // This property was removed, and this change requires a replace.
+        DELETE_REPLACE = 3;
+
+        // This property's value was changed.
+        UPDATE = 4;
+
+        // This property's value was changed, and this change requires a replace.
+        UPDATE_REPLACE = 5;
     }
 }
 
+// `DiffResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.DiffConfig) or
+// [](pulumirpc.ResourceProvider.Diff) call. A `DiffResponse` indicates whether a resource is unchanged, requires
+// updating (that is, can be changed "in place"), or requires replacement (that is, must be destroyed and recreated
+// anew). Legacy implementations may also signal that it is unknown whether there are changes or not.
+//
+// `DiffResponse` has evolved since its inception and there are now a number of ways that providers can signal their
+// intent to callers:
+//
+// * *Simple diffs* utilise the `changes` field to signal which fields are responsible for a change, and the `replaces`
+//   field to further communicate which changes (if any) require a replacement as opposed to an update.
+//
+// * *Detailed diffs* are those with `hasDetailedDiff` set, and utilise the `detailedDiff` field to provide a more
+//   granular view of the changes that have occurred. Detailed diffs are designed to allow providers to control
+//   precisely which field names are displayed as responsible for a change, and to signal more accurately what kind of
+//   change occurred (e.g. a field was added, deleted or updated).
 message DiffResponse {
-    repeated string replaces = 1; // if this update requires a replacement, the set of properties triggering it.
-    repeated string stables = 2;  // an optional list of properties that will not ever change.
-    bool deleteBeforeReplace = 3; // if true, this resource must be deleted before replacing it.
-    DiffChanges changes = 4;      // if true, this diff represents an actual difference and thus requires an update.
+    // A set of properties which have changed and whose changes require the resource being diffed to be replaced. The
+    // caller should replace the resource if this set is non-empty, or if any of the properties specified in
+    // `detailedDiff` have a `*_REPLACE` kind.
+    repeated string replaces = 1;
 
-    // a list of the properties that changed. This should only contain top level property names, it does not
-    // support nested properties. For that use detailedDiff.
+    // An optional list of properties that will not ever change (are stable).
+    repeated string stables = 2;
+
+    // If true, this resource must be deleted *before* its replacement is created.
+    bool deleteBeforeReplace = 3;
+
+    // The result of the diff. Indicates at a high level whether the resource has changed or not (or, in legacy cases,
+    // if the provider does not know).
+    DiffChanges changes = 4;
+
+    // The set of properties which have changed. This field only supports top-level properties. It *does not* support
+    // full [property paths](property-paths); implementations should use `detailedDiff` when this is required.
     repeated string diffs = 5;
 
-    // detailedDiff is an optional field that contains map from each changed property to the type of the change.
-    //
-    // The keys of this map are property paths. These paths are essentially Javascript property access expressions
-    // in which all elements are literals, and obey the following EBNF-ish grammar:
-    //
-    //   propertyName := [a-zA-Z_$] { [a-zA-Z0-9_$] }
-    //   quotedPropertyName := '"' ( '\' '"' | [^"] ) { ( '\' '"' | [^"] ) } '"'
-    //   arrayIndex := { [0-9] }
-    //
-    //   propertyIndex := '[' ( quotedPropertyName | arrayIndex ) ']'
-    //   rootProperty := ( propertyName | propertyIndex )
-    //   propertyAccessor := ( ( '.' propertyName ) |  propertyIndex )
-    //   path := rootProperty { propertyAccessor }
-    //
-    // Examples of valid keys:
-    // - root
-    // - root.nested
-    // - root["nested"]
-    // - root.double.nest
-    // - root["double"].nest
-    // - root["double"]["nest"]
-    // - root.array[0]
-    // - root.array[100]
-    // - root.array[0].nested
-    // - root.array[0][1].nested
-    // - root.nested.array[0].double[1]
-    // - root["key with \"escaped\" quotes"]
-    // - root["key with a ."]
-    // - ["root key with \"escaped\" quotes"].nested
-    // - ["root key with a ."][100]
-    map<string, PropertyDiff> detailedDiff = 6; // a detailed diff appropriate for display.
-    bool hasDetailedDiff = 7; // true if this response contains a detailed diff.
+    // `detailedDiff` can be used to implement more detailed diffs. A detailed diff is a map from [property
+    // paths](property-paths) to [](pulumirpc.PropertyDiff)s, which describe the kind of change that occurred to the
+    // property located at that path. If a provider does not implement this, the caller (typically the Pulumi engine)
+    // will compute a representation based on the simple diff fields (`changes`, `replaces`, and so on).
+    map<string, PropertyDiff> detailedDiff = 6;
 
+    // True if and only if this response contains a `detailedDiff`.
+    bool hasDetailedDiff = 7;
+
+    // The type of high-level diff results.
     enum DiffChanges {
-        DIFF_UNKNOWN = 0; // unknown whether there are changes or not (legacy behavior).
-        DIFF_NONE    = 1; // the diff was performed, and no changes were detected that require an update.
-        DIFF_SOME    = 2; // the diff was performed, and changes were detected that require an update or replacement.
+        // A diff was performed but it is unknown whether there are changes or not. This exists to support legacy
+        // behaviour and should be generally avoided wherever possible.
+        DIFF_UNKNOWN = 0;
+
+        // A diff was performed and there were no changes. An update is not required.
+        DIFF_NONE = 1;
+
+        // A diff was performed, and changes were detected that require an update or replacement.
+        DIFF_SOME = 2;
     }
 }
 
+// `CreateRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Create) call.
 message CreateRequest {
-    string urn = 1;                        // the Pulumi URN for this resource.
-    google.protobuf.Struct properties = 2; // the provider inputs to set during creation.
-    double timeout = 3;                    // the create request timeout represented in seconds.
-    bool preview = 4;                      // true if this is a preview and the provider should not actually create the resource.
-    string name = 5; // the Pulumi name for this resource.
-    string type = 6; // the Pulumi type for this resource.
+    // The URN of the resource being created.
+    string urn = 1;
+
+    // The resource's input properties, to be set during creation. These should have been validated by a call to
+    // [](pulumirpc.ResourceProvider.Check).
+    google.protobuf.Struct properties = 2;
+
+    // A timeout in seconds that the caller is prepared to wait for the operation to complete.
+    double timeout = 3;
+
+    // True if and only if the request is being made as part of a preview/dry run, in which case the provider should not
+    // actually create the resource.
+    bool preview = 4;
+
+    // The name of the resource being created. This must match the name specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the name of the resource.
+    string name = 5;
+
+    // The type of the resource being created. This must match the type specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the type of the resource.
+    string type = 6;
 }
 
+// `CreateResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Create) call. A `CreateResponse`
+// contains the ID of the created resource, as well as any output properties that arose from the creation process.
 message CreateResponse {
-    // NOTE: The partial-update-error equivalent of this message is `ErrorResourceInitFailed`.
+    // The ID of the created resource.
+    string id = 1;
 
-    string id = 1;                         // the ID of the created resource.
-    google.protobuf.Struct properties = 2; // any properties that were computed during creation.
+    // The resource's output properties. Typically this will be a union of the resource's input properties and any
+    // additional values that were computed or made available during creation.
+    google.protobuf.Struct properties = 2;
 }
 
+// `ReadRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Read) call.
 message ReadRequest {
-    string id = 1;                         // the ID of the resource to read.
-    string urn = 2;                        // the Pulumi URN for this resource.
-    google.protobuf.Struct properties = 3; // the current state (sufficiently complete to identify the resource).
-    google.protobuf.Struct inputs = 4;     // the current inputs, if any (only populated during refresh).
-    string name = 5; // the Pulumi name for this resource.
-    string type = 6; // the Pulumi type for this resource.
+    // The ID of the resource to read.
+    string id = 1;
+
+    // The URN of the resource being read.
+    string urn = 2;
+
+    // Any current state for the resource being read. This state should be sufficient to uniquely identify the resource.
+    google.protobuf.Struct properties = 3;
+
+    // Any current input properties for the resource being read. These will only be populated when the
+    // [](pulumirpc.ResourceProvider.Read) call is being made as part of a refresh operation.
+    google.protobuf.Struct inputs = 4;
+
+    // The name of the resource being read. This must match the name specified by the `urn` field, and is passed so that
+    // providers do not have to implement URN parsing in order to extract the name of the resource.
+    string name = 5;
+
+    // The type of the resource being read. This must match the type specified by the `urn` field, and is passed so that
+    // providers do not have to implement URN parsing in order to extract the type of the resource.
+    string type = 6;
 }
 
+// `ReadResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Read) call. A `ReadResponse` contains
+// the ID of the resource being read, as well as any state that was successfully read from the live environment.
 message ReadResponse {
-    string id = 1;                         // the ID of the resource read back (or empty if missing).
-    google.protobuf.Struct properties = 2; // the state of the resource read from the live environment.
-    google.protobuf.Struct inputs = 3;     // the inputs for this resource that would be returned from Check.
+    // The ID of the read resource.
+    string id = 1;
+
+    // The output properties of the resource read from the live environment.
+    google.protobuf.Struct properties = 2;
+
+    // Output-derived input properties for the resource. These are returned as they would be returned from a
+    // [](pulumirpc.ResourceProvider.Check) call with the same values.
+    google.protobuf.Struct inputs = 3;
 }
 
+// `UpdateRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Update) call.
 message UpdateRequest {
-    // NOTE: The partial-update-error equivalent of this message is `ErrorResourceInitFailed`.
+    // The ID of the resource being updated.
+    string id = 1;
 
-    string id = 1;                     // the ID of the resource to update.
-    string urn = 2;                    // the Pulumi URN for this resource.
-    google.protobuf.Struct olds = 3;   // the old values of provider inputs for the resource to update.
+    // The URN of the resource being updated.
+    string urn = 2;
 
-    // the new values of provider inputs for the resource to update, copied from CheckResponse.inputs.
+    // The old *output* properties of the resource being updated.
+    google.protobuf.Struct olds = 3;
+
+    // The new input properties of the resource being updated. These should have been validated by a call to
+    // [](pulumirpc.ResourceProvider.Check).
     google.protobuf.Struct news = 4;
 
-    double timeout = 5;                // the update request timeout represented in seconds.
-    repeated string ignoreChanges = 6; // a set of property paths that should be treated as unchanged.
-    bool preview = 7;                   // true if this is a preview and the provider should not actually create the resource.
-    google.protobuf.Struct old_inputs = 8; // the old input values of the resource to diff.
-    string name = 9; // the Pulumi name for this resource.
-    string type = 10; // the Pulumi type for this resource.
+    // A timeout in seconds that the caller is prepared to wait for the operation to complete.
+    double timeout = 5;
+
+    // A set of [property paths](property-paths) that should be treated as unchanged.
+    repeated string ignoreChanges = 6;
+
+    // True if and only if the request is being made as part of a preview/dry run, in which case the provider should not
+    // actually update the resource.
+    bool preview = 7;
+
+    // The old *input* properties of the resource being updated.
+    google.protobuf.Struct old_inputs = 8;
+
+    // The name of the resource being updated. This must match the name specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the name of the resource.
+    string name = 9;
+
+    // The type of the resource being updated. This must match the type specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the type of the resource.
+    string type = 10;
 }
 
+// `UpdateResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Update) call.
 message UpdateResponse {
-    google.protobuf.Struct properties = 1; // any properties that were computed during updating.
+    // An updated set of resource output properties. Typically this will be a union of the resource's inputs and any
+    // additional values that were computed or made available during the update.
+    google.protobuf.Struct properties = 1;
 }
 
+// `DeleteRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Delete) call.
 message DeleteRequest {
-    string id = 1;                         // the ID of the resource to delete.
-    string urn = 2;                        // the Pulumi URN for this resource.
-    google.protobuf.Struct properties = 3; // the current properties on the resource.
-    double timeout = 4;                    // the delete request timeout represented in seconds.
+    // The ID of the resource to delete.
+    string id = 1;
+
+    // The URN of the resource to delete.
+    string urn = 2;
+
+    // The old *output* properties of the resource being deleted.
+    google.protobuf.Struct properties = 3;
+
+    // A timeout in seconds that the caller is prepared to wait for the operation to complete.
+    double timeout = 4;
+
+    // The old *input* properties of the resource being deleted.
     google.protobuf.Struct old_inputs = 5; // the old input values of the resource to delete.
-    string name = 6; // the Pulumi name for this resource.
-    string type = 7; // the Pulumi type for this resource.
+
+    // The name of the resource being deleted. This must match the name specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the name of the resource.
+    string name = 6;
+
+    // The type of the resource being deleted. This must match the type specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the type of the resource.
+    string type = 7;
 }
 
+// `ConstructRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Construct) call. A
+// `ConstructRequest` captures enough data to be able to register nested components against the caller's resource
+// monitor.
 message ConstructRequest {
-    // PropertyDependencies describes the resources that a particular property depends on.
+    // A `PropertyDependencies` list is a set of URNs that a particular property may depend on.
     message PropertyDependencies {
-        repeated string urns = 1; // A list of URNs this property depends on.
+        // A list of URNs that this property depends on.
+        repeated string urns = 1;
     }
 
-    // CustomTimeouts specifies timeouts for resource provisioning operations.
-    // Use it with the [Timeouts] option when creating new resources
-    // to override default timeouts.
+    // A `CustomTimeouts` object encapsulates a set of timeouts for the various CRUD operations that might be performed
+    // on this resource's nested resources. Timeout values are specified as duration strings, such as `"5ms"` (5
+    // milliseconds), `"40s"` (40 seconds), or `"1m30s"` (1 minute and 30 seconds). The following units of time are
+    // supported:
     //
-    // Each timeout is specified as a duration string such as,
-    // "5ms" (5 milliseconds), "40s" (40 seconds),
-    // and "1m30s" (1 minute, 30 seconds).
-    //
-    // The following units are accepted.
-    //
-    //   - ns: nanoseconds
-    //   - us: microseconds
-    //   - µs: microseconds
-    //   - ms: milliseconds
-    //   - s: seconds
-    //   - m: minutes
-    //   - h: hours
+    // * `ns`: nanoseconds
+    // * `us` or `µs`: microseconds
+    // * `ms`: milliseconds
+    // * `s`: seconds
+    // * `m`: minutes
+    // * `h`: hours
     message CustomTimeouts {
+        // How long a caller is prepared to wait for a nested resource's [](pulumirpc.ResourceProvider.Create) operation
+        // to complete.
         string create = 1;
+
+        // How long a caller is prepared to wait for a nested resource's [](pulumirpc.ResourceProvider.Update) operation
+        // to complete.
         string update = 2;
+
+        // How long a caller is prepared to wait for a nested resource's [](pulumirpc.ResourceProvider.Delete) operation
+        // to complete.
         string delete = 3;
     }
 
-    string project = 1;             // the project name.
-    string stack = 2;               // the name of the stack being deployed into.
-    map<string, string> config = 3; // the configuration variables to apply before running.
-    bool dryRun = 4;                // true if we're only doing a dryrun (preview).
-    int32 parallel = 5;             // the degree of parallelism for resource operations (<=1 for serial).
-    string monitorEndpoint = 6;     // the address for communicating back to the resource monitor.
+    // The project to which this resource and its nested resources will belong.
+    string project = 1;
 
-    string type = 7;                                          // the type of the object allocated.
-    string name = 8;                                          // the name, for URN purposes, of the object.
-    string parent = 9;                                        // an optional parent URN that this child resource belongs to.
-    google.protobuf.Struct inputs = 10;                       // the inputs to the resource constructor.
-    map<string, PropertyDependencies> inputDependencies = 11; // a map from property keys to the dependencies of the property.
-    map<string, string> providers = 13;                       // the map of providers to use for this resource's children.
-    repeated string dependencies = 15;                        // a list of URNs that this resource depends on, as observed by the language host.
-    repeated string configSecretKeys = 16;                    // the configuration keys that have secret values.
-    string organization = 17;                                 // the organization of the stack being deployed into.
+    // The name of the stack being deployed into.
+    string stack = 2;
 
-    // Resource options:
-    // Do not change field IDs. Add new fields at the end.
-    bool protect                            = 12; // true if the resource should be marked protected.
-    repeated string aliases                 = 14; // a list of additional URNs that shoud be considered the same.
-    repeated string additionalSecretOutputs = 18; // additional output properties that should be treated as secrets.
-    CustomTimeouts customTimeouts           = 19; // default timeouts for CRUD operations on this resource.
-    string deletedWith                      = 20; // URN of a resource that, if deleted, also deletes this resource.
-    bool deleteBeforeReplace                = 21; // whether to delete the resource before replacing it.
-    repeated string ignoreChanges           = 22; // properties that should be ignored during a diff
-    repeated string replaceOnChanges        = 23; // properties that, when changed, trigger a replacement
-    bool retainOnDelete                     = 24; // whether to retain the resource in the cloud provider when it is deleted
+    // Configuration for the specified project and stack.
+    map<string, string> config = 3;
 
-    bool accepts_output_values = 25; // the engine can be passed output values back, stateDependencies can be left blank if returning output values.
+    // True if and only if the request is being made as part of a preview/dry run, in which case the provider should not
+    // actually construct the component.
+    bool dryRun = 4;
+
+    // The degree of parallelism that may be used for resource operations. A value less than or equal to 1 indicates
+    // that operations should be performed serially.
+    int32 parallel = 5;
+
+    // The address of the [](pulumirpc.ResourceMonitor) that the provider should connect to in order to send [resource
+    // registrations](resource-registration) for its nested resources.
+    string monitorEndpoint = 6;
+
+    // The type of the component resource being constructed. This must match the type specified by the `urn` field, and
+    // is passed so that providers do not have to implement URN parsing in order to extract the type of the resource.
+    string type = 7;
+
+    // The name of the component resource being constructed. This must match the name specified by the `urn` field, and
+    // is passed so that providers do not have to implement URN parsing in order to extract the name of the resource.
+    string name = 8;
+
+    // Dependencies and resource options
+    //
+    // These are passed so that the component may propagate them to resources it registers against the supplied resource
+    // monitor.
+    //
+    // Do *not* change field IDs. Add new fields at the end with appropriate field IDs as necessary.
+
+    // An optional parent resource that the component (and by extension, its nested resources) should be children of.
+    string parent = 9;
+
+    // The component resource's input properties. Unlike the inputs of custom resources, these will *not* have been
+    // passed to a call to [](pulumirpc.ResourceProvider.Check). By virtue of their being a composition of other
+    // resources, component resources are able to (and therefore expected) to validate their own inputs. Moreover,
+    // [](pulumirpc.ResourceProvider.Check) will be called on any inputs passed to nested custom resources as usual.
+    google.protobuf.Struct inputs = 10;
+
+    // A map of property dependencies for the component resource and its nested resources.
+    map<string, PropertyDependencies> inputDependencies = 11;
+
+    // A map of package names to provider references for the component resource and its nested resources.
+    map<string, string> providers = 13;
+
+    // A list of URNs that this resource and its nested resources depend on.
+    repeated string dependencies = 15;
+
+    // A set of configuration keys whose values are [secret](output-secrets).
+    repeated string configSecretKeys = 16;
+
+    // The organization to which this resource and its nested resources will belong.
+    string organization = 17;
+
+    // True if and only if the resource (and by extension, its nested resources) should be marked as protected.
+    // Protected resources cannot be deleted without first being unprotected.
+    bool protect = 12;
+
+    // A list of additional URNs that should be considered the same as this component's URN (and which will therefore be
+    // used to build aliases for its nested resource URNs). These may be URNs that previously referred to this component
+    // e.g. if it had its parent (and consequently URN) changed.
+    repeated string aliases = 14;
+
+    // A list of input properties whose values should be treated as [secret](output-secrets).
+    repeated string additionalSecretOutputs = 18;
+
+    // A set of custom timeouts that specify how long the caller is prepared to wait for the various CRUD operations of
+    // this resource's nested resources.
+    CustomTimeouts customTimeouts = 19;
+
+    // The URN of a resource that this resource (and thus its nested resources) will be implicitly deleted with. If the
+    // resource referred to by this URN is deleted in the same operation that this resource would be deleted, the
+    // [](pulumirpc.ResourceProvider.Delete) call for this resource will be elided (since this dependency signals that
+    // it will have already been deleted).
+    string deletedWith = 20;
+
+    // If true, this resource (and its nested resources) must be deleted *before* its replacement is created.
+    bool deleteBeforeReplace = 21;
+
+    // A set of [property paths](property-paths) that should be treated as unchanged.
+    repeated string ignoreChanges = 22;
+
+    // A set of properties that, when changed, trigger a replacement.
+    repeated string replaceOnChanges = 23;
+
+    // True if [](pulumirpc.ResourceProvider.Delete) should *not* be called when the resource (and by extension, its
+    // nested resources) are removed from a Pulumi program.
+    bool retainOnDelete = 24;
+
+    // True if the caller is capable of accepting output values in response to the call. If this is set, these outputs
+    // may be used to communicate dependency information and so there is no need to populate
+    // [](pulumirpc.ConstructResponse)'s `stateDependencies` field.
+    bool accepts_output_values = 25;
 }
 
+// `ConstructResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Construct) call.
 message ConstructResponse {
-    // PropertyDependencies describes the resources that a particular property depends on.
+    // A `PropertyDependencies` list is a set of URNs that a particular property may depend on.
     message PropertyDependencies {
-        repeated string urns = 1; // A list of URNs this property depends on.
+        // A list of URNs that this property depends on.
+        repeated string urns = 1;
     }
 
-    string urn = 1;                                          // the URN of the component resource.
-    google.protobuf.Struct state = 2;                        // any properties that were computed during construction.
-    map<string, PropertyDependencies> stateDependencies = 3; // a map from property keys to the dependencies of the property.
+    // The URN of the constructed component resource.
+    string urn = 1;
+
+    // Any output properties that the component registered as part of its construction.
+    google.protobuf.Struct state = 2;
+
+    // A map of property dependencies for the component's outputs. This will be set if the caller indicated that it
+    // could not receive dependency-communicating [output](outputs) values by setting [](pulumirpc.ConstructRequest)'s
+    // `accepts_output_values` field to false.
+    map<string, PropertyDependencies> stateDependencies = 3;
 }
 
 // ErrorResourceInitFailed is sent as a Detail `ResourceProvider.{Create, Update}` fail because a

--- a/sdk/nodejs/proto/provider_grpc_pb.js
+++ b/sdk/nodejs/proto/provider_grpc_pb.js
@@ -424,7 +424,7 @@ getSchema: {
 //
 // As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
 // the properties as present in the program inputs. Though this rule is not required for correctness, violations
-// thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+// thereof can negatively impact the end-user experience, as the provider inputs are used for detecting and
 // rendering diffs.
 checkConfig: {
     path: '/pulumirpc.ResourceProvider/CheckConfig',
@@ -437,7 +437,16 @@ checkConfig: {
     responseSerialize: serialize_pulumirpc_CheckResponse,
     responseDeserialize: deserialize_pulumirpc_CheckResponse,
   },
-  // DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
+  // `DiffConfig` compares an existing ("old") provider configuration with a new configuration and computes the
+// difference (if any) between them. `DiffConfig` is to provider resources what [](pulumirpc.ResourceProvider.Diff)
+// is to individual resources. `DiffConfig` should only be called with values that have at some point been validated
+// by a [](pulumirpc.ResourceProvider.CheckConfig) call. The [](pulumirpc.DiffResponse) returned by a `DiffConfig`
+// call is used primarily to determine whether or not the newly configured provider is capable of managing resources
+// owned by the old provider. If `DiffConfig` indicates that the provider resource needs to be replaced, for
+// instance, then all resources owned by that provider will *also* need to be replaced. Replacement semantics should
+// thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
+// Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
+// AWS access key, should almost certainly not.
 diffConfig: {
     path: '/pulumirpc.ResourceProvider/DiffConfig',
     requestStream: false,
@@ -449,13 +458,18 @@ diffConfig: {
     responseSerialize: serialize_pulumirpc_DiffResponse,
     responseDeserialize: deserialize_pulumirpc_DiffResponse,
   },
-  // Configure configures the resource provider with "globals" that control its behavior.
+  // `Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
 //
-// :::{warning}
-// ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
-// ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
-// ConfigureRequest.args.
-// :::
+// * Provider-specific configuration, which is the set of inputs that have been validated by a previous
+//   [](pulumirpc.ResourceProvider.CheckConfig) call.
+// * Provider-agnostic ("protocol") configuration, such as whether or not the caller supports secrets.
+//
+// The provider is expected to return its own set of protocol configuration, indicating which features it supports
+// in turn so that the caller and the provider can interact appropriately.
+//
+// Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
+// the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
+// indicate which keys are missing.
 configure: {
     path: '/pulumirpc.ResourceProvider/Configure',
     requestStream: false,
@@ -504,11 +518,18 @@ call: {
     responseSerialize: serialize_pulumirpc_CallResponse,
     responseDeserialize: deserialize_pulumirpc_CallResponse,
   },
-  // Check validates that the given property bag is valid for a resource of the given type and returns the inputs
-// that should be passed to successive calls to Diff, Create, or Update for this resource. As a rule, the provider
-// inputs returned by a call to Check should preserve the original representation of the properties as present in
-// the program inputs. Though this rule is not required for correctness, violations thereof can negatively impact
-// the end-user experience, as the provider inputs are using for detecting and rendering diffs.
+  // `Check` validates a set of input properties against a given resource type. A `Check` call returns either a set of
+// checked, known-valid inputs that may subsequently be passed to [](pulumirpc.ResourceProvider.Diff),
+// [](pulumirpc.ResourceProvider.Create), or [](pulumirpc.ResourceProvider.Update); or a set of errors explaining
+// why the inputs are invalid. In the case that a set of inputs are successfully validated and returned, `Check`
+// *may also populate default values* for resource inputs, returning them so that they may be passed to a subsequent
+// call and persisted in the Pulumi state. In the case that `Check` fails and returns a set of errors, it is
+// expected that the caller (typically the Pulumi engine) will fail resource registration.
+//
+// As a rule, the provider inputs returned by a call to `Check` should preserve the original representation of the
+// properties as present in the program inputs. Though this rule is not required for correctness, violations thereof
+// can negatively impact the end-user experience, as the provider inputs are used for detecting and rendering
+// diffs.
 check: {
     path: '/pulumirpc.ResourceProvider/Check',
     requestStream: false,
@@ -520,7 +541,9 @@ check: {
     responseSerialize: serialize_pulumirpc_CheckResponse,
     responseDeserialize: deserialize_pulumirpc_CheckResponse,
   },
-  // Diff checks what impacts a hypothetical update will have on the resource's properties.
+  // `Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
+// difference (if any) between them. `Diff` should only be called with values that have at some point been validated
+// by a [](pulumirpc.ResourceProvider.Check) call.
 diff: {
     path: '/pulumirpc.ResourceProvider/Diff',
     requestStream: false,
@@ -532,8 +555,14 @@ diff: {
     responseSerialize: serialize_pulumirpc_DiffResponse,
     responseDeserialize: deserialize_pulumirpc_DiffResponse,
   },
-  // Create allocates a new instance of the provided resource and returns its unique ID afterwards.  (The input ID
-// must be blank.)  If this call fails, the resource must not have been created (i.e., it is "transactional").
+  // `Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a
+// provider-assigned ID for the resource as well as the output properties that arose from the creation properties.
+// Output properties are typically the union of the resource's input properties and any additional values that were
+// computed or made available during creation.
+//
+// If creation fails, `Create` may return an [](pulumirpc.ErrorResourceInitFailed) error detail explaining why.
+// Moreover, if `Create` does return an error, it must be the case that the resource was *not* created (that is,
+// `Create` can be thought of as transactional or atomic).
 create: {
     path: '/pulumirpc.ResourceProvider/Create',
     requestStream: false,
@@ -545,8 +574,9 @@ create: {
     responseSerialize: serialize_pulumirpc_CreateResponse,
     responseDeserialize: deserialize_pulumirpc_CreateResponse,
   },
-  // Read the current live state associated with a resource.  Enough state must be include in the inputs to uniquely
-// identify the resource; this is typically just the resource ID, but may also include some properties.
+  // `Read` reads the current live state associated with a resource identified by the supplied state. The given state
+// must be sufficient to uniquely identify the resource. This is typically just the resource ID, but may also
+// include other properties.
 read: {
     path: '/pulumirpc.ResourceProvider/Read',
     requestStream: false,
@@ -558,7 +588,7 @@ read: {
     responseSerialize: serialize_pulumirpc_ReadResponse,
     responseDeserialize: deserialize_pulumirpc_ReadResponse,
   },
-  // Update updates an existing resource with new values.
+  // `Update` updates an existing resource according to a new set of inputs, returning a new set of output properties.
 update: {
     path: '/pulumirpc.ResourceProvider/Update',
     requestStream: false,
@@ -570,7 +600,9 @@ update: {
     responseSerialize: serialize_pulumirpc_UpdateResponse,
     responseDeserialize: deserialize_pulumirpc_UpdateResponse,
   },
-  // Delete tears down an existing resource with the given ID.  If it fails, the resource is assumed to still exist.
+  // `Delete` deprovisions an existing resource as specified by its ID. `Delete` should be transactional/atomic -- if
+// a call to `Delete` fails, it must be the case that the resource was *not* deleted and can be assumed to still
+// exist.
 delete: {
     path: '/pulumirpc.ResourceProvider/Delete',
     requestStream: false,
@@ -582,7 +614,20 @@ delete: {
     responseSerialize: serialize_google_protobuf_Empty,
     responseDeserialize: deserialize_google_protobuf_Empty,
   },
-  // Construct creates a new instance of the provided component resource and returns its state.
+  // `Construct` provisions a new [component resource](component-resources). Providers that implement `Construct` are
+// referred to as [component providers](component-providers). `Construct` is to component resources what
+// [](pulumirpc.ResourceProvider.Create) is to [custom resources](custom-resources). Components do not have any
+// lifecycle of their own, and instead embody the lifecycles of the resources that they are composed of. As such,
+// `Construct` is effectively a subprogram whose resources will be persisted in the caller's state. It is
+// consequently passed enough information to manage fully these resources. At a high level, this comprises:
+//
+// * A [](pulumirpc.ResourceMonitor) endpoint which the provider can use to [register](resource-registration) nested
+//   custom or component resources that belong to the component.
+//
+// * A set of input properties.
+//
+// * A full set of [resource options](https://www.pulumi.com/docs/iac/concepts/options/) that the component should
+//   propagate to resources it registers against the supplied resource monitor.
 construct: {
     path: '/pulumirpc.ResourceProvider/Construct',
     requestStream: false,

--- a/sdk/proto/go/provider_grpc.pb.go
+++ b/sdk/proto/go/provider_grpc.pb.go
@@ -69,18 +69,32 @@ type ResourceProviderClient interface {
 	//
 	// As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
 	// the properties as present in the program inputs. Though this rule is not required for correctness, violations
-	// thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+	// thereof can negatively impact the end-user experience, as the provider inputs are used for detecting and
 	// rendering diffs.
 	CheckConfig(ctx context.Context, in *CheckRequest, opts ...grpc.CallOption) (*CheckResponse, error)
-	// DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
+	// `DiffConfig` compares an existing ("old") provider configuration with a new configuration and computes the
+	// difference (if any) between them. `DiffConfig` is to provider resources what [](pulumirpc.ResourceProvider.Diff)
+	// is to individual resources. `DiffConfig` should only be called with values that have at some point been validated
+	// by a [](pulumirpc.ResourceProvider.CheckConfig) call. The [](pulumirpc.DiffResponse) returned by a `DiffConfig`
+	// call is used primarily to determine whether or not the newly configured provider is capable of managing resources
+	// owned by the old provider. If `DiffConfig` indicates that the provider resource needs to be replaced, for
+	// instance, then all resources owned by that provider will *also* need to be replaced. Replacement semantics should
+	// thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
+	// Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
+	// AWS access key, should almost certainly not.
 	DiffConfig(ctx context.Context, in *DiffRequest, opts ...grpc.CallOption) (*DiffResponse, error)
-	// Configure configures the resource provider with "globals" that control its behavior.
+	// `Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
 	//
-	// :::{warning}
-	// ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
-	// ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
-	// ConfigureRequest.args.
-	// :::
+	// * Provider-specific configuration, which is the set of inputs that have been validated by a previous
+	//   [](pulumirpc.ResourceProvider.CheckConfig) call.
+	// * Provider-agnostic ("protocol") configuration, such as whether or not the caller supports secrets.
+	//
+	// The provider is expected to return its own set of protocol configuration, indicating which features it supports
+	// in turn so that the caller and the provider can interact appropriately.
+	//
+	// Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
+	// the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
+	// indicate which keys are missing.
 	Configure(ctx context.Context, in *ConfigureRequest, opts ...grpc.CallOption) (*ConfigureResponse, error)
 	// Invoke dynamically executes a built-in function in the provider.
 	Invoke(ctx context.Context, in *InvokeRequest, opts ...grpc.CallOption) (*InvokeResponse, error)
@@ -89,25 +103,56 @@ type ResourceProviderClient interface {
 	StreamInvoke(ctx context.Context, in *InvokeRequest, opts ...grpc.CallOption) (ResourceProvider_StreamInvokeClient, error)
 	// Call dynamically executes a method in the provider associated with a component resource.
 	Call(ctx context.Context, in *CallRequest, opts ...grpc.CallOption) (*CallResponse, error)
-	// Check validates that the given property bag is valid for a resource of the given type and returns the inputs
-	// that should be passed to successive calls to Diff, Create, or Update for this resource. As a rule, the provider
-	// inputs returned by a call to Check should preserve the original representation of the properties as present in
-	// the program inputs. Though this rule is not required for correctness, violations thereof can negatively impact
-	// the end-user experience, as the provider inputs are using for detecting and rendering diffs.
+	// `Check` validates a set of input properties against a given resource type. A `Check` call returns either a set of
+	// checked, known-valid inputs that may subsequently be passed to [](pulumirpc.ResourceProvider.Diff),
+	// [](pulumirpc.ResourceProvider.Create), or [](pulumirpc.ResourceProvider.Update); or a set of errors explaining
+	// why the inputs are invalid. In the case that a set of inputs are successfully validated and returned, `Check`
+	// *may also populate default values* for resource inputs, returning them so that they may be passed to a subsequent
+	// call and persisted in the Pulumi state. In the case that `Check` fails and returns a set of errors, it is
+	// expected that the caller (typically the Pulumi engine) will fail resource registration.
+	//
+	// As a rule, the provider inputs returned by a call to `Check` should preserve the original representation of the
+	// properties as present in the program inputs. Though this rule is not required for correctness, violations thereof
+	// can negatively impact the end-user experience, as the provider inputs are used for detecting and rendering
+	// diffs.
 	Check(ctx context.Context, in *CheckRequest, opts ...grpc.CallOption) (*CheckResponse, error)
-	// Diff checks what impacts a hypothetical update will have on the resource's properties.
+	// `Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
+	// difference (if any) between them. `Diff` should only be called with values that have at some point been validated
+	// by a [](pulumirpc.ResourceProvider.Check) call.
 	Diff(ctx context.Context, in *DiffRequest, opts ...grpc.CallOption) (*DiffResponse, error)
-	// Create allocates a new instance of the provided resource and returns its unique ID afterwards.  (The input ID
-	// must be blank.)  If this call fails, the resource must not have been created (i.e., it is "transactional").
+	// `Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a
+	// provider-assigned ID for the resource as well as the output properties that arose from the creation properties.
+	// Output properties are typically the union of the resource's input properties and any additional values that were
+	// computed or made available during creation.
+	//
+	// If creation fails, `Create` may return an [](pulumirpc.ErrorResourceInitFailed) error detail explaining why.
+	// Moreover, if `Create` does return an error, it must be the case that the resource was *not* created (that is,
+	// `Create` can be thought of as transactional or atomic).
 	Create(ctx context.Context, in *CreateRequest, opts ...grpc.CallOption) (*CreateResponse, error)
-	// Read the current live state associated with a resource.  Enough state must be include in the inputs to uniquely
-	// identify the resource; this is typically just the resource ID, but may also include some properties.
+	// `Read` reads the current live state associated with a resource identified by the supplied state. The given state
+	// must be sufficient to uniquely identify the resource. This is typically just the resource ID, but may also
+	// include other properties.
 	Read(ctx context.Context, in *ReadRequest, opts ...grpc.CallOption) (*ReadResponse, error)
-	// Update updates an existing resource with new values.
+	// `Update` updates an existing resource according to a new set of inputs, returning a new set of output properties.
 	Update(ctx context.Context, in *UpdateRequest, opts ...grpc.CallOption) (*UpdateResponse, error)
-	// Delete tears down an existing resource with the given ID.  If it fails, the resource is assumed to still exist.
+	// `Delete` deprovisions an existing resource as specified by its ID. `Delete` should be transactional/atomic -- if
+	// a call to `Delete` fails, it must be the case that the resource was *not* deleted and can be assumed to still
+	// exist.
 	Delete(ctx context.Context, in *DeleteRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
-	// Construct creates a new instance of the provided component resource and returns its state.
+	// `Construct` provisions a new [component resource](component-resources). Providers that implement `Construct` are
+	// referred to as [component providers](component-providers). `Construct` is to component resources what
+	// [](pulumirpc.ResourceProvider.Create) is to [custom resources](custom-resources). Components do not have any
+	// lifecycle of their own, and instead embody the lifecycles of the resources that they are composed of. As such,
+	// `Construct` is effectively a subprogram whose resources will be persisted in the caller's state. It is
+	// consequently passed enough information to manage fully these resources. At a high level, this comprises:
+	//
+	// * A [](pulumirpc.ResourceMonitor) endpoint which the provider can use to [register](resource-registration) nested
+	//   custom or component resources that belong to the component.
+	//
+	// * A set of input properties.
+	//
+	// * A full set of [resource options](https://www.pulumi.com/docs/iac/concepts/options/) that the component should
+	//   propagate to resources it registers against the supplied resource monitor.
 	Construct(ctx context.Context, in *ConstructRequest, opts ...grpc.CallOption) (*ConstructResponse, error)
 	// Cancel signals the provider to gracefully shut down and abort any ongoing resource operations.
 	// Operations aborted in this way will return an error (e.g., `Update` and `Create` will either return a
@@ -389,18 +434,32 @@ type ResourceProviderServer interface {
 	//
 	// As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
 	// the properties as present in the program inputs. Though this rule is not required for correctness, violations
-	// thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+	// thereof can negatively impact the end-user experience, as the provider inputs are used for detecting and
 	// rendering diffs.
 	CheckConfig(context.Context, *CheckRequest) (*CheckResponse, error)
-	// DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
+	// `DiffConfig` compares an existing ("old") provider configuration with a new configuration and computes the
+	// difference (if any) between them. `DiffConfig` is to provider resources what [](pulumirpc.ResourceProvider.Diff)
+	// is to individual resources. `DiffConfig` should only be called with values that have at some point been validated
+	// by a [](pulumirpc.ResourceProvider.CheckConfig) call. The [](pulumirpc.DiffResponse) returned by a `DiffConfig`
+	// call is used primarily to determine whether or not the newly configured provider is capable of managing resources
+	// owned by the old provider. If `DiffConfig` indicates that the provider resource needs to be replaced, for
+	// instance, then all resources owned by that provider will *also* need to be replaced. Replacement semantics should
+	// thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
+	// Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
+	// AWS access key, should almost certainly not.
 	DiffConfig(context.Context, *DiffRequest) (*DiffResponse, error)
-	// Configure configures the resource provider with "globals" that control its behavior.
+	// `Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
 	//
-	// :::{warning}
-	// ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
-	// ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
-	// ConfigureRequest.args.
-	// :::
+	// * Provider-specific configuration, which is the set of inputs that have been validated by a previous
+	//   [](pulumirpc.ResourceProvider.CheckConfig) call.
+	// * Provider-agnostic ("protocol") configuration, such as whether or not the caller supports secrets.
+	//
+	// The provider is expected to return its own set of protocol configuration, indicating which features it supports
+	// in turn so that the caller and the provider can interact appropriately.
+	//
+	// Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
+	// the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
+	// indicate which keys are missing.
 	Configure(context.Context, *ConfigureRequest) (*ConfigureResponse, error)
 	// Invoke dynamically executes a built-in function in the provider.
 	Invoke(context.Context, *InvokeRequest) (*InvokeResponse, error)
@@ -409,25 +468,56 @@ type ResourceProviderServer interface {
 	StreamInvoke(*InvokeRequest, ResourceProvider_StreamInvokeServer) error
 	// Call dynamically executes a method in the provider associated with a component resource.
 	Call(context.Context, *CallRequest) (*CallResponse, error)
-	// Check validates that the given property bag is valid for a resource of the given type and returns the inputs
-	// that should be passed to successive calls to Diff, Create, or Update for this resource. As a rule, the provider
-	// inputs returned by a call to Check should preserve the original representation of the properties as present in
-	// the program inputs. Though this rule is not required for correctness, violations thereof can negatively impact
-	// the end-user experience, as the provider inputs are using for detecting and rendering diffs.
+	// `Check` validates a set of input properties against a given resource type. A `Check` call returns either a set of
+	// checked, known-valid inputs that may subsequently be passed to [](pulumirpc.ResourceProvider.Diff),
+	// [](pulumirpc.ResourceProvider.Create), or [](pulumirpc.ResourceProvider.Update); or a set of errors explaining
+	// why the inputs are invalid. In the case that a set of inputs are successfully validated and returned, `Check`
+	// *may also populate default values* for resource inputs, returning them so that they may be passed to a subsequent
+	// call and persisted in the Pulumi state. In the case that `Check` fails and returns a set of errors, it is
+	// expected that the caller (typically the Pulumi engine) will fail resource registration.
+	//
+	// As a rule, the provider inputs returned by a call to `Check` should preserve the original representation of the
+	// properties as present in the program inputs. Though this rule is not required for correctness, violations thereof
+	// can negatively impact the end-user experience, as the provider inputs are used for detecting and rendering
+	// diffs.
 	Check(context.Context, *CheckRequest) (*CheckResponse, error)
-	// Diff checks what impacts a hypothetical update will have on the resource's properties.
+	// `Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
+	// difference (if any) between them. `Diff` should only be called with values that have at some point been validated
+	// by a [](pulumirpc.ResourceProvider.Check) call.
 	Diff(context.Context, *DiffRequest) (*DiffResponse, error)
-	// Create allocates a new instance of the provided resource and returns its unique ID afterwards.  (The input ID
-	// must be blank.)  If this call fails, the resource must not have been created (i.e., it is "transactional").
+	// `Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a
+	// provider-assigned ID for the resource as well as the output properties that arose from the creation properties.
+	// Output properties are typically the union of the resource's input properties and any additional values that were
+	// computed or made available during creation.
+	//
+	// If creation fails, `Create` may return an [](pulumirpc.ErrorResourceInitFailed) error detail explaining why.
+	// Moreover, if `Create` does return an error, it must be the case that the resource was *not* created (that is,
+	// `Create` can be thought of as transactional or atomic).
 	Create(context.Context, *CreateRequest) (*CreateResponse, error)
-	// Read the current live state associated with a resource.  Enough state must be include in the inputs to uniquely
-	// identify the resource; this is typically just the resource ID, but may also include some properties.
+	// `Read` reads the current live state associated with a resource identified by the supplied state. The given state
+	// must be sufficient to uniquely identify the resource. This is typically just the resource ID, but may also
+	// include other properties.
 	Read(context.Context, *ReadRequest) (*ReadResponse, error)
-	// Update updates an existing resource with new values.
+	// `Update` updates an existing resource according to a new set of inputs, returning a new set of output properties.
 	Update(context.Context, *UpdateRequest) (*UpdateResponse, error)
-	// Delete tears down an existing resource with the given ID.  If it fails, the resource is assumed to still exist.
+	// `Delete` deprovisions an existing resource as specified by its ID. `Delete` should be transactional/atomic -- if
+	// a call to `Delete` fails, it must be the case that the resource was *not* deleted and can be assumed to still
+	// exist.
 	Delete(context.Context, *DeleteRequest) (*emptypb.Empty, error)
-	// Construct creates a new instance of the provided component resource and returns its state.
+	// `Construct` provisions a new [component resource](component-resources). Providers that implement `Construct` are
+	// referred to as [component providers](component-providers). `Construct` is to component resources what
+	// [](pulumirpc.ResourceProvider.Create) is to [custom resources](custom-resources). Components do not have any
+	// lifecycle of their own, and instead embody the lifecycles of the resources that they are composed of. As such,
+	// `Construct` is effectively a subprogram whose resources will be persisted in the caller's state. It is
+	// consequently passed enough information to manage fully these resources. At a high level, this comprises:
+	//
+	// * A [](pulumirpc.ResourceMonitor) endpoint which the provider can use to [register](resource-registration) nested
+	//   custom or component resources that belong to the component.
+	//
+	// * A set of input properties.
+	//
+	// * A full set of [resource options](https://www.pulumi.com/docs/iac/concepts/options/) that the component should
+	//   propagate to resources it registers against the supplied resource monitor.
 	Construct(context.Context, *ConstructRequest) (*ConstructResponse, error)
 	// Cancel signals the provider to gracefully shut down and abort any ongoing resource operations.
 	// Operations aborted in this way will return an error (e.g., `Update` and `Create` will either return a

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
@@ -181,6 +181,11 @@ global___GetSchemaResponse = GetSchemaResponse
 
 @typing_extensions.final
 class ConfigureRequest(google.protobuf.message.Message):
+    """`ConfigureRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Configure) call. Requests
+    include both provider-specific inputs (`variables` or `args`) and provider-agnostic ("protocol") configuration
+    (`acceptSecrets`, `acceptResources`, and so on).
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     @typing_extensions.final
@@ -207,18 +212,59 @@ class ConfigureRequest(google.protobuf.message.Message):
     SENDS_OLD_INPUTS_TO_DELETE_FIELD_NUMBER: builtins.int
     @property
     def variables(self) -> google.protobuf.internal.containers.ScalarMap[builtins.str, builtins.str]:
-        """the input properties for the provider, with nested values JSON-encoded; please read from `args` instead."""
+        """:::{warning}
+        `variables` is deprecated; `args` should be used instead wherever possible.
+        :::
+
+        A map of input properties for the provider. Compound values, such as nested objects, should be JSON encoded so
+        that they too can be passed as strings. For instance, the following configuration:
+
+        ```
+        {
+          "a": 42,
+          "b": {
+            "c": "hello",
+            "d": true
+          }
+        }
+        ```
+
+        should be encoded as:
+
+        ```
+        {
+          "a": "42",
+          "b": "{\\"c\\":\\"hello\\",\\"d\\":true}"
+        }
+        ```
+        """
     @property
     def args(self) -> google.protobuf.struct_pb2.Struct:
-        """the input properties for the provider"""
+        """A map of input properties for the provider.
+
+        :::{warning}
+        `args` may include secrets. Because `ConfigureRequest` is sent before [](pulumirpc.ConfigureResponse) can specify
+        whether or not the provider accepts secrets in general, providers *must* handle secrets if they appear in `args`.
+        :::
+        """
     acceptSecrets: builtins.bool
-    """when true, operations should return secrets as strongly typed."""
+    """True if and only if the caller supports secrets. If true, operations should return strongly typed secrets if the
+    provider supports them also.
+    """
     acceptResources: builtins.bool
-    """when true, operations should return resources as strongly typed values to the provider."""
+    """True if and only if the caller supports strongly typed resources. If true, operations should return resources as
+    strongly typed values if the provider supports them also.
+    """
     sends_old_inputs: builtins.bool
-    """when true, diff and update will be called with the old outputs and the old inputs."""
+    """True if and only if the caller supports sending old inputs as part of [](pulumirpc.ResourceProvider.Diff) and
+    [](pulumirpc.ResourceProvider.Update) calls. If true, the provider should expect these fields to be populated in
+    these calls.
+    """
     sends_old_inputs_to_delete: builtins.bool
-    """when true, delete will be called with the old outputs and the old inputs."""
+    """True if and only if the caller supports sending old inputs and outputs as part of
+    [](pulumirpc.ResourceProvider.Delete) calls. If true, the provider should expect these fields to be populated in
+    these calls.
+    """
     def __init__(
         self,
         *,
@@ -236,6 +282,10 @@ global___ConfigureRequest = ConfigureRequest
 
 @typing_extensions.final
 class ConfigureResponse(google.protobuf.message.Message):
+    """`ConfigureResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Configure) call. Its primary
+    purpose is to communicate features that the provider supports back to the caller.
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     ACCEPTSECRETS_FIELD_NUMBER: builtins.int
@@ -243,13 +293,22 @@ class ConfigureResponse(google.protobuf.message.Message):
     ACCEPTRESOURCES_FIELD_NUMBER: builtins.int
     ACCEPTOUTPUTS_FIELD_NUMBER: builtins.int
     acceptSecrets: builtins.bool
-    """when true, the engine should pass secrets as strongly typed values to the provider."""
+    """True if and only if the provider supports secrets. If true, the caller should pass secrets as strongly typed
+    values to the provider.
+    """
     supportsPreview: builtins.bool
-    """when true, the engine should invoke create and update with preview=true during previews."""
+    """True if and only if the provider supports the `preview` field on [](pulumirpc.ResourceProvider.Create) and
+    [](pulumirpc.ResourceProvider.Update) calls. If true, the engine should invoke these calls with `preview` set to
+    `true` during previews.
+    """
     acceptResources: builtins.bool
-    """when true, the engine should pass resources as strongly typed values to the provider."""
+    """True if and only if the provider supports strongly typed resources. If true, the caller should pass resources as
+    strongly typed values to the provider.
+    """
     acceptOutputs: builtins.bool
-    """when true, the engine should pass output values to the provider."""
+    """True if and only if the provider supports output values as inputs. If true, the engine should pass output values
+    to the provider where possible.
+    """
     def __init__(
         self,
         *,
@@ -264,20 +323,32 @@ global___ConfigureResponse = ConfigureResponse
 
 @typing_extensions.final
 class ConfigureErrorMissingKeys(google.protobuf.message.Message):
-    """ConfigureErrorMissingKeys is sent as a Detail on an error returned from `ResourceProvider.Configure`."""
+    """`ConfigureErrorMissingKeys` is the type of error details that may be sent in response to a
+    [](pulumirpc.ResourceProvider.Configure) call when required configuration keys are missing.
+    """
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     @typing_extensions.final
     class MissingKey(google.protobuf.message.Message):
+        """The type of key-value pairs representing keys that are missing from a [](pulumirpc.ResourceProvider.Configure)
+        call.
+        """
+
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
         NAME_FIELD_NUMBER: builtins.int
         DESCRIPTION_FIELD_NUMBER: builtins.int
         name: builtins.str
-        """the Pulumi name (not the provider name!) of the missing config key."""
+        """The name of the missing configuration key.
+
+        :::{note}
+        This should be the *Pulumi name* of the missing key, and not any provider-internal or upstream name. Names
+        that differ between Pulumi and an upstream provider should be translated prior to being returned.
+        :::
+        """
         description: builtins.str
-        """a description of the missing config key, as reported by the provider."""
+        """A description of the missing config key, as reported by the provider."""
         def __init__(
             self,
             *,
@@ -289,7 +360,7 @@ class ConfigureErrorMissingKeys(google.protobuf.message.Message):
     MISSINGKEYS_FIELD_NUMBER: builtins.int
     @property
     def missingKeys(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___ConfigureErrorMissingKeys.MissingKey]:
-        """a list of required configuration keys that were not supplied."""
+        """A list of required configuration keys that were not supplied."""
     def __init__(
         self,
         *,
@@ -643,6 +714,21 @@ global___CheckFailure = CheckFailure
 
 @typing_extensions.final
 class DiffRequest(google.protobuf.message.Message):
+    """`DiffRequest` is the type of requests sent as part of [](pulumirpc.ResourceProvider.DiffConfig) and
+    [](pulumirpc.ResourceProvider.Diff) calls. A `DiffRequest` primarily captures:
+
+    * the URN of the resource whose properties are being compared;
+    * the old and new input properties of the resource; and
+    * the old output properties of the resource.
+
+    In the case of [](pulumirpc.ResourceProvider.DiffConfig), the URN will be the URN of the provider resource being
+    examined, which may or may not be a [default provider](default-providers), and the inputs and outputs will be the
+    provider configuration and state. Inputs supplied to a [](pulumirpc.ResourceProvider.DiffConfig) call should have
+    been previously checked by a call to [](pulumirpc.ResourceProvider.CheckConfig); inputs supplied to a
+    [](pulumirpc.ResourceProvider.Diff) call should have been previously checked by a call to
+    [](pulumirpc.ResourceProvider.Check).
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     ID_FIELD_NUMBER: builtins.int
@@ -654,25 +740,31 @@ class DiffRequest(google.protobuf.message.Message):
     NAME_FIELD_NUMBER: builtins.int
     TYPE_FIELD_NUMBER: builtins.int
     id: builtins.str
-    """the ID of the resource to diff."""
+    """The ID of the resource being diffed."""
     urn: builtins.str
-    """the Pulumi URN for this resource."""
+    """The URN of the resource being diffed."""
     @property
     def olds(self) -> google.protobuf.struct_pb2.Struct:
-        """the old output values of resource to diff."""
+        """The old *output* properties of the resource being diffed."""
     @property
     def news(self) -> google.protobuf.struct_pb2.Struct:
-        """the new input values of resource to diff, copied from CheckResponse.inputs."""
+        """The new *input* properties of the resource being diffed. These should have been validated by an appropriate call
+        to [](pulumirpc.ResourceProvider.CheckConfig) or [](pulumirpc.ResourceProvider.Check).
+        """
     @property
     def ignoreChanges(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """a set of property paths that should be treated as unchanged."""
+        """A set of [property paths](property-paths) that should be treated as unchanged."""
     @property
     def old_inputs(self) -> google.protobuf.struct_pb2.Struct:
-        """the old input values of the resource to diff."""
+        """The old *input* properties of the resource being diffed."""
     name: builtins.str
-    """the Pulumi name for this resource."""
+    """The name of the resource being diffed. This must match the name specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the name of the resource.
+    """
     type: builtins.str
-    """the Pulumi type for this resource."""
+    """The type of the resource being diffed. This must match the type specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the type of the resource.
+    """
     def __init__(
         self,
         *,
@@ -692,6 +784,11 @@ global___DiffRequest = DiffRequest
 
 @typing_extensions.final
 class PropertyDiff(google.protobuf.message.Message):
+    """`PropertyDiff` describes the kind of change that occurred to a property during a diff operation. A `PropertyDiff` may
+    indicate that a property was added, deleted, or updated, and may further indicate that the change requires a
+    replacement.
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     class _Kind:
@@ -701,38 +798,42 @@ class PropertyDiff(google.protobuf.message.Message):
     class _KindEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[PropertyDiff._Kind.ValueType], builtins.type):  # noqa: F821
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
         ADD: PropertyDiff._Kind.ValueType  # 0
-        """this property was added"""
+        """This property was added."""
         ADD_REPLACE: PropertyDiff._Kind.ValueType  # 1
-        """this property was added, and this change requires a replace"""
+        """This property was added, and this change requires a replace."""
         DELETE: PropertyDiff._Kind.ValueType  # 2
-        """this property was removed"""
+        """This property was removed."""
         DELETE_REPLACE: PropertyDiff._Kind.ValueType  # 3
-        """this property was removed, and this change requires a replace"""
+        """This property was removed, and this change requires a replace."""
         UPDATE: PropertyDiff._Kind.ValueType  # 4
-        """this property's value was changed"""
+        """This property's value was changed."""
         UPDATE_REPLACE: PropertyDiff._Kind.ValueType  # 5
-        """this property's value was changed, and this change requires a replace"""
+        """This property's value was changed, and this change requires a replace."""
 
-    class Kind(_Kind, metaclass=_KindEnumTypeWrapper): ...
+    class Kind(_Kind, metaclass=_KindEnumTypeWrapper):
+        """The type of property diff kinds."""
+
     ADD: PropertyDiff.Kind.ValueType  # 0
-    """this property was added"""
+    """This property was added."""
     ADD_REPLACE: PropertyDiff.Kind.ValueType  # 1
-    """this property was added, and this change requires a replace"""
+    """This property was added, and this change requires a replace."""
     DELETE: PropertyDiff.Kind.ValueType  # 2
-    """this property was removed"""
+    """This property was removed."""
     DELETE_REPLACE: PropertyDiff.Kind.ValueType  # 3
-    """this property was removed, and this change requires a replace"""
+    """This property was removed, and this change requires a replace."""
     UPDATE: PropertyDiff.Kind.ValueType  # 4
-    """this property's value was changed"""
+    """This property's value was changed."""
     UPDATE_REPLACE: PropertyDiff.Kind.ValueType  # 5
-    """this property's value was changed, and this change requires a replace"""
+    """This property's value was changed, and this change requires a replace."""
 
     KIND_FIELD_NUMBER: builtins.int
     INPUTDIFF_FIELD_NUMBER: builtins.int
     kind: global___PropertyDiff.Kind.ValueType
-    """The kind of diff asdsociated with this property."""
+    """The kind of diff associated with this property."""
     inputDiff: builtins.bool
-    """The difference is between old and new inputs, not old and new state."""
+    """True if and only if this difference represents one between a pair of old and new inputs, as opposed to a pair of
+    old and new states.
+    """
     def __init__(
         self,
         *,
@@ -745,6 +846,23 @@ global___PropertyDiff = PropertyDiff
 
 @typing_extensions.final
 class DiffResponse(google.protobuf.message.Message):
+    """`DiffResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.DiffConfig) or
+    [](pulumirpc.ResourceProvider.Diff) call. A `DiffResponse` indicates whether a resource is unchanged, requires
+    updating (that is, can be changed "in place"), or requires replacement (that is, must be destroyed and recreated
+    anew). Legacy implementations may also signal that it is unknown whether there are changes or not.
+
+    `DiffResponse` has evolved since its inception and there are now a number of ways that providers can signal their
+    intent to callers:
+
+    * *Simple diffs* utilise the `changes` field to signal which fields are responsible for a change, and the `replaces`
+      field to further communicate which changes (if any) require a replacement as opposed to an update.
+
+    * *Detailed diffs* are those with `hasDetailedDiff` set, and utilise the `detailedDiff` field to provide a more
+      granular view of the changes that have occurred. Detailed diffs are designed to allow providers to control
+      precisely which field names are displayed as responsible for a change, and to signal more accurately what kind of
+      change occurred (e.g. a field was added, deleted or updated).
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     class _DiffChanges:
@@ -754,19 +872,25 @@ class DiffResponse(google.protobuf.message.Message):
     class _DiffChangesEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[DiffResponse._DiffChanges.ValueType], builtins.type):  # noqa: F821
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
         DIFF_UNKNOWN: DiffResponse._DiffChanges.ValueType  # 0
-        """unknown whether there are changes or not (legacy behavior)."""
+        """A diff was performed but it is unknown whether there are changes or not. This exists to support legacy
+        behaviour and should be generally avoided wherever possible.
+        """
         DIFF_NONE: DiffResponse._DiffChanges.ValueType  # 1
-        """the diff was performed, and no changes were detected that require an update."""
+        """A diff was performed and there were no changes. An update is not required."""
         DIFF_SOME: DiffResponse._DiffChanges.ValueType  # 2
-        """the diff was performed, and changes were detected that require an update or replacement."""
+        """A diff was performed, and changes were detected that require an update or replacement."""
 
-    class DiffChanges(_DiffChanges, metaclass=_DiffChangesEnumTypeWrapper): ...
+    class DiffChanges(_DiffChanges, metaclass=_DiffChangesEnumTypeWrapper):
+        """The type of high-level diff results."""
+
     DIFF_UNKNOWN: DiffResponse.DiffChanges.ValueType  # 0
-    """unknown whether there are changes or not (legacy behavior)."""
+    """A diff was performed but it is unknown whether there are changes or not. This exists to support legacy
+    behaviour and should be generally avoided wherever possible.
+    """
     DIFF_NONE: DiffResponse.DiffChanges.ValueType  # 1
-    """the diff was performed, and no changes were detected that require an update."""
+    """A diff was performed and there were no changes. An update is not required."""
     DIFF_SOME: DiffResponse.DiffChanges.ValueType  # 2
-    """the diff was performed, and changes were detected that require an update or replacement."""
+    """A diff was performed, and changes were detected that require an update or replacement."""
 
     @typing_extensions.final
     class DetailedDiffEntry(google.protobuf.message.Message):
@@ -795,55 +919,33 @@ class DiffResponse(google.protobuf.message.Message):
     HASDETAILEDDIFF_FIELD_NUMBER: builtins.int
     @property
     def replaces(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """if this update requires a replacement, the set of properties triggering it."""
+        """A set of properties which have changed and whose changes require the resource being diffed to be replaced. The
+        caller should replace the resource if this set is non-empty, or if any of the properties specified in
+        `detailedDiff` have a `*_REPLACE` kind.
+        """
     @property
     def stables(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """an optional list of properties that will not ever change."""
+        """An optional list of properties that will not ever change (are stable)."""
     deleteBeforeReplace: builtins.bool
-    """if true, this resource must be deleted before replacing it."""
+    """If true, this resource must be deleted *before* its replacement is created."""
     changes: global___DiffResponse.DiffChanges.ValueType
-    """if true, this diff represents an actual difference and thus requires an update."""
+    """The result of the diff. Indicates at a high level whether the resource has changed or not (or, in legacy cases,
+    if the provider does not know).
+    """
     @property
     def diffs(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """a list of the properties that changed. This should only contain top level property names, it does not
-        support nested properties. For that use detailedDiff.
+        """The set of properties which have changed. This field only supports top-level properties. It *does not* support
+        full [property paths](property-paths); implementations should use `detailedDiff` when this is required.
         """
     @property
     def detailedDiff(self) -> google.protobuf.internal.containers.MessageMap[builtins.str, global___PropertyDiff]:
-        """detailedDiff is an optional field that contains map from each changed property to the type of the change.
-
-        The keys of this map are property paths. These paths are essentially Javascript property access expressions
-        in which all elements are literals, and obey the following EBNF-ish grammar:
-
-          propertyName := [a-zA-Z_$] { [a-zA-Z0-9_$] }
-          quotedPropertyName := '"' ( '\\' '"' | [^"] ) { ( '\\' '"' | [^"] ) } '"'
-          arrayIndex := { [0-9] }
-
-          propertyIndex := '[' ( quotedPropertyName | arrayIndex ) ']'
-          rootProperty := ( propertyName | propertyIndex )
-          propertyAccessor := ( ( '.' propertyName ) |  propertyIndex )
-          path := rootProperty { propertyAccessor }
-
-        Examples of valid keys:
-        - root
-        - root.nested
-        - root["nested"]
-        - root.double.nest
-        - root["double"].nest
-        - root["double"]["nest"]
-        - root.array[0]
-        - root.array[100]
-        - root.array[0].nested
-        - root.array[0][1].nested
-        - root.nested.array[0].double[1]
-        - root["key with \\"escaped\\" quotes"]
-        - root["key with a ."]
-        - ["root key with \\"escaped\\" quotes"].nested
-        - ["root key with a ."][100]
-        a detailed diff appropriate for display.
+        """`detailedDiff` can be used to implement more detailed diffs. A detailed diff is a map from [property
+        paths](property-paths) to [](pulumirpc.PropertyDiff)s, which describe the kind of change that occurred to the
+        property located at that path. If a provider does not implement this, the caller (typically the Pulumi engine)
+        will compute a representation based on the simple diff fields (`changes`, `replaces`, and so on).
         """
     hasDetailedDiff: builtins.bool
-    """true if this response contains a detailed diff."""
+    """True if and only if this response contains a `detailedDiff`."""
     def __init__(
         self,
         *,
@@ -861,6 +963,8 @@ global___DiffResponse = DiffResponse
 
 @typing_extensions.final
 class CreateRequest(google.protobuf.message.Message):
+    """`CreateRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Create) call."""
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     URN_FIELD_NUMBER: builtins.int
@@ -870,18 +974,26 @@ class CreateRequest(google.protobuf.message.Message):
     NAME_FIELD_NUMBER: builtins.int
     TYPE_FIELD_NUMBER: builtins.int
     urn: builtins.str
-    """the Pulumi URN for this resource."""
+    """The URN of the resource being created."""
     @property
     def properties(self) -> google.protobuf.struct_pb2.Struct:
-        """the provider inputs to set during creation."""
+        """The resource's input properties, to be set during creation. These should have been validated by a call to
+        [](pulumirpc.ResourceProvider.Check).
+        """
     timeout: builtins.float
-    """the create request timeout represented in seconds."""
+    """A timeout in seconds that the caller is prepared to wait for the operation to complete."""
     preview: builtins.bool
-    """true if this is a preview and the provider should not actually create the resource."""
+    """True if and only if the request is being made as part of a preview/dry run, in which case the provider should not
+    actually create the resource.
+    """
     name: builtins.str
-    """the Pulumi name for this resource."""
+    """The name of the resource being created. This must match the name specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the name of the resource.
+    """
     type: builtins.str
-    """the Pulumi type for this resource."""
+    """The type of the resource being created. This must match the type specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the type of the resource.
+    """
     def __init__(
         self,
         *,
@@ -899,17 +1011,21 @@ global___CreateRequest = CreateRequest
 
 @typing_extensions.final
 class CreateResponse(google.protobuf.message.Message):
-    """NOTE: The partial-update-error equivalent of this message is `ErrorResourceInitFailed`."""
+    """`CreateResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Create) call. A `CreateResponse`
+    contains the ID of the created resource, as well as any output properties that arose from the creation process.
+    """
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     ID_FIELD_NUMBER: builtins.int
     PROPERTIES_FIELD_NUMBER: builtins.int
     id: builtins.str
-    """the ID of the created resource."""
+    """The ID of the created resource."""
     @property
     def properties(self) -> google.protobuf.struct_pb2.Struct:
-        """any properties that were computed during creation."""
+        """The resource's output properties. Typically this will be a union of the resource's input properties and any
+        additional values that were computed or made available during creation.
+        """
     def __init__(
         self,
         *,
@@ -923,6 +1039,8 @@ global___CreateResponse = CreateResponse
 
 @typing_extensions.final
 class ReadRequest(google.protobuf.message.Message):
+    """`ReadRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Read) call."""
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     ID_FIELD_NUMBER: builtins.int
@@ -932,19 +1050,25 @@ class ReadRequest(google.protobuf.message.Message):
     NAME_FIELD_NUMBER: builtins.int
     TYPE_FIELD_NUMBER: builtins.int
     id: builtins.str
-    """the ID of the resource to read."""
+    """The ID of the resource to read."""
     urn: builtins.str
-    """the Pulumi URN for this resource."""
+    """The URN of the resource being read."""
     @property
     def properties(self) -> google.protobuf.struct_pb2.Struct:
-        """the current state (sufficiently complete to identify the resource)."""
+        """Any current state for the resource being read. This state should be sufficient to uniquely identify the resource."""
     @property
     def inputs(self) -> google.protobuf.struct_pb2.Struct:
-        """the current inputs, if any (only populated during refresh)."""
+        """Any current input properties for the resource being read. These will only be populated when the
+        [](pulumirpc.ResourceProvider.Read) call is being made as part of a refresh operation.
+        """
     name: builtins.str
-    """the Pulumi name for this resource."""
+    """The name of the resource being read. This must match the name specified by the `urn` field, and is passed so that
+    providers do not have to implement URN parsing in order to extract the name of the resource.
+    """
     type: builtins.str
-    """the Pulumi type for this resource."""
+    """The type of the resource being read. This must match the type specified by the `urn` field, and is passed so that
+    providers do not have to implement URN parsing in order to extract the type of the resource.
+    """
     def __init__(
         self,
         *,
@@ -962,19 +1086,25 @@ global___ReadRequest = ReadRequest
 
 @typing_extensions.final
 class ReadResponse(google.protobuf.message.Message):
+    """`ReadResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Read) call. A `ReadResponse` contains
+    the ID of the resource being read, as well as any state that was successfully read from the live environment.
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     ID_FIELD_NUMBER: builtins.int
     PROPERTIES_FIELD_NUMBER: builtins.int
     INPUTS_FIELD_NUMBER: builtins.int
     id: builtins.str
-    """the ID of the resource read back (or empty if missing)."""
+    """The ID of the read resource."""
     @property
     def properties(self) -> google.protobuf.struct_pb2.Struct:
-        """the state of the resource read from the live environment."""
+        """The output properties of the resource read from the live environment."""
     @property
     def inputs(self) -> google.protobuf.struct_pb2.Struct:
-        """the inputs for this resource that would be returned from Check."""
+        """Output-derived input properties for the resource. These are returned as they would be returned from a
+        [](pulumirpc.ResourceProvider.Check) call with the same values.
+        """
     def __init__(
         self,
         *,
@@ -989,7 +1119,7 @@ global___ReadResponse = ReadResponse
 
 @typing_extensions.final
 class UpdateRequest(google.protobuf.message.Message):
-    """NOTE: The partial-update-error equivalent of this message is `ErrorResourceInitFailed`."""
+    """`UpdateRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Update) call."""
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1004,29 +1134,37 @@ class UpdateRequest(google.protobuf.message.Message):
     NAME_FIELD_NUMBER: builtins.int
     TYPE_FIELD_NUMBER: builtins.int
     id: builtins.str
-    """the ID of the resource to update."""
+    """The ID of the resource being updated."""
     urn: builtins.str
-    """the Pulumi URN for this resource."""
+    """The URN of the resource being updated."""
     @property
     def olds(self) -> google.protobuf.struct_pb2.Struct:
-        """the old values of provider inputs for the resource to update."""
+        """The old *output* properties of the resource being updated."""
     @property
     def news(self) -> google.protobuf.struct_pb2.Struct:
-        """the new values of provider inputs for the resource to update, copied from CheckResponse.inputs."""
+        """The new input properties of the resource being updated. These should have been validated by a call to
+        [](pulumirpc.ResourceProvider.Check).
+        """
     timeout: builtins.float
-    """the update request timeout represented in seconds."""
+    """A timeout in seconds that the caller is prepared to wait for the operation to complete."""
     @property
     def ignoreChanges(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """a set of property paths that should be treated as unchanged."""
+        """A set of [property paths](property-paths) that should be treated as unchanged."""
     preview: builtins.bool
-    """true if this is a preview and the provider should not actually create the resource."""
+    """True if and only if the request is being made as part of a preview/dry run, in which case the provider should not
+    actually update the resource.
+    """
     @property
     def old_inputs(self) -> google.protobuf.struct_pb2.Struct:
-        """the old input values of the resource to diff."""
+        """The old *input* properties of the resource being updated."""
     name: builtins.str
-    """the Pulumi name for this resource."""
+    """The name of the resource being updated. This must match the name specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the name of the resource.
+    """
     type: builtins.str
-    """the Pulumi type for this resource."""
+    """The type of the resource being updated. This must match the type specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the type of the resource.
+    """
     def __init__(
         self,
         *,
@@ -1048,12 +1186,16 @@ global___UpdateRequest = UpdateRequest
 
 @typing_extensions.final
 class UpdateResponse(google.protobuf.message.Message):
+    """`UpdateResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Update) call."""
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     PROPERTIES_FIELD_NUMBER: builtins.int
     @property
     def properties(self) -> google.protobuf.struct_pb2.Struct:
-        """any properties that were computed during updating."""
+        """An updated set of resource output properties. Typically this will be a union of the resource's inputs and any
+        additional values that were computed or made available during the update.
+        """
     def __init__(
         self,
         *,
@@ -1066,6 +1208,8 @@ global___UpdateResponse = UpdateResponse
 
 @typing_extensions.final
 class DeleteRequest(google.protobuf.message.Message):
+    """`DeleteRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Delete) call."""
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     ID_FIELD_NUMBER: builtins.int
@@ -1076,21 +1220,27 @@ class DeleteRequest(google.protobuf.message.Message):
     NAME_FIELD_NUMBER: builtins.int
     TYPE_FIELD_NUMBER: builtins.int
     id: builtins.str
-    """the ID of the resource to delete."""
+    """The ID of the resource to delete."""
     urn: builtins.str
-    """the Pulumi URN for this resource."""
+    """The URN of the resource to delete."""
     @property
     def properties(self) -> google.protobuf.struct_pb2.Struct:
-        """the current properties on the resource."""
+        """The old *output* properties of the resource being deleted."""
     timeout: builtins.float
-    """the delete request timeout represented in seconds."""
+    """A timeout in seconds that the caller is prepared to wait for the operation to complete."""
     @property
     def old_inputs(self) -> google.protobuf.struct_pb2.Struct:
-        """the old input values of the resource to delete."""
+        """The old *input* properties of the resource being deleted.
+        the old input values of the resource to delete.
+        """
     name: builtins.str
-    """the Pulumi name for this resource."""
+    """The name of the resource being deleted. This must match the name specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the name of the resource.
+    """
     type: builtins.str
-    """the Pulumi type for this resource."""
+    """The type of the resource being deleted. This must match the type specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the type of the resource.
+    """
     def __init__(
         self,
         *,
@@ -1109,18 +1259,23 @@ global___DeleteRequest = DeleteRequest
 
 @typing_extensions.final
 class ConstructRequest(google.protobuf.message.Message):
+    """`ConstructRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Construct) call. A
+    `ConstructRequest` captures enough data to be able to register nested components against the caller's resource
+    monitor.
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     @typing_extensions.final
     class PropertyDependencies(google.protobuf.message.Message):
-        """PropertyDependencies describes the resources that a particular property depends on."""
+        """A `PropertyDependencies` list is a set of URNs that a particular property may depend on."""
 
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
         URNS_FIELD_NUMBER: builtins.int
         @property
         def urns(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-            """A list of URNs this property depends on."""
+            """A list of URNs that this property depends on."""
         def __init__(
             self,
             *,
@@ -1130,23 +1285,17 @@ class ConstructRequest(google.protobuf.message.Message):
 
     @typing_extensions.final
     class CustomTimeouts(google.protobuf.message.Message):
-        """CustomTimeouts specifies timeouts for resource provisioning operations.
-        Use it with the [Timeouts] option when creating new resources
-        to override default timeouts.
+        """A `CustomTimeouts` object encapsulates a set of timeouts for the various CRUD operations that might be performed
+        on this resource's nested resources. Timeout values are specified as duration strings, such as `"5ms"` (5
+        milliseconds), `"40s"` (40 seconds), or `"1m30s"` (1 minute and 30 seconds). The following units of time are
+        supported:
 
-        Each timeout is specified as a duration string such as,
-        "5ms" (5 milliseconds), "40s" (40 seconds),
-        and "1m30s" (1 minute, 30 seconds).
-
-        The following units are accepted.
-
-          - ns: nanoseconds
-          - us: microseconds
-          - µs: microseconds
-          - ms: milliseconds
-          - s: seconds
-          - m: minutes
-          - h: hours
+        * `ns`: nanoseconds
+        * `us` or `µs`: microseconds
+        * `ms`: milliseconds
+        * `s`: seconds
+        * `m`: minutes
+        * `h`: hours
         """
 
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
@@ -1155,8 +1304,17 @@ class ConstructRequest(google.protobuf.message.Message):
         UPDATE_FIELD_NUMBER: builtins.int
         DELETE_FIELD_NUMBER: builtins.int
         create: builtins.str
+        """How long a caller is prepared to wait for a nested resource's [](pulumirpc.ResourceProvider.Create) operation
+        to complete.
+        """
         update: builtins.str
+        """How long a caller is prepared to wait for a nested resource's [](pulumirpc.ResourceProvider.Update) operation
+        to complete.
+        """
         delete: builtins.str
+        """How long a caller is prepared to wait for a nested resource's [](pulumirpc.ResourceProvider.Delete) operation
+        to complete.
+        """
         def __init__(
             self,
             *,
@@ -1242,69 +1400,104 @@ class ConstructRequest(google.protobuf.message.Message):
     RETAINONDELETE_FIELD_NUMBER: builtins.int
     ACCEPTS_OUTPUT_VALUES_FIELD_NUMBER: builtins.int
     project: builtins.str
-    """the project name."""
+    """The project to which this resource and its nested resources will belong."""
     stack: builtins.str
-    """the name of the stack being deployed into."""
+    """The name of the stack being deployed into."""
     @property
     def config(self) -> google.protobuf.internal.containers.ScalarMap[builtins.str, builtins.str]:
-        """the configuration variables to apply before running."""
+        """Configuration for the specified project and stack."""
     dryRun: builtins.bool
-    """true if we're only doing a dryrun (preview)."""
+    """True if and only if the request is being made as part of a preview/dry run, in which case the provider should not
+    actually construct the component.
+    """
     parallel: builtins.int
-    """the degree of parallelism for resource operations (<=1 for serial)."""
+    """The degree of parallelism that may be used for resource operations. A value less than or equal to 1 indicates
+    that operations should be performed serially.
+    """
     monitorEndpoint: builtins.str
-    """the address for communicating back to the resource monitor."""
+    """The address of the [](pulumirpc.ResourceMonitor) that the provider should connect to in order to send [resource
+    registrations](resource-registration) for its nested resources.
+    """
     type: builtins.str
-    """the type of the object allocated."""
+    """The type of the component resource being constructed. This must match the type specified by the `urn` field, and
+    is passed so that providers do not have to implement URN parsing in order to extract the type of the resource.
+    """
     name: builtins.str
-    """the name, for URN purposes, of the object."""
+    """The name of the component resource being constructed. This must match the name specified by the `urn` field, and
+    is passed so that providers do not have to implement URN parsing in order to extract the name of the resource.
+    """
     parent: builtins.str
-    """an optional parent URN that this child resource belongs to."""
+    """Dependencies and resource options
+
+    These are passed so that the component may propagate them to resources it registers against the supplied resource
+    monitor.
+
+    Do *not* change field IDs. Add new fields at the end with appropriate field IDs as necessary.
+
+    An optional parent resource that the component (and by extension, its nested resources) should be children of.
+    """
     @property
     def inputs(self) -> google.protobuf.struct_pb2.Struct:
-        """the inputs to the resource constructor."""
+        """The component resource's input properties. Unlike the inputs of custom resources, these will *not* have been
+        passed to a call to [](pulumirpc.ResourceProvider.Check). By virtue of their being a composition of other
+        resources, component resources are able to (and therefore expected) to validate their own inputs. Moreover,
+        [](pulumirpc.ResourceProvider.Check) will be called on any inputs passed to nested custom resources as usual.
+        """
     @property
     def inputDependencies(self) -> google.protobuf.internal.containers.MessageMap[builtins.str, global___ConstructRequest.PropertyDependencies]:
-        """a map from property keys to the dependencies of the property."""
+        """A map of property dependencies for the component resource and its nested resources."""
     @property
     def providers(self) -> google.protobuf.internal.containers.ScalarMap[builtins.str, builtins.str]:
-        """the map of providers to use for this resource's children."""
+        """A map of package names to provider references for the component resource and its nested resources."""
     @property
     def dependencies(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """a list of URNs that this resource depends on, as observed by the language host."""
+        """A list of URNs that this resource and its nested resources depend on."""
     @property
     def configSecretKeys(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """the configuration keys that have secret values."""
+        """A set of configuration keys whose values are [secret](output-secrets)."""
     organization: builtins.str
-    """the organization of the stack being deployed into."""
+    """The organization to which this resource and its nested resources will belong."""
     protect: builtins.bool
-    """Resource options:
-    Do not change field IDs. Add new fields at the end.
-    true if the resource should be marked protected.
+    """True if and only if the resource (and by extension, its nested resources) should be marked as protected.
+    Protected resources cannot be deleted without first being unprotected.
     """
     @property
     def aliases(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """a list of additional URNs that shoud be considered the same."""
+        """A list of additional URNs that should be considered the same as this component's URN (and which will therefore be
+        used to build aliases for its nested resource URNs). These may be URNs that previously referred to this component
+        e.g. if it had its parent (and consequently URN) changed.
+        """
     @property
     def additionalSecretOutputs(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """additional output properties that should be treated as secrets."""
+        """A list of input properties whose values should be treated as [secret](output-secrets)."""
     @property
     def customTimeouts(self) -> global___ConstructRequest.CustomTimeouts:
-        """default timeouts for CRUD operations on this resource."""
+        """A set of custom timeouts that specify how long the caller is prepared to wait for the various CRUD operations of
+        this resource's nested resources.
+        """
     deletedWith: builtins.str
-    """URN of a resource that, if deleted, also deletes this resource."""
+    """The URN of a resource that this resource (and thus its nested resources) will be implicitly deleted with. If the
+    resource referred to by this URN is deleted in the same operation that this resource would be deleted, the
+    [](pulumirpc.ResourceProvider.Delete) call for this resource will be elided (since this dependency signals that
+    it will have already been deleted).
+    """
     deleteBeforeReplace: builtins.bool
-    """whether to delete the resource before replacing it."""
+    """If true, this resource (and its nested resources) must be deleted *before* its replacement is created."""
     @property
     def ignoreChanges(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """properties that should be ignored during a diff"""
+        """A set of [property paths](property-paths) that should be treated as unchanged."""
     @property
     def replaceOnChanges(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """properties that, when changed, trigger a replacement"""
+        """A set of properties that, when changed, trigger a replacement."""
     retainOnDelete: builtins.bool
-    """whether to retain the resource in the cloud provider when it is deleted"""
+    """True if [](pulumirpc.ResourceProvider.Delete) should *not* be called when the resource (and by extension, its
+    nested resources) are removed from a Pulumi program.
+    """
     accepts_output_values: builtins.bool
-    """the engine can be passed output values back, stateDependencies can be left blank if returning output values."""
+    """True if the caller is capable of accepting output values in response to the call. If this is set, these outputs
+    may be used to communicate dependency information and so there is no need to populate
+    [](pulumirpc.ConstructResponse)'s `stateDependencies` field.
+    """
     def __init__(
         self,
         *,
@@ -1341,18 +1534,20 @@ global___ConstructRequest = ConstructRequest
 
 @typing_extensions.final
 class ConstructResponse(google.protobuf.message.Message):
+    """`ConstructResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Construct) call."""
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     @typing_extensions.final
     class PropertyDependencies(google.protobuf.message.Message):
-        """PropertyDependencies describes the resources that a particular property depends on."""
+        """A `PropertyDependencies` list is a set of URNs that a particular property may depend on."""
 
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
         URNS_FIELD_NUMBER: builtins.int
         @property
         def urns(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-            """A list of URNs this property depends on."""
+            """A list of URNs that this property depends on."""
         def __init__(
             self,
             *,
@@ -1382,13 +1577,16 @@ class ConstructResponse(google.protobuf.message.Message):
     STATE_FIELD_NUMBER: builtins.int
     STATEDEPENDENCIES_FIELD_NUMBER: builtins.int
     urn: builtins.str
-    """the URN of the component resource."""
+    """The URN of the constructed component resource."""
     @property
     def state(self) -> google.protobuf.struct_pb2.Struct:
-        """any properties that were computed during construction."""
+        """Any output properties that the component registered as part of its construction."""
     @property
     def stateDependencies(self) -> google.protobuf.internal.containers.MessageMap[builtins.str, global___ConstructResponse.PropertyDependencies]:
-        """a map from property keys to the dependencies of the property."""
+        """A map of property dependencies for the component's outputs. This will be set if the caller indicated that it
+        could not receive dependency-communicating [output](outputs) values by setting [](pulumirpc.ConstructRequest)'s
+        `accepts_output_values` field to false.
+        """
     def __init__(
         self,
         *,

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
@@ -89,25 +89,40 @@ class ResourceProviderStub:
 
     As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
     the properties as present in the program inputs. Though this rule is not required for correctness, violations
-    thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+    thereof can negatively impact the end-user experience, as the provider inputs are used for detecting and
     rendering diffs.
     """
     DiffConfig: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.DiffRequest,
         pulumi.provider_pb2.DiffResponse,
     ]
-    """DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider."""
+    """`DiffConfig` compares an existing ("old") provider configuration with a new configuration and computes the
+    difference (if any) between them. `DiffConfig` is to provider resources what [](pulumirpc.ResourceProvider.Diff)
+    is to individual resources. `DiffConfig` should only be called with values that have at some point been validated
+    by a [](pulumirpc.ResourceProvider.CheckConfig) call. The [](pulumirpc.DiffResponse) returned by a `DiffConfig`
+    call is used primarily to determine whether or not the newly configured provider is capable of managing resources
+    owned by the old provider. If `DiffConfig` indicates that the provider resource needs to be replaced, for
+    instance, then all resources owned by that provider will *also* need to be replaced. Replacement semantics should
+    thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
+    Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
+    AWS access key, should almost certainly not.
+    """
     Configure: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.ConfigureRequest,
         pulumi.provider_pb2.ConfigureResponse,
     ]
-    """Configure configures the resource provider with "globals" that control its behavior.
+    """`Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
 
-    :::{warning}
-    ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
-    ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
-    ConfigureRequest.args.
-    :::
+    * Provider-specific configuration, which is the set of inputs that have been validated by a previous
+      [](pulumirpc.ResourceProvider.CheckConfig) call.
+    * Provider-agnostic ("protocol") configuration, such as whether or not the caller supports secrets.
+
+    The provider is expected to return its own set of protocol configuration, indicating which features it supports
+    in turn so that the caller and the provider can interact appropriately.
+
+    Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
+    the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
+    indicate which keys are missing.
     """
     Invoke: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.InvokeRequest,
@@ -130,46 +145,80 @@ class ResourceProviderStub:
         pulumi.provider_pb2.CheckRequest,
         pulumi.provider_pb2.CheckResponse,
     ]
-    """Check validates that the given property bag is valid for a resource of the given type and returns the inputs
-    that should be passed to successive calls to Diff, Create, or Update for this resource. As a rule, the provider
-    inputs returned by a call to Check should preserve the original representation of the properties as present in
-    the program inputs. Though this rule is not required for correctness, violations thereof can negatively impact
-    the end-user experience, as the provider inputs are using for detecting and rendering diffs.
+    """`Check` validates a set of input properties against a given resource type. A `Check` call returns either a set of
+    checked, known-valid inputs that may subsequently be passed to [](pulumirpc.ResourceProvider.Diff),
+    [](pulumirpc.ResourceProvider.Create), or [](pulumirpc.ResourceProvider.Update); or a set of errors explaining
+    why the inputs are invalid. In the case that a set of inputs are successfully validated and returned, `Check`
+    *may also populate default values* for resource inputs, returning them so that they may be passed to a subsequent
+    call and persisted in the Pulumi state. In the case that `Check` fails and returns a set of errors, it is
+    expected that the caller (typically the Pulumi engine) will fail resource registration.
+
+    As a rule, the provider inputs returned by a call to `Check` should preserve the original representation of the
+    properties as present in the program inputs. Though this rule is not required for correctness, violations thereof
+    can negatively impact the end-user experience, as the provider inputs are used for detecting and rendering
+    diffs.
     """
     Diff: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.DiffRequest,
         pulumi.provider_pb2.DiffResponse,
     ]
-    """Diff checks what impacts a hypothetical update will have on the resource's properties."""
+    """`Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
+    difference (if any) between them. `Diff` should only be called with values that have at some point been validated
+    by a [](pulumirpc.ResourceProvider.Check) call.
+    """
     Create: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.CreateRequest,
         pulumi.provider_pb2.CreateResponse,
     ]
-    """Create allocates a new instance of the provided resource and returns its unique ID afterwards.  (The input ID
-    must be blank.)  If this call fails, the resource must not have been created (i.e., it is "transactional").
+    """`Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a
+    provider-assigned ID for the resource as well as the output properties that arose from the creation properties.
+    Output properties are typically the union of the resource's input properties and any additional values that were
+    computed or made available during creation.
+
+    If creation fails, `Create` may return an [](pulumirpc.ErrorResourceInitFailed) error detail explaining why.
+    Moreover, if `Create` does return an error, it must be the case that the resource was *not* created (that is,
+    `Create` can be thought of as transactional or atomic).
     """
     Read: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.ReadRequest,
         pulumi.provider_pb2.ReadResponse,
     ]
-    """Read the current live state associated with a resource.  Enough state must be include in the inputs to uniquely
-    identify the resource; this is typically just the resource ID, but may also include some properties.
+    """`Read` reads the current live state associated with a resource identified by the supplied state. The given state
+    must be sufficient to uniquely identify the resource. This is typically just the resource ID, but may also
+    include other properties.
     """
     Update: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.UpdateRequest,
         pulumi.provider_pb2.UpdateResponse,
     ]
-    """Update updates an existing resource with new values."""
+    """`Update` updates an existing resource according to a new set of inputs, returning a new set of output properties."""
     Delete: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.DeleteRequest,
         google.protobuf.empty_pb2.Empty,
     ]
-    """Delete tears down an existing resource with the given ID.  If it fails, the resource is assumed to still exist."""
+    """`Delete` deprovisions an existing resource as specified by its ID. `Delete` should be transactional/atomic -- if
+    a call to `Delete` fails, it must be the case that the resource was *not* deleted and can be assumed to still
+    exist.
+    """
     Construct: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.ConstructRequest,
         pulumi.provider_pb2.ConstructResponse,
     ]
-    """Construct creates a new instance of the provided component resource and returns its state."""
+    """`Construct` provisions a new [component resource](component-resources). Providers that implement `Construct` are
+    referred to as [component providers](component-providers). `Construct` is to component resources what
+    [](pulumirpc.ResourceProvider.Create) is to [custom resources](custom-resources). Components do not have any
+    lifecycle of their own, and instead embody the lifecycles of the resources that they are composed of. As such,
+    `Construct` is effectively a subprogram whose resources will be persisted in the caller's state. It is
+    consequently passed enough information to manage fully these resources. At a high level, this comprises:
+
+    * A [](pulumirpc.ResourceMonitor) endpoint which the provider can use to [register](resource-registration) nested
+      custom or component resources that belong to the component.
+
+    * A set of input properties.
+
+    * A full set of [resource options](https://www.pulumi.com/docs/iac/concepts/options/) that the component should
+      propagate to resources it registers against the supplied resource monitor.
+    """
     Cancel: grpc.UnaryUnaryMultiCallable[
         google.protobuf.empty_pb2.Empty,
         google.protobuf.empty_pb2.Empty,
@@ -276,7 +325,7 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
 
         As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
         the properties as present in the program inputs. Though this rule is not required for correctness, violations
-        thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+        thereof can negatively impact the end-user experience, as the provider inputs are used for detecting and
         rendering diffs.
         """
     
@@ -285,20 +334,35 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         request: pulumi.provider_pb2.DiffRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.DiffResponse:
-        """DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider."""
+        """`DiffConfig` compares an existing ("old") provider configuration with a new configuration and computes the
+        difference (if any) between them. `DiffConfig` is to provider resources what [](pulumirpc.ResourceProvider.Diff)
+        is to individual resources. `DiffConfig` should only be called with values that have at some point been validated
+        by a [](pulumirpc.ResourceProvider.CheckConfig) call. The [](pulumirpc.DiffResponse) returned by a `DiffConfig`
+        call is used primarily to determine whether or not the newly configured provider is capable of managing resources
+        owned by the old provider. If `DiffConfig` indicates that the provider resource needs to be replaced, for
+        instance, then all resources owned by that provider will *also* need to be replaced. Replacement semantics should
+        thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
+        Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
+        AWS access key, should almost certainly not.
+        """
     
     def Configure(
         self,
         request: pulumi.provider_pb2.ConfigureRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.ConfigureResponse:
-        """Configure configures the resource provider with "globals" that control its behavior.
+        """`Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
 
-        :::{warning}
-        ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
-        ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
-        ConfigureRequest.args.
-        :::
+        * Provider-specific configuration, which is the set of inputs that have been validated by a previous
+          [](pulumirpc.ResourceProvider.CheckConfig) call.
+        * Provider-agnostic ("protocol") configuration, such as whether or not the caller supports secrets.
+
+        The provider is expected to return its own set of protocol configuration, indicating which features it supports
+        in turn so that the caller and the provider can interact appropriately.
+
+        Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
+        the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
+        indicate which keys are missing.
         """
     
     def Invoke(
@@ -329,11 +393,18 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         request: pulumi.provider_pb2.CheckRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.CheckResponse:
-        """Check validates that the given property bag is valid for a resource of the given type and returns the inputs
-        that should be passed to successive calls to Diff, Create, or Update for this resource. As a rule, the provider
-        inputs returned by a call to Check should preserve the original representation of the properties as present in
-        the program inputs. Though this rule is not required for correctness, violations thereof can negatively impact
-        the end-user experience, as the provider inputs are using for detecting and rendering diffs.
+        """`Check` validates a set of input properties against a given resource type. A `Check` call returns either a set of
+        checked, known-valid inputs that may subsequently be passed to [](pulumirpc.ResourceProvider.Diff),
+        [](pulumirpc.ResourceProvider.Create), or [](pulumirpc.ResourceProvider.Update); or a set of errors explaining
+        why the inputs are invalid. In the case that a set of inputs are successfully validated and returned, `Check`
+        *may also populate default values* for resource inputs, returning them so that they may be passed to a subsequent
+        call and persisted in the Pulumi state. In the case that `Check` fails and returns a set of errors, it is
+        expected that the caller (typically the Pulumi engine) will fail resource registration.
+
+        As a rule, the provider inputs returned by a call to `Check` should preserve the original representation of the
+        properties as present in the program inputs. Though this rule is not required for correctness, violations thereof
+        can negatively impact the end-user experience, as the provider inputs are used for detecting and rendering
+        diffs.
         """
     
     def Diff(
@@ -341,15 +412,24 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         request: pulumi.provider_pb2.DiffRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.DiffResponse:
-        """Diff checks what impacts a hypothetical update will have on the resource's properties."""
+        """`Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
+        difference (if any) between them. `Diff` should only be called with values that have at some point been validated
+        by a [](pulumirpc.ResourceProvider.Check) call.
+        """
     
     def Create(
         self,
         request: pulumi.provider_pb2.CreateRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.CreateResponse:
-        """Create allocates a new instance of the provided resource and returns its unique ID afterwards.  (The input ID
-        must be blank.)  If this call fails, the resource must not have been created (i.e., it is "transactional").
+        """`Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a
+        provider-assigned ID for the resource as well as the output properties that arose from the creation properties.
+        Output properties are typically the union of the resource's input properties and any additional values that were
+        computed or made available during creation.
+
+        If creation fails, `Create` may return an [](pulumirpc.ErrorResourceInitFailed) error detail explaining why.
+        Moreover, if `Create` does return an error, it must be the case that the resource was *not* created (that is,
+        `Create` can be thought of as transactional or atomic).
         """
     
     def Read(
@@ -357,8 +437,9 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         request: pulumi.provider_pb2.ReadRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.ReadResponse:
-        """Read the current live state associated with a resource.  Enough state must be include in the inputs to uniquely
-        identify the resource; this is typically just the resource ID, but may also include some properties.
+        """`Read` reads the current live state associated with a resource identified by the supplied state. The given state
+        must be sufficient to uniquely identify the resource. This is typically just the resource ID, but may also
+        include other properties.
         """
     
     def Update(
@@ -366,21 +447,38 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         request: pulumi.provider_pb2.UpdateRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.UpdateResponse:
-        """Update updates an existing resource with new values."""
+        """`Update` updates an existing resource according to a new set of inputs, returning a new set of output properties."""
     
     def Delete(
         self,
         request: pulumi.provider_pb2.DeleteRequest,
         context: grpc.ServicerContext,
     ) -> google.protobuf.empty_pb2.Empty:
-        """Delete tears down an existing resource with the given ID.  If it fails, the resource is assumed to still exist."""
+        """`Delete` deprovisions an existing resource as specified by its ID. `Delete` should be transactional/atomic -- if
+        a call to `Delete` fails, it must be the case that the resource was *not* deleted and can be assumed to still
+        exist.
+        """
     
     def Construct(
         self,
         request: pulumi.provider_pb2.ConstructRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.ConstructResponse:
-        """Construct creates a new instance of the provided component resource and returns its state."""
+        """`Construct` provisions a new [component resource](component-resources). Providers that implement `Construct` are
+        referred to as [component providers](component-providers). `Construct` is to component resources what
+        [](pulumirpc.ResourceProvider.Create) is to [custom resources](custom-resources). Components do not have any
+        lifecycle of their own, and instead embody the lifecycles of the resources that they are composed of. As such,
+        `Construct` is effectively a subprogram whose resources will be persisted in the caller's state. It is
+        consequently passed enough information to manage fully these resources. At a high level, this comprises:
+
+        * A [](pulumirpc.ResourceMonitor) endpoint which the provider can use to [register](resource-registration) nested
+          custom or component resources that belong to the component.
+
+        * A set of input properties.
+
+        * A full set of [resource options](https://www.pulumi.com/docs/iac/concepts/options/) that the component should
+          propagate to resources it registers against the supplied resource monitor.
+        """
     
     def Cancel(
         self,


### PR DESCRIPTION
This commit fleshes out the documentation for the following resource
provider methods:

* `DiffConfig`
* `Configure`
* `Check`
* `Diff`
* `Create`
* `Read`
* `Update`
* `Delete`
* `Construct`

Closes #17684
Closes #17685
Closes #17686
Closes #17687
Closes #17688