### PR TITLE
Revert "allow URLs without template for downloading git repos (#17824)"

### DIFF
--- a/changelog/pending/20241126--cli-new--fix-new-to-work-with-local-template-directories-again.yaml
+++ b/changelog/pending/20241126--cli-new--fix-new-to-work-with-local-template-directories-again.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Fix new to work with local template directories again

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -654,13 +654,8 @@ func parseGitRepoURLParts(rawurl string) (gitRepoURLParts, error) {
 	if err != nil {
 		return gitRepoURLParts{}, err
 	}
-	if endpoint.Protocol == "file" {
-		// We want to allow "naked" URLs, such as github.com/pulumi/pulumi-provider in addition to
-		// full URLs such as https://github.com/pulumi/pulumi-provider for convenience.  go-git
-		// parses these as local (file) repositories.  Since we never want to allow those, we prefix
-		// https:// to these URLs, and assume that protocol.
-		rawurl = "https://" + rawurl
-	} else if endpoint.Protocol == "ssh" {
+
+	if endpoint.Protocol == "ssh" {
 		// Normalize SSH URLs (including scp-style git@github.com URLs) into
 		// ssh:// format so we can parse them the same as https:// URLs.
 		rawurl = endpoint.String()

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -144,8 +144,8 @@ func TestParseGitRepoURL(t *testing.T) {
 	// No owner.
 	testError("https://github.com", "invalid Git URL")
 	testError("https://github.com/", "invalid Git URL")
-	testError("git@github.com", "invalid Git URL")
-	testError("git@github.com/", "invalid Git URL")
+	testError("git@github.com", "invalid URL scheme: ")
+	testError("git@github.com/", "invalid URL scheme: ")
 	testError("ssh://git@github.com", "invalid Git URL")
 	testError("ssh://git@github.com/", "invalid Git URL")
 
@@ -160,13 +160,6 @@ func TestParseGitRepoURL(t *testing.T) {
 	// Not HTTPS.
 	testError("http://github.com/pulumi/templates.git", "invalid URL scheme: http")
 	testError("http://github.com/pulumi/templates", "invalid URL scheme: http")
-
-	// "Naked" URLs.
-	pre = "github.com/pulumi/templates"
-	exp = "https://" + pre + ".git"
-	test(exp, "", pre)
-	test(exp, "", pre+"/")
-	test(exp, "templates", pre+"/templates")
 }
 
 func TestGetGitReferenceNameOrHashAndSubDirectory(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/17862.

This reverts commit cfe2ccd36ec8d5990291e0779b1936aafb7f9968.