### PR TITLE
Remove second go.mod in parameterized packages

### DIFF
--- a/pkg/cmd/pulumi/package_add.go
+++ b/pkg/cmd/pulumi/package_add.go
@@ -269,11 +269,11 @@ func printGoLinkInstructions(root string, pkg *schema.Package, out string) error
 		return errors.New("failed to import go language info")
 	}
 
-	fmt.Printf("   go mod edit -replace %s=%s\n", goInfo.ImportBasePath, relOut)
+	fmt.Printf("   go mod edit -replace %s=%s\n", goInfo.ModulePath, relOut)
 	fmt.Println()
 	fmt.Println("You can then use the SDK in your Go code with:")
 	fmt.Println()
-	fmt.Printf("  import \"%s\"\n", goInfo.ImportBasePath)
+	fmt.Printf("  import \"%s\"\n", goInfo.ModulePath)
 	fmt.Println()
 	return nil
 }

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -4687,25 +4687,6 @@ func GeneratePackage(tool string,
 
 	files := codegen.Fs{}
 
-	// If the package is parameterized generate a go.mod for it
-	if pkg.Parameterization != nil {
-		mod := modfile.File{}
-		err = mod.AddModuleStmt(goPkgInfo.ImportBasePath)
-		contract.AssertNoErrorf(err, "could not add module statement to go.mod")
-		err = mod.AddGoStmt("1.21")
-		contract.AssertNoErrorf(err, "could not add Go statement to go.mod")
-		// Parameterized packages need the pulumi SDK >= v3.129.0
-		pulumiPackagePath := "github.com/pulumi/pulumi/sdk/v3"
-		pulumiVersion := "v3.129.0"
-		err = mod.AddRequire(pulumiPackagePath, pulumiVersion)
-		contract.AssertNoErrorf(err, "could not add require statement to go.mod")
-		bytes, err := mod.Format()
-		if err != nil {
-			return nil, fmt.Errorf("format go.mod: %w", err)
-		}
-		files.Add(path.Join(pathPrefix, "go.mod"), bytes)
-	}
-
 	// Generate pulumi-plugin.json
 	pulumiPlugin := &plugin.PulumiPluginJSON{
 		Resource: true,

--- a/tests/integration/go/parameterized/go.mod
+++ b/tests/integration/go/parameterized/go.mod
@@ -8,7 +8,7 @@ replace github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-202
 
 require github.com/pulumi/pulumi/sdk/v3 v3.129.0
 
-require example.com/pulumi-pkg/sdk/go/pkg v1.0.0
+require example.com/pulumi-pkg/sdk/go v1.0.0
 
 require (
 	dario.cat/mergo v1.0.0 // indirect
@@ -94,4 +94,4 @@ require (
 	lukechampine.com/frand v1.4.2 // indirect
 )
 
-replace example.com/pulumi-pkg/sdk/go/pkg => ./sdk/go/pkg
+replace example.com/pulumi-pkg/sdk/go => ./sdk/go


### PR DESCRIPTION
This code wrote a go.mod file one folder below where we actually expected a go.mod file to be written according to SupportPack, since https://github.com/pulumi/pulumi/pull/17923 was merged we were writing out both. This removes the nested go.mod, fixes the integration test that was using that instead of the top level go.mod, and fixes `package add` to refer to the top level go.mod.