### PR TITLE
Bulk out documentation on `Handshake`

### DIFF
--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -18,7 +18,7 @@
 1921230328 1269 proto/pulumi/errors.proto
 420991671 12306 proto/pulumi/language.proto
 2893249402 1992 proto/pulumi/plugin.proto
-1970643301 53674 proto/pulumi/provider.proto
+1526287705 56501 proto/pulumi/provider.proto
 1190662922 17848 proto/pulumi/resource.proto
 607478140 1008 proto/pulumi/source.proto
 3670315643 2603 proto/pulumi/testing/language.proto

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -27,6 +27,11 @@ option go_package = "github.com/pulumi/pulumi/sdk/v3/proto/go;pulumirpc";
 // operations on resources and invocations of functions. Resource providers are primarily managed by the Pulumi engine
 // as part of a deployment in order to interact with the cloud providers underpinning a Pulumi application.
 service ResourceProvider {
+    // `Handshake` is the first call made by the engine to a provider. It is used to pass the engine's address to the
+    // provider so that it may establish its own connections back, and to establish protocol configuration that will be
+    // used to communicate between the two parties. Providers that support `Handshake` implicitly support the set of
+    // feature flags previously handled by `Configure` prior to `Handshake`'s introduction, such as secrets and resource
+    // references.
     rpc Handshake(ProviderHandshakeRequest) returns (ProviderHandshakeResponse) {}
 
     // `Parameterize` is the primary means of supporting [parameterized providers](parameterized-providers), which allow
@@ -93,7 +98,7 @@ service ResourceProvider {
     // AWS access key, should almost certainly not.
     rpc DiffConfig(DiffRequest) returns (DiffResponse) {}
 
-    // `Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
+    // `Configure` is the final stage in configuring a provider instance. Callers may supply two sets of data:
     //
     // * Provider-specific configuration, which is the set of inputs that have been validated by a previous
     //   [](pulumirpc.ResourceProvider.CheckConfig) call.
@@ -105,6 +110,19 @@ service ResourceProvider {
     // Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
     // the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
     // indicate which keys are missing.
+    //
+    // :::{important}
+    // The use of `Configure` to configure protocol features is deprecated in favour of the
+    // [](pulumirpc.ResourceProvider.Handshake) method, which should be implemented by newer providers. To enable
+    // compatibility between older engines and providers:
+    //
+    // * Callers which call `Handshake` *must* call `Configure` with flags such as `acceptSecrets` and `acceptResources`
+    //   set to `true`, since these features predate the introduction of `Handshake` and thus `Handshake`-aware callers
+    //   must support them. See [](pulumirpc.ConfigureRequest) for more information.
+    // * Providers which implement `Handshake` *must* support flags such as `acceptSecrets` and `acceptResources`, and
+    //   indicate as such by always returning `true` for these fields in [](pulumirpc.ConfigureResponse). See
+    //   [](pulumirpc.ConfigureResponse) for more information.
+    // :::
     rpc Configure(ConfigureRequest) returns (ConfigureResponse) {}
 
     // Invoke dynamically executes a built-in function in the provider.
@@ -197,19 +215,25 @@ service ResourceProvider {
     rpc GetMappings(GetMappingsRequest) returns (GetMappingsResponse) {}
 }
 
+// `ProviderHandshakeRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Handshake) call.
 message ProviderHandshakeRequest {
-    // The grpc address for the engine.
+    // The gRPC address of the engine handshaking with the provider. At a minimum, this address will expose an instance
+    // of the [](pulumirpc.Engine) service.
     string engine_address = 1;
 
-    // The optional root directory, where the `PulumiPlugin.yaml` file or provider binary is located.
-    // This can't be sent when the engine is attaching to a provider via a port number.
+    // A *root directory* where the provider's binary, `PulumiPlugin.yaml`, or other identifying source code is located.
+    // In the event that the provider is *not* being booted by the engine (e.g. in the case that the engine has been
+    // asked to attach to an existing running provider instance via a host/port number), this field will be empty.
     string root_directory = 2;
-    // The optional absolute path to the directory of the provider program to execute. Generally, but not
-    // required to be, underneath the root directory. This can't be sent when the engine is attaching to a
-    // provider via a port number.
+
+    // A *program directory* in which the provider should execute. This is generally a subdirectory of the root
+    // directory, though this is not required. In the event that the provider is *not* being booted by the engine (e.g.
+    // in the case that the engine has been asked to attach to an existing running provider instance via a host/port
+    // number), this field will be empty.
     string program_directory = 3;
 }
 
+// `ProviderHandshakeResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Handshake) call.
 message ProviderHandshakeResponse {
 }
 
@@ -314,21 +338,23 @@ message ConfigureRequest {
     google.protobuf.Struct args = 2;
 
     // True if and only if the caller supports secrets. If true, operations should return strongly typed secrets if the
-    // provider supports them also.
+    // provider supports them also. *Must* be true if the caller has previously called
+    // [](pulumirpc.ResourceProvider.Handshake).
     bool acceptSecrets  = 3;
 
     // True if and only if the caller supports strongly typed resources. If true, operations should return resources as
-    // strongly typed values if the provider supports them also.
+    // strongly typed values if the provider supports them also. *Must* be true if the caller has previously called
+    // [](pulumirpc.ResourceProvider.Handshake).
     bool acceptResources = 4;
 
     // True if and only if the caller supports sending old inputs as part of [](pulumirpc.ResourceProvider.Diff) and
     // [](pulumirpc.ResourceProvider.Update) calls. If true, the provider should expect these fields to be populated in
-    // these calls.
+    // these calls. *Must* be true if the caller has previously called [](pulumirpc.ResourceProvider.Handshake).
     bool sends_old_inputs = 5;
 
     // True if and only if the caller supports sending old inputs and outputs as part of
     // [](pulumirpc.ResourceProvider.Delete) calls. If true, the provider should expect these fields to be populated in
-    // these calls.
+    // these calls. *Must* be true if the caller has previously called [](pulumirpc.ResourceProvider.Handshake).
     bool sends_old_inputs_to_delete = 6;
 }
 
@@ -336,20 +362,22 @@ message ConfigureRequest {
 // purpose is to communicate features that the provider supports back to the caller.
 message ConfigureResponse {
     // True if and only if the provider supports secrets. If true, the caller should pass secrets as strongly typed
-    // values to the provider.
+    // values to the provider. *Must* be true if the provider implements [](pulumirpc.ResourceProvider.Handshake).
     bool acceptSecrets = 1;
 
     // True if and only if the provider supports the `preview` field on [](pulumirpc.ResourceProvider.Create) and
     // [](pulumirpc.ResourceProvider.Update) calls. If true, the engine should invoke these calls with `preview` set to
-    // `true` during previews.
+    // `true` during previews. *Must* be true if the provider implements [](pulumirpc.ResourceProvider.Handshake).
     bool supportsPreview = 2;
 
     // True if and only if the provider supports strongly typed resources. If true, the caller should pass resources as
-    // strongly typed values to the provider.
+    // strongly typed values to the provider. *Must* be true if the provider implements
+    // [](pulumirpc.ResourceProvider.Handshake).
     bool acceptResources = 3;
 
     // True if and only if the provider supports output values as inputs. If true, the engine should pass output values
-    // to the provider where possible.
+    // to the provider where possible. *Must* be true if the provider implements
+    // [](pulumirpc.ResourceProvider.Handshake).
     bool acceptOutputs = 4;
 
     // True if the provider accepts and respects Autonaming configuration that the engine provides on behalf of user.

--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -36,19 +36,25 @@ type GetSchemaRequest struct {
 	SubpackageVersion *semver.Version
 }
 
+// The type of requests sent as part of a Handshake call.
 type ProviderHandshakeRequest struct {
-	// The grpc address for the engine.
+	// The gRPC address of the engine handshaking with the provider. At a minimum, this address will expose an instance of
+	// the Engine service.
 	EngineAddress string
 
-	// The optional root directory, where the `PulumiPlugin.yaml` file or provider binary is located.
-	// This can't be sent when the engine is attaching to a provider via a port number.
+	// A *root directory* where the provider's binary, `PulumiPlugin.yaml`, or other identifying source code is located.
+	// In the event that the provider is *not* being booted by the engine (e.g. in the case that the engine has been asked
+	// to attach to an existing running provider instance via a host/port number), this field will be empty.
 	RootDirectory string
-	// The optional absolute path to the directory of the provider program to execute. Generally, but not
-	// required to be, underneath the root directory. This can't be sent when the engine is attaching to a
-	// provider via a port number.
+
+	// A *program directory* in which the provider should execute. This is generally a subdirectory of the root directory,
+	// though this is not required. In the event that the provider is *not* being booted by the engine (e.g. in the case
+	// that the engine has been asked to attach to an existing running provider instance via a host/port number), this
+	// field will be empty.
 	ProgramDirectory string
 }
 
+// The type of responses sent as part of a Handshake call.
 type ProviderHandshakeResponse struct{}
 
 type ParameterizeParameters interface {
@@ -281,6 +287,11 @@ type Provider interface {
 	// Pkg fetches this provider's package.
 	Pkg() tokens.Package
 
+	// Handshake is the first call made by the engine to a provider. It is used to pass the engine's address to the
+	// provider so that it may establish its own connections back, and to establish protocol configuration that will be
+	// used to communicate between the two parties. Providers that support Handshake implicitly support the set of
+	// feature flags previously handled by Configure prior to Handshake's introduction, such as secrets and resource
+	// references.
 	Handshake(context.Context, ProviderHandshakeRequest) (*ProviderHandshakeResponse, error)
 
 	// Parameterize adds a sub-package to this provider instance.

--- a/sdk/proto/go/provider.pb.go
+++ b/sdk/proto/go/provider.pb.go
@@ -209,19 +209,23 @@ func (DiffResponse_DiffChanges) EnumDescriptor() ([]byte, []int) {
 	return file_pulumi_provider_proto_rawDescGZIP(), []int{18, 0}
 }
 
+// `ProviderHandshakeRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Handshake) call.
 type ProviderHandshakeRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The grpc address for the engine.
+	// The gRPC address of the engine handshaking with the provider. At a minimum, this address will expose an instance
+	// of the [](pulumirpc.Engine) service.
 	EngineAddress string `protobuf:"bytes,1,opt,name=engine_address,json=engineAddress,proto3" json:"engine_address,omitempty"`
-	// The optional root directory, where the `PulumiPlugin.yaml` file or provider binary is located.
-	// This can't be sent when the engine is attaching to a provider via a port number.
+	// A *root directory* where the provider's binary, `PulumiPlugin.yaml`, or other identifying source code is located.
+	// In the event that the provider is *not* being booted by the engine (e.g. in the case that the engine has been
+	// asked to attach to an existing running provider instance via a host/port number), this field will be empty.
 	RootDirectory string `protobuf:"bytes,2,opt,name=root_directory,json=rootDirectory,proto3" json:"root_directory,omitempty"`
-	// The optional absolute path to the directory of the provider program to execute. Generally, but not
-	// required to be, underneath the root directory. This can't be sent when the engine is attaching to a
-	// provider via a port number.
+	// A *program directory* in which the provider should execute. This is generally a subdirectory of the root
+	// directory, though this is not required. In the event that the provider is *not* being booted by the engine (e.g.
+	// in the case that the engine has been asked to attach to an existing running provider instance via a host/port
+	// number), this field will be empty.
 	ProgramDirectory string `protobuf:"bytes,3,opt,name=program_directory,json=programDirectory,proto3" json:"program_directory,omitempty"`
 }
 
@@ -278,6 +282,7 @@ func (x *ProviderHandshakeRequest) GetProgramDirectory() string {
 	return ""
 }
 
+// `ProviderHandshakeResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Handshake) call.
 type ProviderHandshakeResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -625,18 +630,20 @@ type ConfigureRequest struct {
 	// :::
 	Args *structpb.Struct `protobuf:"bytes,2,opt,name=args,proto3" json:"args,omitempty"`
 	// True if and only if the caller supports secrets. If true, operations should return strongly typed secrets if the
-	// provider supports them also.
+	// provider supports them also. *Must* be true if the caller has previously called
+	// [](pulumirpc.ResourceProvider.Handshake).
 	AcceptSecrets bool `protobuf:"varint,3,opt,name=acceptSecrets,proto3" json:"acceptSecrets,omitempty"`
 	// True if and only if the caller supports strongly typed resources. If true, operations should return resources as
-	// strongly typed values if the provider supports them also.
+	// strongly typed values if the provider supports them also. *Must* be true if the caller has previously called
+	// [](pulumirpc.ResourceProvider.Handshake).
 	AcceptResources bool `protobuf:"varint,4,opt,name=acceptResources,proto3" json:"acceptResources,omitempty"`
 	// True if and only if the caller supports sending old inputs as part of [](pulumirpc.ResourceProvider.Diff) and
 	// [](pulumirpc.ResourceProvider.Update) calls. If true, the provider should expect these fields to be populated in
-	// these calls.
+	// these calls. *Must* be true if the caller has previously called [](pulumirpc.ResourceProvider.Handshake).
 	SendsOldInputs bool `protobuf:"varint,5,opt,name=sends_old_inputs,json=sendsOldInputs,proto3" json:"sends_old_inputs,omitempty"`
 	// True if and only if the caller supports sending old inputs and outputs as part of
 	// [](pulumirpc.ResourceProvider.Delete) calls. If true, the provider should expect these fields to be populated in
-	// these calls.
+	// these calls. *Must* be true if the caller has previously called [](pulumirpc.ResourceProvider.Handshake).
 	SendsOldInputsToDelete bool `protobuf:"varint,6,opt,name=sends_old_inputs_to_delete,json=sendsOldInputsToDelete,proto3" json:"sends_old_inputs_to_delete,omitempty"`
 }
 
@@ -722,17 +729,19 @@ type ConfigureResponse struct {
 	unknownFields protoimpl.UnknownFields
 
 	// True if and only if the provider supports secrets. If true, the caller should pass secrets as strongly typed
-	// values to the provider.
+	// values to the provider. *Must* be true if the provider implements [](pulumirpc.ResourceProvider.Handshake).
 	AcceptSecrets bool `protobuf:"varint,1,opt,name=acceptSecrets,proto3" json:"acceptSecrets,omitempty"`
 	// True if and only if the provider supports the `preview` field on [](pulumirpc.ResourceProvider.Create) and
 	// [](pulumirpc.ResourceProvider.Update) calls. If true, the engine should invoke these calls with `preview` set to
-	// `true` during previews.
+	// `true` during previews. *Must* be true if the provider implements [](pulumirpc.ResourceProvider.Handshake).
 	SupportsPreview bool `protobuf:"varint,2,opt,name=supportsPreview,proto3" json:"supportsPreview,omitempty"`
 	// True if and only if the provider supports strongly typed resources. If true, the caller should pass resources as
-	// strongly typed values to the provider.
+	// strongly typed values to the provider. *Must* be true if the provider implements
+	// [](pulumirpc.ResourceProvider.Handshake).
 	AcceptResources bool `protobuf:"varint,3,opt,name=acceptResources,proto3" json:"acceptResources,omitempty"`
 	// True if and only if the provider supports output values as inputs. If true, the engine should pass output values
-	// to the provider where possible.
+	// to the provider where possible. *Must* be true if the provider implements
+	// [](pulumirpc.ResourceProvider.Handshake).
 	AcceptOutputs bool `protobuf:"varint,4,opt,name=acceptOutputs,proto3" json:"acceptOutputs,omitempty"`
 	// True if the provider accepts and respects Autonaming configuration that the engine provides on behalf of user.
 	SupportsAutonamingConfiguration bool `protobuf:"varint,5,opt,name=supports_autonaming_configuration,json=supportsAutonamingConfiguration,proto3" json:"supports_autonaming_configuration,omitempty"`

--- a/sdk/proto/go/provider_grpc.pb.go
+++ b/sdk/proto/go/provider_grpc.pb.go
@@ -23,6 +23,11 @@ const _ = grpc.SupportPackageIsVersion7
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ResourceProviderClient interface {
+	// `Handshake` is the first call made by the engine to a provider. It is used to pass the engine's address to the
+	// provider so that it may establish its own connections back, and to establish protocol configuration that will be
+	// used to communicate between the two parties. Providers that support `Handshake` implicitly support the set of
+	// feature flags previously handled by `Configure` prior to `Handshake`'s introduction, such as secrets and resource
+	// references.
 	Handshake(ctx context.Context, in *ProviderHandshakeRequest, opts ...grpc.CallOption) (*ProviderHandshakeResponse, error)
 	// `Parameterize` is the primary means of supporting [parameterized providers](parameterized-providers), which allow
 	// a caller to change a provider's behavior ahead of its [configuration](pulumirpc.ResourceProvider.Configure) and
@@ -84,7 +89,7 @@ type ResourceProviderClient interface {
 	// Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
 	// AWS access key, should almost certainly not.
 	DiffConfig(ctx context.Context, in *DiffRequest, opts ...grpc.CallOption) (*DiffResponse, error)
-	// `Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
+	// `Configure` is the final stage in configuring a provider instance. Callers may supply two sets of data:
 	//
 	// * Provider-specific configuration, which is the set of inputs that have been validated by a previous
 	//   [](pulumirpc.ResourceProvider.CheckConfig) call.
@@ -96,6 +101,19 @@ type ResourceProviderClient interface {
 	// Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
 	// the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
 	// indicate which keys are missing.
+	//
+	// :::{important}
+	// The use of `Configure` to configure protocol features is deprecated in favour of the
+	// [](pulumirpc.ResourceProvider.Handshake) method, which should be implemented by newer providers. To enable
+	// compatibility between older engines and providers:
+	//
+	// * Callers which call `Handshake` *must* call `Configure` with flags such as `acceptSecrets` and `acceptResources`
+	//   set to `true`, since these features predate the introduction of `Handshake` and thus `Handshake`-aware callers
+	//   must support them. See [](pulumirpc.ConfigureRequest) for more information.
+	// * Providers which implement `Handshake` *must* support flags such as `acceptSecrets` and `acceptResources`, and
+	//   indicate as such by always returning `true` for these fields in [](pulumirpc.ConfigureResponse). See
+	//   [](pulumirpc.ConfigureResponse) for more information.
+	// :::
 	Configure(ctx context.Context, in *ConfigureRequest, opts ...grpc.CallOption) (*ConfigureResponse, error)
 	// Invoke dynamically executes a built-in function in the provider.
 	Invoke(ctx context.Context, in *InvokeRequest, opts ...grpc.CallOption) (*InvokeResponse, error)
@@ -398,6 +416,11 @@ func (c *resourceProviderClient) GetMappings(ctx context.Context, in *GetMapping
 // All implementations must embed UnimplementedResourceProviderServer
 // for forward compatibility
 type ResourceProviderServer interface {
+	// `Handshake` is the first call made by the engine to a provider. It is used to pass the engine's address to the
+	// provider so that it may establish its own connections back, and to establish protocol configuration that will be
+	// used to communicate between the two parties. Providers that support `Handshake` implicitly support the set of
+	// feature flags previously handled by `Configure` prior to `Handshake`'s introduction, such as secrets and resource
+	// references.
 	Handshake(context.Context, *ProviderHandshakeRequest) (*ProviderHandshakeResponse, error)
 	// `Parameterize` is the primary means of supporting [parameterized providers](parameterized-providers), which allow
 	// a caller to change a provider's behavior ahead of its [configuration](pulumirpc.ResourceProvider.Configure) and
@@ -459,7 +482,7 @@ type ResourceProviderServer interface {
 	// Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
 	// AWS access key, should almost certainly not.
 	DiffConfig(context.Context, *DiffRequest) (*DiffResponse, error)
-	// `Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
+	// `Configure` is the final stage in configuring a provider instance. Callers may supply two sets of data:
 	//
 	// * Provider-specific configuration, which is the set of inputs that have been validated by a previous
 	//   [](pulumirpc.ResourceProvider.CheckConfig) call.
@@ -471,6 +494,19 @@ type ResourceProviderServer interface {
 	// Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
 	// the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
 	// indicate which keys are missing.
+	//
+	// :::{important}
+	// The use of `Configure` to configure protocol features is deprecated in favour of the
+	// [](pulumirpc.ResourceProvider.Handshake) method, which should be implemented by newer providers. To enable
+	// compatibility between older engines and providers:
+	//
+	// * Callers which call `Handshake` *must* call `Configure` with flags such as `acceptSecrets` and `acceptResources`
+	//   set to `true`, since these features predate the introduction of `Handshake` and thus `Handshake`-aware callers
+	//   must support them. See [](pulumirpc.ConfigureRequest) for more information.
+	// * Providers which implement `Handshake` *must* support flags such as `acceptSecrets` and `acceptResources`, and
+	//   indicate as such by always returning `true` for these fields in [](pulumirpc.ConfigureResponse). See
+	//   [](pulumirpc.ConfigureResponse) for more information.
+	// :::
 	Configure(context.Context, *ConfigureRequest) (*ConfigureResponse, error)
 	// Invoke dynamically executes a built-in function in the provider.
 	Invoke(context.Context, *InvokeRequest) (*InvokeResponse, error)

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
@@ -34,21 +34,27 @@ DESCRIPTOR: google.protobuf.descriptor.FileDescriptor
 
 @typing_extensions.final
 class ProviderHandshakeRequest(google.protobuf.message.Message):
+    """`ProviderHandshakeRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.Handshake) call."""
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     ENGINE_ADDRESS_FIELD_NUMBER: builtins.int
     ROOT_DIRECTORY_FIELD_NUMBER: builtins.int
     PROGRAM_DIRECTORY_FIELD_NUMBER: builtins.int
     engine_address: builtins.str
-    """The grpc address for the engine."""
+    """The gRPC address of the engine handshaking with the provider. At a minimum, this address will expose an instance
+    of the [](pulumirpc.Engine) service.
+    """
     root_directory: builtins.str
-    """The optional root directory, where the `PulumiPlugin.yaml` file or provider binary is located.
-    This can't be sent when the engine is attaching to a provider via a port number.
+    """A *root directory* where the provider's binary, `PulumiPlugin.yaml`, or other identifying source code is located.
+    In the event that the provider is *not* being booted by the engine (e.g. in the case that the engine has been
+    asked to attach to an existing running provider instance via a host/port number), this field will be empty.
     """
     program_directory: builtins.str
-    """The optional absolute path to the directory of the provider program to execute. Generally, but not
-    required to be, underneath the root directory. This can't be sent when the engine is attaching to a
-    provider via a port number.
+    """A *program directory* in which the provider should execute. This is generally a subdirectory of the root
+    directory, though this is not required. In the event that the provider is *not* being booted by the engine (e.g.
+    in the case that the engine has been asked to attach to an existing running provider instance via a host/port
+    number), this field will be empty.
     """
     def __init__(
         self,
@@ -63,6 +69,8 @@ global___ProviderHandshakeRequest = ProviderHandshakeRequest
 
 @typing_extensions.final
 class ProviderHandshakeResponse(google.protobuf.message.Message):
+    """`ProviderHandshakeResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.Handshake) call."""
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     def __init__(
@@ -288,21 +296,23 @@ class ConfigureRequest(google.protobuf.message.Message):
         """
     acceptSecrets: builtins.bool
     """True if and only if the caller supports secrets. If true, operations should return strongly typed secrets if the
-    provider supports them also.
+    provider supports them also. *Must* be true if the caller has previously called
+    [](pulumirpc.ResourceProvider.Handshake).
     """
     acceptResources: builtins.bool
     """True if and only if the caller supports strongly typed resources. If true, operations should return resources as
-    strongly typed values if the provider supports them also.
+    strongly typed values if the provider supports them also. *Must* be true if the caller has previously called
+    [](pulumirpc.ResourceProvider.Handshake).
     """
     sends_old_inputs: builtins.bool
     """True if and only if the caller supports sending old inputs as part of [](pulumirpc.ResourceProvider.Diff) and
     [](pulumirpc.ResourceProvider.Update) calls. If true, the provider should expect these fields to be populated in
-    these calls.
+    these calls. *Must* be true if the caller has previously called [](pulumirpc.ResourceProvider.Handshake).
     """
     sends_old_inputs_to_delete: builtins.bool
     """True if and only if the caller supports sending old inputs and outputs as part of
     [](pulumirpc.ResourceProvider.Delete) calls. If true, the provider should expect these fields to be populated in
-    these calls.
+    these calls. *Must* be true if the caller has previously called [](pulumirpc.ResourceProvider.Handshake).
     """
     def __init__(
         self,
@@ -334,20 +344,22 @@ class ConfigureResponse(google.protobuf.message.Message):
     SUPPORTS_AUTONAMING_CONFIGURATION_FIELD_NUMBER: builtins.int
     acceptSecrets: builtins.bool
     """True if and only if the provider supports secrets. If true, the caller should pass secrets as strongly typed
-    values to the provider.
+    values to the provider. *Must* be true if the provider implements [](pulumirpc.ResourceProvider.Handshake).
     """
     supportsPreview: builtins.bool
     """True if and only if the provider supports the `preview` field on [](pulumirpc.ResourceProvider.Create) and
     [](pulumirpc.ResourceProvider.Update) calls. If true, the engine should invoke these calls with `preview` set to
-    `true` during previews.
+    `true` during previews. *Must* be true if the provider implements [](pulumirpc.ResourceProvider.Handshake).
     """
     acceptResources: builtins.bool
     """True if and only if the provider supports strongly typed resources. If true, the caller should pass resources as
-    strongly typed values to the provider.
+    strongly typed values to the provider. *Must* be true if the provider implements
+    [](pulumirpc.ResourceProvider.Handshake).
     """
     acceptOutputs: builtins.bool
     """True if and only if the provider supports output values as inputs. If true, the engine should pass output values
-    to the provider where possible.
+    to the provider where possible. *Must* be true if the provider implements
+    [](pulumirpc.ResourceProvider.Handshake).
     """
     supports_autonaming_configuration: builtins.bool
     """True if the provider accepts and respects Autonaming configuration that the engine provides on behalf of user."""

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
@@ -135,7 +135,12 @@ class ResourceProviderServicer(object):
     """
 
     def Handshake(self, request, context):
-        """Missing associated documentation comment in .proto file."""
+        """`Handshake` is the first call made by the engine to a provider. It is used to pass the engine's address to the
+        provider so that it may establish its own connections back, and to establish protocol configuration that will be
+        used to communicate between the two parties. Providers that support `Handshake` implicitly support the set of
+        feature flags previously handled by `Configure` prior to `Handshake`'s introduction, such as secrets and resource
+        references.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
@@ -221,7 +226,7 @@ class ResourceProviderServicer(object):
         raise NotImplementedError('Method not implemented!')
 
     def Configure(self, request, context):
-        """`Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
+        """`Configure` is the final stage in configuring a provider instance. Callers may supply two sets of data:
 
         * Provider-specific configuration, which is the set of inputs that have been validated by a previous
         [](pulumirpc.ResourceProvider.CheckConfig) call.
@@ -233,6 +238,19 @@ class ResourceProviderServicer(object):
         Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
         the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
         indicate which keys are missing.
+
+        :::{important}
+        The use of `Configure` to configure protocol features is deprecated in favour of the
+        [](pulumirpc.ResourceProvider.Handshake) method, which should be implemented by newer providers. To enable
+        compatibility between older engines and providers:
+
+        * Callers which call `Handshake` *must* call `Configure` with flags such as `acceptSecrets` and `acceptResources`
+        set to `true`, since these features predate the introduction of `Handshake` and thus `Handshake`-aware callers
+        must support them. See [](pulumirpc.ConfigureRequest) for more information.
+        * Providers which implement `Handshake` *must* support flags such as `acceptSecrets` and `acceptResources`, and
+        indicate as such by always returning `true` for these fields in [](pulumirpc.ConfigureResponse). See
+        [](pulumirpc.ConfigureResponse) for more information.
+        :::
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
@@ -36,6 +36,12 @@ class ResourceProviderStub:
         pulumi.provider_pb2.ProviderHandshakeRequest,
         pulumi.provider_pb2.ProviderHandshakeResponse,
     ]
+    """`Handshake` is the first call made by the engine to a provider. It is used to pass the engine's address to the
+    provider so that it may establish its own connections back, and to establish protocol configuration that will be
+    used to communicate between the two parties. Providers that support `Handshake` implicitly support the set of
+    feature flags previously handled by `Configure` prior to `Handshake`'s introduction, such as secrets and resource
+    references.
+    """
     Parameterize: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.ParameterizeRequest,
         pulumi.provider_pb2.ParameterizeResponse,
@@ -115,7 +121,7 @@ class ResourceProviderStub:
         pulumi.provider_pb2.ConfigureRequest,
         pulumi.provider_pb2.ConfigureResponse,
     ]
-    """`Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
+    """`Configure` is the final stage in configuring a provider instance. Callers may supply two sets of data:
 
     * Provider-specific configuration, which is the set of inputs that have been validated by a previous
       [](pulumirpc.ResourceProvider.CheckConfig) call.
@@ -127,6 +133,19 @@ class ResourceProviderStub:
     Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
     the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
     indicate which keys are missing.
+
+    :::{important}
+    The use of `Configure` to configure protocol features is deprecated in favour of the
+    [](pulumirpc.ResourceProvider.Handshake) method, which should be implemented by newer providers. To enable
+    compatibility between older engines and providers:
+
+    * Callers which call `Handshake` *must* call `Configure` with flags such as `acceptSecrets` and `acceptResources`
+      set to `true`, since these features predate the introduction of `Handshake` and thus `Handshake`-aware callers
+      must support them. See [](pulumirpc.ConfigureRequest) for more information.
+    * Providers which implement `Handshake` *must* support flags such as `acceptSecrets` and `acceptResources`, and
+      indicate as such by always returning `true` for these fields in [](pulumirpc.ConfigureResponse). See
+      [](pulumirpc.ConfigureResponse) for more information.
+    :::
     """
     Invoke: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.InvokeRequest,
@@ -271,7 +290,13 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         self,
         request: pulumi.provider_pb2.ProviderHandshakeRequest,
         context: grpc.ServicerContext,
-    ) -> pulumi.provider_pb2.ProviderHandshakeResponse: ...
+    ) -> pulumi.provider_pb2.ProviderHandshakeResponse:
+        """`Handshake` is the first call made by the engine to a provider. It is used to pass the engine's address to the
+        provider so that it may establish its own connections back, and to establish protocol configuration that will be
+        used to communicate between the two parties. Providers that support `Handshake` implicitly support the set of
+        feature flags previously handled by `Configure` prior to `Handshake`'s introduction, such as secrets and resource
+        references.
+        """
     
     def Parameterize(
         self,
@@ -361,7 +386,7 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         request: pulumi.provider_pb2.ConfigureRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.ConfigureResponse:
-        """`Configure` is the final stage in configuring a provider instance. Callers supply two sets of data:
+        """`Configure` is the final stage in configuring a provider instance. Callers may supply two sets of data:
 
         * Provider-specific configuration, which is the set of inputs that have been validated by a previous
           [](pulumirpc.ResourceProvider.CheckConfig) call.
@@ -373,6 +398,19 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         Providers may expect a *single* call to `Configure`. If a call to `Configure` is missing required configuration,
         the provider may return a set of error details containing [](pulumirpc.ConfigureErrorMissingKeys) values to
         indicate which keys are missing.
+
+        :::{important}
+        The use of `Configure` to configure protocol features is deprecated in favour of the
+        [](pulumirpc.ResourceProvider.Handshake) method, which should be implemented by newer providers. To enable
+        compatibility between older engines and providers:
+
+        * Callers which call `Handshake` *must* call `Configure` with flags such as `acceptSecrets` and `acceptResources`
+          set to `true`, since these features predate the introduction of `Handshake` and thus `Handshake`-aware callers
+          must support them. See [](pulumirpc.ConfigureRequest) for more information.
+        * Providers which implement `Handshake` *must* support flags such as `acceptSecrets` and `acceptResources`, and
+          indicate as such by always returning `true` for these fields in [](pulumirpc.ConfigureResponse). See
+          [](pulumirpc.ConfigureResponse) for more information.
+        :::
         """
     
     def Invoke(


### PR DESCRIPTION
The `Handshake` method was added in #17819 to allow the engine and providers to negotiate protocol details before proceeding. This commit bolsters the documentation for the new method and parts of its implementation, as well as how it should interact with `Configure`.