### PR TITLE
[DRAFT] Only check the package name, not the respsitory, to match packages.

### DIFF
--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/natefinch/atomic"
 
@@ -223,7 +224,8 @@ func LoadPackageReferenceV2(
 
 	name := descriptor.Name
 	if descriptor.Parameterization != nil {
-		name = descriptor.Parameterization.Name
+		path := strings.Split(descriptor.Parameterization.Name, "/")
+		name = path[len(path)-1]
 	}
 	version := descriptor.Version
 	if descriptor.Parameterization != nil {
@@ -374,9 +376,12 @@ func (l *pluginLoader) loadPluginSchemaBytes(
 		if err != nil {
 			return nil, nil, err
 		}
-		if resp.Name != descriptor.Parameterization.Name {
+
+		namePath := strings.Split(descriptor.Parameterization.Name, "/")
+		expectedName := namePath[len(namePath)-1]
+		if resp.Name != expectedName {
 			return nil, nil, fmt.Errorf(
-				"unexpected parameterization response: %s != %s", resp.Name, descriptor.Parameterization.Name)
+				"unexpected parameterization response: %s != %s", resp.Name, expectedName)
 		}
 		if !resp.Version.EQ(descriptor.Parameterization.Version) {
 			return nil, nil, fmt.Errorf(


### PR DESCRIPTION
Now that we have package blocks, they take the form
"[HOSTNAME]/NAMESPACE/packageName"

This causes there to be a naming mismatch when reading from the package
block and causing failures in tests.  This should mitigate that issue,
at the cost of risk of package name conflicts accross repos.

We should be matching against "NAMESPACE/packageName" to be inline with:
https://developer.hashicorp.com/terraform/language/providers/requirements#source-addresses

So I'm going to investigate this while others weigh in.
