### PR TITLE
pass correct permissions to the ci.yml workflow

### DIFF
--- a/.github/workflows/cron-test-all.yml
+++ b/.github/workflows/cron-test-all.yml
@@ -25,6 +25,7 @@ jobs:
     uses: ./.github/workflows/ci.yml
     permissions:
       contents: read
+      id-token: write
     with:
       ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}


### PR DESCRIPTION
The ci.yml workflow needs the 'id-token: write' permission.  I tried to fix this in https://github.com/pulumi/pulumi/pull/17764, but apparently the permissions also need to be passed in from here.  This should hopefully make it run properly.