### PR TITLE
Send same args to shimless and binary plugins

### DIFF
--- a/changelog/pending/20241122--engine--send-the-same-program-arguments-to-shimless-and-binary-plugins.yaml
+++ b/changelog/pending/20241122--engine--send-the-same-program-arguments-to-shimless-and-binary-plugins.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Send the same program arguments to shimless and binary plugins

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -387,7 +387,7 @@ func execPlugin(ctx *Context, bin, prefix string, kind apitype.PluginKind,
 		stdout, stderr, kill, err := runtime.RunPlugin(RunPluginInfo{
 			Info:             info,
 			WorkingDirectory: ctx.Pwd,
-			Args:             pluginArgs,
+			Args:             args,
 			Env:              env,
 		})
 		if err != nil {


### PR DESCRIPTION
Noticed this small discrepancy while looking at the code for component provider support. We should be passing the same args for shimless and binary programs, but we were only passing -v/--logtostderr/--tracing to the binary programs.