### PR TITLE
Document `ResourceProvider.Check` and `ResourceProvider.Diff`

### DIFF
--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -18,7 +18,7 @@
 1921230328 1269 proto/pulumi/errors.proto
 420991671 12306 proto/pulumi/language.proto
 2893249402 1992 proto/pulumi/plugin.proto
-2872121187 42589 proto/pulumi/provider.proto
+474752463 43383 proto/pulumi/provider.proto
 1190662922 17848 proto/pulumi/resource.proto
 607478140 1008 proto/pulumi/source.proto
 3670315643 2603 proto/pulumi/testing/language.proto

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -75,7 +75,7 @@ service ResourceProvider {
     //
     // As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
     // the properties as present in the program inputs. Though this rule is not required for correctness, violations
-    // thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+    // thereof can negatively impact the end-user experience, as the provider inputs are used for detecting and
     // rendering diffs.
     rpc CheckConfig(CheckRequest) returns (CheckResponse) {}
 
@@ -115,13 +115,23 @@ service ResourceProvider {
     // Call dynamically executes a method in the provider associated with a component resource.
     rpc Call(CallRequest) returns (CallResponse) {}
 
-    // Check validates that the given property bag is valid for a resource of the given type and returns the inputs
-    // that should be passed to successive calls to Diff, Create, or Update for this resource. As a rule, the provider
-    // inputs returned by a call to Check should preserve the original representation of the properties as present in
-    // the program inputs. Though this rule is not required for correctness, violations thereof can negatively impact
-    // the end-user experience, as the provider inputs are using for detecting and rendering diffs.
+    // `Check` validates a set of input properties against a given resource type. A `Check` call returns either a set of
+    // checked, known-valid inputs that may subsequently be passed to [](pulumirpc.ResourceProvider.Diff),
+    // [](pulumirpc.ResourceProvider.Create), or [](pulumirpc.ResourceProvider.Update); or a set of errors explaining
+    // why the inputs are invalid. In the case that a set of inputs are successfully validated and returned, `Check`
+    // *may also populate default values* for resource inputs, returning them so that they may be passed to a subsequent
+    // call and persisted in the Pulumi state. In the case that `Check` fails and returns a set of errors, it is
+    // expected that the caller (typically the Pulumi engine) will fail resource registration.
+    //
+    // As a rule, the provider inputs returned by a call to `Check` should preserve the original representation of the
+    // properties as present in the program inputs. Though this rule is not required for correctness, violations thereof
+    // can negatively impact the end-user experience, as the provider inputs are used for detecting and rendering
+    // diffs.
     rpc Check(CheckRequest) returns (CheckResponse) {}
-    // Diff checks what impacts a hypothetical update will have on the resource's properties.
+
+    // `Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
+    // difference (if any) between them. `Diff` should only be called with values that have at some point been validated
+    // by a [](pulumirpc.ResourceProvider.Check) call.
     rpc Diff(DiffRequest) returns (DiffResponse) {}
     // Create allocates a new instance of the provided resource and returns its unique ID afterwards.  (The input ID
     // must be blank.)  If this call fails, the resource must not have been created (i.e., it is "transactional").

--- a/sdk/nodejs/proto/provider_grpc_pb.js
+++ b/sdk/nodejs/proto/provider_grpc_pb.js
@@ -424,7 +424,7 @@ getSchema: {
 //
 // As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
 // the properties as present in the program inputs. Though this rule is not required for correctness, violations
-// thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+// thereof can negatively impact the end-user experience, as the provider inputs are used for detecting and
 // rendering diffs.
 checkConfig: {
     path: '/pulumirpc.ResourceProvider/CheckConfig',
@@ -518,11 +518,18 @@ call: {
     responseSerialize: serialize_pulumirpc_CallResponse,
     responseDeserialize: deserialize_pulumirpc_CallResponse,
   },
-  // Check validates that the given property bag is valid for a resource of the given type and returns the inputs
-// that should be passed to successive calls to Diff, Create, or Update for this resource. As a rule, the provider
-// inputs returned by a call to Check should preserve the original representation of the properties as present in
-// the program inputs. Though this rule is not required for correctness, violations thereof can negatively impact
-// the end-user experience, as the provider inputs are using for detecting and rendering diffs.
+  // `Check` validates a set of input properties against a given resource type. A `Check` call returns either a set of
+// checked, known-valid inputs that may subsequently be passed to [](pulumirpc.ResourceProvider.Diff),
+// [](pulumirpc.ResourceProvider.Create), or [](pulumirpc.ResourceProvider.Update); or a set of errors explaining
+// why the inputs are invalid. In the case that a set of inputs are successfully validated and returned, `Check`
+// *may also populate default values* for resource inputs, returning them so that they may be passed to a subsequent
+// call and persisted in the Pulumi state. In the case that `Check` fails and returns a set of errors, it is
+// expected that the caller (typically the Pulumi engine) will fail resource registration.
+//
+// As a rule, the provider inputs returned by a call to `Check` should preserve the original representation of the
+// properties as present in the program inputs. Though this rule is not required for correctness, violations thereof
+// can negatively impact the end-user experience, as the provider inputs are used for detecting and rendering
+// diffs.
 check: {
     path: '/pulumirpc.ResourceProvider/Check',
     requestStream: false,
@@ -534,7 +541,9 @@ check: {
     responseSerialize: serialize_pulumirpc_CheckResponse,
     responseDeserialize: deserialize_pulumirpc_CheckResponse,
   },
-  // Diff checks what impacts a hypothetical update will have on the resource's properties.
+  // `Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
+// difference (if any) between them. `Diff` should only be called with values that have at some point been validated
+// by a [](pulumirpc.ResourceProvider.Check) call.
 diff: {
     path: '/pulumirpc.ResourceProvider/Diff',
     requestStream: false,

--- a/sdk/proto/go/provider_grpc.pb.go
+++ b/sdk/proto/go/provider_grpc.pb.go
@@ -69,7 +69,7 @@ type ResourceProviderClient interface {
 	//
 	// As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
 	// the properties as present in the program inputs. Though this rule is not required for correctness, violations
-	// thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+	// thereof can negatively impact the end-user experience, as the provider inputs are used for detecting and
 	// rendering diffs.
 	CheckConfig(ctx context.Context, in *CheckRequest, opts ...grpc.CallOption) (*CheckResponse, error)
 	// `DiffConfig` compares an existing ("old") provider configuration with a new configuration and computes the
@@ -103,13 +103,22 @@ type ResourceProviderClient interface {
 	StreamInvoke(ctx context.Context, in *InvokeRequest, opts ...grpc.CallOption) (ResourceProvider_StreamInvokeClient, error)
 	// Call dynamically executes a method in the provider associated with a component resource.
 	Call(ctx context.Context, in *CallRequest, opts ...grpc.CallOption) (*CallResponse, error)
-	// Check validates that the given property bag is valid for a resource of the given type and returns the inputs
-	// that should be passed to successive calls to Diff, Create, or Update for this resource. As a rule, the provider
-	// inputs returned by a call to Check should preserve the original representation of the properties as present in
-	// the program inputs. Though this rule is not required for correctness, violations thereof can negatively impact
-	// the end-user experience, as the provider inputs are using for detecting and rendering diffs.
+	// `Check` validates a set of input properties against a given resource type. A `Check` call returns either a set of
+	// checked, known-valid inputs that may subsequently be passed to [](pulumirpc.ResourceProvider.Diff),
+	// [](pulumirpc.ResourceProvider.Create), or [](pulumirpc.ResourceProvider.Update); or a set of errors explaining
+	// why the inputs are invalid. In the case that a set of inputs are successfully validated and returned, `Check`
+	// *may also populate default values* for resource inputs, returning them so that they may be passed to a subsequent
+	// call and persisted in the Pulumi state. In the case that `Check` fails and returns a set of errors, it is
+	// expected that the caller (typically the Pulumi engine) will fail resource registration.
+	//
+	// As a rule, the provider inputs returned by a call to `Check` should preserve the original representation of the
+	// properties as present in the program inputs. Though this rule is not required for correctness, violations thereof
+	// can negatively impact the end-user experience, as the provider inputs are used for detecting and rendering
+	// diffs.
 	Check(ctx context.Context, in *CheckRequest, opts ...grpc.CallOption) (*CheckResponse, error)
-	// Diff checks what impacts a hypothetical update will have on the resource's properties.
+	// `Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
+	// difference (if any) between them. `Diff` should only be called with values that have at some point been validated
+	// by a [](pulumirpc.ResourceProvider.Check) call.
 	Diff(ctx context.Context, in *DiffRequest, opts ...grpc.CallOption) (*DiffResponse, error)
 	// Create allocates a new instance of the provided resource and returns its unique ID afterwards.  (The input ID
 	// must be blank.)  If this call fails, the resource must not have been created (i.e., it is "transactional").
@@ -403,7 +412,7 @@ type ResourceProviderServer interface {
 	//
 	// As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
 	// the properties as present in the program inputs. Though this rule is not required for correctness, violations
-	// thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+	// thereof can negatively impact the end-user experience, as the provider inputs are used for detecting and
 	// rendering diffs.
 	CheckConfig(context.Context, *CheckRequest) (*CheckResponse, error)
 	// `DiffConfig` compares an existing ("old") provider configuration with a new configuration and computes the
@@ -437,13 +446,22 @@ type ResourceProviderServer interface {
 	StreamInvoke(*InvokeRequest, ResourceProvider_StreamInvokeServer) error
 	// Call dynamically executes a method in the provider associated with a component resource.
 	Call(context.Context, *CallRequest) (*CallResponse, error)
-	// Check validates that the given property bag is valid for a resource of the given type and returns the inputs
-	// that should be passed to successive calls to Diff, Create, or Update for this resource. As a rule, the provider
-	// inputs returned by a call to Check should preserve the original representation of the properties as present in
-	// the program inputs. Though this rule is not required for correctness, violations thereof can negatively impact
-	// the end-user experience, as the provider inputs are using for detecting and rendering diffs.
+	// `Check` validates a set of input properties against a given resource type. A `Check` call returns either a set of
+	// checked, known-valid inputs that may subsequently be passed to [](pulumirpc.ResourceProvider.Diff),
+	// [](pulumirpc.ResourceProvider.Create), or [](pulumirpc.ResourceProvider.Update); or a set of errors explaining
+	// why the inputs are invalid. In the case that a set of inputs are successfully validated and returned, `Check`
+	// *may also populate default values* for resource inputs, returning them so that they may be passed to a subsequent
+	// call and persisted in the Pulumi state. In the case that `Check` fails and returns a set of errors, it is
+	// expected that the caller (typically the Pulumi engine) will fail resource registration.
+	//
+	// As a rule, the provider inputs returned by a call to `Check` should preserve the original representation of the
+	// properties as present in the program inputs. Though this rule is not required for correctness, violations thereof
+	// can negatively impact the end-user experience, as the provider inputs are used for detecting and rendering
+	// diffs.
 	Check(context.Context, *CheckRequest) (*CheckResponse, error)
-	// Diff checks what impacts a hypothetical update will have on the resource's properties.
+	// `Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
+	// difference (if any) between them. `Diff` should only be called with values that have at some point been validated
+	// by a [](pulumirpc.ResourceProvider.Check) call.
 	Diff(context.Context, *DiffRequest) (*DiffResponse, error)
 	// Create allocates a new instance of the provided resource and returns its unique ID afterwards.  (The input ID
 	// must be blank.)  If this call fails, the resource must not have been created (i.e., it is "transactional").

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
@@ -186,7 +186,7 @@ class ResourceProviderServicer(object):
 
         As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
         the properties as present in the program inputs. Though this rule is not required for correctness, violations
-        thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+        thereof can negatively impact the end-user experience, as the provider inputs are used for detecting and
         rendering diffs.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
@@ -250,18 +250,27 @@ class ResourceProviderServicer(object):
         raise NotImplementedError('Method not implemented!')
 
     def Check(self, request, context):
-        """Check validates that the given property bag is valid for a resource of the given type and returns the inputs
-        that should be passed to successive calls to Diff, Create, or Update for this resource. As a rule, the provider
-        inputs returned by a call to Check should preserve the original representation of the properties as present in
-        the program inputs. Though this rule is not required for correctness, violations thereof can negatively impact
-        the end-user experience, as the provider inputs are using for detecting and rendering diffs.
+        """`Check` validates a set of input properties against a given resource type. A `Check` call returns either a set of
+        checked, known-valid inputs that may subsequently be passed to [](pulumirpc.ResourceProvider.Diff),
+        [](pulumirpc.ResourceProvider.Create), or [](pulumirpc.ResourceProvider.Update); or a set of errors explaining
+        why the inputs are invalid. In the case that a set of inputs are successfully validated and returned, `Check`
+        *may also populate default values* for resource inputs, returning them so that they may be passed to a subsequent
+        call and persisted in the Pulumi state. In the case that `Check` fails and returns a set of errors, it is
+        expected that the caller (typically the Pulumi engine) will fail resource registration.
+
+        As a rule, the provider inputs returned by a call to `Check` should preserve the original representation of the
+        properties as present in the program inputs. Though this rule is not required for correctness, violations thereof
+        can negatively impact the end-user experience, as the provider inputs are used for detecting and rendering
+        diffs.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def Diff(self, request, context):
-        """Diff checks what impacts a hypothetical update will have on the resource's properties.
+        """`Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
+        difference (if any) between them. `Diff` should only be called with values that have at some point been validated
+        by a [](pulumirpc.ResourceProvider.Check) call.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
@@ -89,7 +89,7 @@ class ResourceProviderStub:
 
     As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
     the properties as present in the program inputs. Though this rule is not required for correctness, violations
-    thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+    thereof can negatively impact the end-user experience, as the provider inputs are used for detecting and
     rendering diffs.
     """
     DiffConfig: grpc.UnaryUnaryMultiCallable[
@@ -145,17 +145,27 @@ class ResourceProviderStub:
         pulumi.provider_pb2.CheckRequest,
         pulumi.provider_pb2.CheckResponse,
     ]
-    """Check validates that the given property bag is valid for a resource of the given type and returns the inputs
-    that should be passed to successive calls to Diff, Create, or Update for this resource. As a rule, the provider
-    inputs returned by a call to Check should preserve the original representation of the properties as present in
-    the program inputs. Though this rule is not required for correctness, violations thereof can negatively impact
-    the end-user experience, as the provider inputs are using for detecting and rendering diffs.
+    """`Check` validates a set of input properties against a given resource type. A `Check` call returns either a set of
+    checked, known-valid inputs that may subsequently be passed to [](pulumirpc.ResourceProvider.Diff),
+    [](pulumirpc.ResourceProvider.Create), or [](pulumirpc.ResourceProvider.Update); or a set of errors explaining
+    why the inputs are invalid. In the case that a set of inputs are successfully validated and returned, `Check`
+    *may also populate default values* for resource inputs, returning them so that they may be passed to a subsequent
+    call and persisted in the Pulumi state. In the case that `Check` fails and returns a set of errors, it is
+    expected that the caller (typically the Pulumi engine) will fail resource registration.
+
+    As a rule, the provider inputs returned by a call to `Check` should preserve the original representation of the
+    properties as present in the program inputs. Though this rule is not required for correctness, violations thereof
+    can negatively impact the end-user experience, as the provider inputs are used for detecting and rendering
+    diffs.
     """
     Diff: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.DiffRequest,
         pulumi.provider_pb2.DiffResponse,
     ]
-    """Diff checks what impacts a hypothetical update will have on the resource's properties."""
+    """`Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
+    difference (if any) between them. `Diff` should only be called with values that have at some point been validated
+    by a [](pulumirpc.ResourceProvider.Check) call.
+    """
     Create: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.CreateRequest,
         pulumi.provider_pb2.CreateResponse,
@@ -291,7 +301,7 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
 
         As a rule, the provider inputs returned by a call to `CheckConfig` should preserve the original representation of
         the properties as present in the program inputs. Though this rule is not required for correctness, violations
-        thereof can negatively impact the end-user experience, as the provider inputs are using for detecting and
+        thereof can negatively impact the end-user experience, as the provider inputs are used for detecting and
         rendering diffs.
         """
     
@@ -359,11 +369,18 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         request: pulumi.provider_pb2.CheckRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.CheckResponse:
-        """Check validates that the given property bag is valid for a resource of the given type and returns the inputs
-        that should be passed to successive calls to Diff, Create, or Update for this resource. As a rule, the provider
-        inputs returned by a call to Check should preserve the original representation of the properties as present in
-        the program inputs. Though this rule is not required for correctness, violations thereof can negatively impact
-        the end-user experience, as the provider inputs are using for detecting and rendering diffs.
+        """`Check` validates a set of input properties against a given resource type. A `Check` call returns either a set of
+        checked, known-valid inputs that may subsequently be passed to [](pulumirpc.ResourceProvider.Diff),
+        [](pulumirpc.ResourceProvider.Create), or [](pulumirpc.ResourceProvider.Update); or a set of errors explaining
+        why the inputs are invalid. In the case that a set of inputs are successfully validated and returned, `Check`
+        *may also populate default values* for resource inputs, returning them so that they may be passed to a subsequent
+        call and persisted in the Pulumi state. In the case that `Check` fails and returns a set of errors, it is
+        expected that the caller (typically the Pulumi engine) will fail resource registration.
+
+        As a rule, the provider inputs returned by a call to `Check` should preserve the original representation of the
+        properties as present in the program inputs. Though this rule is not required for correctness, violations thereof
+        can negatively impact the end-user experience, as the provider inputs are used for detecting and rendering
+        diffs.
         """
     
     def Diff(
@@ -371,7 +388,10 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         request: pulumi.provider_pb2.DiffRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.DiffResponse:
-        """Diff checks what impacts a hypothetical update will have on the resource's properties."""
+        """`Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
+        difference (if any) between them. `Diff` should only be called with values that have at some point been validated
+        by a [](pulumirpc.ResourceProvider.Check) call.
+        """
     
     def Create(
         self,


### PR DESCRIPTION
This commit fleshes out the documentation for the `Check` and `Diff` methods of resource providers.