### PR TITLE
Remove dead code from Go program generation

### DIFF
--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -572,14 +572,6 @@ func (g *generator) genObjectConsExpressionWithTypeName(
 	destType model.Type,
 	typeName string,
 ) {
-	// TODO: @pgavlin --- ineffectual assignment, was there some work in flight here?
-	// if strings.HasSuffix(typeName, "Args") {
-	// 	isInput = true
-	// }
-	// // invokes are not inputty
-	// if strings.Contains(typeName, ".Lookup") || strings.Contains(typeName, ".Get") {
-	// 	isInput = false
-	// }
 	isMap := strings.HasPrefix(typeName, "map[")
 
 	// TODO: retrieve schema and propagate optionals to emit bool ptr, etc.


### PR DESCRIPTION
Issue #7645 tracks a TODO that is at this point over 3 years old and clearly not contributing anything to Go code generation. This commit removes it so that we can close the noisy issue. Git will preserve it if we ever need to dig it out again!

Closes #7645