### PR TITLE
pass context to git clone utilities

### DIFF
--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -192,7 +192,7 @@ func runNew(ctx context.Context, args newArgs) error {
 		}
 	}
 	// Retrieve the template repo.
-	repo, err := workspace.RetrieveTemplates(args.templateNameOrURL, args.offline, workspace.TemplateKindPulumiProject)
+	repo, err := workspace.RetrieveTemplates(ctx, args.templateNameOrURL, args.offline, workspace.TemplateKindPulumiProject)
 	if err != nil {
 		return err
 	}
@@ -523,9 +523,9 @@ func newNewCmd() *cobra.Command {
 		promptRuntimeOptions: promptRuntimeOptions,
 	}
 
-	getTemplates := func() ([]workspace.Template, error) {
+	getTemplates := func(ctx context.Context) ([]workspace.Template, error) {
 		// Attempt to retrieve available templates.
-		repo, err := workspace.RetrieveTemplates("", false /*offline*/, workspace.TemplateKindPulumiProject)
+		repo, err := workspace.RetrieveTemplates(ctx, "", false /*offline*/, workspace.TemplateKindPulumiProject)
 		if err != nil {
 			logging.Warningf("could not retrieve templates: %v", err)
 			return []workspace.Template{}, err
@@ -590,7 +590,7 @@ func newNewCmd() *cobra.Command {
 				args.templateNameOrURL = cliArgs[0]
 			}
 			if args.listTemplates {
-				templates, err := getTemplates()
+				templates, err := getTemplates(ctx)
 				if err != nil {
 					logging.Warningf("could not list templates: %v", err)
 					return err
@@ -616,7 +616,7 @@ func newNewCmd() *cobra.Command {
 		// Show default help.
 		defaultHelp(cmd, args)
 
-		templates, err := getTemplates()
+		templates, err := getTemplates(cmd.Context())
 		if err != nil {
 			logging.Warningf("could not list templates: %v", err)
 			return

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -192,7 +192,8 @@ func runNew(ctx context.Context, args newArgs) error {
 		}
 	}
 	// Retrieve the template repo.
-	repo, err := workspace.RetrieveTemplates(ctx, args.templateNameOrURL, args.offline, workspace.TemplateKindPulumiProject)
+	repo, err := workspace.RetrieveTemplates(
+		ctx, args.templateNameOrURL, args.offline, workspace.TemplateKindPulumiProject)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -111,7 +111,7 @@ func runNewPolicyPack(ctx context.Context, args newPolicyArgs) error {
 	}
 
 	// Retrieve the templates-policy repo.
-	repo, err := workspace.RetrieveTemplates(args.templateNameOrURL, args.offline, workspace.TemplateKindPolicyPack)
+	repo, err := workspace.RetrieveTemplates(ctx, args.templateNameOrURL, args.offline, workspace.TemplateKindPolicyPack)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -228,7 +228,7 @@ func newUpCmd() *cobra.Command {
 		cmd *cobra.Command,
 	) error {
 		// Retrieve the template repo.
-		repo, err := workspace.RetrieveTemplates(templateNameOrURL, false, workspace.TemplateKindPulumiProject)
+		repo, err := workspace.RetrieveTemplates(ctx, templateNameOrURL, false, workspace.TemplateKindPulumiProject)
 		if err != nil {
 			return err
 		}

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -456,7 +456,9 @@ func GitCloneAndCheckoutCommit(ctx context.Context, url string, commit plumbing.
 	})
 }
 
-func GitCloneOrPull(ctx context.Context, rawurl string, referenceName plumbing.ReferenceName, path string, shallow bool) error {
+func GitCloneOrPull(
+	ctx context.Context, rawurl string, referenceName plumbing.ReferenceName, path string, shallow bool,
+) error {
 	logging.V(10).Infof("Attempting to clone from %s at ref %s", rawurl, referenceName)
 
 	// TODO: https://github.com/go-git/go-git/pull/613 should have resolved the issue preventing this from cloning.
@@ -469,7 +471,9 @@ func GitCloneOrPull(ctx context.Context, rawurl string, referenceName plumbing.R
 }
 
 // GitCloneOrPull clones or updates the specified referenceName (branch or tag) of a Git repository.
-func gitCloneOrPull(ctx context.Context, url string, referenceName plumbing.ReferenceName, path string, shallow bool) error {
+func gitCloneOrPull(
+	ctx context.Context, url string, referenceName plumbing.ReferenceName, path string, shallow bool,
+) error {
 	// For shallow clones, use a depth of 1.
 	depth := 0
 	if shallow {

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -298,7 +298,9 @@ func RetrieveTemplates(ctx context.Context, templateNamePathOrURL string, offlin
 }
 
 // retrieveURLTemplates retrieves the "template repository" at the specified URL.
-func retrieveURLTemplates(ctx context.Context, rawurl string, offline bool, templateKind TemplateKind) (TemplateRepository, error) {
+func retrieveURLTemplates(
+	ctx context.Context, rawurl string, offline bool, templateKind TemplateKind,
+) (TemplateRepository, error) {
 	if offline {
 		return TemplateRepository{}, fmt.Errorf("cannot use %s offline", rawurl)
 	}

--- a/sdk/go/common/workspace/templates_test.go
+++ b/sdk/go/common/workspace/templates_test.go
@@ -15,6 +15,7 @@
 package workspace
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -45,7 +46,7 @@ func TestRetrieveNonExistingTemplate(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := RetrieveTemplates(templateName, false, tt.templateKind)
+			_, err := RetrieveTemplates(context.Background(), templateName, false, tt.templateKind)
 			assert.EqualError(t, err, fmt.Sprintf("template '%s' not found", templateName))
 		})
 	}
@@ -73,7 +74,7 @@ func TestRetrieveStandardTemplate(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.testName, func(t *testing.T) {
-			repository, err := RetrieveTemplates(tt.templateName, false, tt.templateKind)
+			repository, err := RetrieveTemplates(context.Background(), tt.templateName, false, tt.templateKind)
 			assert.NoError(t, err)
 			assert.Equal(t, false, repository.ShouldDelete)
 
@@ -117,7 +118,7 @@ func TestRetrieveHttpsTemplate(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.testName, func(t *testing.T) {
-			repository, err := RetrieveTemplates(tt.templateURL, false, tt.templateKind)
+			repository, err := RetrieveTemplates(context.Background(), tt.templateURL, false, tt.templateKind)
 			assert.NoError(t, err)
 			assert.Equal(t, true, repository.ShouldDelete)
 
@@ -169,7 +170,7 @@ func TestRetrieveHttpsTemplateOffline(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := RetrieveTemplates(tt.templateURL, true, tt.templateKind)
+			_, err := RetrieveTemplates(context.Background(), tt.templateURL, true, tt.templateKind)
 			assert.EqualError(t, err, fmt.Sprintf("cannot use %s offline", tt.templateURL))
 		})
 	}
@@ -194,7 +195,7 @@ func TestRetrieveFileTemplate(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.testName, func(t *testing.T) {
-			repository, err := RetrieveTemplates(".", false, tt.templateKind)
+			repository, err := RetrieveTemplates(context.Background(), ".", false, tt.templateKind)
 			assert.NoError(t, err)
 			assert.Equal(t, false, repository.ShouldDelete)
 


### PR DESCRIPTION
Pass a context to the git clone utilities.  In the future we want to be able to use them to download plugins, which should be cancellable. Pass the context through to allow this.

In theory this is not backwards compatible for this API, but we've recently been allowing similar changes (e.g. in https://github.com/pulumi/pulumi/pull/17621), so I think this is okay to do.