### PR TITLE
Add Go tests for fuzzing the engine

### DIFF
--- a/docs/architecture/deployment-execution/state.md
+++ b/docs/architecture/deployment-execution/state.md
@@ -58,6 +58,8 @@ general principles may be useful:
   resource state. Lifecycle tests allow mocking providers and specifying
   programs directly without an intermediate language host, and provide the best
   means to consistently reproduce an issue or specify a desired behaviour.
+  The lifecycle test suite's [fuzzing](lifecycle-fuzzing) capabilities may help
+  when tracking down hard-to-find issues.
 
 * *Avoid realising [deletions](step-generation-deletions) until the end of an
   operation.* Many snapshot integrity issues arise from resources ending up in

--- a/pkg/engine/lifecycletest/fuzz_test.go
+++ b/pkg/engine/lifecycletest/fuzz_test.go
@@ -1,0 +1,98 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifecycletest
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/fuzzing"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// TestFuzz is a harness for running fuzz tests against the lifecycle test framework. It will generate random lifecycle
+// test fixtures and run them, hunting for possible snapshot integrity errors.
+//
+// Usage:
+//
+// This test will be skipped unless the `PULUMI_LIFECYCLE_TEST_FUZZ` environment variable is set. This is because
+// fuzzing is by its nature potentially flaky, and so we want fine-grained control of when we run fuzzing, especially in
+// CI where a red build can prevent a PR from being merged.
+//
+// If you want to customize the fuzzing that occurs, you can modify (but not commit!) the FixtureOptions passed to
+// fuzzing.GeneratedFixture in this test to your needs.
+func TestFuzz(t *testing.T) {
+	t.Parallel()
+
+	shouldFuzz := os.Getenv("PULUMI_LIFECYCLE_TEST_FUZZ")
+	if shouldFuzz == "" {
+		t.Skip("PULUMI_LIFECYCLE_TEST_FUZZ not set")
+	}
+
+	rapid.Check(t, fuzzing.GeneratedFixture(fuzzing.FixtureOptions{}))
+}
+
+// TestFuzzFromStateFile is a harness for running fuzz tests starting from a JSON state file such as that produced by a
+// `pulumi stack export` command. It can be used to try and reproduce errors that have occurred in a user's stack
+// without having access to the actual program that ran, or logs that might help infer the program that ran.
+//
+// Usage:
+//
+// This test will be skipped unless the `PULUMI_LIFECYCLE_TEST_FUZZ_FROM_STATE_FILE` environment variable is set. The
+// variable should be a path to a suitable JSON file.
+//
+// If you want to customize the fuzzing that occurs, you can modify (but not commit!) the FixtureOptions passed to
+// fuzzing.GeneratedFixture in this test to your needs.
+func TestFuzzFromStateFile(t *testing.T) {
+	t.Parallel()
+
+	stateFile := os.Getenv("PULUMI_LIFECYCLE_TEST_FUZZ_FROM_STATE_FILE")
+	if stateFile == "" {
+		t.Skip("PULUMI_LIFECYCLE_TEST_FUZZ_FROM_STATE_FILE not set")
+	}
+
+	reader, err := os.Open(stateFile)
+	require.NoError(t, err)
+
+	var deployment apitype.UntypedDeployment
+	err = json.NewDecoder(reader).Decode(&deployment)
+	require.NoError(t, err)
+
+	v3Deployment, err := stack.UnmarshalUntypedDeployment(context.Background(), &deployment)
+	require.NoError(t, err)
+
+	if len(v3Deployment.Resources) == 0 {
+		t.Skip("No resources in state file")
+	}
+
+	first := v3Deployment.Resources[0]
+	project := first.URN.Project()
+	stack := first.URN.Stack()
+
+	rapid.Check(t, fuzzing.GeneratedFixture(fuzzing.FixtureOptions{
+		StackSpecOptions: fuzzing.StackSpecOptions{
+			Project: string(project),
+			Stack:   string(stack),
+		},
+		SnapshotSpecOptions: fuzzing.SnapshotSpecOptions{
+			SourceDeploymentV3: v3Deployment,
+		},
+	}))
+}

--- a/pkg/engine/lifecycletest/fuzzing/README.md
+++ b/pkg/engine/lifecycletest/fuzzing/README.md
@@ -66,3 +66,47 @@ By default, reproduction test files will be written to a temporary directory. A
 specific directory can be configured using the
 `PULUMI_LIFECYCLE_TEST_FUZZING_REPRO_DIR` environment variable.
 :::
+
+### Running a suite of fuzz tests
+
+The `TestFuzz` test generates and tests a set of fixtures, and can be run with
+the top-level `test_lifecycle_fuzz` target:
+
+```
+make test_lifecycle_fuzz
+```
+
+You can change how many checks Rapid performs by setting the
+`LIFECYCLE_TEST_FUZZ_CHECKS` Make variable on the command line. For instance, to
+perform 10,000 checks:
+
+```
+make test_lifecycle_fuzz LIFECYCLE_TEST_FUZZ_CHECKS=10000
+```
+
+If you use `go test` directly, make sure you set the
+`PULUMI_LIFECYCLE_TEST_FUZZ` variable to something; the test will be skipped if
+you do not:
+
+```
+(cd pkg/engine/lifecycletest; PULUMI_LIFECYCLE_TEST_FUZZ=1 go test ./... -run '^TestFuzz$')
+```
+
+### Starting from a known state
+
+Rather than generating entirely random scenarios, it can be useful to start from
+a known snapshot, and to fuzz potential provider configurations and operations,
+etc. from there. The `TestFuzzFromStateFile` test is provided to this end. It
+will read state from a JSON file (such as that produced by a `pulumi stack
+export` command) and use this as the starting point for a fuzzing run. Use the
+`PULUMI_LIFECYCLE_TEST_FUZZ_FROM_STATE_FILE` environment variable to specify the
+file to read (if this variable is not set, the test will be skipped):
+
+```
+PULUMI_LIFECYCLE_TEST_FUZZ_FROM_STATE_FILE=/path/to/state.json \
+    make test_lifecycle_fuzz_from_state_file \
+    LIFECYCLE_TEST_FUZZ_CHECKS=10000
+```
+
+In this example we have again configured 10,000 Rapid checks using the
+`LIFECYCLE_TEST_FUZZ_CHECKS` Make variable as before.

--- a/pkg/engine/lifecycletest/fuzzing/provider.go
+++ b/pkg/engine/lifecycletest/fuzzing/provider.go
@@ -496,7 +496,7 @@ func GeneratedProviderSpec(progSpec *ProgramSpec, pso ProviderSpecOptions) *rapi
 		for _, r := range allResources {
 			if providers.IsProviderType(r.Type) {
 				provSpec.AddPackage(tokens.Package(r.Type.Name()))
-			} else {
+			} else if tokens.Token(r.Type).HasModuleMember() {
 				provSpec.AddPackage(r.Type.Package())
 			}
 

--- a/pkg/engine/lifecycletest/fuzzing/resource.go
+++ b/pkg/engine/lifecycletest/fuzzing/resource.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/mitchellh/copystructure"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"golang.org/x/exp/maps"
@@ -51,6 +52,33 @@ type ResourceSpec struct {
 	// A set of tags associated with the resource. These have no bearing on any tests but are included to aid in debugging
 	// and identifying the causes of snapshot integrity issues.
 	Tags map[string]bool
+}
+
+// Creates a ResourceSpec from the given ResourceV3.
+func FromResourceV3(r apitype.ResourceV3) *ResourceSpec {
+	deps := copystructure.Must(copystructure.Copy(r.Dependencies)).([]resource.URN)
+	propDeps := copystructure.Must(copystructure.Copy(r.PropertyDependencies)).(map[resource.PropertyKey][]resource.URN)
+	aliases := copystructure.Must(copystructure.Copy(r.Aliases)).([]resource.URN)
+
+	return &ResourceSpec{
+		Project:              r.URN.Project(),
+		Stack:                r.URN.Stack(),
+		Type:                 r.Type,
+		Name:                 r.URN.Name(),
+		Custom:               r.Custom,
+		Delete:               r.Delete,
+		ID:                   r.ID,
+		Protect:              r.Protect,
+		PendingReplacement:   r.PendingReplacement,
+		RetainOnDelete:       r.RetainOnDelete,
+		Provider:             r.Provider,
+		Parent:               r.Parent,
+		Dependencies:         deps,
+		PropertyDependencies: propDeps,
+		DeletedWith:          r.DeletedWith,
+		Aliases:              aliases,
+		Tags:                 map[string]bool{},
+	}
 }
 
 // AddTag adds the given tag to the given ResourceSpec. Ideally this would be a generic method on ResourceSpec itself,


### PR DESCRIPTION
In #17623 through #17627 and some follow-up PRs, we built out a framework for fuzzing lifecycle tests in order to help track down snapshot integrity violations in the Pulumi engine. All that remains now is to actually provide ways to trigger a fuzzing run in useful ways. This commit kicks this off by introducing two Go test functions that can be run with `go test` or our `Makefile`:

* `TestFuzz` -- this runs the fuzzer and generates a brand new set of scenarios (1,000 by default) and checks whether any of them result in a snapshot integrity error. This test is skipped unless an environment variable is set (which the `Makefile` handles if one runs `make test_lifecycle_fuzz`). The intended purpose of this test is to back one or more CI workflows that will run periodically in order to slowly explore the state space.

* `TestFuzzFromStateFile` -- this accepts a path to a JSON state file (such as that produced by a `pulumi stack export`) and uses that state to seed the fuzzer, subsequently trying to find provider and operation configurations that lead to a snapshot integrity error. This test is skipped unless a state file path is set using the relevant environment variable. The intended purpose of this test is to make it possible to find root causes for user issues when all we have is a state and we'd like to guess the program/provider configurations that led to an issue.

Alongside introducing these two tests, we bulk out the fuzzing documentation a bit to help engineers run them, and link to the new sections from the existing docs on snapshot integrity issues.