### PR TITLE
Autonaming configuration in experimental mode

### DIFF
--- a/changelog/pending/20241203--cli--autonaming-configuration-in-experimental-mode.yaml
+++ b/changelog/pending/20241203--cli--autonaming-configuration-in-experimental-mode.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Autonaming configuration in experimental mode

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -442,8 +442,8 @@ func newPreviewCmd() *cobra.Command {
 			}
 
 			var autonamer autonaming.Autonamer
-			if hasExperimentalCommands() {
-				autonamer, err = autonaming.ParseAutonamingConfig(autonamingStackContext(s), cfg.Config, decrypter)
+			if env.Experimental.Value() {
+				autonamer, err = autonaming.ParseAutonamingConfig(autonamingStackContext(proj, s), cfg.Config, decrypter)
 				if err != nil {
 					return fmt.Errorf("getting autonaming config: %w", err)
 				}

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -468,7 +468,7 @@ func newPreviewCmd() *cobra.Command {
 					GeneratePlan:   env.Experimental.Value() || planFilePath != "",
 					Experimental:   env.Experimental.Value(),
 					AttachDebugger: attachDebugger,
-					Autonaming:     autonamer,
+					Autonamer:      autonamer,
 				},
 				Display: displayOpts,
 			}

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -441,9 +441,9 @@ func newPreviewCmd() *cobra.Command {
 				return err
 			}
 
-			var autonamer deploy.Autonamer
+			var autonamer autonaming.Autonamer
 			if hasExperimentalCommands() {
-				autonamer, err = autonaming.ParseAutonamingConfig(&cfg, decrypter, s)
+				autonamer, err = autonaming.ParseAutonamingConfig(autonamingStackContext(s), cfg.Config, decrypter)
 				if err != nil {
 					return fmt.Errorf("getting autonaming config: %w", err)
 				}

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -33,6 +33,7 @@ import (
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/autonaming"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
@@ -440,6 +441,14 @@ func newPreviewCmd() *cobra.Command {
 				return err
 			}
 
+			var autonamer deploy.Autonamer
+			if hasExperimentalCommands() {
+				autonamer, err = autonaming.ParseAutonamingConfig(&cfg, decrypter, s)
+				if err != nil {
+					return fmt.Errorf("getting autonaming config: %w", err)
+				}
+			}
+
 			opts := backend.UpdateOptions{
 				Engine: engine.UpdateOptions{
 					LocalPolicyPacks:          engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
@@ -459,6 +468,7 @@ func newPreviewCmd() *cobra.Command {
 					GeneratePlan:   env.Experimental.Value() || planFilePath != "",
 					Experimental:   env.Experimental.Value(),
 					AttachDebugger: attachDebugger,
+					Autonaming:     autonamer,
 				},
 				Display: displayOpts,
 			}

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/plan"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/autonaming"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -170,6 +171,15 @@ func newUpCmd() *cobra.Command {
 		if err != nil {
 			return err
 		}
+
+		var autonamer deploy.Autonamer
+		if hasExperimentalCommands() {
+			autonamer, err = autonaming.ParseAutonamingConfig(&cfg, decrypter, s)
+			if err != nil {
+				return fmt.Errorf("getting autonaming config: %w", err)
+			}
+		}
+
 		opts.Engine = engine.UpdateOptions{
 			LocalPolicyPacks:          engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
 			Parallel:                  parallel,
@@ -189,6 +199,7 @@ func newUpCmd() *cobra.Command {
 			Experimental:    env.Experimental.Value(),
 			ContinueOnError: continueOnError,
 			AttachDebugger:  attachDebugger,
+			Autonaming:      autonamer,
 		}
 
 		if planFilePath != "" {

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -199,7 +199,7 @@ func newUpCmd() *cobra.Command {
 			Experimental:    env.Experimental.Value(),
 			ContinueOnError: continueOnError,
 			AttachDebugger:  attachDebugger,
-			Autonaming:      autonamer,
+			Autonamer:       autonamer,
 		}
 
 		if planFilePath != "" {

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -174,8 +174,8 @@ func newUpCmd() *cobra.Command {
 		}
 
 		var autonamer autonaming.Autonamer
-		if hasExperimentalCommands() {
-			autonamer, err = autonaming.ParseAutonamingConfig(autonamingStackContext(s), cfg.Config, decrypter)
+		if env.Experimental.Value() {
+			autonamer, err = autonaming.ParseAutonamingConfig(autonamingStackContext(proj, s), cfg.Config, decrypter)
 			if err != nil {
 				return fmt.Errorf("getting autonaming config: %w", err)
 			}
@@ -898,15 +898,12 @@ func isPreconfiguredEmptyStack(
 	return true
 }
 
-func autonamingStackContext(s backend.Stack) autonaming.StackContext {
+func autonamingStackContext(proj *workspace.Project, s backend.Stack) autonaming.StackContext {
 	organization := "organization"
 	if cs, ok := s.(httpstate.Stack); ok {
 		organization = cs.OrgName()
 	}
-	project := "project"
-	if projName, ok := s.Ref().Project(); ok {
-		project = projName.String()
-	}
+	project := proj.Name.String()
 	stack := s.Ref().Name().String()
 	return autonaming.StackContext{
 		Organization: organization,

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -232,6 +232,7 @@ func newDeployment(
 		DisableOutputValues:       opts.DisableOutputValues,
 		GeneratePlan:              opts.UpdateOptions.GeneratePlan,
 		ContinueOnError:           opts.ContinueOnError,
+		Autonaming:                opts.Autonaming,
 	}
 
 	var depl *deploy.Deployment

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -232,7 +232,7 @@ func newDeployment(
 		DisableOutputValues:       opts.DisableOutputValues,
 		GeneratePlan:              opts.UpdateOptions.GeneratePlan,
 		ContinueOnError:           opts.ContinueOnError,
-		Autonaming:                opts.Autonaming,
+		Autonamer:                 opts.Autonamer,
 	}
 
 	var depl *deploy.Deployment

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -174,6 +174,9 @@ type UpdateOptions struct {
 
 	// AttachDebugger to launch the language host in debug mode.
 	AttachDebugger bool
+
+	// Autonaming has user's preference for custom autonaming options.
+	Autonaming deploy.Autonamer
 }
 
 // HasChanges returns true if there are any non-same changes in the resulting summary.

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	resourceanalyzer "github.com/pulumi/pulumi/pkg/v3/resource/analyzer"
+	"github.com/pulumi/pulumi/pkg/v3/resource/autonaming"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -176,7 +177,7 @@ type UpdateOptions struct {
 	AttachDebugger bool
 
 	// Autonamer can resolve user's preference for custom autonaming options for a given resource.
-	Autonamer deploy.Autonamer
+	Autonamer autonaming.Autonamer
 }
 
 // HasChanges returns true if there are any non-same changes in the resulting summary.

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -175,8 +175,8 @@ type UpdateOptions struct {
 	// AttachDebugger to launch the language host in debug mode.
 	AttachDebugger bool
 
-	// Autonaming has user's preference for custom autonaming options.
-	Autonaming deploy.Autonamer
+	// Autonamer can resolve user's preference for custom autonaming options for a given resource.
+	Autonamer deploy.Autonamer
 }
 
 // HasChanges returns true if there are any non-same changes in the resulting summary.

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -112,6 +112,7 @@ require (
 	golang.org/x/term v0.23.0
 	golang.org/x/text v0.17.0
 	google.golang.org/protobuf v1.35.1
+	lukechampine.com/frand v1.4.2
 )
 
 require (
@@ -264,6 +265,5 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240814211410-ddb44dafa142 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240814211410-ddb44dafa142 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	lukechampine.com/frand v1.4.2 // indirect
 	mvdan.cc/gofumpt v0.5.0 // indirect
 )

--- a/pkg/resource/autonaming/config.go
+++ b/pkg/resource/autonaming/config.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2024, Pulumi Corporation.
+// Copyright 2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/resource/autonaming/config.go
+++ b/pkg/resource/autonaming/config.go
@@ -20,12 +20,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/pulumi/pulumi/pkg/v3/backend"
-	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 )
 
-func resolveNamingConfig(c *namingConfigJSON, eval *stackPatternEval) (autonamingStrategy, error) {
+func resolveNamingConfig(c *namingConfigJSON, eval *stackPatternEval) (Autonamer, error) {
 	hasMode := c.Mode != nil
 	hasPattern := c.Pattern != nil
 	hasEnforce := c.Enforce != nil
@@ -83,10 +81,9 @@ func parseConfigSection(v config.Value) (*autonamingSectionJSON, error) {
 	return autonamingConfig, nil
 }
 
-func ParseAutonamingConfig(cfg *backend.StackConfiguration, decrypter config.Decrypter, s backend.Stack,
-) (deploy.Autonamer, error) {
+func ParseAutonamingConfig(s StackContext, cfg config.Map, decrypter config.Decrypter) (Autonamer, error) {
 	// Get the autonaming config from the stack configuration, return nil if it's not set.
-	v, ok, err := cfg.Config.Get(config.MustParseKey("pulumi:autonaming"), false)
+	v, ok, err := cfg.Get(config.MustParseKey("pulumi:autonaming"), false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get autonaming config: %w", err)
 	}
@@ -125,7 +122,7 @@ func ParseAutonamingConfig(cfg *backend.StackConfiguration, decrypter config.Dec
 
 		provider := providerAutonaming{
 			Default:   naming,
-			Resources: make(map[string]autonamingStrategy),
+			Resources: make(map[string]Autonamer),
 		}
 
 		// Resolve the resource-level naming configs.

--- a/pkg/resource/autonaming/config.go
+++ b/pkg/resource/autonaming/config.go
@@ -1,0 +1,146 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autonaming
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+)
+
+func resolveNamingConfig(c *namingConfigJSON, eval *stackPatternEval) (autonamingStrategy, error) {
+	hasMode := c.Mode != nil
+	hasPattern := c.Pattern != nil
+	hasEnforce := c.Enforce != nil
+
+	if hasMode && (hasPattern || hasEnforce) {
+		return nil, errors.New("cannot specify both mode and pattern/enforce")
+	}
+
+	if hasPattern {
+		pattern, err := eval.resolveStackExpressions(*c.Pattern)
+		if err != nil {
+			return nil, err
+		}
+
+		return &patternAutonaming{
+			Pattern: pattern,
+			Enforce: hasEnforce && *c.Enforce,
+		}, nil
+	}
+
+	if !hasMode {
+		return &defaultAutonamingConfig, nil
+	}
+
+	switch *c.Mode {
+	case "default":
+		return &defaultAutonamingConfig, nil
+	case "verbatim":
+		return &verbatimAutonaming{}, nil
+	case "disabled":
+		return &disabledAutonaming{}, nil
+	default:
+		return nil, fmt.Errorf("invalid naming mode: %s", *c.Mode)
+	}
+}
+
+func parseConfigSection(v config.Value) (*autonamingSectionJSON, error) {
+	vInterface, err := v.ToObject()
+	if err != nil {
+		return nil, fmt.Errorf("invalid autonaming config: %w", err)
+	}
+
+	b, err := json.Marshal(vInterface)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal autonaming config: %w", err)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(b))
+	decoder.DisallowUnknownFields()
+	var autonamingConfig *autonamingSectionJSON
+	if err := decoder.Decode(&autonamingConfig); err != nil {
+		return nil, fmt.Errorf("invalid autonaming config structure: %w", err)
+	}
+
+	return autonamingConfig, nil
+}
+
+func ParseAutonamingConfig(cfg *backend.StackConfiguration, decrypter config.Decrypter, s backend.Stack,
+) (deploy.Autonamer, error) {
+	// Get the autonaming config from the stack configuration, return nil if it's not set.
+	v, ok, err := cfg.Config.Get(config.MustParseKey("pulumi:autonaming"), false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get autonaming config: %w", err)
+	}
+	if !ok {
+		return nil, nil
+	}
+
+	// Parse the autonaming config into a strongly-typed struct.
+	autonamingConfig, err := parseConfigSection(v)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse autonaming config: %w", err)
+	}
+
+	// Helper evaluator for resolving stack-level expressions in the autonaming patterns.
+	eval := newStackPatternEval(s, cfg, decrypter)
+
+	// Resolve the root naming config.
+	rootNaming, err := resolveNamingConfig(&autonamingConfig.namingConfigJSON, eval)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve root naming config: %w", err)
+	}
+
+	// Initialize the global autonaming config.
+	result := &globalAutonaming{
+		Default:   rootNaming,
+		Providers: make(map[string]providerAutonaming),
+	}
+
+	// Resolve the provider-level naming configs.
+	for providerName, providerCfg := range autonamingConfig.Providers {
+		providerCfg := providerCfg
+		naming, err := resolveNamingConfig(&providerCfg.namingConfigJSON, eval)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve naming config for provider %q: %w", providerName, err)
+		}
+
+		provider := providerAutonaming{
+			Default:   naming,
+			Resources: make(map[string]autonamingStrategy),
+		}
+
+		// Resolve the resource-level naming configs.
+		for resourceName, resourceCfg := range providerCfg.Resources {
+			resourceCfg := resourceCfg
+			resourceNaming, err := resolveNamingConfig(&resourceCfg, eval)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve naming config for resource %q: %w", resourceName, err)
+			}
+
+			provider.Resources[resourceName] = resourceNaming
+		}
+
+		result.Providers[providerName] = provider
+	}
+
+	return result, nil
+}

--- a/pkg/resource/autonaming/config_test.go
+++ b/pkg/resource/autonaming/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -136,7 +136,7 @@ pulumi:autonaming:
 			org:  "myorg",
 			configYAML: `
 pulumi:autonaming:
-  pattern: ${org}-${project}-${stack}-${name}-${random(8)}`,
+  pattern: ${organization}-${project}-${stack}-${name}-${random(8)}`,
 			wantConfig: &globalAutonaming{
 				Default: &patternAutonaming{
 					Pattern: "myorg-myproj-mystack-${name}-${random(8)}",

--- a/pkg/resource/autonaming/config_test.go
+++ b/pkg/resource/autonaming/config_test.go
@@ -1,0 +1,333 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autonaming
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestParseAutonamingConfigs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		org        string
+		configYAML string
+		wantConfig *globalAutonaming
+		wantErr    string
+	}{
+		{
+			name:       "empty config returns nil",
+			configYAML: "",
+			wantConfig: nil,
+		},
+		{
+			name: "default config",
+			configYAML: `
+pulumi:autonaming:
+  mode: default`,
+			wantConfig: &globalAutonaming{
+				Default:   &defaultAutonamingConfig,
+				Providers: map[string]providerAutonaming{},
+			},
+		},
+		{
+			name: "basic pattern config",
+			configYAML: `
+pulumi:autonaming:
+  pattern: ${name}-${random(8)}
+  enforce: true`,
+			wantConfig: &globalAutonaming{
+				Default: &patternAutonaming{
+					Pattern: "${name}-${random(8)}",
+					Enforce: true,
+				},
+				Providers: map[string]providerAutonaming{},
+			},
+		},
+		{
+			name: "basic verbatim config",
+			configYAML: `
+pulumi:autonaming:
+  mode: verbatim`,
+			wantConfig: &globalAutonaming{
+				Default:   &verbatimAutonaming{},
+				Providers: map[string]providerAutonaming{},
+			},
+		},
+		{
+			name: "basic disabled config",
+			configYAML: `
+pulumi:autonaming:
+  mode: disabled`,
+			wantConfig: &globalAutonaming{
+				Default:   &disabledAutonaming{},
+				Providers: map[string]providerAutonaming{},
+			},
+		},
+		{
+			name: "provider pattern config",
+			configYAML: `
+pulumi:autonaming:
+  providers:
+    aws:
+      pattern: aws-${name}
+      enforce: false`,
+			wantConfig: &globalAutonaming{
+				Default: &defaultAutonamingConfig,
+				Providers: map[string]providerAutonaming{
+					"aws": {
+						Default: &patternAutonaming{
+							Pattern: "aws-${name}",
+							Enforce: false,
+						},
+						Resources: map[string]autonamingStrategy{},
+					},
+				},
+			},
+		},
+		{
+			name: "resource pattern config",
+			configYAML: `
+pulumi:autonaming:
+  providers:
+    aws:
+      resources:
+        aws:s3/bucket:Bucket:
+          pattern: bucket-${name}
+          enforce: true`,
+			wantConfig: &globalAutonaming{
+				Default: &defaultAutonamingConfig,
+				Providers: map[string]providerAutonaming{
+					"aws": {
+						Default: &defaultAutonamingConfig,
+						Resources: map[string]autonamingStrategy{
+							"aws:s3/bucket:Bucket": &patternAutonaming{
+								Pattern: "bucket-${name}",
+								Enforce: true,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "basic pattern config with org, project, and stack",
+			org:  "myorg",
+			configYAML: `
+pulumi:autonaming:
+  pattern: ${org}-${project}-${stack}-${name}-${random(8)}`,
+			wantConfig: &globalAutonaming{
+				Default: &patternAutonaming{
+					Pattern: "myorg-myproj-mystack-${name}-${random(8)}",
+				},
+				Providers: map[string]providerAutonaming{},
+			},
+		},
+		{
+			name: "config values are available",
+			configYAML: `
+pulumi:autonaming:
+  pattern: ${name}-${config.foo}
+myproj:foo: bar`,
+			wantConfig: &globalAutonaming{
+				Default: &patternAutonaming{
+					Pattern: "${name}-bar",
+				},
+				Providers: map[string]providerAutonaming{},
+			},
+		},
+		{
+			name: "invalid config section returns error",
+			configYAML: `
+pulumi:autonaming: 123`,
+			wantErr: "invalid autonaming config structure",
+		},
+		{
+			name: "invalid mode returns error",
+			configYAML: `
+pulumi:autonaming:
+  mode: invalid`,
+			wantErr: "invalid naming mode: invalid",
+		},
+		{
+			name: "invalid provider mode returns error",
+			configYAML: `
+pulumi:autonaming:
+  mode: verbatim
+  providers:
+    aws:
+      mode: magic`,
+			wantErr: "invalid naming mode: magic",
+		},
+		{
+			name: "invalid resource mode returns error",
+			configYAML: `
+pulumi:autonaming:
+  mode: verbatim
+  providers:
+    aws:
+      resources:
+        aws:s3/bucket:Bucket:
+          mode: custom`,
+			wantErr: "invalid naming mode: custom",
+		},
+		{
+			name: "cannot specify both mode and pattern",
+			configYAML: `
+pulumi:autonaming:
+  mode: verbatim
+  pattern: test-${name}`,
+			wantErr: "cannot specify both mode and pattern/enforce",
+		},
+		{
+			name: "cannot specify both mode and enforce",
+			configYAML: `
+pulumi:autonaming:
+  mode: verbatim
+  enforce: true`,
+			wantErr: "cannot specify both mode and pattern/enforce",
+		},
+		{
+			name: "invalid config structure returns error",
+			configYAML: `
+pulumi:autonaming:
+  mode: verbatim
+  invalid_field: value`,
+			wantErr: "invalid autonaming config structure",
+		},
+		{
+			name: "error in config",
+			configYAML: `
+pulumi:autonaming:
+  pattern: ${name}-${config.unknown}`,
+			wantErr: "no value found for key \"unknown\"",
+		},
+		{
+			name: "complex config with all features",
+			configYAML: `
+pulumi:autonaming:
+  pattern: global-${name}
+  enforce: false
+  providers:
+    aws:
+      pattern: ${stack}-aws-${name}
+      enforce: true
+      resources:
+        aws:s3/bucket:Bucket:
+          pattern: ${config.foo}-bucket-${name}-${uuid}
+          enforce: true
+    azure:
+      mode: verbatim
+      resources:
+        azure:storage/account:Account:
+          mode: disabled
+myproj:foo: bar`,
+			wantConfig: &globalAutonaming{
+				Default: &patternAutonaming{
+					Pattern: "global-${name}",
+					Enforce: false,
+				},
+				Providers: map[string]providerAutonaming{
+					"aws": {
+						Default: &patternAutonaming{
+							Pattern: "mystack-aws-${name}",
+							Enforce: true,
+						},
+						Resources: map[string]autonamingStrategy{
+							"aws:s3/bucket:Bucket": &patternAutonaming{
+								Pattern: "bar-bucket-${name}-${uuid}",
+								Enforce: true,
+							},
+						},
+					},
+					"azure": {
+						Default: &verbatimAutonaming{},
+						Resources: map[string]autonamingStrategy{
+							"azure:storage/account:Account": &disabledAutonaming{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.Map{}
+			err := cfg.UnmarshalYAML(func(v interface{}) error {
+				var raw map[string]config.Value
+				if err := yaml.Unmarshal([]byte(tt.configYAML), &raw); err != nil {
+					return err
+				}
+				target := v.(*map[string]config.Value)
+				*target = raw
+				return nil
+			})
+			require.NoError(t, err)
+
+			decrypter := config.NewPanicCrypter()
+
+			org := tt.org
+			if org == "" {
+				org = "default"
+			}
+			stack := &mockStack{orgName: org}
+			autonamer, err := ParseAutonamingConfig(&backend.StackConfiguration{Config: cfg}, decrypter, stack)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.wantConfig == nil {
+				assert.Nil(t, autonamer)
+			} else {
+				got := autonamer.(*globalAutonaming)
+				assert.Equal(t, tt.wantConfig.Default, got.Default)
+				assert.Equal(t, tt.wantConfig.Providers, got.Providers)
+			}
+		})
+	}
+}
+
+type mockStack struct {
+	httpstate.Stack
+	orgName string
+}
+
+func (m *mockStack) OrgName() string {
+	return m.orgName
+}
+
+func (m *mockStack) Ref() backend.StackReference {
+	return &backend.MockStackReference{
+		ProjectV: "myproj",
+		NameV:    tokens.MustParseStackName("mystack"),
+	}
+}

--- a/pkg/resource/autonaming/json.go
+++ b/pkg/resource/autonaming/json.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2024, Pulumi Corporation.
+// Copyright 2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/resource/autonaming/json.go
+++ b/pkg/resource/autonaming/json.go
@@ -1,0 +1,60 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autonaming
+
+// autonamingSectionJSON represents the root configuration object for Pulumi autonaming
+// Example of a configuration that it encodes (config will convert it to JSON before autonaming receives it):
+//
+// pulumi:autonaming:
+//
+//	mode: default
+//	providers:
+//	  aws:
+//	    pattern: ${name}_${hex(4)}
+//	  azure-native:
+//	    mode: verbatim
+//	    resources:
+//	      "azure-native:storage:Account": ${name}${string(6)}
+type autonamingSectionJSON struct {
+	namingConfigJSON
+
+	// Providers maps provider names to their configurations
+	// Key format: provider name (e.g., "aws")
+	Providers map[string]providerConfigJSON `json:"providers,omitempty"`
+}
+
+// providerConfigJSON represents the configuration for a provider
+type providerConfigJSON struct {
+	namingConfigJSON
+
+	// Resources maps resource types to their specific configurations
+	// Key format: provider:module:type (e.g., "aws:s3/bucket:Bucket")
+	Resources map[string]namingConfigJSON `json:"resources,omitempty"`
+}
+
+// namingConfigJSON represents the base configuration for resource naming.
+// The same set of options can be specified globally, per-provider, or per-resource.
+type namingConfigJSON struct {
+	// Mode specifies the autonaming mode: default (standard Pulumi behavior),
+	// verbatim (use logical names), or disabled (require explicit names)
+	Mode *string `json:"mode,omitempty"`
+
+	// Pattern is a template string for custom name generation.
+	// Example: "${stack}-${name}-${hex(6)}"
+	Pattern *string `json:"pattern,omitempty"`
+
+	// Enforce prevents providers from modifying the specified naming pattern when true
+	Enforce *bool `json:"enforce,omitempty"`
+}

--- a/pkg/resource/autonaming/pattern.go
+++ b/pkg/resource/autonaming/pattern.go
@@ -1,0 +1,183 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autonaming
+
+import (
+	"crypto"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/gofrs/uuid"
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+	"lukechampine.com/frand"
+)
+
+// stackPatternEval is a helper struct for resolving stack-level expressions in autonaming patterns.
+// It's used to resolve ${org}, ${project}, ${stack}, and ${config.key} expressions in patterns.
+// These are all expressions that can be resolved at the startup time because they don't depend
+// on the resource URN.
+type stackPatternEval struct {
+	org            string
+	proj           string
+	stack          string
+	getConfigValue func(key string) (string, error)
+}
+
+// newStackPatternEval creates a new stack pattern evaluator based on the given stack and configuration.
+func newStackPatternEval(s backend.Stack, cfg *backend.StackConfiguration, decrypter config.Decrypter,
+) *stackPatternEval {
+	org := "default"
+	if cs, ok := s.(httpstate.Stack); ok {
+		org = cs.OrgName()
+	}
+	projName, _ := s.Ref().Project()
+	projStr := projName.String()
+	stackStr := s.Ref().Name().String()
+	getConfigValue := func(key string) (string, error) {
+		c, ok, err := cfg.Config.Get(config.MustMakeKey(projStr, key), true)
+		if err != nil {
+			return "", fmt.Errorf("failed to get config value for key %q: %w", key, err)
+		}
+		if !ok {
+			return "", fmt.Errorf("no value found for key %q", key)
+		}
+		v, err := c.Value(decrypter)
+		if err != nil {
+			return "", fmt.Errorf("failed to decrypt value for key %q: %w", key, err)
+		}
+		return v, nil
+	}
+	return &stackPatternEval{
+		org:            org,
+		proj:           projStr,
+		stack:          stackStr,
+		getConfigValue: getConfigValue,
+	}
+}
+
+// resolveStackExpressions resolves the org, project, stack, and config expressions in the given pattern.
+func (e *stackPatternEval) resolveStackExpressions(pattern string) (string, error) {
+	// Replace ${org}, ${project}, ${stack} with values from context
+	pattern = strings.ReplaceAll(pattern, "${org}", e.org)
+	pattern = strings.ReplaceAll(pattern, "${project}", e.proj)
+	pattern = strings.ReplaceAll(pattern, "${stack}", e.stack)
+
+	// Replace ${config.key} with config values
+	configRegex := regexp.MustCompile(`\${config\.([^}]+)}`)
+	var configErr error
+	pattern = configRegex.ReplaceAllStringFunc(pattern, func(match string) string {
+		key := configRegex.FindStringSubmatch(match)[1]
+		v, err := e.getConfigValue(key)
+		if err != nil {
+			configErr = err
+			return ""
+		}
+		return v
+	})
+	if configErr != nil {
+		return "", configErr
+	}
+	return pattern, nil
+}
+
+// generateName generates a final proposed name based on the configured pattern, the resource URN, and random seed.
+// Note that the pattern is expected to have already had stack-level expressions like ${org}, ${project}, ${stack},
+// and ${config.key} resolved before passing to this function.
+func generateName(pattern string, urn urn.URN, randomSeed []byte) (string, bool) {
+	// Replace ${name} with the logical name
+	result := strings.ReplaceAll(pattern, "${name}", urn.Name())
+	hasRandom := false
+
+	// Create a random number generator with the given seed. If no seed is provided, use a default
+	// random number generator.
+	var random *frand.RNG
+	if len(randomSeed) == 0 {
+		random = frand.New()
+	} else {
+		// frand.NewCustom needs a 32 byte seed. Take the SHA256 hash of whatever bytes we've been given as a
+		// seed and pass the 32 byte result of that to frand.
+		hash := crypto.SHA256.New()
+		hash.Write(randomSeed)
+		seed := hash.Sum(nil)
+		bufsize := 1024 // Same bufsize as used by frand.New.
+		rounds := 12    // Same rounds as used by frand.New.
+		random = frand.NewCustom(seed, bufsize, rounds)
+	}
+
+	// Replace ${hex(n)} with random hex string of length n
+	hexRegex := regexp.MustCompile(`\${hex\((\d+)\)}`)
+	result = hexRegex.ReplaceAllStringFunc(result, func(match string) string {
+		n, _ := strconv.Atoi(hexRegex.FindStringSubmatch(match)[1])
+		b := make([]byte, n/2+1)
+		_, _ = random.Read(b)
+		hasRandom = true
+		return hex.EncodeToString(b)[:n]
+	})
+
+	// Replace ${alphanum(n)} with random alphanumeric string of length n
+	alphaRegex := regexp.MustCompile(`\${alphanum\((\d+)\)}`)
+	result = alphaRegex.ReplaceAllStringFunc(result, func(match string) string {
+		n, _ := strconv.Atoi(alphaRegex.FindStringSubmatch(match)[1])
+		const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = chars[random.Intn(len(chars))]
+		}
+		hasRandom = true
+		return string(b)
+	})
+
+	// Replace ${string(n)} with random letter string of length n
+	strRegex := regexp.MustCompile(`\${string\((\d+)\)}`)
+	result = strRegex.ReplaceAllStringFunc(result, func(match string) string {
+		n, _ := strconv.Atoi(strRegex.FindStringSubmatch(match)[1])
+		const chars = "abcdefghijklmnopqrstuvwxyz"
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = chars[random.Intn(len(chars))]
+		}
+		hasRandom = true
+		return string(b)
+	})
+
+	// Replace ${num(n)} with random digit string of length n
+	numRegex := regexp.MustCompile(`\${num\((\d+)\)}`)
+	result = numRegex.ReplaceAllStringFunc(result, func(match string) string {
+		n, _ := strconv.Atoi(numRegex.FindStringSubmatch(match)[1])
+		const chars = "0123456789"
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = chars[random.Intn(len(chars))]
+		}
+		hasRandom = true
+		return string(b)
+	})
+
+	// Replace ${uuid} with random UUID
+	if strings.Contains(result, "${uuid}") {
+		uuidBytes := make([]byte, 16)
+		_, _ = random.Read(uuidBytes)
+		result = strings.ReplaceAll(result, "${uuid}", uuid.Must(uuid.FromBytes(uuidBytes)).String())
+		hasRandom = true
+	}
+
+	return result, hasRandom
+}

--- a/pkg/resource/autonaming/pattern_test.go
+++ b/pkg/resource/autonaming/pattern_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2024, Pulumi Corporation.
+// Copyright 2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ func TestResolveStackExpressions(t *testing.T) {
 	}{
 		{
 			name:     "basic variable replacement",
-			pattern:  "${org}-${project}-${stack}",
+			pattern:  "${organization}-${project}-${stack}",
 			org:      "myorg",
 			proj:     "myproj",
 			stack:    "dev",
@@ -106,7 +106,7 @@ func TestResolveStackExpressions(t *testing.T) {
 		},
 		{
 			name:    "multiple replacements",
-			pattern: "${org}/${project}/${stack}/${config.region}",
+			pattern: "${organization}/${project}/${stack}/${config.region}",
 			org:     "myorg",
 			proj:    "myproj",
 			stack:   "dev",
@@ -143,9 +143,9 @@ func TestResolveStackExpressions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			eval := &stackPatternEval{
-				org:   tt.org,
-				proj:  tt.proj,
-				stack: tt.stack,
+				organization: tt.org,
+				project:      tt.proj,
+				stack:        tt.stack,
 				getConfigValue: func(key string) (string, error) {
 					if err, hasErr := tt.configErrs[key]; hasErr {
 						return "", err

--- a/pkg/resource/autonaming/pattern_test.go
+++ b/pkg/resource/autonaming/pattern_test.go
@@ -142,10 +142,13 @@ func TestResolveStackExpressions(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			stack := StackContext{
+				Organization: tt.org,
+				Project:      tt.proj,
+				Stack:        tt.stack,
+			}
 			eval := &stackPatternEval{
-				organization: tt.org,
-				project:      tt.proj,
-				stack:        tt.stack,
+				ctx: stack,
 				getConfigValue: func(key string) (string, error) {
 					if err, hasErr := tt.configErrs[key]; hasErr {
 						return "", err

--- a/pkg/resource/autonaming/pattern_test.go
+++ b/pkg/resource/autonaming/pattern_test.go
@@ -1,0 +1,170 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package autonaming
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateName(t *testing.T) {
+	t.Parallel()
+	urn := urn.New("mystack", "myproject", "", "aws:s3/bucket:Bucket", "myresource")
+	randomSeed := []byte("test seed")
+
+	tests := []struct {
+		name          string
+		pattern       string
+		want          string
+		wantHasRandom bool
+	}{
+		{
+			name:          "hex generation",
+			pattern:       "${name}-${hex(4)}",
+			want:          "myresource-ccf3",
+			wantHasRandom: true,
+		},
+		{
+			name:          "alphanum generation",
+			pattern:       "${name}-${alphanum(5)}",
+			want:          "myresource-uqk8s",
+			wantHasRandom: true,
+		},
+		{
+			name:          "string generation",
+			pattern:       "${name}-${string(6)}",
+			want:          "myresource-qekgoj",
+			wantHasRandom: true,
+		},
+		{
+			name:          "num generation",
+			pattern:       "${num(7)}_${name}",
+			want:          "4080051_myresource",
+			wantHasRandom: true,
+		},
+		{
+			name:          "uuid generation",
+			pattern:       "${uuid}",
+			want:          "ccf35be6-7106-5ccd-784a-fa394fcdb57c",
+			wantHasRandom: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, hasRandom := generateName(tt.pattern, urn, randomSeed)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantHasRandom, hasRandom)
+		})
+	}
+}
+
+func TestResolveStackExpressions(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		pattern     string
+		org         string
+		proj        string
+		stack       string
+		configVals  map[string]string
+		configErrs  map[string]error
+		expected    string
+		expectError bool
+	}{
+		{
+			name:     "basic variable replacement",
+			pattern:  "${org}-${project}-${stack}",
+			org:      "myorg",
+			proj:     "myproj",
+			stack:    "dev",
+			expected: "myorg-myproj-dev",
+		},
+		{
+			name:    "config value replacement",
+			pattern: "prefix-${config.environment}-suffix",
+			configVals: map[string]string{
+				"environment": "production",
+			},
+			expected: "prefix-production-suffix",
+		},
+		{
+			name:    "multiple replacements",
+			pattern: "${org}/${project}/${stack}/${config.region}",
+			org:     "myorg",
+			proj:    "myproj",
+			stack:   "dev",
+			configVals: map[string]string{
+				"region": "us-west-2",
+			},
+			expected: "myorg/myproj/dev/us-west-2",
+		},
+		{
+			name:    "missing config value",
+			pattern: "${config.missing}",
+			configErrs: map[string]error{
+				"missing": fmt.Errorf("no value found for key %q", "missing"),
+			},
+			expectError: true,
+		},
+		{
+			name:    "config error",
+			pattern: "${config.secret}",
+			configErrs: map[string]error{
+				"secret": fmt.Errorf("failed to decrypt value for key %q: unauthorized", "secret"),
+			},
+			expectError: true,
+		},
+		{
+			name:     "no replacements needed",
+			pattern:  "static-name",
+			expected: "static-name",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			eval := &stackPatternEval{
+				org:   tt.org,
+				proj:  tt.proj,
+				stack: tt.stack,
+				getConfigValue: func(key string) (string, error) {
+					if err, hasErr := tt.configErrs[key]; hasErr {
+						return "", err
+					}
+					if val, hasVal := tt.configVals[key]; hasVal {
+						return val, nil
+					}
+					return "", fmt.Errorf("unexpected config key: %q", key)
+				},
+			}
+
+			result, err := eval.resolveStackExpressions(tt.pattern)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/resource/autonaming/strategy.go
+++ b/pkg/resource/autonaming/strategy.go
@@ -1,0 +1,154 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autonaming
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+// autonamingStrategy is a strategy for autonaming a resource.
+type autonamingStrategy interface {
+	GetOptions(urn urn.URN, randomSeed []byte) (opts *plugin.AutonamingOptions, deleteBeforeCreate bool)
+}
+
+// defaultAutonaming is the default autonaming config, which is equivalent to
+// no custom autonaming.
+type defaultAutonaming struct{}
+
+// defaultAutonamingConfig is the default instance of defaultAutonaming.
+var defaultAutonamingConfig = defaultAutonaming{}
+
+func (a *defaultAutonaming) GetOptions(urn.URN, []byte) (opts *plugin.AutonamingOptions, deleteBeforeCreate bool) {
+	return nil, false
+}
+
+// verbatimAutonaming is an autonaming config that enforces the use of a
+// logical resource name as the physical resource name literally, with no transformations.
+type verbatimAutonaming struct{}
+
+func (a *verbatimAutonaming) GetOptions(urn urn.URN, _ []byte,
+) (opts *plugin.AutonamingOptions, deleteBeforeCreate bool) {
+	return &plugin.AutonamingOptions{
+		ProposedName: urn.Name(),
+		Mode:         plugin.AutonamingModeEnforce,
+	}, true
+}
+
+// disabledAutonaming is an autonaming config that disables autonaming altogether.
+type disabledAutonaming struct{}
+
+func (a *disabledAutonaming) GetOptions(urn.URN, []byte) (opts *plugin.AutonamingOptions, deleteBeforeCreate bool) {
+	return &plugin.AutonamingOptions{
+		Mode: plugin.AutonamingModeDisabled,
+	}, true
+}
+
+// patternAutonaming is an autonaming config that uses a pattern to generate a name.
+type patternAutonaming struct {
+	// Pattern is the pattern to use to generate the name.
+	Pattern string
+	// Enforce, if true, will enforce the use of the generated name, as opposed to proposing it.
+	// A proposed name can still be overridden by the provider, while an enforced name cannot.
+	Enforce bool
+}
+
+func (a *patternAutonaming) GetOptions(urn urn.URN, randomSeed []byte,
+) (opts *plugin.AutonamingOptions, deleteBeforeCreate bool) {
+	mode := plugin.AutonamingModePropose
+	if a.Enforce {
+		mode = plugin.AutonamingModeEnforce
+	}
+	proposedName, hasRandom := generateName(a.Pattern, urn, randomSeed)
+	return &plugin.AutonamingOptions{
+		ProposedName:    proposedName,
+		Mode:            mode,
+		WarnIfNoSupport: a.Enforce,
+	}, !hasRandom
+}
+
+// providerAutonaming represents the configuration for a provider
+type providerAutonaming struct {
+	// Default is the default autonaming config for the provider unless overridden by a more specific
+	// resource config.
+	Default autonamingStrategy
+
+	// Resources maps resource types to their specific configurations
+	// Key format: provider:module:type (e.g., "aws:s3/bucket:Bucket")
+	Resources map[string]autonamingStrategy
+}
+
+// globalAutonaming represents the root configuration object for Pulumi autonaming
+type globalAutonaming struct {
+	// Default is the default autonaming config for all the providers unless overridden by a more specific
+	// provider config.
+	Default autonamingStrategy
+
+	// Providers maps provider names to their configurations
+	// Key format: provider name (e.g., "aws")
+	Providers map[string]providerAutonaming
+}
+
+func (o *globalAutonaming) pluginOptionsForResourceType(resourceType tokens.Type) (autonamingStrategy, bool, error) {
+	token := string(resourceType)
+
+	// Parse resource type into provider and type
+	parts := strings.Split(token, ":")
+	if len(parts) != 3 {
+		return nil, false, fmt.Errorf("invalid resource type format: %s", resourceType)
+	}
+	provider := parts[0]
+
+	// Check type-specific config
+	if pConfig, ok := o.Providers[provider]; ok {
+		if rConfig, ok := pConfig.Resources[token]; ok {
+			return rConfig, false, nil
+		}
+		if pConfig.Default != nil {
+			return pConfig.Default, false, nil
+		}
+	}
+	// Fall back to global config
+	if o.Default != nil {
+		return o.Default, true, nil
+	}
+	return &defaultAutonamingConfig, true, nil
+}
+
+func (o *globalAutonaming) AutonamingForResource(urn urn.URN, randomSeed []byte,
+) (*plugin.AutonamingOptions, bool, error) {
+	naming, isTopLevelOrDefault, err := o.pluginOptionsForResourceType(urn.Type())
+	if err != nil {
+		return nil, false, err
+	}
+
+	opts, deleteBeforeCreate := naming.GetOptions(urn, randomSeed)
+	if opts == nil {
+		// If the strategy returns nil, it means the user hasn't overridden the default autonaming for this resource.
+		return nil, false, nil
+	}
+
+	if !isTopLevelOrDefault {
+		// If the strategy comes from a provider- or resource-specific config, it's specific enough that the user
+		// definitely intended it to apply to this resource. Therefore, we should always warn if it turns out
+		// the provider doesn't actually support autonaming customization.
+		opts.WarnIfNoSupport = true
+	}
+	return opts, deleteBeforeCreate, nil
+}

--- a/pkg/resource/autonaming/strategy_test.go
+++ b/pkg/resource/autonaming/strategy_test.go
@@ -1,0 +1,270 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package autonaming
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGlobalAutonaming_AutonamingForResource(t *testing.T) {
+	t.Parallel()
+	makeURN := func(name, typ string) urn.URN {
+		return urn.New("mystack", "myproject", "", tokens.Type(typ), name)
+	}
+
+	tests := []struct {
+		name                   string
+		options                globalAutonaming
+		urn                    urn.URN
+		wantOptions            *plugin.AutonamingOptions
+		wantDeleteBeforeCreate bool
+		wantErrMsg             string
+	}{
+		{
+			name:        "no config returns no options",
+			options:     globalAutonaming{},
+			urn:         makeURN("myresource", "aws:s3/bucket:Bucket"),
+			wantOptions: nil,
+		},
+		{
+			name: "default config returns no options",
+			options: globalAutonaming{
+				Default: &defaultAutonamingConfig,
+			},
+			urn:         makeURN("myresource", "aws:s3/bucket:Bucket"),
+			wantOptions: nil,
+		},
+		{
+			name: "verbatim config enforces logical name",
+			options: globalAutonaming{
+				Default: &verbatimAutonaming{},
+			},
+			urn: makeURN("myresource", "aws:s3/bucket:Bucket"),
+			wantOptions: &plugin.AutonamingOptions{
+				ProposedName:    "myresource",
+				Mode:            plugin.AutonamingModeEnforce,
+				WarnIfNoSupport: false,
+			},
+			wantDeleteBeforeCreate: true,
+		},
+		{
+			name: "verbatim config on provider enforces logical name",
+			options: globalAutonaming{
+				Default: &defaultAutonamingConfig,
+				Providers: map[string]providerAutonaming{
+					"aws": {
+						Default: &verbatimAutonaming{},
+					},
+				},
+			},
+			urn: makeURN("myresource", "aws:s3/bucket:Bucket"),
+			wantOptions: &plugin.AutonamingOptions{
+				ProposedName:    "myresource",
+				Mode:            plugin.AutonamingModeEnforce,
+				WarnIfNoSupport: true,
+			},
+			wantDeleteBeforeCreate: true,
+		},
+		{
+			name: "verbatim config on resource enforces logical name",
+			options: globalAutonaming{
+				Default: &defaultAutonamingConfig,
+				Providers: map[string]providerAutonaming{
+					"aws": {
+						Default: &defaultAutonamingConfig,
+						Resources: map[string]autonamingStrategy{
+							"aws:s3/bucket:Bucket": &verbatimAutonaming{},
+						},
+					},
+				},
+			},
+			urn: makeURN("myresource", "aws:s3/bucket:Bucket"),
+			wantOptions: &plugin.AutonamingOptions{
+				ProposedName:    "myresource",
+				Mode:            plugin.AutonamingModeEnforce,
+				WarnIfNoSupport: true,
+			},
+			wantDeleteBeforeCreate: true,
+		},
+		{
+			name: "disabled config",
+			options: globalAutonaming{
+				Default: &disabledAutonaming{},
+			},
+			urn: makeURN("myresource", "aws:s3/bucket:Bucket"),
+			wantOptions: &plugin.AutonamingOptions{
+				Mode:            plugin.AutonamingModeDisabled,
+				WarnIfNoSupport: false,
+			},
+			wantDeleteBeforeCreate: true,
+		},
+		{
+			name: "disabled config on provider",
+			options: globalAutonaming{
+				Default: &defaultAutonamingConfig,
+				Providers: map[string]providerAutonaming{
+					"aws": {
+						Default: &disabledAutonaming{},
+					},
+				},
+			},
+			urn: makeURN("myresource", "aws:s3/bucket:Bucket"),
+			wantOptions: &plugin.AutonamingOptions{
+				Mode:            plugin.AutonamingModeDisabled,
+				WarnIfNoSupport: true,
+			},
+			wantDeleteBeforeCreate: true,
+		},
+		{
+			name: "disabled config on resource",
+			options: globalAutonaming{
+				Default: &verbatimAutonaming{},
+				Providers: map[string]providerAutonaming{
+					"aws": {
+						Default: &verbatimAutonaming{},
+						Resources: map[string]autonamingStrategy{
+							"aws:s3/bucket:Bucket": &disabledAutonaming{},
+						},
+					},
+				},
+			},
+			urn: makeURN("myresource", "aws:s3/bucket:Bucket"),
+			wantOptions: &plugin.AutonamingOptions{
+				Mode:            plugin.AutonamingModeDisabled,
+				WarnIfNoSupport: true,
+			},
+			wantDeleteBeforeCreate: true,
+		},
+		{
+			name: "provider-specific config overrides default",
+			options: globalAutonaming{
+				Default: &defaultAutonamingConfig,
+				Providers: map[string]providerAutonaming{
+					"aws": {
+						Default: &patternAutonaming{
+							Pattern: "aws-${name}",
+							Enforce: false,
+						},
+					},
+				},
+			},
+			urn: makeURN("myresource", "aws:s3/bucket:Bucket"),
+			wantOptions: &plugin.AutonamingOptions{
+				ProposedName:    "aws-myresource",
+				Mode:            plugin.AutonamingModePropose,
+				WarnIfNoSupport: true,
+			},
+			wantDeleteBeforeCreate: true,
+		},
+		{
+			name: "resource-specific config overrides provider default",
+			options: globalAutonaming{
+				Default: &defaultAutonamingConfig,
+				Providers: map[string]providerAutonaming{
+					"aws": {
+						Default: &patternAutonaming{
+							Pattern: "aws-${name}",
+							Enforce: false,
+						},
+						Resources: map[string]autonamingStrategy{
+							"aws:s3/bucket:Bucket": &patternAutonaming{
+								Pattern: "bucket-${name}",
+								Enforce: true,
+							},
+						},
+					},
+				},
+			},
+			urn: makeURN("myresource", "aws:s3/bucket:Bucket"),
+			wantOptions: &plugin.AutonamingOptions{
+				ProposedName:    "bucket-myresource",
+				Mode:            plugin.AutonamingModeEnforce,
+				WarnIfNoSupport: true,
+			},
+			wantDeleteBeforeCreate: true,
+		},
+		{
+			name: "invalid resource type returns error",
+			options: globalAutonaming{
+				Default: &defaultAutonamingConfig,
+			},
+			urn:        makeURN("myresource", "invalid:type"),
+			wantErrMsg: "invalid resource type format: invalid:type",
+		},
+		{
+			name: "unrelated provider and resource configs are ignored",
+			options: globalAutonaming{
+				Default: &defaultAutonamingConfig,
+				Providers: map[string]providerAutonaming{
+					"azure": {
+						Default: &disabledAutonaming{},
+					},
+					"aws": {
+						Default: &defaultAutonamingConfig,
+						Resources: map[string]autonamingStrategy{
+							"aws:s3/object:Object": &disabledAutonaming{},
+						},
+					},
+				},
+			},
+			urn:                    makeURN("myresource", "aws:s3/bucket:Bucket"),
+			wantOptions:            nil,
+			wantDeleteBeforeCreate: false,
+		},
+		{
+			name: "global config is used if provider does not define a config other than specific resource",
+			options: globalAutonaming{
+				Default: &verbatimAutonaming{},
+				Providers: map[string]providerAutonaming{
+					"aws": {
+						Resources: map[string]autonamingStrategy{
+							"aws:s3/object:Object": &disabledAutonaming{},
+						},
+					},
+				},
+			},
+			urn: makeURN("myresource", "aws:s3/bucket:Bucket"),
+			wantOptions: &plugin.AutonamingOptions{
+				ProposedName:    "myresource",
+				Mode:            plugin.AutonamingModeEnforce,
+				WarnIfNoSupport: false,
+			},
+			wantDeleteBeforeCreate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, deleteBeforeCreate, err := tt.options.AutonamingForResource(tt.urn, nil)
+
+			if tt.wantErrMsg != "" {
+				assert.Error(t, err)
+				assert.Equal(t, tt.wantErrMsg, err.Error())
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantDeleteBeforeCreate, deleteBeforeCreate)
+			assert.Equal(t, tt.wantOptions, got)
+		})
+	}
+}

--- a/pkg/resource/autonaming/strategy_test.go
+++ b/pkg/resource/autonaming/strategy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2024, Pulumi Corporation.
+// Copyright 2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,12 +29,12 @@ func TestGlobalAutonaming_AutonamingForResource(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                   string
-		options                globalAutonaming
-		urn                    urn.URN
-		wantOptions            *plugin.AutonamingOptions
-		wantDeleteBeforeCreate bool
-		wantErrMsg             string
+		name                    string
+		options                 globalAutonaming
+		urn                     urn.URN
+		wantOptions             *plugin.AutonamingOptions
+		wantDeleteBeforeReplace bool
+		wantErrMsg              string
 	}{
 		{
 			name:        "no config returns no options",
@@ -61,7 +61,7 @@ func TestGlobalAutonaming_AutonamingForResource(t *testing.T) {
 				Mode:            plugin.AutonamingModeEnforce,
 				WarnIfNoSupport: false,
 			},
-			wantDeleteBeforeCreate: true,
+			wantDeleteBeforeReplace: true,
 		},
 		{
 			name: "verbatim config on provider enforces logical name",
@@ -79,7 +79,7 @@ func TestGlobalAutonaming_AutonamingForResource(t *testing.T) {
 				Mode:            plugin.AutonamingModeEnforce,
 				WarnIfNoSupport: true,
 			},
-			wantDeleteBeforeCreate: true,
+			wantDeleteBeforeReplace: true,
 		},
 		{
 			name: "verbatim config on resource enforces logical name",
@@ -100,7 +100,7 @@ func TestGlobalAutonaming_AutonamingForResource(t *testing.T) {
 				Mode:            plugin.AutonamingModeEnforce,
 				WarnIfNoSupport: true,
 			},
-			wantDeleteBeforeCreate: true,
+			wantDeleteBeforeReplace: true,
 		},
 		{
 			name: "disabled config",
@@ -112,7 +112,7 @@ func TestGlobalAutonaming_AutonamingForResource(t *testing.T) {
 				Mode:            plugin.AutonamingModeDisabled,
 				WarnIfNoSupport: false,
 			},
-			wantDeleteBeforeCreate: true,
+			wantDeleteBeforeReplace: true,
 		},
 		{
 			name: "disabled config on provider",
@@ -129,7 +129,7 @@ func TestGlobalAutonaming_AutonamingForResource(t *testing.T) {
 				Mode:            plugin.AutonamingModeDisabled,
 				WarnIfNoSupport: true,
 			},
-			wantDeleteBeforeCreate: true,
+			wantDeleteBeforeReplace: true,
 		},
 		{
 			name: "disabled config on resource",
@@ -149,7 +149,7 @@ func TestGlobalAutonaming_AutonamingForResource(t *testing.T) {
 				Mode:            plugin.AutonamingModeDisabled,
 				WarnIfNoSupport: true,
 			},
-			wantDeleteBeforeCreate: true,
+			wantDeleteBeforeReplace: true,
 		},
 		{
 			name: "provider-specific config overrides default",
@@ -170,7 +170,7 @@ func TestGlobalAutonaming_AutonamingForResource(t *testing.T) {
 				Mode:            plugin.AutonamingModePropose,
 				WarnIfNoSupport: true,
 			},
-			wantDeleteBeforeCreate: true,
+			wantDeleteBeforeReplace: true,
 		},
 		{
 			name: "resource-specific config overrides provider default",
@@ -197,7 +197,7 @@ func TestGlobalAutonaming_AutonamingForResource(t *testing.T) {
 				Mode:            plugin.AutonamingModeEnforce,
 				WarnIfNoSupport: true,
 			},
-			wantDeleteBeforeCreate: true,
+			wantDeleteBeforeReplace: true,
 		},
 		{
 			name: "invalid resource type returns error",
@@ -223,9 +223,9 @@ func TestGlobalAutonaming_AutonamingForResource(t *testing.T) {
 					},
 				},
 			},
-			urn:                    makeURN("myresource", "aws:s3/bucket:Bucket"),
-			wantOptions:            nil,
-			wantDeleteBeforeCreate: false,
+			urn:                     makeURN("myresource", "aws:s3/bucket:Bucket"),
+			wantOptions:             nil,
+			wantDeleteBeforeReplace: false,
 		},
 		{
 			name: "global config is used if provider does not define a config other than specific resource",
@@ -245,7 +245,7 @@ func TestGlobalAutonaming_AutonamingForResource(t *testing.T) {
 				Mode:            plugin.AutonamingModeEnforce,
 				WarnIfNoSupport: false,
 			},
-			wantDeleteBeforeCreate: true,
+			wantDeleteBeforeReplace: true,
 		},
 	}
 
@@ -254,7 +254,7 @@ func TestGlobalAutonaming_AutonamingForResource(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, deleteBeforeCreate, err := tt.options.AutonamingForResource(tt.urn, nil)
+			got, deleteBeforeReplace, err := tt.options.AutonamingForResource(tt.urn, nil)
 
 			if tt.wantErrMsg != "" {
 				assert.Error(t, err)
@@ -263,7 +263,7 @@ func TestGlobalAutonaming_AutonamingForResource(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
-			assert.Equal(t, tt.wantDeleteBeforeCreate, deleteBeforeCreate)
+			assert.Equal(t, tt.wantDeleteBeforeReplace, deleteBeforeReplace)
 			assert.Equal(t, tt.wantOptions, got)
 		})
 	}

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -83,6 +84,16 @@ type Options struct {
 	GeneratePlan bool
 	// true if we should continue with the deployment even if a resource operation fails.
 	ContinueOnError bool
+	// Autonaming is user's configuration for custom autonaming to apply to (some) resources.
+	Autonaming Autonamer
+}
+
+// Autonamer is a resolver for custom autonaming options for resources.
+type Autonamer interface {
+	// AutonamingForResource returns the autonaming options for a resource, and whether it
+	// should be required to be deleted before creating.
+	AutonamingForResource(urn urn.URN, randomSeed []byte) (opts *plugin.AutonamingOptions,
+		deleteBeforeCreate bool, err error)
 }
 
 // DegreeOfParallelism returns the degree of parallelism that should be used during the

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -25,6 +25,7 @@ import (
 	uuid "github.com/gofrs/uuid"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/pkg/v3/resource/autonaming"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/resource/graph"
 	"github.com/pulumi/pulumi/pkg/v3/util/gsync"
@@ -32,7 +33,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -85,15 +85,7 @@ type Options struct {
 	// true if we should continue with the deployment even if a resource operation fails.
 	ContinueOnError bool
 	// Autonamer can resolve user's preference for custom autonaming options for a given resource.
-	Autonamer Autonamer
-}
-
-// Autonamer is a resolver for custom autonaming options for resources.
-type Autonamer interface {
-	// AutonamingForResource returns the autonaming options for a resource, and whether it
-	// should be required to be deleted before creating.
-	AutonamingForResource(urn urn.URN, randomSeed []byte) (opts *plugin.AutonamingOptions,
-		deleteBeforeReplace bool, err error)
+	Autonamer autonaming.Autonamer
 }
 
 // DegreeOfParallelism returns the degree of parallelism that should be used during the

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -84,8 +84,8 @@ type Options struct {
 	GeneratePlan bool
 	// true if we should continue with the deployment even if a resource operation fails.
 	ContinueOnError bool
-	// Autonaming is user's configuration for custom autonaming to apply to (some) resources.
-	Autonaming Autonamer
+	// Autonamer can resolve user's preference for custom autonaming options for a given resource.
+	Autonamer Autonamer
 }
 
 // Autonamer is a resolver for custom autonaming options for resources.
@@ -93,7 +93,7 @@ type Autonamer interface {
 	// AutonamingForResource returns the autonaming options for a resource, and whether it
 	// should be required to be deleted before creating.
 	AutonamingForResource(urn urn.URN, randomSeed []byte) (opts *plugin.AutonamingOptions,
-		deleteBeforeCreate bool, err error)
+		deleteBeforeReplace bool, err error)
 }
 
 // DegreeOfParallelism returns the degree of parallelism that should be used during the

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -626,10 +626,7 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, err
 	var autonaming *plugin.AutonamingOptions
 	if sg.deployment.opts.Autonamer != nil {
 		var dbr bool
-		autonaming, dbr, err = sg.deployment.opts.Autonamer.AutonamingForResource(urn, randomSeed)
-		if err != nil {
-			return nil, fmt.Errorf("failed to determine autonaming setting: %w", err)
-		}
+		autonaming, dbr = sg.deployment.opts.Autonamer.AutonamingForResource(urn, randomSeed)
 		// If autonaming settings had no randomness in the name, we must delete before creating a replacement.
 		if dbr {
 			goal.DeleteBeforeReplace = &dbr

--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -119,6 +119,27 @@ type ConfigureRequest struct {
 
 type ConfigureResponse struct{}
 
+// The mode that controls how the provider handles the proposed name. If not specified, defaults to `Propose`.
+type AutonamingMode int32
+
+const (
+	// Propose: The provider may use the proposed name as a suggestion but is free to modify it.
+	AutonamingModePropose AutonamingMode = iota
+	// Enforce: The provider must use exactly the proposed name or return an error.
+	AutonamingModeEnforce = 1
+	// Disabled: The provider should disable automatic naming and return an error if no explicit name is provided
+	// by user's program.
+	AutonamingModeDisabled = 2
+)
+
+// Configuration for automatic resource naming behavior. This structure contains fields that control how the provider
+// handles resource names, including proposed names and naming modes.
+type AutonamingOptions struct {
+	ProposedName    string
+	Mode            AutonamingMode
+	WarnIfNoSupport bool
+}
+
 type CheckRequest struct {
 	URN  resource.URN
 	Name string
@@ -127,6 +148,7 @@ type CheckRequest struct {
 	Olds, News    resource.PropertyMap
 	AllowUnknowns bool
 	RandomSeed    []byte
+	Autonaming    *AutonamingOptions
 }
 
 type CheckResponse struct {

--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -135,8 +135,12 @@ const (
 // Configuration for automatic resource naming behavior. This structure contains fields that control how the provider
 // handles resource names, including proposed names and naming modes.
 type AutonamingOptions struct {
-	ProposedName    string
-	Mode            AutonamingMode
+	// ProposedName is the name that the provider should use for the resource.
+	ProposedName string
+	// Mode is the mode that controls how the provider handles the proposed name.
+	Mode AutonamingMode
+	// WarnIfNoSupport indicates whether the provider plugin should log a warning if the provider does not support
+	// autonaming configuration.
 	WarnIfNoSupport bool
 }
 

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -101,6 +101,9 @@ type pluginProtocol struct {
 
 	// True if this plugin supports previews for Create and Update.
 	supportsPreview bool
+
+	// True if this plugin supports custom autonaming configuration.
+	supportsAutonamingConfiguration bool
 }
 
 // pluginConfig holds the configuration of the provider
@@ -940,10 +943,11 @@ func (p *provider) Configure(ctx context.Context, req ConfigureRequest) (Configu
 
 		if p.protocol == nil {
 			p.protocol = &pluginProtocol{
-				acceptSecrets:   resp.GetAcceptSecrets(),
-				acceptResources: resp.GetAcceptResources(),
-				supportsPreview: resp.GetSupportsPreview(),
-				acceptOutputs:   resp.GetAcceptOutputs(),
+				acceptSecrets:                   resp.GetAcceptSecrets(),
+				acceptResources:                 resp.GetAcceptResources(),
+				supportsPreview:                 resp.GetSupportsPreview(),
+				acceptOutputs:                   resp.GetAcceptOutputs(),
+				supportsAutonamingConfiguration: resp.GetSupportsAutonamingConfiguration(),
 			}
 		}
 
@@ -998,6 +1002,18 @@ func (p *provider) Check(ctx context.Context, req CheckRequest) (CheckResponse, 
 		return CheckResponse{}, err
 	}
 
+	var autonaming *pulumirpc.CheckRequest_AutonamingOptions
+	if req.Autonaming != nil {
+		if protocol.supportsAutonamingConfiguration {
+			autonaming = &pulumirpc.CheckRequest_AutonamingOptions{
+				ProposedName: req.Autonaming.ProposedName,
+				Mode:         pulumirpc.CheckRequest_AutonamingOptions_Mode(req.Autonaming.Mode),
+			}
+		} else if req.Autonaming.WarnIfNoSupport {
+			logging.V(3).Infof("%s warning: provider does not support autonaming configuration", label)
+		}
+	}
+
 	resp, err := client.Check(p.requestContext(), &pulumirpc.CheckRequest{
 		Urn:        string(req.URN),
 		Name:       req.URN.Name(),
@@ -1005,6 +1021,7 @@ func (p *provider) Check(ctx context.Context, req CheckRequest) (CheckResponse, 
 		Olds:       molds,
 		News:       mnews,
 		RandomSeed: req.RandomSeed,
+		Autonaming: autonaming,
 	})
 	if err != nil {
 		rpcError := rpcerror.Convert(err)

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -37,6 +37,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
@@ -1010,7 +1011,10 @@ func (p *provider) Check(ctx context.Context, req CheckRequest) (CheckResponse, 
 				Mode:         pulumirpc.CheckRequest_AutonamingOptions_Mode(req.Autonaming.Mode),
 			}
 		} else if req.Autonaming.WarnIfNoSupport {
-			logging.V(3).Infof("%s warning: provider does not support autonaming configuration", label)
+			p.ctx.Diag.Warningf(diag.Message(req.URN,
+				"%s resource has a custom autonaming setting but the provider does not support "+
+					"autonaming configuration, consider upgrading to a newer version"),
+				req.URN)
 		}
 	}
 

--- a/sdk/go/common/resource/plugin/provider_server.go
+++ b/sdk/go/common/resource/plugin/provider_server.go
@@ -398,6 +398,14 @@ func (p *providerServer) Check(ctx context.Context, req *pulumirpc.CheckRequest)
 		return nil, err
 	}
 
+	var autonaming *AutonamingOptions
+	if req.Autonaming != nil {
+		autonaming = &AutonamingOptions{
+			ProposedName: req.Autonaming.ProposedName,
+			Mode:         AutonamingMode(req.Autonaming.Mode),
+		}
+	}
+
 	resp, err := p.provider.Check(ctx, CheckRequest{
 		URN:           urn,
 		Name:          req.Name,
@@ -406,6 +414,7 @@ func (p *providerServer) Check(ctx context.Context, req *pulumirpc.CheckRequest)
 		News:          inputs,
 		AllowUnknowns: true,
 		RandomSeed:    req.RandomSeed,
+		Autonaming:    autonaming,
 	})
 	if err != nil {
 		return nil, err

--- a/tests/integration/autonaming/Pulumi.yaml
+++ b/tests/integration/autonaming/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: autonaming
+description: A program with autonamed resources.
+runtime: nodejs

--- a/tests/integration/autonaming/index.ts
+++ b/tests/integration/autonaming/index.ts
@@ -1,0 +1,13 @@
+// Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+class Named extends pulumi.CustomResource {
+    public readonly name!: pulumi.Output<string>;
+    constructor(name: string, resourceName?: string) {
+        super("testprovider:index:Named", name, { name: resourceName });
+    }
+}
+
+export let autoName = new Named("test1").name;
+export let explicitName = new Named("test2", "explicit-name").name;

--- a/tests/integration/autonaming/package.json
+++ b/tests/integration/autonaming/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "autonaming",
+    "license": "Apache-2.0",
+    "devDependencies": {
+        "typescript": "^2.5.3"
+    }
+}

--- a/tests/testprovider/main.go
+++ b/tests/testprovider/main.go
@@ -84,8 +84,8 @@ var testProviders = func() map[string]testProvider {
 		"testprovider:index:doMultiEcho":       ep,
 		"testprovider:index:FailsOnDelete":     &failsOnDeleteProvider{},
 		"testprovider:index:FailsOnCreate":     &failsOnCreateProvider{},
+		"testprovider:index:Named":             &namedProvider{},
 	}
-
 	return testProviders
 }()
 
@@ -136,7 +136,8 @@ func (p *testproviderProvider) DiffConfig(ctx context.Context, req *rpc.DiffRequ
 // Configure configures the resource provider with "globals" that control its behavior.
 func (p *testproviderProvider) Configure(_ context.Context, req *rpc.ConfigureRequest) (*rpc.ConfigureResponse, error) {
 	return &rpc.ConfigureResponse{
-		AcceptSecrets: true,
+		AcceptSecrets:                   true,
+		SupportsAutonamingConfiguration: true,
 	}, nil
 }
 

--- a/tests/testprovider/named.go
+++ b/tests/testprovider/named.go
@@ -1,0 +1,165 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build !all
+// +build !all
+
+package main
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func init() {
+	providerSchema.Resources["testprovider:index:Named"] = pschema.ResourceSpec{
+		ObjectTypeSpec: pschema.ObjectTypeSpec{
+			Description: "A test resource that has an auto-generated name.",
+			Properties: map[string]pschema.PropertySpec{
+				"name": {
+					TypeSpec: pschema.TypeSpec{
+						Type: "string",
+					},
+					Description: "The name of the resource.",
+				},
+			},
+			Type: "object",
+		},
+		InputProperties: map[string]pschema.PropertySpec{
+			"name": {
+				TypeSpec: pschema.TypeSpec{
+					Type: "string",
+				},
+				Description: "Optional explicit name.",
+			},
+		},
+	}
+}
+
+type namedProvider struct {
+	id int
+}
+
+func (p *namedProvider) Check(ctx context.Context, req *rpc.CheckRequest) (*rpc.CheckResponse, error) {
+	news, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
+	if err != nil {
+		return nil, err
+	}
+	_, ok := news["name"]
+	if !ok {
+		generatedName := "default-name"
+		if req.Autonaming != nil {
+			switch req.Autonaming.Mode {
+			case rpc.CheckRequest_AutonamingOptions_DISABLE:
+				generatedName = ""
+			case rpc.CheckRequest_AutonamingOptions_ENFORCE:
+				generatedName = req.Autonaming.GetProposedName()
+			case rpc.CheckRequest_AutonamingOptions_PROPOSE:
+				generatedName = strings.ToLower(req.Autonaming.GetProposedName())
+			}
+		}
+		if generatedName != "" {
+			news["name"] = resource.NewStringProperty(generatedName)
+		}
+	}
+
+	inputs, err := plugin.MarshalProperties(
+		news,
+		plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &rpc.CheckResponse{Inputs: inputs, Failures: nil}, nil
+}
+
+func (p *namedProvider) Diff(ctx context.Context, req *rpc.DiffRequest) (*rpc.DiffResponse, error) {
+	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
+	if err != nil {
+		return nil, err
+	}
+
+	news, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
+	if err != nil {
+		return nil, err
+	}
+
+	d := olds.Diff(news)
+	changes := rpc.DiffResponse_DIFF_NONE
+	var replaces []string
+	if d != nil && d.Changed("echo") {
+		changes = rpc.DiffResponse_DIFF_SOME
+		replaces = append(replaces, "echo")
+	}
+
+	return &rpc.DiffResponse{
+		Changes:  changes,
+		Replaces: replaces,
+	}, nil
+}
+
+func (p *namedProvider) Create(ctx context.Context, req *rpc.CreateRequest) (*rpc.CreateResponse, error) {
+	inputs, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{
+		KeepUnknowns: true,
+		SkipNulls:    true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	outputProperties, err := plugin.MarshalProperties(
+		inputs,
+		plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	p.id++
+	return &rpc.CreateResponse{
+		Id:         strconv.Itoa(p.id),
+		Properties: outputProperties,
+	}, nil
+}
+
+func (p *namedProvider) Read(ctx context.Context, req *rpc.ReadRequest) (*rpc.ReadResponse, error) {
+	return &rpc.ReadResponse{
+		Id:         req.Id,
+		Properties: req.Properties,
+	}, nil
+}
+
+func (p *namedProvider) Update(ctx context.Context, req *rpc.UpdateRequest) (*rpc.UpdateResponse, error) {
+	panic("Update not implemented")
+}
+
+func (p *namedProvider) Delete(ctx context.Context, req *rpc.DeleteRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (p *namedProvider) Invoke(ctx context.Context, req *rpc.InvokeRequest) (*rpc.InvokeResponse, error) {
+	panic("Invoke not implemented")
+}
+
+func (p *namedProvider) Call(ctx context.Context, req *rpc.CallRequest) (*rpc.CallResponse, error) {
+	panic("Call not implemented")
+}


### PR DESCRIPTION
CLI-side implementation of #17592 towards #1518

It adds autonaming configuration support to `up` and `preview` commands if the `PULUMI_EXPERIMENTAL` flag is enabled. Users can specify `pulumi:autonaming` configuration and get names customized across their resources, once the provider-side feature lands everywhere. Example:

```yaml
pulumi:autonaming:
  mode: default
  providers:
    aws:
      pattern: ${name}_${hex(4)}  # AWS - use underscore and shorter suffix
    azure-native:
      mode: verbatim  # disable name mangling for Azure
      resources:
        "azure-native:storage:Account": ${name}${string(6)}  # storage accounts are globally unique, so add a suffix
```

All the significant changes are isolated inside the new `pkg/resource/autonaming` module, all the rest is wiring of parameters from cmd to provider.

See #17592 for the specification of behavior, it's supposed to be implemented according to that design and in full.

Here is a draft of TF Bridge changes for references: https://github.com/pulumi/pulumi-terraform-bridge/pull/2675