### PR TITLE
Don't recreate virtualenvs when using venv

### DIFF
--- a/changelog/pending/20241202--cli-install--dont-recreate-virtualenvs-when-using-venv.yaml
+++ b/changelog/pending/20241202--cli-install--dont-recreate-virtualenvs-when-using-venv.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/install
+  description: Don't recreate virtualenvs when using venv

--- a/sdk/python/toolchain/uv.go
+++ b/sdk/python/toolchain/uv.go
@@ -180,7 +180,8 @@ func (u *uv) InstallDependencies(ctx context.Context, cwd string, useLanguageVer
 func (u *uv) EnsureVenv(ctx context.Context, cwd string, useLanguageVersionTools, showOutput bool,
 	infoWriter, errorWriter io.Writer,
 ) error {
-	venvCmd := u.uvCommand(ctx, cwd, showOutput, infoWriter, errorWriter, "venv", "--quiet", u.virtualenvPath)
+	venvCmd := u.uvCommand(ctx, cwd, showOutput, infoWriter, errorWriter, "venv", "--quiet",
+		"--allow-existing", u.virtualenvPath)
 	if err := venvCmd.Run(); err != nil {
 		return errorWithStderr(err, "error creating virtual environment")
 	}

--- a/sdk/python/toolchain/uv_test.go
+++ b/sdk/python/toolchain/uv_test.go
@@ -111,7 +111,8 @@ func TestEnsureVenv(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a virtualenv and record the directory's inode.
-	err = uv.EnsureVenv(context.Background(), root, false /* useLanguageVersionTools */, false /* showOutput */, nil /* infoWriter */, nil /* infoWriter */)
+	err = uv.EnsureVenv(context.Background(), root, false /* useLanguageVersionTools */, false, /* showOutput */
+		nil /* infoWriter */, nil /* infoWriter */)
 	require.NoError(t, err)
 	info, err := os.Stat(filepath.Join(root, ".venv"))
 	require.NoError(t, err)
@@ -120,7 +121,8 @@ func TestEnsureVenv(t *testing.T) {
 	inode1 := stat.Ino
 
 	// Run EnsureVenv again and ensure the directory's inode is the same.
-	err = uv.EnsureVenv(context.Background(), root, false /* useLanguageVersionTools */, false /* showOutput */, nil /* infoWriter */, nil /* infoWriter */)
+	err = uv.EnsureVenv(context.Background(), root, false /* useLanguageVersionTools */, false, /* showOutput */
+		nil /* infoWriter */, nil /* infoWriter */)
 	require.NoError(t, err)
 	info, err = os.Stat(filepath.Join(root, ".venv"))
 	require.NoError(t, err)

--- a/sdk/python/toolchain/uv_test.go
+++ b/sdk/python/toolchain/uv_test.go
@@ -15,8 +15,10 @@
 package toolchain
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/blang/semver"
@@ -99,4 +101,32 @@ func TestUvVersion(t *testing.T) {
 
 	_, err = uv.uvVersion("uv 0.4.25")
 	require.ErrorContains(t, err, "less than the minimum required version")
+}
+
+func TestEnsureVenv(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	uv, err := newUv(root, "")
+	require.NoError(t, err)
+
+	// Create a virtualenv and record the directory's inode.
+	err = uv.EnsureVenv(context.Background(), root, false /* useLanguageVersionTools */, false /* showOutput */, nil /* infoWriter */, nil /* infoWriter */)
+	require.NoError(t, err)
+	info, err := os.Stat(filepath.Join(root, ".venv"))
+	require.NoError(t, err)
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	require.True(t, ok)
+	inode1 := stat.Ino
+
+	// Run EnsureVenv again and ensure the directory's inode is the same.
+	err = uv.EnsureVenv(context.Background(), root, false /* useLanguageVersionTools */, false /* showOutput */, nil /* infoWriter */, nil /* infoWriter */)
+	require.NoError(t, err)
+	info, err = os.Stat(filepath.Join(root, ".venv"))
+	require.NoError(t, err)
+	stat, ok = info.Sys().(*syscall.Stat_t)
+	require.True(t, ok)
+	inode2 := stat.Ino
+
+	require.Equal(t, inode1, inode2)
 }


### PR DESCRIPTION
Preserve the existing virtualenv when running EnsureVenv. While
recreating is very fast with uv, editors and LSPs notice the file
changes and reparse the venv.

Fixes https://github.com/pulumi/pulumi/issues/17831
