### PR TITLE
Fix checking assertions in the log callback of nodejs engine tests

### DIFF
--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -1747,7 +1747,7 @@ describe("rpc", () => {
                                     try {
                                         opts.log(ctx, severity, message, urn, streamId);
                                     } catch (e) {
-                                        logError = e
+                                        logError = e;
                                     }
                                 }
                             }
@@ -1833,7 +1833,7 @@ describe("rpc", () => {
                 }
 
                 if (logError) {
-                    assert.fail(logError)
+                    assert.fail(logError);
                 }
             }
         });

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -1614,6 +1614,7 @@ describe("rpc", () => {
                 let rootResource: string | undefined;
                 let regCnt = 0;
                 let logCnt = 0;
+                let logError = undefined; // Used to track errors or assertion failures in the log callback
                 const monitor = await createMockEngineAsync(
                     opts,
                     // Invoke callback
@@ -1743,7 +1744,11 @@ describe("rpc", () => {
                             if (!opts.expectedLogs.ignoreDebug || severity !== engineproto.LogSeverity.DEBUG) {
                                 logCnt++;
                                 if (opts.log) {
-                                    opts.log(ctx, severity, message, urn, streamId);
+                                    try {
+                                        opts.log(ctx, severity, message, urn, streamId);
+                                    } catch (e) {
+                                        logError = e
+                                    }
                                 }
                             }
                         }
@@ -1825,6 +1830,10 @@ describe("rpc", () => {
                     if (logs.count) {
                         assert.strictEqual(logCnt, logs.count, `Expected exactly ${logs.count} logs; got ${logCnt}`);
                     }
+                }
+
+                if (logError) {
+                    assert.fail(logError)
                 }
             }
         });


### PR DESCRIPTION
While adding a new test in https://github.com/pulumi/pulumi/pull/17632 I noticed that assertions or thrown errors in the log callback are not actually checked. This PR fixes this by tracking any error thrown from the callback and then failing the test if one was found.

Somewhat surprisingly, we did not break anything, even though the tests didn't always check what we thought they did. I validated the fix by intentionally breaking some of the tests and asserting that they started failing.