### PR TITLE
Move `pulumi new` helpers out of `pkg/cmd/pulumi/util`

### DIFF
--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -1416,3 +1416,23 @@ func compareStackProjectName(b backend.Backend, stackName, projectName string) e
 	return fmt.Errorf("project name (--name %s) and stack reference project name (--stack %s) must be the same",
 		projectName, stackProjectName)
 }
+
+func buildStackName(stackName string) (string, error) {
+	// If we already have a slash (e.g. org/stack, or org/proj/stack) don't add the default org.
+	if strings.Contains(stackName, "/") {
+		return stackName, nil
+	}
+
+	// We never have a project at the point of calling buildStackName (only called from new), so we just pass
+	// nil for the project and only check the global settings.
+	defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(nil)
+	if err != nil {
+		return "", err
+	}
+
+	if defaultOrg != "" {
+		return fmt.Sprintf("%s/%s", defaultOrg, stackName), nil
+	}
+
+	return stackName, nil
+}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -757,26 +757,6 @@ func getRefreshOption(proj *workspace.Project, refresh string) (bool, error) {
 	return false, nil
 }
 
-func buildStackName(stackName string) (string, error) {
-	// If we already have a slash (e.g. org/stack, or org/proj/stack) don't add the default org.
-	if strings.Contains(stackName, "/") {
-		return stackName, nil
-	}
-
-	// We never have a project at the point of calling buildStackName (only called from new), so we just pass
-	// nil for the project and only check the global settings.
-	defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(nil)
-	if err != nil {
-		return "", err
-	}
-
-	if defaultOrg != "" {
-		return fmt.Sprintf("%s/%s", defaultOrg, stackName), nil
-	}
-
-	return stackName, nil
-}
-
 // we only want to log a secrets decryption for a Pulumi Cloud backend project
 // we will allow any secrets provider to be used (Pulumi Cloud or passphrase/cloud/etc)
 // we will log the message and not worry about the response. The types


### PR DESCRIPTION
This commit continues the process of breaking up
`pkg/cmd/pulumi/util.go` by moving the `buildStackName` function so that it is next to its only use site in `pulumi new`.