### PR TITLE
add missing permissions to the cron-test-all job

### DIFF
--- a/.github/workflows/cron-test-all.yml
+++ b/.github/workflows/cron-test-all.yml
@@ -1,5 +1,9 @@
 name: Run full language matrix of tests daily
 
+permissions:
+  contents: read
+  id-token: write
+
 on:
   schedule:
     - cron: "27 5 * * *"


### PR DESCRIPTION
ci.yml that we're calling from here needs these permissions.  The calling workflow needs to include them as well, otherwise the callee is not allowed to get them.  Fix that.

I think we didn't get an issue open because of this failure because the workflow never really ran.  I'll keep an eye on it for the next days though to make sure issues are opened correctly.