### PR TITLE
Enable support pack for all parameterized packages

### DIFF
--- a/changelog/pending/20241204--sdkgen-go--fix-writing-of-go-mod-files-for-parameterized-packages.yaml
+++ b/changelog/pending/20241204--sdkgen-go--fix-writing-of-go-mod-files-for-parameterized-packages.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/go
+  description: Fix writing of go.mod files for parameterized packages

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -2231,7 +2231,7 @@ func genPackageMetadata(pkg *schema.Package,
 	if pkg.Version != nil && ok && lang.RespectSchemaVersion {
 		version = pkg.Version.String()
 		files.Add("version.txt", []byte(version))
-	} else if pkg.SupportPack || pkg.Parameterization != nil {
+	} else if pkg.SupportPack {
 		if pkg.Version == nil {
 			return errors.New("package version is required")
 		}

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -2415,7 +2415,7 @@ func genNPMPackageMetadata(pkg *schema.Package, info NodePackageInfo, localDepen
 		pluginVersion = version
 	}
 	// Parameterized schemas _always_ respect schema version
-	if pkg.SupportPack || pkg.Parameterization != nil {
+	if pkg.SupportPack {
 		if pkg.Version == nil {
 			return "", errors.New("package version is required")
 		}

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -2291,7 +2291,7 @@ func genPackageMetadata(
 		requires = updatedRequires
 	}
 	// Parameterized schemas _always_ respect schema version
-	if pkg.SupportPack || pkg.Parameterization != nil {
+	if pkg.SupportPack {
 		if pkg.Version == nil {
 			return "", errors.New("package version is required")
 		}
@@ -3310,7 +3310,7 @@ func genPyprojectTOML(tool string,
 	if pkg.Version != nil && ok && info.RespectSchemaVersion {
 		version = PypiVersion(*pkg.Version)
 	}
-	if pkg.SupportPack || pkg.Parameterization != nil {
+	if pkg.SupportPack {
 		if pkg.Version == nil {
 			return "", errors.New("package version is required")
 		}

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -255,6 +255,13 @@ func newBinder(info PackageInfoSpec, spec specSource, loader Loader,
 	if info.Meta != nil {
 		supportPack = info.Meta.SupportPack
 	}
+	// Parameterized packages must always be built in SupportPack mode.
+	if info.Parameterization != nil {
+		supportPack = true
+	}
+
+	parameterization, parameterizationDiagnostics := bindParameterization(info.Parameterization)
+	diags = diags.Extend(parameterizationDiagnostics)
 
 	pkg := &Package{
 		SupportPack:         supportPack,
@@ -273,6 +280,7 @@ func newBinder(info PackageInfoSpec, spec specSource, loader Loader,
 		AllowedPackageNames: info.AllowedPackageNames,
 		LogoURL:             info.LogoURL,
 		Language:            language,
+		Parameterization:    parameterization,
 	}
 
 	// We want to use the same loader instance for all referenced packages, so only instantiate the loader if the

--- a/pkg/codegen/schema/package_reference.go
+++ b/pkg/codegen/schema/package_reference.go
@@ -44,7 +44,8 @@ type PackageReference interface {
 	// Repository returns the package repository.
 	Repository() string
 
-	// SupportPack specifies the package definition can be packed by language plugins
+	// SupportPack specifies the package definition can be packed by language plugins, this is always true for
+	// parameterized packages.
 	SupportPack() bool
 
 	// Types returns the package's types.

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -965,8 +965,11 @@ func (pkg *Package) MarshalSpec() (spec *PackageSpec, err error) {
 	}
 
 	var metadata *MetadataSpec
-	if pkg.moduleFormat != nil || pkg.SupportPack {
-		metadata = &MetadataSpec{SupportPack: pkg.SupportPack}
+	// Don't set support pack in meta spec if Parameterization is present because that implictly sets
+	// SupportPack when reading back in anyway.
+	supportPack := pkg.SupportPack && pkg.Parameterization == nil
+	if pkg.moduleFormat != nil || supportPack {
+		metadata = &MetadataSpec{SupportPack: supportPack}
 		if pkg.moduleFormat != nil {
 			metadata.ModuleFormat = pkg.moduleFormat.String()
 		}
@@ -1983,6 +1986,9 @@ type PackageInfoSpec struct {
 
 	// Language specifies additional language-specific data about the package.
 	Language map[string]RawMessage `json:"language,omitempty" yaml:"language,omitempty"`
+
+	// Parameterization is the optional parameterization for this package.
+	Parameterization *ParameterizationSpec `json:"parameterization,omitempty" yaml:"parameterization,omitempty"`
 }
 
 // BaseProviderSpec is the serializable description of a Pulumi base provider.
@@ -2076,6 +2082,7 @@ func (p *PackageSpec) Info() PackageInfoSpec {
 		Meta:                p.Meta,
 		AllowedPackageNames: p.AllowedPackageNames,
 		Language:            p.Language,
+		Parameterization:    p.Parameterization,
 	}
 }
 
@@ -2095,6 +2102,4 @@ type PartialPackageSpec struct {
 	Resources map[string]json.RawMessage `json:"resources,omitempty" yaml:"resources,omitempty"`
 	// Functions is a map from token to FunctionSpec that describes the set of functions defined by this package.
 	Functions map[string]json.RawMessage `json:"functions,omitempty" yaml:"functions,omitempty"`
-	// Parameterization contains parameterization information about the package.
-	Parameterization *ParameterizationSpec `json:"parameterization,omitempty" yaml:"parameterization,omitempty"`
 }


### PR DESCRIPTION
SupportPack was added to write out sdks in a new style appropriate for use in conformance tests and for local sdks. When adding parameterized we tried to treat them the same, always writing out in the new style. But we we're inconsistent and didn't always check for "parameterization != nil" at the same time as "supportPack". 

This changes the schema loader to just do that as part of marshal/unmarshal schema.

The only thing this actually affects is Go sdkgen in that parameterized providers now write out their top level go.mod as expected.