### PR TITLE
Upgrade pulumi-dotnet to 3.71.0

### DIFF
--- a/changelog/pending/20241205--sdk-dotnet--upgrade-pulumi-dotnet-to-3-71-0.yaml
+++ b/changelog/pending/20241205--sdk-dotnet--upgrade-pulumi-dotnet-to-3-71-0.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/dotnet
+  description: Upgrade pulumi-dotnet to 3.71.0

--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -378,4 +378,4 @@ const (
 )
 
 // PulumiDotnetSDKVersion is the version of the Pulumi .NET SDK to use in program-gen tests
-const PulumiDotnetSDKVersion = "3.69.0"
+const PulumiDotnetSDKVersion = "3.71.0"

--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -32,7 +32,7 @@ download_release() {
 }
 
 # shellcheck disable=SC2043
-for i in "github.com/pulumi/pulumi-java java" "github.com/pulumi/pulumi-yaml yaml" "github.com/pulumi/pulumi-dotnet dotnet v3.69.0"; do
+for i in "github.com/pulumi/pulumi-java java" "github.com/pulumi/pulumi-yaml yaml" "github.com/pulumi/pulumi-dotnet dotnet v3.71.0"; do
   set -- $i # treat strings in loop as args
   REPO="$1"
   PULUMI_LANG="$2"


### PR DESCRIPTION
Pull in the latest release. This unblocks .NET codegen for the new DependsOn option for invokes.