### PR TITLE
Fix merging InvokeOptions.version

### DIFF
--- a/changelog/pending/20241112--sdk-python--fix-merging-invokeoptions-version.yaml
+++ b/changelog/pending/20241112--sdk-python--fix-merging-invokeoptions-version.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix merging InvokeOptions.version

--- a/sdk/python/lib/pulumi/invoke.py
+++ b/sdk/python/lib/pulumi/invoke.py
@@ -131,7 +131,7 @@ class InvokeOptions:
             if source.plugin_download_url is None
             else source.plugin_download_url
         )
-        dest.version = dest.version if source.version is None else source.version
+        dest.version = dest.version if (source.version in [None, ""]) else source.version
 
         return dest
 

--- a/sdk/python/lib/pulumi/invoke.py
+++ b/sdk/python/lib/pulumi/invoke.py
@@ -131,7 +131,9 @@ class InvokeOptions:
             if source.plugin_download_url is None
             else source.plugin_download_url
         )
-        dest.version = dest.version if (source.version in [None, ""]) else source.version
+        dest.version = (
+            dest.version if (source.version in [None, ""]) else source.version
+        )
 
         return dest
 

--- a/sdk/python/lib/pulumi/invoke.py
+++ b/sdk/python/lib/pulumi/invoke.py
@@ -54,7 +54,7 @@ class InvokeOptions:
         self,
         parent: Optional["Resource"] = None,
         provider: Optional["ProviderResource"] = None,
-        version: Optional[str] = "",
+        version: Optional[str] = None,
         plugin_download_url: Optional[str] = None,
     ) -> None:
         """
@@ -131,9 +131,7 @@ class InvokeOptions:
             if source.plugin_download_url is None
             else source.plugin_download_url
         )
-        dest.version = (
-            dest.version if (source.version in [None, ""]) else source.version
-        )
+        dest.version = dest.version if source.version is None else source.version
 
         return dest
 

--- a/sdk/python/lib/test/test_invoke.py
+++ b/sdk/python/lib/test/test_invoke.py
@@ -98,6 +98,7 @@ def test_invoke_empty_return(tok: str, version: str, empty: bool, expected) -> N
         (InvokeOptions(version="1.0.0"), InvokeOptions(version="2.0.0"), "2.0.0"),
         (None, InvokeOptions(version="2.0.0"), "2.0.0"),
         (InvokeOptions(version="1.0.0"), None, "1.0.0"),
+        (InvokeOptions(version="1.0.0"), InvokeOptions(version=""), ""),
     ],
 )
 def test_invoke_merge(a: InvokeOptions, b: InvokeOptions, expected: str) -> None:

--- a/sdk/python/lib/test/test_invoke.py
+++ b/sdk/python/lib/test/test_invoke.py
@@ -15,6 +15,7 @@
 import pytest
 
 import pulumi
+from pulumi import InvokeOptions
 
 
 class MyMocks(pulumi.runtime.Mocks):
@@ -89,3 +90,17 @@ def test_invoke_empty_return(tok: str, version: str, empty: bool, expected) -> N
     props = {"empty": True} if empty else {}
     opts = pulumi.InvokeOptions(version=version) if version else None
     assert pulumi.runtime.invoke(tok, props, opts).value == expected
+
+
+@pytest.mark.parametrize(
+    "a,b,expected",
+    [
+        (InvokeOptions(version="1.0.0"), InvokeOptions(version="2.0.0"), "2.0.0"),
+        (None, InvokeOptions(version="2.0.0"), "2.0.0"),
+        (InvokeOptions(version="1.0.0"), None, "1.0.0"),
+    ]
+)
+def test_invoke_merge(a: InvokeOptions, b: InvokeOptions, expected: str) -> None:
+    if a is not None:
+        assert a.merge(b).version == expected
+    assert InvokeOptions.merge(a, b).version == expected

--- a/sdk/python/lib/test/test_invoke.py
+++ b/sdk/python/lib/test/test_invoke.py
@@ -98,7 +98,7 @@ def test_invoke_empty_return(tok: str, version: str, empty: bool, expected) -> N
         (InvokeOptions(version="1.0.0"), InvokeOptions(version="2.0.0"), "2.0.0"),
         (None, InvokeOptions(version="2.0.0"), "2.0.0"),
         (InvokeOptions(version="1.0.0"), None, "1.0.0"),
-    ]
+    ],
 )
 def test_invoke_merge(a: InvokeOptions, b: InvokeOptions, expected: str) -> None:
     if a is not None:


### PR DESCRIPTION
`InvokeOptions.version` was defaulting to the empty string `""` and not `None`, see https://github.com/pulumi/pulumi/blob/1a97d95583a491bb32ec24fe71817f1627f1cf58/sdk/python/lib/pulumi/invoke.py#L57

While working on https://github.com/pulumi/pulumi/issues/17749 I noticed that the merge function was not expecting the empty string, and clearing out the version on merge when it probably shouldn't.

Since this is typed as `Optional[str]`, code that uses this value already has to deal with `None`, and we can update it to default to `None` instead.