### PR TITLE
workspace.CopyTemplateFiles overwrite dirs with force

### DIFF
--- a/changelog/pending/20241106--sdk-go--workspace-copytemplatefiles-overwrites-directories-when-called-with-force-true.yaml
+++ b/changelog/pending/20241106--sdk-go--workspace-copytemplatefiles-overwrites-directories-when-called-with-force-true.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: sdk/go
-  description: workspace.CopyTemplateFiles overwrites directories when called with force=true (#17653)
+  description: Overwrite directories in workspace.CopyTemplateFiles when called with force=true

--- a/changelog/pending/20241106--sdk-go--workspace-copytemplatefiles-overwrites-directories-when-called-with-force-true.yaml
+++ b/changelog/pending/20241106--sdk-go--workspace-copytemplatefiles-overwrites-directories-when-called-with-force-true.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: workspace.CopyTemplateFiles overwrites directories when called with force=true

--- a/changelog/pending/20241106--sdk-go--workspace-copytemplatefiles-overwrites-directories-when-called-with-force-true.yaml
+++ b/changelog/pending/20241106--sdk-go--workspace-copytemplatefiles-overwrites-directories-when-called-with-force-true.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: sdk/go
-  description: workspace.CopyTemplateFiles overwrites directories when called with force=true
+  description: workspace.CopyTemplateFiles overwrites directories when called with force=true (#17653)

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -752,7 +752,6 @@ func writeAllBytes(filename string, bytes []byte, overwrite bool, mode os.FileMo
 				return err
 			}
 		}
-
 	}
 
 	f, err := os.OpenFile(filename, flag, mode)

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -743,11 +743,13 @@ func writeAllBytes(filename string, bytes []byte, overwrite bool, mode os.FileMo
 	} else {
 		flag = flag | os.O_EXCL
 	}
-
-	info, err := os.Stat(filename)
-	if err == nil {
-		if info.IsDir() {
-			os.Remove(filename)
+	
+	if overwrite {
+		info, err := os.Stat(filename)
+		if err == nil {
+			if info.IsDir() {
+				os.Remove(filename)
+			}
 		}
 	}
 

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -745,12 +745,14 @@ func writeAllBytes(filename string, bytes []byte, overwrite bool, mode os.FileMo
 	}
 
 	if overwrite {
-		info, err := os.Stat(filename)
-		if err == nil {
-			if info.IsDir() {
-				os.Remove(filename)
+		info, _ := os.Stat(filename)
+		if info != nil && info.IsDir() {
+			err := os.RemoveAll(filename)
+			if err != nil {
+				return err
 			}
 		}
+
 	}
 
 	f, err := os.OpenFile(filename, flag, mode)

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -528,7 +528,11 @@ func CopyTemplateFiles(
 		func(entry os.DirEntry, source string, dest string) error {
 			if entry.IsDir() {
 				// Create the destination directory.
-				return os.Mkdir(dest, 0o700)
+				if force { 
+					return os.MkdirAll(dest, 0o700) 
+				} else { 
+					return os.Mkdir(dest, 0o700) 
+				}
 			}
 
 			// Read the source file.

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -743,7 +743,7 @@ func writeAllBytes(filename string, bytes []byte, overwrite bool, mode os.FileMo
 	} else {
 		flag = flag | os.O_EXCL
 	}
-	
+
 	if overwrite {
 		info, err := os.Stat(filename)
 		if err == nil {

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -528,11 +528,11 @@ func CopyTemplateFiles(
 		func(entry os.DirEntry, source string, dest string) error {
 			if entry.IsDir() {
 				// Create the destination directory.
-				if force { 
-					return os.MkdirAll(dest, 0o700) 
-				} else { 
-					return os.Mkdir(dest, 0o700) 
+				if force {
+					// MkdirAll will overwrite existing directories
+					return os.MkdirAll(dest, 0o700)
 				}
+				return os.Mkdir(dest, 0o700)
 			}
 
 			// Read the source file.

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -529,7 +529,11 @@ func CopyTemplateFiles(
 			if entry.IsDir() {
 				// Create the destination directory.
 				if force {
-					// MkdirAll will overwrite existing directories
+					info, _ := os.Stat(dest)
+					if info != nil && !info.IsDir() {
+						os.Remove(dest)
+					}
+					// MkdirAll will not error out if dest is a directory that already exists
 					return os.MkdirAll(dest, 0o700)
 				}
 				return os.Mkdir(dest, 0o700)
@@ -557,7 +561,7 @@ func CopyTemplateFiles(
 			// Originally we just wrote in 0600 mode, but
 			// this does not preserve the executable bit.
 			// With the new logic below, we try to be at
-			// least as permissive as 0600 and whathever
+			// least as permissive as 0600 and whatever
 			// permissions the source file or symlink had.
 			var mode os.FileMode
 			sourceStat, err := os.Lstat(source)
@@ -738,6 +742,13 @@ func writeAllBytes(filename string, bytes []byte, overwrite bool, mode os.FileMo
 		flag = flag | os.O_TRUNC
 	} else {
 		flag = flag | os.O_EXCL
+	}
+
+	info, err := os.Stat(filename)
+	if err == nil {
+		if info.IsDir() {
+			os.Remove(filename)
+		}
 	}
 
 	f, err := os.OpenFile(filename, flag, mode)

--- a/sdk/go/common/workspace/templates_test.go
+++ b/sdk/go/common/workspace/templates_test.go
@@ -330,7 +330,7 @@ func TestCopyTemplateFiles(t *testing.T) {
 			err := os.RemoveAll(testDataDir)
 			assert.NoError(t, err)
 		}()
-		
+
 		directories := []string{"src"}
 		files := []string{"src/main.go", "Pulumi.yaml", "Pulumi.dev.yaml"}
 
@@ -340,7 +340,7 @@ func TestCopyTemplateFiles(t *testing.T) {
 		assert.NoError(t, err)
 
 		// change the src directory in the destination dir to a file
-		err = os.RemoveAll(copyDestDir+"/src")
+		err = os.RemoveAll(copyDestDir + "/src")
 		assert.NoError(t, err)
 
 		err = os.WriteFile(copyDestDir+"/src", []byte("testing"), 0o600)
@@ -350,7 +350,7 @@ func TestCopyTemplateFiles(t *testing.T) {
 		err = CopyTemplateFiles(projectDir, copyDestDir, false, "testProjectName", "testProjectDescription")
 		assert.Error(t, err)
 	})
-	
+
 	t.Run("OverwriteDirectoryOverFileForce", func(t *testing.T) {
 		testDataDir := "CopyTemplateFilesTestData-OverwriteDirectoryOverFileForce"
 
@@ -358,7 +358,7 @@ func TestCopyTemplateFiles(t *testing.T) {
 			err := os.RemoveAll(testDataDir)
 			assert.NoError(t, err)
 		}()
-		
+
 		directories := []string{"src"}
 		files := []string{"src/main.go", "Pulumi.yaml", "Pulumi.dev.yaml"}
 
@@ -368,7 +368,7 @@ func TestCopyTemplateFiles(t *testing.T) {
 		assert.NoError(t, err)
 
 		// change the src directory in the destination dir to a file
-		err = os.RemoveAll(copyDestDir+"/src")
+		err = os.RemoveAll(copyDestDir + "/src")
 		assert.NoError(t, err)
 
 		err = os.WriteFile(copyDestDir+"/src", []byte("testing"), 0o600)
@@ -386,7 +386,7 @@ func TestCopyTemplateFiles(t *testing.T) {
 			err := os.RemoveAll(testDataDir)
 			assert.NoError(t, err)
 		}()
-		
+
 		directories := []string{"src"}
 		files := []string{"src/main.go", "Pulumi.yaml", "Pulumi.dev.yaml"}
 
@@ -396,7 +396,7 @@ func TestCopyTemplateFiles(t *testing.T) {
 		assert.NoError(t, err)
 
 		// change the Pulumi.dev.yaml file in the destination dir to a dir
-		err = os.RemoveAll(copyDestDir+"/Pulumi.dev.yaml")
+		err = os.RemoveAll(copyDestDir + "/Pulumi.dev.yaml")
 		assert.NoError(t, err)
 
 		err = os.Mkdir(copyDestDir+"/Pulumi.dev.yaml", 0o700)
@@ -414,7 +414,7 @@ func TestCopyTemplateFiles(t *testing.T) {
 			err := os.RemoveAll(testDataDir)
 			assert.NoError(t, err)
 		}()
-		
+
 		directories := []string{"src"}
 		files := []string{"src/main.go", "Pulumi.yaml", "Pulumi.dev.yaml"}
 
@@ -424,7 +424,7 @@ func TestCopyTemplateFiles(t *testing.T) {
 		assert.NoError(t, err)
 
 		// change the Pulumi.dev.yaml file in the destination dir to a dir
-		err = os.RemoveAll(copyDestDir+"/Pulumi.dev.yaml")
+		err = os.RemoveAll(copyDestDir + "/Pulumi.dev.yaml")
 		assert.NoError(t, err)
 
 		err = os.Mkdir(copyDestDir+"/Pulumi.dev.yaml", 0o700)

--- a/sdk/go/common/workspace/templates_test.go
+++ b/sdk/go/common/workspace/templates_test.go
@@ -251,7 +251,7 @@ func TestCopyTemplateFiles(t *testing.T) {
 
 	for _, tt := range tests {
 		tt := tt
-		t.Run("Copy"+tt.testName, func(t *testing.T) {
+		t.Run("Copy "+tt.testName+": force=false", func(t *testing.T) {
 			testDataDir := "CopyTemplateFilesTestData-Copy"
 
 			defer func() {
@@ -268,7 +268,7 @@ func TestCopyTemplateFiles(t *testing.T) {
 
 	for _, tt := range tests {
 		tt := tt
-		t.Run("CopyForce"+tt.testName, func(t *testing.T) {
+		t.Run("Copy "+tt.testName+": force=true", func(t *testing.T) {
 			testDataDir := "CopyTemplateFilesTestData-CopyForce"
 
 			defer func() {
@@ -285,7 +285,7 @@ func TestCopyTemplateFiles(t *testing.T) {
 
 	for _, tt := range tests {
 		tt := tt
-		t.Run("Overwrite"+tt.testName, func(t *testing.T) {
+		t.Run("Overwrite "+tt.testName+": force=false", func(t *testing.T) {
 			testDataDir := "CopyTemplateFilesTestData-Overwrite"
 
 			defer func() {
@@ -305,7 +305,7 @@ func TestCopyTemplateFiles(t *testing.T) {
 
 	for _, tt := range tests {
 		tt := tt
-		t.Run("OverwriteForce"+tt.testName, func(t *testing.T) {
+		t.Run("Overwrite "+tt.testName+": force=true", func(t *testing.T) {
 			testDataDir := "CopyTemplateFilesTestData-OverwriteForce"
 
 			defer func() {
@@ -323,7 +323,7 @@ func TestCopyTemplateFiles(t *testing.T) {
 		})
 	}
 
-	t.Run("OverwriteDirectoryOverFile", func(t *testing.T) {
+	t.Run("Overwrite directory over file: force=false", func(t *testing.T) {
 		testDataDir := "CopyTemplateFilesTestData-OverwriteDirectoryOverFile"
 
 		defer func() {
@@ -351,7 +351,7 @@ func TestCopyTemplateFiles(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("OverwriteDirectoryOverFileForce", func(t *testing.T) {
+	t.Run("Overwrite directory over file: force=true", func(t *testing.T) {
 		testDataDir := "CopyTemplateFilesTestData-OverwriteDirectoryOverFileForce"
 
 		defer func() {
@@ -379,8 +379,8 @@ func TestCopyTemplateFiles(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("OverwriteFileOverDirectory", func(t *testing.T) {
-		testDataDir := "CopyTemplateFilesTestData-OverwriteFileOverDirectory"
+	t.Run("Overwrite file over empty directory: force=false", func(t *testing.T) {
+		testDataDir := "CopyTemplateFilesTestData-OverwriteFileOverEmptyDirectory"
 
 		defer func() {
 			err := os.RemoveAll(testDataDir)
@@ -407,8 +407,8 @@ func TestCopyTemplateFiles(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("OverwriteFileOverDirectoryForce", func(t *testing.T) {
-		testDataDir := "CopyTemplateFilesTestData-OverwriteFileOverDirectoryForce"
+	t.Run("Overwrite file over empty directory: force=true", func(t *testing.T) {
+		testDataDir := "CopyTemplateFilesTestData-OverwriteFileOverEmptyDirectoryForce"
 
 		defer func() {
 			err := os.RemoveAll(testDataDir)
@@ -428,6 +428,38 @@ func TestCopyTemplateFiles(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = os.Mkdir(copyDestDir+"/Pulumi.dev.yaml", 0o700)
+		assert.NoError(t, err)
+
+		// copy the same files again to test overwriting - expect no error with force
+		err = CopyTemplateFiles(projectDir, copyDestDir, true, "testProjectName", "testProjectDescription")
+		assert.NoError(t, err)
+	})
+
+	t.Run("Overwrite file over non-empty directory: force=true", func(t *testing.T) {
+		testDataDir := "CopyTemplateFilesTestData-OverwriteFileOverNonEmptyDirectoryWithForce"
+
+		defer func() {
+			err := os.RemoveAll(testDataDir)
+			assert.NoError(t, err)
+		}()
+
+		directories := []string{"src"}
+		files := []string{"src/main.go", "Pulumi.yaml", "Pulumi.dev.yaml"}
+
+		projectDir, copyDestDir := setupTestData(t, testDataDir, files, directories)
+
+		err := CopyTemplateFiles(projectDir, copyDestDir, true, "testProjectName", "testProjectDescription")
+		assert.NoError(t, err)
+
+		// change the Pulumi.dev.yaml file in the destination dir to a dir
+		err = os.RemoveAll(copyDestDir + "/Pulumi.dev.yaml")
+		assert.NoError(t, err)
+
+		err = os.Mkdir(copyDestDir+"/Pulumi.dev.yaml", 0o700)
+		assert.NoError(t, err)
+
+		// add a file to the dir
+		err = os.WriteFile(copyDestDir+"/Pulumi.dev.yaml/README.md", []byte("testing"), 0o600)
 		assert.NoError(t, err)
 
 		// copy the same files again to test overwriting - expect no error with force

--- a/sdk/go/common/workspace/templates_test.go
+++ b/sdk/go/common/workspace/templates_test.go
@@ -205,43 +205,44 @@ func TestRetrieveFileTemplate(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest
 func TestCopyTemplateFiles(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
-		testName     string
+		testName    string
 		directories []string
-		files []string
+		files       []string
 	}{
 		{
-			testName:     "FlatProject",
-			files: []string{"main.go", "Pulumi.yaml", "Pulumi.dev.yaml",},
+			testName: "FlatProject",
+			files:    []string{"main.go", "Pulumi.yaml", "Pulumi.dev.yaml"},
 		},
 		{
-			testName:	"NestedProject",
+			testName:    "NestedProject",
 			directories: []string{"src"},
-			files: []string{"src/main.go", "Pulumi.yaml", "Pulumi.dev.yaml",},
+			files:       []string{"src/main.go", "Pulumi.yaml", "Pulumi.dev.yaml"},
 		},
 	}
 
-	setupTestData := func(t *testing.T, files []string, directories []string) (string, string) {
-		testDataDir := "CopyTemplateFilesTestData"
+	setupTestData := func(t *testing.T, testDataDir string, files []string, directories []string) (string, string) {
 		err := os.MkdirAll(testDataDir, 0o700)
 		assert.NoError(t, err)
 
 		projectDir := testDataDir + "/project"
 		err = os.MkdirAll(projectDir, 0o700)
 		assert.NoError(t, err)
-		
+
 		copyDestDir := testDataDir + "/tmp"
 		err = os.MkdirAll(copyDestDir, 0o700)
 		assert.NoError(t, err)
 
 		for _, dirName := range directories {
-			err := os.MkdirAll(projectDir + "/" + dirName, 0o700)
+			err := os.MkdirAll(projectDir+"/"+dirName, 0o700)
 			assert.NoError(t, err)
 		}
 
 		for _, fileName := range files {
-			err := os.WriteFile(projectDir + "/" + fileName, []byte("testing"), 0o600)
+			err := os.WriteFile(projectDir+"/"+fileName, []byte("testing"), 0o600)
 			assert.NoError(t, err)
 		}
 
@@ -250,13 +251,15 @@ func TestCopyTemplateFiles(t *testing.T) {
 
 	for _, tt := range tests {
 		tt := tt
-		t.Run("Copy" + tt.testName, func(t *testing.T) {
+		t.Run("Copy"+tt.testName, func(t *testing.T) {
+			testDataDir := "CopyTemplateFilesTestData-Copy"
+
 			defer func() {
-				err := os.RemoveAll("CopyTemplateFilesTestData")
+				err := os.RemoveAll(testDataDir)
 				assert.NoError(t, err)
 			}()
 
-			projectDir, copyDestDir := setupTestData(t, tt.files, tt.directories)
+			projectDir, copyDestDir := setupTestData(t, testDataDir, tt.files, tt.directories)
 
 			err := CopyTemplateFiles(projectDir, copyDestDir, false, "testProjectName", "testProjectDescription")
 			assert.NoError(t, err)
@@ -265,13 +268,15 @@ func TestCopyTemplateFiles(t *testing.T) {
 
 	for _, tt := range tests {
 		tt := tt
-		t.Run("CopyForce" + tt.testName, func(t *testing.T) {
+		t.Run("CopyForce"+tt.testName, func(t *testing.T) {
+			testDataDir := "CopyTemplateFilesTestData-CopyForce"
+
 			defer func() {
-				err := os.RemoveAll("CopyTemplateFilesTestData")
+				err := os.RemoveAll(testDataDir)
 				assert.NoError(t, err)
 			}()
 
-			projectDir, copyDestDir := setupTestData(t, tt.files, tt.directories)
+			projectDir, copyDestDir := setupTestData(t, testDataDir, tt.files, tt.directories)
 
 			err := CopyTemplateFiles(projectDir, copyDestDir, true, "testProjectName", "testProjectDescription")
 			assert.NoError(t, err)
@@ -280,13 +285,15 @@ func TestCopyTemplateFiles(t *testing.T) {
 
 	for _, tt := range tests {
 		tt := tt
-		t.Run("Overwrite" + tt.testName, func(t *testing.T) {
+		t.Run("Overwrite"+tt.testName, func(t *testing.T) {
+			testDataDir := "CopyTemplateFilesTestData-Overwrite"
+
 			defer func() {
-				err := os.RemoveAll("CopyTemplateFilesTestData")
+				err := os.RemoveAll(testDataDir)
 				assert.NoError(t, err)
 			}()
 
-			projectDir, copyDestDir := setupTestData(t, tt.files, tt.directories)
+			projectDir, copyDestDir := setupTestData(t, testDataDir, tt.files, tt.directories)
 
 			err := CopyTemplateFiles(projectDir, copyDestDir, false, "testProjectName", "testProjectDescription")
 			assert.NoError(t, err)
@@ -298,13 +305,15 @@ func TestCopyTemplateFiles(t *testing.T) {
 
 	for _, tt := range tests {
 		tt := tt
-		t.Run("OverwriteForce" + tt.testName, func(t *testing.T) {
+		t.Run("OverwriteForce"+tt.testName, func(t *testing.T) {
+			testDataDir := "CopyTemplateFilesTestData-OverwriteForce"
+
 			defer func() {
-				err := os.RemoveAll("CopyTemplateFilesTestData")
+				err := os.RemoveAll(testDataDir)
 				assert.NoError(t, err)
 			}()
 
-			projectDir, copyDestDir := setupTestData(t, tt.files, tt.directories)
+			projectDir, copyDestDir := setupTestData(t, testDataDir, tt.files, tt.directories)
 
 			err := CopyTemplateFiles(projectDir, copyDestDir, true, "testProjectName", "testProjectDescription")
 			assert.NoError(t, err)

--- a/sdk/go/common/workspace/templates_test.go
+++ b/sdk/go/common/workspace/templates_test.go
@@ -322,4 +322,60 @@ func TestCopyTemplateFiles(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+	
+	t.Run("OverwriteDirectoryOverFileForce", func(t *testing.T) {
+		testDataDir := "CopyTemplateFilesTestData-OverwriteDirectoryOverFileForce"
+
+		defer func() {
+			err := os.RemoveAll(testDataDir)
+			assert.NoError(t, err)
+		}()
+		
+		directories := []string{"src"}
+		files := []string{"src/main.go", "Pulumi.yaml", "Pulumi.dev.yaml"}
+
+		projectDir, copyDestDir := setupTestData(t, testDataDir, files, directories)
+
+		err := CopyTemplateFiles(projectDir, copyDestDir, true, "testProjectName", "testProjectDescription")
+		assert.NoError(t, err)
+
+		// change the src directory in the destination dir to a file
+		err = os.RemoveAll(copyDestDir+"/src")
+		assert.NoError(t, err)
+
+		err = os.WriteFile(copyDestDir+"/src", []byte("testing"), 0o600)
+		assert.NoError(t, err)
+
+		// copy the same files again to test overwriting - expect no error with force
+		err = CopyTemplateFiles(projectDir, copyDestDir, true, "testProjectName", "testProjectDescription")
+		assert.NoError(t, err)
+	})
+
+	t.Run("OverwriteFileOverDirectoryForce", func(t *testing.T) {
+		testDataDir := "CopyTemplateFilesTestData-OverwriteFileOverDirectoryForce"
+
+		defer func() {
+			err := os.RemoveAll(testDataDir)
+			assert.NoError(t, err)
+		}()
+		
+		directories := []string{"src"}
+		files := []string{"src/main.go", "Pulumi.yaml", "Pulumi.dev.yaml"}
+
+		projectDir, copyDestDir := setupTestData(t, testDataDir, files, directories)
+
+		err := CopyTemplateFiles(projectDir, copyDestDir, true, "testProjectName", "testProjectDescription")
+		assert.NoError(t, err)
+
+		// change the Pulumi.dev.yaml file in the destination dir to a dir
+		err = os.RemoveAll(copyDestDir+"/Pulumi.dev.yaml")
+		assert.NoError(t, err)
+
+		err = os.Mkdir(copyDestDir+"/Pulumi.dev.yaml", 0o700)
+		assert.NoError(t, err)
+
+		// copy the same files again to test overwriting - expect no error with force
+		err = CopyTemplateFiles(projectDir, copyDestDir, true, "testProjectName", "testProjectDescription")
+		assert.NoError(t, err)
+	})
 }


### PR DESCRIPTION
`workspace.CopyTemplateFiles()` can be called with `force=true`, which currently allows files to be overwritten, but errors when trying to overwrite directories. This commit enables overwriting directories when called with `force=true`.
Fixes #17653 