### PR TITLE
document property paths in the providers implementers guide

### DIFF
--- a/developer-docs/providers/implementers-guide.md
+++ b/developer-docs/providers/implementers-guide.md
@@ -131,7 +131,9 @@ secret value, and should wrap any resource output values that are always sensiti
 
 #### Property Paths
 
-TODO: write this up
+A `Property Path` represents a path to one or more properties within a set of values.
+See the [type system documentation](property-paths) for
+more information.
 
 ## Schema
 


### PR DESCRIPTION
We already have documentation for these, so just add a sentence and a link to the docs that have some more information on this.