### PR TITLE
Break out `pulumi about`

### DIFF
--- a/pkg/cmd/pulumi/about/about.go
+++ b/pkg/cmd/pulumi/about/about.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package about
 
 import (
 	"context"
@@ -48,7 +48,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func newAboutCmd() *cobra.Command {
+func NewAboutCmd() *cobra.Command {
 	var jsonOut bool
 	var transitiveDependencies bool
 	var stack string

--- a/pkg/cmd/pulumi/about/about_env.go
+++ b/pkg/cmd/pulumi/about/about_env.go
@@ -16,7 +16,7 @@
 //
 // Public environmental variables should be declared as a module level variable.
 
-package main
+package about
 
 import (
 	"errors"

--- a/pkg/cmd/pulumi/about/about_test.go
+++ b/pkg/cmd/pulumi/about/about_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package about
 
 import (
 	"runtime"

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -46,6 +46,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/about"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/util/tracing"
 	"github.com/pulumi/pulumi/pkg/v3/version"
@@ -367,7 +368,7 @@ func NewPulumiCmd() *cobra.Command {
 			Name: "Other Commands",
 			Commands: []*cobra.Command{
 				newVersionCmd(),
-				newAboutCmd(),
+				about.NewAboutCmd(),
 				newGenCompletionCmd(cmd),
 			},
 		},


### PR DESCRIPTION
This commit breaks out the `about` command and its subcommands into a new subpackage of `pkg/cmd/pulumi`. In doing so we are able to better encapsulate the components of the command and more clearly delineate the "APIs" of each command hierarchy.