### PR TITLE
implement RunPlugin for nodejs

### DIFF
--- a/changelog/pending/20241108--sdk-nodejs--implement-runplugin-for-the-nodejs-language-runtime.yaml
+++ b/changelog/pending/20241108--sdk-nodejs--implement-runplugin-for-the-nodejs-language-runtime.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Implement RunPlugin for the NodeJS language runtime

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -43,6 +43,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/blang/semver"
@@ -77,6 +78,9 @@ const (
 	// The path to the "run" program which will spawn the rest of the language host. This may be overridden with
 	// PULUMI_LANGUAGE_NODEJS_RUN_PATH, which we do in some testing cases.
 	defaultRunPath = "@pulumi/pulumi/cmd/run"
+
+	// The path to run a pluginn.
+	defaultRunPluginPath = "@pulumi/pulumi/cmd/run-plugin"
 
 	// The runtime expects the config object to be saved to this environment variable.
 	pulumiConfigVar = "PULUMI_CONFIG"
@@ -154,17 +158,21 @@ func main() {
 }
 
 // locateModule resolves a node module name to a file path that can be loaded
-func locateModule(ctx context.Context, mod, programDir, nodeBin string) (string, error) {
+func locateModule(ctx context.Context, mod, programDir, nodeBin string, isPlugin bool) (string, error) {
+	installCommand := "pulumi install"
+	if isPlugin {
+		installCommand = fmt.Sprintf("npm install in %s", programDir)
+	}
 	script := fmt.Sprintf(`try {
 		console.log(require.resolve('%s'));
 	} catch (error) {
 		if (error.code === 'MODULE_NOT_FOUND') {
-			console.error("It looks like the Pulumi SDK has not been installed. Have you run pulumi install?")
+			console.error("It looks like the Pulumi SDK has not been installed. Have you run %s?")
 		} else {
 			console.error(error.message);
 		}
 		process.exit(1);
-	}`, mod)
+	}`, mod, installCommand)
 	// The Volta package manager installs shim executables that route to the user's chosen nodejs
 	// version. On Windows this does not properly handle arguments with newlines, so we need to
 	// ensure that the script is a single line.
@@ -658,7 +666,7 @@ func (host *nodeLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 		req.Info.ProgramDirectory = filepath.Join(programDirectory, "bin")
 	}
 
-	runPath, err = locateModule(ctx, runPath, programDirectory, nodeBin)
+	runPath, err = locateModule(ctx, runPath, programDirectory, nodeBin, false)
 	if err != nil {
 		return &pulumirpc.RunResponse{Error: err.Error()}, nil
 	}
@@ -1345,7 +1353,86 @@ func (host *nodeLanguageHost) GetProgramDependencies(
 func (host *nodeLanguageHost) RunPlugin(
 	req *pulumirpc.RunPluginRequest, server pulumirpc.LanguageRuntime_RunPluginServer,
 ) error {
-	return errors.New("not supported")
+	logging.V(5).Infof("Attempting to run nodejs plugin in %s", req.Info.ProgramDirectory)
+	ctx := context.Background()
+
+	closer, stdout, stderr, err := rpcutil.MakeRunPluginStreams(server, false)
+	if err != nil {
+		return err
+	}
+	// best effort close, but we try an explicit close and error check at the end as well
+	defer closer.Close()
+
+	nodeBin, err := exec.LookPath("node")
+	if err != nil {
+		return err
+	}
+
+	if logging.V(5) {
+		commandStr := strings.Join(req.Args, " ")
+		logging.V(5).Infoln("Language host launching process: ", nodeBin, commandStr)
+	}
+
+	opts, err := parseOptions(req.Info.Options.AsMap())
+	if err != nil {
+		return err
+	}
+
+	env := os.Environ()
+	if opts.typescript {
+		env = append(env, "PULUMI_NODEJS_TYPESCRIPT=true")
+	}
+	if opts.tsconfigpath != "" {
+		env = append(env, "PULUMI_NODEJS_TSCONFIG_PATH="+opts.tsconfigpath)
+	}
+
+	runPath := os.Getenv("PULUMI_LANGUAGE_NODEJS_RUN_PATH")
+	if runPath == "" {
+		runPath = defaultRunPluginPath
+	}
+
+	runPath, err = locateModule(ctx, runPath, req.Info.ProgramDirectory, nodeBin, true)
+	if err != nil {
+		return err
+	}
+
+	args := []string{runPath}
+
+	nodeargs, err := shlex.Split(opts.nodeargs)
+	if err != nil {
+		return err
+	}
+
+	nodeargs = append(nodeargs, req.Info.EntryPoint)
+
+	args = append(args, nodeargs...)
+
+	// Now simply spawn a process to execute the requested program, wiring up stdout/stderr directly.
+	cmd := exec.Command(nodeBin, args...) // nolint: gas // intentionally running dynamic program name.
+	cmd.Dir = req.Pwd
+	cmd.Env = req.Env
+	cmd.Stdout, cmd.Stderr = stdout, stderr
+	if err := cmd.Run(); err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			// If the program ran, but exited with a non-zero error code.  This will happen often, since user
+			// errors will trigger this.  So, the error message should look as nice as possible.
+			if status, stok := exiterr.Sys().(syscall.WaitStatus); stok {
+				err = fmt.Errorf("Program exited with non-zero exit code: %d", status.ExitStatus())
+			} else {
+				err = fmt.Errorf("Program exited unexpectedly: %w", exiterr)
+			}
+		} else {
+			// Otherwise, we didn't even get to run the program.  This ought to never happen unless there's
+			// a bug or system condition that prevented us from running the language exec.  Issue a scarier error.
+			err = fmt.Errorf("Problem executing plugin program (could not run language executor): %w", err)
+		}
+	}
+
+	if err := closer.Close(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (host *nodeLanguageHost) GenerateProject(

--- a/sdk/nodejs/cmd/run-plugin/index.ts
+++ b/sdk/nodejs/cmd/run-plugin/index.ts
@@ -1,0 +1,127 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The very first thing we do is set up unhandled exception and rejection hooks to ensure that these
+// events cause us to exit with a non-zero code. It is critically important that we do this early:
+// if we do not, unhandled rejections in particular may cause us to exit with a 0 exit code, which
+// will trick the engine into thinking that the program ran successfully. This can cause the engine
+// to decide to delete all of a stack's resources.
+//
+// We track all uncaught errors here.  If we have any, we will make sure we always have a non-0 exit
+// code.
+const uncaughtErrors = new Set<Error>();
+
+// We also track errors we know were logged to the user using our standard `log.error` call from
+// inside our uncaught-error-handler in run.ts.  If all uncaught-errors above were also known to all
+// be logged properly to the user, then we know the user has the information they need to proceed.
+// We can then report the langhost that it should just stop running immediately and not print any
+// additional superfluous information.
+const loggedErrors = new Set<Error>();
+
+let programRunning = false;
+const uncaughtHandler = (err: Error) => {
+    uncaughtErrors.add(err);
+    if (!programRunning) {
+        console.error(err.stack || err.message || "" + err);
+    }
+};
+
+// Keep track if we already logged the information about an unhandled error to the user..  If
+// so, we end with a different exit code.  The language host recognizes this and will not print
+// any further messages to the user since we already took care of it.
+//
+// 32 was picked so as to be very unlikely to collide with any of the error codes documented by
+// nodejs here:
+// https://github.com/nodejs/node-v0.x-archive/blob/master/doc/api/process.markdown#exit-codes
+const nodeJSProcessExitedAfterLoggingUserActionableMessage = 32;
+
+process.on("uncaughtException", uncaughtHandler);
+// @ts-ignore 'unhandledRejection' will almost always invoke uncaughtHandler with an Error. so just
+// suppress the TS strictness here.
+process.on("unhandledRejection", uncaughtHandler);
+process.on("exit", (code: number) => {
+    // If there were any uncaught errors at all, we always want to exit with an error code. If we
+    // did not, it could be disastrous for the user.  i.e. not all resources may have been created,
+    // but the 0 code would indicate we could proceed.  That could lead to many (or all) of the
+    // user resources being deleted.
+    if (code === 0 && uncaughtErrors.size > 0) {
+        // Now Check if this error was already logged to the user in a visible fashion.  If not
+        // we will exit with '1', indicating that the host should give a generic message about
+        // things not working.
+        for (const err of uncaughtErrors) {
+            if (!loggedErrors.has(err)) {
+                process.exitCode = 1;
+                return;
+            }
+        }
+
+        process.exitCode = nodeJSProcessExitedAfterLoggingUserActionableMessage;
+    }
+});
+
+// As the second thing we do, ensure that we're connected to v8's inspector API.  We need to do
+// this as some information is only sent out as events, without any way to query for it after the
+// fact.  For example, we want to keep track of ScriptId->FileNames so that we can appropriately
+// report errors for Functions we cannot serialize.  This can only be done (up to Node11 at least)
+// by register to hear about scripts being parsed.
+import * as v8Hooks from "../../runtime/closure/v8Hooks";
+
+// This is the entrypoint for running a Node.js program with minimal scaffolding.
+import minimist from "minimist";
+
+function usage(): void {
+    console.error(`usage: RUN <program>`);
+}
+
+function printErrorUsageAndExit(message: string): never {
+    console.error(message);
+    usage();
+    return process.exit(-1);
+}
+
+function main(args: string[]): void {
+    // See usage above for the intended usage of this program, including flags and required args.
+    const argv: minimist.ParsedArgs = minimist(args, {});
+
+    // Finally, ensure we have a program to run.
+    if (argv._.length < 1) {
+        return printErrorUsageAndExit("error: Usage: RUN <program>");
+    }
+
+    // Ensure that our v8 hooks have been initialized.  Then actually load and run the user program.
+    v8Hooks.isInitializedAsync().then(() => {
+        const promise: Promise<void> = require("./run").run({
+            argv,
+            programStarted: () => {
+                programRunning = true;
+            },
+            reportLoggedError: (err: Error) => loggedErrors.add(err),
+            runInStack: false,
+            typeScript: true, // Should have no deleterious impact on JS codebases.
+        });
+
+        // when the user's program completes successfully, set programRunning back to false.  That
+        // way, if the Pulumi scaffolding code ends up throwing an exception during teardown, it
+        // will get printed directly to the console.
+        //
+        // Note: we only do this in the 'resolved' arg of '.then' (not the 'rejected' arg).  If the
+        // users code throws an exception, this promise will get rejected, and we don't want touch
+        // or otherwise intercept the exception or change the programRunning state here at all.
+        promise.then(() => {
+            programRunning = false;
+        });
+    });
+}
+
+main(process.argv.slice(2));

--- a/sdk/nodejs/cmd/run-plugin/index.ts
+++ b/sdk/nodejs/cmd/run-plugin/index.ts
@@ -37,13 +37,13 @@ const uncaughtHandler = (err: Error) => {
     }
 };
 
-// Keep track if we already logged the information about an unhandled error to the user..  If
-// so, we end with a different exit code.  The language host recognizes this and will not print
+// Keep track if we already logged the information about an unhandled error to the user.  If
+// so, we end with a different exit code. The language host recognizes this and will not print
 // any further messages to the user since we already took care of it.
 //
 // 32 was picked so as to be very unlikely to collide with any of the error codes documented by
 // nodejs here:
-// https://github.com/nodejs/node-v0.x-archive/blob/master/doc/api/process.markdown#exit-codes
+// https://nodejs.org/api/process.html#process_exit_codes
 const nodeJSProcessExitedAfterLoggingUserActionableMessage = 32;
 
 process.on("uncaughtException", uncaughtHandler);
@@ -81,11 +81,10 @@ import * as v8Hooks from "../../runtime/closure/v8Hooks";
 import minimist from "minimist";
 
 function usage(): void {
-    console.error(`usage: RUN <program>`);
+    console.error("usage: RUN <program>");
 }
 
-function printErrorUsageAndExit(message: string): never {
-    console.error(message);
+function printUsageAndExit(): never {
     usage();
     return process.exit(-1);
 }
@@ -96,7 +95,7 @@ function main(args: string[]): void {
 
     // Finally, ensure we have a program to run.
     if (argv._.length < 1) {
-        return printErrorUsageAndExit("error: Usage: RUN <program>");
+        return printUsageAndExit();
     }
 
     // Ensure that our v8 hooks have been initialized.  Then actually load and run the user program.
@@ -107,7 +106,6 @@ function main(args: string[]): void {
                 programRunning = true;
             },
             reportLoggedError: (err: Error) => loggedErrors.add(err),
-            runInStack: false,
             typeScript: true, // Should have no deleterious impact on JS codebases.
         });
 

--- a/sdk/nodejs/cmd/run-plugin/run.ts
+++ b/sdk/nodejs/cmd/run-plugin/run.ts
@@ -30,7 +30,7 @@ import * as stack from "../../runtime/stack";
 //
 // 32 was picked so as to be very unlikely to collide with any of the error codes documented by
 // nodejs here:
-// https://github.com/nodejs/node-v0.x-archive/blob/master/doc/api/process.markdown#exit-codes
+// https://nodejs.org/api/process.html#process_exit_codes
 const nodeJSProcessExitedAfterLoggingUserActionableMessage = 32;
 
 /**
@@ -141,12 +141,13 @@ function throwOrPrintModuleLoadError(program: string, error: Error): void {
 
 /** @internal */
 export interface RunOpts {
-    // TODO: Explicitly pass `main` in here instead of just argv.
-
+    // The argv for the program to start
     argv: minimist.ParsedArgs;
+    // A callback to indicate that the program has started running.
     programStarted: () => void;
+    // A callback to report an error that was logged.
     reportLoggedError: (err: Error) => void;
-    runInStack: boolean;
+    // Whether or not the program is a typescript program.
     typeScript: boolean;
 }
 
@@ -300,5 +301,5 @@ ${errMsg}`,
         }
     };
 
-    return opts.runInStack ? stack.runInPulumiStack(runProgram) : runProgram();
+    return runProgram();
 }

--- a/sdk/nodejs/cmd/run-plugin/run.ts
+++ b/sdk/nodejs/cmd/run-plugin/run.ts
@@ -1,0 +1,304 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The tsnode import is used for type-checking only. Do not reference it in the emitted code.
+import * as tsnode from "ts-node";
+import * as fs from "fs";
+import * as util from "util";
+import * as minimist from "minimist";
+import * as path from "path";
+import * as tsutils from "../../tsutils";
+import { ResourceError, RunError } from "../../errors";
+import * as log from "../../log";
+import * as settings from "../../runtime/settings";
+import * as stack from "../../runtime/stack";
+
+// Keep track if we already logged the information about an unhandled error to the user..  If
+// so, we end with a different exit code.  The language host recognizes this and will not print
+// any further messages to the user since we already took care of it.
+//
+// 32 was picked so as to be very unlikely to collide with any of the error codes documented by
+// nodejs here:
+// https://github.com/nodejs/node-v0.x-archive/blob/master/doc/api/process.markdown#exit-codes
+const nodeJSProcessExitedAfterLoggingUserActionableMessage = 32;
+
+/**
+ * Attempts to provide a detailed error message for module load failure if the
+ * module that failed to load is the top-level module.
+ * @param program The name of the program given to `run`, i.e. the top level module
+ * @param error The error that occured. Must be a module load error.
+ */
+function reportModuleLoadFailure(program: string, error: Error): never {
+    throwOrPrintModuleLoadError(program, error);
+
+    // Note: from this point on, we've printed something to the user telling them about the problem.
+    // So we can let our langhost know it doesn't need to report any further issues.
+    return process.exit(nodeJSProcessExitedAfterLoggingUserActionableMessage);
+}
+
+function throwOrPrintModuleLoadError(program: string, error: Error): void {
+    // error is guaranteed to be a Node module load error. Node emits a very specific string in its
+    // error message for module load errors, which includes the module it was trying to load.
+    const errorRegex = /Cannot find module '(.*)'/;
+
+    // If there's no match, who knows what this exception is; it's not something we can provide an
+    // intelligent diagnostic for.
+    const moduleNameMatches = errorRegex.exec(error.message);
+    if (moduleNameMatches === null) {
+        throw error;
+    }
+
+    // Is the module that failed to load exactly the one that this script considered to be the
+    // top-level module for this program?
+    //
+    // We are only interested in producing good diagnostics for top-level module loads, since
+    // anything else are probably user code issues.
+    const moduleName = moduleNameMatches[1];
+    if (moduleName !== program) {
+        throw error;
+    }
+
+    // Note: from this point on, we've printed something to the user telling them about the problem.
+    // So we can let our langhost know it doesn't need to report any further issues.
+    console.error(`We failed to locate the entry point for your program: ${program}`);
+
+    // From here on out, we're going to try to inspect the program we're being asked to run a little
+    // to see what sort of details we can glean from it, in the hopes of producing a better error
+    // message.
+    //
+    // The first step of this is trying to slurp up a package.json for this program, if one exists.
+    const stat = fs.lstatSync(program);
+    let projectRoot: string;
+    if (stat.isDirectory()) {
+        projectRoot = program;
+    } else {
+        projectRoot = path.dirname(program);
+    }
+
+    let packageObject: Record<string, any>;
+    try {
+        const packageJson = path.join(projectRoot, "package.json");
+        packageObject = require(packageJson);
+    } catch {
+        // This is all best-effort so if we can't load the package.json file, that's
+        // fine.
+        return;
+    }
+
+    console.error("Here's what we think went wrong:");
+
+    // The objective here is to emit the best diagnostic we can, starting from the
+    // most specific to the least specific.
+    const deps = packageObject["dependencies"] || {};
+    const devDeps = packageObject["devDependencies"] || {};
+    const scripts = packageObject["scripts"] || {};
+    const mainProperty = packageObject["main"] || "index.js";
+
+    // Is there a build script associated with this program? It's a little confusing that the Pulumi
+    // CLI doesn't run build scripts before running the program so call that out explicitly.
+
+    if ("build" in scripts) {
+        const command = scripts["build"];
+        console.error(`  * Your program looks like it has a build script associated with it ('${command}').\n`);
+        console.error(
+            "Pulumi does not run build scripts before running your program. " +
+                `Please run '${command}', 'yarn build', or 'npm run build' and try again.`,
+        );
+        return;
+    }
+
+    // Not all typescript programs have build scripts. If we think it's a typescript program, tell
+    // the user to run tsc.
+    if ("typescript" in deps || "typescript" in devDeps) {
+        console.error("  * Your program looks like a TypeScript program. Have you run 'tsc'?");
+        return;
+    }
+
+    // Not all projects are typescript. If there's a main property, check that the file exists.
+    if (mainProperty !== undefined && typeof mainProperty === "string") {
+        const mainFile = path.join(projectRoot, mainProperty);
+        if (!fs.existsSync(mainFile)) {
+            console.error(`  * Your program's 'main' file (${mainFile}) does not exist.`);
+            return;
+        }
+    }
+
+    console.error("  * Pulumi encountered an unexpected error.");
+    console.error(`    Raw exception message: ${error.message}`);
+    return;
+}
+
+/** @internal */
+export interface RunOpts {
+    // TODO: Explicitly pass `main` in here instead of just argv.
+
+    argv: minimist.ParsedArgs;
+    programStarted: () => void;
+    reportLoggedError: (err: Error) => void;
+    runInStack: boolean;
+    typeScript: boolean;
+}
+
+/** @internal */
+export function run(opts: RunOpts): Promise<Record<string, any> | undefined> | Promise<void> {
+    // If there is a --pwd directive, switch directories.
+    const pwd: string | undefined = opts.argv["pwd"];
+    if (pwd) {
+        process.chdir(pwd);
+    }
+
+    // We provide reasonable defaults for many ts options, meaning you don't need to have a
+    // tsconfig.json present if you want to use TypeScript with Pulumi. However, ts-node's default
+    // behavior is to walk up from the cwd to find a tsconfig.json. For us, it's reasonable to say
+    // that the "root" of the project is the cwd, if there's a tsconfig.json file here. Otherwise,
+    // just tell ts-node to not load project options at all. This helps with cases like
+    // pulumi/pulumi#1772.
+    const tsConfigPath = "tsconfig.json";
+
+    if (opts.typeScript) {
+        const { tsnodeRequire, typescriptRequire } = tsutils.typeScriptRequireStrings();
+        const skipProject = !fs.existsSync(tsConfigPath);
+        const compilerOptions: object = tsutils.loadTypeScriptCompilerOptions(tsConfigPath);
+        const tsn: typeof tsnode = require(tsnodeRequire);
+        tsn.register({
+            typeCheck: true,
+            skipProject: skipProject,
+            compiler: typescriptRequire,
+            compilerOptions: {
+                target: "es6",
+                module: "commonjs",
+                moduleResolution: "node",
+                sourceMap: "true",
+                ...compilerOptions,
+            },
+        });
+    }
+
+    let program: string = opts.argv._[0];
+    if (!path.isAbsolute(program)) {
+        // If this isn't an absolute path, make it relative to the working directory.
+        program = path.join(process.cwd(), program);
+    }
+
+    // Now fake out the process-wide argv, to make the program think it was run normally.
+    const programArgs: string[] = opts.argv._.slice(1);
+    process.argv = [process.argv[0], process.argv[1], ...programArgs];
+
+    // Set up the process uncaught exception, unhandled rejection, and program exit handlers.
+    const errorSet = new Set<Error>();
+
+    const uncaughtHandler = (err: Error) => {
+        // In node, if you throw an error in a chained promise, but the exception is not finally
+        // handled, then you can end up getting an unhandledRejection for each exception/promise
+        // pair.  Because the exception is the same through all of these, we keep track of it and
+        // only report it once so the user doesn't get N messages for the same thing.
+        if (errorSet.has(err)) {
+            return;
+        }
+
+        errorSet.add(err);
+
+        // colorize stack trace if exists
+        const stackMessage = err.stack && util.inspect(err, { colors: true });
+
+        // Default message should be to include the full stack (which includes the message), or
+        // fallback to just the message if we can't get the stack.
+        //
+        // If both the stack and message are empty, then just stringify the err object itself. This
+        // is also necessary as users can throw arbitrary things in JS (including non-Errors).
+        const defaultMessage = stackMessage || err.message || "" + err;
+
+        // First, log the error.
+        if (RunError.isInstance(err)) {
+            // Always hide the stack for RunErrors.
+            log.error(err.message);
+        } else if (err.name === "TSError" || err.name === SyntaxError.name) {
+            // Hide stack frames as TSError/SyntaxError have messages containing
+            // where the error is located
+            const errOut = err.stack?.toString() || "";
+            let errMsg = err.message;
+
+            const errParts = errOut.split(err.message);
+            if (errParts.length === 2) {
+                errMsg = errParts[0] + err.message;
+            }
+
+            log.error(
+                `Running program '${program}' failed with an unhandled exception:
+${errMsg}`,
+            );
+        } else if (ResourceError.isInstance(err)) {
+            // Hide the stack if requested to by the ResourceError creator.
+            const message = err.hideStack ? err.message : defaultMessage;
+            log.error(message, err.resource);
+        } else {
+            log.error(
+                `Running program '${program}' failed with an unhandled exception:
+    ${defaultMessage}`,
+            );
+        }
+
+        opts.reportLoggedError(err);
+    };
+
+    process.on("uncaughtException", uncaughtHandler);
+    // @ts-ignore 'unhandledRejection' will almost always invoke uncaughtHandler with an Error. so
+    // just suppress the TS strictness here.
+    process.on("unhandledRejection", uncaughtHandler);
+    process.on("exit", settings.disconnectSync);
+
+    // Trigger callback to update a sentinel variable tracking
+    // whether the program is running.
+    opts.programStarted();
+
+    // Construct a `Stack` resource to represent the outputs of the program.
+    const runProgram = async () => {
+        // We run the program inside this context so that it adopts all resources.
+        //
+        // IDEA: This will miss any resources created on other turns of the event loop.  I think
+        // that's a fundamental problem with the current Component design though - not sure what
+        // else we could do here.
+        //
+        // Now go ahead and execute the code. The process will remain alive until the message
+        // loop empties.
+        log.debug(`Running program '${program}' in pwd '${process.cwd()}' w/ args: ${programArgs}`);
+        try {
+            // Execute the module and capture any module outputs it exported. If the exported value
+            // was itself a Function, then just execute it.  This allows for exported top level
+            // async functions that pulumi programs can live in.  Finally, await the value we get
+            // back.  That way, if it is async and throws an exception, we properly capture it here
+            // and handle it.
+            const reqResult = require(program);
+            const invokeResult = reqResult instanceof Function ? reqResult() : reqResult;
+
+            return await invokeResult;
+        } catch (e) {
+            // User JavaScript can throw anything, so if it's not an Error it's definitely
+            // not something we want to catch up here.
+            if (!(e instanceof Error)) {
+                throw e;
+            }
+
+            // Give a better error message, if we can.
+            const errorCode = (<any>e).code;
+            if (errorCode === "MODULE_NOT_FOUND") {
+                reportModuleLoadFailure(program, e);
+            }
+
+            throw e;
+        }
+    };
+
+    return opts.runInStack ? stack.runInPulumiStack(runProgram) : runProgram();
+}

--- a/sdk/nodejs/cmd/run-policy-pack/index.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/index.ts
@@ -43,7 +43,7 @@ const uncaughtHandler = (err: Error) => {
 //
 // 32 was picked so as to be very unlikely to collide with any of the error codes documented by
 // nodejs here:
-// https://github.com/nodejs/node-v0.x-archive/blob/master/doc/api/process.markdown#exit-codes
+// https://nodejs.org/api/process.html#process_exit_codes
 const nodeJSProcessExitedAfterLoggingUserActionableMessage = 32;
 
 process.on("uncaughtException", uncaughtHandler);
@@ -81,11 +81,10 @@ import * as v8Hooks from "../../runtime/closure/v8Hooks";
 import minimist from "minimist";
 
 function usage(): void {
-    console.error(`usage: RUN <engine-address> <program>`);
+    console.error("usage: RUN <engine-address> <program>");
 }
 
-function printErrorUsageAndExit(message: string): never {
-    console.error(message);
+function printUsageAndExit(): never {
     usage();
     return process.exit(-1);
 }
@@ -96,7 +95,7 @@ function main(args: string[]): void {
 
     // Finally, ensure we have a program to run.
     if (argv._.length < 2) {
-        return printErrorUsageAndExit("error: Usage: RUN <engine-address> <program>");
+        return printUsageAndExit();
     }
 
     // Remove <engine-address> so we simply execute the program.

--- a/sdk/nodejs/cmd/run-policy-pack/run.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/run.ts
@@ -30,7 +30,7 @@ import * as stack from "../../runtime/stack";
 //
 // 32 was picked so as to be very unlikely to collide with any of the error codes documented by
 // nodejs here:
-// https://github.com/nodejs/node-v0.x-archive/blob/master/doc/api/process.markdown#exit-codes
+// https://nodejs.org/api/process.html#process_exit_codes
 const nodeJSProcessExitedAfterLoggingUserActionableMessage = 32;
 
 /**
@@ -141,8 +141,6 @@ function throwOrPrintModuleLoadError(program: string, error: Error): void {
 
 /** @internal */
 export interface RunOpts {
-    // TODO: Explicitly pass `main` in here instead of just argv.
-
     argv: minimist.ParsedArgs;
     programStarted: () => void;
     reportLoggedError: (err: Error) => void;

--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -47,7 +47,7 @@ const uncaughtHandler = (err: Error) => {
 //
 // 32 was picked so as to be very unlikely to collide with any of the error codes documented by
 // nodejs here:
-// https://github.com/nodejs/node-v0.x-archive/blob/master/doc/api/process.markdown#exit-codes
+// https://nodejs.org/api/process.html#process_exit_codes
 /** @internal */
 export const nodeJSProcessExitedAfterLoggingUserActionableMessage = 32;
 

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -61,6 +61,8 @@
         "cmd/run/index.ts",
         "cmd/run/run.ts",
         "cmd/run/tracing.ts",
+        "cmd/run-plugin/index.ts",
+        "cmd/run-plugin/run.ts",
         "cmd/run-policy-pack/index.ts",
         "cmd/run-policy-pack/run.ts",
         "automation/index.ts",


### PR DESCRIPTION
Implement RunPlugin for NodeJS. This follows a similar path as the rest of the language runtime does, spawning a NodeJS program, which in turn runs the plugin itself.  The run-plugin code was cribbed from run-policy-pack, which works similarly.

Note that this means that in addition to a recent language runtime, this also requires the plugin to reference a recent version of the Pulumi SDK.  Since the main purpose of implementing this is supporting a new feature that should be okay though.

Fixes https://github.com/pulumi/pulumi/issues/17663