### PR TITLE
l3-component-simple test

### DIFF
--- a/cmd/pulumi-test-language/tests/l3_component_simple.go
+++ b/cmd/pulumi-test-language/tests/l3_component_simple.go
@@ -1,0 +1,69 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	LanguageTests["l3-component-simple"] = LanguageTest{
+		Providers: []plugin.Provider{&providers.SimpleProvider{}},
+		Runs: []TestRun{
+			{
+				Assert: func(l *L,
+					projectDirectory string, err error,
+					snap *deploy.Snapshot, changes display.ResourceChanges,
+				) {
+					RequireStackResource(l, err, changes)
+
+					// Check we have the one simple resource in the snapshot, its provider, its parent component and the
+					// stack.
+					require.Len(l, snap.Resources, 4, "expected 4 resources in snapshot")
+
+					component := RequireSingleResource(l, snap.Resources, "components:index:MyComponent")
+
+					// TODO(https://github.com/pulumi/pulumi/issues/10533): Languages are inconsistent in whether they
+					// send inputs for components.
+					// want := resource.NewPropertyMapFromMap(map[string]any{
+					// 	"input": true,
+					// })
+					// assert.Equal(l, want, component.Inputs, "expected component inputs to be %v", want)
+					want := resource.NewPropertyMapFromMap(map[string]any{
+						"output": true,
+					})
+					assert.Equal(l, want, component.Outputs, "expected component outputs to be %v", want)
+
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:simple")
+
+					simple := RequireSingleResource(l, snap.Resources, "simple:index:Resource")
+					assert.Equal(l, component.URN, simple.Parent, "expected simple resource to have component as parent")
+
+					want = resource.NewPropertyMapFromMap(map[string]any{
+						"value": true,
+					})
+					assert.Equal(l, want, simple.Inputs, "expected inputs to be %v", want)
+					assert.Equal(l, simple.Inputs, simple.Outputs, "expected inputs and outputs to match")
+				},
+			},
+		},
+	}
+}

--- a/cmd/pulumi-test-language/tests/testdata/l3-component-simple/main.pp
+++ b/cmd/pulumi-test-language/tests/testdata/l3-component-simple/main.pp
@@ -1,0 +1,7 @@
+component someComponent "./myComponent" {
+    input = true
+}
+
+output result { 
+    value = someComponent.output
+}

--- a/cmd/pulumi-test-language/tests/testdata/l3-component-simple/myComponent/main.pp
+++ b/cmd/pulumi-test-language/tests/testdata/l3-component-simple/myComponent/main.pp
@@ -1,0 +1,11 @@
+config input bool {
+    description = "A simple input"
+}
+
+resource "res" "simple:index:Resource" {
+    value = input
+}
+
+output output { 
+    value = res.value
+}

--- a/sdk/go/pulumi-language-go/language_test.go
+++ b/sdk/go/pulumi-language-go/language_test.go
@@ -205,6 +205,13 @@ var programOverrides = map[string]*testingrpc.PrepareLanguageTestsRequest_Progra
 			filepath.Join("testdata", "overrides", "l2-provider-call"),
 		},
 	},
+
+	// Doesn't add necessary casts for pulumi inputs
+	"l3-component-simple": {
+		Paths: []string{
+			filepath.Join("testdata", "overrides", "l3-component-simple"),
+		},
+	},
 }
 
 func TestLanguage(t *testing.T) {

--- a/sdk/go/pulumi-language-go/testdata/overrides/l3-component-simple/Pulumi.yaml
+++ b/sdk/go/pulumi-language-go/testdata/overrides/l3-component-simple/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-simple
+runtime: go

--- a/sdk/go/pulumi-language-go/testdata/overrides/l3-component-simple/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/overrides/l3-component-simple/go.mod
@@ -1,0 +1,12 @@
+module l3-component-simple
+
+go 1.20
+
+require (
+	github.com/pulumi/pulumi/sdk/v3 v3.30.0
+	example.com/pulumi-simple/sdk/go/v2 v2.0.0
+)
+
+replace github.com/pulumi/pulumi/sdk/v3 => ../../artifacts/github.com_pulumi_pulumi_sdk_v3
+
+replace example.com/pulumi-simple/sdk/go/v2 => ../../artifacts/example.com_pulumi-simple_sdk_go_v2

--- a/sdk/go/pulumi-language-go/testdata/overrides/l3-component-simple/main.go
+++ b/sdk/go/pulumi-language-go/testdata/overrides/l3-component-simple/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		someComponent, err := NewMyComponent(ctx, "someComponent", &MyComponentArgs{
+			Input: pulumi.Bool(true),
+		})
+		if err != nil {
+			return err
+		}
+		ctx.Export("result", someComponent.Output)
+		return nil
+	})
+}

--- a/sdk/go/pulumi-language-go/testdata/overrides/l3-component-simple/myComponent.go
+++ b/sdk/go/pulumi-language-go/testdata/overrides/l3-component-simple/myComponent.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+
+	"example.com/pulumi-simple/sdk/go/v2/simple"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+type MyComponentArgs struct {
+	Input pulumi.BoolInput
+}
+
+type MyComponent struct {
+	pulumi.ResourceState
+	Output pulumi.AnyOutput
+}
+
+func NewMyComponent(
+	ctx *pulumi.Context,
+	name string,
+	args *MyComponentArgs,
+	opts ...pulumi.ResourceOption,
+) (*MyComponent, error) {
+	var componentResource MyComponent
+	err := ctx.RegisterComponentResource("components:index:MyComponent", name, &componentResource, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res, err := simple.NewResource(ctx, fmt.Sprintf("%s-res", name), &simple.ResourceArgs{
+		Value: args.Input,
+	}, pulumi.Parent(&componentResource))
+	if err != nil {
+		return nil, err
+	}
+	err = ctx.RegisterResourceOutputs(&componentResource, pulumi.Map{
+		"output": res.Value,
+	})
+	if err != nil {
+		return nil, err
+	}
+	componentResource.Output = res.Value.ApplyT(func(v interface{}) interface{} {
+		return v
+	}).(pulumi.AnyOutput)
+	return &componentResource, nil
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l3-component-simple/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l3-component-simple/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l3-component-simple/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l3-component-simple/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: l3-component-simple
+runtime:
+  name: nodejs
+  options:
+    typescript: false

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l3-component-simple/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l3-component-simple/index.ts
@@ -1,0 +1,5 @@
+import * as pulumi from "@pulumi/pulumi";
+import { MyComponent } from "./myComponent";
+
+const someComponent = new MyComponent("someComponent", {input: true});
+export const result = someComponent.output;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l3-component-simple/myComponent.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l3-component-simple/myComponent.ts
@@ -1,0 +1,24 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as simple from "@pulumi/simple";
+
+interface MyComponentArgs {
+    /**
+     * A simple input
+     */
+    input: pulumi.Input<boolean>,
+}
+
+export class MyComponent extends pulumi.ComponentResource {
+    public output: pulumi.Output<boolean>;
+    constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("components:index:MyComponent", name, args, opts);
+        const res = new simple.Resource(`${name}-res`, {value: args.input}, {
+            parent: this,
+        });
+
+        this.output = res.value;
+        this.registerOutputs({
+            output: res.value,
+        });
+    }
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l3-component-simple/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l3-component-simple/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "l3-component-simple",
+	"devDependencies": {
+		"@types/node": "^18"
+	},
+	"dependencies": {
+		"typescript": "^4.0.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l3-component-simple/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l3-component-simple/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2016",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts",
+		"myComponent.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l3-component-simple/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l3-component-simple/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l3-component-simple/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l3-component-simple/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-simple
+runtime: nodejs

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l3-component-simple/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l3-component-simple/index.ts
@@ -1,0 +1,5 @@
+import * as pulumi from "@pulumi/pulumi";
+import { MyComponent } from "./myComponent";
+
+const someComponent = new MyComponent("someComponent", {input: true});
+export const result = someComponent.output;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l3-component-simple/myComponent.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l3-component-simple/myComponent.ts
@@ -1,0 +1,24 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as simple from "@pulumi/simple";
+
+interface MyComponentArgs {
+    /**
+     * A simple input
+     */
+    input: pulumi.Input<boolean>,
+}
+
+export class MyComponent extends pulumi.ComponentResource {
+    public output: pulumi.Output<boolean>;
+    constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("components:index:MyComponent", name, args, opts);
+        const res = new simple.Resource(`${name}-res`, {value: args.input}, {
+            parent: this,
+        });
+
+        this.output = res.value;
+        this.registerOutputs({
+            output: res.value,
+        });
+    }
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l3-component-simple/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l3-component-simple/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "l3-component-simple",
+	"devDependencies": {
+		"@types/node": "^18"
+	},
+	"dependencies": {
+		"typescript": "^4.0.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l3-component-simple/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l3-component-simple/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2016",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts",
+		"myComponent.ts",
+	]
+}

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -177,8 +177,9 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 
 // Add test names here that are expected to fail and the reason why they are failing
 var expectedFailures = map[string]string{
-	"l1-builtin-try": "Temporarily disabled until pr #18915 is submitted",
-	"l1-builtin-can": "Temporarily disabled until pr #18916 is submitted",
+	"l1-builtin-try":      "Temporarily disabled until pr #18915 is submitted",
+	"l1-builtin-can":      "Temporarily disabled until pr #18916 is submitted",
+	"l3-component-simple": " https://github.com/pulumi/pulumi/issues/19067",
 }
 
 func TestLanguage(t *testing.T) {


### PR DESCRIPTION
Adds a simple conformance test that component resources work. We added support for these for converting TF modules, but this is also good for testing that the runtimes treat component resources the same way.

Currently this only tests Typescript because I ran into programgen issues for both Go and Python. 

Go is missing a load of types to go from literals to Input types. 
Python is outputting TypedDicts with `total=false` that then don't type check when accessed.