### PR TITLE
add lint_fix Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,8 @@ brew::
 .PHONY: lint_%
 lint:: golangci-lint.ensure lint_golang
 
+lint_fix:: lint_golang_fix
+
 lint_golang:: lint_deps
 	$(eval GOLANGCI_LINT_CONFIG = $(shell pwd)/.golangci.yml)
 	@$(foreach pkg,$(LINT_GOLANG_PKGS),(cd $(pkg) && \
@@ -114,6 +116,17 @@ lint_golang:: lint_deps
 			--config $(GOLANGCI_LINT_CONFIG) \
 			--timeout 5m \
 			--path-prefix $(pkg)) \
+		&&) true
+
+lint_golang_fix::
+	$(eval GOLANGCI_LINT_CONFIG = $(shell pwd)/.golangci.yml)
+	@$(foreach pkg,$(LINT_GOLANG_PKGS),(cd $(pkg) && \
+		echo "[golangci-lint] Linting $(pkg)..." && \
+		golangci-lint run $(GOLANGCI_LINT_ARGS) \
+			--config $(GOLANGCI_LINT_CONFIG) \
+			--timeout 5m \
+			--path-prefix $(pkg) \
+			--fix) \
 		&&) true
 
 lint_deps:

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -30,6 +30,10 @@ lint:: ensure
 	yarn run eslint -c .eslintrc.js --ext .ts .
 	yarn biome ci .
 
+lint_fix:: ensure
+	yarn run eslint -c .eslintrc.js --ext .ts --fix .
+	yarn biome format --write .
+
 build_package:: ensure
 	yarn run tsc
 	mkdir -p bin/tests/automation/data/

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -54,6 +54,16 @@ lint:: ensure
 	. venv/*/activate && \
 		python -m pyright
 
+lint_fix:: ensure
+	. venv/*/activate && \
+		python -m black $(BLACK_FLAGS)
+	. venv/*/activate && \
+		MYPYPATH=./stubs python -m mypy ./lib/pulumi --config-file=mypy.ini
+	. venv/*/activate && \
+		python -m pylint ./lib/pulumi --rcfile=.pylintrc
+	. venv/*/activate && \
+		python -m pyright
+
 format:: ensure
 	. venv/*/activate && \
 		python -m black $(BLACK_FLAGS)

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -55,14 +55,8 @@ lint:: ensure
 		python -m pyright
 
 lint_fix:: ensure
-	. venv/*/activate && \
-		python -m black $(BLACK_FLAGS)
-	. venv/*/activate && \
-		MYPYPATH=./stubs python -m mypy ./lib/pulumi --config-file=mypy.ini
-	. venv/*/activate && \
-		python -m pylint ./lib/pulumi --rcfile=.pylintrc
-	. venv/*/activate && \
-		python -m pyright
+	make format
+	make lint
 
 format:: ensure
 	. venv/*/activate && \


### PR DESCRIPTION
Some of the linters we're using have an option to fix some of the lint errors they are finding.  This obviously only works for the simple cases, and nothing too complex, but can still be useful.

Since there are a bunch of different tools we're using, it's not always easy to remember which option needs to be passed to which tool. Add `lint_fix` Makefile targets that pass these options to our linters where available, to help fix these issues more easily.