### PR TITLE
Split public and internal representation of InvokeOptions

### DIFF
--- a/changelog/pending/20241120--sdk-go--split-public-and-internal-representation-of-invokeoptions.yaml
+++ b/changelog/pending/20241120--sdk-go--split-public-and-internal-representation-of-invokeoptions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/go
+  description: Split public and internal representation of InvokeOptions

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -318,19 +318,19 @@ func TestInvokeOptionComposite(t *testing.T) {
 	tests := []struct {
 		name  string
 		input []InvokeOption
-		want  *InvokeOptions
+		want  *invokeOptions
 	}{
 		{
 			name:  "no options",
 			input: []InvokeOption{},
-			want:  &InvokeOptions{},
+			want:  &invokeOptions{},
 		},
 		{
 			name: "single option",
 			input: []InvokeOption{
 				Version("test"),
 			},
-			want: &InvokeOptions{
+			want: &invokeOptions{
 				Version: "test",
 			},
 		},
@@ -340,7 +340,7 @@ func TestInvokeOptionComposite(t *testing.T) {
 				Version("test1"),
 				Version("test2"),
 			},
-			want: &InvokeOptions{
+			want: &invokeOptions{
 				Version: "test2",
 			},
 		},
@@ -351,7 +351,7 @@ func TestInvokeOptionComposite(t *testing.T) {
 				Version("test2"),
 				Version("test1"),
 			},
-			want: &InvokeOptions{
+			want: &invokeOptions{
 				Version: "test1",
 			},
 		},
@@ -361,7 +361,7 @@ func TestInvokeOptionComposite(t *testing.T) {
 				Version("test"),
 				PluginDownloadURL("url"),
 			},
-			want: &InvokeOptions{
+			want: &invokeOptions{
 				Version:           "test",
 				PluginDownloadURL: "url",
 			},
@@ -373,7 +373,7 @@ func TestInvokeOptionComposite(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			opts := &InvokeOptions{}
+			opts := &invokeOptions{}
 			CompositeInvoke(tt.input...).applyInvokeOption(opts)
 			assert.Equal(t, tt.want, opts)
 		})


### PR DESCRIPTION
In preparation for allowing the DependsOn and DependsOnInputs options to work for (Output form) invokes, we split the public and internal representations of InvokeOptions.

This matches resourceOptions and ResourceOptions, where the public type is a snapshot of the private type. The private parameterization field is moved to the private invokeOptions type.
