### PR TITLE
Add OutputWithDependencies

### DIFF
--- a/changelog/pending/20241125--sdk-go--add-outputwithdependencies.yaml
+++ b/changelog/pending/20241125--sdk-go--add-outputwithdependencies.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Add OutputWithDependencies

--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -174,6 +174,14 @@ func ToOutputWithContext(ctx context.Context, v interface{}) Output {
 	return internal.ToOutputWithContext(ctx, v)
 }
 
+func OutputWithDependencies(ctx context.Context, o Output, deps ...Resource) Output {
+	r := make([]internal.Resource, len(deps))
+	for i, d := range deps {
+		r[i] = d.(internal.Resource)
+	}
+	return internal.OutputWithDependencies(ctx, o, r...)
+}
+
 func init() {
 	internal.AnyOutputType = anyOutputType
 }


### PR DESCRIPTION
Add `OutputWithDependencies` to the Go SDK which creates a new Output
from the passed in Output and augments it with additional Resource
dependencies.
