### PR TITLE
Break out plan I/O from `pkg/cmd/pulumi/util`

### DIFF
--- a/pkg/cmd/pulumi/plan/plan.go
+++ b/pkg/cmd/pulumi/plan/plan.go
@@ -1,0 +1,57 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+func Write(path string, plan *deploy.Plan, enc config.Encrypter, showSecrets bool) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer contract.IgnoreClose(f)
+
+	deploymentPlan, err := stack.SerializePlan(plan, enc, showSecrets)
+	if err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(f)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "    ")
+	return encoder.Encode(deploymentPlan)
+}
+
+func Read(path string, dec config.Decrypter, enc config.Encrypter) (*deploy.Plan, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer contract.IgnoreClose(f)
+
+	var deploymentPlan apitype.DeploymentPlanV1
+	if err := json.NewDecoder(f).Decode(&deploymentPlan); err != nil {
+		return nil, err
+	}
+	return stack.DeserializePlan(deploymentPlan, dec, enc)
+}

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
+	pkgPlan "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/plan"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
@@ -492,7 +493,7 @@ func newPreviewCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					if err = writePlan(planFilePath, plan, encrypter, showSecrets); err != nil {
+					if err = pkgPlan.Write(planFilePath, plan, encrypter, showSecrets); err != nil {
 						return err
 					}
 

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/plan"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
@@ -189,11 +190,11 @@ func newUpCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			plan, err := readPlan(planFilePath, dec, enc)
+			p, err := plan.Read(planFilePath, dec, enc)
 			if err != nil {
 				return err
 			}
-			opts.Engine.Plan = plan
+			opts.Engine.Plan = p
 		}
 
 		changes, err := s.Update(ctx, backend.UpdateOperation{

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -51,7 +51,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -756,37 +755,6 @@ func getRefreshOption(proj *workspace.Project, refresh string) (bool, error) {
 
 	// the default functionality right now is to always skip a refresh
 	return false, nil
-}
-
-func writePlan(path string, plan *deploy.Plan, enc config.Encrypter, showSecrets bool) error {
-	f, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer contract.IgnoreClose(f)
-
-	deploymentPlan, err := stack.SerializePlan(plan, enc, showSecrets)
-	if err != nil {
-		return err
-	}
-	encoder := json.NewEncoder(f)
-	encoder.SetEscapeHTML(false)
-	encoder.SetIndent("", "    ")
-	return encoder.Encode(deploymentPlan)
-}
-
-func readPlan(path string, dec config.Decrypter, enc config.Encrypter) (*deploy.Plan, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer contract.IgnoreClose(f)
-
-	var deploymentPlan apitype.DeploymentPlanV1
-	if err := json.NewDecoder(f).Decode(&deploymentPlan); err != nil {
-		return nil, err
-	}
-	return stack.DeserializePlan(deploymentPlan, dec, enc)
 }
 
 func buildStackName(stackName string) (string, error) {


### PR DESCRIPTION
This commit continues the process of breaking up
`pkg/cmd/pulumi/util.go` by hoisting out functions for reading and writing plans to their own subpackage.