### PR TITLE
Clean up documentation to support the bridge

### DIFF
--- a/cmd/pulumi-test-language/README.md
+++ b/cmd/pulumi-test-language/README.md
@@ -110,7 +110,7 @@ Python. This function works as follows:
   * Assertions are verified and the next test is processed until there are no
     more remaining.
 
-```{mermaid}
+```mermaid
 :caption: The lifecycle of a language conformance test suite
 :zoom:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Home
+# Pulumi developer documentation
 
 Welcome to the Pulumi developer documentation! This site is designed to provide
 complete documentation for maintainers of and contributors to Pulumi.
@@ -7,7 +7,7 @@ complete documentation for maintainers of and contributors to Pulumi.
 :maxdepth: 2
 :titlesonly:
 
-self
+Home <self>
 /docs/documentation
 /docs/architecture/README
 /docs/references/README

--- a/docs/architecture/deployment-execution/import.md
+++ b/docs/architecture/deployment-execution/import.md
@@ -49,7 +49,7 @@ of operations:
 If all of these steps succeed, the user is left with a definition for `R` in
 their Pulumi program that matches that in the stack's state exactly.
 
-```{mermaid}
+```mermaid
 :caption: Importing a resource using the `import` resource option
 :zoom:
 
@@ -122,7 +122,7 @@ representation of `R`'s desired state in the language used by the destination
 stack's Pulumi program. The user can then copy the generated definition into
 their Pulumi program.
 
-```{mermaid}
+```mermaid
 :caption: Importing a resource using the `pulumi import` CLI
 :zoom:
 

--- a/docs/architecture/deployment-execution/resource-registration.md
+++ b/docs/architecture/deployment-execution/resource-registration.md
@@ -214,7 +214,7 @@ const d = new Resource("d", { input: b.output })
 
 The dependency graph for this program is as follows:
 
-```{mermaid}
+```mermaid
 flowchart TD
     b --> a
     c --> a
@@ -253,7 +253,7 @@ necessary.
 
 ### Creating a resource
 
-```{mermaid}
+```mermaid
 :zoom:
 
 sequenceDiagram
@@ -278,7 +278,7 @@ sequenceDiagram
 
 ### Updating a resource
 
-```{mermaid}
+```mermaid
 :zoom:
 
 sequenceDiagram
@@ -305,7 +305,7 @@ sequenceDiagram
 
 ### Replacing a resource (create-before-replace)
 
-```{mermaid}
+```mermaid
 :zoom:
 
 sequenceDiagram
@@ -339,7 +339,7 @@ sequenceDiagram
 
 ### Replacing a resource (delete-before-replace)
 
-```{mermaid}
+```mermaid
 :zoom:
 
 sequenceDiagram
@@ -368,7 +368,7 @@ sequenceDiagram
 
 ### Importing a resource
 
-```{mermaid}
+```mermaid
 :zoom:
 
 sequenceDiagram
@@ -395,7 +395,7 @@ sequenceDiagram
 
 ### Leaving a resource unchanged
 
-```{mermaid}
+```mermaid
 :zoom:
 
 sequenceDiagram

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -2,7 +2,7 @@
 
 MyST supports [Mermaid](https://mermaid.js.org) diagrams. Mermaid is a
 diagramming and charting tool that renders Markdown-inspired text definitions to
-create and modify diagrams dynamically. Use the ```` ```{mermaid} ```` language
+create and modify diagrams dynamically. Use the ```` ```mermaid ```` language
 type to create a diagram. This page gives some examples (taken from the official
 site at the time of writing) but as always you can find more comprehensive
 information in the official documentation.
@@ -10,7 +10,7 @@ information in the official documentation.
 ## Flow charts
 
 ````markdown
-```{mermaid}
+```mermaid
 graph TD;
     A-->B;
     A-->C;
@@ -19,7 +19,7 @@ graph TD;
 ```
 ````
 
-```{mermaid}
+```mermaid
 graph TD;
     A-->B;
     A-->C;
@@ -30,7 +30,7 @@ graph TD;
 ## Sequence diagrams
 
 ````markdown
-```{mermaid}
+```mermaid
 sequenceDiagram
     participant Alice
     participant Bob
@@ -45,7 +45,7 @@ sequenceDiagram
 ```
 ````
 
-```{mermaid}
+```mermaid
 sequenceDiagram
     participant Alice
     participant Bob
@@ -62,7 +62,7 @@ sequenceDiagram
 ## Gantt charts
 
 ````markdown
-```{mermaid}
+```mermaid
 gantt
 dateFormat YYYY-MM-DD
 title      Adding GANTT charts to Mermaid
@@ -76,7 +76,7 @@ Future task2               :         des4, after des3, 5d
 ```
 ````
 
-```{mermaid}
+```mermaid
 gantt
 dateFormat YYYY-MM-DD
 title      Adding GANTT charts to Mermaid
@@ -92,7 +92,7 @@ Future task2               :         des4, after des3, 5d
 ## Class diagrams
 
 ````markdown
-```{mermaid}
+```mermaid
 classDiagram
 Class01 <|-- AveryLongClass : Cool
 Class03 *-- Class04
@@ -110,7 +110,7 @@ Class08 <--> C2: Cool label
 ```
 ````
 
-```{mermaid}
+```mermaid
 classDiagram
 Class01 <|-- AveryLongClass : Cool
 Class03 *-- Class04
@@ -130,7 +130,7 @@ Class08 <--> C2: Cool label
 ## Commit graphs and trees (Git graphs)
 
 ````markdown
-```{mermaid}
+```mermaid
     gitGraph
        commit
        commit
@@ -144,7 +144,7 @@ Class08 <--> C2: Cool label
 ```
 ````
 
-```{mermaid}
+```mermaid
     gitGraph
        commit
        commit
@@ -160,7 +160,7 @@ Class08 <--> C2: Cool label
 ## Entity-relationship (ER) diagrams
 
 ````markdown
-```{mermaid}
+```mermaid
 erDiagram
     CUSTOMER ||--o{ ORDER : places
     ORDER ||--|{ LINE-ITEM : contains
@@ -168,7 +168,7 @@ erDiagram
 ```
 ````
 
-```{mermaid}
+```mermaid
 erDiagram
     CUSTOMER ||--o{ ORDER : places
     ORDER ||--|{ LINE-ITEM : contains
@@ -178,7 +178,7 @@ erDiagram
 ## User journey diagrams
 
 ````markdown
-```{mermaid}
+```mermaid
 journey
     title My working day
     section Go to work
@@ -191,7 +191,7 @@ journey
 ```
 ````
 
-```{mermaid}
+```mermaid
 journey
     title My working day
     section Go to work

--- a/docs/references/README.md
+++ b/docs/references/README.md
@@ -9,4 +9,5 @@ TypeDocs from the NodeJS/TypeScript SDK, and so on).
 :titlesonly:
 
 /proto/README
+Terraform Bridge <https://pulumi-developer-docs.readthedocs.io/projects/pulumi-terraform-bridge/en/latest/docs/README.html>
 :::

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "myst_parser",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosectionlabel",
+    "sphinx.ext.intersphinx",
     "sphinx_tabs.tabs",
     "sphinxcontrib.mermaid",
     "sphinxcontrib.programoutput",
@@ -56,6 +57,17 @@ myst_enable_extensions = [
 ]
 
 myst_links_external_new_tab = True
+
+# Languages listed here will be interpreted as directives when encountered after
+# a code fence. For instance, if MyST sees the string "```mermaid", and mermaid
+# is configured here, it will interpret it as if it had been written as a
+# directive, e.g. "```{mermaid}".
+#
+# This is useful for interoperability with tools that have special support for
+# certain languages. GitHub, for instance, will render Mermaid diagrams if it
+# encounters them, so it's beneficial for us to be able to write them as
+# "normal" code blocks rather than as directives.
+myst_fence_as_directive = ["mermaid"]
 
 # Configure some custom MyST URL schemes for easy linking to GitHub files and
 # issues.
@@ -75,6 +87,23 @@ myst_url_schemes = {
         "classes": ["github"],
     },
 }
+
+# Intersphinx enables linking to references and the like in other Sphinx
+# documentation sites. We configure it here so that we can link to the various
+# Pulumi projects that are all hosted under the root Pulumi site.
+intersphinx_mapping = {
+    # Terrafom Bridge developer documentation
+    # https://github.com/pulumi/pulumi-terraform-bridge
+    "tfbridge": ("https://pulumi-developer-docs.readthedocs.io/projects/pulumi-terraform-bridge/en/latest/", None),
+}
+
+# Sphinx defaults to trying to automatically resolve *unresolved* labels using
+# Intersphinx mappings. This can have unintended side effects, such as local
+# references suddenly resolving to external locations. As a result we disable
+# this behaviour here. See
+# https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_disabled_reftypes
+# for more information.
+intersphinx_disabled_reftypes = ["*"]
 
 # The types of source files and suffixes that Sphinx should recognise and parse.
 source_suffix = {


### PR DESCRIPTION
This commit makes a few changes to our developer documentation in order to make way for pulumi/pulumi-terraform-bridge#2623, which adds Sphinx developer documentation to the Terraform Bridge. Namely:

* We introduce `intersphinx`, which allows for cross-referencing between multiple Sphinx documentation sites as though they were in one site. We won't introduce such links until the bridge documentation is merged and deployed, but in theory links such as `tfbridge:some-label` will resolve correctly thereafter.
* We rename the root page from "Home", to "Pulumi developer documentation", since both the `pulumi/pulumi` and bridge documentation sites will have a root and it could be confusing if they were both called "Home".
* While we're here, we copy a trick from the bridge PR that allows us to just write Mermaid diagrams using `mermaid` instead of `{mermaid}`. This means that GitHub will render them in our Markdown files, which is nice.