### PR TITLE
Replace splats with explict property copying for JSON data

### DIFF
--- a/changelog/pending/20241113--sdk-python--fix-an-exception-in-automation-api-when-reading-whoami-results.yaml
+++ b/changelog/pending/20241113--sdk-python--fix-an-exception-in-automation-api-when-reading-whoami-results.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix an exception in automation api when reading `whoami` results.

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -377,7 +377,15 @@ class LocalWorkspace(Workspace):
         if ver >= VersionInfo(3, 58):
             result = self._run_pulumi_cmd_sync(["whoami", "--json"])
             who_am_i_json = json.loads(result.stdout)
-            return WhoAmIResult(**who_am_i_json)
+            return WhoAmIResult(
+                user=who_am_i_json["user"],
+                url=who_am_i_json["url"] if "url" in who_am_i_json else None,
+                organizations=(
+                    who_am_i_json["organizations"]
+                    if "organizations" in who_am_i_json
+                    else None
+                ),
+            )
 
         result = self._run_pulumi_cmd_sync(["whoami"])
         return WhoAmIResult(user=result.stdout.strip())
@@ -541,7 +549,10 @@ class LocalWorkspace(Workspace):
             ["stack", "export", "--show-secrets", "--stack", stack_name]
         )
         state_json = json.loads(result.stdout)
-        return Deployment(**state_json)
+        return Deployment(
+            version=state_json["version"] if "version" in state_json else None,
+            deployment=state_json["deployment"] if "deployment" in state_json else None,
+        )
 
     def import_stack(self, stack_name: str, state: Deployment) -> None:
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as file:


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/17734.

There were a couple of places in the python automation API where we would read in JSON data from the CLI and [splat](https://docs.python.org/3/tutorial/controlflow.html#unpacking-argument-lists) the data into a constructor to return that data in a typed python class.

This hits issues whenever new data is returned from the CLI that the python class has not yet been updated to understand (see https://github.com/pulumi/pulumi/issues/17734 for the motivating example this time round).
While it's easy to add the new field to the class to fix the issue, we'll just hit this again if we ever add any other new fields.

This PR removes the splat operator and just explicitly lists out the arguments to set. This also allows the python name to differ from the JSON name (see https://github.com/pulumi/pulumi/pull/17735#discussion_r1840259869 for an example where that would have been sub-optimal).
