### PR TITLE
Catch BaseException in automation API server

### DIFF
--- a/changelog/pending/20241203--auto-python--catch-baseexception-in-automation-api-server.yaml
+++ b/changelog/pending/20241203--auto-python--catch-baseexception-in-automation-api-server.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/python
+  description: Catch BaseException in automation API server

--- a/sdk/python/lib/pulumi/automation/_server.py
+++ b/sdk/python/lib/pulumi/automation/_server.py
@@ -93,7 +93,7 @@ class LanguageServer(LanguageRuntimeServicer):
                     log.error(msg)
                     result.error = msg
                     return result
-            except Exception as exn:  # noqa: BLE001 catch blind exception
+            except BaseException as exn:  # noqa: BLE001 catch blind exception
                 msg = str(
                     f"python inline source runtime error: {exn}\n{traceback.format_exc()}"
                 )

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -30,6 +30,7 @@ from pulumi.automation import (
     ConfigValue,
     EngineEvent,
     InvalidVersionError,
+    InlineSourceRuntimeError,
     LocalWorkspace,
     LocalWorkspaceOptions,
     OpType,
@@ -1334,6 +1335,28 @@ class TestLocalWorkspace(unittest.TestCase):
         # not high enough to support install
         mock_cmd.version = VersionInfo(3, 90)
         self.assertRaises(InvalidVersionError, ws.install)
+
+    @pytest.mark.timeout(20)  # This test will hang indefinitely if the bug is present
+    def test_pytest_raises_does_not_hang(self):
+        # This inline program is itself a test, just as a user could write using the
+        # automation API for writing their tests.
+        # This test is a regression test for
+        # https://github.com/pulumi/pulumi/issues/17133 where a test failure
+        # should cause `stack.preview()` to fail, but would instead it hangs
+        # indefinitely.
+        def program():
+            with pytest.raises(ValueError):
+                _a = 1 + 2  # No error here, pytest.raises should fail
+
+        project_name = "inline_python"
+        stack_name = stack_namer(project_name)
+        stack = create_stack(stack_name, program=program, project_name=project_name)
+
+        # We expect the above program to fail.
+        with pytest.raises(InlineSourceRuntimeError):
+            stack.preview()
+
+        stack.workspace.remove_stack(stack_name)
 
 
 def pulumi_program():

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -1342,7 +1342,7 @@ class TestLocalWorkspace(unittest.TestCase):
         # automation API for writing their tests.
         # This test is a regression test for
         # https://github.com/pulumi/pulumi/issues/17133 where a test failure
-        # should cause `stack.preview()` to fail, but would instead it hangs
+        # should cause `stack.preview()` to fail, but would instead hang
         # indefinitely.
         def program():
             with pytest.raises(ValueError):


### PR DESCRIPTION
Automation API is useful for writing tests for Pulumi programs, and a
user could write a test as follows:

```python
def program():
    with pytest.raises(ValueError):
        _a = 1 + 2  # No error here, pytest.raises should fail

stack = create_stack("mystack", program=program, project_name="proj")

with pytest.raises(InlineSourceRuntimeError):
    stack.preview()
```

If the block in `pytest.raises` does not raise the expected error or any
error, `pytest.raises` fails the test by raising an `OutcomeException`.
This exception class inherits from `BaseException`, not `Exception`, so
we would previously not catch this, and fail to report an error from the
automation API server's `Run` method, causing the call to `stack.preview`
to hang indefinitely.

Fixes https://github.com/pulumi/pulumi/issues/17133
