### PR TITLE
increase the timeout for running CI tests

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -97,7 +97,7 @@ jobs:
 
     runs-on: ${{ inputs.platform }}
 
-    timeout-minutes: 60
+    timeout-minutes: 70
     continue-on-error: ${{ inputs.continue-on-error }}
     steps:
       - if: contains(inputs.platform, 'ubuntu')


### PR DESCRIPTION
Currently we are setting the timout in our CI jobs to 60 minutes.  We also set the timeout for Go tests to 1h (see GO_TEST_FLAGS in build/common.mk).  This means the GitHub action times out before the `go test` does, which in turn means that if there are timeouts there's no information of what timed out.  Normally Go test prints the current stack trace of every goroutine that is currently running.

By raising the GitHub actions imposed timeout to 70 minutes, we'll allow `go test` to time out first, which should provide helpful debuging information in the case of timeouts.

(one example of this happening is here: https://github.com/pulumi/pulumi/actions/runs/11702940046/job/32592316950?pr=17567)