### PR TITLE
Add `codegen/docs.NewContext` and supported methods

### DIFF
--- a/changelog/pending/20241107--pkg--allow-generating-docs-in-parallel.yaml
+++ b/changelog/pending/20241107--pkg--allow-generating-docs-in-parallel.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: pkg
+  description: Allow generating docs in parallel

--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -508,7 +508,7 @@ func TestExamplesProcessing(t *testing.T) {
 func generatePackage(tool string, pkg *schema.Package, extraFiles map[string][]byte) (map[string][]byte, error) {
 	dctx := newDocGenContext()
 	dctx.initialize(tool, pkg)
-	return dctx.generatePackage(tool, pkg)
+	return dctx.generatePackage()
 }
 
 func TestGeneratePackage(t *testing.T) {

--- a/pkg/codegen/docs/package_tree_test.go
+++ b/pkg/codegen/docs/package_tree_test.go
@@ -240,7 +240,7 @@ func TestGeneratePackageTreeNested(t *testing.T) {
 		},
 	}
 
-	prep := func(t *testing.T, tc testCase) (*docGenContext, *schema.Package) {
+	prep := func(t *testing.T, tc testCase) *docGenContext {
 		t.Helper()
 
 		schemaPkg, err := schema.ImportSpec(tc.spec, nil)
@@ -249,7 +249,7 @@ func TestGeneratePackageTreeNested(t *testing.T) {
 		c := newDocGenContext()
 		c.initialize("test", schemaPkg)
 
-		return c, schemaPkg
+		return c
 	}
 
 	for _, tc := range testCases {
@@ -268,7 +268,7 @@ func TestGeneratePackageTreeNested(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 
-				c, _ := prep(t, tc)
+				c := prep(t, tc)
 
 				items, err := c.generatePackageTree()
 				require.NoError(t, err)
@@ -284,9 +284,9 @@ func TestGeneratePackageTreeNested(t *testing.T) {
 			t.Run(name+"/generatePackage", func(t *testing.T) {
 				t.Parallel()
 
-				c, schemaPkg := prep(t, tc)
+				c := prep(t, tc)
 
-				files, err := c.generatePackage("test", schemaPkg)
+				files, err := c.generatePackage()
 				require.NoError(t, err)
 
 				for f := range files {

--- a/pkg/codegen/docs/utils.go
+++ b/pkg/codegen/docs/utils.go
@@ -133,3 +133,11 @@ func removeLeadingUnderscores(s string) string {
 	}
 	return sb.String()
 }
+
+// noCopy tells go vet that any type that contains this type should not be copied.
+//
+// https://github.com/golang/go/issues/8005#issuecomment-190753527
+type noCopy struct{}
+
+// Lock is a type hint for go vet. It need not be called.
+func (*noCopy) Lock() {}


### PR DESCRIPTION
Add support for calling `GeneratePackage` and `GeneratePackageTree` in parallel. State is already encapsulated via `*docGenContext`, and tests of `GeneratePackage` already run in parallel, this just exposes the context abstraction to users.