### PR TITLE
Update pulumi --help documentation to use bucketv2/BucketV2

### DIFF
--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -214,8 +214,8 @@ func newSearchCmd() *cobra.Command {
 		&scmd.queryParams, "query", "q", nil,
 		"A Pulumi Query to send to Pulumi Cloud for resource search."+
 			"May be formatted as a single query, or multiple:\n"+
-			"\t-q \"type:aws:s3/bucket:Bucket modified:>=2023-09-01\"\n"+
-			"\t-q \"type:aws:s3/bucket:Bucket\" -q \"modified:>=2023-09-01\"\n"+
+			"\t-q \"type:aws:s3/bucketv2:BucketV2 modified:>=2023-09-01\"\n"+
+			"\t-q \"type:aws:s3/bucketv2:BucketV2\" -q \"modified:>=2023-09-01\"\n"+
 			"See https://www.pulumi.com/docs/pulumi-cloud/insights/search/#query-syntax for syntax reference.",
 	)
 	cmd.PersistentFlags().VarP(


### PR DESCRIPTION
As part of https://github.com/pulumi/home/issues/3583 documentation is updated to recommend BucketV2 usage over Bucket. Part of the documentation is generated automatically from `pulumi --help`. To get this right the Pulumi CLI itself needs to be updated. This change updates the example used in `pulumi --help` to use BucketV2 instead of Bucket.