### PR TITLE
Conformance tests check GetRequiredPackages

### DIFF
--- a/changelog/pending/20241203--sdk-nodejs-python--update-python-and-nodejs-to-use-the-new-getrequiredpackage-functionality.yaml
+++ b/changelog/pending/20241203--sdk-nodejs-python--update-python-and-nodejs-to-use-the-new-getrequiredpackage-functionality.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs,python
+  description: Update Python and NodeJS to use the new GetRequiredPackage functionality

--- a/cmd/pulumi-test-language/l2resourcesimple_test.go
+++ b/cmd/pulumi-test-language/l2resourcesimple_test.go
@@ -422,9 +422,7 @@ func TestL2SimpleResource_MissingRequiredPlugins(t *testing.T) {
 	assert.False(t, runResponse.Success)
 	require.Len(t, runResponse.Messages, 1)
 	failureMessage := runResponse.Messages[0]
-	assert.Contains(t, failureMessage,
-		"expected no error, got unexpected required plugins: "+
-			"actual [language-mock@<nil>], expected [language-mock@<nil> resource-simple@2.0.0]")
+	assert.Contains(t, failureMessage, "missing expected package simple-2.0.0")
 }
 
 // Run a simple successful test with a mocked runtime that edits the snapshot files.

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -4695,6 +4695,11 @@ func GeneratePackage(tool string,
 	}
 	if goPkgInfo.RespectSchemaVersion && pkg.Version != nil {
 		pulumiPlugin.Version = pkg.Version.String()
+	} else if pkg.SupportPack {
+		if pkg.Version == nil {
+			return nil, errors.New("package version is required")
+		}
+		pulumiPlugin.Version = pkg.Version.String()
 	}
 
 	if pkg.Parameterization != nil {

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -2413,14 +2413,13 @@ func genNPMPackageMetadata(pkg *schema.Package, info NodePackageInfo, localDepen
 	if pkg.Version != nil && info.RespectSchemaVersion {
 		version = pkg.Version.String()
 		pluginVersion = version
-	}
-	// Parameterized schemas _always_ respect schema version
-	if pkg.SupportPack {
+	} else if pkg.SupportPack {
+		// Parameterized schemas _always_ respect schema version
 		if pkg.Version == nil {
 			return "", errors.New("package version is required")
 		}
-		pluginVersion = pkg.Version.String()
-		version = pluginVersion
+		version = pkg.Version.String()
+		pluginVersion = version
 	}
 
 	var pulumiPlugin plugin.PulumiPluginJSON

--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -111,13 +111,13 @@ func TestParseRunParams(t *testing.T) {
 	}
 }
 
-func TestGetPlugin(t *testing.T) {
+func TestGetPackage(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
 		Name          string
 		Mod           *modInfo
-		Expected      *pulumirpc.PluginDependency
+		Expected      *pulumirpc.PackageDependency
 		ExpectedError string
 		JSON          *plugin.PulumiPluginJSON
 		JSONPath      string
@@ -128,7 +128,7 @@ func TestGetPlugin(t *testing.T) {
 				Path:    "github.com/pulumi/pulumi-aws/sdk",
 				Version: "v1.29.0",
 			},
-			Expected: &pulumirpc.PluginDependency{
+			Expected: &pulumirpc.PackageDependency{
 				Name:    "aws",
 				Version: "v1.29.0",
 			},
@@ -139,7 +139,7 @@ func TestGetPlugin(t *testing.T) {
 				Path:    "github.com/pulumi/pulumi-aws/sdk",
 				Version: "v1.29.1-0.20200403140640-efb5e2a48a86",
 			},
-			Expected: &pulumirpc.PluginDependency{
+			Expected: &pulumirpc.PackageDependency{
 				Name:    "aws",
 				Version: "v1.29.0",
 			},
@@ -174,7 +174,7 @@ func TestGetPlugin(t *testing.T) {
 				Path:    "github.com/pulumi/pulumi-aws/sdk",
 				Version: "v2.0.0-beta.1",
 			},
-			Expected: &pulumirpc.PluginDependency{
+			Expected: &pulumirpc.PackageDependency{
 				Name:    "aws",
 				Version: "v2.0.0-beta.1",
 			},
@@ -184,7 +184,7 @@ func TestGetPlugin(t *testing.T) {
 				Path:    "github.com/pulumi/pulumi-kubernetes/sdk",
 				Version: "v1.5.8",
 			},
-			Expected: &pulumirpc.PluginDependency{
+			Expected: &pulumirpc.PackageDependency{
 				Name:    "kubernetes",
 				Version: "v1.5.8",
 			},
@@ -195,7 +195,7 @@ func TestGetPlugin(t *testing.T) {
 				Path:    "github.com/me/myself/i",
 				Version: "invalid-Version",
 			},
-			Expected: &pulumirpc.PluginDependency{
+			Expected: &pulumirpc.PackageDependency{
 				Name:    "thing1",
 				Version: "v1.2.3",
 				Server:  "myserver.com",
@@ -237,7 +237,7 @@ func TestGetPlugin(t *testing.T) {
 				Resource: true,
 			},
 			JSONPath: "go",
-			Expected: &pulumirpc.PluginDependency{
+			Expected: &pulumirpc.PackageDependency{
 				Name:    "name",
 				Version: "v1.2.3",
 			},
@@ -253,7 +253,7 @@ func TestGetPlugin(t *testing.T) {
 				Resource: true,
 			},
 			JSONPath: filepath.Join("go", "name"),
-			Expected: &pulumirpc.PluginDependency{
+			Expected: &pulumirpc.PackageDependency{
 				Name:    "name",
 				Version: "v1.2.3",
 			},
@@ -305,7 +305,7 @@ func TestGetPlugin(t *testing.T) {
 				assert.NoError(t, err, "Failed to write pulumi-plugin.json")
 			}
 
-			actual, err := c.Mod.getPlugin(t.TempDir())
+			actual, err := c.Mod.getPackage(t.TempDir())
 			if c.ExpectedError != "" {
 				assert.EqualError(t, err, c.ExpectedError)
 			} else {
@@ -415,13 +415,11 @@ func testPluginsAndDependencies(t *testing.T, progDir string) {
 	host := newLanguageHost("0.0.0.0:0", progDir, "")
 	ctx := context.Background()
 
-	t.Run("GetRequiredPlugins", func(t *testing.T) {
+	t.Run("GetRequiredPackages", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
 
-		res, err := host.GetRequiredPlugins(ctx, &pulumirpc.GetRequiredPluginsRequest{ //nolint:staticcheck // Deprecated API.
-			Project: "deprecated",
-			Pwd:     progDir,
+		res, err := host.GetRequiredPackages(ctx, &pulumirpc.GetRequiredPackagesRequest{
 			Info: &pulumirpc.ProgramInfo{
 				RootDirectory:    progDir,
 				ProgramDirectory: progDir,
@@ -430,8 +428,8 @@ func testPluginsAndDependencies(t *testing.T, progDir string) {
 		})
 		require.NoError(t, err)
 
-		require.Len(t, res.Plugins, 1)
-		plug := res.Plugins[0]
+		require.Len(t, res.Packages, 1)
+		plug := res.Packages[0]
 
 		assert.Equal(t, "example", plug.Name, "plugin name")
 		assert.Equal(t, "v1.2.3", plug.Version, "plugin version")

--- a/sdk/go/pulumi-language-go/testdata/sdks/alpha-3.0.0-alpha.1.internal/alpha/pulumi-plugin.json
+++ b/sdk/go/pulumi-language-go/testdata/sdks/alpha-3.0.0-alpha.1.internal/alpha/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "alpha"
+  "name": "alpha",
+  "version": "3.0.0-alpha.1.internal"
 }

--- a/sdk/go/pulumi-language-go/testdata/sdks/asset-archive-5.0.0/assetarchive/pulumi-plugin.json
+++ b/sdk/go/pulumi-language-go/testdata/sdks/asset-archive-5.0.0/assetarchive/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "asset-archive"
+  "name": "asset-archive",
+  "version": "5.0.0"
 }

--- a/sdk/go/pulumi-language-go/testdata/sdks/config-9.0.0/config/pulumi-plugin.json
+++ b/sdk/go/pulumi-language-go/testdata/sdks/config-9.0.0/config/pulumi-plugin.json
@@ -1,5 +1,6 @@
 {
   "resource": true,
   "name": "config",
+  "version": "9.0.0",
   "server": "http://example.com"
 }

--- a/sdk/go/pulumi-language-go/testdata/sdks/config-grpc-1.0.0/configgrpc/pulumi-plugin.json
+++ b/sdk/go/pulumi-language-go/testdata/sdks/config-grpc-1.0.0/configgrpc/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "config-grpc"
+  "name": "config-grpc",
+  "version": "1.0.0"
 }

--- a/sdk/go/pulumi-language-go/testdata/sdks/fail_on_create-4.0.0/fail_on_create/pulumi-plugin.json
+++ b/sdk/go/pulumi-language-go/testdata/sdks/fail_on_create-4.0.0/fail_on_create/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "fail_on_create"
+  "name": "fail_on_create",
+  "version": "4.0.0"
 }

--- a/sdk/go/pulumi-language-go/testdata/sdks/large-4.3.2/large/pulumi-plugin.json
+++ b/sdk/go/pulumi-language-go/testdata/sdks/large-4.3.2/large/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "large"
+  "name": "large",
+  "version": "4.3.2"
 }

--- a/sdk/go/pulumi-language-go/testdata/sdks/primitive-7.0.0/primitive/pulumi-plugin.json
+++ b/sdk/go/pulumi-language-go/testdata/sdks/primitive-7.0.0/primitive/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "primitive"
+  "name": "primitive",
+  "version": "7.0.0"
 }

--- a/sdk/go/pulumi-language-go/testdata/sdks/primitive-ref-11.0.0/primitiveref/pulumi-plugin.json
+++ b/sdk/go/pulumi-language-go/testdata/sdks/primitive-ref-11.0.0/primitiveref/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "primitive-ref"
+  "name": "primitive-ref",
+  "version": "11.0.0"
 }

--- a/sdk/go/pulumi-language-go/testdata/sdks/ref-ref-12.0.0/refref/pulumi-plugin.json
+++ b/sdk/go/pulumi-language-go/testdata/sdks/ref-ref-12.0.0/refref/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "ref-ref"
+  "name": "ref-ref",
+  "version": "12.0.0"
 }

--- a/sdk/go/pulumi-language-go/testdata/sdks/secret-14.0.0/secret/pulumi-plugin.json
+++ b/sdk/go/pulumi-language-go/testdata/sdks/secret-14.0.0/secret/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "secret"
+  "name": "secret",
+  "version": "14.0.0"
 }

--- a/sdk/go/pulumi-language-go/testdata/sdks/simple-2.0.0/simple/pulumi-plugin.json
+++ b/sdk/go/pulumi-language-go/testdata/sdks/simple-2.0.0/simple/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "simple"
+  "name": "simple",
+  "version": "2.0.0"
 }

--- a/sdk/go/pulumi-language-go/testdata/sdks/simple-invoke-10.0.0/simpleinvoke/pulumi-plugin.json
+++ b/sdk/go/pulumi-language-go/testdata/sdks/simple-invoke-10.0.0/simpleinvoke/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "simple-invoke"
+  "name": "simple-invoke",
+  "version": "10.0.0"
 }

--- a/sdk/go/pulumi-language-go/testdata/sdks/subpackage-2.0.0/subpackage/pulumi-plugin.json
+++ b/sdk/go/pulumi-language-go/testdata/sdks/subpackage-2.0.0/subpackage/pulumi-plugin.json
@@ -4,7 +4,7 @@
   "version": "1.2.3",
   "parameterization": {
     "name": "subpackage",
-    "version": "",
+    "version": "2.0.0",
     "value": "SGVsbG9Xb3JsZA=="
   }
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
@@ -140,7 +140,7 @@ func TestCompatibleVersions(t *testing.T) {
 	}
 }
 
-func TestGetRequiredPlugins(t *testing.T) {
+func TestGetRequiredPackages(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -174,8 +174,7 @@ func TestGetRequiredPlugins(t *testing.T) {
 	}
 
 	host := &nodeLanguageHost{}
-	resp, err := host.GetRequiredPlugins(context.Background(), &pulumirpc.GetRequiredPluginsRequest{
-		Program: dir,
+	resp, err := host.GetRequiredPackages(context.Background(), &pulumirpc.GetRequiredPackagesRequest{
 		Info: &pulumirpc.ProgramInfo{
 			RootDirectory:    dir,
 			ProgramDirectory: dir,
@@ -185,7 +184,7 @@ func TestGetRequiredPlugins(t *testing.T) {
 	require.NoError(t, err)
 
 	actual := make(map[string]string)
-	for _, plugin := range resp.GetPlugins() {
+	for _, plugin := range resp.Packages {
 		actual[plugin.Name] = plugin.Version
 	}
 	assert.Equal(t, map[string]string{
@@ -194,7 +193,7 @@ func TestGetRequiredPlugins(t *testing.T) {
 	}, actual)
 }
 
-func TestGetRequiredPluginsSymlinkCycles(t *testing.T) {
+func TestGetRequiredPackagesSymlinkCycles(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -232,8 +231,7 @@ func TestGetRequiredPluginsSymlinkCycles(t *testing.T) {
 	require.NoError(t, err)
 
 	host := &nodeLanguageHost{}
-	resp, err := host.GetRequiredPlugins(context.Background(), &pulumirpc.GetRequiredPluginsRequest{
-		Program: dir,
+	resp, err := host.GetRequiredPackages(context.Background(), &pulumirpc.GetRequiredPackagesRequest{
 		Info: &pulumirpc.ProgramInfo{
 			RootDirectory:    dir,
 			ProgramDirectory: dir,
@@ -243,7 +241,7 @@ func TestGetRequiredPluginsSymlinkCycles(t *testing.T) {
 	require.NoError(t, err)
 
 	actual := make(map[string]string)
-	for _, plugin := range resp.GetPlugins() {
+	for _, plugin := range resp.Packages {
 		actual[plugin.Name] = plugin.Version
 	}
 	assert.Equal(t, map[string]string{
@@ -252,7 +250,7 @@ func TestGetRequiredPluginsSymlinkCycles(t *testing.T) {
 	}, actual)
 }
 
-func TestGetRequiredPluginsSymlinkCycles2(t *testing.T) {
+func TestGetRequiredPackagesSymlinkCycles2(t *testing.T) {
 	t.Parallel()
 
 	dir := filepath.Join(t.TempDir(), "testdir")
@@ -292,8 +290,7 @@ func TestGetRequiredPluginsSymlinkCycles2(t *testing.T) {
 	require.NoError(t, err)
 
 	host := &nodeLanguageHost{}
-	resp, err := host.GetRequiredPlugins(context.Background(), &pulumirpc.GetRequiredPluginsRequest{
-		Program: dir,
+	resp, err := host.GetRequiredPackages(context.Background(), &pulumirpc.GetRequiredPackagesRequest{
 		Info: &pulumirpc.ProgramInfo{
 			RootDirectory:    dir,
 			ProgramDirectory: dir,
@@ -303,7 +300,7 @@ func TestGetRequiredPluginsSymlinkCycles2(t *testing.T) {
 	require.NoError(t, err)
 
 	actual := make(map[string]string)
-	for _, plugin := range resp.GetPlugins() {
+	for _, plugin := range resp.Packages {
 		actual[plugin.Name] = plugin.Version
 	}
 	assert.Equal(t, map[string]string{
@@ -312,7 +309,7 @@ func TestGetRequiredPluginsSymlinkCycles2(t *testing.T) {
 	}, actual)
 }
 
-func TestGetRequiredPluginsNestedPolicyPack(t *testing.T) {
+func TestGetRequiredPackagesNestedPolicyPack(t *testing.T) {
 	t.Parallel()
 
 	dir := filepath.Join(t.TempDir(), "testdir")
@@ -348,8 +345,7 @@ func TestGetRequiredPluginsNestedPolicyPack(t *testing.T) {
 	}
 
 	host := &nodeLanguageHost{}
-	resp, err := host.GetRequiredPlugins(context.Background(), &pulumirpc.GetRequiredPluginsRequest{
-		Program: dir,
+	resp, err := host.GetRequiredPackages(context.Background(), &pulumirpc.GetRequiredPackagesRequest{
 		Info: &pulumirpc.ProgramInfo{
 			RootDirectory:    dir,
 			ProgramDirectory: dir,
@@ -359,7 +355,7 @@ func TestGetRequiredPluginsNestedPolicyPack(t *testing.T) {
 	require.NoError(t, err)
 
 	actual := make(map[string]string)
-	for _, plugin := range resp.GetPlugins() {
+	for _, plugin := range resp.Packages {
 		actual[plugin.Name] = plugin.Version
 	}
 	assert.Equal(t, map[string]string{

--- a/sdk/python/cmd/pulumi-language-python/main_test.go
+++ b/sdk/python/cmd/pulumi-language-python/main_test.go
@@ -218,7 +218,7 @@ func TestDeterminePulumiPackages(t *testing.T) {
 		assert.Equal(t, "pip-install-test", pipInstallTest.Name)
 		assert.NotEmpty(t, pipInstallTest.Location)
 
-		plugin, err := determinePluginDependency(pipInstallTest)
+		plugin, err := determinePackageDependency(pipInstallTest)
 		assert.NoError(t, err)
 		assert.NotNil(t, plugin)
 		assert.Equal(t, "thing1", plugin.Name)
@@ -261,7 +261,7 @@ func TestDeterminePulumiPackages(t *testing.T) {
 		assert.NotEmpty(t, packages[0].Location)
 
 		// There should be no associated plugin since its `resource` field is set to `false`.
-		plugin, err := determinePluginDependency(packages[0])
+		plugin, err := determinePackageDependency(packages[0])
 		assert.NoError(t, err)
 		assert.Nil(t, plugin)
 	})


### PR DESCRIPTION
This also updates Python, Go, and NodeJS to use GetRequiredPackages instead of GetRequiredPlugins, as they get tested via conformance testing.