### PR TITLE
Log a message about deleting requirements.txt when converting to using Poetry

### DIFF
--- a/changelog/pending/20241107--sdk-python--log-a-message-about-deleting-requirements-txt-when-converting-to-using-poetry.yaml
+++ b/changelog/pending/20241107--sdk-python--log-a-message-about-deleting-requirements-txt-when-converting-to-using-poetry.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Log a message about deleting requirements.txt when converting to using Poetry

--- a/sdk/python/toolchain/poetry.go
+++ b/sdk/python/toolchain/poetry.go
@@ -113,7 +113,7 @@ func (p *poetry) InstallDependencies(ctx context.Context,
 		}
 		requirementsTxt := filepath.Join(requirementsTxtDir, "requirements.txt")
 		pyprojectToml := filepath.Join(requirementsTxtDir, "pyproject.toml")
-		if err := p.convertRequirementsTxt(requirementsTxt, pyprojectToml); err != nil {
+		if err := p.convertRequirementsTxt(requirementsTxt, pyprojectToml, showOutput, infoWriter); err != nil {
 			return err
 		}
 	}
@@ -249,7 +249,7 @@ func (p *poetry) virtualenvPath(ctx context.Context) (string, error) {
 	return virtualenvPath, nil
 }
 
-func (p *poetry) convertRequirementsTxt(requirementsTxt, pyprojectToml string) error {
+func (p *poetry) convertRequirementsTxt(requirementsTxt, pyprojectToml string, showOutput bool, infoWriter io.Writer) error {
 	f, err := os.Open(requirementsTxt)
 	if err != nil {
 		return fmt.Errorf("failed to open %q", requirementsTxt)
@@ -278,6 +278,12 @@ func (p *poetry) convertRequirementsTxt(requirementsTxt, pyprojectToml string) e
 
 	if err := os.Remove(requirementsTxt); err != nil {
 		return fmt.Errorf("failed to remove %q", requirementsTxt)
+	}
+	if showOutput {
+		if _, err := infoWriter.Write([]byte("Deleted requirements.txt, " +
+			"dependencies for this project are tracked in pyproject.toml\n")); err != nil {
+			return fmt.Errorf("failed to write to infoWriter: %w", err)
+		}
 	}
 
 	return nil

--- a/sdk/python/toolchain/poetry.go
+++ b/sdk/python/toolchain/poetry.go
@@ -249,7 +249,9 @@ func (p *poetry) virtualenvPath(ctx context.Context) (string, error) {
 	return virtualenvPath, nil
 }
 
-func (p *poetry) convertRequirementsTxt(requirementsTxt, pyprojectToml string, showOutput bool, infoWriter io.Writer) error {
+func (p *poetry) convertRequirementsTxt(requirementsTxt, pyprojectToml string, showOutput bool,
+	infoWriter io.Writer,
+) error {
 	f, err := os.Open(requirementsTxt)
 	if err != nil {
 		return fmt.Errorf("failed to open %q", requirementsTxt)

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -592,13 +592,14 @@ in-project = true`
 	template := "python"
 
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
-	e.RunCommand("pulumi", "new", template, "--force", "--non-interactive", "--yes",
+	out, _ := e.RunCommand("pulumi", "new", template, "--force", "--non-interactive", "--yes",
 		"--name", "test_project",
 		"--description", "A python test using poetry as toolchain",
 		"--stack", "test",
 		"--runtime-options", "toolchain=poetry",
 	)
 
+	require.Contains(t, out, "Deleted requirements.txt")
 	require.True(t, e.PathExists("pyproject.toml"), "pyproject.toml was created")
 	require.False(t, e.PathExists("requirements.txt"), "requirements.txt was removed")
 


### PR DESCRIPTION
Follow up to https://github.com/pulumi/pulumi/pull/17609#discussion_r1832695404

When we convert a requirements.txt based project to use Poetry & pyproject.toml, inform the user that requirements.txt was deleted and that dependencies are tracked in pyproject.toml.