### PR TITLE
add NewPluginSpec helper function

### DIFF
--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -31,6 +31,7 @@ import (
 
 	cmdDiag "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/diag"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/newcmd"
+	"github.com/pulumi/pulumi/pkg/v3/util"
 
 	javagen "github.com/pulumi/pulumi-java/pkg/codegen/java"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
@@ -58,7 +59,47 @@ import (
 
 type projectGeneratorFunc func(directory string, project workspace.Project, p *pcl.Program) error
 
-func NewConvertCmd() *cobra.Command {
+func loadConverterPlugin(
+	ctx *plugin.Context,
+	name string,
+	log func(sev diag.Severity, msg string),
+) (plugin.Converter, error) {
+	// Default to the known version of the plugin, this ensures we use the version of the yaml-converter
+	// that aligns with the yaml codegen we've linked to for this CLI release.
+	pluginSpec, err := workspace.NewPluginSpec(name, apitype.ConverterPlugin, "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create plugin spec: %w", err)
+	}
+	if versionSet := util.SetKnownPluginVersion(&pluginSpec); versionSet {
+		ctx.Diag.Infof(
+			diag.Message("", "Using version %s for pulumi-converter-%s"), pluginSpec.Version, pluginSpec.Name)
+	}
+
+	// Try and load the converter plugin for this
+	converter, err := plugin.NewConverter(ctx, name, pluginSpec.Version)
+	if err != nil {
+		// If NewConverter returns a MissingError, we can try and install the plugin if it was missing and try again,
+		// unless auto plugin installs are turned off.
+		var me *workspace.MissingError
+		if !errors.As(err, &me) || env.DisableAutomaticPluginAcquisition.Value() {
+			// Not a MissingError, return the original error.
+			return nil, fmt.Errorf("load %q: %w", name, err)
+		}
+
+		_, err = pkgWorkspace.InstallPlugin(ctx.Base(), pluginSpec, log)
+		if err != nil {
+			return nil, fmt.Errorf("install %q: %w", name, err)
+		}
+
+		converter, err = plugin.NewConverter(ctx, name, pluginSpec.Version)
+		if err != nil {
+			return nil, fmt.Errorf("load %q: %w", name, err)
+		}
+	}
+	return converter, nil
+}
+
+func newConvertCmd() *cobra.Command {
 	var outDir string
 	var from string
 	var language string

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -66,7 +66,7 @@ func loadConverterPlugin(
 ) (plugin.Converter, error) {
 	// Default to the known version of the plugin, this ensures we use the version of the yaml-converter
 	// that aligns with the yaml codegen we've linked to for this CLI release.
-	pluginSpec, err := workspace.NewPluginSpec(name, apitype.ConverterPlugin, "", nil)
+	pluginSpec, err := workspace.NewPluginSpec(name, apitype.ConverterPlugin, nil, "", nil)
 	if err != nil {
 		return nil, fmt.Errorf("create plugin spec: %w", err)
 	}

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -705,7 +705,7 @@ func NewImportCmd() *cobra.Command {
 						pCtx.Diag.Logf(sev, diag.RawMessage("", msg))
 					}
 
-					pluginSpec, err := workspace.NewPluginSpec(string(provider), apitype.ResourcePlugin, "", nil)
+					pluginSpec, err := workspace.NewPluginSpec(string(provider), apitype.ResourcePlugin, nil, "", nil)
 					if err != nil {
 						pCtx.Diag.Warningf(diag.Message("", "failed to create plugin spec for provider %q: %v"), provider, err)
 						return nil

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -705,9 +705,10 @@ func NewImportCmd() *cobra.Command {
 						pCtx.Diag.Logf(sev, diag.RawMessage("", msg))
 					}
 
-					pluginSpec := workspace.PluginSpec{
-						Name: string(provider),
-						Kind: apitype.ResourcePlugin,
+					pluginSpec, err := workspace.NewPluginSpec(string(provider), apitype.ResourcePlugin, "", nil)
+					if err != nil {
+						pCtx.Diag.Warningf(diag.Message("", "failed to create plugin spec for provider %q: %v"), provider, err)
+						return nil
 					}
 					version, err := pkgWorkspace.InstallPlugin(ctx, pluginSpec, log)
 					if err != nil {

--- a/pkg/cmd/pulumi/plugin/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install.go
@@ -138,13 +138,11 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 			}
 		}
 
-		pluginSpec := workspace.PluginSpec{
-			Kind:              apitype.PluginKind(args[0]),
-			Name:              args[1],
-			Version:           version,
-			PluginDownloadURL: cmd.serverURL, // If empty, will use default plugin source.
-			Checksums:         checksums,
+		pluginSpec, err := workspace.NewPluginSpec(args[1], apitype.PluginKind(args[0]), cmd.serverURL, checksums)
+		if err != nil {
+			return err
 		}
+		pluginSpec.Version = version
 
 		// Bundled plugins are generally not installable with this command. They are expected to be
 		// distributed with Pulumi itself. But we turn this check off if PULUMI_DEV is set so we can

--- a/pkg/cmd/pulumi/plugin/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install.go
@@ -138,11 +138,10 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 			}
 		}
 
-		pluginSpec, err := workspace.NewPluginSpec(args[1], apitype.PluginKind(args[0]), cmd.serverURL, checksums)
+		pluginSpec, err := workspace.NewPluginSpec(args[1], apitype.PluginKind(args[0]), version, cmd.serverURL, checksums)
 		if err != nil {
 			return err
 		}
-		pluginSpec.Version = version
 
 		// Bundled plugins are generally not installable with this command. They are expected to be
 		// distributed with Pulumi itself. But we turn this check off if PULUMI_DEV is set so we can

--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -79,7 +79,7 @@ func (cmd *pluginRunCmd) run(ctx context.Context, args []string) error {
 		}
 
 		// TODO: Add support for --server and --checksums.
-		pluginSpec, err := workspace.NewPluginSpec(args[0], kind, "", nil)
+		pluginSpec, err := workspace.NewPluginSpec(args[0], kind, nil, "", nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -78,11 +78,10 @@ func (cmd *pluginRunCmd) run(ctx context.Context, args []string) error {
 			return fmt.Errorf("could not get plugin path: %w", err)
 		}
 
-		pluginSpec := workspace.PluginSpec{
-			Kind:    kind,
-			Name:    name,
-			Version: version,
-			// TODO: Add support for --server and --checksums.
+		// TODO: Add support for --server and --checksums.
+		pluginSpec, err := workspace.NewPluginSpec(args[0], kind, "", nil)
+		if err != nil {
+			return err
 		}
 
 		log := func(sev diag.Severity, msg string) {

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -865,17 +865,24 @@ type PluginSpec struct {
 }
 
 func NewPluginSpec(
-	source string, kind apitype.PluginKind, pluginDownloadURL string, checksums map[string][]byte,
+	source string,
+	kind apitype.PluginKind,
+	version *semver.Version,
+	pluginDownloadURL string,
+	checksums map[string][]byte,
 ) (PluginSpec, error) {
 	name := source
 	isGitPlugin := false
 	versionStr := ""
 
 	// Parse the version if available.  This can either be a simple semver version, or a git commit hash.
-	var version *semver.Version
 	if s := strings.SplitN(source, "@", 2); len(s) == 2 {
 		name = s[0]
 		versionStr = s[1]
+	}
+
+	if versionStr != "" && version != nil {
+		return PluginSpec{}, errors.New("cannot specify a version when the version is part of the name")
 	}
 
 	urlRegex := regexp.MustCompile(`^[^\./].*\.[a-z]+/[a-zA-Z0-9-/]*[a-zA-Z0-9]$`)

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -925,16 +925,12 @@ func NewPluginSpec(
 		Version:           version,
 		PluginDownloadURL: pluginDownloadURL,
 		Checksums:         checksums,
-		isGitPlugin:       isGitPlugin,
 	}, nil
 }
 
 // Dir gets the expected plugin directory for this plugin.
 func (spec PluginSpec) Dir() string {
 	dir := fmt.Sprintf("%s-%s", spec.Kind, spec.Name)
-	if spec.isGitPlugin {
-		dir = strings.ReplaceAll(dir, "/", "_")
-	}
 	if spec.Version != nil {
 		dir = fmt.Sprintf("%s-v%s", dir, spec.Version.String())
 	}
@@ -987,10 +983,6 @@ func (spec PluginSpec) String() string {
 		version = fmt.Sprintf("-%s", v)
 	}
 	return spec.Name + version
-}
-
-func (spec PluginSpec) RemotePlugin() bool {
-	return spec.isGitPlugin
 }
 
 // PluginInfo provides basic information about a plugin.  Each plugin gets installed into a system-wide

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -932,7 +932,9 @@ func NewPluginSpec(
 // Dir gets the expected plugin directory for this plugin.
 func (spec PluginSpec) Dir() string {
 	dir := fmt.Sprintf("%s-%s", spec.Kind, spec.Name)
-	dir = strings.ReplaceAll(dir, "/", "_")
+	if spec.isGitPlugin {
+		dir = strings.ReplaceAll(dir, "/", "_")
+	}
 	if spec.Version != nil {
 		dir = fmt.Sprintf("%s-v%s", dir, spec.Version.String())
 	}

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -880,7 +880,7 @@ func NewPluginSpec(
 		versionStr = s[1]
 	}
 
-	urlRegex := regexp.MustCompile(`[^\.].*\..+/.+$`)
+	urlRegex := regexp.MustCompile(`^[^\./].*\.[a-z]+/[a-zA-Z0-9-/]*[a-zA-Z0-9]$`)
 	if urlRegex.MatchString(name) {
 		u, err := url.Parse(name)
 		// If we don't have a URL, we just treat it as a normal plugin name.

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -862,8 +862,6 @@ type PluginSpec struct {
 
 	// if set will be used to validate the plugin downloaded matches. This is keyed by "$os-$arch", e.g. "linux-x64".
 	Checksums map[string][]byte
-
-	isGitPlugin bool
 }
 
 func NewPluginSpec(

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1702,6 +1702,7 @@ func TestNewPluginSpec(t *testing.T) {
 		source             string
 		version            *semver.Version
 		kind               apitype.PluginKind
+		pluginDownloadURL  string
 		ExpectedPluginSpec PluginSpec
 		Error              error
 	}{
@@ -1826,6 +1827,19 @@ func TestNewPluginSpec(t *testing.T) {
 				Checksums:         nil,
 			},
 		},
+		{
+			name:              "plugin download url and git url",
+			source:            "github.com/pulumi/pulumi-example@v1.0.0",
+			kind:              apitype.ResourcePlugin,
+			pluginDownloadURL: "https://example.com/pulumi-example",
+			Error:             errors.New("cannot specify a plugin download URL when the plugin name is a URL"),
+		},
+		{
+			name:   "invalid version with git plugin",
+			source: "github.com/pulumi/pulumi-example@v1.0.0.0",
+			kind:   apitype.ResourcePlugin,
+			Error:  errors.New("VERSION must be valid semver or git commit hash: v1.0.0.0"),
+		},
 	}
 
 	for _, c := range cases {
@@ -1833,7 +1847,7 @@ func TestNewPluginSpec(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
-			spec, err := NewPluginSpec(c.source, c.kind, c.version, "", nil)
+			spec, err := NewPluginSpec(c.source, c.kind, c.version, c.pluginDownloadURL, nil)
 			if c.Error != nil {
 				require.EqualError(t, err, c.Error.Error())
 				return

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1715,7 +1715,6 @@ func TestNewPluginSpec(t *testing.T) {
 				PluginDownloadURL: "",
 				PluginDir:         "",
 				Checksums:         nil,
-				isGitPlugin:       false,
 			},
 		},
 		{
@@ -1729,7 +1728,6 @@ func TestNewPluginSpec(t *testing.T) {
 				PluginDownloadURL: "",
 				PluginDir:         "",
 				Checksums:         nil,
-				isGitPlugin:       false,
 			},
 		},
 		{
@@ -1749,7 +1747,6 @@ func TestNewPluginSpec(t *testing.T) {
 				PluginDownloadURL: "github.com/pulumi/pulumi-example",
 				PluginDir:         "",
 				Checksums:         nil,
-				isGitPlugin:       true,
 			},
 		},
 		{
@@ -1763,7 +1760,6 @@ func TestNewPluginSpec(t *testing.T) {
 				PluginDownloadURL: "github.com/pulumi/pulumi-example",
 				PluginDir:         "",
 				Checksums:         nil,
-				isGitPlugin:       true,
 			},
 		},
 		{
@@ -1777,7 +1773,6 @@ func TestNewPluginSpec(t *testing.T) {
 				PluginDownloadURL: "github.com/pulumi/pulumi-example",
 				PluginDir:         "",
 				Checksums:         nil,
-				isGitPlugin:       true,
 			},
 		},
 		{
@@ -1796,7 +1791,6 @@ func TestNewPluginSpec(t *testing.T) {
 				Version:           nil,
 				PluginDownloadURL: "",
 				Checksums:         nil,
-				isGitPlugin:       false,
 			},
 		},
 		{
@@ -1809,7 +1803,6 @@ func TestNewPluginSpec(t *testing.T) {
 				Version:           nil,
 				PluginDownloadURL: "",
 				Checksums:         nil,
-				isGitPlugin:       false,
 			},
 		},
 	}

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1700,6 +1700,7 @@ func TestNewPluginSpec(t *testing.T) {
 	cases := []struct {
 		name               string
 		source             string
+		version            *semver.Version
 		kind               apitype.PluginKind
 		ExpectedPluginSpec PluginSpec
 		Error              error
@@ -1805,6 +1806,26 @@ func TestNewPluginSpec(t *testing.T) {
 				Checksums:         nil,
 			},
 		},
+		{
+			name:    "conflicting versions error",
+			source:  "plugin@v1.0.0",
+			version: &v1,
+			kind:    apitype.ResourcePlugin,
+			Error:   errors.New("cannot specify a version when the version is part of the name"),
+		},
+		{
+			name:    "passed in version is used",
+			source:  "plugin",
+			kind:    apitype.ResourcePlugin,
+			version: &v1,
+			ExpectedPluginSpec: PluginSpec{
+				Name:              "plugin",
+				Kind:              apitype.ResourcePlugin,
+				Version:           &v1,
+				PluginDownloadURL: "",
+				Checksums:         nil,
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -1812,7 +1833,7 @@ func TestNewPluginSpec(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
-			spec, err := NewPluginSpec(c.source, c.kind, "", nil)
+			spec, err := NewPluginSpec(c.source, c.kind, c.version, "", nil)
 			if c.Error != nil {
 				require.EqualError(t, err, c.Error.Error())
 				return

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1786,6 +1786,32 @@ func TestNewPluginSpec(t *testing.T) {
 			kind:   apitype.ResourcePlugin,
 			Error:  errors.New("VERSION must be valid semver or git commit hash: abcd"),
 		},
+		{
+			name:   "local plugin",
+			source: "./test/plugin",
+			kind:   apitype.ResourcePlugin,
+			ExpectedPluginSpec: PluginSpec{
+				Name:              "./test/plugin",
+				Kind:              apitype.ResourcePlugin,
+				Version:           nil,
+				PluginDownloadURL: "",
+				Checksums:         nil,
+				isGitPlugin:       false,
+			},
+		},
+		{
+			name:   "local plugin absolute path",
+			source: "/test/plugin",
+			kind:   apitype.ResourcePlugin,
+			ExpectedPluginSpec: PluginSpec{
+				Name:              "/test/plugin",
+				Kind:              apitype.ResourcePlugin,
+				Version:           nil,
+				PluginDownloadURL: "",
+				Checksums:         nil,
+				isGitPlugin:       false,
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1691,3 +1691,115 @@ func TestProjectPluginsWithSymlink(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(tempdir, "symlink", "pulumi-resource-aws"), path)
 }
+
+func TestNewPluginSpec(t *testing.T) {
+	t.Parallel()
+
+	v1 := semver.MustParse("1.0.0")
+	v0deadbeef := semver.MustParse("0.0.0-xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	cases := []struct {
+		name               string
+		source             string
+		kind               apitype.PluginKind
+		ExpectedPluginSpec PluginSpec
+		Error              error
+	}{
+		{
+			name:   "regular plugin",
+			source: "pulumi-example",
+			kind:   apitype.ResourcePlugin,
+			ExpectedPluginSpec: PluginSpec{
+				Name:              "pulumi-example",
+				Kind:              apitype.ResourcePlugin,
+				Version:           nil,
+				PluginDownloadURL: "",
+				PluginDir:         "",
+				Checksums:         nil,
+				isGitPlugin:       false,
+			},
+		},
+		{
+			name:   "plugin with version",
+			source: "pulumi-example@v1.0.0",
+			kind:   apitype.ResourcePlugin,
+			ExpectedPluginSpec: PluginSpec{
+				Name:              "pulumi-example",
+				Kind:              apitype.ResourcePlugin,
+				Version:           &v1,
+				PluginDownloadURL: "",
+				PluginDir:         "",
+				Checksums:         nil,
+				isGitPlugin:       false,
+			},
+		},
+		{
+			name:   "plugin with invalid semver",
+			source: "pulumi-example@v1.0.0.0",
+			kind:   apitype.ResourcePlugin,
+			Error:  errors.New("VERSION must be valid semver: Invalid character(s) found in patch number \"0.0\""),
+		},
+		{
+			name:   "git plugin",
+			source: "github.com/pulumi/pulumi-example",
+			kind:   apitype.ResourcePlugin,
+			ExpectedPluginSpec: PluginSpec{
+				Name:              "github.com_pulumi_pulumi-example",
+				Kind:              apitype.ResourcePlugin,
+				Version:           nil,
+				PluginDownloadURL: "github.com/pulumi/pulumi-example",
+				PluginDir:         "",
+				Checksums:         nil,
+				isGitPlugin:       true,
+			},
+		},
+		{
+			name:   "git plugin with version",
+			source: "github.com/pulumi/pulumi-example@v1.0.0",
+			kind:   apitype.ResourcePlugin,
+			ExpectedPluginSpec: PluginSpec{
+				Name:              "github.com_pulumi_pulumi-example",
+				Kind:              apitype.ResourcePlugin,
+				Version:           &v1,
+				PluginDownloadURL: "github.com/pulumi/pulumi-example",
+				PluginDir:         "",
+				Checksums:         nil,
+				isGitPlugin:       true,
+			},
+		},
+		{
+			name:   "git plugin with commit hash version",
+			source: "github.com/pulumi/pulumi-example@deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+			kind:   apitype.ResourcePlugin,
+			ExpectedPluginSpec: PluginSpec{
+				Name:              "github.com_pulumi_pulumi-example",
+				Kind:              apitype.ResourcePlugin,
+				Version:           &v0deadbeef,
+				PluginDownloadURL: "github.com/pulumi/pulumi-example",
+				PluginDir:         "",
+				Checksums:         nil,
+				isGitPlugin:       true,
+			},
+		},
+		{
+			name:   "git plugin with invalid version hash",
+			source: "github.com/pulumi/pulumi-example@abcd",
+			kind:   apitype.ResourcePlugin,
+			Error:  errors.New("VERSION must be valid semver or git commit hash: abcd"),
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			spec, err := NewPluginSpec(c.source, c.kind, "", nil)
+			if c.Error != nil {
+				require.EqualError(t, err, c.Error.Error())
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.ExpectedPluginSpec, spec)
+		})
+	}
+}


### PR DESCRIPTION
We want to be able to get plugins from arbitrary git repositories.  To do this, we need to parse the URL we get passed, so we can resolve it properly.

Introduce a new NewPluginSpec helper to do that, so we can use it consistently throughout the codebase.

Also extend this method to recognize such plugin names, and deal with them appropriately, setting the `PluginDownloadURL`, and specifying that this is a remote plugin.

Note that we also need to mangle the names slightly, as `/` will create new subfolders on the filesystem, which doesn't work well with our current plugin detection mechanisms.  Rather than trying to make that work, replace them with `_`, which currently cannot be used in plugin names, and thus are safe to re-use here.

This is the first step towards allowing users to specify git repositories as plugins.