### PR TITLE
Add autonaming configuration to Go Provider SDK

### DIFF
--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -119,6 +119,27 @@ type ConfigureRequest struct {
 
 type ConfigureResponse struct{}
 
+// The mode that controls how the provider handles the proposed name. If not specified, defaults to `Propose`.
+type AutonamingMode int32
+
+const (
+	// Propose: The provider may use the proposed name as a suggestion but is free to modify it.
+	AutonamingModePropose AutonamingMode = iota
+	// Enforce: The provider must use exactly the proposed name or return an error.
+	AutonamingModeEnforce = 1
+	// Disabled: The provider should disable automatic naming and return an error if no explicit name is provided
+	// by user's program.
+	AutonamingModeDisabled = 2
+)
+
+// Configuration for automatic resource naming behavior. This structure contains fields that control how the provider
+// handles resource names, including proposed names and naming modes.
+type AutonamingOptions struct {
+	ProposedName    string
+	Mode            AutonamingMode
+	WarnIfNoSupport bool
+}
+
 type CheckRequest struct {
 	URN  resource.URN
 	Name string
@@ -127,6 +148,7 @@ type CheckRequest struct {
 	Olds, News    resource.PropertyMap
 	AllowUnknowns bool
 	RandomSeed    []byte
+	Autonaming    *AutonamingOptions
 }
 
 type CheckResponse struct {

--- a/sdk/go/common/resource/plugin/provider_server.go
+++ b/sdk/go/common/resource/plugin/provider_server.go
@@ -398,6 +398,14 @@ func (p *providerServer) Check(ctx context.Context, req *pulumirpc.CheckRequest)
 		return nil, err
 	}
 
+	var autonaming *AutonamingOptions
+	if req.Autonaming != nil {
+		autonaming = &AutonamingOptions{
+			ProposedName: req.Autonaming.ProposedName,
+			Mode:         AutonamingMode(req.Autonaming.Mode),
+		}
+	}
+
 	resp, err := p.provider.Check(ctx, CheckRequest{
 		URN:           urn,
 		Name:          req.Name,
@@ -406,6 +414,7 @@ func (p *providerServer) Check(ctx context.Context, req *pulumirpc.CheckRequest)
 		News:          inputs,
 		AllowUnknowns: true,
 		RandomSeed:    req.RandomSeed,
+		Autonaming:    autonaming,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add autonaming configuration to the Go provider SDK. I'm slightly confused about where I should be going with the supportsAutonamingConfiguration, but this is consistent with my previous PRs.