### PR TITLE
Add ConfigFile to GetConfig and SetConfig Ops In Go Automation API

### DIFF
--- a/changelog/pending/20241205--auto-go--add-configfile-to-getconfig-and-setconfig-operations.yaml
+++ b/changelog/pending/20241205--auto-go--add-configfile-to-getconfig-and-setconfig-operations.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: auto/go
-  description: Add ConfigFile to GetConfig and SetConfig operations
+  description: Add ConfigFile to GetConfig and SetConfig operations, add GetAllConfigWithOptions to extend GetAllConfig

--- a/changelog/pending/20241205--auto-go--add-configfile-to-getconfig-and-setconfig-operations.yaml
+++ b/changelog/pending/20241205--auto-go--add-configfile-to-getconfig-and-setconfig-operations.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Add ConfigFile to GetConfig and SetConfig operations

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -207,9 +207,6 @@ func (l *LocalWorkspace) GetConfigWithOptions(
 		if opts.ConfigFile != "" {
 			args = append(args, "--config-file", opts.ConfigFile)
 		}
-		if opts.ShowSecrets {
-			return val, newAutoError(errors.New("GetConfigWithOptions does not support ShowSecrets option"), "", "", 1)
-		}
 	}
 	args = append(args, key, "--json", "--stack", stackName)
 	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, args...)
@@ -226,14 +223,14 @@ func (l *LocalWorkspace) GetConfigWithOptions(
 // GetAllConfig returns the config map for the specified stack name, scoped to the current workspace.
 // LocalWorkspace reads this config from the matching Pulumi.stack.yaml file.
 func (l *LocalWorkspace) GetAllConfig(ctx context.Context, stackName string) (ConfigMap, error) {
-	return l.GetAllConfigWithOptions(ctx, stackName, &ConfigOptions{ShowSecrets: true})
+	return l.GetAllConfigWithOptions(ctx, stackName, &GetAllConfigOptions{ShowSecrets: true})
 }
 
 // GetAllConfigWithOptions returns the config map for the specified stack name
-// using the optional ConfigOptions, scoped to the current workspace.
+// using the optional GetAllConfigOptions, scoped to the current workspace.
 // LocalWorkspace reads this config from the matching Pulumi.stack.yaml file.
 func (l *LocalWorkspace) GetAllConfigWithOptions(
-	ctx context.Context, stackName string, opts *ConfigOptions,
+	ctx context.Context, stackName string, opts *GetAllConfigOptions,
 ) (ConfigMap, error) {
 	var val ConfigMap
 	args := []string{"config"}
@@ -243,9 +240,6 @@ func (l *LocalWorkspace) GetAllConfigWithOptions(
 		}
 		if opts.ConfigFile != "" {
 			args = append(args, "--config-file", opts.ConfigFile)
-		}
-		if opts.Path {
-			return val, newAutoError(errors.New("GetAllConfigWithOptions does not support path option"), "", "", 1)
 		}
 	}
 	args = append(args, "--json", "--stack", stackName)
@@ -278,9 +272,6 @@ func (l *LocalWorkspace) SetConfigWithOptions(
 		}
 		if opts.ConfigFile != "" {
 			args = append(args, "--config-file", opts.ConfigFile)
-		}
-		if opts.ShowSecrets {
-			return newAutoError(errors.New("SetConfigWithOptions does not support ShowSecrets option"), "", "", 1)
 		}
 	}
 	secretArg := "--plaintext"
@@ -315,9 +306,6 @@ func (l *LocalWorkspace) SetAllConfigWithOptions(
 		}
 		if opts.ConfigFile != "" {
 			args = append(args, "--config-file", opts.ConfigFile)
-		}
-		if opts.ShowSecrets {
-			return newAutoError(errors.New("SetAllConfigWithOptions does not support ShowSecrets option"), "", "", 1)
 		}
 	}
 	for k, v := range config {
@@ -354,9 +342,6 @@ func (l *LocalWorkspace) RemoveConfigWithOptions(
 		if opts.ConfigFile != "" {
 			args = append(args, "--config-file", opts.ConfigFile)
 		}
-		if opts.ShowSecrets {
-			return newAutoError(errors.New("RemoveConfigWithOptions does not support ShowSecrets option"), "", "", 1)
-		}
 	}
 	args = append(args, key, "--stack", stackName)
 	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, args...)
@@ -385,9 +370,6 @@ func (l *LocalWorkspace) RemoveAllConfigWithOptions(
 		}
 		if opts.ConfigFile != "" {
 			args = append(args, "--config-file", opts.ConfigFile)
-		}
-		if opts.ShowSecrets {
-			return newAutoError(errors.New("RemoveAllConfigWithOptions does not support ShowSecrets option"), "", "", 1)
 		}
 	}
 	args = append(args, keys...)

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -204,6 +204,12 @@ func (l *LocalWorkspace) GetConfigWithOptions(
 		if opts.Path {
 			args = append(args, "--path")
 		}
+		if opts.ConfigFile != "" {
+			args = append(args, "--config-file", opts.ConfigFile)
+		}
+		if opts.ShowSecrets {
+			return val, newAutoError(errors.New("GetConfigWithOptions does not support ShowSecrets option"), "", "", 1)
+		}
 	}
 	args = append(args, key, "--json", "--stack", stackName)
 	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, args...)
@@ -220,8 +226,30 @@ func (l *LocalWorkspace) GetConfigWithOptions(
 // GetAllConfig returns the config map for the specified stack name, scoped to the current workspace.
 // LocalWorkspace reads this config from the matching Pulumi.stack.yaml file.
 func (l *LocalWorkspace) GetAllConfig(ctx context.Context, stackName string) (ConfigMap, error) {
+	return l.GetAllConfigWithOptions(ctx, stackName, &ConfigOptions{ShowSecrets: true})
+}
+
+// GetAllConfigWithOptions returns the config map for the specified stack name
+// using the optional ConfigOptions, scoped to the current workspace.
+// LocalWorkspace reads this config from the matching Pulumi.stack.yaml file.
+func (l *LocalWorkspace) GetAllConfigWithOptions(
+	ctx context.Context, stackName string, opts *ConfigOptions,
+) (ConfigMap, error) {
 	var val ConfigMap
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "--show-secrets", "--json", "--stack", stackName)
+	args := []string{"config"}
+	if opts != nil {
+		if opts.ShowSecrets {
+			args = append(args, "--show-secrets")
+		}
+		if opts.ConfigFile != "" {
+			args = append(args, "--config-file", opts.ConfigFile)
+		}
+		if opts.Path {
+			return val, newAutoError(errors.New("GetAllConfigWithOptions does not support path option"), "", "", 1)
+		}
+	}
+	args = append(args, "--json", "--stack", stackName)
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, args...)
 	if err != nil {
 		return val, newAutoError(fmt.Errorf("unable to read config: %w", err), stdout, stderr, errCode)
 	}
@@ -247,6 +275,12 @@ func (l *LocalWorkspace) SetConfigWithOptions(
 	if opts != nil {
 		if opts.Path {
 			args = append(args, "--path")
+		}
+		if opts.ConfigFile != "" {
+			args = append(args, "--config-file", opts.ConfigFile)
+		}
+		if opts.ShowSecrets {
+			return newAutoError(errors.New("SetConfigWithOptions does not support ShowSecrets option"), "", "", 1)
 		}
 	}
 	secretArg := "--plaintext"
@@ -278,6 +312,12 @@ func (l *LocalWorkspace) SetAllConfigWithOptions(
 	if opts != nil {
 		if opts.Path {
 			args = append(args, "--path")
+		}
+		if opts.ConfigFile != "" {
+			args = append(args, "--config-file", opts.ConfigFile)
+		}
+		if opts.ShowSecrets {
+			return newAutoError(errors.New("SetAllConfigWithOptions does not support ShowSecrets option"), "", "", 1)
 		}
 	}
 	for k, v := range config {
@@ -311,6 +351,12 @@ func (l *LocalWorkspace) RemoveConfigWithOptions(
 		if opts.Path {
 			args = append(args, "--path")
 		}
+		if opts.ConfigFile != "" {
+			args = append(args, "--config-file", opts.ConfigFile)
+		}
+		if opts.ShowSecrets {
+			return newAutoError(errors.New("RemoveConfigWithOptions does not support ShowSecrets option"), "", "", 1)
+		}
 	}
 	args = append(args, key, "--stack", stackName)
 	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, args...)
@@ -336,6 +382,12 @@ func (l *LocalWorkspace) RemoveAllConfigWithOptions(
 	if opts != nil {
 		if opts.Path {
 			args = append(args, "--path")
+		}
+		if opts.ConfigFile != "" {
+			args = append(args, "--config-file", opts.ConfigFile)
+		}
+		if opts.ShowSecrets {
+			return newAutoError(errors.New("RemoveAllConfigWithOptions does not support ShowSecrets option"), "", "", 1)
 		}
 	}
 	args = append(args, keys...)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -1041,8 +1041,9 @@ func (s *Stack) GetAllConfig(ctx context.Context) (ConfigMap, error) {
 	return s.Workspace().GetAllConfig(ctx, s.Name())
 }
 
-// GetAllConfigWithOptions returns the full config map using the optional ConfigOptions.
-func (s *Stack) GetAllConfigWithOptions(ctx context.Context, opts *ConfigOptions) (ConfigMap, error) {
+// GetAllConfigWithOptions returns the full config map with optional ConfigAllConfigOptions.
+// Allows using a config file and controlling how secrets are shown
+func (s *Stack) GetAllConfigWithOptions(ctx context.Context, opts *GetAllConfigOptions) (ConfigMap, error) {
 	return s.Workspace().GetAllConfigWithOptions(ctx, s.Name(), opts)
 }
 

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -1041,6 +1041,11 @@ func (s *Stack) GetAllConfig(ctx context.Context) (ConfigMap, error) {
 	return s.Workspace().GetAllConfig(ctx, s.Name())
 }
 
+// GetAllConfigWithOptions returns the full config map using the optional ConfigOptions.
+func (s *Stack) GetAllConfigWithOptions(ctx context.Context, opts *ConfigOptions) (ConfigMap, error) {
+	return s.Workspace().GetAllConfigWithOptions(ctx, s.Name(), opts)
+}
+
 // SetConfig sets the specified config key-value pair.
 func (s *Stack) SetConfig(ctx context.Context, key string, val ConfigValue) error {
 	return s.Workspace().SetConfig(ctx, s.Name(), key, val)

--- a/sdk/go/auto/workspace.go
+++ b/sdk/go/auto/workspace.go
@@ -62,9 +62,9 @@ type Workspace interface {
 	// GetAllConfig returns the config map for the specified stack name, scoped to the current workspace.
 	GetAllConfig(context.Context, string) (ConfigMap, error)
 	// GetAllConfigWithOptions returns the config map for the specified stack name
-	// using the optional ConfigOptions,
+	// using the optional GetAllConfigOptions,
 	// scoped to the current workspace.
-	GetAllConfigWithOptions(context.Context, string, *ConfigOptions) (ConfigMap, error)
+	GetAllConfigWithOptions(context.Context, string, *GetAllConfigOptions) (ConfigMap, error)
 	// SetConfig sets the specified key-value pair on the provided stack name.
 	SetConfig(context.Context, string, string, ConfigValue) error
 	// SetConfigWithOptions sets the specified key-value pair on the provided stack name
@@ -168,12 +168,18 @@ type ConfigValue struct {
 }
 
 // ConfigOptions is a configuration option used by a Pulumi program.
-// Allows to use the path flag while getting/setting the configuration.
-// Allows to use the config file flag while getting/setting the configuration.
-// Allows to show secrets while getting the configuration.
 type ConfigOptions struct {
-	Path        bool
-	ConfigFile  string
+	// Allows to use the path flag while getting/setting the configuration.
+	Path bool
+	// Allows to use the config file flag while getting/setting the configuration.
+	ConfigFile string
+}
+
+// GetAllConfigOptions is a configuration option used by a Pulumi program.
+type GetAllConfigOptions struct {
+	// Allows to use the config file flag while getting/setting the configuration.
+	ConfigFile string
+	// Allows to show secrets while getting the configuration.
 	ShowSecrets bool
 }
 

--- a/sdk/go/auto/workspace.go
+++ b/sdk/go/auto/workspace.go
@@ -61,6 +61,10 @@ type Workspace interface {
 	GetConfigWithOptions(context.Context, string, string, *ConfigOptions) (ConfigValue, error)
 	// GetAllConfig returns the config map for the specified stack name, scoped to the current workspace.
 	GetAllConfig(context.Context, string) (ConfigMap, error)
+	// GetAllConfigWithOptions returns the config map for the specified stack name
+	// using the optional ConfigOptions,
+	// scoped to the current workspace.
+	GetAllConfigWithOptions(context.Context, string, *ConfigOptions) (ConfigMap, error)
 	// SetConfig sets the specified key-value pair on the provided stack name.
 	SetConfig(context.Context, string, string, ConfigValue) error
 	// SetConfigWithOptions sets the specified key-value pair on the provided stack name
@@ -165,8 +169,12 @@ type ConfigValue struct {
 
 // ConfigOptions is a configuration option used by a Pulumi program.
 // Allows to use the path flag while getting/setting the configuration.
+// Allows to use the config file flag while getting/setting the configuration.
+// Allows to show secrets while getting the configuration.
 type ConfigOptions struct {
-	Path bool
+	Path        bool
+	ConfigFile  string
+	ShowSecrets bool
 }
 
 // ConfigMap is a map of ConfigValue used by Pulumi programs.


### PR DESCRIPTION
Add ConfigFile to ConfigOptions for GetConfig and SetConfig operations to allow for users to specify a config file to read and write to during these operations.

Add a new GetAllConfigWithOptions function to allow users to specify a config file to read from and also if they want to show secrets

Error handling has been added to operations that do not support specific config options such as SetAllConfigWithOptions returning a newAutoError if ShowSecrets is set to true in the ConfigOptions.

GetAllConfig has been refactored to use the new GetAllConfigWithOptions function to follow the pattern the other functions are using.

Test cases have been added to test the new functionality and error handling and also to verify that the GetallConfig refactor works as it previously did.