### PR TITLE
Break out JSON helpers from `pkg/cmd/pulumi/util`

### DIFF
--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
@@ -68,7 +69,7 @@ func newAboutCmd() *cobra.Command {
 			ctx := cmd.Context()
 			summary := getSummaryAbout(ctx, pkgWorkspace.Instance, DefaultLoginManager, transitiveDependencies, stack)
 			if jsonOut {
-				return printJSON(summary)
+				return ui.PrintJSON(summary)
 			}
 			summary.Print()
 			return nil

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -1038,7 +1038,7 @@ func listConfig(
 
 			configValues[key.String()] = entry
 		}
-		err := fprintJSON(stdout, configValues)
+		err := ui.FprintJSON(stdout, configValues)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/config_env.go
+++ b/pkg/cmd/pulumi/config_env.go
@@ -130,7 +130,7 @@ func (cmd *configEnvCmd) listStackEnvironments(ctx context.Context, jsonOut bool
 		if len(imports) == 0 {
 			fprintf(cmd.stdout, "[]\n")
 		} else {
-			err := fprintJSON(cmd.stdout, imports)
+			err := ui.FprintJSON(cmd.stdout, imports)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import (
 	mobytime "github.com/moby/moby/api/types/time"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -153,7 +154,7 @@ func newLogsCmd() *cobra.Command {
 						}
 					}
 
-					return printJSON(entries)
+					return ui.PrintJSON(entries)
 				}
 
 				for _, logEntry := range logs {
@@ -168,7 +169,7 @@ func newLogsCmd() *cobra.Command {
 								strings.TrimRight(logEntry.Message, "\n"),
 							)
 						} else {
-							err = printJSON(logEntryJSON{
+							err = ui.PrintJSON(logEntryJSON{
 								ID:        logEntry.ID,
 								Timestamp: eventTime.UTC().Format(timeFormat),
 								Message:   logEntry.Message,

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -1416,3 +1416,23 @@ func compareStackProjectName(b backend.Backend, stackName, projectName string) e
 	return fmt.Errorf("project name (--name %s) and stack reference project name (--stack %s) must be the same",
 		projectName, stackProjectName)
 }
+
+func buildStackName(stackName string) (string, error) {
+	// If we already have a slash (e.g. org/stack, or org/proj/stack) don't add the default org.
+	if strings.Contains(stackName, "/") {
+		return stackName, nil
+	}
+
+	// We never have a project at the point of calling buildStackName (only called from new), so we just pass
+	// nil for the project and only check the global settings.
+	defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(nil)
+	if err != nil {
+		return "", err
+	}
+
+	if defaultOrg != "" {
+		return fmt.Sprintf("%s/%s", defaultOrg, stackName), nil
+	}
+
+	return stackName, nil
+}

--- a/pkg/cmd/pulumi/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin_ls.go
@@ -121,7 +121,7 @@ func formatPluginsJSON(plugins []workspace.PluginInfo) error {
 		}
 	}
 
-	return printJSON(jsonPluginInfo)
+	return ui.PrintJSON(jsonPluginInfo)
 }
 
 func formatPluginConsole(plugins []workspace.PluginInfo) error {

--- a/pkg/cmd/pulumi/policy_group_ls.go
+++ b/pkg/cmd/pulumi/policy_group_ls.go
@@ -162,5 +162,5 @@ func formatPolicyGroupsJSON(policyGroups []apitype.PolicyGroupSummary) error {
 			NumStacks:      group.NumStacks,
 		}
 	}
-	return printJSON(output)
+	return ui.PrintJSON(output)
 }

--- a/pkg/cmd/pulumi/policy_ls.go
+++ b/pkg/cmd/pulumi/policy_ls.go
@@ -137,5 +137,5 @@ func formatPolicyPacksJSON(policyPacks []apitype.PolicyPackWithVersions) error {
 			Versions: pack.VersionTags,
 		}
 	}
-	return printJSON(output)
+	return ui.PrintJSON(output)
 }

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -245,7 +245,7 @@ func stringifyOutput(v interface{}) string {
 		return s
 	}
 
-	o, err := makeJSONString(v, false /* single line */)
+	o, err := ui.MakeJSONString(v, false /* single line */)
 	if err != nil {
 		return "error: could not format value"
 	}

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -186,7 +187,7 @@ func displayUpdatesJSON(updates []backend.UpdateInfo, decrypter config.Decrypter
 		updatesJSON[idx] = info
 	}
 
-	return printJSON(updatesJSON)
+	return ui.PrintJSON(updatesJSON)
 }
 
 func displayUpdatesConsole(updates []backend.UpdateInfo, page int, opts display.Options, noHumanize bool) error {

--- a/pkg/cmd/pulumi/stack_ls.go
+++ b/pkg/cmd/pulumi/stack_ls.go
@@ -251,7 +251,7 @@ func formatStackSummariesJSON(
 		output[idx] = summaryJSON
 	}
 
-	return fprintJSON(stdout, output)
+	return ui.FprintJSON(stdout, output)
 }
 
 func formatStackSummariesConsole(b backend.Backend, currentStack string, stackSummaries []backend.StackSummary) error {

--- a/pkg/cmd/pulumi/stack_output.go
+++ b/pkg/cmd/pulumi/stack_output.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -192,11 +193,11 @@ type jsonStackOutputWriter struct {
 var _ stackOutputWriter = (*jsonStackOutputWriter)(nil)
 
 func (w *jsonStackOutputWriter) WriteOne(_ string, v interface{}) error {
-	return fprintJSON(w.W, v)
+	return ui.FprintJSON(w.W, v)
 }
 
 func (w *jsonStackOutputWriter) WriteMany(outputs map[string]interface{}) error {
-	return fprintJSON(w.W, outputs)
+	return ui.FprintJSON(w.W, outputs)
 }
 
 // newShellStackOutputWriter builds a stackOutputWriter

--- a/pkg/cmd/pulumi/stack_tag.go
+++ b/pkg/cmd/pulumi/stack_tag.go
@@ -115,7 +115,7 @@ func newStackTagLsCmd(stack *string) *cobra.Command {
 			tags := s.Tags()
 
 			if jsonOut {
-				return printJSON(tags)
+				return ui.PrintJSON(tags)
 			}
 
 			printStackTags(tags)

--- a/pkg/cmd/pulumi/state_edit_encoder.go
+++ b/pkg/cmd/pulumi/state_edit_encoder.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -45,7 +46,7 @@ func (se *jsonSnapshotEncoder) SnapshotToText(snap *deploy.Snapshot) (snapshotTe
 		return nil, err
 	}
 
-	s, err := makeJSONString(dep, true /* multiline */)
+	s, err := ui.MakeJSONString(dep, true /* multiline */)
 	return snapshotText(s), err
 }
 

--- a/pkg/cmd/pulumi/ui/json.go
+++ b/pkg/cmd/pulumi/ui/json.go
@@ -1,0 +1,67 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ui
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+// MakeJSONString turns the given value into a JSON string. If multiline is true, the JSON will be formatted with
+// indentation and a trailing newline.
+func MakeJSONString(v interface{}, multiline bool) (string, error) {
+	var out bytes.Buffer
+
+	// json.Marshal escapes HTML characters, which we don't want,
+	// so change that with json.NewEncoder.
+	encoder := json.NewEncoder(&out)
+	encoder.SetEscapeHTML(false)
+
+	if multiline {
+		encoder.SetIndent("", "  ")
+	}
+
+	if err := encoder.Encode(v); err != nil {
+		return "", err
+	}
+
+	// json.NewEncoder always adds a trailing newline. Remove it.
+	bs := out.Bytes()
+	if !multiline {
+		if n := len(bs); n > 0 && bs[n-1] == '\n' {
+			bs = bs[:n-1]
+		}
+	}
+
+	return string(bs), nil
+}
+
+// PrintJSON simply prints out some object, formatted as JSON, using standard indentation.
+func PrintJSON(v interface{}) error {
+	return FprintJSON(os.Stdout, v)
+}
+
+// FprintJSON simply prints out some object, formatted as JSON, using standard indentation.
+func FprintJSON(w io.Writer, v interface{}) error {
+	jsonStr, err := MakeJSONString(v, true /* multi line */)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprint(w, jsonStr)
+	return err
+}

--- a/pkg/cmd/pulumi/ui/json_test.go
+++ b/pkg/cmd/pulumi/ui/json_test.go
@@ -1,0 +1,73 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ui
+
+import (
+	"testing"
+)
+
+func Test_MakeJSONString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     interface{}
+		multiline bool
+		expected  string
+	}{
+		{
+			name:      "simple-string/multiline",
+			input:     map[string]interface{}{"my_password": "password"},
+			multiline: true,
+			expected: `{
+  "my_password": "password"
+}
+`,
+		},
+		{
+			name:     "simple-string",
+			input:    map[string]interface{}{"my_password": "password"},
+			expected: `{"my_password":"password"}`,
+		},
+		{
+			name:      "special-char-string/multiline",
+			input:     map[string]interface{}{"special_password": "pass&word"},
+			multiline: true,
+			expected: `{
+  "special_password": "pass&word"
+}
+`,
+		},
+		{
+			name:     "special-char-string",
+			input:    map[string]interface{}{"special_password": "pass&word"},
+			expected: `{"special_password":"pass&word"}`,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := MakeJSONString(tt.input, tt.multiline)
+			if err != nil {
+				t.Errorf("MakeJSONString() error = %v", err)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("MakeJSONString() got = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -757,26 +757,6 @@ func getRefreshOption(proj *workspace.Project, refresh string) (bool, error) {
 	return false, nil
 }
 
-func buildStackName(stackName string) (string, error) {
-	// If we already have a slash (e.g. org/stack, or org/proj/stack) don't add the default org.
-	if strings.Contains(stackName, "/") {
-		return stackName, nil
-	}
-
-	// We never have a project at the point of calling buildStackName (only called from new), so we just pass
-	// nil for the project and only check the global settings.
-	defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(nil)
-	if err != nil {
-		return "", err
-	}
-
-	if defaultOrg != "" {
-		return fmt.Sprintf("%s/%s", defaultOrg, stackName), nil
-	}
-
-	return stackName, nil
-}
-
 // we only want to log a secrets decryption for a Pulumi Cloud backend project
 // we will allow any secrets provider to be used (Pulumi Cloud or passphrase/cloud/etc)
 // we will log the message and not worry about the response. The types

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -15,13 +15,10 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -654,50 +651,6 @@ func readPolicyProject(pwd string) (*workspace.PolicyPackProject, string, string
 	}
 
 	return proj, path, filepath.Dir(path), nil
-}
-
-// makeJSONString turns the given value into a JSON string.
-// If multiline is true, the JSON will be formatted with indentation and a trailing newline.
-func makeJSONString(v interface{}, multiline bool) (string, error) {
-	var out bytes.Buffer
-
-	// json.Marshal escapes HTML characters, which we don't want,
-	// so change that with json.NewEncoder.
-	encoder := json.NewEncoder(&out)
-	encoder.SetEscapeHTML(false)
-
-	if multiline {
-		encoder.SetIndent("", "  ")
-	}
-
-	if err := encoder.Encode(v); err != nil {
-		return "", err
-	}
-
-	// json.NewEncoder always adds a trailing newline. Remove it.
-	bs := out.Bytes()
-	if !multiline {
-		if n := len(bs); n > 0 && bs[n-1] == '\n' {
-			bs = bs[:n-1]
-		}
-	}
-
-	return string(bs), nil
-}
-
-// printJSON simply prints out some object, formatted as JSON, using standard indentation.
-func printJSON(v interface{}) error {
-	return fprintJSON(os.Stdout, v)
-}
-
-// fprintJSON simply prints out some object, formatted as JSON, using standard indentation.
-func fprintJSON(w io.Writer, v interface{}) error {
-	jsonStr, err := makeJSONString(v, true /* multi line */)
-	if err != nil {
-		return err
-	}
-	_, err = fmt.Fprint(w, jsonStr)
-	return err
 }
 
 // updateFlagsToOptions ensures that the given update flags represent a valid combination.  If so, an UpdateOptions

--- a/pkg/cmd/pulumi/util_test.go
+++ b/pkg/cmd/pulumi/util_test.go
@@ -29,60 +29,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func Test_makeJSONString(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name      string
-		input     interface{}
-		multiline bool
-		expected  string
-	}{
-		{
-			name:      "simple-string/multiline",
-			input:     map[string]interface{}{"my_password": "password"},
-			multiline: true,
-			expected: `{
-  "my_password": "password"
-}
-`,
-		},
-		{
-			name:     "simple-string",
-			input:    map[string]interface{}{"my_password": "password"},
-			expected: `{"my_password":"password"}`,
-		},
-		{
-			name:      "special-char-string/multiline",
-			input:     map[string]interface{}{"special_password": "pass&word"},
-			multiline: true,
-			expected: `{
-  "special_password": "pass&word"
-}
-`,
-		},
-		{
-			name:     "special-char-string",
-			input:    map[string]interface{}{"special_password": "pass&word"},
-			expected: `{"special_password":"pass&word"}`,
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got, err := makeJSONString(tt.input, tt.multiline)
-			if err != nil {
-				t.Errorf("makeJSONString() error = %v", err)
-				return
-			}
-			if got != tt.expected {
-				t.Errorf("makeJSONString() got = %v, expected %v", got, tt.expected)
-			}
-		})
-	}
-}
-
 func TestGetRefreshOption(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/whoami.go
+++ b/pkg/cmd/pulumi/whoami.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -99,7 +100,7 @@ func (cmd *whoAmICmd) Run(ctx context.Context) error {
 	}
 
 	if cmd.jsonOut {
-		return fprintJSON(cmd.Stdout, WhoAmIJSON{
+		return ui.FprintJSON(cmd.Stdout, WhoAmIJSON{
 			User:             name,
 			Organizations:    orgs,
 			URL:              b.URL(),


### PR DESCRIPTION
This commit continues the process of breaking up
`pkg/cmd/pulumi/util.go` by hoisting out functions for printing JSON to their own subpackage.