### PR TITLE
allow URLs without template for downloading git repos

### DIFF
--- a/changelog/pending/20241121--cli-new--allow-urls-without-a-scheme-for-downloading-templates.yaml
+++ b/changelog/pending/20241121--cli-new--allow-urls-without-a-scheme-for-downloading-templates.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/new
+  description: Allow URLs without a scheme for downloading templates

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -660,10 +660,6 @@ func parseGitRepoURLParts(rawurl string) (gitRepoURLParts, error) {
 		// parses these as local (file) repositories.  Since we never want to allow those, we prefix
 		// https:// to these URLs, and assume that protocol.
 		rawurl = "https://" + rawurl
-		endpoint, err = transport.NewEndpoint(rawurl)
-		if err != nil {
-			return gitRepoURLParts{}, err
-		}
 	} else if endpoint.Protocol == "ssh" {
 		// Normalize SSH URLs (including scp-style git@github.com URLs) into
 		// ssh:// format so we can parse them the same as https:// URLs.

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -650,6 +650,14 @@ type gitRepoURLParts struct {
 }
 
 func parseGitRepoURLParts(rawurl string) (gitRepoURLParts, error) {
+	urlRegex := regexp.MustCompile(`^[^\./][a-zA-Z0-9-]*\.[a-z]+/[a-zA-Z0-9-/]+$`)
+	if urlRegex.MatchString(rawurl) {
+		// We want to allow "naked" URLs, such as github.com/pulumi/pulumi-provider in addition to
+		// full URLs such as https://github.com/pulumi/pulumi-provider for convenience.  Prefix
+		// https:// to these URLs, as we assume that protocol.
+		fmt.Println("matched", rawurl)
+		rawurl = "https://" + rawurl
+	}
 	endpoint, err := transport.NewEndpoint(rawurl)
 	if err != nil {
 		return gitRepoURLParts{}, err

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -655,7 +655,6 @@ func parseGitRepoURLParts(rawurl string) (gitRepoURLParts, error) {
 		// We want to allow "naked" URLs, such as github.com/pulumi/pulumi-provider in addition to
 		// full URLs such as https://github.com/pulumi/pulumi-provider for convenience.  Prefix
 		// https:// to these URLs, as we assume that protocol.
-		fmt.Println("matched", rawurl)
 		rawurl = "https://" + rawurl
 	}
 	endpoint, err := transport.NewEndpoint(rawurl)

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -144,8 +144,8 @@ func TestParseGitRepoURL(t *testing.T) {
 	// No owner.
 	testError("https://github.com", "invalid Git URL")
 	testError("https://github.com/", "invalid Git URL")
-	testError("git@github.com", "invalid URL scheme: ")
-	testError("git@github.com/", "invalid URL scheme: ")
+	testError("git@github.com", "invalid Git URL")
+	testError("git@github.com/", "invalid Git URL")
 	testError("ssh://git@github.com", "invalid Git URL")
 	testError("ssh://git@github.com/", "invalid Git URL")
 

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -160,6 +160,13 @@ func TestParseGitRepoURL(t *testing.T) {
 	// Not HTTPS.
 	testError("http://github.com/pulumi/templates.git", "invalid URL scheme: http")
 	testError("http://github.com/pulumi/templates", "invalid URL scheme: http")
+
+	// "Naked" URLs.
+	pre = "github.com/pulumi/templates"
+	exp = "https://" + pre + ".git"
+	test(exp, "", pre)
+	test(exp, "", pre+"/")
+	test(exp, "templates", pre+"/templates")
 }
 
 func TestGetGitReferenceNameOrHashAndSubDirectory(t *testing.T) {


### PR DESCRIPTION
For remote plugins we want to allow URLs without a scheme to be used for specifying the plugin location.  We want to be consistent with this for example for downloading templates in pulumi new.

Allow this parsing of Git URLs in the git utility.