### PR TITLE
work around race where auto API summary event is not found

### DIFF
--- a/changelog/pending/20241121--auto-go--work-around-a-race-where-the-summary-event-in-the-automation-api-sometimes-cannot-be-found.yaml
+++ b/changelog/pending/20241121--auto-go--work-around-a-race-where-the-summary-event-in-the-automation-api-sometimes-cannot-be-found.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/go
+  description: Work around a race where the summary event in the automation API sometimes cannot be found

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -1704,7 +1704,7 @@ func (fw *fileWatcher) Close() {
 	if runtime.GOOS == "windows" {
 		time.Sleep(300 * time.Millisecond)
 	} else {
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(150 * time.Millisecond)
 	}
 
 	//nolint:errcheck


### PR DESCRIPTION
We tried to fix this race in https://github.com/pulumi/pulumi/pull/15856, but it seems like it still comes up occasionally (see https://github.com/pulumi/pulumi/issues/15235).  Try a slightly longer sleep that may help here (as we can't repro it locally, but see it occasionally in  CI, which is usually a bit slower)

Part of https://github.com/pulumi/pulumi/issues/15235