### PR TITLE
Remove PluginDownloadURL from Parameterization

### DIFF
--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -2044,7 +2044,7 @@ func (mod *modContext) genUtilities() (string, error) {
 	if def.Parameterization != nil {
 		templateData.BaseProviderName = def.Parameterization.BaseProvider.Name
 		templateData.BaseProviderVersion = def.Parameterization.BaseProvider.Version.String()
-		templateData.BaseProviderPluginDownloadURL = def.Parameterization.BaseProvider.PluginDownloadURL
+		templateData.BaseProviderPluginDownloadURL = def.PluginDownloadURL
 		templateData.ParameterValue = base64.StdEncoding.EncodeToString(def.Parameterization.Parameter)
 	}
 

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -4719,7 +4719,6 @@ func GeneratePackage(tool string,
 	if pkg.Parameterization != nil {
 		pulumiPlugin.Name = pkg.Parameterization.BaseProvider.Name
 		pulumiPlugin.Version = pkg.Parameterization.BaseProvider.Version.String()
-		pulumiPlugin.Server = pkg.Parameterization.BaseProvider.PluginDownloadURL
 	}
 
 	pulumiPluginJSON, err := pulumiPlugin.JSON()

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -2427,9 +2427,9 @@ func genNPMPackageMetadata(pkg *schema.Package, info NodePackageInfo, localDepen
 	if pkg.Parameterization != nil {
 		pulumiPlugin = plugin.PulumiPluginJSON{
 			Resource: true,
+			Server:   pkg.PluginDownloadURL,
 			Name:     pkg.Parameterization.BaseProvider.Name,
 			Version:  pkg.Parameterization.BaseProvider.Version.String(),
-			Server:   pkg.Parameterization.BaseProvider.PluginDownloadURL,
 		}
 	} else {
 		pulumiPlugin = plugin.PulumiPluginJSON{
@@ -2901,7 +2901,7 @@ export async function getPackage() : Promise<string | undefined> {
 }
 `,
 			def.Name, def.Version, parameterValue,
-			def.Parameterization.BaseProvider.Name, def.Parameterization.BaseProvider.Version.String(), def.Parameterization.BaseProvider.PluginDownloadURL)
+			def.Parameterization.BaseProvider.Name, def.Parameterization.BaseProvider.Version.String(), def.PluginDownloadURL)
 	}
 
 	return err

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -2249,7 +2249,6 @@ func genPulumiPluginFile(pkg *schema.Package) ([]byte, error) {
 	if pkg.Parameterization != nil {
 		plugin.Name = pkg.Parameterization.BaseProvider.Name
 		plugin.Version = pkg.Parameterization.BaseProvider.Version.String()
-		plugin.Server = pkg.Parameterization.BaseProvider.PluginDownloadURL
 	}
 
 	return plugin.JSON()

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -1409,9 +1409,8 @@ func bindParameterization(spec *ParameterizationSpec) (*Parameterization, hcl.Di
 
 	return &Parameterization{
 		BaseProvider: BaseProvider{
-			Name:              spec.BaseProvider.Name,
-			Version:           ver,
-			PluginDownloadURL: spec.BaseProvider.PluginDownloadURL,
+			Name:    spec.BaseProvider.Name,
+			Version: ver,
 		},
 		Parameter: spec.Parameter,
 	}, nil

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -585,8 +585,6 @@ type BaseProvider struct {
 	Name string
 	// Version is the version of the provider.
 	Version semver.Version
-	// PluginDownloadURL is the URL to use to acquire the provider plugin binary, if any.
-	PluginDownloadURL string
 }
 
 type Parameterization struct {
@@ -978,9 +976,8 @@ func (pkg *Package) MarshalSpec() (spec *PackageSpec, err error) {
 	if pkg.Parameterization != nil {
 		parameterization = &ParameterizationSpec{
 			BaseProvider: BaseProviderSpec{
-				Name:              pkg.Parameterization.BaseProvider.Name,
-				Version:           pkg.Parameterization.BaseProvider.Version.String(),
-				PluginDownloadURL: pkg.Parameterization.BaseProvider.PluginDownloadURL,
+				Name:    pkg.Parameterization.BaseProvider.Name,
+				Version: pkg.Parameterization.BaseProvider.Version.String(),
 			},
 			Parameter: pkg.Parameterization.Parameter,
 		}
@@ -1994,8 +1991,6 @@ type BaseProviderSpec struct {
 	Name string `json:"name" yaml:"name"`
 	// The version of the base provider.
 	Version string `json:"version" yaml:"version"`
-	// The plugin download URL for the base provider.
-	PluginDownloadURL string `json:"pluginDownloadURL,omitempty" yaml:"pluginDownloadURL,omitempty"`
 }
 
 // ParameterizationSpec is the serializable description of a provider parameterization.


### PR DESCRIPTION
There's no need to have this in the Parameterization.BaseProvider section. There's only ever one plugin being referenced by a package, and thus one PluginDownloadURL and the field is already in the top level of the package schema. So just use that, don't duplicated/move it.