### PR TITLE
Fix pnpm pack for pnpm@9.13

### DIFF
--- a/changelog/pending/20241113--sdk-nodejs--fix-pnpm-pack-for-pnpmat9-13.yaml
+++ b/changelog/pending/20241113--sdk-nodejs--fix-pnpm-pack-for-pnpmat9-13.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix pnpm pack for pnpm@9.13


### PR DESCRIPTION
For pnpm versions <9.13, pnpm pack outputs a single line with the name
of the tarball. On pnpm versions >=9.13, pnpm pack lists all the packed
files, and the last line is the tarball.

https://github.com/pnpm/pnpm/pull/8707
