### PR TITLE
Document `ResourceProvider.Construct`

### DIFF
--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -18,7 +18,7 @@
 1921230328 1269 proto/pulumi/errors.proto
 420991671 12306 proto/pulumi/language.proto
 2893249402 1992 proto/pulumi/plugin.proto
-409138574 47261 proto/pulumi/provider.proto
+2562367642 51683 proto/pulumi/provider.proto
 1190662922 17848 proto/pulumi/resource.proto
 607478140 1008 proto/pulumi/source.proto
 3670315643 2603 proto/pulumi/testing/language.proto

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -157,7 +157,20 @@ service ResourceProvider {
     // exist.
     rpc Delete(DeleteRequest) returns (google.protobuf.Empty) {}
 
-    // Construct creates a new instance of the provided component resource and returns its state.
+    // `Construct` provisions a new [component resource](component-resources). Providers that implement `Construct` are
+    // referred to as [component providers](component-providers). `Construct` is to component resources what
+    // [](pulumirpc.ResourceProvider.Create) is to [custom resources](custom-resources). Components do not have any
+    // lifecycle of their own, and instead embody the lifecycles of the resources that they are composed of. As such,
+    // `Construct` is effectively a subprogram whose resources will be persisted in the caller's state. It is
+    // consequently passed enough information to manage fully these resources. At a high level, this comprises:
+    //
+    // * A [](pulumirpc.ResourceMonitor) endpoint which the provider can use to [register](resource-registration) nested
+    //   custom or component resources that belong to the component.
+    //
+    // * A set of input properties.
+    //
+    // * A full set of [resource options](https://www.pulumi.com/docs/iac/concepts/options/) that the component should
+    //   propagate to resources it registers against the supplied resource monitor.
     rpc Construct(ConstructRequest) returns (ConstructResponse) {}
 
     // Cancel signals the provider to gracefully shut down and abort any ongoing resource operations.
@@ -751,76 +764,160 @@ message DeleteRequest {
     string type = 7;
 }
 
+// `ConstructRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Construct) call. A
+// `ConstructRequest` captures enough data to be able to register nested components against the caller's resource
+// monitor.
 message ConstructRequest {
-    // PropertyDependencies describes the resources that a particular property depends on.
+    // A `PropertyDependencies` list is a set of URNs that a particular property may depend on.
     message PropertyDependencies {
-        repeated string urns = 1; // A list of URNs this property depends on.
+        // A list of URNs that this property depends on.
+        repeated string urns = 1;
     }
 
-    // CustomTimeouts specifies timeouts for resource provisioning operations.
-    // Use it with the [Timeouts] option when creating new resources
-    // to override default timeouts.
+    // A `CustomTimeouts` object encapsulates a set of timeouts for the various CRUD operations that might be performed
+    // on this resource's nested resources. Timeout values are specified as duration strings, such as `"5ms"` (5
+    // milliseconds), `"40s"` (40 seconds), or `"1m30s"` (1 minute and 30 seconds). The following units of time are
+    // supported:
     //
-    // Each timeout is specified as a duration string such as,
-    // "5ms" (5 milliseconds), "40s" (40 seconds),
-    // and "1m30s" (1 minute, 30 seconds).
-    //
-    // The following units are accepted.
-    //
-    //   - ns: nanoseconds
-    //   - us: microseconds
-    //   - µs: microseconds
-    //   - ms: milliseconds
-    //   - s: seconds
-    //   - m: minutes
-    //   - h: hours
+    // * `ns`: nanoseconds
+    // * `us` or `µs`: microseconds
+    // * `ms`: milliseconds
+    // * `s`: seconds
+    // * `m`: minutes
+    // * `h`: hours
     message CustomTimeouts {
+        // How long a caller is prepared to wait for a nested resource's [](pulumirpc.ResourceProvider.Create) operation
+        // to complete.
         string create = 1;
+
+        // How long a caller is prepared to wait for a nested resource's [](pulumirpc.ResourceProvider.Update) operation
+        // to complete.
         string update = 2;
+
+        // How long a caller is prepared to wait for a nested resource's [](pulumirpc.ResourceProvider.Delete) operation
+        // to complete.
         string delete = 3;
     }
 
-    string project = 1;             // the project name.
-    string stack = 2;               // the name of the stack being deployed into.
-    map<string, string> config = 3; // the configuration variables to apply before running.
-    bool dryRun = 4;                // true if we're only doing a dryrun (preview).
-    int32 parallel = 5;             // the degree of parallelism for resource operations (<=1 for serial).
-    string monitorEndpoint = 6;     // the address for communicating back to the resource monitor.
+    // The project to which this resource and its nested resources will belong.
+    string project = 1;
 
-    string type = 7;                                          // the type of the object allocated.
-    string name = 8;                                          // the name, for URN purposes, of the object.
-    string parent = 9;                                        // an optional parent URN that this child resource belongs to.
-    google.protobuf.Struct inputs = 10;                       // the inputs to the resource constructor.
-    map<string, PropertyDependencies> inputDependencies = 11; // a map from property keys to the dependencies of the property.
-    map<string, string> providers = 13;                       // the map of providers to use for this resource's children.
-    repeated string dependencies = 15;                        // a list of URNs that this resource depends on, as observed by the language host.
-    repeated string configSecretKeys = 16;                    // the configuration keys that have secret values.
-    string organization = 17;                                 // the organization of the stack being deployed into.
+    // The name of the stack being deployed into.
+    string stack = 2;
 
-    // Resource options:
-    // Do not change field IDs. Add new fields at the end.
-    bool protect                            = 12; // true if the resource should be marked protected.
-    repeated string aliases                 = 14; // a list of additional URNs that shoud be considered the same.
-    repeated string additionalSecretOutputs = 18; // additional output properties that should be treated as secrets.
-    CustomTimeouts customTimeouts           = 19; // default timeouts for CRUD operations on this resource.
-    string deletedWith                      = 20; // URN of a resource that, if deleted, also deletes this resource.
-    bool deleteBeforeReplace                = 21; // whether to delete the resource before replacing it.
-    repeated string ignoreChanges           = 22; // properties that should be ignored during a diff
-    repeated string replaceOnChanges        = 23; // properties that, when changed, trigger a replacement
-    bool retainOnDelete                     = 24; // whether to retain the resource in the cloud provider when it is deleted
+    // Configuration for the specified project and stack.
+    map<string, string> config = 3;
 
-    bool accepts_output_values = 25; // the engine can be passed output values back, stateDependencies can be left blank if returning output values.
+    // True if and only if the request is being made as part of a preview/dry run, in which case the provider should not
+    // actually construct the component.
+    bool dryRun = 4;
+
+    // The degree of parallelism that may be used for resource operations. A value less than or equal to 1 indicates
+    // that operations should be performed serially.
+    int32 parallel = 5;
+
+    // The address of the [](pulumirpc.ResourceMonitor) that the provider should connect to in order to send [resource
+    // registrations](resource-registration) for its nested resources.
+    string monitorEndpoint = 6;
+
+    // The type of the component resource being constructed. This must match the type specified by the `urn` field, and
+    // is passed so that providers do not have to implement URN parsing in order to extract the type of the resource.
+    string type = 7;
+
+    // The name of the component resource being constructed. This must match the name specified by the `urn` field, and
+    // is passed so that providers do not have to implement URN parsing in order to extract the name of the resource.
+    string name = 8;
+
+    // Dependencies and resource options
+    //
+    // These are passed so that the component may propagate them to resources it registers against the supplied resource
+    // monitor.
+    //
+    // Do *not* change field IDs. Add new fields at the end with appropriate field IDs as necessary.
+
+    // An optional parent resource that the component (and by extension, its nested resources) should be children of.
+    string parent = 9;
+
+    // The component resource's input properties. Unlike the inputs of custom resources, these will *not* have been
+    // passed to a call to [](pulumirpc.ResourceProvider.Check). By virtue of their being a composition of other
+    // resources, component resources are able to (and therefore expected) to validate their own inputs. Moreover,
+    // [](pulumirpc.ResourceProvider.Check) will be called on any inputs passed to nested custom resources as usual.
+    google.protobuf.Struct inputs = 10;
+
+    // A map of property dependencies for the component resource and its nested resources.
+    map<string, PropertyDependencies> inputDependencies = 11;
+
+    // A map of package names to provider references for the component resource and its nested resources.
+    map<string, string> providers = 13;
+
+    // A list of URNs that this resource and its nested resources depend on.
+    repeated string dependencies = 15;
+
+    // A set of configuration keys whose values are [secret](output-secrets).
+    repeated string configSecretKeys = 16;
+
+    // The organization to which this resource and its nested resources will belong.
+    string organization = 17;
+
+    // True if and only if the resource (and by extension, its nested resources) should be marked as protected.
+    // Protected resources cannot be deleted without first being unprotected.
+    bool protect = 12;
+
+    // A list of additional URNs that should be considered the same as this component's URN (and which will therefore be
+    // used to build aliases for its nested resource URNs). These may be URNs that previously referred to this component
+    // e.g. if it had its parent (and consequently URN) changed.
+    repeated string aliases = 14;
+
+    // A list of input properties whose values should be treated as [secret](output-secrets).
+    repeated string additionalSecretOutputs = 18;
+
+    // A set of custom timeouts that specify how long the caller is prepared to wait for the various CRUD operations of
+    // this resource's nested resources.
+    CustomTimeouts customTimeouts = 19;
+
+    // The URN of a resource that this resource (and thus its nested resources) will be implicitly deleted with. If the
+    // resource referred to by this URN is deleted in the same operation that this resource would be deleted, the
+    // [](pulumirpc.ResourceProvider.Delete) call for this resource will be elided (since this dependency signals that
+    // it will have already been deleted).
+    string deletedWith = 20;
+
+    // If true, this resource (and its nested resources) must be deleted *before* its replacement is created.
+    bool deleteBeforeReplace = 21;
+
+    // A set of [property paths](property-paths) that should be treated as unchanged.
+    repeated string ignoreChanges = 22;
+
+    // A set of properties that, when changed, trigger a replacement.
+    repeated string replaceOnChanges = 23;
+
+    // True if [](pulumirpc.ResourceProvider.Delete) should *not* be called when the resource (and by extension, its
+    // nested resources) are removed from a Pulumi program.
+    bool retainOnDelete = 24;
+
+    // True if the caller is capable of accepting output values in response to the call. If this is set, these outputs
+    // may be used to communicate dependency information and so there is no need to populate
+    // [](pulumirpc.ConstructResponse)'s `stateDependencies` field.
+    bool accepts_output_values = 25;
 }
 
+// `ConstructResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Construct) call.
 message ConstructResponse {
-    // PropertyDependencies describes the resources that a particular property depends on.
+    // A `PropertyDependencies` list is a set of URNs that a particular property may depend on.
     message PropertyDependencies {
-        repeated string urns = 1; // A list of URNs this property depends on.
+        // A list of URNs that this property depends on.
+        repeated string urns = 1;
     }
 
-    string urn = 1;                                          // the URN of the component resource.
-    google.protobuf.Struct state = 2;                        // any properties that were computed during construction.
-    map<string, PropertyDependencies> stateDependencies = 3; // a map from property keys to the dependencies of the property.
+    // The URN of the constructed component resource.
+    string urn = 1;
+
+    // Any output properties that the component registered as part of its construction.
+    google.protobuf.Struct state = 2;
+
+    // A map of property dependencies for the component's outputs. This will be set if the caller indicated that it
+    // could not receive dependency-communicating [output](outputs) values by setting [](pulumirpc.ConstructRequest)'s
+    // `accepts_output_values` field to false.
+    map<string, PropertyDependencies> stateDependencies = 3;
 }
 
 // ErrorResourceInitFailed is sent as a Detail `ResourceProvider.{Create, Update}` fail because a

--- a/sdk/nodejs/proto/provider_grpc_pb.js
+++ b/sdk/nodejs/proto/provider_grpc_pb.js
@@ -614,7 +614,20 @@ delete: {
     responseSerialize: serialize_google_protobuf_Empty,
     responseDeserialize: deserialize_google_protobuf_Empty,
   },
-  // Construct creates a new instance of the provided component resource and returns its state.
+  // `Construct` provisions a new [component resource](component-resources). Providers that implement `Construct` are
+// referred to as [component providers](component-providers). `Construct` is to component resources what
+// [](pulumirpc.ResourceProvider.Create) is to [custom resources](custom-resources). Components do not have any
+// lifecycle of their own, and instead embody the lifecycles of the resources that they are composed of. As such,
+// `Construct` is effectively a subprogram whose resources will be persisted in the caller's state. It is
+// consequently passed enough information to manage fully these resources. At a high level, this comprises:
+//
+// * A [](pulumirpc.ResourceMonitor) endpoint which the provider can use to [register](resource-registration) nested
+//   custom or component resources that belong to the component.
+//
+// * A set of input properties.
+//
+// * A full set of [resource options](https://www.pulumi.com/docs/iac/concepts/options/) that the component should
+//   propagate to resources it registers against the supplied resource monitor.
 construct: {
     path: '/pulumirpc.ResourceProvider/Construct',
     requestStream: false,

--- a/sdk/proto/go/provider.pb.go
+++ b/sdk/proto/go/provider.pb.go
@@ -2159,38 +2159,82 @@ func (x *DeleteRequest) GetType() string {
 	return ""
 }
 
+// `ConstructRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Construct) call. A
+// `ConstructRequest` captures enough data to be able to register nested components against the caller's resource
+// monitor.
 type ConstructRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Project           string                                            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`                                                                                                              // the project name.
-	Stack             string                                            `protobuf:"bytes,2,opt,name=stack,proto3" json:"stack,omitempty"`                                                                                                                  // the name of the stack being deployed into.
-	Config            map[string]string                                 `protobuf:"bytes,3,rep,name=config,proto3" json:"config,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`                        // the configuration variables to apply before running.
-	DryRun            bool                                              `protobuf:"varint,4,opt,name=dryRun,proto3" json:"dryRun,omitempty"`                                                                                                               // true if we're only doing a dryrun (preview).
-	Parallel          int32                                             `protobuf:"varint,5,opt,name=parallel,proto3" json:"parallel,omitempty"`                                                                                                           // the degree of parallelism for resource operations (<=1 for serial).
-	MonitorEndpoint   string                                            `protobuf:"bytes,6,opt,name=monitorEndpoint,proto3" json:"monitorEndpoint,omitempty"`                                                                                              // the address for communicating back to the resource monitor.
-	Type              string                                            `protobuf:"bytes,7,opt,name=type,proto3" json:"type,omitempty"`                                                                                                                    // the type of the object allocated.
-	Name              string                                            `protobuf:"bytes,8,opt,name=name,proto3" json:"name,omitempty"`                                                                                                                    // the name, for URN purposes, of the object.
-	Parent            string                                            `protobuf:"bytes,9,opt,name=parent,proto3" json:"parent,omitempty"`                                                                                                                // an optional parent URN that this child resource belongs to.
-	Inputs            *structpb.Struct                                  `protobuf:"bytes,10,opt,name=inputs,proto3" json:"inputs,omitempty"`                                                                                                               // the inputs to the resource constructor.
-	InputDependencies map[string]*ConstructRequest_PropertyDependencies `protobuf:"bytes,11,rep,name=inputDependencies,proto3" json:"inputDependencies,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"` // a map from property keys to the dependencies of the property.
-	Providers         map[string]string                                 `protobuf:"bytes,13,rep,name=providers,proto3" json:"providers,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`                 // the map of providers to use for this resource's children.
-	Dependencies      []string                                          `protobuf:"bytes,15,rep,name=dependencies,proto3" json:"dependencies,omitempty"`                                                                                                   // a list of URNs that this resource depends on, as observed by the language host.
-	ConfigSecretKeys  []string                                          `protobuf:"bytes,16,rep,name=configSecretKeys,proto3" json:"configSecretKeys,omitempty"`                                                                                           // the configuration keys that have secret values.
-	Organization      string                                            `protobuf:"bytes,17,opt,name=organization,proto3" json:"organization,omitempty"`                                                                                                   // the organization of the stack being deployed into.
-	// Resource options:
-	// Do not change field IDs. Add new fields at the end.
-	Protect                 bool                             `protobuf:"varint,12,opt,name=protect,proto3" json:"protect,omitempty"`                                                      // true if the resource should be marked protected.
-	Aliases                 []string                         `protobuf:"bytes,14,rep,name=aliases,proto3" json:"aliases,omitempty"`                                                       // a list of additional URNs that shoud be considered the same.
-	AdditionalSecretOutputs []string                         `protobuf:"bytes,18,rep,name=additionalSecretOutputs,proto3" json:"additionalSecretOutputs,omitempty"`                       // additional output properties that should be treated as secrets.
-	CustomTimeouts          *ConstructRequest_CustomTimeouts `protobuf:"bytes,19,opt,name=customTimeouts,proto3" json:"customTimeouts,omitempty"`                                         // default timeouts for CRUD operations on this resource.
-	DeletedWith             string                           `protobuf:"bytes,20,opt,name=deletedWith,proto3" json:"deletedWith,omitempty"`                                               // URN of a resource that, if deleted, also deletes this resource.
-	DeleteBeforeReplace     bool                             `protobuf:"varint,21,opt,name=deleteBeforeReplace,proto3" json:"deleteBeforeReplace,omitempty"`                              // whether to delete the resource before replacing it.
-	IgnoreChanges           []string                         `protobuf:"bytes,22,rep,name=ignoreChanges,proto3" json:"ignoreChanges,omitempty"`                                           // properties that should be ignored during a diff
-	ReplaceOnChanges        []string                         `protobuf:"bytes,23,rep,name=replaceOnChanges,proto3" json:"replaceOnChanges,omitempty"`                                     // properties that, when changed, trigger a replacement
-	RetainOnDelete          bool                             `protobuf:"varint,24,opt,name=retainOnDelete,proto3" json:"retainOnDelete,omitempty"`                                        // whether to retain the resource in the cloud provider when it is deleted
-	AcceptsOutputValues     bool                             `protobuf:"varint,25,opt,name=accepts_output_values,json=acceptsOutputValues,proto3" json:"accepts_output_values,omitempty"` // the engine can be passed output values back, stateDependencies can be left blank if returning output values.
+	// The project to which this resource and its nested resources will belong.
+	Project string `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	// The name of the stack being deployed into.
+	Stack string `protobuf:"bytes,2,opt,name=stack,proto3" json:"stack,omitempty"`
+	// Configuration for the specified project and stack.
+	Config map[string]string `protobuf:"bytes,3,rep,name=config,proto3" json:"config,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	// True if and only if the request is being made as part of a preview/dry run, in which case the provider should not
+	// actually construct the component.
+	DryRun bool `protobuf:"varint,4,opt,name=dryRun,proto3" json:"dryRun,omitempty"`
+	// The degree of parallelism that may be used for resource operations. A value less than or equal to 1 indicates
+	// that operations should be performed serially.
+	Parallel int32 `protobuf:"varint,5,opt,name=parallel,proto3" json:"parallel,omitempty"`
+	// The address of the [](pulumirpc.ResourceMonitor) that the provider should connect to in order to send [resource
+	// registrations](resource-registration) for its nested resources.
+	MonitorEndpoint string `protobuf:"bytes,6,opt,name=monitorEndpoint,proto3" json:"monitorEndpoint,omitempty"`
+	// The type of the component resource being constructed. This must match the type specified by the `urn` field, and
+	// is passed so that providers do not have to implement URN parsing in order to extract the type of the resource.
+	Type string `protobuf:"bytes,7,opt,name=type,proto3" json:"type,omitempty"`
+	// The name of the component resource being constructed. This must match the name specified by the `urn` field, and
+	// is passed so that providers do not have to implement URN parsing in order to extract the name of the resource.
+	Name string `protobuf:"bytes,8,opt,name=name,proto3" json:"name,omitempty"`
+	// An optional parent resource that the component (and by extension, its nested resources) should be children of.
+	Parent string `protobuf:"bytes,9,opt,name=parent,proto3" json:"parent,omitempty"`
+	// The component resource's input properties. Unlike the inputs of custom resources, these will *not* have been
+	// passed to a call to [](pulumirpc.ResourceProvider.Check). By virtue of their being a composition of other
+	// resources, component resources are able to (and therefore expected) to validate their own inputs. Moreover,
+	// [](pulumirpc.ResourceProvider.Check) will be called on any inputs passed to nested custom resources as usual.
+	Inputs *structpb.Struct `protobuf:"bytes,10,opt,name=inputs,proto3" json:"inputs,omitempty"`
+	// A map of property dependencies for the component resource and its nested resources.
+	InputDependencies map[string]*ConstructRequest_PropertyDependencies `protobuf:"bytes,11,rep,name=inputDependencies,proto3" json:"inputDependencies,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	// A map of package names to provider references for the component resource and its nested resources.
+	Providers map[string]string `protobuf:"bytes,13,rep,name=providers,proto3" json:"providers,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	// A list of URNs that this resource and its nested resources depend on.
+	Dependencies []string `protobuf:"bytes,15,rep,name=dependencies,proto3" json:"dependencies,omitempty"`
+	// A set of configuration keys whose values are [secret](output-secrets).
+	ConfigSecretKeys []string `protobuf:"bytes,16,rep,name=configSecretKeys,proto3" json:"configSecretKeys,omitempty"`
+	// The organization to which this resource and its nested resources will belong.
+	Organization string `protobuf:"bytes,17,opt,name=organization,proto3" json:"organization,omitempty"`
+	// True if and only if the resource (and by extension, its nested resources) should be marked as protected.
+	// Protected resources cannot be deleted without first being unprotected.
+	Protect bool `protobuf:"varint,12,opt,name=protect,proto3" json:"protect,omitempty"`
+	// A list of additional URNs that should be considered the same as this component's URN (and which will therefore be
+	// used to build aliases for its nested resource URNs). These may be URNs that previously referred to this component
+	// e.g. if it had its parent (and consequently URN) changed.
+	Aliases []string `protobuf:"bytes,14,rep,name=aliases,proto3" json:"aliases,omitempty"`
+	// A list of input properties whose values should be treated as [secret](output-secrets).
+	AdditionalSecretOutputs []string `protobuf:"bytes,18,rep,name=additionalSecretOutputs,proto3" json:"additionalSecretOutputs,omitempty"`
+	// A set of custom timeouts that specify how long the caller is prepared to wait for the various CRUD operations of
+	// this resource's nested resources.
+	CustomTimeouts *ConstructRequest_CustomTimeouts `protobuf:"bytes,19,opt,name=customTimeouts,proto3" json:"customTimeouts,omitempty"`
+	// The URN of a resource that this resource (and thus its nested resources) will be implicitly deleted with. If the
+	// resource referred to by this URN is deleted in the same operation that this resource would be deleted, the
+	// [](pulumirpc.ResourceProvider.Delete) call for this resource will be elided (since this dependency signals that
+	// it will have already been deleted).
+	DeletedWith string `protobuf:"bytes,20,opt,name=deletedWith,proto3" json:"deletedWith,omitempty"`
+	// If true, this resource (and its nested resources) must be deleted *before* its replacement is created.
+	DeleteBeforeReplace bool `protobuf:"varint,21,opt,name=deleteBeforeReplace,proto3" json:"deleteBeforeReplace,omitempty"`
+	// A set of [property paths](property-paths) that should be treated as unchanged.
+	IgnoreChanges []string `protobuf:"bytes,22,rep,name=ignoreChanges,proto3" json:"ignoreChanges,omitempty"`
+	// A set of properties that, when changed, trigger a replacement.
+	ReplaceOnChanges []string `protobuf:"bytes,23,rep,name=replaceOnChanges,proto3" json:"replaceOnChanges,omitempty"`
+	// True if [](pulumirpc.ResourceProvider.Delete) should *not* be called when the resource (and by extension, its
+	// nested resources) are removed from a Pulumi program.
+	RetainOnDelete bool `protobuf:"varint,24,opt,name=retainOnDelete,proto3" json:"retainOnDelete,omitempty"`
+	// True if the caller is capable of accepting output values in response to the call. If this is set, these outputs
+	// may be used to communicate dependency information and so there is no need to populate
+	// [](pulumirpc.ConstructResponse)'s `stateDependencies` field.
+	AcceptsOutputValues bool `protobuf:"varint,25,opt,name=accepts_output_values,json=acceptsOutputValues,proto3" json:"accepts_output_values,omitempty"`
 }
 
 func (x *ConstructRequest) Reset() {
@@ -2400,14 +2444,20 @@ func (x *ConstructRequest) GetAcceptsOutputValues() bool {
 	return false
 }
 
+// `ConstructResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Construct) call.
 type ConstructResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Urn               string                                             `protobuf:"bytes,1,opt,name=urn,proto3" json:"urn,omitempty"`                                                                                                                     // the URN of the component resource.
-	State             *structpb.Struct                                   `protobuf:"bytes,2,opt,name=state,proto3" json:"state,omitempty"`                                                                                                                 // any properties that were computed during construction.
-	StateDependencies map[string]*ConstructResponse_PropertyDependencies `protobuf:"bytes,3,rep,name=stateDependencies,proto3" json:"stateDependencies,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"` // a map from property keys to the dependencies of the property.
+	// The URN of the constructed component resource.
+	Urn string `protobuf:"bytes,1,opt,name=urn,proto3" json:"urn,omitempty"`
+	// Any output properties that the component registered as part of its construction.
+	State *structpb.Struct `protobuf:"bytes,2,opt,name=state,proto3" json:"state,omitempty"`
+	// A map of property dependencies for the component's outputs. This will be set if the caller indicated that it
+	// could not receive dependency-communicating [output](outputs) values by setting [](pulumirpc.ConstructRequest)'s
+	// `accepts_output_values` field to false.
+	StateDependencies map[string]*ConstructResponse_PropertyDependencies `protobuf:"bytes,3,rep,name=stateDependencies,proto3" json:"stateDependencies,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 
 func (x *ConstructResponse) Reset() {
@@ -3035,13 +3085,14 @@ func (x *CallResponse_ReturnDependencies) GetUrns() []string {
 	return nil
 }
 
-// PropertyDependencies describes the resources that a particular property depends on.
+// A `PropertyDependencies` list is a set of URNs that a particular property may depend on.
 type ConstructRequest_PropertyDependencies struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Urns []string `protobuf:"bytes,1,rep,name=urns,proto3" json:"urns,omitempty"` // A list of URNs this property depends on.
+	// A list of URNs that this property depends on.
+	Urns []string `protobuf:"bytes,1,rep,name=urns,proto3" json:"urns,omitempty"`
 }
 
 func (x *ConstructRequest_PropertyDependencies) Reset() {
@@ -3083,30 +3134,30 @@ func (x *ConstructRequest_PropertyDependencies) GetUrns() []string {
 	return nil
 }
 
-// CustomTimeouts specifies timeouts for resource provisioning operations.
-// Use it with the [Timeouts] option when creating new resources
-// to override default timeouts.
+// A `CustomTimeouts` object encapsulates a set of timeouts for the various CRUD operations that might be performed
+// on this resource's nested resources. Timeout values are specified as duration strings, such as `"5ms"` (5
+// milliseconds), `"40s"` (40 seconds), or `"1m30s"` (1 minute and 30 seconds). The following units of time are
+// supported:
 //
-// Each timeout is specified as a duration string such as,
-// "5ms" (5 milliseconds), "40s" (40 seconds),
-// and "1m30s" (1 minute, 30 seconds).
-//
-// The following units are accepted.
-//
-//   - ns: nanoseconds
-//   - us: microseconds
-//   - µs: microseconds
-//   - ms: milliseconds
-//   - s: seconds
-//   - m: minutes
-//   - h: hours
+// * `ns`: nanoseconds
+// * `us` or `µs`: microseconds
+// * `ms`: milliseconds
+// * `s`: seconds
+// * `m`: minutes
+// * `h`: hours
 type ConstructRequest_CustomTimeouts struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
+	// How long a caller is prepared to wait for a nested resource's [](pulumirpc.ResourceProvider.Create) operation
+	// to complete.
 	Create string `protobuf:"bytes,1,opt,name=create,proto3" json:"create,omitempty"`
+	// How long a caller is prepared to wait for a nested resource's [](pulumirpc.ResourceProvider.Update) operation
+	// to complete.
 	Update string `protobuf:"bytes,2,opt,name=update,proto3" json:"update,omitempty"`
+	// How long a caller is prepared to wait for a nested resource's [](pulumirpc.ResourceProvider.Delete) operation
+	// to complete.
 	Delete string `protobuf:"bytes,3,opt,name=delete,proto3" json:"delete,omitempty"`
 }
 
@@ -3163,13 +3214,14 @@ func (x *ConstructRequest_CustomTimeouts) GetDelete() string {
 	return ""
 }
 
-// PropertyDependencies describes the resources that a particular property depends on.
+// A `PropertyDependencies` list is a set of URNs that a particular property may depend on.
 type ConstructResponse_PropertyDependencies struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Urns []string `protobuf:"bytes,1,rep,name=urns,proto3" json:"urns,omitempty"` // A list of URNs this property depends on.
+	// A list of URNs that this property depends on.
+	Urns []string `protobuf:"bytes,1,rep,name=urns,proto3" json:"urns,omitempty"`
 }
 
 func (x *ConstructResponse_PropertyDependencies) Reset() {

--- a/sdk/proto/go/provider_grpc.pb.go
+++ b/sdk/proto/go/provider_grpc.pb.go
@@ -139,7 +139,20 @@ type ResourceProviderClient interface {
 	// a call to `Delete` fails, it must be the case that the resource was *not* deleted and can be assumed to still
 	// exist.
 	Delete(ctx context.Context, in *DeleteRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
-	// Construct creates a new instance of the provided component resource and returns its state.
+	// `Construct` provisions a new [component resource](component-resources). Providers that implement `Construct` are
+	// referred to as [component providers](component-providers). `Construct` is to component resources what
+	// [](pulumirpc.ResourceProvider.Create) is to [custom resources](custom-resources). Components do not have any
+	// lifecycle of their own, and instead embody the lifecycles of the resources that they are composed of. As such,
+	// `Construct` is effectively a subprogram whose resources will be persisted in the caller's state. It is
+	// consequently passed enough information to manage fully these resources. At a high level, this comprises:
+	//
+	// * A [](pulumirpc.ResourceMonitor) endpoint which the provider can use to [register](resource-registration) nested
+	//   custom or component resources that belong to the component.
+	//
+	// * A set of input properties.
+	//
+	// * A full set of [resource options](https://www.pulumi.com/docs/iac/concepts/options/) that the component should
+	//   propagate to resources it registers against the supplied resource monitor.
 	Construct(ctx context.Context, in *ConstructRequest, opts ...grpc.CallOption) (*ConstructResponse, error)
 	// Cancel signals the provider to gracefully shut down and abort any ongoing resource operations.
 	// Operations aborted in this way will return an error (e.g., `Update` and `Create` will either return a
@@ -491,7 +504,20 @@ type ResourceProviderServer interface {
 	// a call to `Delete` fails, it must be the case that the resource was *not* deleted and can be assumed to still
 	// exist.
 	Delete(context.Context, *DeleteRequest) (*emptypb.Empty, error)
-	// Construct creates a new instance of the provided component resource and returns its state.
+	// `Construct` provisions a new [component resource](component-resources). Providers that implement `Construct` are
+	// referred to as [component providers](component-providers). `Construct` is to component resources what
+	// [](pulumirpc.ResourceProvider.Create) is to [custom resources](custom-resources). Components do not have any
+	// lifecycle of their own, and instead embody the lifecycles of the resources that they are composed of. As such,
+	// `Construct` is effectively a subprogram whose resources will be persisted in the caller's state. It is
+	// consequently passed enough information to manage fully these resources. At a high level, this comprises:
+	//
+	// * A [](pulumirpc.ResourceMonitor) endpoint which the provider can use to [register](resource-registration) nested
+	//   custom or component resources that belong to the component.
+	//
+	// * A set of input properties.
+	//
+	// * A full set of [resource options](https://www.pulumi.com/docs/iac/concepts/options/) that the component should
+	//   propagate to resources it registers against the supplied resource monitor.
 	Construct(context.Context, *ConstructRequest) (*ConstructResponse, error)
 	// Cancel signals the provider to gracefully shut down and abort any ongoing resource operations.
 	// Operations aborted in this way will return an error (e.g., `Update` and `Create` will either return a

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
@@ -1259,18 +1259,23 @@ global___DeleteRequest = DeleteRequest
 
 @typing_extensions.final
 class ConstructRequest(google.protobuf.message.Message):
+    """`ConstructRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Construct) call. A
+    `ConstructRequest` captures enough data to be able to register nested components against the caller's resource
+    monitor.
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     @typing_extensions.final
     class PropertyDependencies(google.protobuf.message.Message):
-        """PropertyDependencies describes the resources that a particular property depends on."""
+        """A `PropertyDependencies` list is a set of URNs that a particular property may depend on."""
 
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
         URNS_FIELD_NUMBER: builtins.int
         @property
         def urns(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-            """A list of URNs this property depends on."""
+            """A list of URNs that this property depends on."""
         def __init__(
             self,
             *,
@@ -1280,23 +1285,17 @@ class ConstructRequest(google.protobuf.message.Message):
 
     @typing_extensions.final
     class CustomTimeouts(google.protobuf.message.Message):
-        """CustomTimeouts specifies timeouts for resource provisioning operations.
-        Use it with the [Timeouts] option when creating new resources
-        to override default timeouts.
+        """A `CustomTimeouts` object encapsulates a set of timeouts for the various CRUD operations that might be performed
+        on this resource's nested resources. Timeout values are specified as duration strings, such as `"5ms"` (5
+        milliseconds), `"40s"` (40 seconds), or `"1m30s"` (1 minute and 30 seconds). The following units of time are
+        supported:
 
-        Each timeout is specified as a duration string such as,
-        "5ms" (5 milliseconds), "40s" (40 seconds),
-        and "1m30s" (1 minute, 30 seconds).
-
-        The following units are accepted.
-
-          - ns: nanoseconds
-          - us: microseconds
-          - µs: microseconds
-          - ms: milliseconds
-          - s: seconds
-          - m: minutes
-          - h: hours
+        * `ns`: nanoseconds
+        * `us` or `µs`: microseconds
+        * `ms`: milliseconds
+        * `s`: seconds
+        * `m`: minutes
+        * `h`: hours
         """
 
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
@@ -1305,8 +1304,17 @@ class ConstructRequest(google.protobuf.message.Message):
         UPDATE_FIELD_NUMBER: builtins.int
         DELETE_FIELD_NUMBER: builtins.int
         create: builtins.str
+        """How long a caller is prepared to wait for a nested resource's [](pulumirpc.ResourceProvider.Create) operation
+        to complete.
+        """
         update: builtins.str
+        """How long a caller is prepared to wait for a nested resource's [](pulumirpc.ResourceProvider.Update) operation
+        to complete.
+        """
         delete: builtins.str
+        """How long a caller is prepared to wait for a nested resource's [](pulumirpc.ResourceProvider.Delete) operation
+        to complete.
+        """
         def __init__(
             self,
             *,
@@ -1392,69 +1400,104 @@ class ConstructRequest(google.protobuf.message.Message):
     RETAINONDELETE_FIELD_NUMBER: builtins.int
     ACCEPTS_OUTPUT_VALUES_FIELD_NUMBER: builtins.int
     project: builtins.str
-    """the project name."""
+    """The project to which this resource and its nested resources will belong."""
     stack: builtins.str
-    """the name of the stack being deployed into."""
+    """The name of the stack being deployed into."""
     @property
     def config(self) -> google.protobuf.internal.containers.ScalarMap[builtins.str, builtins.str]:
-        """the configuration variables to apply before running."""
+        """Configuration for the specified project and stack."""
     dryRun: builtins.bool
-    """true if we're only doing a dryrun (preview)."""
+    """True if and only if the request is being made as part of a preview/dry run, in which case the provider should not
+    actually construct the component.
+    """
     parallel: builtins.int
-    """the degree of parallelism for resource operations (<=1 for serial)."""
+    """The degree of parallelism that may be used for resource operations. A value less than or equal to 1 indicates
+    that operations should be performed serially.
+    """
     monitorEndpoint: builtins.str
-    """the address for communicating back to the resource monitor."""
+    """The address of the [](pulumirpc.ResourceMonitor) that the provider should connect to in order to send [resource
+    registrations](resource-registration) for its nested resources.
+    """
     type: builtins.str
-    """the type of the object allocated."""
+    """The type of the component resource being constructed. This must match the type specified by the `urn` field, and
+    is passed so that providers do not have to implement URN parsing in order to extract the type of the resource.
+    """
     name: builtins.str
-    """the name, for URN purposes, of the object."""
+    """The name of the component resource being constructed. This must match the name specified by the `urn` field, and
+    is passed so that providers do not have to implement URN parsing in order to extract the name of the resource.
+    """
     parent: builtins.str
-    """an optional parent URN that this child resource belongs to."""
+    """Dependencies and resource options
+
+    These are passed so that the component may propagate them to resources it registers against the supplied resource
+    monitor.
+
+    Do *not* change field IDs. Add new fields at the end with appropriate field IDs as necessary.
+
+    An optional parent resource that the component (and by extension, its nested resources) should be children of.
+    """
     @property
     def inputs(self) -> google.protobuf.struct_pb2.Struct:
-        """the inputs to the resource constructor."""
+        """The component resource's input properties. Unlike the inputs of custom resources, these will *not* have been
+        passed to a call to [](pulumirpc.ResourceProvider.Check). By virtue of their being a composition of other
+        resources, component resources are able to (and therefore expected) to validate their own inputs. Moreover,
+        [](pulumirpc.ResourceProvider.Check) will be called on any inputs passed to nested custom resources as usual.
+        """
     @property
     def inputDependencies(self) -> google.protobuf.internal.containers.MessageMap[builtins.str, global___ConstructRequest.PropertyDependencies]:
-        """a map from property keys to the dependencies of the property."""
+        """A map of property dependencies for the component resource and its nested resources."""
     @property
     def providers(self) -> google.protobuf.internal.containers.ScalarMap[builtins.str, builtins.str]:
-        """the map of providers to use for this resource's children."""
+        """A map of package names to provider references for the component resource and its nested resources."""
     @property
     def dependencies(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """a list of URNs that this resource depends on, as observed by the language host."""
+        """A list of URNs that this resource and its nested resources depend on."""
     @property
     def configSecretKeys(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """the configuration keys that have secret values."""
+        """A set of configuration keys whose values are [secret](output-secrets)."""
     organization: builtins.str
-    """the organization of the stack being deployed into."""
+    """The organization to which this resource and its nested resources will belong."""
     protect: builtins.bool
-    """Resource options:
-    Do not change field IDs. Add new fields at the end.
-    true if the resource should be marked protected.
+    """True if and only if the resource (and by extension, its nested resources) should be marked as protected.
+    Protected resources cannot be deleted without first being unprotected.
     """
     @property
     def aliases(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """a list of additional URNs that shoud be considered the same."""
+        """A list of additional URNs that should be considered the same as this component's URN (and which will therefore be
+        used to build aliases for its nested resource URNs). These may be URNs that previously referred to this component
+        e.g. if it had its parent (and consequently URN) changed.
+        """
     @property
     def additionalSecretOutputs(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """additional output properties that should be treated as secrets."""
+        """A list of input properties whose values should be treated as [secret](output-secrets)."""
     @property
     def customTimeouts(self) -> global___ConstructRequest.CustomTimeouts:
-        """default timeouts for CRUD operations on this resource."""
+        """A set of custom timeouts that specify how long the caller is prepared to wait for the various CRUD operations of
+        this resource's nested resources.
+        """
     deletedWith: builtins.str
-    """URN of a resource that, if deleted, also deletes this resource."""
+    """The URN of a resource that this resource (and thus its nested resources) will be implicitly deleted with. If the
+    resource referred to by this URN is deleted in the same operation that this resource would be deleted, the
+    [](pulumirpc.ResourceProvider.Delete) call for this resource will be elided (since this dependency signals that
+    it will have already been deleted).
+    """
     deleteBeforeReplace: builtins.bool
-    """whether to delete the resource before replacing it."""
+    """If true, this resource (and its nested resources) must be deleted *before* its replacement is created."""
     @property
     def ignoreChanges(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """properties that should be ignored during a diff"""
+        """A set of [property paths](property-paths) that should be treated as unchanged."""
     @property
     def replaceOnChanges(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """properties that, when changed, trigger a replacement"""
+        """A set of properties that, when changed, trigger a replacement."""
     retainOnDelete: builtins.bool
-    """whether to retain the resource in the cloud provider when it is deleted"""
+    """True if [](pulumirpc.ResourceProvider.Delete) should *not* be called when the resource (and by extension, its
+    nested resources) are removed from a Pulumi program.
+    """
     accepts_output_values: builtins.bool
-    """the engine can be passed output values back, stateDependencies can be left blank if returning output values."""
+    """True if the caller is capable of accepting output values in response to the call. If this is set, these outputs
+    may be used to communicate dependency information and so there is no need to populate
+    [](pulumirpc.ConstructResponse)'s `stateDependencies` field.
+    """
     def __init__(
         self,
         *,
@@ -1491,18 +1534,20 @@ global___ConstructRequest = ConstructRequest
 
 @typing_extensions.final
 class ConstructResponse(google.protobuf.message.Message):
+    """`ConstructResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Construct) call."""
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     @typing_extensions.final
     class PropertyDependencies(google.protobuf.message.Message):
-        """PropertyDependencies describes the resources that a particular property depends on."""
+        """A `PropertyDependencies` list is a set of URNs that a particular property may depend on."""
 
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
         URNS_FIELD_NUMBER: builtins.int
         @property
         def urns(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-            """A list of URNs this property depends on."""
+            """A list of URNs that this property depends on."""
         def __init__(
             self,
             *,
@@ -1532,13 +1577,16 @@ class ConstructResponse(google.protobuf.message.Message):
     STATE_FIELD_NUMBER: builtins.int
     STATEDEPENDENCIES_FIELD_NUMBER: builtins.int
     urn: builtins.str
-    """the URN of the component resource."""
+    """The URN of the constructed component resource."""
     @property
     def state(self) -> google.protobuf.struct_pb2.Struct:
-        """any properties that were computed during construction."""
+        """Any output properties that the component registered as part of its construction."""
     @property
     def stateDependencies(self) -> google.protobuf.internal.containers.MessageMap[builtins.str, global___ConstructResponse.PropertyDependencies]:
-        """a map from property keys to the dependencies of the property."""
+        """A map of property dependencies for the component's outputs. This will be set if the caller indicated that it
+        could not receive dependency-communicating [output](outputs) values by setting [](pulumirpc.ConstructRequest)'s
+        `accepts_output_values` field to false.
+        """
     def __init__(
         self,
         *,

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
@@ -316,7 +316,20 @@ class ResourceProviderServicer(object):
         raise NotImplementedError('Method not implemented!')
 
     def Construct(self, request, context):
-        """Construct creates a new instance of the provided component resource and returns its state.
+        """`Construct` provisions a new [component resource](component-resources). Providers that implement `Construct` are
+        referred to as [component providers](component-providers). `Construct` is to component resources what
+        [](pulumirpc.ResourceProvider.Create) is to [custom resources](custom-resources). Components do not have any
+        lifecycle of their own, and instead embody the lifecycles of the resources that they are composed of. As such,
+        `Construct` is effectively a subprogram whose resources will be persisted in the caller's state. It is
+        consequently passed enough information to manage fully these resources. At a high level, this comprises:
+
+        * A [](pulumirpc.ResourceMonitor) endpoint which the provider can use to [register](resource-registration) nested
+        custom or component resources that belong to the component.
+
+        * A set of input properties.
+
+        * A full set of [resource options](https://www.pulumi.com/docs/iac/concepts/options/) that the component should
+        propagate to resources it registers against the supplied resource monitor.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
@@ -204,7 +204,21 @@ class ResourceProviderStub:
         pulumi.provider_pb2.ConstructRequest,
         pulumi.provider_pb2.ConstructResponse,
     ]
-    """Construct creates a new instance of the provided component resource and returns its state."""
+    """`Construct` provisions a new [component resource](component-resources). Providers that implement `Construct` are
+    referred to as [component providers](component-providers). `Construct` is to component resources what
+    [](pulumirpc.ResourceProvider.Create) is to [custom resources](custom-resources). Components do not have any
+    lifecycle of their own, and instead embody the lifecycles of the resources that they are composed of. As such,
+    `Construct` is effectively a subprogram whose resources will be persisted in the caller's state. It is
+    consequently passed enough information to manage fully these resources. At a high level, this comprises:
+
+    * A [](pulumirpc.ResourceMonitor) endpoint which the provider can use to [register](resource-registration) nested
+      custom or component resources that belong to the component.
+
+    * A set of input properties.
+
+    * A full set of [resource options](https://www.pulumi.com/docs/iac/concepts/options/) that the component should
+      propagate to resources it registers against the supplied resource monitor.
+    """
     Cancel: grpc.UnaryUnaryMultiCallable[
         google.protobuf.empty_pb2.Empty,
         google.protobuf.empty_pb2.Empty,
@@ -450,7 +464,21 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         request: pulumi.provider_pb2.ConstructRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.ConstructResponse:
-        """Construct creates a new instance of the provided component resource and returns its state."""
+        """`Construct` provisions a new [component resource](component-resources). Providers that implement `Construct` are
+        referred to as [component providers](component-providers). `Construct` is to component resources what
+        [](pulumirpc.ResourceProvider.Create) is to [custom resources](custom-resources). Components do not have any
+        lifecycle of their own, and instead embody the lifecycles of the resources that they are composed of. As such,
+        `Construct` is effectively a subprogram whose resources will be persisted in the caller's state. It is
+        consequently passed enough information to manage fully these resources. At a high level, this comprises:
+
+        * A [](pulumirpc.ResourceMonitor) endpoint which the provider can use to [register](resource-registration) nested
+          custom or component resources that belong to the component.
+
+        * A set of input properties.
+
+        * A full set of [resource options](https://www.pulumi.com/docs/iac/concepts/options/) that the component should
+          propagate to resources it registers against the supplied resource monitor.
+        """
     
     def Cancel(
         self,


### PR DESCRIPTION
This commit fleshes out the documentation for the `Construct` method of resource providers.