### PR TITLE
WIP Allow providers to suppress output via a handshake flag

### DIFF
--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -69,12 +69,13 @@ func NewAnalyzer(host Host, ctx *Context, name tokens.QName) (Analyzer, error) {
 
 	dialOpts := rpcutil.OpenTracingInterceptorDialOptions()
 
-	plug, _, err := newPlugin(ctx, ctx.Pwd, path, fmt.Sprintf("%v (analyzer)", name),
+	plug, _, runTrace, err := newPlugin(ctx, ctx.Pwd, path, fmt.Sprintf("%v (analyzer)", name),
 		apitype.AnalyzerPlugin, []string{host.ServerAddr(), ctx.Pwd}, nil, /*env*/
 		testConnection, dialOpts)
 	if err != nil {
 		return nil, err
 	}
+	runTrace.init(ctx)
 	contract.Assertf(plug != nil, "unexpected nil analyzer plugin for %s", name)
 
 	return &analyzer{
@@ -136,7 +137,7 @@ func NewPolicyAnalyzer(
 		}
 	}
 
-	plug, _, err := newPlugin(ctx, pwd, pluginPath, fmt.Sprintf("%v (analyzer)", name),
+	plug, _, runTrace, err := newPlugin(ctx, pwd, pluginPath, fmt.Sprintf("%v (analyzer)", name),
 		apitype.AnalyzerPlugin, args, env, testConnection,
 		analyzerPluginDialOptions(ctx, fmt.Sprintf("%v", name)))
 	if err != nil {
@@ -153,6 +154,7 @@ func NewPolicyAnalyzer(
 		return nil, fmt.Errorf("policy pack %q failed to start: %w", string(name), err)
 	}
 	contract.Assertf(plug != nil, "unexpected nil analyzer plugin for %s", name)
+	runTrace.init(ctx)
 
 	return &analyzer{
 		ctx:     ctx,

--- a/sdk/go/common/resource/plugin/converter_plugin.go
+++ b/sdk/go/common/resource/plugin/converter_plugin.go
@@ -52,12 +52,13 @@ func NewConverter(ctx *Context, name string, version *semver.Version) (Converter
 
 	contract.Assertf(path != "", "unexpected empty path for plugin %s", name)
 
-	plug, _, err := newPlugin(ctx, ctx.Pwd, path, prefix,
+	plug, _, runTrace, err := newPlugin(ctx, ctx.Pwd, path, prefix,
 		apitype.ConverterPlugin, []string{}, os.Environ(),
 		testConnection, converterPluginDialOptions(ctx, name, ""))
 	if err != nil {
 		return nil, err
 	}
+	runTrace.init(ctx)
 
 	contract.Assertf(plug != nil, "unexpected nil converter plugin for %s", name)
 

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -68,13 +68,14 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime, workingDirectory strin
 		return nil, err
 	}
 
-	plug, _, err := newPlugin(ctx, workingDirectory, path, runtime,
+	plug, _, runTrace, err := newPlugin(ctx, workingDirectory, path, runtime,
 		apitype.LanguagePlugin, args, nil, /*env*/
 		testConnection, langRuntimePluginDialOptions(ctx, runtime))
 	if err != nil {
 		return nil, err
 	}
 	contract.Assertf(plug != nil, "unexpected nil language plugin for %s", runtime)
+	runTrace.init(ctx)
 
 	return &langhost{
 		ctx:     ctx,


### PR DESCRIPTION
This starts work on a flag to allow providers to opt into suppressing their stdout and stderr streams, largely to show that it is possible. This would add complexity to the provider/engine protocol, since it introduces a new flag to the `Handshake` between providers and engine.

This removes the improved error message introduced in https://github.com/pulumi/pulumi/pull/3307. I do not expect that the error message will still be displayed to users, since it is intended to work with versions of `pulumi` that are not compatible with policy.

Motivated by https://github.com/pulumi/pulumi-terraform-bridge/issues/2489

---

### Alternatives

We could switch plugin's stdout and stderr to write to debug logs (instead of info). This way they wouldn't be visible to users by default. This would reduce complexity in the engine and opt providers into the correct strategy (structured logging) in exchange for a cosmetic breaking change.

