### PR TITLE
Document `ResourceProvider.Configure`

### DIFF
--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -18,7 +18,7 @@
 1921230328 1269 proto/pulumi/errors.proto
 420991671 12306 proto/pulumi/language.proto
 2893249402 1992 proto/pulumi/plugin.proto
-4068219036 35607 proto/pulumi/provider.proto
+2967065344 39420 proto/pulumi/provider.proto
 1190662922 17848 proto/pulumi/resource.proto
 607478140 1008 proto/pulumi/source.proto
 3670315643 2603 proto/pulumi/testing/language.proto

--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -18,7 +18,7 @@
 1921230328 1269 proto/pulumi/errors.proto
 420991671 12306 proto/pulumi/language.proto
 2893249402 1992 proto/pulumi/plugin.proto
-2293184687 31670 proto/pulumi/provider.proto
+4068219036 35607 proto/pulumi/provider.proto
 1190662922 17848 proto/pulumi/resource.proto
 607478140 1008 proto/pulumi/source.proto
 3670315643 2603 proto/pulumi/testing/language.proto

--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -18,7 +18,7 @@
 1921230328 1269 proto/pulumi/errors.proto
 420991671 12306 proto/pulumi/language.proto
 2893249402 1992 proto/pulumi/plugin.proto
-2967065344 39420 proto/pulumi/provider.proto
+2872121187 42589 proto/pulumi/provider.proto
 1190662922 17848 proto/pulumi/resource.proto
 607478140 1008 proto/pulumi/source.proto
 3670315643 2603 proto/pulumi/testing/language.proto

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -59,7 +59,24 @@ service ResourceProvider {
     // GetSchema fetches the schema for this resource provider.
     rpc GetSchema(GetSchemaRequest) returns (GetSchemaResponse) {}
 
-    // CheckConfig validates the configuration for this resource provider.
+    // `CheckConfig` validates a set of configuration inputs that will be passed to this provider instance.
+    // `CheckConfig` is to provider resources what [](pulumirpc.ResourceProvider.Check) is to individual resources, and
+    // is the first stage in configuring (that is, eventually executing a [](pulumirpc.ResourceProvider.Configure) call)
+    // a provider using user-supplied values. In the case that provider inputs are coming from some source that has been
+    // checked previously (e.g. a Pulumi state), it is not necessary to call `CheckConfig`.
+    //
+    // A `CheckConfig` call returns either a set of checked, known-valid inputs that may subsequently be passed to
+    // [](pulumirpc.ResourceProvider.DiffConfig) and/or [](pulumirpc.ResourceProvider.Configure), or a set of errors
+    // explaining why the inputs are invalid. In the case that a set of inputs are successfully validated and returned,
+    // `CheckConfig` *may also populate default values* for provider configuration, returning them so that they may be
+    // passed to a subsequent [](pulumirpc.ResourceProvider.Configure) call and persisted in the Pulumi state. In the
+    // case that `CheckConfig` fails and returns a set of errors, it is expected that the caller (typically the Pulumi
+    // engine) will fail provider registration.
+    //
+    // As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
+    // the properties as present in the program inputs. Though this rule is not required for correctness, violations
+    // thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+    // rendering diffs.
     rpc CheckConfig(CheckRequest) returns (CheckResponse) {}
     // DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
     rpc DiffConfig(DiffRequest) returns (DiffResponse) {}
@@ -276,37 +293,74 @@ message CallResponse {
     map<string, ReturnDependencies> returnDependencies = 2;
 }
 
+// `CheckRequest` is the type of requests sent as part of [](pulumirpc.ResourceProvider.CheckConfig) and
+// [](pulumirpc.ResourceProvider.Check) calls. A `CheckRequest` primarily captures the URN and inputs of the resource
+// being checked. In the case of [](pulumirpc.ResourceProvider.CheckConfig), the URN will be the URN of the provider
+// resource being constructed, which may or may not be a [default provider](default-providers), and the inputs will be
+// the provider configuration.
 message CheckRequest {
-    string urn = 1;                  // the Pulumi URN for this resource.
-    google.protobuf.Struct olds = 2; // the old Pulumi inputs for this resource, if any.
+    // The URN of the resource whose inputs are being checked. In the case of
+    // [](pulumirpc.ResourceProvider.CheckConfig), this will be the URN of the provider resource being constructed,
+    // which may or may not be a [default provider](default-providers).
+    string urn = 1;
 
-    // the new Pulumi inputs for this resource.
+    // The old input properties or configuration for the resource, if any.
+    google.protobuf.Struct olds = 2;
+
+    // The new input properties or configuration for the resource, if any.
     //
-    // Note that if the user specifies the ignoreChanges resource option, the value of news passed
-    // to the provider here may differ from the values written in the program source. It will be pre-processed by
-    // replacing every ignoreChanges property by a matching value from the old inputs stored in the state.
-    //
-    // See also: https://www.pulumi.com/docs/concepts/options/ignorechanges/
+    // :::{note}
+    // If this resource has been specified with the
+    // [`ignoreChanges`](https://www.pulumi.com/docs/concepts/options/ignorechanges/), then the values in `news` may
+    // differ from those written in the Pulumi program registering this resource. In such cases, the caller (e.g. the
+    // Pulumi engine) is expected to preprocess the `news` value by replacing every property matched by `ignoreChanges`
+    // with its corresponding `olds` value (effectively ignoring the change).
+    // :::
     google.protobuf.Struct news = 3;
 
-    // We used to send sequenceNumber but that has been replaced by randomSeed.
+    // `CheckRequest`s originally contained sequence numbers, but they have since been replaced by random seeds.
     reserved 4;
     reserved "sequenceNumber";
 
-    bytes randomSeed = 5;            // a deterministically random hash, primarily intended for global unique naming.
+    // A random but deterministically computed hash, intended to be used for generating globally unique names.
+    bytes randomSeed = 5;
 
-    string name = 6; // the Pulumi name for this resource.
-    string type = 7; // the Pulumi type for this resource.
+    // The name of the resource being checked. This must match the name specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the name of the resource.
+    string name = 6;
+
+    // The type of the resource being checked. This must match the type specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the type of the resource.
+    string type = 7;
 }
 
+// `CheckResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.CheckConfig) or
+// [](pulumirpc.ResourceProvider.Check) call. A `CheckResponse` may contain either:
+//
+// * a set of checked, known-valid `inputs`. In the case of [](pulumirpc.ResourceProvider.CheckConfig), these may
+//   subsequently be passed to [](pulumirpc.ResourceProvider.DiffConfig) and/or
+//   [](pulumirpc.ResourceProvider.Configure). In the case of [](pulumirpc.ResourceProvider.Check), these may be passed
+//   to any of the supported lifecycle methods that accept provider inputs.
+// * a set of `failures` detailing invalid inputs.
+//
+// In cases where the supplied set of inputs is valid, a `CheckResponse` may contain default values that should
+// persisted to Pulumi state and passed to subsequent calls.
 message CheckResponse {
-    google.protobuf.Struct inputs = 1;  // the provider inputs for this resource.
-    repeated CheckFailure failures = 2; // any validation failures that occurred.
+    // A valid, checked set of inputs. May contain defaults.
+    google.protobuf.Struct inputs = 1;
+
+    // Any validation failures that occurred.
+    repeated CheckFailure failures = 2;
 }
 
+// A `CheckFailure` describes a single validation error that arose as part of a
+// [](pulumirpc.ResourceProvider.CheckConfig) or [](pulumirpc.ResourceProvider.Check) call.
 message CheckFailure {
-    string property = 1; // the property that failed validation.
-    string reason = 2;   // the reason that the property failed validation.
+    // The input property that failed validation.
+    string property = 1;
+
+    // The reason that the named property failed validation.
+    string reason = 2;
 }
 
 message DiffRequest {

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -78,7 +78,17 @@ service ResourceProvider {
     // thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
     // rendering diffs.
     rpc CheckConfig(CheckRequest) returns (CheckResponse) {}
-    // DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
+
+    // `DiffConfig` compares an existing ("old") provider configuration with a new configuration and computes the
+    // difference (if any) between them. `DiffConfig` is to provider resources what [](pulumirpc.ResourceProvider.Diff)
+    // is to individual resources. `DiffConfig` should only be called with values that have at some point been validated
+    // by a [](pulumirpc.ResourceProvider.CheckConfig) call. The [](pulumirpc.DiffResponse) returned by a `DiffConfig`
+    // call is used primarily to determine whether or not the newly configured provider is capable of managing resources
+    // owned by the old provider. If `DiffConfig` indicates that the provider resource needs to be replaced, for
+    // instance, then all resources owned by that provider will *also* need to be replaced. Replacement semantics should
+    // thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
+    // Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
+    // AWS access key, should almost certainly not.
     rpc DiffConfig(DiffRequest) returns (DiffResponse) {}
 
     // Configure configures the resource provider with "globals" that control its behavior.
@@ -363,81 +373,136 @@ message CheckFailure {
     string reason = 2;
 }
 
+// `DiffRequest` is the type of requests sent as part of [](pulumirpc.ResourceProvider.DiffConfig) and
+// [](pulumirpc.ResourceProvider.Diff) calls. A `DiffRequest` primarily captures:
+//
+// * the URN of the resource whose properties are being compared;
+// * the old and new input properties of the resource; and
+// * the old output properties of the resource.
+//
+// In the case of [](pulumirpc.ResourceProvider.DiffConfig), the URN will be the URN of the provider resource being
+// examined, which may or may not be a [default provider](default-providers), and the inputs and outputs will be the
+// provider configuration and state. Inputs supplied to a [](pulumirpc.ResourceProvider.DiffConfig) call should have
+// been previously checked by a call to [](pulumirpc.ResourceProvider.CheckConfig); inputs supplied to a
+// [](pulumirpc.ResourceProvider.Diff) call should have been previously checked by a call to
+// [](pulumirpc.ResourceProvider.Check).
 message DiffRequest {
-    string id = 1;                     // the ID of the resource to diff.
-    string urn = 2;                    // the Pulumi URN for this resource.
-    google.protobuf.Struct olds = 3;   // the old output values of resource to diff.
+    // The ID of the resource being diffed.
+    string id = 1;
 
-    // the new input values of resource to diff, copied from CheckResponse.inputs.
+    // The URN of the resource being diffed.
+    string urn = 2;
+
+    // The old *output* properties of the resource being diffed.
+    google.protobuf.Struct olds = 3;
+
+    // The new *input* properties of the resource being diffed. These should have been validated by an appropriate call
+    // to [](pulumirpc.ResourceProvider.CheckConfig) or [](pulumirpc.ResourceProvider.Check).
     google.protobuf.Struct news = 4;
 
-    repeated string ignoreChanges = 5; // a set of property paths that should be treated as unchanged.
-    google.protobuf.Struct old_inputs = 6;   // the old input values of the resource to diff.
-    string name = 7; // the Pulumi name for this resource.
-    string type = 8; // the Pulumi type for this resource.
+    // A set of [property paths](property-paths) that should be treated as unchanged.
+    repeated string ignoreChanges = 5;
+
+    // The old *input* properties of the resource being diffed.
+    google.protobuf.Struct old_inputs = 6;
+
+    // The name of the resource being diffed. This must match the name specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the name of the resource.
+    string name = 7;
+
+    // The type of the resource being diffed. This must match the type specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the type of the resource.
+    string type = 8;
 }
 
+// `PropertyDiff` describes the kind of change that occurred to a property during a diff operation. A `PropertyDiff` may
+// indicate that a property was added, deleted, or updated, and may further indicate that the change requires a
+// replacement.
 message PropertyDiff {
-    Kind kind = 1; // The kind of diff asdsociated with this property.
-    bool inputDiff = 2; // The difference is between old and new inputs, not old and new state.
+    // The kind of diff associated with this property.
+    Kind kind = 1;
 
+    // True if and only if this difference represents one between a pair of old and new inputs, as opposed to a pair of
+    // old and new states.
+    bool inputDiff = 2;
+
+    // The type of property diff kinds.
     enum Kind {
-        ADD = 0;            // this property was added
-        ADD_REPLACE = 1;    // this property was added, and this change requires a replace
-        DELETE = 2;         // this property was removed
-        DELETE_REPLACE = 3; // this property was removed, and this change requires a replace
-        UPDATE = 4;         // this property's value was changed
-        UPDATE_REPLACE = 5; // this property's value was changed, and this change requires a replace
+        // This property was added.
+        ADD = 0;
+
+        // This property was added, and this change requires a replace.
+        ADD_REPLACE = 1;
+
+        // This property was removed.
+        DELETE = 2;
+
+        // This property was removed, and this change requires a replace.
+        DELETE_REPLACE = 3;
+
+        // This property's value was changed.
+        UPDATE = 4;
+
+        // This property's value was changed, and this change requires a replace.
+        UPDATE_REPLACE = 5;
     }
 }
 
+// `DiffResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.DiffConfig) or
+// [](pulumirpc.ResourceProvider.Diff) call. A `DiffResponse` indicates whether a resource is unchanged, requires
+// updating (that is, can be changed "in place"), or requires replacement (that is, must be destroyed and recreated
+// anew). Legacy implementations may also signal that it is unknown whether there are changes or not.
+//
+// `DiffResponse` has evolved since its inception and there are now a number of ways that providers can signal their
+// intent to callers:
+//
+// * *Simple diffs* utilise the `changes` field to signal which fields are responsible for a change, and the `replaces`
+//   field to further communicate which changes (if any) require a replacement as opposed to an update.
+//
+// * *Detailed diffs* are those with `hasDetailedDiff` set, and utilise the `detailedDiff` field to provide a more
+//   granular view of the changes that have occurred. Detailed diffs are designed to allow providers to control
+//   precisely which field names are displayed as responsible for a change, and to signal more accurately what kind of
+//   change occurred (e.g. a field was added, deleted or updated).
 message DiffResponse {
-    repeated string replaces = 1; // if this update requires a replacement, the set of properties triggering it.
-    repeated string stables = 2;  // an optional list of properties that will not ever change.
-    bool deleteBeforeReplace = 3; // if true, this resource must be deleted before replacing it.
-    DiffChanges changes = 4;      // if true, this diff represents an actual difference and thus requires an update.
+    // A set of properties which have changed and whose changes require the resource being diffed to be replaced. The
+    // caller should replace the resource if this set is non-empty, or if any of the properties specified in
+    // `detailedDiff` have a `*_REPLACE` kind.
+    repeated string replaces = 1;
 
-    // a list of the properties that changed. This should only contain top level property names, it does not
-    // support nested properties. For that use detailedDiff.
+    // An optional list of properties that will not ever change (are stable).
+    repeated string stables = 2;
+
+    // If true, this resource must be deleted *before* its replacement is created.
+    bool deleteBeforeReplace = 3;
+
+    // The result of the diff. Indicates at a high level whether the resource has changed or not (or, in legacy cases,
+    // if the provider does not know).
+    DiffChanges changes = 4;
+
+    // The set of properties which have changed. This field only supports top-level properties. It *does not* support
+    // full [property paths](property-paths); implementations should use `detailedDiff` when this is required.
     repeated string diffs = 5;
 
-    // detailedDiff is an optional field that contains map from each changed property to the type of the change.
-    //
-    // The keys of this map are property paths. These paths are essentially Javascript property access expressions
-    // in which all elements are literals, and obey the following EBNF-ish grammar:
-    //
-    //   propertyName := [a-zA-Z_$] { [a-zA-Z0-9_$] }
-    //   quotedPropertyName := '"' ( '\' '"' | [^"] ) { ( '\' '"' | [^"] ) } '"'
-    //   arrayIndex := { [0-9] }
-    //
-    //   propertyIndex := '[' ( quotedPropertyName | arrayIndex ) ']'
-    //   rootProperty := ( propertyName | propertyIndex )
-    //   propertyAccessor := ( ( '.' propertyName ) |  propertyIndex )
-    //   path := rootProperty { propertyAccessor }
-    //
-    // Examples of valid keys:
-    // - root
-    // - root.nested
-    // - root["nested"]
-    // - root.double.nest
-    // - root["double"].nest
-    // - root["double"]["nest"]
-    // - root.array[0]
-    // - root.array[100]
-    // - root.array[0].nested
-    // - root.array[0][1].nested
-    // - root.nested.array[0].double[1]
-    // - root["key with \"escaped\" quotes"]
-    // - root["key with a ."]
-    // - ["root key with \"escaped\" quotes"].nested
-    // - ["root key with a ."][100]
-    map<string, PropertyDiff> detailedDiff = 6; // a detailed diff appropriate for display.
-    bool hasDetailedDiff = 7; // true if this response contains a detailed diff.
+    // `detailedDiff` can be used to implement more detailed diffs. A detailed diff is a map from [property
+    // paths](property-paths) to [](pulumirpc.PropertyDiff)s, which describe the kind of change that occurred to the
+    // property located at that path. If a provider does not implement this, the caller (typically the Pulumi engine)
+    // will compute a representation based on the simple diff fields (`changes`, `replaces`, and so on).
+    map<string, PropertyDiff> detailedDiff = 6;
 
+    // True if and only if this response contains a `detailedDiff`.
+    bool hasDetailedDiff = 7;
+
+    // The type of high-level diff results.
     enum DiffChanges {
-        DIFF_UNKNOWN = 0; // unknown whether there are changes or not (legacy behavior).
-        DIFF_NONE    = 1; // the diff was performed, and no changes were detected that require an update.
-        DIFF_SOME    = 2; // the diff was performed, and changes were detected that require an update or replacement.
+        // A diff was performed but it is unknown whether there are changes or not. This exists to support legacy
+        // behaviour and should be generally avoided wherever possible.
+        DIFF_UNKNOWN = 0;
+
+        // A diff was performed and there were no changes. An update is not required.
+        DIFF_NONE = 1;
+
+        // A diff was performed, and changes were detected that require an update or replacement.
+        DIFF_SOME = 2;
     }
 }
 

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -91,13 +91,18 @@ service ResourceProvider {
     // AWS access key, should almost certainly not.
     rpc DiffConfig(DiffRequest) returns (DiffResponse) {}
 
-    // Configure configures the resource provider with "globals" that control its behavior.
+    // `Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
     //
-    // :::{warning}
-    // ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
-    // ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
-    // ConfigureRequest.args.
-    // :::
+    // * Provider-specific configuration, which is the set of inputs that have been validated by a previous
+    //   [](pulumirpc.ResourceProvider.CheckConfig) call.
+    // * Provider-agnostic ("protocol") configuration, such as whether or not the caller supports secrets.
+    //
+    // The provider is expected to return its own set of protocol configuration, indicating which features it supports
+    // in turn so that the caller and the provider can interact appropriately.
+    //
+    // Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
+    // the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
+    // indicate which keys are missing.
     rpc Configure(ConfigureRequest) returns (ConfigureResponse) {}
 
     // Invoke dynamically executes a built-in function in the provider.
@@ -215,32 +220,105 @@ message GetSchemaResponse {
     string schema = 1; // the JSON-encoded schema.
 }
 
+// `ConfigureRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Configure) call. Requests
+// include both provider-specific inputs (`variables` or `args`) and provider-agnostic ("protocol") configuration
+// (`acceptSecrets`, `acceptResources`, and so on).
 message ConfigureRequest {
-    // the input properties for the provider, with nested values JSON-encoded; please read from `args` instead.
+    // :::{warning}
+    // `variables` is deprecated; `args` should be used instead wherever possible.
+    // :::
+    //
+    // A map of input properties for the provider. Compound values, such as nested objects, should be JSON encoded so
+    // that they too can be passed as strings. For instance, the following configuration:
+    //
+    // ```
+    // {
+    //   "a": 42,
+    //   "b": {
+    //     "c": "hello",
+    //     "d": true
+    //   }
+    // }
+    // ```
+    //
+    // should be encoded as:
+    //
+    // ```
+    // {
+    //   "a": "42",
+    //   "b": "{\"c\":\"hello\",\"d\":true}"
+    // }
+    // ```
     map<string, string> variables = 1;
 
-    google.protobuf.Struct args = 2;   // the input properties for the provider
-    bool acceptSecrets  = 3;           // when true, operations should return secrets as strongly typed.
-    bool acceptResources = 4;          // when true, operations should return resources as strongly typed values to the provider.
-    bool sends_old_inputs = 5;         // when true, diff and update will be called with the old outputs and the old inputs.
-    bool sends_old_inputs_to_delete = 6; // when true, delete will be called with the old outputs and the old inputs.
+    // A map of input properties for the provider.
+    //
+    // :::{warning}
+    // `args` may include secrets. Because `ConfigureRequest` is sent before [](pulumirpc.ConfigureResponse) can specify
+    // whether or not the provider accepts secrets in general, providers *must* handle secrets if they appear in `args`.
+    // :::
+    google.protobuf.Struct args = 2;
+
+    // True if and only if the caller supports secrets. If true, operations should return strongly typed secrets if the
+    // provider supports them also.
+    bool acceptSecrets  = 3;
+
+    // True if and only if the caller supports strongly typed resources. If true, operations should return resources as
+    // strongly typed values if the provider supports them also.
+    bool acceptResources = 4;
+
+    // True if and only if the caller supports sending old inputs as part of [](pulumirpc.ResourceProvider.Diff) and
+    // [](pulumirpc.ResourceProvider.Update) calls. If true, the provider should expect these fields to be populated in
+    // these calls.
+    bool sends_old_inputs = 5;
+
+    // True if and only if the caller supports sending old inputs and outputs as part of
+    // [](pulumirpc.ResourceProvider.Delete) calls. If true, the provider should expect these fields to be populated in
+    // these calls.
+    bool sends_old_inputs_to_delete = 6;
 }
 
+// `ConfigureResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Configure) call. Its primary
+// purpose is to communicate features that the provider supports back to the caller.
 message ConfigureResponse {
-    bool acceptSecrets = 1;   // when true, the engine should pass secrets as strongly typed values to the provider.
-    bool supportsPreview = 2; // when true, the engine should invoke create and update with preview=true during previews.
-    bool acceptResources = 3; // when true, the engine should pass resources as strongly typed values to the provider.
-    bool acceptOutputs = 4;   // when true, the engine should pass output values to the provider.
+    // True if and only if the provider supports secrets. If true, the caller should pass secrets as strongly typed
+    // values to the provider.
+    bool acceptSecrets = 1;
+
+    // True if and only if the provider supports the `preview` field on [](pulumirpc.ResourceProvider.Create) and
+    // [](pulumirpc.ResourceProvider.Update) calls. If true, the engine should invoke these calls with `preview` set to
+    // `true` during previews.
+    bool supportsPreview = 2;
+
+    // True if and only if the provider supports strongly typed resources. If true, the caller should pass resources as
+    // strongly typed values to the provider.
+    bool acceptResources = 3;
+
+    // True if and only if the provider supports output values as inputs. If true, the engine should pass output values
+    // to the provider where possible.
+    bool acceptOutputs = 4;
 }
 
-// ConfigureErrorMissingKeys is sent as a Detail on an error returned from `ResourceProvider.Configure`.
+// `ConfigureErrorMissingKeys` is the type of error details that may be sent in response to a
+// [](pulumirpc.ResourceProvider.Configure) call when required configuration keys are missing.
 message ConfigureErrorMissingKeys {
+    // The type of key-value pairs representing keys that are missing from a [](pulumirpc.ResourceProvider.Configure)
+    // call.
     message MissingKey {
-        string name = 1;        // the Pulumi name (not the provider name!) of the missing config key.
-        string description = 2; // a description of the missing config key, as reported by the provider.
+        // The name of the missing configuration key.
+        //
+        // :::{note}
+        // This should be the *Pulumi name* of the missing key, and not any provider-internal or upstream name. Names
+        // that differ between Pulumi and an upstream provider should be translated prior to being returned.
+        // :::
+        string name = 1;
+
+        // A description of the missing config key, as reported by the provider.
+        string description = 2;
     }
 
-    repeated MissingKey missingKeys = 1; // a list of required configuration keys that were not supplied.
+    // A list of required configuration keys that were not supplied.
+    repeated MissingKey missingKeys = 1;
 }
 
 message InvokeRequest {

--- a/sdk/nodejs/proto/provider_grpc_pb.js
+++ b/sdk/nodejs/proto/provider_grpc_pb.js
@@ -437,7 +437,16 @@ checkConfig: {
     responseSerialize: serialize_pulumirpc_CheckResponse,
     responseDeserialize: deserialize_pulumirpc_CheckResponse,
   },
-  // DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
+  // `DiffConfig` compares an existing ("old") provider configuration with a new configuration and computes the
+// difference (if any) between them. `DiffConfig` is to provider resources what [](pulumirpc.ResourceProvider.Diff)
+// is to individual resources. `DiffConfig` should only be called with values that have at some point been validated
+// by a [](pulumirpc.ResourceProvider.CheckConfig) call. The [](pulumirpc.DiffResponse) returned by a `DiffConfig`
+// call is used primarily to determine whether or not the newly configured provider is capable of managing resources
+// owned by the old provider. If `DiffConfig` indicates that the provider resource needs to be replaced, for
+// instance, then all resources owned by that provider will *also* need to be replaced. Replacement semantics should
+// thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
+// Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
+// AWS access key, should almost certainly not.
 diffConfig: {
     path: '/pulumirpc.ResourceProvider/DiffConfig',
     requestStream: false,

--- a/sdk/nodejs/proto/provider_grpc_pb.js
+++ b/sdk/nodejs/proto/provider_grpc_pb.js
@@ -408,7 +408,24 @@ getSchema: {
     responseSerialize: serialize_pulumirpc_GetSchemaResponse,
     responseDeserialize: deserialize_pulumirpc_GetSchemaResponse,
   },
-  // CheckConfig validates the configuration for this resource provider.
+  // `CheckConfig` validates a set of configuration inputs that will be passed to this provider instance.
+// `CheckConfig` is to provider resources what [](pulumirpc.ResourceProvider.Check) is to individual resources, and
+// is the first stage in configuring (that is, eventually executing a [](pulumirpc.ResourceProvider.Configure) call)
+// a provider using user-supplied values. In the case that provider inputs are coming from some source that has been
+// checked previously (e.g. a Pulumi state), it is not necessary to call `CheckConfig`.
+//
+// A `CheckConfig` call returns either a set of checked, known-valid inputs that may subsequently be passed to
+// [](pulumirpc.ResourceProvider.DiffConfig) and/or [](pulumirpc.ResourceProvider.Configure), or a set of errors
+// explaining why the inputs are invalid. In the case that a set of inputs are successfully validated and returned,
+// `CheckConfig` *may also populate default values* for provider configuration, returning them so that they may be
+// passed to a subsequent [](pulumirpc.ResourceProvider.Configure) call and persisted in the Pulumi state. In the
+// case that `CheckConfig` fails and returns a set of errors, it is expected that the caller (typically the Pulumi
+// engine) will fail provider registration.
+//
+// As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
+// the properties as present in the program inputs. Though this rule is not required for correctness, violations
+// thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+// rendering diffs.
 checkConfig: {
     path: '/pulumirpc.ResourceProvider/CheckConfig',
     requestStream: false,

--- a/sdk/nodejs/proto/provider_grpc_pb.js
+++ b/sdk/nodejs/proto/provider_grpc_pb.js
@@ -458,13 +458,18 @@ diffConfig: {
     responseSerialize: serialize_pulumirpc_DiffResponse,
     responseDeserialize: deserialize_pulumirpc_DiffResponse,
   },
-  // Configure configures the resource provider with "globals" that control its behavior.
+  // `Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
 //
-// :::{warning}
-// ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
-// ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
-// ConfigureRequest.args.
-// :::
+// * Provider-specific configuration, which is the set of inputs that have been validated by a previous
+//   [](pulumirpc.ResourceProvider.CheckConfig) call.
+// * Provider-agnostic ("protocol") configuration, such as whether or not the caller supports secrets.
+//
+// The provider is expected to return its own set of protocol configuration, indicating which features it supports
+// in turn so that the caller and the provider can interact appropriately.
+//
+// Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
+// the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
+// indicate which keys are missing.
 configure: {
     path: '/pulumirpc.ResourceProvider/Configure',
     requestStream: false,

--- a/sdk/proto/go/provider.pb.go
+++ b/sdk/proto/go/provider.pb.go
@@ -36,15 +36,22 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// The type of property diff kinds.
 type PropertyDiff_Kind int32
 
 const (
-	PropertyDiff_ADD            PropertyDiff_Kind = 0 // this property was added
-	PropertyDiff_ADD_REPLACE    PropertyDiff_Kind = 1 // this property was added, and this change requires a replace
-	PropertyDiff_DELETE         PropertyDiff_Kind = 2 // this property was removed
-	PropertyDiff_DELETE_REPLACE PropertyDiff_Kind = 3 // this property was removed, and this change requires a replace
-	PropertyDiff_UPDATE         PropertyDiff_Kind = 4 // this property's value was changed
-	PropertyDiff_UPDATE_REPLACE PropertyDiff_Kind = 5 // this property's value was changed, and this change requires a replace
+	// This property was added.
+	PropertyDiff_ADD PropertyDiff_Kind = 0
+	// This property was added, and this change requires a replace.
+	PropertyDiff_ADD_REPLACE PropertyDiff_Kind = 1
+	// This property was removed.
+	PropertyDiff_DELETE PropertyDiff_Kind = 2
+	// This property was removed, and this change requires a replace.
+	PropertyDiff_DELETE_REPLACE PropertyDiff_Kind = 3
+	// This property's value was changed.
+	PropertyDiff_UPDATE PropertyDiff_Kind = 4
+	// This property's value was changed, and this change requires a replace.
+	PropertyDiff_UPDATE_REPLACE PropertyDiff_Kind = 5
 )
 
 // Enum value maps for PropertyDiff_Kind.
@@ -94,12 +101,17 @@ func (PropertyDiff_Kind) EnumDescriptor() ([]byte, []int) {
 	return file_pulumi_provider_proto_rawDescGZIP(), []int{15, 0}
 }
 
+// The type of high-level diff results.
 type DiffResponse_DiffChanges int32
 
 const (
-	DiffResponse_DIFF_UNKNOWN DiffResponse_DiffChanges = 0 // unknown whether there are changes or not (legacy behavior).
-	DiffResponse_DIFF_NONE    DiffResponse_DiffChanges = 1 // the diff was performed, and no changes were detected that require an update.
-	DiffResponse_DIFF_SOME    DiffResponse_DiffChanges = 2 // the diff was performed, and changes were detected that require an update or replacement.
+	// A diff was performed but it is unknown whether there are changes or not. This exists to support legacy
+	// behaviour and should be generally avoided wherever possible.
+	DiffResponse_DIFF_UNKNOWN DiffResponse_DiffChanges = 0
+	// A diff was performed and there were no changes. An update is not required.
+	DiffResponse_DIFF_NONE DiffResponse_DiffChanges = 1
+	// A diff was performed, and changes were detected that require an update or replacement.
+	DiffResponse_DIFF_SOME DiffResponse_DiffChanges = 2
 )
 
 // Enum value maps for DiffResponse_DiffChanges.
@@ -1166,20 +1178,43 @@ func (x *CheckFailure) GetReason() string {
 	return ""
 }
 
+// `DiffRequest` is the type of requests sent as part of [](pulumirpc.ResourceProvider.DiffConfig) and
+// [](pulumirpc.ResourceProvider.Diff) calls. A `DiffRequest` primarily captures:
+//
+// * the URN of the resource whose properties are being compared;
+// * the old and new input properties of the resource; and
+// * the old output properties of the resource.
+//
+// In the case of [](pulumirpc.ResourceProvider.DiffConfig), the URN will be the URN of the provider resource being
+// examined, which may or may not be a [default provider](default-providers), and the inputs and outputs will be the
+// provider configuration and state. Inputs supplied to a [](pulumirpc.ResourceProvider.DiffConfig) call should have
+// been previously checked by a call to [](pulumirpc.ResourceProvider.CheckConfig); inputs supplied to a
+// [](pulumirpc.ResourceProvider.Diff) call should have been previously checked by a call to
+// [](pulumirpc.ResourceProvider.Check).
 type DiffRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id   string           `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`     // the ID of the resource to diff.
-	Urn  string           `protobuf:"bytes,2,opt,name=urn,proto3" json:"urn,omitempty"`   // the Pulumi URN for this resource.
-	Olds *structpb.Struct `protobuf:"bytes,3,opt,name=olds,proto3" json:"olds,omitempty"` // the old output values of resource to diff.
-	// the new input values of resource to diff, copied from CheckResponse.inputs.
-	News          *structpb.Struct `protobuf:"bytes,4,opt,name=news,proto3" json:"news,omitempty"`
-	IgnoreChanges []string         `protobuf:"bytes,5,rep,name=ignoreChanges,proto3" json:"ignoreChanges,omitempty"`          // a set of property paths that should be treated as unchanged.
-	OldInputs     *structpb.Struct `protobuf:"bytes,6,opt,name=old_inputs,json=oldInputs,proto3" json:"old_inputs,omitempty"` // the old input values of the resource to diff.
-	Name          string           `protobuf:"bytes,7,opt,name=name,proto3" json:"name,omitempty"`                            // the Pulumi name for this resource.
-	Type          string           `protobuf:"bytes,8,opt,name=type,proto3" json:"type,omitempty"`                            // the Pulumi type for this resource.
+	// The ID of the resource being diffed.
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// The URN of the resource being diffed.
+	Urn string `protobuf:"bytes,2,opt,name=urn,proto3" json:"urn,omitempty"`
+	// The old *output* properties of the resource being diffed.
+	Olds *structpb.Struct `protobuf:"bytes,3,opt,name=olds,proto3" json:"olds,omitempty"`
+	// The new *input* properties of the resource being diffed. These should have been validated by an appropriate call
+	// to [](pulumirpc.ResourceProvider.CheckConfig) or [](pulumirpc.ResourceProvider.Check).
+	News *structpb.Struct `protobuf:"bytes,4,opt,name=news,proto3" json:"news,omitempty"`
+	// A set of [property paths](property-paths) that should be treated as unchanged.
+	IgnoreChanges []string `protobuf:"bytes,5,rep,name=ignoreChanges,proto3" json:"ignoreChanges,omitempty"`
+	// The old *input* properties of the resource being diffed.
+	OldInputs *structpb.Struct `protobuf:"bytes,6,opt,name=old_inputs,json=oldInputs,proto3" json:"old_inputs,omitempty"`
+	// The name of the resource being diffed. This must match the name specified by the `urn` field, and is passed so
+	// that providers do not have to implement URN parsing in order to extract the name of the resource.
+	Name string `protobuf:"bytes,7,opt,name=name,proto3" json:"name,omitempty"`
+	// The type of the resource being diffed. This must match the type specified by the `urn` field, and is passed so
+	// that providers do not have to implement URN parsing in order to extract the type of the resource.
+	Type string `protobuf:"bytes,8,opt,name=type,proto3" json:"type,omitempty"`
 }
 
 func (x *DiffRequest) Reset() {
@@ -1270,13 +1305,19 @@ func (x *DiffRequest) GetType() string {
 	return ""
 }
 
+// `PropertyDiff` describes the kind of change that occurred to a property during a diff operation. A `PropertyDiff` may
+// indicate that a property was added, deleted, or updated, and may further indicate that the change requires a
+// replacement.
 type PropertyDiff struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Kind      PropertyDiff_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=pulumirpc.PropertyDiff_Kind" json:"kind,omitempty"` // The kind of diff asdsociated with this property.
-	InputDiff bool              `protobuf:"varint,2,opt,name=inputDiff,proto3" json:"inputDiff,omitempty"`                        // The difference is between old and new inputs, not old and new state.
+	// The kind of diff associated with this property.
+	Kind PropertyDiff_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=pulumirpc.PropertyDiff_Kind" json:"kind,omitempty"`
+	// True if and only if this difference represents one between a pair of old and new inputs, as opposed to a pair of
+	// old and new states.
+	InputDiff bool `protobuf:"varint,2,opt,name=inputDiff,proto3" json:"inputDiff,omitempty"`
 }
 
 func (x *PropertyDiff) Reset() {
@@ -1325,50 +1366,47 @@ func (x *PropertyDiff) GetInputDiff() bool {
 	return false
 }
 
+// `DiffResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.DiffConfig) or
+// [](pulumirpc.ResourceProvider.Diff) call. A `DiffResponse` indicates whether a resource is unchanged, requires
+// updating (that is, can be changed "in place"), or requires replacement (that is, must be destroyed and recreated
+// anew). Legacy implementations may also signal that it is unknown whether there are changes or not.
+//
+// `DiffResponse` has evolved since its inception and there are now a number of ways that providers can signal their
+// intent to callers:
+//
+// * *Simple diffs* utilise the `changes` field to signal which fields are responsible for a change, and the `replaces`
+//   field to further communicate which changes (if any) require a replacement as opposed to an update.
+//
+// * *Detailed diffs* are those with `hasDetailedDiff` set, and utilise the `detailedDiff` field to provide a more
+//   granular view of the changes that have occurred. Detailed diffs are designed to allow providers to control
+//   precisely which field names are displayed as responsible for a change, and to signal more accurately what kind of
+//   change occurred (e.g. a field was added, deleted or updated).
 type DiffResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Replaces            []string                 `protobuf:"bytes,1,rep,name=replaces,proto3" json:"replaces,omitempty"`                                        // if this update requires a replacement, the set of properties triggering it.
-	Stables             []string                 `protobuf:"bytes,2,rep,name=stables,proto3" json:"stables,omitempty"`                                          // an optional list of properties that will not ever change.
-	DeleteBeforeReplace bool                     `protobuf:"varint,3,opt,name=deleteBeforeReplace,proto3" json:"deleteBeforeReplace,omitempty"`                 // if true, this resource must be deleted before replacing it.
-	Changes             DiffResponse_DiffChanges `protobuf:"varint,4,opt,name=changes,proto3,enum=pulumirpc.DiffResponse_DiffChanges" json:"changes,omitempty"` // if true, this diff represents an actual difference and thus requires an update.
-	// a list of the properties that changed. This should only contain top level property names, it does not
-	// support nested properties. For that use detailedDiff.
+	// A set of properties which have changed and whose changes require the resource being diffed to be replaced. The
+	// caller should replace the resource if this set is non-empty, or if any of the properties specified in
+	// `detailedDiff` have a `*_REPLACE` kind.
+	Replaces []string `protobuf:"bytes,1,rep,name=replaces,proto3" json:"replaces,omitempty"`
+	// An optional list of properties that will not ever change (are stable).
+	Stables []string `protobuf:"bytes,2,rep,name=stables,proto3" json:"stables,omitempty"`
+	// If true, this resource must be deleted *before* its replacement is created.
+	DeleteBeforeReplace bool `protobuf:"varint,3,opt,name=deleteBeforeReplace,proto3" json:"deleteBeforeReplace,omitempty"`
+	// The result of the diff. Indicates at a high level whether the resource has changed or not (or, in legacy cases,
+	// if the provider does not know).
+	Changes DiffResponse_DiffChanges `protobuf:"varint,4,opt,name=changes,proto3,enum=pulumirpc.DiffResponse_DiffChanges" json:"changes,omitempty"`
+	// The set of properties which have changed. This field only supports top-level properties. It *does not* support
+	// full [property paths](property-paths); implementations should use `detailedDiff` when this is required.
 	Diffs []string `protobuf:"bytes,5,rep,name=diffs,proto3" json:"diffs,omitempty"`
-	// detailedDiff is an optional field that contains map from each changed property to the type of the change.
-	//
-	// The keys of this map are property paths. These paths are essentially Javascript property access expressions
-	// in which all elements are literals, and obey the following EBNF-ish grammar:
-	//
-	//   propertyName := [a-zA-Z_$] { [a-zA-Z0-9_$] }
-	//   quotedPropertyName := '"' ( '\' '"' | [^"] ) { ( '\' '"' | [^"] ) } '"'
-	//   arrayIndex := { [0-9] }
-	//
-	//   propertyIndex := '[' ( quotedPropertyName | arrayIndex ) ']'
-	//   rootProperty := ( propertyName | propertyIndex )
-	//   propertyAccessor := ( ( '.' propertyName ) |  propertyIndex )
-	//   path := rootProperty { propertyAccessor }
-	//
-	// Examples of valid keys:
-	// - root
-	// - root.nested
-	// - root["nested"]
-	// - root.double.nest
-	// - root["double"].nest
-	// - root["double"]["nest"]
-	// - root.array[0]
-	// - root.array[100]
-	// - root.array[0].nested
-	// - root.array[0][1].nested
-	// - root.nested.array[0].double[1]
-	// - root["key with \"escaped\" quotes"]
-	// - root["key with a ."]
-	// - ["root key with \"escaped\" quotes"].nested
-	// - ["root key with a ."][100]
-	DetailedDiff    map[string]*PropertyDiff `protobuf:"bytes,6,rep,name=detailedDiff,proto3" json:"detailedDiff,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"` // a detailed diff appropriate for display.
-	HasDetailedDiff bool                     `protobuf:"varint,7,opt,name=hasDetailedDiff,proto3" json:"hasDetailedDiff,omitempty"`                                                                                  // true if this response contains a detailed diff.
+	// `detailedDiff` can be used to implement more detailed diffs. A detailed diff is a map from [property
+	// paths](property-paths) to [](pulumirpc.PropertyDiff)s, which describe the kind of change that occurred to the
+	// property located at that path. If a provider does not implement this, the caller (typically the Pulumi engine)
+	// will compute a representation based on the simple diff fields (`changes`, `replaces`, and so on).
+	DetailedDiff map[string]*PropertyDiff `protobuf:"bytes,6,rep,name=detailedDiff,proto3" json:"detailedDiff,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	// True if and only if this response contains a `detailedDiff`.
+	HasDetailedDiff bool `protobuf:"varint,7,opt,name=hasDetailedDiff,proto3" json:"hasDetailedDiff,omitempty"`
 }
 
 func (x *DiffResponse) Reset() {

--- a/sdk/proto/go/provider_grpc.pb.go
+++ b/sdk/proto/go/provider_grpc.pb.go
@@ -83,13 +83,18 @@ type ResourceProviderClient interface {
 	// Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
 	// AWS access key, should almost certainly not.
 	DiffConfig(ctx context.Context, in *DiffRequest, opts ...grpc.CallOption) (*DiffResponse, error)
-	// Configure configures the resource provider with "globals" that control its behavior.
+	// `Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
 	//
-	// :::{warning}
-	// ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
-	// ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
-	// ConfigureRequest.args.
-	// :::
+	// * Provider-specific configuration, which is the set of inputs that have been validated by a previous
+	//   [](pulumirpc.ResourceProvider.CheckConfig) call.
+	// * Provider-agnostic ("protocol") configuration, such as whether or not the caller supports secrets.
+	//
+	// The provider is expected to return its own set of protocol configuration, indicating which features it supports
+	// in turn so that the caller and the provider can interact appropriately.
+	//
+	// Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
+	// the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
+	// indicate which keys are missing.
 	Configure(ctx context.Context, in *ConfigureRequest, opts ...grpc.CallOption) (*ConfigureResponse, error)
 	// Invoke dynamically executes a built-in function in the provider.
 	Invoke(ctx context.Context, in *InvokeRequest, opts ...grpc.CallOption) (*InvokeResponse, error)
@@ -412,13 +417,18 @@ type ResourceProviderServer interface {
 	// Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
 	// AWS access key, should almost certainly not.
 	DiffConfig(context.Context, *DiffRequest) (*DiffResponse, error)
-	// Configure configures the resource provider with "globals" that control its behavior.
+	// `Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
 	//
-	// :::{warning}
-	// ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
-	// ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
-	// ConfigureRequest.args.
-	// :::
+	// * Provider-specific configuration, which is the set of inputs that have been validated by a previous
+	//   [](pulumirpc.ResourceProvider.CheckConfig) call.
+	// * Provider-agnostic ("protocol") configuration, such as whether or not the caller supports secrets.
+	//
+	// The provider is expected to return its own set of protocol configuration, indicating which features it supports
+	// in turn so that the caller and the provider can interact appropriately.
+	//
+	// Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
+	// the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
+	// indicate which keys are missing.
 	Configure(context.Context, *ConfigureRequest) (*ConfigureResponse, error)
 	// Invoke dynamically executes a built-in function in the provider.
 	Invoke(context.Context, *InvokeRequest) (*InvokeResponse, error)

--- a/sdk/proto/go/provider_grpc.pb.go
+++ b/sdk/proto/go/provider_grpc.pb.go
@@ -72,7 +72,16 @@ type ResourceProviderClient interface {
 	// thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
 	// rendering diffs.
 	CheckConfig(ctx context.Context, in *CheckRequest, opts ...grpc.CallOption) (*CheckResponse, error)
-	// DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
+	// `DiffConfig` compares an existing ("old") provider configuration with a new configuration and computes the
+	// difference (if any) between them. `DiffConfig` is to provider resources what [](pulumirpc.ResourceProvider.Diff)
+	// is to individual resources. `DiffConfig` should only be called with values that have at some point been validated
+	// by a [](pulumirpc.ResourceProvider.CheckConfig) call. The [](pulumirpc.DiffResponse) returned by a `DiffConfig`
+	// call is used primarily to determine whether or not the newly configured provider is capable of managing resources
+	// owned by the old provider. If `DiffConfig` indicates that the provider resource needs to be replaced, for
+	// instance, then all resources owned by that provider will *also* need to be replaced. Replacement semantics should
+	// thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
+	// Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
+	// AWS access key, should almost certainly not.
 	DiffConfig(ctx context.Context, in *DiffRequest, opts ...grpc.CallOption) (*DiffResponse, error)
 	// Configure configures the resource provider with "globals" that control its behavior.
 	//
@@ -392,7 +401,16 @@ type ResourceProviderServer interface {
 	// thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
 	// rendering diffs.
 	CheckConfig(context.Context, *CheckRequest) (*CheckResponse, error)
-	// DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
+	// `DiffConfig` compares an existing ("old") provider configuration with a new configuration and computes the
+	// difference (if any) between them. `DiffConfig` is to provider resources what [](pulumirpc.ResourceProvider.Diff)
+	// is to individual resources. `DiffConfig` should only be called with values that have at some point been validated
+	// by a [](pulumirpc.ResourceProvider.CheckConfig) call. The [](pulumirpc.DiffResponse) returned by a `DiffConfig`
+	// call is used primarily to determine whether or not the newly configured provider is capable of managing resources
+	// owned by the old provider. If `DiffConfig` indicates that the provider resource needs to be replaced, for
+	// instance, then all resources owned by that provider will *also* need to be replaced. Replacement semantics should
+	// thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
+	// Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
+	// AWS access key, should almost certainly not.
 	DiffConfig(context.Context, *DiffRequest) (*DiffResponse, error)
 	// Configure configures the resource provider with "globals" that control its behavior.
 	//

--- a/sdk/proto/go/provider_grpc.pb.go
+++ b/sdk/proto/go/provider_grpc.pb.go
@@ -53,7 +53,24 @@ type ResourceProviderClient interface {
 	Parameterize(ctx context.Context, in *ParameterizeRequest, opts ...grpc.CallOption) (*ParameterizeResponse, error)
 	// GetSchema fetches the schema for this resource provider.
 	GetSchema(ctx context.Context, in *GetSchemaRequest, opts ...grpc.CallOption) (*GetSchemaResponse, error)
-	// CheckConfig validates the configuration for this resource provider.
+	// `CheckConfig` validates a set of configuration inputs that will be passed to this provider instance.
+	// `CheckConfig` is to provider resources what [](pulumirpc.ResourceProvider.Check) is to individual resources, and
+	// is the first stage in configuring (that is, eventually executing a [](pulumirpc.ResourceProvider.Configure) call)
+	// a provider using user-supplied values. In the case that provider inputs are coming from some source that has been
+	// checked previously (e.g. a Pulumi state), it is not necessary to call `CheckConfig`.
+	//
+	// A `CheckConfig` call returns either a set of checked, known-valid inputs that may subsequently be passed to
+	// [](pulumirpc.ResourceProvider.DiffConfig) and/or [](pulumirpc.ResourceProvider.Configure), or a set of errors
+	// explaining why the inputs are invalid. In the case that a set of inputs are successfully validated and returned,
+	// `CheckConfig` *may also populate default values* for provider configuration, returning them so that they may be
+	// passed to a subsequent [](pulumirpc.ResourceProvider.Configure) call and persisted in the Pulumi state. In the
+	// case that `CheckConfig` fails and returns a set of errors, it is expected that the caller (typically the Pulumi
+	// engine) will fail provider registration.
+	//
+	// As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
+	// the properties as present in the program inputs. Though this rule is not required for correctness, violations
+	// thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+	// rendering diffs.
 	CheckConfig(ctx context.Context, in *CheckRequest, opts ...grpc.CallOption) (*CheckResponse, error)
 	// DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
 	DiffConfig(ctx context.Context, in *DiffRequest, opts ...grpc.CallOption) (*DiffResponse, error)
@@ -356,7 +373,24 @@ type ResourceProviderServer interface {
 	Parameterize(context.Context, *ParameterizeRequest) (*ParameterizeResponse, error)
 	// GetSchema fetches the schema for this resource provider.
 	GetSchema(context.Context, *GetSchemaRequest) (*GetSchemaResponse, error)
-	// CheckConfig validates the configuration for this resource provider.
+	// `CheckConfig` validates a set of configuration inputs that will be passed to this provider instance.
+	// `CheckConfig` is to provider resources what [](pulumirpc.ResourceProvider.Check) is to individual resources, and
+	// is the first stage in configuring (that is, eventually executing a [](pulumirpc.ResourceProvider.Configure) call)
+	// a provider using user-supplied values. In the case that provider inputs are coming from some source that has been
+	// checked previously (e.g. a Pulumi state), it is not necessary to call `CheckConfig`.
+	//
+	// A `CheckConfig` call returns either a set of checked, known-valid inputs that may subsequently be passed to
+	// [](pulumirpc.ResourceProvider.DiffConfig) and/or [](pulumirpc.ResourceProvider.Configure), or a set of errors
+	// explaining why the inputs are invalid. In the case that a set of inputs are successfully validated and returned,
+	// `CheckConfig` *may also populate default values* for provider configuration, returning them so that they may be
+	// passed to a subsequent [](pulumirpc.ResourceProvider.Configure) call and persisted in the Pulumi state. In the
+	// case that `CheckConfig` fails and returns a set of errors, it is expected that the caller (typically the Pulumi
+	// engine) will fail provider registration.
+	//
+	// As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
+	// the properties as present in the program inputs. Though this rule is not required for correctness, violations
+	// thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+	// rendering diffs.
 	CheckConfig(context.Context, *CheckRequest) (*CheckResponse, error)
 	// DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
 	DiffConfig(context.Context, *DiffRequest) (*DiffResponse, error)

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
@@ -643,6 +643,21 @@ global___CheckFailure = CheckFailure
 
 @typing_extensions.final
 class DiffRequest(google.protobuf.message.Message):
+    """`DiffRequest` is the type of requests sent as part of [](pulumirpc.ResourceProvider.DiffConfig) and
+    [](pulumirpc.ResourceProvider.Diff) calls. A `DiffRequest` primarily captures:
+
+    * the URN of the resource whose properties are being compared;
+    * the old and new input properties of the resource; and
+    * the old output properties of the resource.
+
+    In the case of [](pulumirpc.ResourceProvider.DiffConfig), the URN will be the URN of the provider resource being
+    examined, which may or may not be a [default provider](default-providers), and the inputs and outputs will be the
+    provider configuration and state. Inputs supplied to a [](pulumirpc.ResourceProvider.DiffConfig) call should have
+    been previously checked by a call to [](pulumirpc.ResourceProvider.CheckConfig); inputs supplied to a
+    [](pulumirpc.ResourceProvider.Diff) call should have been previously checked by a call to
+    [](pulumirpc.ResourceProvider.Check).
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     ID_FIELD_NUMBER: builtins.int
@@ -654,25 +669,31 @@ class DiffRequest(google.protobuf.message.Message):
     NAME_FIELD_NUMBER: builtins.int
     TYPE_FIELD_NUMBER: builtins.int
     id: builtins.str
-    """the ID of the resource to diff."""
+    """The ID of the resource being diffed."""
     urn: builtins.str
-    """the Pulumi URN for this resource."""
+    """The URN of the resource being diffed."""
     @property
     def olds(self) -> google.protobuf.struct_pb2.Struct:
-        """the old output values of resource to diff."""
+        """The old *output* properties of the resource being diffed."""
     @property
     def news(self) -> google.protobuf.struct_pb2.Struct:
-        """the new input values of resource to diff, copied from CheckResponse.inputs."""
+        """The new *input* properties of the resource being diffed. These should have been validated by an appropriate call
+        to [](pulumirpc.ResourceProvider.CheckConfig) or [](pulumirpc.ResourceProvider.Check).
+        """
     @property
     def ignoreChanges(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """a set of property paths that should be treated as unchanged."""
+        """A set of [property paths](property-paths) that should be treated as unchanged."""
     @property
     def old_inputs(self) -> google.protobuf.struct_pb2.Struct:
-        """the old input values of the resource to diff."""
+        """The old *input* properties of the resource being diffed."""
     name: builtins.str
-    """the Pulumi name for this resource."""
+    """The name of the resource being diffed. This must match the name specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the name of the resource.
+    """
     type: builtins.str
-    """the Pulumi type for this resource."""
+    """The type of the resource being diffed. This must match the type specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the type of the resource.
+    """
     def __init__(
         self,
         *,
@@ -692,6 +713,11 @@ global___DiffRequest = DiffRequest
 
 @typing_extensions.final
 class PropertyDiff(google.protobuf.message.Message):
+    """`PropertyDiff` describes the kind of change that occurred to a property during a diff operation. A `PropertyDiff` may
+    indicate that a property was added, deleted, or updated, and may further indicate that the change requires a
+    replacement.
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     class _Kind:
@@ -701,38 +727,42 @@ class PropertyDiff(google.protobuf.message.Message):
     class _KindEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[PropertyDiff._Kind.ValueType], builtins.type):  # noqa: F821
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
         ADD: PropertyDiff._Kind.ValueType  # 0
-        """this property was added"""
+        """This property was added."""
         ADD_REPLACE: PropertyDiff._Kind.ValueType  # 1
-        """this property was added, and this change requires a replace"""
+        """This property was added, and this change requires a replace."""
         DELETE: PropertyDiff._Kind.ValueType  # 2
-        """this property was removed"""
+        """This property was removed."""
         DELETE_REPLACE: PropertyDiff._Kind.ValueType  # 3
-        """this property was removed, and this change requires a replace"""
+        """This property was removed, and this change requires a replace."""
         UPDATE: PropertyDiff._Kind.ValueType  # 4
-        """this property's value was changed"""
+        """This property's value was changed."""
         UPDATE_REPLACE: PropertyDiff._Kind.ValueType  # 5
-        """this property's value was changed, and this change requires a replace"""
+        """This property's value was changed, and this change requires a replace."""
 
-    class Kind(_Kind, metaclass=_KindEnumTypeWrapper): ...
+    class Kind(_Kind, metaclass=_KindEnumTypeWrapper):
+        """The type of property diff kinds."""
+
     ADD: PropertyDiff.Kind.ValueType  # 0
-    """this property was added"""
+    """This property was added."""
     ADD_REPLACE: PropertyDiff.Kind.ValueType  # 1
-    """this property was added, and this change requires a replace"""
+    """This property was added, and this change requires a replace."""
     DELETE: PropertyDiff.Kind.ValueType  # 2
-    """this property was removed"""
+    """This property was removed."""
     DELETE_REPLACE: PropertyDiff.Kind.ValueType  # 3
-    """this property was removed, and this change requires a replace"""
+    """This property was removed, and this change requires a replace."""
     UPDATE: PropertyDiff.Kind.ValueType  # 4
-    """this property's value was changed"""
+    """This property's value was changed."""
     UPDATE_REPLACE: PropertyDiff.Kind.ValueType  # 5
-    """this property's value was changed, and this change requires a replace"""
+    """This property's value was changed, and this change requires a replace."""
 
     KIND_FIELD_NUMBER: builtins.int
     INPUTDIFF_FIELD_NUMBER: builtins.int
     kind: global___PropertyDiff.Kind.ValueType
-    """The kind of diff asdsociated with this property."""
+    """The kind of diff associated with this property."""
     inputDiff: builtins.bool
-    """The difference is between old and new inputs, not old and new state."""
+    """True if and only if this difference represents one between a pair of old and new inputs, as opposed to a pair of
+    old and new states.
+    """
     def __init__(
         self,
         *,
@@ -745,6 +775,23 @@ global___PropertyDiff = PropertyDiff
 
 @typing_extensions.final
 class DiffResponse(google.protobuf.message.Message):
+    """`DiffResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.DiffConfig) or
+    [](pulumirpc.ResourceProvider.Diff) call. A `DiffResponse` indicates whether a resource is unchanged, requires
+    updating (that is, can be changed "in place"), or requires replacement (that is, must be destroyed and recreated
+    anew). Legacy implementations may also signal that it is unknown whether there are changes or not.
+
+    `DiffResponse` has evolved since its inception and there are now a number of ways that providers can signal their
+    intent to callers:
+
+    * *Simple diffs* utilise the `changes` field to signal which fields are responsible for a change, and the `replaces`
+      field to further communicate which changes (if any) require a replacement as opposed to an update.
+
+    * *Detailed diffs* are those with `hasDetailedDiff` set, and utilise the `detailedDiff` field to provide a more
+      granular view of the changes that have occurred. Detailed diffs are designed to allow providers to control
+      precisely which field names are displayed as responsible for a change, and to signal more accurately what kind of
+      change occurred (e.g. a field was added, deleted or updated).
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     class _DiffChanges:
@@ -754,19 +801,25 @@ class DiffResponse(google.protobuf.message.Message):
     class _DiffChangesEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[DiffResponse._DiffChanges.ValueType], builtins.type):  # noqa: F821
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
         DIFF_UNKNOWN: DiffResponse._DiffChanges.ValueType  # 0
-        """unknown whether there are changes or not (legacy behavior)."""
+        """A diff was performed but it is unknown whether there are changes or not. This exists to support legacy
+        behaviour and should be generally avoided wherever possible.
+        """
         DIFF_NONE: DiffResponse._DiffChanges.ValueType  # 1
-        """the diff was performed, and no changes were detected that require an update."""
+        """A diff was performed and there were no changes. An update is not required."""
         DIFF_SOME: DiffResponse._DiffChanges.ValueType  # 2
-        """the diff was performed, and changes were detected that require an update or replacement."""
+        """A diff was performed, and changes were detected that require an update or replacement."""
 
-    class DiffChanges(_DiffChanges, metaclass=_DiffChangesEnumTypeWrapper): ...
+    class DiffChanges(_DiffChanges, metaclass=_DiffChangesEnumTypeWrapper):
+        """The type of high-level diff results."""
+
     DIFF_UNKNOWN: DiffResponse.DiffChanges.ValueType  # 0
-    """unknown whether there are changes or not (legacy behavior)."""
+    """A diff was performed but it is unknown whether there are changes or not. This exists to support legacy
+    behaviour and should be generally avoided wherever possible.
+    """
     DIFF_NONE: DiffResponse.DiffChanges.ValueType  # 1
-    """the diff was performed, and no changes were detected that require an update."""
+    """A diff was performed and there were no changes. An update is not required."""
     DIFF_SOME: DiffResponse.DiffChanges.ValueType  # 2
-    """the diff was performed, and changes were detected that require an update or replacement."""
+    """A diff was performed, and changes were detected that require an update or replacement."""
 
     @typing_extensions.final
     class DetailedDiffEntry(google.protobuf.message.Message):
@@ -795,55 +848,33 @@ class DiffResponse(google.protobuf.message.Message):
     HASDETAILEDDIFF_FIELD_NUMBER: builtins.int
     @property
     def replaces(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """if this update requires a replacement, the set of properties triggering it."""
+        """A set of properties which have changed and whose changes require the resource being diffed to be replaced. The
+        caller should replace the resource if this set is non-empty, or if any of the properties specified in
+        `detailedDiff` have a `*_REPLACE` kind.
+        """
     @property
     def stables(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """an optional list of properties that will not ever change."""
+        """An optional list of properties that will not ever change (are stable)."""
     deleteBeforeReplace: builtins.bool
-    """if true, this resource must be deleted before replacing it."""
+    """If true, this resource must be deleted *before* its replacement is created."""
     changes: global___DiffResponse.DiffChanges.ValueType
-    """if true, this diff represents an actual difference and thus requires an update."""
+    """The result of the diff. Indicates at a high level whether the resource has changed or not (or, in legacy cases,
+    if the provider does not know).
+    """
     @property
     def diffs(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """a list of the properties that changed. This should only contain top level property names, it does not
-        support nested properties. For that use detailedDiff.
+        """The set of properties which have changed. This field only supports top-level properties. It *does not* support
+        full [property paths](property-paths); implementations should use `detailedDiff` when this is required.
         """
     @property
     def detailedDiff(self) -> google.protobuf.internal.containers.MessageMap[builtins.str, global___PropertyDiff]:
-        """detailedDiff is an optional field that contains map from each changed property to the type of the change.
-
-        The keys of this map are property paths. These paths are essentially Javascript property access expressions
-        in which all elements are literals, and obey the following EBNF-ish grammar:
-
-          propertyName := [a-zA-Z_$] { [a-zA-Z0-9_$] }
-          quotedPropertyName := '"' ( '\\' '"' | [^"] ) { ( '\\' '"' | [^"] ) } '"'
-          arrayIndex := { [0-9] }
-
-          propertyIndex := '[' ( quotedPropertyName | arrayIndex ) ']'
-          rootProperty := ( propertyName | propertyIndex )
-          propertyAccessor := ( ( '.' propertyName ) |  propertyIndex )
-          path := rootProperty { propertyAccessor }
-
-        Examples of valid keys:
-        - root
-        - root.nested
-        - root["nested"]
-        - root.double.nest
-        - root["double"].nest
-        - root["double"]["nest"]
-        - root.array[0]
-        - root.array[100]
-        - root.array[0].nested
-        - root.array[0][1].nested
-        - root.nested.array[0].double[1]
-        - root["key with \\"escaped\\" quotes"]
-        - root["key with a ."]
-        - ["root key with \\"escaped\\" quotes"].nested
-        - ["root key with a ."][100]
-        a detailed diff appropriate for display.
+        """`detailedDiff` can be used to implement more detailed diffs. A detailed diff is a map from [property
+        paths](property-paths) to [](pulumirpc.PropertyDiff)s, which describe the kind of change that occurred to the
+        property located at that path. If a provider does not implement this, the caller (typically the Pulumi engine)
+        will compute a representation based on the simple diff fields (`changes`, `replaces`, and so on).
         """
     hasDetailedDiff: builtins.bool
-    """true if this response contains a detailed diff."""
+    """True if and only if this response contains a `detailedDiff`."""
     def __init__(
         self,
         *,

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
@@ -521,6 +521,13 @@ global___CallResponse = CallResponse
 
 @typing_extensions.final
 class CheckRequest(google.protobuf.message.Message):
+    """`CheckRequest` is the type of requests sent as part of [](pulumirpc.ResourceProvider.CheckConfig) and
+    [](pulumirpc.ResourceProvider.Check) calls. A `CheckRequest` primarily captures the URN and inputs of the resource
+    being checked. In the case of [](pulumirpc.ResourceProvider.CheckConfig), the URN will be the URN of the provider
+    resource being constructed, which may or may not be a [default provider](default-providers), and the inputs will be
+    the provider configuration.
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     URN_FIELD_NUMBER: builtins.int
@@ -530,26 +537,35 @@ class CheckRequest(google.protobuf.message.Message):
     NAME_FIELD_NUMBER: builtins.int
     TYPE_FIELD_NUMBER: builtins.int
     urn: builtins.str
-    """the Pulumi URN for this resource."""
+    """The URN of the resource whose inputs are being checked. In the case of
+    [](pulumirpc.ResourceProvider.CheckConfig), this will be the URN of the provider resource being constructed,
+    which may or may not be a [default provider](default-providers).
+    """
     @property
     def olds(self) -> google.protobuf.struct_pb2.Struct:
-        """the old Pulumi inputs for this resource, if any."""
+        """The old input properties or configuration for the resource, if any."""
     @property
     def news(self) -> google.protobuf.struct_pb2.Struct:
-        """the new Pulumi inputs for this resource.
+        """The new input properties or configuration for the resource, if any.
 
-        Note that if the user specifies the ignoreChanges resource option, the value of news passed
-        to the provider here may differ from the values written in the program source. It will be pre-processed by
-        replacing every ignoreChanges property by a matching value from the old inputs stored in the state.
-
-        See also: https://www.pulumi.com/docs/concepts/options/ignorechanges/
+        :::{note}
+        If this resource has been specified with the
+        [`ignoreChanges`](https://www.pulumi.com/docs/concepts/options/ignorechanges/), then the values in `news` may
+        differ from those written in the Pulumi program registering this resource. In such cases, the caller (e.g. the
+        Pulumi engine) is expected to preprocess the `news` value by replacing every property matched by `ignoreChanges`
+        with its corresponding `olds` value (effectively ignoring the change).
+        :::
         """
     randomSeed: builtins.bytes
-    """a deterministically random hash, primarily intended for global unique naming."""
+    """A random but deterministically computed hash, intended to be used for generating globally unique names."""
     name: builtins.str
-    """the Pulumi name for this resource."""
+    """The name of the resource being checked. This must match the name specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the name of the resource.
+    """
     type: builtins.str
-    """the Pulumi type for this resource."""
+    """The type of the resource being checked. This must match the type specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the type of the resource.
+    """
     def __init__(
         self,
         *,
@@ -567,16 +583,29 @@ global___CheckRequest = CheckRequest
 
 @typing_extensions.final
 class CheckResponse(google.protobuf.message.Message):
+    """`CheckResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.CheckConfig) or
+    [](pulumirpc.ResourceProvider.Check) call. A `CheckResponse` may contain either:
+
+    * a set of checked, known-valid `inputs`. In the case of [](pulumirpc.ResourceProvider.CheckConfig), these may
+      subsequently be passed to [](pulumirpc.ResourceProvider.DiffConfig) and/or
+      [](pulumirpc.ResourceProvider.Configure). In the case of [](pulumirpc.ResourceProvider.Check), these may be passed
+      to any of the supported lifecycle methods that accept provider inputs.
+    * a set of `failures` detailing invalid inputs.
+
+    In cases where the supplied set of inputs is valid, a `CheckResponse` may contain default values that should
+    persisted to Pulumi state and passed to subsequent calls.
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     INPUTS_FIELD_NUMBER: builtins.int
     FAILURES_FIELD_NUMBER: builtins.int
     @property
     def inputs(self) -> google.protobuf.struct_pb2.Struct:
-        """the provider inputs for this resource."""
+        """A valid, checked set of inputs. May contain defaults."""
     @property
     def failures(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___CheckFailure]:
-        """any validation failures that occurred."""
+        """Any validation failures that occurred."""
     def __init__(
         self,
         *,
@@ -590,14 +619,18 @@ global___CheckResponse = CheckResponse
 
 @typing_extensions.final
 class CheckFailure(google.protobuf.message.Message):
+    """A `CheckFailure` describes a single validation error that arose as part of a
+    [](pulumirpc.ResourceProvider.CheckConfig) or [](pulumirpc.ResourceProvider.Check) call.
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     PROPERTY_FIELD_NUMBER: builtins.int
     REASON_FIELD_NUMBER: builtins.int
     property: builtins.str
-    """the property that failed validation."""
+    """The input property that failed validation."""
     reason: builtins.str
-    """the reason that the property failed validation."""
+    """The reason that the named property failed validation."""
     def __init__(
         self,
         *,

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
@@ -194,7 +194,16 @@ class ResourceProviderServicer(object):
         raise NotImplementedError('Method not implemented!')
 
     def DiffConfig(self, request, context):
-        """DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
+        """`DiffConfig` compares an existing ("old") provider configuration with a new configuration and computes the
+        difference (if any) between them. `DiffConfig` is to provider resources what [](pulumirpc.ResourceProvider.Diff)
+        is to individual resources. `DiffConfig` should only be called with values that have at some point been validated
+        by a [](pulumirpc.ResourceProvider.CheckConfig) call. The [](pulumirpc.DiffResponse) returned by a `DiffConfig`
+        call is used primarily to determine whether or not the newly configured provider is capable of managing resources
+        owned by the old provider. If `DiffConfig` indicates that the provider resource needs to be replaced, for
+        instance, then all resources owned by that provider will *also* need to be replaced. Replacement semantics should
+        thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
+        Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
+        AWS access key, should almost certainly not.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
@@ -170,7 +170,24 @@ class ResourceProviderServicer(object):
         raise NotImplementedError('Method not implemented!')
 
     def CheckConfig(self, request, context):
-        """CheckConfig validates the configuration for this resource provider.
+        """`CheckConfig` validates a set of configuration inputs that will be passed to this provider instance.
+        `CheckConfig` is to provider resources what [](pulumirpc.ResourceProvider.Check) is to individual resources, and
+        is the first stage in configuring (that is, eventually executing a [](pulumirpc.ResourceProvider.Configure) call)
+        a provider using user-supplied values. In the case that provider inputs are coming from some source that has been
+        checked previously (e.g. a Pulumi state), it is not necessary to call `CheckConfig`.
+
+        A `CheckConfig` call returns either a set of checked, known-valid inputs that may subsequently be passed to
+        [](pulumirpc.ResourceProvider.DiffConfig) and/or [](pulumirpc.ResourceProvider.Configure), or a set of errors
+        explaining why the inputs are invalid. In the case that a set of inputs are successfully validated and returned,
+        `CheckConfig` *may also populate default values* for provider configuration, returning them so that they may be
+        passed to a subsequent [](pulumirpc.ResourceProvider.Configure) call and persisted in the Pulumi state. In the
+        case that `CheckConfig` fails and returns a set of errors, it is expected that the caller (typically the Pulumi
+        engine) will fail provider registration.
+
+        As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
+        the properties as present in the program inputs. Though this rule is not required for correctness, violations
+        thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+        rendering diffs.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
@@ -210,13 +210,18 @@ class ResourceProviderServicer(object):
         raise NotImplementedError('Method not implemented!')
 
     def Configure(self, request, context):
-        """Configure configures the resource provider with "globals" that control its behavior.
+        """`Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
 
-        :::{warning}
-        ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
-        ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
-        ConfigureRequest.args.
-        :::
+        * Provider-specific configuration, which is the set of inputs that have been validated by a previous
+        [](pulumirpc.ResourceProvider.CheckConfig) call.
+        * Provider-agnostic ("protocol") configuration, such as whether or not the caller supports secrets.
+
+        The provider is expected to return its own set of protocol configuration, indicating which features it supports
+        in turn so that the caller and the provider can interact appropriately.
+
+        Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
+        the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
+        indicate which keys are missing.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
@@ -111,13 +111,18 @@ class ResourceProviderStub:
         pulumi.provider_pb2.ConfigureRequest,
         pulumi.provider_pb2.ConfigureResponse,
     ]
-    """Configure configures the resource provider with "globals" that control its behavior.
+    """`Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
 
-    :::{warning}
-    ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
-    ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
-    ConfigureRequest.args.
-    :::
+    * Provider-specific configuration, which is the set of inputs that have been validated by a previous
+      [](pulumirpc.ResourceProvider.CheckConfig) call.
+    * Provider-agnostic ("protocol") configuration, such as whether or not the caller supports secrets.
+
+    The provider is expected to return its own set of protocol configuration, indicating which features it supports
+    in turn so that the caller and the provider can interact appropriately.
+
+    Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
+    the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
+    indicate which keys are missing.
     """
     Invoke: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.InvokeRequest,
@@ -312,13 +317,18 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         request: pulumi.provider_pb2.ConfigureRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.ConfigureResponse:
-        """Configure configures the resource provider with "globals" that control its behavior.
+        """`Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
 
-        :::{warning}
-        ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
-        ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
-        ConfigureRequest.args.
-        :::
+        * Provider-specific configuration, which is the set of inputs that have been validated by a previous
+          [](pulumirpc.ResourceProvider.CheckConfig) call.
+        * Provider-agnostic ("protocol") configuration, such as whether or not the caller supports secrets.
+
+        The provider is expected to return its own set of protocol configuration, indicating which features it supports
+        in turn so that the caller and the provider can interact appropriately.
+
+        Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
+        the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
+        indicate which keys are missing.
         """
     
     def Invoke(

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
@@ -73,7 +73,25 @@ class ResourceProviderStub:
         pulumi.provider_pb2.CheckRequest,
         pulumi.provider_pb2.CheckResponse,
     ]
-    """CheckConfig validates the configuration for this resource provider."""
+    """`CheckConfig` validates a set of configuration inputs that will be passed to this provider instance.
+    `CheckConfig` is to provider resources what [](pulumirpc.ResourceProvider.Check) is to individual resources, and
+    is the first stage in configuring (that is, eventually executing a [](pulumirpc.ResourceProvider.Configure) call)
+    a provider using user-supplied values. In the case that provider inputs are coming from some source that has been
+    checked previously (e.g. a Pulumi state), it is not necessary to call `CheckConfig`.
+
+    A `CheckConfig` call returns either a set of checked, known-valid inputs that may subsequently be passed to
+    [](pulumirpc.ResourceProvider.DiffConfig) and/or [](pulumirpc.ResourceProvider.Configure), or a set of errors
+    explaining why the inputs are invalid. In the case that a set of inputs are successfully validated and returned,
+    `CheckConfig` *may also populate default values* for provider configuration, returning them so that they may be
+    passed to a subsequent [](pulumirpc.ResourceProvider.Configure) call and persisted in the Pulumi state. In the
+    case that `CheckConfig` fails and returns a set of errors, it is expected that the caller (typically the Pulumi
+    engine) will fail provider registration.
+
+    As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
+    the properties as present in the program inputs. Though this rule is not required for correctness, violations
+    thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+    rendering diffs.
+    """
     DiffConfig: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.DiffRequest,
         pulumi.provider_pb2.DiffResponse,
@@ -242,7 +260,25 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         request: pulumi.provider_pb2.CheckRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.CheckResponse:
-        """CheckConfig validates the configuration for this resource provider."""
+        """`CheckConfig` validates a set of configuration inputs that will be passed to this provider instance.
+        `CheckConfig` is to provider resources what [](pulumirpc.ResourceProvider.Check) is to individual resources, and
+        is the first stage in configuring (that is, eventually executing a [](pulumirpc.ResourceProvider.Configure) call)
+        a provider using user-supplied values. In the case that provider inputs are coming from some source that has been
+        checked previously (e.g. a Pulumi state), it is not necessary to call `CheckConfig`.
+
+        A `CheckConfig` call returns either a set of checked, known-valid inputs that may subsequently be passed to
+        [](pulumirpc.ResourceProvider.DiffConfig) and/or [](pulumirpc.ResourceProvider.Configure), or a set of errors
+        explaining why the inputs are invalid. In the case that a set of inputs are successfully validated and returned,
+        `CheckConfig` *may also populate default values* for provider configuration, returning them so that they may be
+        passed to a subsequent [](pulumirpc.ResourceProvider.Configure) call and persisted in the Pulumi state. In the
+        case that `CheckConfig` fails and returns a set of errors, it is expected that the caller (typically the Pulumi
+        engine) will fail provider registration.
+
+        As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
+        the properties as present in the program inputs. Though this rule is not required for correctness, violations
+        thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+        rendering diffs.
+        """
     
     def DiffConfig(
         self,

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
@@ -96,7 +96,17 @@ class ResourceProviderStub:
         pulumi.provider_pb2.DiffRequest,
         pulumi.provider_pb2.DiffResponse,
     ]
-    """DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider."""
+    """`DiffConfig` compares an existing ("old") provider configuration with a new configuration and computes the
+    difference (if any) between them. `DiffConfig` is to provider resources what [](pulumirpc.ResourceProvider.Diff)
+    is to individual resources. `DiffConfig` should only be called with values that have at some point been validated
+    by a [](pulumirpc.ResourceProvider.CheckConfig) call. The [](pulumirpc.DiffResponse) returned by a `DiffConfig`
+    call is used primarily to determine whether or not the newly configured provider is capable of managing resources
+    owned by the old provider. If `DiffConfig` indicates that the provider resource needs to be replaced, for
+    instance, then all resources owned by that provider will *also* need to be replaced. Replacement semantics should
+    thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
+    Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
+    AWS access key, should almost certainly not.
+    """
     Configure: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.ConfigureRequest,
         pulumi.provider_pb2.ConfigureResponse,
@@ -285,7 +295,17 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         request: pulumi.provider_pb2.DiffRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.DiffResponse:
-        """DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider."""
+        """`DiffConfig` compares an existing ("old") provider configuration with a new configuration and computes the
+        difference (if any) between them. `DiffConfig` is to provider resources what [](pulumirpc.ResourceProvider.Diff)
+        is to individual resources. `DiffConfig` should only be called with values that have at some point been validated
+        by a [](pulumirpc.ResourceProvider.CheckConfig) call. The [](pulumirpc.DiffResponse) returned by a `DiffConfig`
+        call is used primarily to determine whether or not the newly configured provider is capable of managing resources
+        owned by the old provider. If `DiffConfig` indicates that the provider resource needs to be replaced, for
+        instance, then all resources owned by that provider will *also* need to be replaced. Replacement semantics should
+        thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
+        Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
+        AWS access key, should almost certainly not.
+        """
     
     def Configure(
         self,


### PR DESCRIPTION
This commit fleshes out the documentation for the `Configure` method of resource providers.