### PR TITLE
Reduce binary size by stripping debug information

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,8 +15,10 @@ builds:
   goos: ['linux', 'darwin', 'windows']
   goarch: ['amd64', 'arm64']
   goamd64: ['v1']
+  flags:
+    - -trimpath
   ldflags:
-    - -X github.com/pulumi/pulumi/pkg/v3/version.Version=v{{.Env.PULUMI_VERSION}}
+    - -w -s -X github.com/pulumi/pulumi/pkg/v3/version.Version=v{{.Env.PULUMI_VERSION}}
   mod_timestamp: '{{ .CommitTimestamp }}'
   tags:
     # Enforce the pure Go implementation of os/user, even when cgo is available.

--- a/changelog/pending/20241126--cli--reduce-binary-size-by-stripping-debug-information.yaml
+++ b/changelog/pending/20241126--cli--reduce-binary-size-by-stripping-debug-information.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Reduce binary size by stripping debug information


### PR DESCRIPTION
Strip the symbol table and DWARF debug information from the production
and dev releases. Note that stack traces don't lose any information from this change.

Binary size is reduced by ~30%:

* pulumi: 94M -> 67M
* pulumi-language-python: 33M -> 23M

Also use `-trimpath` for tidier module paths in stack traces. Before:

```
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/debug/stack.go:26 +0x64
github.com/pulumi/pulumi/pkg/v3/resource/deploy.SnapshotIntegrityErrorf({0x1060e97ad?, 0x40?}, {0x14000dbd1b8?, 0x40?, 0x40?})
        /Users/julien/Projects/pulumi/pulumi/pkg/resource/deploy/snapshot.go:617 +0x30
```

With `-trimpath` absolute file system paths will begin either a module path@version (when using modules) or a plain import path (when using the standard library)

```
runtime/debug.Stack()
        runtime/debug/stack.go:26 +0x64
github.com/pulumi/pulumi/pkg/v3/resource/deploy.SnapshotIntegrityErrorf({0x10269586d?, 0x40?}, {0x14001cc11b8?, 0x40?, 0x40?})
        github.com/pulumi/pulumi/pkg/v3/resource/deploy/snapshot.go:617 +0x30
github.com/pulumi/pulumi/pkg/v3/resource/deploy.(*Snapshot).VerifyIntegrity(0x14001fc6c80)
```

Note that local builds via the makefiles are unchanged and contain the full debug information. The new flags only apply when running via goreleaser, which we use in CI to build the binaries.
