### PR TITLE
Add 'parameterization' to pulumi-plugin.json

### DIFF
--- a/changelog/pending/20241126--sdkgen--include-parameterization-details-in-pulumi-plugin-json.yaml
+++ b/changelog/pending/20241126--sdkgen--include-parameterization-details-in-pulumi-plugin-json.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdkgen
+  description: Include parameterization details in pulumi-plugin.json

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -2254,6 +2254,17 @@ func genPackageMetadata(pkg *schema.Package,
 		Server:   pkg.PluginDownloadURL,
 		Version:  version,
 	}
+	if pkg.Parameterization != nil {
+		// For a parameterized package the plugin name/version is from the base provider information, not the
+		// top-level package name/version.
+		pulumiPlugin.Parameterization = &plugin.PulumiParameterizationJSON{
+			Name:    pulumiPlugin.Name,
+			Version: pulumiPlugin.Version,
+			Value:   pkg.Parameterization.Parameter,
+		}
+		pulumiPlugin.Name = pkg.Parameterization.BaseProvider.Name
+		pulumiPlugin.Version = pkg.Parameterization.BaseProvider.Version.String()
+	}
 
 	plugin, err := (pulumiPlugin).JSON()
 	if err != nil {

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -4717,6 +4717,13 @@ func GeneratePackage(tool string,
 	}
 
 	if pkg.Parameterization != nil {
+		// For a parameterized package the plugin name/version is from the base provider information, not the
+		// top-level package name/version.
+		pulumiPlugin.Parameterization = &plugin.PulumiParameterizationJSON{
+			Name:    pulumiPlugin.Name,
+			Version: pulumiPlugin.Version,
+			Value:   pkg.Parameterization.Parameter,
+		}
 		pulumiPlugin.Name = pkg.Parameterization.BaseProvider.Name
 		pulumiPlugin.Version = pkg.Parameterization.BaseProvider.Version.String()
 	}

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -2430,6 +2430,11 @@ func genNPMPackageMetadata(pkg *schema.Package, info NodePackageInfo, localDepen
 			Server:   pkg.PluginDownloadURL,
 			Name:     pkg.Parameterization.BaseProvider.Name,
 			Version:  pkg.Parameterization.BaseProvider.Version.String(),
+			Parameterization: &plugin.PulumiParameterizationJSON{
+				Name:    pkg.Name,
+				Version: pkg.Version.String(),
+				Value:   pkg.Parameterization.Parameter,
+			},
 		}
 	} else {
 		pulumiPlugin = plugin.PulumiPluginJSON{

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -45,6 +45,15 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+type PulumiParameterizationJSON struct {
+	// The name of the parameterized package.
+	Name string `json:"name"`
+	// The version of the parameterized package.
+	Version string `json:"version"`
+	// The parameter value of the parameterized package.
+	Value []byte `json:"value"`
+}
+
 // PulumiPluginJSON represents additional information about a package's associated Pulumi plugin.
 // For Python, the content is inside a pulumi-plugin.json file inside the package.
 // For Node.js, the content is within the package.json file, under the "pulumi" node.
@@ -59,6 +68,8 @@ type PulumiPluginJSON struct {
 	Version string `json:"version,omitempty"`
 	// Optional plugin server. If not set, the default server is used when installing the plugin.
 	Server string `json:"server,omitempty"`
+	// Parameterization information for the package.
+	Parameterization *PulumiParameterizationJSON `json:"parameterization,omitempty"`
 }
 
 func (plugin *PulumiPluginJSON) JSON() ([]byte, error) {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/subpackage-2.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/subpackage-2.0.0/package.json
@@ -15,6 +15,11 @@
     "pulumi": {
         "resource": true,
         "name": "parameterized",
-        "version": "1.2.3"
+        "version": "1.2.3",
+        "parameterization": {
+            "name": "subpackage",
+            "version": "2.0.0",
+            "value": "SGVsbG9Xb3JsZA=="
+        }
     }
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/subpackage-2.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/subpackage-2.0.0/package.json
@@ -15,6 +15,11 @@
     "pulumi": {
         "resource": true,
         "name": "parameterized",
-        "version": "1.2.3"
+        "version": "1.2.3",
+        "parameterization": {
+            "name": "subpackage",
+            "version": "2.0.0",
+            "value": "SGVsbG9Xb3JsZA=="
+        }
     }
 }

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/pulumi-plugin.json
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/pulumi-plugin.json
@@ -1,5 +1,10 @@
 {
   "resource": true,
   "name": "parameterized",
-  "version": "1.2.3"
+  "version": "1.2.3",
+  "parameterization": {
+    "name": "subpackage",
+    "version": "2.0.0",
+    "value": "SGVsbG9Xb3JsZA=="
+  }
 }

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/pulumi-plugin.json
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/pulumi-plugin.json
@@ -1,5 +1,10 @@
 {
   "resource": true,
   "name": "parameterized",
-  "version": "1.2.3"
+  "version": "1.2.3",
+  "parameterization": {
+    "name": "subpackage",
+    "version": "2.0.0",
+    "value": "SGVsbG9Xb3JsZA=="
+  }
 }

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/pulumi-plugin.json
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/pulumi-plugin.json
@@ -1,5 +1,10 @@
 {
   "resource": true,
   "name": "parameterized",
-  "version": "1.2.3"
+  "version": "1.2.3",
+  "parameterization": {
+    "name": "subpackage",
+    "version": "2.0.0",
+    "value": "SGVsbG9Xb3JsZA=="
+  }
 }


### PR DESCRIPTION
Part of https://github.com/pulumi/pulumi/issues/17507

For importing resources of parameterized resources we need to be able to find the parameterized package descriptions without running the users program. This is the first part of fixing that. We add the parameterized information about the package into it's pulumi-plugin.json file, so this file now describes the overall package not just the base provider plugin.

Once this is merged there are two follow ups;
1) See about fixing sdk-gen to not emit the large byte value twice (in the source code where we currently have it, and now in the pulumi-plugin.json). We can probably fix all the sdks to just read from the embedded plugin file.
2) Update the language hosts to support a "GetAllPackages" instead of "GetAllPlugins" to read out this information from the pulumi-plugin.json files.