### PR TITLE
stop the token source loop correctly on 403 errors

### DIFF
--- a/changelog/pending/20241107--engine--fix-frequent-retries-on-403-errors-when-the-update-token-expires.yaml
+++ b/changelog/pending/20241107--engine--fix-frequent-retries-on-403-errors-when-the-update-token-expires.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix frequent retries on 403 errors when the update token expires

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -183,7 +183,7 @@ func (b *cloudBackend) newUpdate(ctx context.Context, stackRef backend.StackRefe
 				ctx, update, currentToken, duration)
 			if err != nil {
 				// Translate 403 status codes to expired token errors to stop the token refresh loop.
-				var apierr apitype.ErrorResponse
+				var apierr *apitype.ErrorResponse
 				if errors.As(err, &apierr) && apierr.Code == 403 {
 					return "", time.Time{}, expiredTokenError{err}
 				}

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -160,6 +160,24 @@ func (b *cloudBackend) newQuery(ctx context.Context,
 	return &cloudQuery{root: op.Root, proj: op.Proj}, nil
 }
 
+func RenewLeaseFunc(
+	client *client.Client, update client.UpdateIdentifier, assumedExpires func() time.Time,
+) func(ctx context.Context, duration time.Duration, currentToken string) (string, time.Time, error) {
+	return func(ctx context.Context, duration time.Duration, currentToken string) (string, time.Time, error) {
+		tok, err := client.RenewUpdateLease(
+			ctx, update, currentToken, duration)
+		if err != nil {
+			// Translate 403 status codes to expired token errors to stop the token refresh loop.
+			var apierr *apitype.ErrorResponse
+			if errors.As(err, &apierr) && apierr.Code == 403 {
+				return "", time.Time{}, expiredTokenError{err}
+			}
+			return "", time.Time{}, err
+		}
+		return tok, assumedExpires(), err
+	}
+}
+
 func (b *cloudBackend) newUpdate(ctx context.Context, stackRef backend.StackReference, op backend.UpdateOperation,
 	update client.UpdateIdentifier, token string,
 ) (*cloudUpdate, error) {
@@ -174,23 +192,7 @@ func (b *cloudBackend) newUpdate(ctx context.Context, stackRef backend.StackRefe
 			return time.Now().Add(duration)
 		}
 
-		renewLease := func(
-			ctx context.Context,
-			duration time.Duration,
-			currentToken string,
-		) (string, time.Time, error) {
-			tok, err := b.Client().RenewUpdateLease(
-				ctx, update, currentToken, duration)
-			if err != nil {
-				// Translate 403 status codes to expired token errors to stop the token refresh loop.
-				var apierr *apitype.ErrorResponse
-				if errors.As(err, &apierr) && apierr.Code == 403 {
-					return "", time.Time{}, expiredTokenError{err}
-				}
-				return "", time.Time{}, err
-			}
-			return tok, assumedExpires(), err
-		}
+		renewLease := RenewLeaseFunc(b.Client(), update, assumedExpires)
 
 		ts, err := newTokenSource(ctx, clockwork.NewRealClock(), token, assumedExpires(), duration, renewLease)
 		if err != nil {


### PR DESCRIPTION
In the token source loop, when a 403 error happens, there's no way it's going to succeed in the future, and we want to abort it.  We try to do so currently, however we're passing the incorrect type to `errors.As`, and thus never get an expiredTokenError, and never abort the loop.

Note that we are no longer retrying this in a tight loop, but if someone calls `GetToken` frequently for whatever reason, we'd still end up in the same situation as in https://github.com/pulumi/home/issues/3660.

Fix that, and add a test that reproduces the whole round trip through the client by setting up a fake http server.

Fixes https://github.com/pulumi/pulumi/issues/17551