### PR TITLE
[sdk/nodejs] Throw from output() on circular structures

### DIFF
--- a/changelog/pending/20241125--sdk-nodejs--throw-from-output-on-circular-structures.yaml
+++ b/changelog/pending/20241125--sdk-nodejs--throw-from-output-on-circular-structures.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Throw from `output()` on circular structures

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -574,9 +574,9 @@ function outputRec(val: any, seen?: Set<object>, preallocatedError?: Error): any
     }
 
     // Used to track whether we've seen this object before, so we can throw an error about circular
-    // structures. The Set is allocated when the first "container" object encountered, either an array
-    // or object.
-    seen = seen ?? new Set<object>();
+    // structures. The Set is allocated when the first "container" object is encountered, either an array
+    // or object. Any subsequent recursive calls get a new Set based on the passed-in one.
+    seen = new Set(seen);
 
     // In order to present a useful stack trace if an error occurs, we preallocate an error here.
     // V8 captures a stack trace at the moment an Error is created and this stack trace will lead

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -535,19 +535,23 @@ function outputRec(val: any): any {
         // themselves.  They are always 'known' (i.e. we can safely 'apply' off of them even during
         // preview).
         return val;
-    } else if (Resource.isInstance(val)) {
+    }
+    if (Resource.isInstance(val)) {
         // Don't unwrap Resources, there are existing codepaths that return Resources through
         // Outputs and we want to preserve them as is when flattening.
         return val;
-    } else if (isUnknown(val)) {
+    }
+    if (isUnknown(val)) {
         return val;
-    } else if (val instanceof Promise) {
+    }
+    if (val instanceof Promise) {
         // Recurse into the value the Promise points to.  This may end up producing a
         // Promise<Output>. Wrap this in another Output as the final result.  This Output's
         // construction will be able to merge the inner Output's data with its own.  See
         // liftInnerOutput for more details.
         return createSimpleOutput(val.then((v) => outputRec(v)));
-    } else if (Output.isInstance(val)) {
+    }
+    if (Output.isInstance(val)) {
         // We create a new output here from the raw pieces of the original output in order to
         // accommodate outputs from downlevel SxS SDKs.  This ensures that within this package it is
         // safe to assume the implementation of any Output returned by the `output` function.
@@ -567,7 +571,8 @@ function outputRec(val: any): any {
             allResources,
         );
         return newOutput.apply(outputRec, /*runWithUnknowns*/ true);
-    } else if (val instanceof Array) {
+    }
+    if (val instanceof Array) {
         const allValues = [];
         let hasOutputs = false;
         for (const v of val) {
@@ -592,37 +597,37 @@ function outputRec(val: any): any {
         const promisedArray = Promise.all(allValues.map((v) => getAwaitableValue(v)));
         const [syncResources, isKnown, isSecret, allResources] = getResourcesAndDetails(allValues);
         return new Output(syncResources, promisedArray, isKnown, isSecret, allResources);
-    } else {
-        const promisedValues: { key: string; value: any }[] = [];
-        let hasOutputs = false;
-        for (const k of Object.keys(val)) {
-            const ev = outputRec(val[k]);
-
-            promisedValues.push({ key: k, value: ev });
-            if (Output.isInstance(ev)) {
-                hasOutputs = true;
-            }
-        }
-
-        if (!hasOutputs) {
-            // Note: we intentionally return a new value here and not 'val'.  This ensures we get a
-            // copy.  This has been behavior we've had since the beginning and there may be subtle
-            // logic out there that depends on this that we would not want ot break.
-            return promisedValues.reduce(
-                (o, kvp) => {
-                    o[kvp.key] = kvp.value;
-                    return o;
-                },
-                <any>{},
-            );
-        }
-
-        const promisedObject = getPromisedObject(promisedValues);
-        const [syncResources, isKnown, isSecret, allResources] = getResourcesAndDetails(
-            promisedValues.map((kvp) => kvp.value),
-        );
-        return new Output(syncResources, promisedObject, isKnown, isSecret, allResources);
     }
+
+    const promisedValues: { key: string; value: any }[] = [];
+    let hasOutputs = false;
+    for (const k of Object.keys(val)) {
+        const ev = outputRec(val[k]);
+
+        promisedValues.push({ key: k, value: ev });
+        if (Output.isInstance(ev)) {
+            hasOutputs = true;
+        }
+    }
+
+    if (!hasOutputs) {
+        // Note: we intentionally return a new value here and not 'val'.  This ensures we get a
+        // copy.  This has been behavior we've had since the beginning and there may be subtle
+        // logic out there that depends on this that we would not want ot break.
+        return promisedValues.reduce(
+            (o, kvp) => {
+                o[kvp.key] = kvp.value;
+                return o;
+            },
+            <any>{},
+        );
+    }
+
+    const promisedObject = getPromisedObject(promisedValues);
+    const [syncResources, isKnown, isSecret, allResources] = getResourcesAndDetails(
+        promisedValues.map((kvp) => kvp.value),
+    );
+    return new Output(syncResources, promisedObject, isKnown, isSecret, allResources);
 }
 
 /**

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -583,12 +583,15 @@ function outputRec(val: any, seen?: Set<object>, preallocatedError?: Error): any
     // directly to user code.
     preallocatedError = preallocatedError ?? new Error("Cannot create an Output from a circular structure");
 
-    if (val instanceof Array) {
-        if (seen.has(val)) {
-            throw preallocatedError;
-        }
-        seen.add(val);
+    // Throw an error if we've seen this object before.
+    if (seen.has(val)) {
+        throw preallocatedError;
+    }
 
+    // Track that we've seen this object.
+    seen.add(val);
+
+    if (val instanceof Array) {
         const allValues = [];
         let hasOutputs = false;
         for (const v of val) {
@@ -614,11 +617,6 @@ function outputRec(val: any, seen?: Set<object>, preallocatedError?: Error): any
         const [syncResources, isKnown, isSecret, allResources] = getResourcesAndDetails(allValues);
         return new Output(syncResources, promisedArray, isKnown, isSecret, allResources);
     }
-
-    if (seen.has(val)) {
-        throw preallocatedError;
-    }
-    seen.add(val);
 
     const promisedValues: { key: string; value: any }[] = [];
     let hasOutputs = false;

--- a/sdk/nodejs/tests/output.spec.ts
+++ b/sdk/nodejs/tests/output.spec.ts
@@ -137,6 +137,22 @@ describe("output", () => {
                     await output(a).promise();
                 },
             },
+            {
+                name: "promise object in array in object",
+                block: async () => {
+                    const a: any = { b: [] };
+                    a.b.push(Promise.resolve(a));
+                    await output(a).promise();
+                },
+            },
+            {
+                name: "promise array in object in array",
+                block: async () => {
+                    const a: any[] = [];
+                    a.push({ b: Promise.resolve(a) });
+                    await output(a).promise();
+                },
+            },
         ];
         for (const { name, block } of asyncCases) {
             it(name, () => {

--- a/sdk/nodejs/tests/output.spec.ts
+++ b/sdk/nodejs/tests/output.spec.ts
@@ -145,6 +145,57 @@ describe("output", () => {
         }
     });
 
+    describe("doesn't throw for non-circular structures", () => {
+        it("same object in array", async () => {
+            const a = {};
+            const b = [a, a];
+            const o = output(b);
+            assert.deepStrictEqual(await o.promise(), [a, a]);
+        });
+        it("same array in object", async () => {
+            const a: any[] = [];
+            const b = { a: a, b: a };
+            const o = output(b);
+            assert.deepStrictEqual(await o.promise(), { a: a, b: a });
+        });
+        it("same promise object in array", async () => {
+            const a = Promise.resolve({});
+            const b = [a, a];
+            const o = output(b);
+            assert.deepStrictEqual(await o.promise(), [{}, {}]);
+        });
+        it("same object in promise in array", async () => {
+            const a = {};
+            const b = [Promise.resolve(a), Promise.resolve(a)];
+            const o = output(b);
+            assert.deepStrictEqual(await o.promise(), [{}, {}]);
+        });
+        it("same promise array in object", async () => {
+            const a = Promise.resolve([]);
+            const b = { a: a, b: a };
+            const o = output(b);
+            assert.deepStrictEqual(await o.promise(), { a: [], b: [] });
+        });
+        it("same array in promise in object", async () => {
+            const a: any[] = [];
+            const b = { a: Promise.resolve(a), b: Promise.resolve(a) };
+            const o = output(b);
+            assert.deepStrictEqual(await o.promise(), { a: [], b: [] });
+        });
+        it("same output object in array", async () => {
+            const a = output({});
+            const b = [a, a];
+            const o = output(b);
+            assert.deepStrictEqual(await o.promise(), [{}, {}]);
+        });
+        it("same output array in object", async () => {
+            const a = output([]);
+            const b = { a: a, b: a };
+            const o = output(b);
+            assert.deepStrictEqual(await o.promise(), { a: [], b: [] });
+        });
+    });
+
     it("propagates true isKnown bit from inner Output", async () => {
         runtime._setIsDryRun(true);
 


### PR DESCRIPTION
Note to reviewers: Review each commit separately. The first commit contains only formatting changes (no functional changes). The actual fix is in the second commit.

---

`pulumi.output(...)` cannot handle circular structures. Passing one to `output()` will currently result in a "Maximum call stack exceeded" error.

This commit adds a better error message for when a circular structure is detected, so that users know what the actual problem is and can address it. The error that is thrown is similar to the error thrown when passing a circular structure to `JSON.stringify()`.

Note: It may be possible to make circular structures work with `output()`, but it would require more time/effort to get the implementation right and not regress the perf fix from https://github.com/pulumi/pulumi/pull/3851.

Fixes #17778