### PR TITLE
Generate more accurate reproductions when fuzzing

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/program.go
+++ b/pkg/engine/lifecycletest/fuzzing/program.go
@@ -140,7 +140,7 @@ func (ps *ProgramSpec) Pretty(indent string) string {
 	} else {
 		rendered += fmt.Sprintf("\n%s  Registrations (%d):", indent, len(ps.ResourceRegistrations))
 		for _, r := range ps.ResourceRegistrations {
-			rendered += fmt.Sprintf("\n%s%s", indent, r.Pretty(indent+"    "))
+			rendered += fmt.Sprintf("\n%s    %s", indent, r.Pretty(indent+"    "))
 		}
 	}
 
@@ -149,7 +149,7 @@ func (ps *ProgramSpec) Pretty(indent string) string {
 	} else {
 		rendered += fmt.Sprintf("\n%s  Drops (%d):", indent, len(ps.Drops))
 		for _, r := range ps.Drops {
-			rendered += fmt.Sprintf("\n%s%s", indent, r.Pretty(indent+"    "))
+			rendered += fmt.Sprintf("\n%s    %s", indent, r.Pretty(indent+"    "))
 		}
 	}
 

--- a/pkg/engine/lifecycletest/fuzzing/snapshot.go
+++ b/pkg/engine/lifecycletest/fuzzing/snapshot.go
@@ -36,6 +36,24 @@ type SnapshotSpec struct {
 	Resources []*ResourceSpec
 }
 
+// Creates a SnapshotSpec from the given deploy.Snapshot.
+func FromSnapshot(s *deploy.Snapshot) *SnapshotSpec {
+	ss := &SnapshotSpec{
+		Providers: map[tokens.Package]*ResourceSpec{},
+	}
+
+	for _, r := range s.Resources {
+		rs := FromResource(r)
+		if providers.IsProviderType(rs.Type) {
+			ss.AddProvider(rs)
+		} else {
+			ss.AddResource(rs)
+		}
+	}
+
+	return ss
+}
+
 // Creates a SnapshotSpec from the ResourceV3s in the given DeploymentV3.
 func FromDeploymentV3(d *apitype.DeploymentV3) *SnapshotSpec {
 	ss := &SnapshotSpec{
@@ -90,7 +108,7 @@ func (s *SnapshotSpec) Pretty(indent string) string {
 	} else {
 		rendered += fmt.Sprintf("\n%s  Resources (%d):", indent, len(s.Resources))
 		for _, r := range s.Resources {
-			rendered += fmt.Sprintf("\n%s%s", indent, r.Pretty(indent+"    "))
+			rendered += fmt.Sprintf("\n%s    %s", indent, r.Pretty(indent+"    "))
 		}
 	}
 


### PR DESCRIPTION
Fuzzed lifecycle tests work slightly differently to their handwritten counterparts. A handwritten test will typically "start from nothing". An initial snapshot is built from an empty state and starting program, before subsequent operations are executed on this state to test behaviour. In constrast, fuzzed tests create arbitrary starting snapshots "out of thin air", before running an operation to see if a bug can be triggered. Ideally, any starting state conjured by a fuzz test is actually reproducible from an empty state and some combination of operations, but it may be that this is not the case, or that the number of operations required to reach the state is very high. In such cases, it is handy to have the exact code the fuzz test used to hand when reproducing and isolating behaviour. To this end, this commit extends the `reprogen` functionality of the suite to generate this code as well as the existing "handwritten" approximation. This should also aid in minimising failing test cases quickly when bugs are found.