### PR TITLE
Document `ResourceProvider.Update` and `ResourceProvider.Delete`

### DIFF
--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -18,7 +18,7 @@
 1921230328 1269 proto/pulumi/errors.proto
 420991671 12306 proto/pulumi/language.proto
 2893249402 1992 proto/pulumi/plugin.proto
-2184730073 45735 proto/pulumi/provider.proto
+409138574 47261 proto/pulumi/provider.proto
 1190662922 17848 proto/pulumi/resource.proto
 607478140 1008 proto/pulumi/source.proto
 3670315643 2603 proto/pulumi/testing/language.proto

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -148,9 +148,13 @@ service ResourceProvider {
     // must be sufficient to uniquely identify the resource. This is typically just the resource ID, but may also
     // include other properties.
     rpc Read(ReadRequest) returns (ReadResponse) {}
-    // Update updates an existing resource with new values.
+
+    // `Update` updates an existing resource according to a new set of inputs, returning a new set of output properties.
     rpc Update(UpdateRequest) returns (UpdateResponse) {}
-    // Delete tears down an existing resource with the given ID.  If it fails, the resource is assumed to still exist.
+
+    // `Delete` deprovisions an existing resource as specified by its ID. `Delete` should be transactional/atomic -- if
+    // a call to `Delete` fails, it must be the case that the resource was *not* deleted and can be assumed to still
+    // exist.
     rpc Delete(DeleteRequest) returns (google.protobuf.Empty) {}
 
     // Construct creates a new instance of the provided component resource and returns its state.
@@ -677,36 +681,74 @@ message ReadResponse {
     google.protobuf.Struct inputs = 3;
 }
 
+// `UpdateRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Update) call.
 message UpdateRequest {
-    // NOTE: The partial-update-error equivalent of this message is `ErrorResourceInitFailed`.
+    // The ID of the resource being updated.
+    string id = 1;
 
-    string id = 1;                     // the ID of the resource to update.
-    string urn = 2;                    // the Pulumi URN for this resource.
-    google.protobuf.Struct olds = 3;   // the old values of provider inputs for the resource to update.
+    // The URN of the resource being updated.
+    string urn = 2;
 
-    // the new values of provider inputs for the resource to update, copied from CheckResponse.inputs.
+    // The old *output* properties of the resource being updated.
+    google.protobuf.Struct olds = 3;
+
+    // The new input properties of the resource being updated. These should have been validated by a call to
+    // [](pulumirpc.ResourceProvider.Check).
     google.protobuf.Struct news = 4;
 
-    double timeout = 5;                // the update request timeout represented in seconds.
-    repeated string ignoreChanges = 6; // a set of property paths that should be treated as unchanged.
-    bool preview = 7;                   // true if this is a preview and the provider should not actually create the resource.
-    google.protobuf.Struct old_inputs = 8; // the old input values of the resource to diff.
-    string name = 9; // the Pulumi name for this resource.
-    string type = 10; // the Pulumi type for this resource.
+    // A timeout in seconds that the caller is prepared to wait for the operation to complete.
+    double timeout = 5;
+
+    // A set of [property paths](property-paths) that should be treated as unchanged.
+    repeated string ignoreChanges = 6;
+
+    // True if and only if the request is being made as part of a preview/dry run, in which case the provider should not
+    // actually update the resource.
+    bool preview = 7;
+
+    // The old *input* properties of the resource being updated.
+    google.protobuf.Struct old_inputs = 8;
+
+    // The name of the resource being updated. This must match the name specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the name of the resource.
+    string name = 9;
+
+    // The type of the resource being updated. This must match the type specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the type of the resource.
+    string type = 10;
 }
 
+// `UpdateResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Update) call.
 message UpdateResponse {
-    google.protobuf.Struct properties = 1; // any properties that were computed during updating.
+    // An updated set of resource output properties. Typically this will be a union of the resource's inputs and any
+    // additional values that were computed or made available during the update.
+    google.protobuf.Struct properties = 1;
 }
 
+// `DeleteRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Delete) call.
 message DeleteRequest {
-    string id = 1;                         // the ID of the resource to delete.
-    string urn = 2;                        // the Pulumi URN for this resource.
-    google.protobuf.Struct properties = 3; // the current properties on the resource.
-    double timeout = 4;                    // the delete request timeout represented in seconds.
+    // The ID of the resource to delete.
+    string id = 1;
+
+    // The URN of the resource to delete.
+    string urn = 2;
+
+    // The old *output* properties of the resource being deleted.
+    google.protobuf.Struct properties = 3;
+
+    // A timeout in seconds that the caller is prepared to wait for the operation to complete.
+    double timeout = 4;
+
+    // The old *input* properties of the resource being deleted.
     google.protobuf.Struct old_inputs = 5; // the old input values of the resource to delete.
-    string name = 6; // the Pulumi name for this resource.
-    string type = 7; // the Pulumi type for this resource.
+
+    // The name of the resource being deleted. This must match the name specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the name of the resource.
+    string name = 6;
+
+    // The type of the resource being deleted. This must match the type specified by the `urn` field, and is passed so
+    // that providers do not have to implement URN parsing in order to extract the type of the resource.
+    string type = 7;
 }
 
 message ConstructRequest {

--- a/sdk/nodejs/proto/provider_grpc_pb.js
+++ b/sdk/nodejs/proto/provider_grpc_pb.js
@@ -588,7 +588,7 @@ read: {
     responseSerialize: serialize_pulumirpc_ReadResponse,
     responseDeserialize: deserialize_pulumirpc_ReadResponse,
   },
-  // Update updates an existing resource with new values.
+  // `Update` updates an existing resource according to a new set of inputs, returning a new set of output properties.
 update: {
     path: '/pulumirpc.ResourceProvider/Update',
     requestStream: false,
@@ -600,7 +600,9 @@ update: {
     responseSerialize: serialize_pulumirpc_UpdateResponse,
     responseDeserialize: deserialize_pulumirpc_UpdateResponse,
   },
-  // Delete tears down an existing resource with the given ID.  If it fails, the resource is assumed to still exist.
+  // `Delete` deprovisions an existing resource as specified by its ID. `Delete` should be transactional/atomic -- if
+// a call to `Delete` fails, it must be the case that the resource was *not* deleted and can be assumed to still
+// exist.
 delete: {
     path: '/pulumirpc.ResourceProvider/Delete',
     requestStream: false,

--- a/sdk/proto/go/provider.pb.go
+++ b/sdk/proto/go/provider.pb.go
@@ -1870,22 +1870,36 @@ func (x *ReadResponse) GetInputs() *structpb.Struct {
 	return nil
 }
 
+// `UpdateRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Update) call.
 type UpdateRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id   string           `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`     // the ID of the resource to update.
-	Urn  string           `protobuf:"bytes,2,opt,name=urn,proto3" json:"urn,omitempty"`   // the Pulumi URN for this resource.
-	Olds *structpb.Struct `protobuf:"bytes,3,opt,name=olds,proto3" json:"olds,omitempty"` // the old values of provider inputs for the resource to update.
-	// the new values of provider inputs for the resource to update, copied from CheckResponse.inputs.
-	News          *structpb.Struct `protobuf:"bytes,4,opt,name=news,proto3" json:"news,omitempty"`
-	Timeout       float64          `protobuf:"fixed64,5,opt,name=timeout,proto3" json:"timeout,omitempty"`                    // the update request timeout represented in seconds.
-	IgnoreChanges []string         `protobuf:"bytes,6,rep,name=ignoreChanges,proto3" json:"ignoreChanges,omitempty"`          // a set of property paths that should be treated as unchanged.
-	Preview       bool             `protobuf:"varint,7,opt,name=preview,proto3" json:"preview,omitempty"`                     // true if this is a preview and the provider should not actually create the resource.
-	OldInputs     *structpb.Struct `protobuf:"bytes,8,opt,name=old_inputs,json=oldInputs,proto3" json:"old_inputs,omitempty"` // the old input values of the resource to diff.
-	Name          string           `protobuf:"bytes,9,opt,name=name,proto3" json:"name,omitempty"`                            // the Pulumi name for this resource.
-	Type          string           `protobuf:"bytes,10,opt,name=type,proto3" json:"type,omitempty"`                           // the Pulumi type for this resource.
+	// The ID of the resource being updated.
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// The URN of the resource being updated.
+	Urn string `protobuf:"bytes,2,opt,name=urn,proto3" json:"urn,omitempty"`
+	// The old *output* properties of the resource being updated.
+	Olds *structpb.Struct `protobuf:"bytes,3,opt,name=olds,proto3" json:"olds,omitempty"`
+	// The new input properties of the resource being updated. These should have been validated by a call to
+	// [](pulumirpc.ResourceProvider.Check).
+	News *structpb.Struct `protobuf:"bytes,4,opt,name=news,proto3" json:"news,omitempty"`
+	// A timeout in seconds that the caller is prepared to wait for the operation to complete.
+	Timeout float64 `protobuf:"fixed64,5,opt,name=timeout,proto3" json:"timeout,omitempty"`
+	// A set of [property paths](property-paths) that should be treated as unchanged.
+	IgnoreChanges []string `protobuf:"bytes,6,rep,name=ignoreChanges,proto3" json:"ignoreChanges,omitempty"`
+	// True if and only if the request is being made as part of a preview/dry run, in which case the provider should not
+	// actually update the resource.
+	Preview bool `protobuf:"varint,7,opt,name=preview,proto3" json:"preview,omitempty"`
+	// The old *input* properties of the resource being updated.
+	OldInputs *structpb.Struct `protobuf:"bytes,8,opt,name=old_inputs,json=oldInputs,proto3" json:"old_inputs,omitempty"`
+	// The name of the resource being updated. This must match the name specified by the `urn` field, and is passed so
+	// that providers do not have to implement URN parsing in order to extract the name of the resource.
+	Name string `protobuf:"bytes,9,opt,name=name,proto3" json:"name,omitempty"`
+	// The type of the resource being updated. This must match the type specified by the `urn` field, and is passed so
+	// that providers do not have to implement URN parsing in order to extract the type of the resource.
+	Type string `protobuf:"bytes,10,opt,name=type,proto3" json:"type,omitempty"`
 }
 
 func (x *UpdateRequest) Reset() {
@@ -1990,12 +2004,15 @@ func (x *UpdateRequest) GetType() string {
 	return ""
 }
 
+// `UpdateResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Update) call.
 type UpdateResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Properties *structpb.Struct `protobuf:"bytes,1,opt,name=properties,proto3" json:"properties,omitempty"` // any properties that were computed during updating.
+	// An updated set of resource output properties. Typically this will be a union of the resource's inputs and any
+	// additional values that were computed or made available during the update.
+	Properties *structpb.Struct `protobuf:"bytes,1,opt,name=properties,proto3" json:"properties,omitempty"`
 }
 
 func (x *UpdateResponse) Reset() {
@@ -2037,18 +2054,28 @@ func (x *UpdateResponse) GetProperties() *structpb.Struct {
 	return nil
 }
 
+// `DeleteRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Delete) call.
 type DeleteRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id         string           `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                // the ID of the resource to delete.
-	Urn        string           `protobuf:"bytes,2,opt,name=urn,proto3" json:"urn,omitempty"`                              // the Pulumi URN for this resource.
-	Properties *structpb.Struct `protobuf:"bytes,3,opt,name=properties,proto3" json:"properties,omitempty"`                // the current properties on the resource.
-	Timeout    float64          `protobuf:"fixed64,4,opt,name=timeout,proto3" json:"timeout,omitempty"`                    // the delete request timeout represented in seconds.
-	OldInputs  *structpb.Struct `protobuf:"bytes,5,opt,name=old_inputs,json=oldInputs,proto3" json:"old_inputs,omitempty"` // the old input values of the resource to delete.
-	Name       string           `protobuf:"bytes,6,opt,name=name,proto3" json:"name,omitempty"`                            // the Pulumi name for this resource.
-	Type       string           `protobuf:"bytes,7,opt,name=type,proto3" json:"type,omitempty"`                            // the Pulumi type for this resource.
+	// The ID of the resource to delete.
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// The URN of the resource to delete.
+	Urn string `protobuf:"bytes,2,opt,name=urn,proto3" json:"urn,omitempty"`
+	// The old *output* properties of the resource being deleted.
+	Properties *structpb.Struct `protobuf:"bytes,3,opt,name=properties,proto3" json:"properties,omitempty"`
+	// A timeout in seconds that the caller is prepared to wait for the operation to complete.
+	Timeout float64 `protobuf:"fixed64,4,opt,name=timeout,proto3" json:"timeout,omitempty"`
+	// The old *input* properties of the resource being deleted.
+	OldInputs *structpb.Struct `protobuf:"bytes,5,opt,name=old_inputs,json=oldInputs,proto3" json:"old_inputs,omitempty"` // the old input values of the resource to delete.
+	// The name of the resource being deleted. This must match the name specified by the `urn` field, and is passed so
+	// that providers do not have to implement URN parsing in order to extract the name of the resource.
+	Name string `protobuf:"bytes,6,opt,name=name,proto3" json:"name,omitempty"`
+	// The type of the resource being deleted. This must match the type specified by the `urn` field, and is passed so
+	// that providers do not have to implement URN parsing in order to extract the type of the resource.
+	Type string `protobuf:"bytes,7,opt,name=type,proto3" json:"type,omitempty"`
 }
 
 func (x *DeleteRequest) Reset() {

--- a/sdk/proto/go/provider_grpc.pb.go
+++ b/sdk/proto/go/provider_grpc.pb.go
@@ -133,9 +133,11 @@ type ResourceProviderClient interface {
 	// must be sufficient to uniquely identify the resource. This is typically just the resource ID, but may also
 	// include other properties.
 	Read(ctx context.Context, in *ReadRequest, opts ...grpc.CallOption) (*ReadResponse, error)
-	// Update updates an existing resource with new values.
+	// `Update` updates an existing resource according to a new set of inputs, returning a new set of output properties.
 	Update(ctx context.Context, in *UpdateRequest, opts ...grpc.CallOption) (*UpdateResponse, error)
-	// Delete tears down an existing resource with the given ID.  If it fails, the resource is assumed to still exist.
+	// `Delete` deprovisions an existing resource as specified by its ID. `Delete` should be transactional/atomic -- if
+	// a call to `Delete` fails, it must be the case that the resource was *not* deleted and can be assumed to still
+	// exist.
 	Delete(ctx context.Context, in *DeleteRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// Construct creates a new instance of the provided component resource and returns its state.
 	Construct(ctx context.Context, in *ConstructRequest, opts ...grpc.CallOption) (*ConstructResponse, error)
@@ -483,9 +485,11 @@ type ResourceProviderServer interface {
 	// must be sufficient to uniquely identify the resource. This is typically just the resource ID, but may also
 	// include other properties.
 	Read(context.Context, *ReadRequest) (*ReadResponse, error)
-	// Update updates an existing resource with new values.
+	// `Update` updates an existing resource according to a new set of inputs, returning a new set of output properties.
 	Update(context.Context, *UpdateRequest) (*UpdateResponse, error)
-	// Delete tears down an existing resource with the given ID.  If it fails, the resource is assumed to still exist.
+	// `Delete` deprovisions an existing resource as specified by its ID. `Delete` should be transactional/atomic -- if
+	// a call to `Delete` fails, it must be the case that the resource was *not* deleted and can be assumed to still
+	// exist.
 	Delete(context.Context, *DeleteRequest) (*emptypb.Empty, error)
 	// Construct creates a new instance of the provided component resource and returns its state.
 	Construct(context.Context, *ConstructRequest) (*ConstructResponse, error)

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
@@ -1119,7 +1119,7 @@ global___ReadResponse = ReadResponse
 
 @typing_extensions.final
 class UpdateRequest(google.protobuf.message.Message):
-    """NOTE: The partial-update-error equivalent of this message is `ErrorResourceInitFailed`."""
+    """`UpdateRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Update) call."""
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1134,29 +1134,37 @@ class UpdateRequest(google.protobuf.message.Message):
     NAME_FIELD_NUMBER: builtins.int
     TYPE_FIELD_NUMBER: builtins.int
     id: builtins.str
-    """the ID of the resource to update."""
+    """The ID of the resource being updated."""
     urn: builtins.str
-    """the Pulumi URN for this resource."""
+    """The URN of the resource being updated."""
     @property
     def olds(self) -> google.protobuf.struct_pb2.Struct:
-        """the old values of provider inputs for the resource to update."""
+        """The old *output* properties of the resource being updated."""
     @property
     def news(self) -> google.protobuf.struct_pb2.Struct:
-        """the new values of provider inputs for the resource to update, copied from CheckResponse.inputs."""
+        """The new input properties of the resource being updated. These should have been validated by a call to
+        [](pulumirpc.ResourceProvider.Check).
+        """
     timeout: builtins.float
-    """the update request timeout represented in seconds."""
+    """A timeout in seconds that the caller is prepared to wait for the operation to complete."""
     @property
     def ignoreChanges(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """a set of property paths that should be treated as unchanged."""
+        """A set of [property paths](property-paths) that should be treated as unchanged."""
     preview: builtins.bool
-    """true if this is a preview and the provider should not actually create the resource."""
+    """True if and only if the request is being made as part of a preview/dry run, in which case the provider should not
+    actually update the resource.
+    """
     @property
     def old_inputs(self) -> google.protobuf.struct_pb2.Struct:
-        """the old input values of the resource to diff."""
+        """The old *input* properties of the resource being updated."""
     name: builtins.str
-    """the Pulumi name for this resource."""
+    """The name of the resource being updated. This must match the name specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the name of the resource.
+    """
     type: builtins.str
-    """the Pulumi type for this resource."""
+    """The type of the resource being updated. This must match the type specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the type of the resource.
+    """
     def __init__(
         self,
         *,
@@ -1178,12 +1186,16 @@ global___UpdateRequest = UpdateRequest
 
 @typing_extensions.final
 class UpdateResponse(google.protobuf.message.Message):
+    """`UpdateResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Update) call."""
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     PROPERTIES_FIELD_NUMBER: builtins.int
     @property
     def properties(self) -> google.protobuf.struct_pb2.Struct:
-        """any properties that were computed during updating."""
+        """An updated set of resource output properties. Typically this will be a union of the resource's inputs and any
+        additional values that were computed or made available during the update.
+        """
     def __init__(
         self,
         *,
@@ -1196,6 +1208,8 @@ global___UpdateResponse = UpdateResponse
 
 @typing_extensions.final
 class DeleteRequest(google.protobuf.message.Message):
+    """`DeleteRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Delete) call."""
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     ID_FIELD_NUMBER: builtins.int
@@ -1206,21 +1220,27 @@ class DeleteRequest(google.protobuf.message.Message):
     NAME_FIELD_NUMBER: builtins.int
     TYPE_FIELD_NUMBER: builtins.int
     id: builtins.str
-    """the ID of the resource to delete."""
+    """The ID of the resource to delete."""
     urn: builtins.str
-    """the Pulumi URN for this resource."""
+    """The URN of the resource to delete."""
     @property
     def properties(self) -> google.protobuf.struct_pb2.Struct:
-        """the current properties on the resource."""
+        """The old *output* properties of the resource being deleted."""
     timeout: builtins.float
-    """the delete request timeout represented in seconds."""
+    """A timeout in seconds that the caller is prepared to wait for the operation to complete."""
     @property
     def old_inputs(self) -> google.protobuf.struct_pb2.Struct:
-        """the old input values of the resource to delete."""
+        """The old *input* properties of the resource being deleted.
+        the old input values of the resource to delete.
+        """
     name: builtins.str
-    """the Pulumi name for this resource."""
+    """The name of the resource being deleted. This must match the name specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the name of the resource.
+    """
     type: builtins.str
-    """the Pulumi type for this resource."""
+    """The type of the resource being deleted. This must match the type specified by the `urn` field, and is passed so
+    that providers do not have to implement URN parsing in order to extract the type of the resource.
+    """
     def __init__(
         self,
         *,

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
@@ -300,14 +300,16 @@ class ResourceProviderServicer(object):
         raise NotImplementedError('Method not implemented!')
 
     def Update(self, request, context):
-        """Update updates an existing resource with new values.
+        """`Update` updates an existing resource according to a new set of inputs, returning a new set of output properties.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def Delete(self, request, context):
-        """Delete tears down an existing resource with the given ID.  If it fails, the resource is assumed to still exist.
+        """`Delete` deprovisions an existing resource as specified by its ID. `Delete` should be transactional/atomic -- if
+        a call to `Delete` fails, it must be the case that the resource was *not* deleted and can be assumed to still
+        exist.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
@@ -191,12 +191,15 @@ class ResourceProviderStub:
         pulumi.provider_pb2.UpdateRequest,
         pulumi.provider_pb2.UpdateResponse,
     ]
-    """Update updates an existing resource with new values."""
+    """`Update` updates an existing resource according to a new set of inputs, returning a new set of output properties."""
     Delete: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.DeleteRequest,
         google.protobuf.empty_pb2.Empty,
     ]
-    """Delete tears down an existing resource with the given ID.  If it fails, the resource is assumed to still exist."""
+    """`Delete` deprovisions an existing resource as specified by its ID. `Delete` should be transactional/atomic -- if
+    a call to `Delete` fails, it must be the case that the resource was *not* deleted and can be assumed to still
+    exist.
+    """
     Construct: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.ConstructRequest,
         pulumi.provider_pb2.ConstructResponse,
@@ -430,14 +433,17 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         request: pulumi.provider_pb2.UpdateRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.UpdateResponse:
-        """Update updates an existing resource with new values."""
+        """`Update` updates an existing resource according to a new set of inputs, returning a new set of output properties."""
     
     def Delete(
         self,
         request: pulumi.provider_pb2.DeleteRequest,
         context: grpc.ServicerContext,
     ) -> google.protobuf.empty_pb2.Empty:
-        """Delete tears down an existing resource with the given ID.  If it fails, the resource is assumed to still exist."""
+        """`Delete` deprovisions an existing resource as specified by its ID. `Delete` should be transactional/atomic -- if
+        a call to `Delete` fails, it must be the case that the resource was *not* deleted and can be assumed to still
+        exist.
+        """
     
     def Construct(
         self,


### PR DESCRIPTION
This commit fleshes out the documentation for the `Update` and `Delete` methods of resource providers.