### PR TITLE
run the full language matrix of tests daily

### DIFF
--- a/.github/workflows/cron-test-all.yml
+++ b/.github/workflows/cron-test-all.yml
@@ -1,0 +1,60 @@
+name: Run full language matrix of tests daily
+
+on:
+  schedule:
+    - cron: "27 5 * * *"
+
+jobs:
+  info:
+    name: info
+    uses: ./.github/workflows/ci-info.yml
+    permissions:
+      contents: read
+    with:
+      ref: ${{ github.ref }}
+      is-snapshot: true
+    secrets: inherit
+
+  ci:
+    name: CI
+    needs: [info]
+    uses: ./.github/workflows/ci.yml
+    permissions:
+      contents: read
+    with:
+      ref: ${{ github.ref }}
+      version: ${{ needs.info.outputs.version }}
+      lint: true
+      # codegen tests are not the fastest, but we want to run them
+      # on PR to get correct coverage numbers.
+      test-codegen: true
+      test-version-sets: 'all'
+      integration-test-platforms: ubuntu-latest
+      acceptance-test-platforms: 'macos-latest windows-latest'
+      enable-coverage: true
+    secrets: inherit
+
+  performance-gate:
+    name: Performance Gate
+    needs: [info]
+    uses: ./.github/workflows/ci-performance-gate.yml
+    permissions:
+      contents: read
+    with:
+      ref: ${{ github.ref }}
+      version: ${{ needs.info.outputs.version }}
+      test-version-sets: 'all'
+      performance-test-platforms: ubuntu-latest
+    secrets: inherit
+
+  ci-ok:
+    name: ci-ok
+    needs: [ci, performance-gate]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI failed
+        if: ${{ needs.ci.result != 'success' }}
+        run: exit 1
+      - name: CI succeeded
+        run: exit 0

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -144,10 +144,9 @@ MINIMUM_SUPPORTED_VERSION_SET = {
 }
 
 ALL_VERSION_SET = {
-    "name": ["all"],
-    "dotnet": ["6", "7", "8"],
+    "dotnet": ["6", "8"],
     "go": ["1.22.x", "1.23.x"],
-    "nodejs": ["18.x", "19.x", "20.x", "21.x", "22.x", "23.x"],
+    "nodejs": ["18.x", "20.x", "22.x", "23.x"],
     "python": ["3.8.x", "3.9.x", "3.10.x", "3.11.x", "3.12.x", "3.13.x"],
 }
 
@@ -465,6 +464,8 @@ def get_version_sets(args: argparse.Namespace):
             longest = len(ALL_VERSION_SET[max(ALL_VERSION_SET, key=lambda k: len(ALL_VERSION_SET[k]))])
             for i in range(0, longest):
                 this_set = {**MINIMUM_SUPPORTED_VERSION_SET}
+                # Set the name.  This will be shown in the name of the CI job.
+                this_set["name"] = f"all-{i}"
                 for lang, versions in ALL_VERSION_SET.items():
                     if len(versions) > i:
                         this_set[lang] = versions[i]

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -143,6 +143,14 @@ MINIMUM_SUPPORTED_VERSION_SET = {
     "python": "3.8.x",
 }
 
+ALL_VERSION_SET = {
+    "name": ["all"],
+    "dotnet": ["6", "7", "8"],
+    "go": ["1.22.x", "1.23.x"],
+    "nodejs": ["18.x", "19.x", "20.x", "21.x", "22.x", "23.x"],
+    "python": ["3.8.x", "3.9.x", "3.10.x", "3.11.x", "3.12.x", "3.13.x"],
+}
+
 CURRENT_VERSION_SET = {
     "name": "current",
     "dotnet": "8",
@@ -453,6 +461,14 @@ def get_version_sets(args: argparse.Namespace):
             version_sets.append(MINIMUM_SUPPORTED_VERSION_SET)
         elif named_version_set == "current":
             version_sets.append(CURRENT_VERSION_SET)
+        elif named_version_set == "all":
+            longest = len(ALL_VERSION_SET[max(ALL_VERSION_SET, key=lambda k: len(ALL_VERSION_SET[k]))])
+            for i in range(0, longest):
+                this_set = {**MINIMUM_SUPPORTED_VERSION_SET}
+                for lang, versions in ALL_VERSION_SET.items():
+                    if len(versions) > i:
+                        this_set[lang] = versions[i]
+                version_sets.append(this_set)
         else:
             raise argparse.ArgumentError(argument=None, message=f"Unknown version set {named_version_set}")
 
@@ -568,7 +584,7 @@ def add_generate_matrix_args(parser: argparse.ArgumentParser):
         action="store",
         nargs="*",
         default=["minimum"],
-        choices=["minimum", "current"],
+        choices=["minimum", "current", "all"],
         help="Named set of versions to use. Defaults to minimum supported versions. Available sets: minimum, current",
     )
     default_versions = ",".join(


### PR DESCRIPTION
Currently we run all tests twice when running the tests in the merge queue.  Once with the oldest version of all languages we support, and once with the most recent one.  This leaves out all of the ones in the middle.

Ideally we would like to test all of those as well, but that's way too expensive to do on every merge.  Instead add a cron job that does exactly this test once a day.  If it fails this will automatically open an issue for us to take a look.

This will end up being quite a lot of jobs, so we're trying to run after the workday finished in the Americas, and before it starts in Europe, as to not overwhelm CI too much, as most employees will be asleep (apart from @brandonpollack23, but hopefully there's still enough CI runners left to pick up those jobs).

One potential downside is that we might get more issues opened because of CI flakyness (e.g. especially downloading dependencies etc.), but it's probably worth a try and see if that's going to be too annoying. For the most part these tests should always be green, unless something is really screwy.

Hopefully this will also allow us to only run one version set (probably minimum to make sure we're backwards compatible) during merge, so overall it might even reduce the load on the CI system.  We should however only do that once this has been proven out, so that will be a separate PR.