### PR TITLE
Move EscEnvironmentMetadata to apitype

### DIFF
--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -977,16 +977,12 @@ func addUpdatePlanMetadataToEnvironment(env map[string]string, updatePlan bool) 
 	env[backend.UpdatePlan] = strconv.FormatBool(updatePlan)
 }
 
-type EscEnvironmentMetadata struct {
-	Name string `json:"name"`
-}
-
 // addEscMetadataToEnvironment populates the environment metadata bag with the ESC environments
 // used as part of the stack update.
 func addEscMetadataToEnvironment(env map[string]string, escEnvironments []string) {
-	envs := make([]EscEnvironmentMetadata, len(escEnvironments))
+	envs := make([]apitype.EscEnvironmentMetadata, len(escEnvironments))
 	for i, s := range escEnvironments {
-		envs[i] = EscEnvironmentMetadata{Name: s}
+		envs[i] = apitype.EscEnvironmentMetadata{ID: s}
 	}
 
 	jsonData, err := json.Marshal(envs)

--- a/pkg/cmd/pulumi/util_test.go
+++ b/pkg/cmd/pulumi/util_test.go
@@ -477,7 +477,7 @@ func TestAddEscMetadataToEnvironment(t *testing.T) {
 
 	addEscMetadataToEnvironment(env, []string{"proj/env1", "proj/env2@stable"})
 
-	expected := "[{\"name\":\"proj/env1\"},{\"name\":\"proj/env2@stable\"}]"
+	expected := "[{\"id\":\"proj/env1\"},{\"id\":\"proj/env2@stable\"}]"
 	assert.Equal(t, expected, env[backend.StackEnvironments])
 }
 

--- a/sdk/go/common/apitype/updates.go
+++ b/sdk/go/common/apitype/updates.go
@@ -70,6 +70,12 @@ type UpdateMetadata struct {
 	Environment map[string]string `json:"environment"`
 }
 
+// EscEnvironmentMetadata describes the ESC Environments used in an update.
+type EscEnvironmentMetadata struct {
+	// This will be in the format of "[project/]name[@tag/version]"
+	ID string `json:"id"`
+}
+
 type MessageSeverity string
 
 const (


### PR DESCRIPTION
We would like to move this type to apitype so it can be reused in the service