### PR TITLE
Suggest `state repair` as part of integrity panics

### DIFF
--- a/changelog/pending/20241204--cli--suggest-state-repair-as-part-of-integrity-panics.yaml
+++ b/changelog/pending/20241204--cli--suggest-state-repair-as-part-of-integrity-panics.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Suggest `state repair` as part of integrity panics

--- a/pkg/cmd/pulumi/errors.go
+++ b/pkg/cmd/pulumi/errors.go
@@ -107,6 +107,14 @@ func printSnapshotIntegrityError(err error, sie deploy.SnapshotIntegrityError) {
 	var message strings.Builder
 	message.WriteString(`The Pulumi CLI encountered a snapshot integrity error. This is a bug!
 
+You can try to repair your snapshot as follows:
+
+` + "* Using the `pulumi state repair` command." + ` This is the recommended approach.
+  Run ` + "`pulumi state repair --help`" + ` for more information.
+` + "* Passing the `--disable-integrity-checking` flag." + ` This will disable integrity
+  checking on many Pulumi commands. This is riskier, but may allow you to
+  execute fine-grained repairs using e.g. ` + "`pulumi state delete`" + `.
+
 ================================================================================
 We would appreciate a report: https://github.com/pulumi/pulumi/issues/
 `)


### PR DESCRIPTION
When the Pulumi CLI encounters a snapshot integrity error, we emit an error message asking the user to file an issue. We don't however give them much advice on how to proceed. In #17445 we introduced the `state repair` command, which can fix a large number of issues that cause snapshot integrity failures. In this commit, we inform users of `state repair` in the hope that it might unblock them, or offer a neater solution than e.g. `state delete` and the like that we've previously observed people using. As a fallback, we also mention the `--disable-integrity-checking` flag that users have used previously, to make it a bit more discoverable.

Fixes #4984

![image](https://github.com/user-attachments/assets/4c030ff6-8132-4836-9f7d-f8dbc51d898f)
![image](https://github.com/user-attachments/assets/f81c844f-07ea-4ca5-989b-589169a6d166)
