### PR TITLE
implement parameterize in the NodeJS provider interface

### DIFF
--- a/changelog/pending/20241111--sdk-nodejs--support-parameterization-for-typescript-providers.yaml
+++ b/changelog/pending/20241111--sdk-nodejs--support-parameterization-for-typescript-providers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Support parameterization for TypeScript providers

--- a/sdk/nodejs/provider/provider.ts
+++ b/sdk/nodejs/provider/provider.ts
@@ -154,6 +154,24 @@ export interface InvokeResult {
 }
 
 /**
+ * {@link ParameterizeResult} represents the results of a call to
+ * {@link ResourceProvider.parameterize}.  It contains the ame and
+ * version that can be used to identify the sub-package that now
+ * exists as a result of parameterization.
+ */
+export interface ParameterizeResult {
+    /**
+     * The name of the sub-package parameterized.
+     */
+    readonly name: string;
+
+    /**
+     * The version of the sub-package parameterized.
+     */
+    readonly version: string;
+}
+
+/**
  * {@link Provider} represents an object that implements the resources and
  * functions for a particular Pulumi package.
  */
@@ -269,4 +287,26 @@ export interface Provider {
      *  The inputs to the function.
      */
     invoke?: (token: string, inputs: any) => Promise<InvokeResult>;
+
+    /**
+     * Parameterizes a sub-package.
+     *
+     * @param args
+     *   A parameter value, represented as an array of strings,
+     *   as might be provided by a command-line invocation, such
+     *   as that used to generate an SDK.
+     */
+    parameterizeArgs?: (args: string[]) => Promise<ParameterizeResult>;
+
+    /**
+     * Parameterizes a sub-package.
+     *
+     * @param name
+     *   The sub-package name for this sub-schema parameterization.
+     * @param version
+     *   The sub-package version for this sub-schema parameterization.
+     * @param value
+     *   The embedded value from the sub-package.
+     */
+    parameterizeValue?: (name: string, version: string, value: string) => Promise<ParameterizeResult>;
 }

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -128,23 +128,23 @@ class Server implements grpc.UntypedServiceImplementation {
         let res = null;
         if (call.request.hasArgs()) {
             if (!this.provider.parameterizeArgs) {
-		callback(new Error("parameterizeArgs not implemented"), undefined);
-		return;
+                callback(new Error("parameterizeArgs not implemented"), undefined);
+                return;
             }
 
-	    res = await this.provider.parameterizeArgs(call.request.getArgs().getArgsList());
+            res = await this.provider.parameterizeArgs(call.request.getArgs().getArgsList());
         } else {
             if (!this.provider.parameterizeValue) {
-		callback(new Error("parameterizeValue not implemented"), undefined);
-		return;
+                callback(new Error("parameterizeValue not implemented"), undefined);
+                return;
             }
 
-	    const b64 = call.request.getValue().getValue_asB64();
-	    res = await this.provider.parameterizeValue(
-		call.request.getValue().getName(),
-		call.request.getValue().getVersion(),
-		Buffer.from(b64, 'base64').toString('utf-8'),
-	    );
+            const b64 = call.request.getValue().getValue_asB64();
+            res = await this.provider.parameterizeValue(
+                call.request.getValue().getName(),
+                call.request.getValue().getVersion(),
+                Buffer.from(b64, "base64").toString("utf-8"),
+            );
         }
 
         const resp = new provproto.ParameterizeResponse();

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -124,6 +124,35 @@ class Server implements grpc.UntypedServiceImplementation {
         callback(undefined, resp);
     }
 
+    public async parameterize(call: any, callback: any): Promise<void> {
+        let res = null;
+        if (call.request.hasArgs()) {
+            if (!this.provider.parameterizeArgs) {
+		callback(new Error("parameterizeArgs not implemented"), undefined);
+		return;
+            }
+
+	    res = await this.provider.parameterizeArgs(call.request.getArgs().getArgsList());
+        } else {
+            if (!this.provider.parameterizeValue) {
+		callback(new Error("parameterizeValue not implemented"), undefined);
+		return;
+            }
+
+	    const b64 = call.request.getValue().getValue_asB64();
+	    res = await this.provider.parameterizeValue(
+		call.request.getValue().getName(),
+		call.request.getValue().getVersion(),
+		Buffer.from(b64, 'base64').toString('utf-8'),
+	    );
+        }
+
+        const resp = new provproto.ParameterizeResponse();
+        resp.setName(res.name);
+        resp.setVersion(res.version);
+        callback(undefined, resp);
+    }
+
     // CRUD resource methods
 
     public async check(call: any, callback: any): Promise<void> {


### PR DESCRIPTION
Parameterized providers are currently only possible to use in Go. However we want to bring this functionality to other languages as well.  Implement this in NodeJS.

There's potentially still an API design question here.  I've split the parameterize method up into `parameterizeValue` and `parameterizeArgs` functions, which should be easier to use for the implementer, as TypeScript doesn't support overloading with different types.  Curious about peoples thoughts on that.

Fixes https://github.com/pulumi/pulumi/issues/17733