### PR TITLE
Document `ResourceProvider.Create` and `ResourceProvider.Read`

### DIFF
--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -18,7 +18,7 @@
 1921230328 1269 proto/pulumi/errors.proto
 420991671 12306 proto/pulumi/language.proto
 2893249402 1992 proto/pulumi/plugin.proto
-474752463 43383 proto/pulumi/provider.proto
+2184730073 45735 proto/pulumi/provider.proto
 1190662922 17848 proto/pulumi/resource.proto
 607478140 1008 proto/pulumi/source.proto
 3670315643 2603 proto/pulumi/testing/language.proto

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -133,11 +133,20 @@ service ResourceProvider {
     // difference (if any) between them. `Diff` should only be called with values that have at some point been validated
     // by a [](pulumirpc.ResourceProvider.Check) call.
     rpc Diff(DiffRequest) returns (DiffResponse) {}
-    // Create allocates a new instance of the provided resource and returns its unique ID afterwards.  (The input ID
-    // must be blank.)  If this call fails, the resource must not have been created (i.e., it is "transactional").
+
+    // `Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a
+    // provider-assigned ID for the resource as well as the output properties that arose from the creation properties.
+    // Output properties are typically the union of the resource's input properties and any additional values that were
+    // computed or made available during creation.
+    //
+    // If creation fails, `Create` may return an [](pulumirpc.ErrorResourceInitFailed) error detail explaining why.
+    // Moreover, if `Create` does return an error, it must be the case that the resource was *not* created (that is,
+    // `Create` can be thought of as transactional or atomic).
     rpc Create(CreateRequest) returns (CreateResponse) {}
-    // Read the current live state associated with a resource.  Enough state must be include in the inputs to uniquely
-    // identify the resource; this is typically just the resource ID, but may also include some properties.
+
+    // `Read` reads the current live state associated with a resource identified by the supplied state. The given state
+    // must be sufficient to uniquely identify the resource. This is typically just the resource ID, but may also
+    // include other properties.
     rpc Read(ReadRequest) returns (ReadResponse) {}
     // Update updates an existing resource with new values.
     rpc Update(UpdateRequest) returns (UpdateResponse) {}
@@ -594,35 +603,78 @@ message DiffResponse {
     }
 }
 
+// `CreateRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Create) call.
 message CreateRequest {
-    string urn = 1;                        // the Pulumi URN for this resource.
-    google.protobuf.Struct properties = 2; // the provider inputs to set during creation.
-    double timeout = 3;                    // the create request timeout represented in seconds.
-    bool preview = 4;                      // true if this is a preview and the provider should not actually create the resource.
-    string name = 5; // the Pulumi name for this resource.
-    string type = 6; // the Pulumi type for this resource.
+    // The URN of the resource being created.
+    string urn = 1;
+
+    // The resource's input properties, to be set during creation. These should have been validated by a call to
+    // [](pulumirpc.ResourceProvider.Check).
+    google.protobuf.Struct properties = 2;
+
+    // A timeout in seconds that the caller is prepared to wait for the operation to complete.
+    double timeout = 3;
+
+    // True if and only if the request is being made as part of a preview/dry run, in which case the provider should not
+    // actually create the resource.
+    bool preview = 4;
+
+    // The name of the resource being created. This must match the name specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the name of the resource.
+    string name = 5;
+
+    // The type of the resource being created. This must match the type specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the type of the resource.
+    string type = 6;
 }
 
+// `CreateResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Create) call. A `CreateResponse`
+// contains the ID of the created resource, as well as any output properties that arose from the creation process.
 message CreateResponse {
-    // NOTE: The partial-update-error equivalent of this message is `ErrorResourceInitFailed`.
+    // The ID of the created resource.
+    string id = 1;
 
-    string id = 1;                         // the ID of the created resource.
-    google.protobuf.Struct properties = 2; // any properties that were computed during creation.
+    // The resource's output properties. Typically this will be a union of the resource's input properties and any
+    // additional values that were computed or made available during creation.
+    google.protobuf.Struct properties = 2;
 }
 
+// `ReadRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Read) call.
 message ReadRequest {
-    string id = 1;                         // the ID of the resource to read.
-    string urn = 2;                        // the Pulumi URN for this resource.
-    google.protobuf.Struct properties = 3; // the current state (sufficiently complete to identify the resource).
-    google.protobuf.Struct inputs = 4;     // the current inputs, if any (only populated during refresh).
-    string name = 5; // the Pulumi name for this resource.
-    string type = 6; // the Pulumi type for this resource.
+    // The ID of the resource to read.
+    string id = 1;
+
+    // The URN of the resource being read.
+    string urn = 2;
+
+    // Any current state for the resource being read. This state should be sufficient to uniquely identify the resource.
+    google.protobuf.Struct properties = 3;
+
+    // Any current input properties for the resource being read. These will only be populated when the
+    // [](pulumirpc.ResourceProvider.Read) call is being made as part of a refresh operation.
+    google.protobuf.Struct inputs = 4;
+
+    // The name of the resource being read. This must match the name specified by the `urn` field, and is passed so that
+    // providers do not have to implement URN parsing in order to extract the name of the resource.
+    string name = 5;
+
+    // The type of the resource being read. This must match the type specified by the `urn` field, and is passed so that
+    // providers do not have to implement URN parsing in order to extract the type of the resource.
+    string type = 6;
 }
 
+// `ReadResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Read) call. A `ReadResponse` contains
+// the ID of the resource being read, as well as any state that was successfully read from the live environment.
 message ReadResponse {
-    string id = 1;                         // the ID of the resource read back (or empty if missing).
-    google.protobuf.Struct properties = 2; // the state of the resource read from the live environment.
-    google.protobuf.Struct inputs = 3;     // the inputs for this resource that would be returned from Check.
+    // The ID of the read resource.
+    string id = 1;
+
+    // The output properties of the resource read from the live environment.
+    google.protobuf.Struct properties = 2;
+
+    // Output-derived input properties for the resource. These are returned as they would be returned from a
+    // [](pulumirpc.ResourceProvider.Check) call with the same values.
+    google.protobuf.Struct inputs = 3;
 }
 
 message UpdateRequest {

--- a/sdk/nodejs/proto/provider_grpc_pb.js
+++ b/sdk/nodejs/proto/provider_grpc_pb.js
@@ -555,8 +555,14 @@ diff: {
     responseSerialize: serialize_pulumirpc_DiffResponse,
     responseDeserialize: deserialize_pulumirpc_DiffResponse,
   },
-  // Create allocates a new instance of the provided resource and returns its unique ID afterwards.  (The input ID
-// must be blank.)  If this call fails, the resource must not have been created (i.e., it is "transactional").
+  // `Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a
+// provider-assigned ID for the resource as well as the output properties that arose from the creation properties.
+// Output properties are typically the union of the resource's input properties and any additional values that were
+// computed or made available during creation.
+//
+// If creation fails, `Create` may return an [](pulumirpc.ErrorResourceInitFailed) error detail explaining why.
+// Moreover, if `Create` does return an error, it must be the case that the resource was *not* created (that is,
+// `Create` can be thought of as transactional or atomic).
 create: {
     path: '/pulumirpc.ResourceProvider/Create',
     requestStream: false,
@@ -568,8 +574,9 @@ create: {
     responseSerialize: serialize_pulumirpc_CreateResponse,
     responseDeserialize: deserialize_pulumirpc_CreateResponse,
   },
-  // Read the current live state associated with a resource.  Enough state must be include in the inputs to uniquely
-// identify the resource; this is typically just the resource ID, but may also include some properties.
+  // `Read` reads the current live state associated with a resource identified by the supplied state. The given state
+// must be sufficient to uniquely identify the resource. This is typically just the resource ID, but may also
+// include other properties.
 read: {
     path: '/pulumirpc.ResourceProvider/Read',
     requestStream: false,

--- a/sdk/proto/go/provider.pb.go
+++ b/sdk/proto/go/provider.pb.go
@@ -1546,17 +1546,28 @@ func (x *DiffResponse) GetHasDetailedDiff() bool {
 	return false
 }
 
+// `CreateRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Create) call.
 type CreateRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Urn        string           `protobuf:"bytes,1,opt,name=urn,proto3" json:"urn,omitempty"`               // the Pulumi URN for this resource.
-	Properties *structpb.Struct `protobuf:"bytes,2,opt,name=properties,proto3" json:"properties,omitempty"` // the provider inputs to set during creation.
-	Timeout    float64          `protobuf:"fixed64,3,opt,name=timeout,proto3" json:"timeout,omitempty"`     // the create request timeout represented in seconds.
-	Preview    bool             `protobuf:"varint,4,opt,name=preview,proto3" json:"preview,omitempty"`      // true if this is a preview and the provider should not actually create the resource.
-	Name       string           `protobuf:"bytes,5,opt,name=name,proto3" json:"name,omitempty"`             // the Pulumi name for this resource.
-	Type       string           `protobuf:"bytes,6,opt,name=type,proto3" json:"type,omitempty"`             // the Pulumi type for this resource.
+	// The URN of the resource being created.
+	Urn string `protobuf:"bytes,1,opt,name=urn,proto3" json:"urn,omitempty"`
+	// The resource's input properties, to be set during creation. These should have been validated by a call to
+	// [](pulumirpc.ResourceProvider.Check).
+	Properties *structpb.Struct `protobuf:"bytes,2,opt,name=properties,proto3" json:"properties,omitempty"`
+	// A timeout in seconds that the caller is prepared to wait for the operation to complete.
+	Timeout float64 `protobuf:"fixed64,3,opt,name=timeout,proto3" json:"timeout,omitempty"`
+	// True if and only if the request is being made as part of a preview/dry run, in which case the provider should not
+	// actually create the resource.
+	Preview bool `protobuf:"varint,4,opt,name=preview,proto3" json:"preview,omitempty"`
+	// The name of the resource being created. This must match the name specified by the `urn` field, and is passed so
+	// that providers do not have to implement URN parsing in order to extract the name of the resource.
+	Name string `protobuf:"bytes,5,opt,name=name,proto3" json:"name,omitempty"`
+	// The type of the resource being created. This must match the type specified by the `urn` field, and is passed so
+	// that providers do not have to implement URN parsing in order to extract the type of the resource.
+	Type string `protobuf:"bytes,6,opt,name=type,proto3" json:"type,omitempty"`
 }
 
 func (x *CreateRequest) Reset() {
@@ -1633,13 +1644,18 @@ func (x *CreateRequest) GetType() string {
 	return ""
 }
 
+// `CreateResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Create) call. A `CreateResponse`
+// contains the ID of the created resource, as well as any output properties that arose from the creation process.
 type CreateResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id         string           `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                 // the ID of the created resource.
-	Properties *structpb.Struct `protobuf:"bytes,2,opt,name=properties,proto3" json:"properties,omitempty"` // any properties that were computed during creation.
+	// The ID of the created resource.
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// The resource's output properties. Typically this will be a union of the resource's input properties and any
+	// additional values that were computed or made available during creation.
+	Properties *structpb.Struct `protobuf:"bytes,2,opt,name=properties,proto3" json:"properties,omitempty"`
 }
 
 func (x *CreateResponse) Reset() {
@@ -1688,17 +1704,27 @@ func (x *CreateResponse) GetProperties() *structpb.Struct {
 	return nil
 }
 
+// `ReadRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Read) call.
 type ReadRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id         string           `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                 // the ID of the resource to read.
-	Urn        string           `protobuf:"bytes,2,opt,name=urn,proto3" json:"urn,omitempty"`               // the Pulumi URN for this resource.
-	Properties *structpb.Struct `protobuf:"bytes,3,opt,name=properties,proto3" json:"properties,omitempty"` // the current state (sufficiently complete to identify the resource).
-	Inputs     *structpb.Struct `protobuf:"bytes,4,opt,name=inputs,proto3" json:"inputs,omitempty"`         // the current inputs, if any (only populated during refresh).
-	Name       string           `protobuf:"bytes,5,opt,name=name,proto3" json:"name,omitempty"`             // the Pulumi name for this resource.
-	Type       string           `protobuf:"bytes,6,opt,name=type,proto3" json:"type,omitempty"`             // the Pulumi type for this resource.
+	// The ID of the resource to read.
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// The URN of the resource being read.
+	Urn string `protobuf:"bytes,2,opt,name=urn,proto3" json:"urn,omitempty"`
+	// Any current state for the resource being read. This state should be sufficient to uniquely identify the resource.
+	Properties *structpb.Struct `protobuf:"bytes,3,opt,name=properties,proto3" json:"properties,omitempty"`
+	// Any current input properties for the resource being read. These will only be populated when the
+	// [](pulumirpc.ResourceProvider.Read) call is being made as part of a refresh operation.
+	Inputs *structpb.Struct `protobuf:"bytes,4,opt,name=inputs,proto3" json:"inputs,omitempty"`
+	// The name of the resource being read. This must match the name specified by the `urn` field, and is passed so that
+	// providers do not have to implement URN parsing in order to extract the name of the resource.
+	Name string `protobuf:"bytes,5,opt,name=name,proto3" json:"name,omitempty"`
+	// The type of the resource being read. This must match the type specified by the `urn` field, and is passed so that
+	// providers do not have to implement URN parsing in order to extract the type of the resource.
+	Type string `protobuf:"bytes,6,opt,name=type,proto3" json:"type,omitempty"`
 }
 
 func (x *ReadRequest) Reset() {
@@ -1775,14 +1801,20 @@ func (x *ReadRequest) GetType() string {
 	return ""
 }
 
+// `ReadResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Read) call. A `ReadResponse` contains
+// the ID of the resource being read, as well as any state that was successfully read from the live environment.
 type ReadResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id         string           `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                 // the ID of the resource read back (or empty if missing).
-	Properties *structpb.Struct `protobuf:"bytes,2,opt,name=properties,proto3" json:"properties,omitempty"` // the state of the resource read from the live environment.
-	Inputs     *structpb.Struct `protobuf:"bytes,3,opt,name=inputs,proto3" json:"inputs,omitempty"`         // the inputs for this resource that would be returned from Check.
+	// The ID of the read resource.
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// The output properties of the resource read from the live environment.
+	Properties *structpb.Struct `protobuf:"bytes,2,opt,name=properties,proto3" json:"properties,omitempty"`
+	// Output-derived input properties for the resource. These are returned as they would be returned from a
+	// [](pulumirpc.ResourceProvider.Check) call with the same values.
+	Inputs *structpb.Struct `protobuf:"bytes,3,opt,name=inputs,proto3" json:"inputs,omitempty"`
 }
 
 func (x *ReadResponse) Reset() {

--- a/sdk/proto/go/provider_grpc.pb.go
+++ b/sdk/proto/go/provider_grpc.pb.go
@@ -120,11 +120,18 @@ type ResourceProviderClient interface {
 	// difference (if any) between them. `Diff` should only be called with values that have at some point been validated
 	// by a [](pulumirpc.ResourceProvider.Check) call.
 	Diff(ctx context.Context, in *DiffRequest, opts ...grpc.CallOption) (*DiffResponse, error)
-	// Create allocates a new instance of the provided resource and returns its unique ID afterwards.  (The input ID
-	// must be blank.)  If this call fails, the resource must not have been created (i.e., it is "transactional").
+	// `Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a
+	// provider-assigned ID for the resource as well as the output properties that arose from the creation properties.
+	// Output properties are typically the union of the resource's input properties and any additional values that were
+	// computed or made available during creation.
+	//
+	// If creation fails, `Create` may return an [](pulumirpc.ErrorResourceInitFailed) error detail explaining why.
+	// Moreover, if `Create` does return an error, it must be the case that the resource was *not* created (that is,
+	// `Create` can be thought of as transactional or atomic).
 	Create(ctx context.Context, in *CreateRequest, opts ...grpc.CallOption) (*CreateResponse, error)
-	// Read the current live state associated with a resource.  Enough state must be include in the inputs to uniquely
-	// identify the resource; this is typically just the resource ID, but may also include some properties.
+	// `Read` reads the current live state associated with a resource identified by the supplied state. The given state
+	// must be sufficient to uniquely identify the resource. This is typically just the resource ID, but may also
+	// include other properties.
 	Read(ctx context.Context, in *ReadRequest, opts ...grpc.CallOption) (*ReadResponse, error)
 	// Update updates an existing resource with new values.
 	Update(ctx context.Context, in *UpdateRequest, opts ...grpc.CallOption) (*UpdateResponse, error)
@@ -463,11 +470,18 @@ type ResourceProviderServer interface {
 	// difference (if any) between them. `Diff` should only be called with values that have at some point been validated
 	// by a [](pulumirpc.ResourceProvider.Check) call.
 	Diff(context.Context, *DiffRequest) (*DiffResponse, error)
-	// Create allocates a new instance of the provided resource and returns its unique ID afterwards.  (The input ID
-	// must be blank.)  If this call fails, the resource must not have been created (i.e., it is "transactional").
+	// `Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a
+	// provider-assigned ID for the resource as well as the output properties that arose from the creation properties.
+	// Output properties are typically the union of the resource's input properties and any additional values that were
+	// computed or made available during creation.
+	//
+	// If creation fails, `Create` may return an [](pulumirpc.ErrorResourceInitFailed) error detail explaining why.
+	// Moreover, if `Create` does return an error, it must be the case that the resource was *not* created (that is,
+	// `Create` can be thought of as transactional or atomic).
 	Create(context.Context, *CreateRequest) (*CreateResponse, error)
-	// Read the current live state associated with a resource.  Enough state must be include in the inputs to uniquely
-	// identify the resource; this is typically just the resource ID, but may also include some properties.
+	// `Read` reads the current live state associated with a resource identified by the supplied state. The given state
+	// must be sufficient to uniquely identify the resource. This is typically just the resource ID, but may also
+	// include other properties.
 	Read(context.Context, *ReadRequest) (*ReadResponse, error)
 	// Update updates an existing resource with new values.
 	Update(context.Context, *UpdateRequest) (*UpdateResponse, error)

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
@@ -963,6 +963,8 @@ global___DiffResponse = DiffResponse
 
 @typing_extensions.final
 class CreateRequest(google.protobuf.message.Message):
+    """`CreateRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Create) call."""
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     URN_FIELD_NUMBER: builtins.int
@@ -972,18 +974,26 @@ class CreateRequest(google.protobuf.message.Message):
     NAME_FIELD_NUMBER: builtins.int
     TYPE_FIELD_NUMBER: builtins.int
     urn: builtins.str
-    """the Pulumi URN for this resource."""
+    """The URN of the resource being created."""
     @property
     def properties(self) -> google.protobuf.struct_pb2.Struct:
-        """the provider inputs to set during creation."""
+        """The resource's input properties, to be set during creation. These should have been validated by a call to
+        [](pulumirpc.ResourceProvider.Check).
+        """
     timeout: builtins.float
-    """the create request timeout represented in seconds."""
+    """A timeout in seconds that the caller is prepared to wait for the operation to complete."""
     preview: builtins.bool
-    """true if this is a preview and the provider should not actually create the resource."""
+    """True if and only if the request is being made as part of a preview/dry run, in which case the provider should not
+    actually create the resource.
+    """
     name: builtins.str
-    """the Pulumi name for this resource."""
+    """The name of the resource being created. This must match the name specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the name of the resource.
+    """
     type: builtins.str
-    """the Pulumi type for this resource."""
+    """The type of the resource being created. This must match the type specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the type of the resource.
+    """
     def __init__(
         self,
         *,
@@ -1001,17 +1011,21 @@ global___CreateRequest = CreateRequest
 
 @typing_extensions.final
 class CreateResponse(google.protobuf.message.Message):
-    """NOTE: The partial-update-error equivalent of this message is `ErrorResourceInitFailed`."""
+    """`CreateResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Create) call. A `CreateResponse`
+    contains the ID of the created resource, as well as any output properties that arose from the creation process.
+    """
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     ID_FIELD_NUMBER: builtins.int
     PROPERTIES_FIELD_NUMBER: builtins.int
     id: builtins.str
-    """the ID of the created resource."""
+    """The ID of the created resource."""
     @property
     def properties(self) -> google.protobuf.struct_pb2.Struct:
-        """any properties that were computed during creation."""
+        """The resource's output properties. Typically this will be a union of the resource's input properties and any
+        additional values that were computed or made available during creation.
+        """
     def __init__(
         self,
         *,
@@ -1025,6 +1039,8 @@ global___CreateResponse = CreateResponse
 
 @typing_extensions.final
 class ReadRequest(google.protobuf.message.Message):
+    """`ReadRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Read) call."""
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     ID_FIELD_NUMBER: builtins.int
@@ -1034,19 +1050,25 @@ class ReadRequest(google.protobuf.message.Message):
     NAME_FIELD_NUMBER: builtins.int
     TYPE_FIELD_NUMBER: builtins.int
     id: builtins.str
-    """the ID of the resource to read."""
+    """The ID of the resource to read."""
     urn: builtins.str
-    """the Pulumi URN for this resource."""
+    """The URN of the resource being read."""
     @property
     def properties(self) -> google.protobuf.struct_pb2.Struct:
-        """the current state (sufficiently complete to identify the resource)."""
+        """Any current state for the resource being read. This state should be sufficient to uniquely identify the resource."""
     @property
     def inputs(self) -> google.protobuf.struct_pb2.Struct:
-        """the current inputs, if any (only populated during refresh)."""
+        """Any current input properties for the resource being read. These will only be populated when the
+        [](pulumirpc.ResourceProvider.Read) call is being made as part of a refresh operation.
+        """
     name: builtins.str
-    """the Pulumi name for this resource."""
+    """The name of the resource being read. This must match the name specified by the `urn` field, and is passed so that
+    providers do not have to implement URN parsing in order to extract the name of the resource.
+    """
     type: builtins.str
-    """the Pulumi type for this resource."""
+    """The type of the resource being read. This must match the type specified by the `urn` field, and is passed so that
+    providers do not have to implement URN parsing in order to extract the type of the resource.
+    """
     def __init__(
         self,
         *,
@@ -1064,19 +1086,25 @@ global___ReadRequest = ReadRequest
 
 @typing_extensions.final
 class ReadResponse(google.protobuf.message.Message):
+    """`ReadResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Read) call. A `ReadResponse` contains
+    the ID of the resource being read, as well as any state that was successfully read from the live environment.
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     ID_FIELD_NUMBER: builtins.int
     PROPERTIES_FIELD_NUMBER: builtins.int
     INPUTS_FIELD_NUMBER: builtins.int
     id: builtins.str
-    """the ID of the resource read back (or empty if missing)."""
+    """The ID of the read resource."""
     @property
     def properties(self) -> google.protobuf.struct_pb2.Struct:
-        """the state of the resource read from the live environment."""
+        """The output properties of the resource read from the live environment."""
     @property
     def inputs(self) -> google.protobuf.struct_pb2.Struct:
-        """the inputs for this resource that would be returned from Check."""
+        """Output-derived input properties for the resource. These are returned as they would be returned from a
+        [](pulumirpc.ResourceProvider.Check) call with the same values.
+        """
     def __init__(
         self,
         *,

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
@@ -277,16 +277,23 @@ class ResourceProviderServicer(object):
         raise NotImplementedError('Method not implemented!')
 
     def Create(self, request, context):
-        """Create allocates a new instance of the provided resource and returns its unique ID afterwards.  (The input ID
-        must be blank.)  If this call fails, the resource must not have been created (i.e., it is "transactional").
+        """`Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a
+        provider-assigned ID for the resource as well as the output properties that arose from the creation properties.
+        Output properties are typically the union of the resource's input properties and any additional values that were
+        computed or made available during creation.
+
+        If creation fails, `Create` may return an [](pulumirpc.ErrorResourceInitFailed) error detail explaining why.
+        Moreover, if `Create` does return an error, it must be the case that the resource was *not* created (that is,
+        `Create` can be thought of as transactional or atomic).
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def Read(self, request, context):
-        """Read the current live state associated with a resource.  Enough state must be include in the inputs to uniquely
-        identify the resource; this is typically just the resource ID, but may also include some properties.
+        """`Read` reads the current live state associated with a resource identified by the supplied state. The given state
+        must be sufficient to uniquely identify the resource. This is typically just the resource ID, but may also
+        include other properties.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
@@ -170,15 +170,22 @@ class ResourceProviderStub:
         pulumi.provider_pb2.CreateRequest,
         pulumi.provider_pb2.CreateResponse,
     ]
-    """Create allocates a new instance of the provided resource and returns its unique ID afterwards.  (The input ID
-    must be blank.)  If this call fails, the resource must not have been created (i.e., it is "transactional").
+    """`Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a
+    provider-assigned ID for the resource as well as the output properties that arose from the creation properties.
+    Output properties are typically the union of the resource's input properties and any additional values that were
+    computed or made available during creation.
+
+    If creation fails, `Create` may return an [](pulumirpc.ErrorResourceInitFailed) error detail explaining why.
+    Moreover, if `Create` does return an error, it must be the case that the resource was *not* created (that is,
+    `Create` can be thought of as transactional or atomic).
     """
     Read: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.ReadRequest,
         pulumi.provider_pb2.ReadResponse,
     ]
-    """Read the current live state associated with a resource.  Enough state must be include in the inputs to uniquely
-    identify the resource; this is typically just the resource ID, but may also include some properties.
+    """`Read` reads the current live state associated with a resource identified by the supplied state. The given state
+    must be sufficient to uniquely identify the resource. This is typically just the resource ID, but may also
+    include other properties.
     """
     Update: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.UpdateRequest,
@@ -398,8 +405,14 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         request: pulumi.provider_pb2.CreateRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.CreateResponse:
-        """Create allocates a new instance of the provided resource and returns its unique ID afterwards.  (The input ID
-        must be blank.)  If this call fails, the resource must not have been created (i.e., it is "transactional").
+        """`Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a
+        provider-assigned ID for the resource as well as the output properties that arose from the creation properties.
+        Output properties are typically the union of the resource's input properties and any additional values that were
+        computed or made available during creation.
+
+        If creation fails, `Create` may return an [](pulumirpc.ErrorResourceInitFailed) error detail explaining why.
+        Moreover, if `Create` does return an error, it must be the case that the resource was *not* created (that is,
+        `Create` can be thought of as transactional or atomic).
         """
     
     def Read(
@@ -407,8 +420,9 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         request: pulumi.provider_pb2.ReadRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.ReadResponse:
-        """Read the current live state associated with a resource.  Enough state must be include in the inputs to uniquely
-        identify the resource; this is typically just the resource ID, but may also include some properties.
+        """`Read` reads the current live state associated with a resource identified by the supplied state. The given state
+        must be sufficient to uniquely identify the resource. This is typically just the resource ID, but may also
+        include other properties.
         """
     
     def Update(


### PR DESCRIPTION
This commit fleshes out the documentation for the `Create` and `Read` methods of resource providers.