### PR TITLE
Codegen for .NET InvokeOutputOptions

### DIFF
--- a/changelog/pending/20241202--sdkgen-dotnet--codegen-for-net-invokeoutputoptions.yaml
+++ b/changelog/pending/20241202--sdkgen-dotnet--codegen-for-net-invokeoutputoptions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/dotnet
+  description: Codegen for .NET InvokeOutputOptions

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -1594,7 +1594,7 @@ func (mod *modContext) genFunctionOutputVersion(w io.Writer, fun *schema.Functio
 	}
 
 	if fun.MultiArgumentInputs && outputOptions {
-		return fmt.Errorf("output options are not supported when using multi-argument inputs ")
+		return errors.New("outputOptions is not supported when using multi-argument inputs")
 	}
 
 	var argsDefault, sigil string
@@ -1623,7 +1623,7 @@ func (mod *modContext) genFunctionOutputVersion(w io.Writer, fun *schema.Functio
 			// For the InvokeOutputOptions variant, arguments can not optional, otherwise we
 			// can't differentiate between the two options variants.
 			if outputArgsParamDef != "" && argsDefault != "" {
-				outputArgsParamDef = fmt.Sprintf("%s args, ", argsTypeName)
+				outputArgsParamDef = argsTypeName + " args, "
 			}
 			fmt.Fprintf(w, "        public static Output%s Invoke(%sInvokeOutputOptions options)\n",
 				typeParamOrEmpty(typeParameter), outputArgsParamDef)

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -1520,9 +1520,9 @@ func (mod *modContext) genFunction(w io.Writer, fun *schema.Function) error {
 		return err
 	}
 
-	// Emit the Output method with InvokeOutputOutputOptions
+	// Emit the Output method with InvokeOutputOptions
 	//
-	// We have to make the `InvokeOutputOutputOptions options` required so that
+	// We have to make the `InvokeOutputOptions options` required so that
 	// it can be differentiated from the overload that takes `InvokeOptions
 	// options`. This means that preceding arguments to the method must also be
 	// required.

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -610,7 +610,13 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 
 		if len(expr.Args) == 3 {
 			if invokeOptions, ok := expr.Args[2].(*model.ObjectConsExpression); ok {
-				g.Fgen(w, ", new() {\n")
+				// For output form invokes, explicitly use the InvokeOutputOptions class for options
+				// to ensure we pick the correct overload that supports `DependsOn`.
+				if pcl.IsOutputVersionInvokeCall(expr) {
+					g.Fgen(w, ", new InvokeOutputOptions() {\n")
+				} else {
+					g.Fgen(w, ", new() {\n")
+				}
 				g.Indented(func() {
 					for _, item := range invokeOptions.Items {
 						key := pcl.LiteralValueString(item.Key)

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -610,13 +610,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 
 		if len(expr.Args) == 3 {
 			if invokeOptions, ok := expr.Args[2].(*model.ObjectConsExpression); ok {
-				// For output form invokes, explicitly use the InvokeOutputOptions class for options
-				// to ensure we pick the correct overload that supports `DependsOn`.
-				if pcl.IsOutputVersionInvokeCall(expr) {
-					g.Fgen(w, ", new InvokeOutputOptions() {\n")
-				} else {
-					g.Fgen(w, ", new() {\n")
-				}
+				g.Fgen(w, ", new() {\n")
 				g.Indented(func() {
 					for _, item := range invokeOptions.Items {
 						key := pcl.LiteralValueString(item.Key)

--- a/pkg/codegen/dotnet/templates.go
+++ b/pkg/codegen/dotnet/templates.go
@@ -81,7 +81,16 @@ namespace {{.Namespace}}
             dst.PluginDownloadURL = src?.PluginDownloadURL ?? "{{.PluginDownloadURL}}";{{end}}
             return dst;
         }
-{{if .HasParameterization }}		public static global::Pulumi.RegisterPackageRequest PackageParameterization()
+
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;{{if ne .PluginDownloadURL "" }}
+            dst.PluginDownloadURL = src?.PluginDownloadURL ?? "{{.PluginDownloadURL}}";{{end}}
+            return dst;
+        }
+
+        {{if .HasParameterization }}		public static global::Pulumi.RegisterPackageRequest PackageParameterization()
 		{
 			return new global::Pulumi.RegisterPackageRequest(
 				name: "{{.BaseProviderName}}",

--- a/pkg/codegen/dotnet/templates.go
+++ b/pkg/codegen/dotnet/templates.go
@@ -90,7 +90,7 @@ namespace {{.Namespace}}
             return dst;
         }
 {{if .HasParameterization }}
-public static global::Pulumi.RegisterPackageRequest PackageParameterization()
+        public static global::Pulumi.RegisterPackageRequest PackageParameterization()
         {
             return new global::Pulumi.RegisterPackageRequest(
                 name: "{{.BaseProviderName}}",

--- a/pkg/codegen/dotnet/templates.go
+++ b/pkg/codegen/dotnet/templates.go
@@ -89,18 +89,19 @@ namespace {{.Namespace}}
             dst.PluginDownloadURL = src?.PluginDownloadURL ?? "{{.PluginDownloadURL}}";{{end}}
             return dst;
         }
-
-        {{if .HasParameterization }}		public static global::Pulumi.RegisterPackageRequest PackageParameterization()
-		{
-			return new global::Pulumi.RegisterPackageRequest(
-				name: "{{.BaseProviderName}}",
-				version: "{{.BaseProviderVersion}}",
-				downloadUrl: "{{.BaseProviderPluginDownloadURL}}",
-				parameterization: new global::Pulumi.RegisterPackageRequest.PackageParameterization(
-					name: "{{.PackageName}}",
-					version: "{{.PackageVersion}}",
-					value: global::System.Convert.FromBase64String("{{.ParameterValue}}")));
-        }{{end}}
+{{if .HasParameterization }}
+public static global::Pulumi.RegisterPackageRequest PackageParameterization()
+        {
+            return new global::Pulumi.RegisterPackageRequest(
+                name: "{{.BaseProviderName}}",
+                version: "{{.BaseProviderVersion}}",
+                downloadUrl: "{{.BaseProviderPluginDownloadURL}}",
+                parameterization: new global::Pulumi.RegisterPackageRequest.PackageParameterization(
+                    name: "{{.PackageName}}",
+                    version: "{{.PackageVersion}}",
+                    value: global::System.Convert.FromBase64String("{{.ParameterValue}}")));
+        }
+{{end}}
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/assets-and-archives/dotnet/GetAssets.cs
+++ b/tests/testdata/codegen/assets-and-archives/dotnet/GetAssets.cs
@@ -16,6 +16,9 @@ namespace Pulumi.Example
 
         public static Output<GetAssetsResult> Invoke(GetAssetsInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<GetAssetsResult>("example::GetAssets", args ?? new GetAssetsInvokeArgs(), options.WithDefaults());
+
+        public static Output<GetAssetsResult> Invoke(GetAssetsInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<GetAssetsResult>("example::GetAssets", args ?? new GetAssetsInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/assets-and-archives/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/assets-and-archives/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/assets-and-archives/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/assets-and-archives/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/assets-and-archives/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/assets-and-archives/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/azure-native-nested-types/dotnet/Pulumi.AzureNative.csproj
+++ b/tests/testdata/codegen/azure-native-nested-types/dotnet/Pulumi.AzureNative.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 

--- a/tests/testdata/codegen/azure-native-nested-types/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/azure-native-nested-types/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.AzureNative
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/azure-native-nested-types/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/azure-native-nested-types/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.AzureNative
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/config-variables/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/config-variables/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/config-variables/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/config-variables/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/config-variables/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/config-variables/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/csharp-invoke-options-pp/csharp-invoke-options.pp
+++ b/tests/testdata/codegen/csharp-invoke-options-pp/csharp-invoke-options.pp
@@ -10,3 +10,13 @@ zone = invoke("aws:index:getAvailabilityZones", {
     version = "1.2.3"
     pluginDownloadUrl = "https://example.com"
 })
+
+resource server "aws:ec2:Instance" {
+	instanceType = "t2.micro"
+}
+
+zoneWithDepends = invoke("aws:index:getAvailabilityZones", {
+    allAvailabilityZones = true
+}, {
+    dependsOn: [server]
+})

--- a/tests/testdata/codegen/csharp-invoke-options-pp/csharp-invoke-options.pp
+++ b/tests/testdata/codegen/csharp-invoke-options-pp/csharp-invoke-options.pp
@@ -10,13 +10,3 @@ zone = invoke("aws:index:getAvailabilityZones", {
     version = "1.2.3"
     pluginDownloadUrl = "https://example.com"
 })
-
-resource server "aws:ec2:Instance" {
-	instanceType = "t2.micro"
-}
-
-zoneWithDepends = invoke("aws:index:getAvailabilityZones", {
-    allAvailabilityZones = true
-}, {
-    dependsOn: [server]
-})

--- a/tests/testdata/codegen/csharp-invoke-options-pp/dotnet/csharp-invoke-options.cs
+++ b/tests/testdata/codegen/csharp-invoke-options-pp/dotnet/csharp-invoke-options.cs
@@ -13,11 +13,26 @@ return await Deployment.RunAsync(() =>
     var zone = Aws.GetAvailabilityZones.Invoke(new()
     {
         AllAvailabilityZones = true,
-    }, new() {
+    }, new InvokeOutputOptions() {
         Provider = explicitProvider,
         Parent = explicitProvider,
         Version = "1.2.3",
         PluginDownloadURL = "https://example.com",
+    });
+
+    var server = new Aws.Ec2.Instance("server", new()
+    {
+        InstanceType = Aws.Ec2.InstanceType.T2_Micro,
+    });
+
+    var zoneWithDepends = Aws.GetAvailabilityZones.Invoke(new()
+    {
+        AllAvailabilityZones = true,
+    }, new InvokeOutputOptions() {
+        DependsOn = new[]
+        {
+            server,
+        },
     });
 
 });

--- a/tests/testdata/codegen/csharp-invoke-options-pp/dotnet/csharp-invoke-options.cs
+++ b/tests/testdata/codegen/csharp-invoke-options-pp/dotnet/csharp-invoke-options.cs
@@ -13,26 +13,11 @@ return await Deployment.RunAsync(() =>
     var zone = Aws.GetAvailabilityZones.Invoke(new()
     {
         AllAvailabilityZones = true,
-    }, new InvokeOutputOptions() {
+    }, new() {
         Provider = explicitProvider,
         Parent = explicitProvider,
         Version = "1.2.3",
         PluginDownloadURL = "https://example.com",
-    });
-
-    var server = new Aws.Ec2.Instance("server", new()
-    {
-        InstanceType = Aws.Ec2.InstanceType.T2_Micro,
-    });
-
-    var zoneWithDepends = Aws.GetAvailabilityZones.Invoke(new()
-    {
-        AllAvailabilityZones = true,
-    }, new InvokeOutputOptions() {
-        DependsOn = new[]
-        {
-            server,
-        },
     });
 
 });

--- a/tests/testdata/codegen/cyclic-types/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/cyclic-types/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/cyclic-types/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/cyclic-types/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/cyclic-types/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/cyclic-types/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/dash-named-schema/dotnet/Pulumi.FooBar.csproj
+++ b/tests/testdata/codegen/dash-named-schema/dotnet/Pulumi.FooBar.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
     <PackageReference Include="Pulumi.Aws" Version="4.20" ExcludeAssets="contentFiles" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.7" ExcludeAssets="contentFiles" />
     <PackageReference Include="Pulumi.Random" Version="4.2" ExcludeAssets="contentFiles" />

--- a/tests/testdata/codegen/dash-named-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/dash-named-schema/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.FooBar
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/dash-named-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/dash-named-schema/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.FooBar
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/dashed-import-schema/dotnet/Pulumi.Plant.csproj
+++ b/tests/testdata/codegen/dashed-import-schema/dotnet/Pulumi.Plant.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/dashed-import-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/dashed-import-schema/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Plant
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/dashed-import-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/dashed-import-schema/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Plant
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/different-enum/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/different-enum/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Plant
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/different-enum/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/different-enum/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Plant
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/enum-reference/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/enum-reference/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.33.2" />
+    <PackageReference Include="Pulumi" Version="3.71.0" />
     <PackageReference Include="Pulumi.GoogleNative" Version="0.20.0" ExcludeAssets="contentFiles" />
   </ItemGroup>
 

--- a/tests/testdata/codegen/enum-reference/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/enum-reference/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/enum-reference/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/enum-reference/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/enum-reference/schema.json
+++ b/tests/testdata/codegen/enum-reference/schema.json
@@ -19,7 +19,7 @@
         },
         "csharp": {
             "packageReferences": {
-                "Pulumi": "3.33.2",
+                "Pulumi": "3.71.0",
                 "Pulumi.GoogleNative": "0.20.0"
             }
         },

--- a/tests/testdata/codegen/external-resource-schema/dotnet/ArgFunction.cs
+++ b/tests/testdata/codegen/external-resource-schema/dotnet/ArgFunction.cs
@@ -16,6 +16,9 @@ namespace Pulumi.Example
 
         public static Output<ArgFunctionResult> Invoke(ArgFunctionInvokeArgs? args = null, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<ArgFunctionResult>("example::argFunction", args ?? new ArgFunctionInvokeArgs(), options.WithDefaults());
+
+        public static Output<ArgFunctionResult> Invoke(ArgFunctionInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<ArgFunctionResult>("example::argFunction", args ?? new ArgFunctionInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/external-resource-schema/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/external-resource-schema/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.23" />
+    <PackageReference Include="Pulumi" Version="3.71" />
     <PackageReference Include="Pulumi.Aws" Version="4.20" ExcludeAssets="contentFiles" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.7.0" ExcludeAssets="contentFiles" />
     <PackageReference Include="Pulumi.Random" Version="4.2.0" ExcludeAssets="contentFiles" />

--- a/tests/testdata/codegen/external-resource-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/external-resource-schema/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/external-resource-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/external-resource-schema/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/external-resource-schema/schema.json
+++ b/tests/testdata/codegen/external-resource-schema/schema.json
@@ -143,7 +143,7 @@
   "language": {
     "csharp": {
       "packageReferences": {
-        "Pulumi": "3.23",
+        "Pulumi": "3.71",
         "Pulumi.Aws": "4.20",
         "Pulumi.Kubernetes": "3.7.0",
         "Pulumi.Random": "4.2.0"

--- a/tests/testdata/codegen/functions-secrets/dotnet/FuncWithSecrets.cs
+++ b/tests/testdata/codegen/functions-secrets/dotnet/FuncWithSecrets.cs
@@ -16,6 +16,9 @@ namespace Pulumi.Mypkg
 
         public static Output<FuncWithSecretsResult> Invoke(FuncWithSecretsInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<FuncWithSecretsResult>("mypkg::funcWithSecrets", args ?? new FuncWithSecretsInvokeArgs(), options.WithDefaults());
+
+        public static Output<FuncWithSecretsResult> Invoke(FuncWithSecretsInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<FuncWithSecretsResult>("mypkg::funcWithSecrets", args ?? new FuncWithSecretsInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/functions-secrets/dotnet/Pulumi.Mypkg.csproj
+++ b/tests/testdata/codegen/functions-secrets/dotnet/Pulumi.Mypkg.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/functions-secrets/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/functions-secrets/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Mypkg
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/functions-secrets/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/functions-secrets/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Mypkg
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/hyphen-url/dotnet/Pulumi.Registrygeoreplication.csproj
+++ b/tests/testdata/codegen/hyphen-url/dotnet/Pulumi.Registrygeoreplication.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
     <PackageReference Include="Pulumi.AzureNative" Version="1.28.*" ExcludeAssets="contentFiles" />
   </ItemGroup>
 

--- a/tests/testdata/codegen/hyphen-url/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/hyphen-url/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Registrygeoreplication
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/hyphen-url/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/hyphen-url/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Registrygeoreplication
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/kubernetes20/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/kubernetes20/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Kubernetes
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/kubernetes20/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/kubernetes20/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Kubernetes
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/legacy-names/dotnet/Pulumi.Legacy_names.csproj
+++ b/tests/testdata/codegen/legacy-names/dotnet/Pulumi.Legacy_names.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/legacy-names/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/legacy-names/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Legacy_names
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/legacy-names/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/legacy-names/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Legacy_names
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/naming-collisions/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/naming-collisions/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/naming-collisions/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/naming-collisions/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/naming-collisions/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/naming-collisions/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/nested-module-thirdparty/dotnet/Pulumi.FooBar.csproj
+++ b/tests/testdata/codegen/nested-module-thirdparty/dotnet/Pulumi.FooBar.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/nested-module-thirdparty/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/nested-module-thirdparty/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.FooBar
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/nested-module-thirdparty/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/nested-module-thirdparty/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.FooBar
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/nested-module/dotnet/Pulumi.Foo.csproj
+++ b/tests/testdata/codegen/nested-module/dotnet/Pulumi.Foo.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.12" />
+    <PackageReference Include="Pulumi" Version="3.71" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/nested-module/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/nested-module/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Foo
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/nested-module/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/nested-module/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Foo
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/nested-module/schema.json
+++ b/tests/testdata/codegen/nested-module/schema.json
@@ -21,7 +21,7 @@
   "language": {
     "csharp": {
       "packageReferences": {
-        "Pulumi": "3.12"
+        "Pulumi": "3.71"
       }
     },
     "go": {

--- a/tests/testdata/codegen/other-owned/dotnet/ArgFunction.cs
+++ b/tests/testdata/codegen/other-owned/dotnet/ArgFunction.cs
@@ -17,6 +17,9 @@ namespace Other.Example
 
         public static Output<ArgFunctionResult> Invoke(ArgFunctionInvokeArgs? args = null, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<ArgFunctionResult>("example::argFunction", args ?? new ArgFunctionInvokeArgs(), options.WithDefaults());
+
+        public static Output<ArgFunctionResult> Invoke(ArgFunctionInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<ArgFunctionResult>("example::argFunction", args ?? new ArgFunctionInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/other-owned/dotnet/Other.Example.csproj
+++ b/tests/testdata/codegen/other-owned/dotnet/Other.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.23" />
+    <PackageReference Include="Pulumi" Version="3.71" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/other-owned/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/other-owned/dotnet/Utilities.cs
@@ -65,7 +65,6 @@ namespace Other.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/other-owned/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/other-owned/dotnet/Utilities.cs
@@ -57,6 +57,15 @@ namespace Other.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            dst.PluginDownloadURL = src?.PluginDownloadURL ?? "example.com/download";
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/other-owned/schema.json
+++ b/tests/testdata/codegen/other-owned/schema.json
@@ -249,7 +249,7 @@
   "language": {
     "csharp": {
       "packageReferences": {
-        "Pulumi": "3.23"
+        "Pulumi": "3.71"
       },
       "rootNamespace": "Other"
     },

--- a/tests/testdata/codegen/output-funcs-edgeorder/dotnet/ListConfigurations.cs
+++ b/tests/testdata/codegen/output-funcs-edgeorder/dotnet/ListConfigurations.cs
@@ -24,6 +24,13 @@ namespace Pulumi.Myedgeorder
         /// </summary>
         public static Output<ListConfigurationsResult> Invoke(ListConfigurationsInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<ListConfigurationsResult>("myedgeorder::listConfigurations", args ?? new ListConfigurationsInvokeArgs(), options.WithDefaults());
+
+        /// <summary>
+        /// The list of configurations.
+        /// API Version: 2020-12-01-preview.
+        /// </summary>
+        public static Output<ListConfigurationsResult> Invoke(ListConfigurationsInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<ListConfigurationsResult>("myedgeorder::listConfigurations", args ?? new ListConfigurationsInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/output-funcs-edgeorder/dotnet/ListProductFamilies.cs
+++ b/tests/testdata/codegen/output-funcs-edgeorder/dotnet/ListProductFamilies.cs
@@ -24,6 +24,13 @@ namespace Pulumi.Myedgeorder
         /// </summary>
         public static Output<ListProductFamiliesResult> Invoke(ListProductFamiliesInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<ListProductFamiliesResult>("myedgeorder::listProductFamilies", args ?? new ListProductFamiliesInvokeArgs(), options.WithDefaults());
+
+        /// <summary>
+        /// The list of product families.
+        /// API Version: 2020-12-01-preview.
+        /// </summary>
+        public static Output<ListProductFamiliesResult> Invoke(ListProductFamiliesInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<ListProductFamiliesResult>("myedgeorder::listProductFamilies", args ?? new ListProductFamiliesInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/output-funcs-edgeorder/dotnet/Pulumi.Myedgeorder.csproj
+++ b/tests/testdata/codegen/output-funcs-edgeorder/dotnet/Pulumi.Myedgeorder.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/output-funcs-edgeorder/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/output-funcs-edgeorder/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Myedgeorder
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/output-funcs-edgeorder/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/output-funcs-edgeorder/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Myedgeorder
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/output-funcs-tfbridge20/dotnet/GetAmiIds.cs
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/dotnet/GetAmiIds.cs
@@ -23,6 +23,12 @@ namespace Pulumi.Mypkg
         /// </summary>
         public static Output<GetAmiIdsResult> Invoke(GetAmiIdsInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<GetAmiIdsResult>("mypkg::getAmiIds", args ?? new GetAmiIdsInvokeArgs(), options.WithDefaults());
+
+        /// <summary>
+        /// Taken from pulumi-AWS to regress an issue
+        /// </summary>
+        public static Output<GetAmiIdsResult> Invoke(GetAmiIdsInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<GetAmiIdsResult>("mypkg::getAmiIds", args ?? new GetAmiIdsInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/output-funcs-tfbridge20/dotnet/ListStorageAccountKeys.cs
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/dotnet/ListStorageAccountKeys.cs
@@ -24,6 +24,13 @@ namespace Pulumi.Mypkg
         /// </summary>
         public static Output<ListStorageAccountKeysResult> Invoke(ListStorageAccountKeysInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<ListStorageAccountKeysResult>("mypkg::listStorageAccountKeys", args ?? new ListStorageAccountKeysInvokeArgs(), options.WithDefaults());
+
+        /// <summary>
+        /// The response from the ListKeys operation.
+        /// API Version: 2021-02-01.
+        /// </summary>
+        public static Output<ListStorageAccountKeysResult> Invoke(ListStorageAccountKeysInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<ListStorageAccountKeysResult>("mypkg::listStorageAccountKeys", args ?? new ListStorageAccountKeysInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/output-funcs-tfbridge20/dotnet/Pulumi.Mypkg.csproj
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/dotnet/Pulumi.Mypkg.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/output-funcs-tfbridge20/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Mypkg
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/output-funcs-tfbridge20/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Mypkg
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/output-funcs/dotnet/FuncWithAllOptionalInputs.cs
+++ b/tests/testdata/codegen/output-funcs/dotnet/FuncWithAllOptionalInputs.cs
@@ -22,6 +22,12 @@ namespace Pulumi.Mypkg
         /// </summary>
         public static Output<FuncWithAllOptionalInputsResult> Invoke(FuncWithAllOptionalInputsInvokeArgs? args = null, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<FuncWithAllOptionalInputsResult>("mypkg::funcWithAllOptionalInputs", args ?? new FuncWithAllOptionalInputsInvokeArgs(), options.WithDefaults());
+
+        /// <summary>
+        /// Check codegen of functions with all optional inputs.
+        /// </summary>
+        public static Output<FuncWithAllOptionalInputsResult> Invoke(FuncWithAllOptionalInputsInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<FuncWithAllOptionalInputsResult>("mypkg::funcWithAllOptionalInputs", args ?? new FuncWithAllOptionalInputsInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/output-funcs/dotnet/FuncWithDefaultValue.cs
+++ b/tests/testdata/codegen/output-funcs/dotnet/FuncWithDefaultValue.cs
@@ -22,6 +22,12 @@ namespace Pulumi.Mypkg
         /// </summary>
         public static Output<FuncWithDefaultValueResult> Invoke(FuncWithDefaultValueInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<FuncWithDefaultValueResult>("mypkg::funcWithDefaultValue", args ?? new FuncWithDefaultValueInvokeArgs(), options.WithDefaults());
+
+        /// <summary>
+        /// Check codegen of functions with default values.
+        /// </summary>
+        public static Output<FuncWithDefaultValueResult> Invoke(FuncWithDefaultValueInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<FuncWithDefaultValueResult>("mypkg::funcWithDefaultValue", args ?? new FuncWithDefaultValueInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/output-funcs/dotnet/FuncWithDictParam.cs
+++ b/tests/testdata/codegen/output-funcs/dotnet/FuncWithDictParam.cs
@@ -22,6 +22,12 @@ namespace Pulumi.Mypkg
         /// </summary>
         public static Output<FuncWithDictParamResult> Invoke(FuncWithDictParamInvokeArgs? args = null, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<FuncWithDictParamResult>("mypkg::funcWithDictParam", args ?? new FuncWithDictParamInvokeArgs(), options.WithDefaults());
+
+        /// <summary>
+        /// Check codegen of functions with a Dict&lt;str,str&gt; parameter.
+        /// </summary>
+        public static Output<FuncWithDictParamResult> Invoke(FuncWithDictParamInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<FuncWithDictParamResult>("mypkg::funcWithDictParam", args ?? new FuncWithDictParamInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/output-funcs/dotnet/FuncWithListParam.cs
+++ b/tests/testdata/codegen/output-funcs/dotnet/FuncWithListParam.cs
@@ -22,6 +22,12 @@ namespace Pulumi.Mypkg
         /// </summary>
         public static Output<FuncWithListParamResult> Invoke(FuncWithListParamInvokeArgs? args = null, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<FuncWithListParamResult>("mypkg::funcWithListParam", args ?? new FuncWithListParamInvokeArgs(), options.WithDefaults());
+
+        /// <summary>
+        /// Check codegen of functions with a List parameter.
+        /// </summary>
+        public static Output<FuncWithListParamResult> Invoke(FuncWithListParamInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<FuncWithListParamResult>("mypkg::funcWithListParam", args ?? new FuncWithListParamInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/output-funcs/dotnet/GetBastionShareableLink.cs
+++ b/tests/testdata/codegen/output-funcs/dotnet/GetBastionShareableLink.cs
@@ -24,6 +24,13 @@ namespace Pulumi.Mypkg
         /// </summary>
         public static Output<GetBastionShareableLinkResult> Invoke(GetBastionShareableLinkInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<GetBastionShareableLinkResult>("mypkg::getBastionShareableLink", args ?? new GetBastionShareableLinkInvokeArgs(), options.WithDefaults());
+
+        /// <summary>
+        /// Response for all the Bastion Shareable Link endpoints.
+        /// API Version: 2020-11-01.
+        /// </summary>
+        public static Output<GetBastionShareableLinkResult> Invoke(GetBastionShareableLinkInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<GetBastionShareableLinkResult>("mypkg::getBastionShareableLink", args ?? new GetBastionShareableLinkInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/output-funcs/dotnet/GetClientConfig.cs
+++ b/tests/testdata/codegen/output-funcs/dotnet/GetClientConfig.cs
@@ -22,6 +22,12 @@ namespace Pulumi.Mypkg
         /// </summary>
         public static Output<GetClientConfigResult> Invoke(InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<GetClientConfigResult>("mypkg::getClientConfig", InvokeArgs.Empty, options.WithDefaults());
+
+        /// <summary>
+        /// Failing example taken from azure-native. Original doc: Use this function to access the current configuration of the native Azure provider.
+        /// </summary>
+        public static Output<GetClientConfigResult> Invoke(InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<GetClientConfigResult>("mypkg::getClientConfig", InvokeArgs.Empty, options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/output-funcs/dotnet/GetIntegrationRuntimeObjectMetadatum.cs
+++ b/tests/testdata/codegen/output-funcs/dotnet/GetIntegrationRuntimeObjectMetadatum.cs
@@ -24,6 +24,13 @@ namespace Pulumi.Mypkg
         /// </summary>
         public static Output<GetIntegrationRuntimeObjectMetadatumResult> Invoke(GetIntegrationRuntimeObjectMetadatumInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<GetIntegrationRuntimeObjectMetadatumResult>("mypkg::getIntegrationRuntimeObjectMetadatum", args ?? new GetIntegrationRuntimeObjectMetadatumInvokeArgs(), options.WithDefaults());
+
+        /// <summary>
+        /// Another failing example. A list of SSIS object metadata.
+        /// API Version: 2018-06-01.
+        /// </summary>
+        public static Output<GetIntegrationRuntimeObjectMetadatumResult> Invoke(GetIntegrationRuntimeObjectMetadatumInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<GetIntegrationRuntimeObjectMetadatumResult>("mypkg::getIntegrationRuntimeObjectMetadatum", args ?? new GetIntegrationRuntimeObjectMetadatumInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/output-funcs/dotnet/ListStorageAccountKeys.cs
+++ b/tests/testdata/codegen/output-funcs/dotnet/ListStorageAccountKeys.cs
@@ -24,6 +24,13 @@ namespace Pulumi.Mypkg
         /// </summary>
         public static Output<ListStorageAccountKeysResult> Invoke(ListStorageAccountKeysInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<ListStorageAccountKeysResult>("mypkg::listStorageAccountKeys", args ?? new ListStorageAccountKeysInvokeArgs(), options.WithDefaults());
+
+        /// <summary>
+        /// The response from the ListKeys operation.
+        /// API Version: 2021-02-01.
+        /// </summary>
+        public static Output<ListStorageAccountKeysResult> Invoke(ListStorageAccountKeysInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<ListStorageAccountKeysResult>("mypkg::listStorageAccountKeys", args ?? new ListStorageAccountKeysInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/output-funcs/dotnet/Pulumi.Mypkg.csproj
+++ b/tests/testdata/codegen/output-funcs/dotnet/Pulumi.Mypkg.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/output-funcs/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/output-funcs/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Mypkg
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/output-funcs/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/output-funcs/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Mypkg
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/plain-and-default/dotnet/Pulumi.FooBar.csproj
+++ b/tests/testdata/codegen/plain-and-default/dotnet/Pulumi.FooBar.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/plain-and-default/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/plain-and-default/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.FooBar
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/plain-and-default/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/plain-and-default/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.FooBar
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/plain-object-defaults/dotnet/FuncWithAllOptionalInputs.cs
+++ b/tests/testdata/codegen/plain-object-defaults/dotnet/FuncWithAllOptionalInputs.cs
@@ -22,6 +22,12 @@ namespace Pulumi.Example
         /// </summary>
         public static Output<FuncWithAllOptionalInputsResult> Invoke(FuncWithAllOptionalInputsInvokeArgs? args = null, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<FuncWithAllOptionalInputsResult>("example::funcWithAllOptionalInputs", args ?? new FuncWithAllOptionalInputsInvokeArgs(), options.WithDefaults());
+
+        /// <summary>
+        /// Check codegen of functions with all optional inputs.
+        /// </summary>
+        public static Output<FuncWithAllOptionalInputsResult> Invoke(FuncWithAllOptionalInputsInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<FuncWithAllOptionalInputsResult>("example::funcWithAllOptionalInputs", args ?? new FuncWithAllOptionalInputsInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/plain-object-defaults/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/plain-object-defaults/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/plain-object-defaults/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/plain-object-defaults/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/plain-object-defaults/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/plain-object-defaults/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/plain-object-disable-defaults/dotnet/FuncWithAllOptionalInputs.cs
+++ b/tests/testdata/codegen/plain-object-disable-defaults/dotnet/FuncWithAllOptionalInputs.cs
@@ -23,6 +23,12 @@ namespace Pulumi.Mypkg
         /// </summary>
         public static Output<FuncWithAllOptionalInputsResult> Invoke(FuncWithAllOptionalInputsInvokeArgs? args = null, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<FuncWithAllOptionalInputsResult>("mypkg::funcWithAllOptionalInputs", args ?? new FuncWithAllOptionalInputsInvokeArgs(), options.WithDefaults());
+
+        /// <summary>
+        /// Check codegen of functions with all optional inputs.
+        /// </summary>
+        public static Output<FuncWithAllOptionalInputsResult> Invoke(FuncWithAllOptionalInputsInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<FuncWithAllOptionalInputsResult>("mypkg::funcWithAllOptionalInputs", args ?? new FuncWithAllOptionalInputsInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/plain-object-disable-defaults/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/plain-object-disable-defaults/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/plain-object-disable-defaults/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/plain-object-disable-defaults/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/plain-object-disable-defaults/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/plain-object-disable-defaults/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/plain-schema-gh6957/dotnet/Pulumi.Xyz.csproj
+++ b/tests/testdata/codegen/plain-schema-gh6957/dotnet/Pulumi.Xyz.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.26.1" />
+    <PackageReference Include="Pulumi" Version="3.71.0" />
     <PackageReference Include="Pulumi.Aws" Version="4.*" ExcludeAssets="contentFiles" />
   </ItemGroup>
 

--- a/tests/testdata/codegen/plain-schema-gh6957/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/plain-schema-gh6957/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Xyz
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/plain-schema-gh6957/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/plain-schema-gh6957/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Xyz
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/plain-schema-gh6957/schema.json
+++ b/tests/testdata/codegen/plain-schema-gh6957/schema.json
@@ -41,7 +41,7 @@
   "language": {
     "csharp": {
       "packageReferences": {
-        "Pulumi": "3.26.1",
+        "Pulumi": "3.71.0",
         "Pulumi.Aws": "4.*"
       }
     },

--- a/tests/testdata/codegen/provider-config-schema/dotnet/Configstation/FuncWithAllOptionalInputs.cs
+++ b/tests/testdata/codegen/provider-config-schema/dotnet/Configstation/FuncWithAllOptionalInputs.cs
@@ -23,6 +23,12 @@ namespace Configstation.Pulumi.Configstation
         /// </summary>
         public static Output<FuncWithAllOptionalInputsResult> Invoke(FuncWithAllOptionalInputsInvokeArgs? args = null, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<FuncWithAllOptionalInputsResult>("configstation::funcWithAllOptionalInputs", args ?? new FuncWithAllOptionalInputsInvokeArgs(), options.WithDefaults());
+
+        /// <summary>
+        /// Check codegen of functions with all optional inputs.
+        /// </summary>
+        public static Output<FuncWithAllOptionalInputsResult> Invoke(FuncWithAllOptionalInputsInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<FuncWithAllOptionalInputsResult>("configstation::funcWithAllOptionalInputs", args ?? new FuncWithAllOptionalInputsInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/provider-config-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/provider-config-schema/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Configstation.Pulumi.Configstation
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/provider-config-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/provider-config-schema/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Configstation.Pulumi.Configstation
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/provider-type-schema/dotnet/Pulumi.ProviderType.csproj
+++ b/tests/testdata/codegen/provider-type-schema/dotnet/Pulumi.ProviderType.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/provider-type-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/provider-type-schema/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.ProviderType
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/provider-type-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/provider-type-schema/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.ProviderType
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/regress-8403/dotnet/GetCustomDbRoles.cs
+++ b/tests/testdata/codegen/regress-8403/dotnet/GetCustomDbRoles.cs
@@ -16,6 +16,9 @@ namespace Pulumi.Mongodbatlas
 
         public static Output<GetCustomDbRolesResult> Invoke(InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<GetCustomDbRolesResult>("mongodbatlas::getCustomDbRoles", InvokeArgs.Empty, options.WithDefaults());
+
+        public static Output<GetCustomDbRolesResult> Invoke(InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<GetCustomDbRolesResult>("mongodbatlas::getCustomDbRoles", InvokeArgs.Empty, options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/regress-8403/dotnet/Pulumi.Mongodbatlas.csproj
+++ b/tests/testdata/codegen/regress-8403/dotnet/Pulumi.Mongodbatlas.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/regress-8403/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/regress-8403/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Mongodbatlas
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/regress-8403/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/regress-8403/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Mongodbatlas
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/regress-node-8110/dotnet/Pulumi.My8110.csproj
+++ b/tests/testdata/codegen/regress-node-8110/dotnet/Pulumi.My8110.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/regress-node-8110/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/regress-node-8110/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.My8110
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/regress-node-8110/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/regress-node-8110/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.My8110
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/replace-on-change/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/replace-on-change/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/replace-on-change/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/replace-on-change/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/replace-on-change/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/replace-on-change/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/resource-args-python/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/resource-args-python/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/resource-args-python/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/resource-args-python/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/resource-args-python/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/resource-args-python/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/resource-property-overlap/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/resource-property-overlap/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/resource-property-overlap/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/resource-property-overlap/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/resource-property-overlap/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/resource-property-overlap/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/secrets/dotnet/Pulumi.Mypkg.csproj
+++ b/tests/testdata/codegen/secrets/dotnet/Pulumi.Mypkg.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/secrets/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/secrets/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Mypkg
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/secrets/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/secrets/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Mypkg
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-enum-schema/dotnet/Pulumi.Plant.csproj
+++ b/tests/testdata/codegen/simple-enum-schema/dotnet/Pulumi.Plant.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/simple-enum-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simple-enum-schema/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Plant
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-enum-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simple-enum-schema/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Plant
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-methods-schema/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-methods-schema/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
     <PackageReference Include="Pulumi.Random" Version="4.2.0" ExcludeAssets="contentFiles" />
   </ItemGroup>
 

--- a/tests/testdata/codegen/simple-methods-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simple-methods-schema/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-methods-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simple-methods-schema/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-plain-schema/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-plain-schema/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/simple-plain-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simple-plain-schema/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-plain-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simple-plain-schema/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/dotnet/ArgFunction.cs
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/dotnet/ArgFunction.cs
@@ -16,6 +16,9 @@ namespace Pulumi.Example
 
         public static Output<ArgFunctionResult> Invoke(ArgFunctionInvokeArgs? args = null, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<ArgFunctionResult>("example::argFunction", args ?? new ArgFunctionInvokeArgs(), options.WithDefaults());
+
+        public static Output<ArgFunctionResult> Invoke(ArgFunctionInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<ArgFunctionResult>("example::argFunction", args ?? new ArgFunctionInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.23" />
+    <PackageReference Include="Pulumi" Version="3.71" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/schema.json
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/schema.json
@@ -117,7 +117,7 @@
   "language": {
     "csharp": {
       "packageReferences": {
-        "Pulumi": "3.23"
+        "Pulumi": "3.71"
       }
     },
     "go": {

--- a/tests/testdata/codegen/simple-resource-schema/dotnet/ArgFunction.cs
+++ b/tests/testdata/codegen/simple-resource-schema/dotnet/ArgFunction.cs
@@ -16,6 +16,9 @@ namespace Pulumi.Example
 
         public static Output<ArgFunctionResult> Invoke(ArgFunctionInvokeArgs? args = null, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<ArgFunctionResult>("example::argFunction", args ?? new ArgFunctionInvokeArgs(), options.WithDefaults());
+
+        public static Output<ArgFunctionResult> Invoke(ArgFunctionInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<ArgFunctionResult>("example::argFunction", args ?? new ArgFunctionInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/simple-resource-schema/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-resource-schema/dotnet/Pulumi.Example.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/simple-resource-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simple-resource-schema/dotnet/Utilities.cs
@@ -65,7 +65,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-resource-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simple-resource-schema/dotnet/Utilities.cs
@@ -57,6 +57,15 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            dst.PluginDownloadURL = src?.PluginDownloadURL ?? "example.com/download";
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-resource-with-aliases/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-resource-with-aliases/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/simple-resource-with-aliases/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simple-resource-with-aliases/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-resource-with-aliases/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simple-resource-with-aliases/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-yaml-schema/dotnet/ArgFunction.cs
+++ b/tests/testdata/codegen/simple-yaml-schema/dotnet/ArgFunction.cs
@@ -16,6 +16,9 @@ namespace Pulumi.Example
 
         public static Output<ArgFunctionResult> Invoke(ArgFunctionInvokeArgs? args = null, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<ArgFunctionResult>("example::argFunction", args ?? new ArgFunctionInvokeArgs(), options.WithDefaults());
+
+        public static Output<ArgFunctionResult> Invoke(ArgFunctionInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<ArgFunctionResult>("example::argFunction", args ?? new ArgFunctionInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/simple-yaml-schema/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-yaml-schema/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.23" />
+    <PackageReference Include="Pulumi" Version="3.71" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/simple-yaml-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simple-yaml-schema/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-yaml-schema/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simple-yaml-schema/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simple-yaml-schema/schema.yaml
+++ b/tests/testdata/codegen/simple-yaml-schema/schema.yaml
@@ -140,7 +140,7 @@ functions:
         result:
           "$ref": "#/resources/example::Resource"
 language:
-  csharp: { "packageReferences": { "Pulumi": "3.23" } }
+  csharp: { "packageReferences": { "Pulumi": "3.71" } }
   go:
     {
       "importBasePath": "simple-yaml-schema/example",

--- a/tests/testdata/codegen/simplified-invokes/dotnet/Abs.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/Abs.cs
@@ -24,6 +24,13 @@ namespace Pulumi.Std
         /// </summary>
         public static Output<AbsResult> Invoke(AbsInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<AbsResult>("std:index:Abs", args ?? new AbsInvokeArgs(), options.WithDefaults());
+
+        /// <summary>
+        /// Returns the absolute value of a given float. 
+        /// Example: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.
+        /// </summary>
+        public static Output<AbsResult> Invoke(AbsInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<AbsResult>("std:index:Abs", args ?? new AbsInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/simplified-invokes/dotnet/AbsMultiArgs.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/AbsMultiArgs.cs
@@ -36,6 +36,19 @@ namespace Pulumi.Std
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
             return global::Pulumi.Deployment.Instance.Invoke<AbsMultiArgsResult>("std:index:AbsMultiArgs", args, invokeOptions.WithDefaults());
         }
+
+        /// <summary>
+        /// Returns the absolute value of a given float. 
+        /// Example: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.
+        /// </summary>
+        public static Output<AbsMultiArgsResult> Invoke(Input<double> a, Input<double?> b, InvokeOutputOptions invokeOptions)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, object?>();
+            builder["a"] = a;
+            builder["b"] = b;
+            var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
+            return global::Pulumi.Deployment.Instance.Invoke<AbsMultiArgsResult>("std:index:AbsMultiArgs", args, invokeOptions.WithDefaults());
+        }
     }
 
 

--- a/tests/testdata/codegen/simplified-invokes/dotnet/AbsMultiArgs.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/AbsMultiArgs.cs
@@ -36,19 +36,6 @@ namespace Pulumi.Std
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
             return global::Pulumi.Deployment.Instance.Invoke<AbsMultiArgsResult>("std:index:AbsMultiArgs", args, invokeOptions.WithDefaults());
         }
-
-        /// <summary>
-        /// Returns the absolute value of a given float. 
-        /// Example: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.
-        /// </summary>
-        public static Output<AbsMultiArgsResult> Invoke(Input<double> a, Input<double?> b, InvokeOutputOptions invokeOptions)
-        {
-            var builder = ImmutableDictionary.CreateBuilder<string, object?>();
-            builder["a"] = a;
-            builder["b"] = b;
-            var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
-            return global::Pulumi.Deployment.Instance.Invoke<AbsMultiArgsResult>("std:index:AbsMultiArgs", args, invokeOptions.WithDefaults());
-        }
     }
 
 

--- a/tests/testdata/codegen/simplified-invokes/dotnet/AbsMultiArgsReducedOutput.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/AbsMultiArgsReducedOutput.cs
@@ -36,18 +36,5 @@ namespace Pulumi.Std
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
             return global::Pulumi.Deployment.Instance.InvokeSingle<double>("std:index:AbsMultiArgsReducedOutput", args, invokeOptions.WithDefaults());
         }
-
-        /// <summary>
-        /// Returns the absolute value of a given float. 
-        /// Example: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.
-        /// </summary>
-        public static Output<double> Invoke(Input<double> a, Input<double?> b, InvokeOutputOptions invokeOptions)
-        {
-            var builder = ImmutableDictionary.CreateBuilder<string, object?>();
-            builder["a"] = a;
-            builder["b"] = b;
-            var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
-            return global::Pulumi.Deployment.Instance.InvokeSingle<double>("std:index:AbsMultiArgsReducedOutput", args, invokeOptions.WithDefaults());
-        }
     }
 }

--- a/tests/testdata/codegen/simplified-invokes/dotnet/AbsMultiArgsReducedOutput.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/AbsMultiArgsReducedOutput.cs
@@ -36,5 +36,18 @@ namespace Pulumi.Std
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
             return global::Pulumi.Deployment.Instance.InvokeSingle<double>("std:index:AbsMultiArgsReducedOutput", args, invokeOptions.WithDefaults());
         }
+
+        /// <summary>
+        /// Returns the absolute value of a given float. 
+        /// Example: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.
+        /// </summary>
+        public static Output<double> Invoke(Input<double> a, Input<double?> b, InvokeOutputOptions invokeOptions)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, object?>();
+            builder["a"] = a;
+            builder["b"] = b;
+            var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
+            return global::Pulumi.Deployment.Instance.InvokeSingle<double>("std:index:AbsMultiArgsReducedOutput", args, invokeOptions.WithDefaults());
+        }
     }
 }

--- a/tests/testdata/codegen/simplified-invokes/dotnet/AbsMultiArgsReducedOutputSwapped.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/AbsMultiArgsReducedOutputSwapped.cs
@@ -36,5 +36,18 @@ namespace Pulumi.Std
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
             return global::Pulumi.Deployment.Instance.InvokeSingle<double>("std:index:AbsMultiArgsReducedOutputSwapped", args, invokeOptions.WithDefaults());
         }
+
+        /// <summary>
+        /// Returns the absolute value of a given float. 
+        /// Example: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.
+        /// </summary>
+        public static Output<double> Invoke(Input<double> b, Input<double> a, InvokeOutputOptions invokeOptions)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, object?>();
+            builder["b"] = b;
+            builder["a"] = a;
+            var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
+            return global::Pulumi.Deployment.Instance.InvokeSingle<double>("std:index:AbsMultiArgsReducedOutputSwapped", args, invokeOptions.WithDefaults());
+        }
     }
 }

--- a/tests/testdata/codegen/simplified-invokes/dotnet/AbsMultiArgsReducedOutputSwapped.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/AbsMultiArgsReducedOutputSwapped.cs
@@ -36,18 +36,5 @@ namespace Pulumi.Std
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
             return global::Pulumi.Deployment.Instance.InvokeSingle<double>("std:index:AbsMultiArgsReducedOutputSwapped", args, invokeOptions.WithDefaults());
         }
-
-        /// <summary>
-        /// Returns the absolute value of a given float. 
-        /// Example: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.
-        /// </summary>
-        public static Output<double> Invoke(Input<double> b, Input<double> a, InvokeOutputOptions invokeOptions)
-        {
-            var builder = ImmutableDictionary.CreateBuilder<string, object?>();
-            builder["b"] = b;
-            builder["a"] = a;
-            var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
-            return global::Pulumi.Deployment.Instance.InvokeSingle<double>("std:index:AbsMultiArgsReducedOutputSwapped", args, invokeOptions.WithDefaults());
-        }
     }
 }

--- a/tests/testdata/codegen/simplified-invokes/dotnet/AbsReducedOutput.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/AbsReducedOutput.cs
@@ -24,6 +24,13 @@ namespace Pulumi.Std
         /// </summary>
         public static Output<double> Invoke(AbsReducedOutputInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.InvokeSingle<double>("std:index:AbsReducedOutput", args ?? new AbsReducedOutputInvokeArgs(), options.WithDefaults());
+
+        /// <summary>
+        /// Returns the absolute value of a given float. 
+        /// Example: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.
+        /// </summary>
+        public static Output<double> Invoke(AbsReducedOutputInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.InvokeSingle<double>("std:index:AbsReducedOutput", args ?? new AbsReducedOutputInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/simplified-invokes/dotnet/GetArchive.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/GetArchive.cs
@@ -26,5 +26,13 @@ namespace Pulumi.Std
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
             return global::Pulumi.Deployment.Instance.InvokeSingle<Archive>("std:index:GetArchive", args, invokeOptions.WithDefaults());
         }
+
+        public static Output<Archive> Invoke(Input<double?> a, InvokeOutputOptions invokeOptions)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, object?>();
+            builder["a"] = a;
+            var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
+            return global::Pulumi.Deployment.Instance.InvokeSingle<Archive>("std:index:GetArchive", args, invokeOptions.WithDefaults());
+        }
     }
 }

--- a/tests/testdata/codegen/simplified-invokes/dotnet/GetArchive.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/GetArchive.cs
@@ -26,13 +26,5 @@ namespace Pulumi.Std
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
             return global::Pulumi.Deployment.Instance.InvokeSingle<Archive>("std:index:GetArchive", args, invokeOptions.WithDefaults());
         }
-
-        public static Output<Archive> Invoke(Input<double?> a, InvokeOutputOptions invokeOptions)
-        {
-            var builder = ImmutableDictionary.CreateBuilder<string, object?>();
-            builder["a"] = a;
-            var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
-            return global::Pulumi.Deployment.Instance.InvokeSingle<Archive>("std:index:GetArchive", args, invokeOptions.WithDefaults());
-        }
     }
 }

--- a/tests/testdata/codegen/simplified-invokes/dotnet/GetArrayCustomResult.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/GetArrayCustomResult.cs
@@ -26,5 +26,13 @@ namespace Pulumi.Std
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
             return global::Pulumi.Deployment.Instance.InvokeSingle<List<Outputs.CustomResult>>("std:index:GetArrayCustomResult", args, invokeOptions.WithDefaults());
         }
+
+        public static Output<List<Outputs.CustomResult>> Invoke(Input<double?> a, InvokeOutputOptions invokeOptions)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, object?>();
+            builder["a"] = a;
+            var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
+            return global::Pulumi.Deployment.Instance.InvokeSingle<List<Outputs.CustomResult>>("std:index:GetArrayCustomResult", args, invokeOptions.WithDefaults());
+        }
     }
 }

--- a/tests/testdata/codegen/simplified-invokes/dotnet/GetArrayCustomResult.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/GetArrayCustomResult.cs
@@ -26,13 +26,5 @@ namespace Pulumi.Std
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
             return global::Pulumi.Deployment.Instance.InvokeSingle<List<Outputs.CustomResult>>("std:index:GetArrayCustomResult", args, invokeOptions.WithDefaults());
         }
-
-        public static Output<List<Outputs.CustomResult>> Invoke(Input<double?> a, InvokeOutputOptions invokeOptions)
-        {
-            var builder = ImmutableDictionary.CreateBuilder<string, object?>();
-            builder["a"] = a;
-            var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
-            return global::Pulumi.Deployment.Instance.InvokeSingle<List<Outputs.CustomResult>>("std:index:GetArrayCustomResult", args, invokeOptions.WithDefaults());
-        }
     }
 }

--- a/tests/testdata/codegen/simplified-invokes/dotnet/GetAsset.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/GetAsset.cs
@@ -26,5 +26,13 @@ namespace Pulumi.Std
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
             return global::Pulumi.Deployment.Instance.InvokeSingle<AssetOrArchive>("std:index:GetAsset", args, invokeOptions.WithDefaults());
         }
+
+        public static Output<AssetOrArchive> Invoke(Input<double?> a, InvokeOutputOptions invokeOptions)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, object?>();
+            builder["a"] = a;
+            var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
+            return global::Pulumi.Deployment.Instance.InvokeSingle<AssetOrArchive>("std:index:GetAsset", args, invokeOptions.WithDefaults());
+        }
     }
 }

--- a/tests/testdata/codegen/simplified-invokes/dotnet/GetAsset.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/GetAsset.cs
@@ -26,13 +26,5 @@ namespace Pulumi.Std
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
             return global::Pulumi.Deployment.Instance.InvokeSingle<AssetOrArchive>("std:index:GetAsset", args, invokeOptions.WithDefaults());
         }
-
-        public static Output<AssetOrArchive> Invoke(Input<double?> a, InvokeOutputOptions invokeOptions)
-        {
-            var builder = ImmutableDictionary.CreateBuilder<string, object?>();
-            builder["a"] = a;
-            var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
-            return global::Pulumi.Deployment.Instance.InvokeSingle<AssetOrArchive>("std:index:GetAsset", args, invokeOptions.WithDefaults());
-        }
     }
 }

--- a/tests/testdata/codegen/simplified-invokes/dotnet/GetCustomResult.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/GetCustomResult.cs
@@ -26,5 +26,13 @@ namespace Pulumi.Std
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
             return global::Pulumi.Deployment.Instance.Invoke<Outputs.CustomResult>("std:index:GetCustomResult", args, invokeOptions.WithDefaults());
         }
+
+        public static Output<Outputs.CustomResult> Invoke(Input<double?> a, InvokeOutputOptions invokeOptions)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, object?>();
+            builder["a"] = a;
+            var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
+            return global::Pulumi.Deployment.Instance.Invoke<Outputs.CustomResult>("std:index:GetCustomResult", args, invokeOptions.WithDefaults());
+        }
     }
 }

--- a/tests/testdata/codegen/simplified-invokes/dotnet/GetCustomResult.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/GetCustomResult.cs
@@ -26,13 +26,5 @@ namespace Pulumi.Std
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
             return global::Pulumi.Deployment.Instance.Invoke<Outputs.CustomResult>("std:index:GetCustomResult", args, invokeOptions.WithDefaults());
         }
-
-        public static Output<Outputs.CustomResult> Invoke(Input<double?> a, InvokeOutputOptions invokeOptions)
-        {
-            var builder = ImmutableDictionary.CreateBuilder<string, object?>();
-            builder["a"] = a;
-            var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
-            return global::Pulumi.Deployment.Instance.Invoke<Outputs.CustomResult>("std:index:GetCustomResult", args, invokeOptions.WithDefaults());
-        }
     }
 }

--- a/tests/testdata/codegen/simplified-invokes/dotnet/GetDictionary.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/GetDictionary.cs
@@ -26,5 +26,13 @@ namespace Pulumi.Std
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
             return global::Pulumi.Deployment.Instance.Invoke<Dictionary<string, Outputs.AnotherCustomResult>>("std:index:GetDictionary", args, invokeOptions.WithDefaults());
         }
+
+        public static Output<Dictionary<string, Outputs.AnotherCustomResult>> Invoke(Input<double?> a, InvokeOutputOptions invokeOptions)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, object?>();
+            builder["a"] = a;
+            var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
+            return global::Pulumi.Deployment.Instance.Invoke<Dictionary<string, Outputs.AnotherCustomResult>>("std:index:GetDictionary", args, invokeOptions.WithDefaults());
+        }
     }
 }

--- a/tests/testdata/codegen/simplified-invokes/dotnet/GetDictionary.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/GetDictionary.cs
@@ -26,13 +26,5 @@ namespace Pulumi.Std
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
             return global::Pulumi.Deployment.Instance.Invoke<Dictionary<string, Outputs.AnotherCustomResult>>("std:index:GetDictionary", args, invokeOptions.WithDefaults());
         }
-
-        public static Output<Dictionary<string, Outputs.AnotherCustomResult>> Invoke(Input<double?> a, InvokeOutputOptions invokeOptions)
-        {
-            var builder = ImmutableDictionary.CreateBuilder<string, object?>();
-            builder["a"] = a;
-            var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
-            return global::Pulumi.Deployment.Instance.Invoke<Dictionary<string, Outputs.AnotherCustomResult>>("std:index:GetDictionary", args, invokeOptions.WithDefaults());
-        }
     }
 }

--- a/tests/testdata/codegen/simplified-invokes/dotnet/Pulumi.Std.csproj
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/Pulumi.Std.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.50.0" />
+    <PackageReference Include="Pulumi" Version="3.71.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/simplified-invokes/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Std
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simplified-invokes/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Std
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/simplified-invokes/schema.json
+++ b/tests/testdata/codegen/simplified-invokes/schema.json
@@ -12,7 +12,7 @@
     "language": {
       "csharp": {
         "packageReferences": {
-          "Pulumi": "3.50.0"
+          "Pulumi": "3.71.0"
         }
       },
       "nodejs": {

--- a/tests/testdata/codegen/unions-inline/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/unions-inline/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/unions-inline/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/unions-inline/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/unions-inline/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/unions-inline/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/unions-inside-arrays/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/unions-inside-arrays/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/unions-inside-arrays/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/unions-inside-arrays/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Example
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/unions-inside-arrays/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/unions-inside-arrays/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Example
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/urn-id-properties/dotnet/Pulumi.Urnid.csproj
+++ b/tests/testdata/codegen/urn-id-properties/dotnet/Pulumi.Urnid.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/urn-id-properties/dotnet/Test.cs
+++ b/tests/testdata/codegen/urn-id-properties/dotnet/Test.cs
@@ -22,6 +22,12 @@ namespace Pulumi.Urnid
         /// </summary>
         public static Output<TestResult> Invoke(TestInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<TestResult>("urnid:index:Test", args ?? new TestInvokeArgs(), options.WithDefaults());
+
+        /// <summary>
+        /// It's fine for invokes to use urn and id
+        /// </summary>
+        public static Output<TestResult> Invoke(TestInvokeArgs args, InvokeOutputOptions options)
+            => global::Pulumi.Deployment.Instance.Invoke<TestResult>("urnid:index:Test", args ?? new TestInvokeArgs(), options.WithDefaults());
     }
 
 

--- a/tests/testdata/codegen/urn-id-properties/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/urn-id-properties/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Urnid
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/urn-id-properties/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/urn-id-properties/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Urnid
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/using-shared-types-in-config/dotnet/Pulumi.Credentials.csproj
+++ b/tests/testdata/codegen/using-shared-types-in-config/dotnet/Pulumi.Credentials.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/using-shared-types-in-config/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/using-shared-types-in-config/dotnet/Utilities.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Credentials
             return dst;
         }
 
-        
         private readonly static string version;
         public static string Version => version;
 

--- a/tests/testdata/codegen/using-shared-types-in-config/dotnet/Utilities.cs
+++ b/tests/testdata/codegen/using-shared-types-in-config/dotnet/Utilities.cs
@@ -56,6 +56,14 @@ namespace Pulumi.Credentials
             return dst;
         }
 
+        public static global::Pulumi.InvokeOutputOptions WithDefaults(this global::Pulumi.InvokeOutputOptions? src)
+        {
+            var dst = src ?? new global::Pulumi.InvokeOutputOptions{};
+            dst.Version = src?.Version ?? Version;
+            return dst;
+        }
+
+        
         private readonly static string version;
         public static string Version => version;
 


### PR DESCRIPTION
Add codegen for https://github.com/pulumi/pulumi-dotnet/pull/412

Generate variants of output form invokes that take `InvokeOutputOptions` as options, which allow specifying DependsOn. This requires a release of https://github.com/pulumi/pulumi-dotnet/pull/412 first.