### PR TITLE
Fix login --interactive when no accounts are in the credentials file

### DIFF
--- a/changelog/pending/20241125--cli--fix-login-interactive-when-no-accounts-are-in-the-credentials-file.yaml
+++ b/changelog/pending/20241125--cli--fix-login-interactive-when-no-accounts-are-in-the-credentials-file.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix login --interactive when no accounts are in the credentials file

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -134,11 +134,14 @@ func newLoginCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				act, err := chooseAccount(creds.Accounts, displayOptions)
-				if err != nil {
-					return err
+				// If there are no accounts, skip this step and continue on with the default behavior below.
+				if len(creds.Accounts) > 0 {
+					act, err := chooseAccount(creds.Accounts, displayOptions)
+					if err != nil {
+						return err
+					}
+					cloudURL = act
 				}
-				cloudURL = act
 			}
 			if cloudURL == "" {
 				var err error


### PR DESCRIPTION
Spotted by @thomas11 in internal slack:
```
pulumi login --interactive
error: no account selected; please use `pulumi login --interactive` to choose one
```

Looks like this was from loading an empty credentials file in interactive mode and then immediately error'ing that there was no account to choose.
