### PR TITLE
Fix parameterised dotnet packages to have version.txt

### DIFF
--- a/changelog/pending/20241125--sdkgen-dotnet--fix-parameterized-packages-to-have-version-txt.yaml
+++ b/changelog/pending/20241125--sdkgen-dotnet--fix-parameterized-packages-to-have-version-txt.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/dotnet
+  description: Fix parameterized packages to have version.txt

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -2231,7 +2231,7 @@ func genPackageMetadata(pkg *schema.Package,
 	if pkg.Version != nil && ok && lang.RespectSchemaVersion {
 		version = pkg.Version.String()
 		files.Add("version.txt", []byte(version))
-	} else if pkg.SupportPack {
+	} else if pkg.SupportPack || pkg.Parameterization != nil {
 		if pkg.Version == nil {
 			return errors.New("package version is required")
 		}


### PR DESCRIPTION
Noticed this while trying to add parameterise to the dotnet sdk. It couldn't generate a valid local sdk, we must have missed testing this when adding local gen-sdk support for parameterised packages.