### PR TITLE
Rewrite conformance test snapshots filewise

### DIFF
--- a/cmd/pulumi-test-language/snapshots.go
+++ b/cmd/pulumi-test-language/snapshots.go
@@ -84,26 +84,13 @@ func copyDirectory(fs iofs.FS, src string, dst string, edits []compiledReplaceme
 			}
 
 			src := string(data)
-			for len(src) > 0 {
-				// Find a line of text
-				i := strings.Index(src, "\n")
-				text := src
-				if i == -1 {
-					// Last line, process text (set to src above) then exit the loop
-					src = ""
-				} else {
-					// Extract the line of text _including_ the newline and remove it from src
-					text = src[:i+1]
-					src = src[i+1:]
-				}
+			for _, edit := range editsToApply {
+				src = edit.Pattern.ReplaceAllString(src, edit.Replacement)
+			}
 
-				for _, edit := range editsToApply {
-					text = edit.Pattern.ReplaceAllString(text, edit.Replacement)
-				}
-				_, err = dstFile.WriteString(text)
-				if err != nil {
-					return fmt.Errorf("write file %s: %w", dstPath, err)
-				}
+			n, err := dstFile.WriteString(src)
+			if err != nil || n != len(src) {
+				return fmt.Errorf("write file %s: %w", dstPath, err)
 			}
 		} else {
 			// Can just do a straight copy


### PR DESCRIPTION
When we run language conformance tests, we compare the SDKs and programs generated as part of each test with snapshots generated from the last known-good run. To accommodate the fact that some parts of the generated SDKs and programs being compared will change between runs (such as e.g. core SDK version numbers), the conformance test framework supports rewriting these variable parts into fixed strings using regular expressions. The NodeJS suite, for instance, has the following piece of configuration:

```go
{
  Path:        "package\\.json",
  Pattern:     fmt.Sprintf("pulumi-pulumi-%s\\.tgz", sdk.Version.String()),
  Replacement: "pulumi-pulumi-CORE.VERSION.tgz",
},
```

This replaces dependencies of the form `pulumi-pulumi-<version>.tgz` in generated `package.json` files with the fixed string `pulumi-pulumi-CORE.VERSION.tgz`, allowing comparisons to pass as the tests are run over ever-changing versions of the core SDK.

Presently, these rewrites are applied linewise. However, there are cases where a multi-line replacement is necessary to ensure a clean rewriting. Consider rewriting a Java `pom.xml` to avoid embedding version numbers for the `pulumi` library. The offending lines have the form:

```xml
<groupId>com.pulumi</groupId>
<artifactId>pulumi</artifactId>
<version>0.0.1</version>
```

we want to rewrite the `0.0.1` to something like `CORE.VERSION`. However, using a pattern such as `<version>.*</version>` will rewrite the versions of _all_ dependencies and such in the POM, which is not desirable since we would like to be alerted if they change. We thus want a multi-line expression that captures something like `<artifactId>pulumi</artifactId>\n...<version>.*</version>`. Go supports such expressions using the `(?m)` flag -- we just need to make it work by rewriting files wholesale rather than line-by-line. This commit does just that. All existing expressions should continue to work unchanged, since they are single-line by default (in the absence of the `(?m)` flag).