### PR TITLE
simplify the keep running in the service backend

### DIFF
--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -80,7 +80,6 @@ func (u *cloudUpdate) GetTarget() *deploy.Target {
 
 func (u *cloudUpdate) Complete(status apitype.UpdateStatus) error {
 	defer u.tokenSource.Close()
-	defer u.backend.resetSleep()
 
 	return u.backend.client.CompleteUpdate(u.context, u.update, status, u.tokenSource)
 }


### PR DESCRIPTION
Simplify keeping the machine running in the service backend.  Instead of splitting it up, we can simply make sure to keep the computer running for the whole apply.  This also removes the risk of the resetSleep function being nil, and potentially panic'ing.  (This is currently not possible, but the setup we currently have is somewhat brittle)

Thanks @lunaris for pointing this out.