### PR TITLE
Don't hang indefinitely on failed inputs

### DIFF
--- a/changelog/pending/20241202--auto-nodejs--dont-hang-indefinitely-on-failed-inputs.yaml
+++ b/changelog/pending/20241202--auto-nodejs--dont-hang-indefinitely-on-failed-inputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/nodejs
+  description: Don't hang indefinitely on failed inputs

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -509,201 +509,217 @@ export function registerResource(
     // with a non-useful stack trace.
     const preallocError = new Error();
     debuggablePromise(
-        resopAsync.then(async (resop) => {
-            log.debug(
-                `RegisterResource RPC prepared: t=${t}, name=${name}` +
-                    (excessiveDebugOutput ? `, obj=${JSON.stringify(resop.serializedProps)}` : ``),
-            );
-
-            await awaitStackRegistrations();
-
-            const callbacks: Callback[] = [];
-            if (opts.transforms !== undefined && opts.transforms.length > 0) {
-                if (!getStore().supportsTransforms) {
-                    throw new Error("The Pulumi CLI does not support transforms. Please update the Pulumi CLI");
-                }
-
-                const callbackServer = getCallbacks();
-                if (callbackServer === undefined) {
-                    throw new Error("Callback server could not initialize");
-                }
-
-                for (const transform of opts.transforms) {
-                    callbacks.push(await callbackServer.registerTransform(transform));
-                }
-            }
-
-            // If we have a package reference, we need to wait for it to resolve.
-            let packageRefStr = undefined;
-            if (packageRef !== undefined) {
-                packageRefStr = await packageRef;
-                if (packageRefStr !== undefined) {
-                    // If we have a package reference we can clear some of the resource options
-                    opts.version = undefined;
-                    opts.pluginDownloadURL = undefined;
-                }
-            }
-
-            const req = new resproto.RegisterResourceRequest();
-            req.setPackageref(packageRefStr || "");
-            req.setType(t);
-            req.setName(name);
-            req.setParent(resop.parentURN || "");
-            req.setCustom(custom);
-            req.setObject(gstruct.Struct.fromJavaScript(resop.serializedProps));
-            req.setProtect(opts.protect || false);
-            req.setProvider(resop.providerRef || "");
-            req.setDependenciesList(Array.from(resop.allDirectDependencyURNs));
-            req.setDeletebeforereplace((<any>opts).deleteBeforeReplace || false);
-            req.setDeletebeforereplacedefined((<any>opts).deleteBeforeReplace !== undefined);
-            req.setIgnorechangesList(opts.ignoreChanges || []);
-            req.setVersion(opts.version || "");
-            req.setAcceptsecrets(true);
-            req.setAcceptresources(!utils.disableResourceReferences);
-            req.setAdditionalsecretoutputsList((<any>opts).additionalSecretOutputs || []);
-            if (resop.monitorSupportsStructuredAliases) {
-                const aliasesList = await mapAliasesForRequest(resop.aliases, resop.parentURN);
-                req.setAliasesList(aliasesList);
-            } else {
-                const urns = new Array<string>();
-                resop.aliases.forEach((v) => {
-                    if (typeof v === "string") {
-                        urns.push(v);
-                    }
-                });
-                req.setAliasurnsList(urns);
-            }
-            req.setImportid(resop.import || "");
-            req.setSupportspartialvalues(true);
-            req.setRemote(remote);
-            req.setReplaceonchangesList(opts.replaceOnChanges || []);
-            req.setPlugindownloadurl(opts.pluginDownloadURL || "");
-            req.setRetainondelete(opts.retainOnDelete || false);
-            req.setDeletedwith(resop.deletedWithURN || "");
-            req.setAliasspecs(true);
-            req.setSourceposition(marshalSourcePosition(sourcePosition));
-            req.setTransformsList(callbacks);
-            req.setSupportsresultreporting(true);
-
-            if (resop.deletedWithURN && !getStore().supportsDeletedWith) {
-                throw new Error(
-                    "The Pulumi CLI does not support the DeletedWith option. Please update the Pulumi CLI.",
+        resopAsync
+            .then(async (resop) => {
+                log.debug(
+                    `RegisterResource RPC prepared: t=${t}, name=${name}` +
+                        (excessiveDebugOutput ? `, obj=${JSON.stringify(resop.serializedProps)}` : ``),
                 );
-            }
 
-            const customTimeouts = new resproto.RegisterResourceRequest.CustomTimeouts();
-            if (opts.customTimeouts != null) {
-                customTimeouts.setCreate(opts.customTimeouts.create || "");
-                customTimeouts.setUpdate(opts.customTimeouts.update || "");
-                customTimeouts.setDelete(opts.customTimeouts.delete || "");
-            }
-            req.setCustomtimeouts(customTimeouts);
+                await awaitStackRegistrations();
 
-            const propertyDependencies = req.getPropertydependenciesMap();
-            for (const [key, resourceURNs] of resop.propertyToDirectDependencyURNs) {
-                const deps = new resproto.RegisterResourceRequest.PropertyDependencies();
-                deps.setUrnsList(Array.from(resourceURNs));
-                propertyDependencies.set(key, deps);
-            }
+                const callbacks: Callback[] = [];
+                if (opts.transforms !== undefined && opts.transforms.length > 0) {
+                    if (!getStore().supportsTransforms) {
+                        throw new Error("The Pulumi CLI does not support transforms. Please update the Pulumi CLI");
+                    }
 
-            const providerRefs = req.getProvidersMap();
-            for (const [key, ref] of resop.providerRefs) {
-                providerRefs.set(key, ref);
-            }
+                    const callbackServer = getCallbacks();
+                    if (callbackServer === undefined) {
+                        throw new Error("Callback server could not initialize");
+                    }
 
-            // Now run the operation, serializing the invocation if necessary.
-            const opLabel = `monitor.registerResource(${label})`;
-            runAsyncResourceOp(opLabel, async () => {
-                let resp: any = {};
-                let err: Error | undefined;
-                try {
-                    if (monitor) {
-                        // If we're running with an attachment to the engine, perform the operation.
-                        resp = await debuggablePromise(
-                            new Promise((resolve, reject) =>
-                                monitor.registerResource(
-                                    req,
-                                    (
-                                        rpcErr: grpc.ServiceError | null,
-                                        innerResponse: resproto.RegisterResourceResponse | undefined,
-                                    ) => {
-                                        if (rpcErr) {
-                                            err = rpcErr;
-                                            // If the monitor is unavailable, it is in the process of shutting down or has already
-                                            // shut down. Don't emit an error and don't do any more RPCs, just exit.
-                                            if (
-                                                rpcErr.code === grpc.status.UNAVAILABLE ||
-                                                rpcErr.code === grpc.status.CANCELLED
-                                            ) {
-                                                // Re-emit the message
-                                                terminateRpcs();
-                                                rpcErr.message = "Resource monitor is terminating";
-                                                (<any>preallocError).code = rpcErr.code;
+                    for (const transform of opts.transforms) {
+                        callbacks.push(await callbackServer.registerTransform(transform));
+                    }
+                }
+
+                // If we have a package reference, we need to wait for it to resolve.
+                let packageRefStr = undefined;
+                if (packageRef !== undefined) {
+                    packageRefStr = await packageRef;
+                    if (packageRefStr !== undefined) {
+                        // If we have a package reference we can clear some of the resource options
+                        opts.version = undefined;
+                        opts.pluginDownloadURL = undefined;
+                    }
+                }
+
+                const req = new resproto.RegisterResourceRequest();
+                req.setPackageref(packageRefStr || "");
+                req.setType(t);
+                req.setName(name);
+                req.setParent(resop.parentURN || "");
+                req.setCustom(custom);
+                req.setObject(gstruct.Struct.fromJavaScript(resop.serializedProps));
+                req.setProtect(opts.protect || false);
+                req.setProvider(resop.providerRef || "");
+                req.setDependenciesList(Array.from(resop.allDirectDependencyURNs));
+                req.setDeletebeforereplace((<any>opts).deleteBeforeReplace || false);
+                req.setDeletebeforereplacedefined((<any>opts).deleteBeforeReplace !== undefined);
+                req.setIgnorechangesList(opts.ignoreChanges || []);
+                req.setVersion(opts.version || "");
+                req.setAcceptsecrets(true);
+                req.setAcceptresources(!utils.disableResourceReferences);
+                req.setAdditionalsecretoutputsList((<any>opts).additionalSecretOutputs || []);
+                if (resop.monitorSupportsStructuredAliases) {
+                    const aliasesList = await mapAliasesForRequest(resop.aliases, resop.parentURN);
+                    req.setAliasesList(aliasesList);
+                } else {
+                    const urns = new Array<string>();
+                    resop.aliases.forEach((v) => {
+                        if (typeof v === "string") {
+                            urns.push(v);
+                        }
+                    });
+                    req.setAliasurnsList(urns);
+                }
+                req.setImportid(resop.import || "");
+                req.setSupportspartialvalues(true);
+                req.setRemote(remote);
+                req.setReplaceonchangesList(opts.replaceOnChanges || []);
+                req.setPlugindownloadurl(opts.pluginDownloadURL || "");
+                req.setRetainondelete(opts.retainOnDelete || false);
+                req.setDeletedwith(resop.deletedWithURN || "");
+                req.setAliasspecs(true);
+                req.setSourceposition(marshalSourcePosition(sourcePosition));
+                req.setTransformsList(callbacks);
+                req.setSupportsresultreporting(true);
+
+                if (resop.deletedWithURN && !getStore().supportsDeletedWith) {
+                    throw new Error(
+                        "The Pulumi CLI does not support the DeletedWith option. Please update the Pulumi CLI.",
+                    );
+                }
+
+                const customTimeouts = new resproto.RegisterResourceRequest.CustomTimeouts();
+                if (opts.customTimeouts != null) {
+                    customTimeouts.setCreate(opts.customTimeouts.create || "");
+                    customTimeouts.setUpdate(opts.customTimeouts.update || "");
+                    customTimeouts.setDelete(opts.customTimeouts.delete || "");
+                }
+                req.setCustomtimeouts(customTimeouts);
+
+                const propertyDependencies = req.getPropertydependenciesMap();
+                for (const [key, resourceURNs] of resop.propertyToDirectDependencyURNs) {
+                    const deps = new resproto.RegisterResourceRequest.PropertyDependencies();
+                    deps.setUrnsList(Array.from(resourceURNs));
+                    propertyDependencies.set(key, deps);
+                }
+
+                const providerRefs = req.getProvidersMap();
+                for (const [key, ref] of resop.providerRefs) {
+                    providerRefs.set(key, ref);
+                }
+
+                // Now run the operation, serializing the invocation if necessary.
+                const opLabel = `monitor.registerResource(${label})`;
+                runAsyncResourceOp(opLabel, async () => {
+                    let resp: any = {};
+                    let err: Error | undefined;
+                    try {
+                        if (monitor) {
+                            // If we're running with an attachment to the engine, perform the operation.
+                            resp = await debuggablePromise(
+                                new Promise((resolve, reject) =>
+                                    monitor.registerResource(
+                                        req,
+                                        (
+                                            rpcErr: grpc.ServiceError | null,
+                                            innerResponse: resproto.RegisterResourceResponse | undefined,
+                                        ) => {
+                                            if (rpcErr) {
+                                                err = rpcErr;
+                                                // If the monitor is unavailable, it is in the process of shutting down or has already
+                                                // shut down. Don't emit an error and don't do any more RPCs, just exit.
+                                                if (
+                                                    rpcErr.code === grpc.status.UNAVAILABLE ||
+                                                    rpcErr.code === grpc.status.CANCELLED
+                                                ) {
+                                                    // Re-emit the message
+                                                    terminateRpcs();
+                                                    rpcErr.message = "Resource monitor is terminating";
+                                                    (<any>preallocError).code = rpcErr.code;
+                                                }
+
+                                                // Node lets us hack the message as long as we do it before accessing the `stack` property.
+                                                log.debug(
+                                                    `RegisterResource RPC finished: ${label}; err: ${rpcErr}, resp: ${innerResponse}`,
+                                                );
+                                                preallocError.message = `failed to register new resource ${name} [${t}]: ${rpcErr.message}`;
+                                                reject(preallocError);
+                                            } else {
+                                                log.debug(
+                                                    `RegisterResource RPC finished: ${label}; err: ${rpcErr}, resp: ${innerResponse}`,
+                                                );
+                                                resolve(innerResponse);
                                             }
-
-                                            // Node lets us hack the message as long as we do it before accessing the `stack` property.
-                                            log.debug(
-                                                `RegisterResource RPC finished: ${label}; err: ${rpcErr}, resp: ${innerResponse}`,
-                                            );
-                                            preallocError.message = `failed to register new resource ${name} [${t}]: ${rpcErr.message}`;
-                                            reject(preallocError);
-                                        } else {
-                                            log.debug(
-                                                `RegisterResource RPC finished: ${label}; err: ${rpcErr}, resp: ${innerResponse}`,
-                                            );
-                                            resolve(innerResponse);
-                                        }
-                                    },
+                                        },
+                                    ),
                                 ),
-                            ),
-                            opLabel,
-                        );
-                    } else {
-                        // If we aren't attached to the engine, in test mode, mock up a fake response for testing purposes.
-                        const mockurn = await createUrn(req.getName(), req.getType(), req.getParent()).promise();
+                                opLabel,
+                            );
+                        } else {
+                            // If we aren't attached to the engine, in test mode, mock up a fake response for testing purposes.
+                            const mockurn = await createUrn(req.getName(), req.getType(), req.getParent()).promise();
+                            resp = {
+                                getUrn: () => mockurn,
+                                getId: () => undefined,
+                                getObject: () => req.getObject(),
+                                getPropertydependenciesMap: () => undefined,
+                                getResult: () => 0,
+                            };
+                        }
+                    } catch (e) {
+                        err = e;
                         resp = {
-                            getUrn: () => mockurn,
+                            getUrn: () => "",
                             getId: () => undefined,
                             getObject: () => req.getObject(),
                             getPropertydependenciesMap: () => undefined,
                             getResult: () => 0,
                         };
                     }
-                } catch (e) {
-                    err = e;
-                    resp = {
-                        getUrn: () => "",
-                        getId: () => undefined,
-                        getObject: () => req.getObject(),
-                        getPropertydependenciesMap: () => undefined,
-                        getResult: () => 0,
-                    };
-                }
 
-                resop.resolveURN(resp.getUrn(), err);
+                    resop.resolveURN(resp.getUrn(), err);
 
-                // Note: 'id || undefined' is intentional.  We intentionally collapse falsy values to
-                // undefined so that later parts of our system don't have to deal with values like 'null'.
-                if (resop.resolveID) {
-                    const id = resp.getId() || undefined;
-                    resop.resolveID(id, id !== undefined, err);
-                }
-
-                const deps: Record<string, Resource[]> = {};
-                const rpcDeps = resp.getPropertydependenciesMap();
-                if (rpcDeps) {
-                    for (const [k, propertyDeps] of resp.getPropertydependenciesMap().entries()) {
-                        const urns = <URN[]>propertyDeps.getUrnsList();
-                        deps[k] = urns.map((urn) => newDependency(urn));
+                    // Note: 'id || undefined' is intentional.  We intentionally collapse falsy values to
+                    // undefined so that later parts of our system don't have to deal with values like 'null'.
+                    if (resop.resolveID) {
+                        const id = resp.getId() || undefined;
+                        resop.resolveID(id, id !== undefined, err);
                     }
-                }
 
-                // Now resolve the output properties.
-                const keepUnknowns = resp.getResult() !== resproto.Result.SUCCESS;
-                await resolveOutputs(res, t, name, props, resp.getObject(), deps, resop.resolvers, err, keepUnknowns);
+                    const deps: Record<string, Resource[]> = {};
+                    const rpcDeps = resp.getPropertydependenciesMap();
+                    if (rpcDeps) {
+                        for (const [k, propertyDeps] of resp.getPropertydependenciesMap().entries()) {
+                            const urns = <URN[]>propertyDeps.getUrnsList();
+                            deps[k] = urns.map((urn) => newDependency(urn));
+                        }
+                    }
+
+                    // Now resolve the output properties.
+                    const keepUnknowns = resp.getResult() !== resproto.Result.SUCCESS;
+                    await resolveOutputs(
+                        res,
+                        t,
+                        name,
+                        props,
+                        resp.getObject(),
+                        deps,
+                        resop.resolvers,
+                        err,
+                        keepUnknowns,
+                    );
+                    done();
+                });
+            })
+            .catch((err) => {
+                // If we fail to prepare the resource, we need to ensure that we still call done to prevent a hang.
                 done();
-            });
-        }),
+                throw err;
+            }),
         label,
     );
 }


### PR DESCRIPTION
Ensure we always mark the register resource RPC call as completed, even
when an error occurs.

Fixes https://github.com/pulumi/pulumi/issues/17613
