### PR TITLE
pass correct working directory to RunPlugin

### DIFF
--- a/changelog/pending/20241113--engine--pass-correct-working-directory-to-runplugin.yaml
+++ b/changelog/pending/20241113--engine--pass-correct-working-directory-to-runplugin.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Pass correct working directory to RunPlugin

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -444,7 +444,7 @@ func (h *langhost) RunPlugin(info RunPluginInfo) (io.Reader, io.Reader, context.
 	ctx, kill := context.WithCancel(h.ctx.Request())
 
 	resp, err := h.client.RunPlugin(ctx, &pulumirpc.RunPluginRequest{
-		Pwd:  minfo.GetProgramDirectory(),
+		Pwd:  info.WorkingDirectory,
 		Args: info.Args,
 		Env:  info.Env,
 		Info: minfo,

--- a/sdk/go/common/resource/plugin/langruntime_test.go
+++ b/sdk/go/common/resource/plugin/langruntime_test.go
@@ -15,9 +15,15 @@
 package plugin
 
 import (
+	"context"
 	"testing"
 
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/require"
+
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	grpc "google.golang.org/grpc"
 )
 
 func TestMakeExecutablePromptChoices(t *testing.T) {
@@ -41,4 +47,82 @@ func TestMakeExecutablePromptChoices(t *testing.T) {
 	require.Equal(t, choices[2].DisplayName, "zzz_does_not_exist [not found]")
 	require.Equal(t, choices[3].StringValue, "aaa_does_not_exist")
 	require.Equal(t, choices[3].DisplayName, "aaa_does_not_exist [not found]")
+}
+
+type MockLanguageRuntimeClient struct {
+	RunPluginF (func(ctx context.Context, info *pulumirpc.RunPluginRequest) (pulumirpc.LanguageRuntime_RunPluginClient, error))
+}
+
+func (m *MockLanguageRuntimeClient) RunPlugin(ctx context.Context, info *pulumirpc.RunPluginRequest, _ ...grpc.CallOption) (pulumirpc.LanguageRuntime_RunPluginClient, error) {
+	return m.RunPluginF(ctx, info)
+}
+
+func (m *MockLanguageRuntimeClient) GetRequiredPlugins(ctx context.Context, in *pulumirpc.GetRequiredPluginsRequest, opts ...grpc.CallOption) (*pulumirpc.GetRequiredPluginsResponse, error) {
+	panic("not implemented")
+}
+
+func (m *MockLanguageRuntimeClient) Run(ctx context.Context, in *pulumirpc.RunRequest, opts ...grpc.CallOption) (*pulumirpc.RunResponse, error) {
+	panic("not implemented")
+}
+
+func (m *MockLanguageRuntimeClient) GetPluginInfo(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*pulumirpc.PluginInfo, error) {
+	panic("not implemented")
+}
+
+func (m *MockLanguageRuntimeClient) InstallDependencies(ctx context.Context, in *pulumirpc.InstallDependenciesRequest, opts ...grpc.CallOption) (pulumirpc.LanguageRuntime_InstallDependenciesClient, error) {
+	panic("not implemented")
+}
+
+func (m *MockLanguageRuntimeClient) RuntimeOptionsPrompts(ctx context.Context, in *pulumirpc.RuntimeOptionsRequest, opts ...grpc.CallOption) (*pulumirpc.RuntimeOptionsResponse, error) {
+	panic("not implemented")
+}
+
+func (m *MockLanguageRuntimeClient) About(ctx context.Context, in *pulumirpc.AboutRequest, opts ...grpc.CallOption) (*pulumirpc.AboutResponse, error) {
+	panic("not implemented")
+}
+
+func (m *MockLanguageRuntimeClient) GetProgramDependencies(ctx context.Context, in *pulumirpc.GetProgramDependenciesRequest, opts ...grpc.CallOption) (*pulumirpc.GetProgramDependenciesResponse, error) {
+	panic("not implemented")
+}
+
+func (m *MockLanguageRuntimeClient) GenerateProgram(ctx context.Context, in *pulumirpc.GenerateProgramRequest, opts ...grpc.CallOption) (*pulumirpc.GenerateProgramResponse, error) {
+	panic("not implemented")
+}
+
+func (m *MockLanguageRuntimeClient) GenerateProject(ctx context.Context, in *pulumirpc.GenerateProjectRequest, opts ...grpc.CallOption) (*pulumirpc.GenerateProjectResponse, error) {
+	panic("not implemented")
+}
+
+func (m *MockLanguageRuntimeClient) GeneratePackage(ctx context.Context, in *pulumirpc.GeneratePackageRequest, opts ...grpc.CallOption) (*pulumirpc.GeneratePackageResponse, error) {
+	panic("not implemented")
+}
+
+func (m *MockLanguageRuntimeClient) Pack(ctx context.Context, in *pulumirpc.PackRequest, opts ...grpc.CallOption) (*pulumirpc.PackResponse, error) {
+	panic("not implemented")
+}
+
+func TestRunPluginPassesCorrectPwd(t *testing.T) {
+	t.Parallel()
+
+	mockLanguageRuntime := &MockLanguageRuntimeClient{
+		RunPluginF: func(ctx context.Context, info *pulumirpc.RunPluginRequest) (pulumirpc.LanguageRuntime_RunPluginClient, error) {
+			require.Equal(t, "/tmp", info.Pwd)
+			return nil, nil
+		},
+	}
+
+	pCtx, err := NewContext(nil, nil, nil, nil, "", nil, false, nil)
+	require.NoError(t, err)
+	host := &langhost{
+		ctx:     pCtx,
+		runtime: "go",
+		plug:    nil,
+		client:  mockLanguageRuntime,
+	}
+
+	// Test that the plugin is run with the correct working directory.
+	_, _, _, err = host.RunPlugin(RunPluginInfo{
+		WorkingDirectory: "/tmp",
+	})
+	require.NoError(t, err)
 }

--- a/sdk/go/common/resource/plugin/langruntime_test.go
+++ b/sdk/go/common/resource/plugin/langruntime_test.go
@@ -16,6 +16,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
@@ -129,12 +130,13 @@ func (m *MockLanguageRuntimeClient) Pack(
 func TestRunPluginPassesCorrectPwd(t *testing.T) {
 	t.Parallel()
 
+	returnErr := errors.New("erroring so we don't need to implement the whole thing")
 	mockLanguageRuntime := &MockLanguageRuntimeClient{
 		RunPluginF: func(
 			ctx context.Context, info *pulumirpc.RunPluginRequest,
 		) (pulumirpc.LanguageRuntime_RunPluginClient, error) {
 			require.Equal(t, "/tmp", info.Pwd)
-			return nil, nil
+			return nil, returnErr
 		},
 	}
 
@@ -151,5 +153,5 @@ func TestRunPluginPassesCorrectPwd(t *testing.T) {
 	_, _, _, err = host.RunPlugin(RunPluginInfo{
 		WorkingDirectory: "/tmp",
 	})
-	require.NoError(t, err)
+	require.Equal(t, returnErr, err)
 }

--- a/sdk/go/common/resource/plugin/langruntime_test.go
+++ b/sdk/go/common/resource/plugin/langruntime_test.go
@@ -50,54 +50,79 @@ func TestMakeExecutablePromptChoices(t *testing.T) {
 }
 
 type MockLanguageRuntimeClient struct {
-	RunPluginF (func(ctx context.Context, info *pulumirpc.RunPluginRequest) (pulumirpc.LanguageRuntime_RunPluginClient, error))
+	RunPluginF (func(ctx context.Context, info *pulumirpc.RunPluginRequest,
+	) (pulumirpc.LanguageRuntime_RunPluginClient, error))
 }
 
-func (m *MockLanguageRuntimeClient) RunPlugin(ctx context.Context, info *pulumirpc.RunPluginRequest, _ ...grpc.CallOption) (pulumirpc.LanguageRuntime_RunPluginClient, error) {
+func (m *MockLanguageRuntimeClient) RunPlugin(
+	ctx context.Context, info *pulumirpc.RunPluginRequest, _ ...grpc.CallOption,
+) (pulumirpc.LanguageRuntime_RunPluginClient, error) {
 	return m.RunPluginF(ctx, info)
 }
 
-func (m *MockLanguageRuntimeClient) GetRequiredPlugins(ctx context.Context, in *pulumirpc.GetRequiredPluginsRequest, opts ...grpc.CallOption) (*pulumirpc.GetRequiredPluginsResponse, error) {
+func (m *MockLanguageRuntimeClient) GetRequiredPlugins(
+	ctx context.Context, in *pulumirpc.GetRequiredPluginsRequest, opts ...grpc.CallOption,
+) (*pulumirpc.GetRequiredPluginsResponse, error) {
 	panic("not implemented")
 }
 
-func (m *MockLanguageRuntimeClient) Run(ctx context.Context, in *pulumirpc.RunRequest, opts ...grpc.CallOption) (*pulumirpc.RunResponse, error) {
+func (m *MockLanguageRuntimeClient) Run(
+	ctx context.Context, in *pulumirpc.RunRequest, opts ...grpc.CallOption,
+) (*pulumirpc.RunResponse, error) {
 	panic("not implemented")
 }
 
-func (m *MockLanguageRuntimeClient) GetPluginInfo(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*pulumirpc.PluginInfo, error) {
+func (m *MockLanguageRuntimeClient) GetPluginInfo(
+	ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption,
+) (*pulumirpc.PluginInfo, error) {
 	panic("not implemented")
 }
 
-func (m *MockLanguageRuntimeClient) InstallDependencies(ctx context.Context, in *pulumirpc.InstallDependenciesRequest, opts ...grpc.CallOption) (pulumirpc.LanguageRuntime_InstallDependenciesClient, error) {
+func (m *MockLanguageRuntimeClient) InstallDependencies(
+	ctx context.Context, in *pulumirpc.InstallDependenciesRequest, opts ...grpc.CallOption,
+) (pulumirpc.LanguageRuntime_InstallDependenciesClient, error) {
 	panic("not implemented")
 }
 
-func (m *MockLanguageRuntimeClient) RuntimeOptionsPrompts(ctx context.Context, in *pulumirpc.RuntimeOptionsRequest, opts ...grpc.CallOption) (*pulumirpc.RuntimeOptionsResponse, error) {
+func (m *MockLanguageRuntimeClient) RuntimeOptionsPrompts(
+	ctx context.Context, in *pulumirpc.RuntimeOptionsRequest, opts ...grpc.CallOption,
+) (*pulumirpc.RuntimeOptionsResponse, error) {
 	panic("not implemented")
 }
 
-func (m *MockLanguageRuntimeClient) About(ctx context.Context, in *pulumirpc.AboutRequest, opts ...grpc.CallOption) (*pulumirpc.AboutResponse, error) {
+func (m *MockLanguageRuntimeClient) About(
+	ctx context.Context, in *pulumirpc.AboutRequest, opts ...grpc.CallOption,
+) (*pulumirpc.AboutResponse, error) {
 	panic("not implemented")
 }
 
-func (m *MockLanguageRuntimeClient) GetProgramDependencies(ctx context.Context, in *pulumirpc.GetProgramDependenciesRequest, opts ...grpc.CallOption) (*pulumirpc.GetProgramDependenciesResponse, error) {
+func (m *MockLanguageRuntimeClient) GetProgramDependencies(
+	ctx context.Context, in *pulumirpc.GetProgramDependenciesRequest, opts ...grpc.CallOption,
+) (*pulumirpc.GetProgramDependenciesResponse, error) {
 	panic("not implemented")
 }
 
-func (m *MockLanguageRuntimeClient) GenerateProgram(ctx context.Context, in *pulumirpc.GenerateProgramRequest, opts ...grpc.CallOption) (*pulumirpc.GenerateProgramResponse, error) {
+func (m *MockLanguageRuntimeClient) GenerateProgram(
+	ctx context.Context, in *pulumirpc.GenerateProgramRequest, opts ...grpc.CallOption,
+) (*pulumirpc.GenerateProgramResponse, error) {
 	panic("not implemented")
 }
 
-func (m *MockLanguageRuntimeClient) GenerateProject(ctx context.Context, in *pulumirpc.GenerateProjectRequest, opts ...grpc.CallOption) (*pulumirpc.GenerateProjectResponse, error) {
+func (m *MockLanguageRuntimeClient) GenerateProject(
+	ctx context.Context, in *pulumirpc.GenerateProjectRequest, opts ...grpc.CallOption,
+) (*pulumirpc.GenerateProjectResponse, error) {
 	panic("not implemented")
 }
 
-func (m *MockLanguageRuntimeClient) GeneratePackage(ctx context.Context, in *pulumirpc.GeneratePackageRequest, opts ...grpc.CallOption) (*pulumirpc.GeneratePackageResponse, error) {
+func (m *MockLanguageRuntimeClient) GeneratePackage(
+	ctx context.Context, in *pulumirpc.GeneratePackageRequest, opts ...grpc.CallOption,
+) (*pulumirpc.GeneratePackageResponse, error) {
 	panic("not implemented")
 }
 
-func (m *MockLanguageRuntimeClient) Pack(ctx context.Context, in *pulumirpc.PackRequest, opts ...grpc.CallOption) (*pulumirpc.PackResponse, error) {
+func (m *MockLanguageRuntimeClient) Pack(
+	ctx context.Context, in *pulumirpc.PackRequest, opts ...grpc.CallOption,
+) (*pulumirpc.PackResponse, error) {
 	panic("not implemented")
 }
 
@@ -105,7 +130,9 @@ func TestRunPluginPassesCorrectPwd(t *testing.T) {
 	t.Parallel()
 
 	mockLanguageRuntime := &MockLanguageRuntimeClient{
-		RunPluginF: func(ctx context.Context, info *pulumirpc.RunPluginRequest) (pulumirpc.LanguageRuntime_RunPluginClient, error) {
+		RunPluginF: func(
+			ctx context.Context, info *pulumirpc.RunPluginRequest,
+		) (pulumirpc.LanguageRuntime_RunPluginClient, error) {
 			require.Equal(t, "/tmp", info.Pwd)
 			return nil, nil
 		},


### PR DESCRIPTION
RunPlugin expects the working directory of the program to be passed in in the plugin request.  This was the case until
https://github.com/pulumi/pulumi/pull/15191.  In that PR we switched from passing pwd (which is the same as `ctx.Pwd` a layer above) to minfo.GetProgramDirectory(), which is the path from which the plugin is executed.  Fix this by passing in `info.WorkingDirectory`, which a layer above is `ctx.Pwd`.

Add a test for this as well to make sure we're not regressing this again.

Likely nobody noticed this, because most plugins probably don't rely on this path, and most providers are not being run using `RunPlugin`.