### PR TITLE
Clean up environment variable checks in `pkg/cmd`

### DIFF
--- a/pkg/cmd/pulumi/ai.go
+++ b/pkg/cmd/pulumi/ai.go
@@ -24,6 +24,7 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
@@ -56,7 +57,7 @@ func newAICommand() *cobra.Command {
 		Use:    "ai",
 		Short:  "Basic Pulumi AI CLI commands.",
 		Long:   "Contains the current set of supported CLI functionality for the Pulumi AI service.",
-		Hidden: !hasExperimentalCommands(),
+		Hidden: !env.Experimental.Value(),
 		Args:   cmdutil.NoArgs,
 		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/pkg/cmd/pulumi/convert-trace.go
+++ b/pkg/cmd/pulumi/convert-trace.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
@@ -714,7 +715,7 @@ func newConvertTraceCmd() *cobra.Command {
 			"pprof format. The converted trace is written to stdout, and can be\n" +
 			"inspected using `go tool pprof`.",
 		Args:   cmdutil.ExactArgs(1),
-		Hidden: !hasDebugCommands(),
+		Hidden: !env.DebugCommands.Value(),
 		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			store := appdash.NewMemoryStore()
 			if err := readTrace(args[0], store); err != nil {

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -111,7 +111,7 @@ func newDestroyCmd() *cobra.Command {
 				skipPreview = true
 			}
 
-			yes = yes || skipPreview || skipConfirmations()
+			yes = yes || skipPreview || env.SkipConfirmations.Value()
 			interactive := cmdutil.Interactive()
 			if !interactive && !yes && !previewOnly {
 				return errors.New("--yes or --skip-preview or --preview-only " +
@@ -277,12 +277,12 @@ func newDestroyCmd() *cobra.Command {
 				Refresh:                   refreshOption,
 				Targets:                   deploy.NewUrnTargets(targetUrns),
 				TargetDependents:          targetDependents,
-				UseLegacyDiff:             useLegacyDiff(),
-				UseLegacyRefreshDiff:      useLegacyRefreshDiff(),
-				DisableProviderPreview:    disableProviderPreview(),
-				DisableResourceReferences: disableResourceReferences(),
-				DisableOutputValues:       disableOutputValues(),
-				Experimental:              hasExperimentalCommands(),
+				UseLegacyDiff:             env.EnableLegacyDiff.Value(),
+				UseLegacyRefreshDiff:      env.EnableLegacyRefreshDiff.Value(),
+				DisableProviderPreview:    env.DisableProviderPreview.Value(),
+				DisableResourceReferences: env.DisableResourceReferences.Value(),
+				DisableOutputValues:       env.DisableOutputValues.Value(),
+				Experimental:              env.Experimental.Value(),
 				ContinueOnError:           continueOnError,
 			}
 
@@ -405,7 +405,7 @@ func newDestroyCmd() *cobra.Command {
 	// Remote flags
 	remoteArgs.applyFlags(cmd)
 
-	if hasDebugCommands() {
+	if env.DebugCommands.Value() {
 		cmd.PersistentFlags().StringVar(
 			&eventLogPath, "event-log", "",
 			"Log events to a file at this path")

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -793,7 +793,7 @@ func newImportCmd() *cobra.Command {
 				return err
 			}
 
-			yes = yes || skipPreview || skipConfirmations()
+			yes = yes || skipPreview || env.SkipConfirmations.Value()
 			interactive := cmdutil.Interactive()
 			if !interactive && !yes && !previewOnly {
 				return errors.New("--yes or --skip-preview or --preview-only" +
@@ -942,9 +942,9 @@ func newImportCmd() *cobra.Command {
 			opts.Engine = engine.UpdateOptions{
 				Parallel:             parallel,
 				Debug:                debug,
-				UseLegacyDiff:        useLegacyDiff(),
-				UseLegacyRefreshDiff: useLegacyRefreshDiff(),
-				Experimental:         hasExperimentalCommands(),
+				UseLegacyDiff:        env.EnableLegacyDiff.Value(),
+				UseLegacyRefreshDiff: env.EnableLegacyRefreshDiff.Value(),
+				Experimental:         env.Experimental.Value(),
 			}
 
 			_, err = s.Import(ctx, backend.UpdateOperation{
@@ -1082,7 +1082,7 @@ func newImportCmd() *cobra.Command {
 		&from, "from", "",
 		"Invoke a converter to import the resources")
 
-	if hasDebugCommands() {
+	if env.DebugCommands.Value() {
 		cmd.PersistentFlags().StringVar(
 			&eventLogPath, "event-log", "",
 			"Log events to a file at this path")

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -607,7 +608,7 @@ func newNewCmd() *cobra.Command {
 				return nil
 			}
 
-			args.yes = args.yes || skipConfirmations()
+			args.yes = args.yes || env.SkipConfirmations.Value()
 			args.interactive = isInteractive()
 			return runNew(ctx, args)
 		}),

--- a/pkg/cmd/pulumi/plugin_rm.go
+++ b/pkg/cmd/pulumi/plugin_rm.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/go-multierror"
@@ -51,7 +52,7 @@ func newPluginRmCmd() *cobra.Command {
 			"in order to execute a Pulumi program, it must be re-downloaded and installed\n" +
 			"using the plugin install command.",
 		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
-			yes = yes || skipConfirmations()
+			yes = yes || env.SkipConfirmations.Value()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/policy_rm.go
+++ b/pkg/cmd/pulumi/policy_rm.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/spf13/cobra"
@@ -39,7 +40,7 @@ func newPolicyRmCmd() *cobra.Command {
 			"The Policy Pack must be disabled from all Policy Groups before it can be removed.",
 		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			yes = yes || skipConfirmations()
+			yes = yes || env.SkipConfirmations.Value()
 			// Obtain current PolicyPack, tied to the Pulumi Cloud backend.
 			policyPack, err := requirePolicyPack(ctx, args[0], cmdBackend.DefaultLoginManager)
 			if err != nil {

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -38,6 +38,7 @@ import (
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -438,17 +439,17 @@ func newPreviewCmd() *cobra.Command {
 					Debug:                     debug,
 					Refresh:                   refreshOption,
 					ReplaceTargets:            deploy.NewUrnTargets(replaceURNs),
-					UseLegacyDiff:             useLegacyDiff(),
-					UseLegacyRefreshDiff:      useLegacyRefreshDiff(),
-					DisableProviderPreview:    disableProviderPreview(),
-					DisableResourceReferences: disableResourceReferences(),
-					DisableOutputValues:       disableOutputValues(),
+					UseLegacyDiff:             env.EnableLegacyDiff.Value(),
+					UseLegacyRefreshDiff:      env.EnableLegacyRefreshDiff.Value(),
+					DisableProviderPreview:    env.DisableProviderPreview.Value(),
+					DisableResourceReferences: env.DisableResourceReferences.Value(),
+					DisableOutputValues:       env.DisableOutputValues.Value(),
 					Targets:                   deploy.NewUrnTargets(targetURNs),
 					TargetDependents:          targetDependents,
 					// If we're trying to save a plan then we _need_ to generate it. We also turn this on in
 					// experimental mode to just get more testing of it.
-					GeneratePlan:   hasExperimentalCommands() || planFilePath != "",
-					Experimental:   hasExperimentalCommands(),
+					GeneratePlan:   env.Experimental.Value() || planFilePath != "",
+					Experimental:   env.Experimental.Value(),
 					AttachDebugger: attachDebugger,
 				},
 				Display: displayOpts,
@@ -557,7 +558,7 @@ func newPreviewCmd() *cobra.Command {
 		&showSecrets, "show-secrets", "", false,
 		"[EXPERIMENTAL] Emit secrets in plaintext in the plan file. Defaults to `false`")
 
-	if !hasExperimentalCommands() {
+	if !env.Experimental.Value() {
 		contract.AssertNoErrorf(cmd.PersistentFlags().MarkHidden("save-plan"),
 			`Could not mark "save-plan" as hidden`)
 		contract.AssertNoErrorf(cmd.Flags().MarkHidden("show-secrets"),
@@ -643,7 +644,7 @@ func newPreviewCmd() *cobra.Command {
 	// Remote flags
 	remoteArgs.applyFlags(cmd)
 
-	if hasDebugCommands() {
+	if env.DebugCommands.Value() {
 		cmd.PersistentFlags().StringVar(
 			&eventLogPath, "event-log", "",
 			"Log events to a file at this path")

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -415,7 +415,7 @@ func NewPulumiCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&tracingHeaderFlag, "tracing-header", "",
 		"Include the tracing header with the given contents.")
 
-	if !hasDebugCommands() {
+	if !env.DebugCommands.Value() {
 		err := cmd.PersistentFlags().MarkHidden("tracing-header")
 		contract.IgnoreError(err)
 	}

--- a/pkg/cmd/pulumi/query.go
+++ b/pkg/cmd/pulumi/query.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
@@ -49,7 +50,7 @@ func newQueryCmd() *cobra.Command {
 			"The program to run is loaded from the project in the current directory by default. Use the `-C` or\n" +
 			"`--cwd` flag to use a different directory.",
 		Args:   cmdutil.NoArgs,
-		Hidden: !hasExperimentalCommands() && !hasDebugCommands(),
+		Hidden: !env.Experimental.Value() && !env.DebugCommands.Value(),
 		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			interactive := cmdutil.Interactive()
@@ -82,7 +83,7 @@ issue at https://github.com/pulumi/pulumi/issues/16964.
 			}
 
 			opts.Engine = engine.UpdateOptions{
-				Experimental: hasExperimentalCommands(),
+				Experimental: env.Experimental.Value(),
 			}
 
 			err = b.Query(ctx, backend.QueryOperation{

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -36,6 +36,7 @@ import (
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -101,7 +102,7 @@ func newRefreshCmd() *cobra.Command {
 				skipPreview = true
 			}
 
-			yes = yes || skipPreview || skipConfirmations()
+			yes = yes || skipPreview || env.SkipConfirmations.Value()
 			interactive := cmdutil.Interactive()
 			if !interactive && !yes && !previewOnly {
 				return errors.New("--yes or --skip-preview or --preview-only " +
@@ -269,13 +270,13 @@ func newRefreshCmd() *cobra.Command {
 			opts.Engine = engine.UpdateOptions{
 				Parallel:                  parallel,
 				Debug:                     debug,
-				UseLegacyDiff:             useLegacyDiff(),
-				UseLegacyRefreshDiff:      useLegacyRefreshDiff(),
-				DisableProviderPreview:    disableProviderPreview(),
-				DisableResourceReferences: disableResourceReferences(),
-				DisableOutputValues:       disableOutputValues(),
+				UseLegacyDiff:             env.EnableLegacyDiff.Value(),
+				UseLegacyRefreshDiff:      env.EnableLegacyRefreshDiff.Value(),
+				DisableProviderPreview:    env.DisableProviderPreview.Value(),
+				DisableResourceReferences: env.DisableResourceReferences.Value(),
+				DisableOutputValues:       env.DisableOutputValues.Value(),
 				Targets:                   deploy.NewUrnTargets(targetUrns),
-				Experimental:              hasExperimentalCommands(),
+				Experimental:              env.Experimental.Value(),
 			}
 
 			changes, err := s.Refresh(ctx, backend.UpdateOperation{
@@ -373,7 +374,7 @@ func newRefreshCmd() *cobra.Command {
 	// Remote flags
 	remoteArgs.applyFlags(cmd)
 
-	if hasDebugCommands() {
+	if env.DebugCommands.Value() {
 		cmd.PersistentFlags().StringVar(
 			&eventLogPath, "event-log", "",
 			"Log events to a file at this path")

--- a/pkg/cmd/pulumi/replay_events.go
+++ b/pkg/cmd/pulumi/replay_events.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -59,7 +60,7 @@ func newReplayEventsCmd() *cobra.Command {
 			"This command loads events from the indicated file and renders them\n" +
 			"using either the progress view or the diff view.\n",
 		Args:   cmdutil.ExactArgs(2),
-		Hidden: !hasDebugCommands(),
+		Hidden: !env.DebugCommands.Value(),
 		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			var action apitype.UpdateKind
 			switch args[0] {

--- a/pkg/cmd/pulumi/stack_rm.go
+++ b/pkg/cmd/pulumi/stack_rm.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 
 	"github.com/spf13/cobra"
@@ -53,7 +54,7 @@ func newStackRmCmd() *cobra.Command {
 		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
-			yes = yes || skipConfirmations()
+			yes = yes || env.SkipConfirmations.Value()
 			// Use the stack provided or, if missing, default to the current one.
 			if len(args) > 0 {
 				if stack != "" {

--- a/pkg/cmd/pulumi/state_delete.go
+++ b/pkg/cmd/pulumi/state_delete.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/edit"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 
@@ -41,7 +42,7 @@ type stateDeleteCmd struct {
 func (cmd *stateDeleteCmd) Run(
 	ctx context.Context, args []string, ws pkgWorkspace.Context, lm backend.LoginManager,
 ) error {
-	cmd.yes = cmd.yes || skipConfirmations()
+	cmd.yes = cmd.yes || env.SkipConfirmations.Value()
 	var urn resource.URN
 	if len(args) == 0 {
 		if !cmdutil.Interactive() {

--- a/pkg/cmd/pulumi/state_edit.go
+++ b/pkg/cmd/pulumi/state_edit.go
@@ -33,6 +33,7 @@ import (
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/spf13/cobra"
@@ -47,7 +48,7 @@ func newStateEditCommand() *cobra.Command {
 		Use: "edit",
 		// TODO(dixler) Add test for unicode round-tripping before unhiding.
 		// TODO(fraser) This needs tests _in general_ it is currently basically untested.
-		Hidden: !hasExperimentalCommands(),
+		Hidden: !env.Experimental.Value(),
 		Short:  "Edit the current stack's state in your EDITOR",
 		Long: `[EXPERIMENTAL] Edit the current stack's state in your EDITOR
 

--- a/pkg/cmd/pulumi/state_rename.go
+++ b/pkg/cmd/pulumi/state_rename.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/resource/edit"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -179,7 +180,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
-			yes = yes || skipConfirmations()
+			yes = yes || env.SkipConfirmations.Value()
 
 			if len(args) < 2 && !cmdutil.Interactive() {
 				return missingNonInteractiveArg("resource URN", "new name")

--- a/pkg/cmd/pulumi/state_unprotect.go
+++ b/pkg/cmd/pulumi/state_unprotect.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/edit"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -49,7 +50,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
-			yes = yes || skipConfirmations()
+			yes = yes || env.SkipConfirmations.Value()
 			// Show the confirmation prompt if the user didn't pass the --yes parameter to skip it.
 			showPrompt := !yes
 

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -168,17 +168,17 @@ func newUpCmd() *cobra.Command {
 			Debug:                     debug,
 			Refresh:                   refreshOption,
 			ReplaceTargets:            deploy.NewUrnTargets(replaceURNs),
-			UseLegacyDiff:             useLegacyDiff(),
-			UseLegacyRefreshDiff:      useLegacyRefreshDiff(),
-			DisableProviderPreview:    disableProviderPreview(),
-			DisableResourceReferences: disableResourceReferences(),
-			DisableOutputValues:       disableOutputValues(),
+			UseLegacyDiff:             env.EnableLegacyDiff.Value(),
+			UseLegacyRefreshDiff:      env.EnableLegacyRefreshDiff.Value(),
+			DisableProviderPreview:    env.DisableProviderPreview.Value(),
+			DisableResourceReferences: env.DisableResourceReferences.Value(),
+			DisableOutputValues:       env.DisableOutputValues.Value(),
 			Targets:                   deploy.NewUrnTargets(targetURNs),
 			TargetDependents:          targetDependents,
 			// Trigger a plan to be generated during the preview phase which can be constrained to during the
 			// update phase.
 			GeneratePlan:    true,
-			Experimental:    hasExperimentalCommands(),
+			Experimental:    env.Experimental.Value(),
 			ContinueOnError: continueOnError,
 			AttachDebugger:  attachDebugger,
 		}
@@ -416,10 +416,10 @@ func newUpCmd() *cobra.Command {
 
 			// If we're in experimental mode then we trigger a plan to be generated during the preview phase
 			// which will be constrained to during the update phase.
-			GeneratePlan: hasExperimentalCommands(),
-			Experimental: hasExperimentalCommands(),
+			GeneratePlan: env.Experimental.Value(),
+			Experimental: env.Experimental.Value(),
 
-			UseLegacyRefreshDiff: useLegacyRefreshDiff(),
+			UseLegacyRefreshDiff: env.EnableLegacyRefreshDiff.Value(),
 			ContinueOnError:      continueOnError,
 
 			AttachDebugger: attachDebugger,
@@ -479,7 +479,7 @@ func newUpCmd() *cobra.Command {
 				skipPreview = true
 			}
 
-			yes = yes || skipPreview || skipConfirmations()
+			yes = yes || skipPreview || env.SkipConfirmations.Value()
 
 			interactive := cmdutil.Interactive()
 			if !interactive && !yes {
@@ -703,14 +703,14 @@ func newUpCmd() *cobra.Command {
 		"[EXPERIMENTAL] Path to a plan file to use for the update. The update will not "+
 			"perform operations that exceed its plan (e.g. replacements instead of updates, or updates instead"+
 			"of sames).")
-	if !hasExperimentalCommands() {
+	if !env.Experimental.Value() {
 		contract.AssertNoErrorf(cmd.PersistentFlags().MarkHidden("plan"), `Could not mark "plan" as hidden`)
 	}
 
 	// Remote flags
 	remoteArgs.applyFlags(cmd)
 
-	if hasDebugCommands() {
+	if env.DebugCommands.Value() {
 		cmd.PersistentFlags().StringVar(
 			&eventLogPath, "event-log", "",
 			"Log events to a file at this path")

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -46,7 +46,6 @@ import (
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -54,44 +53,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/deepcopy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
-
-func hasDebugCommands() bool {
-	return env.DebugCommands.Value()
-}
-
-func hasExperimentalCommands() bool {
-	return env.Experimental.Value()
-}
-
-func useLegacyDiff() bool {
-	return env.EnableLegacyDiff.Value()
-}
-
-func useLegacyRefreshDiff() bool {
-	return env.EnableLegacyRefreshDiff.Value()
-}
-
-func disableProviderPreview() bool {
-	return env.DisableProviderPreview.Value()
-}
-
-func disableResourceReferences() bool {
-	return env.DisableResourceReferences.Value()
-}
-
-func disableOutputValues() bool {
-	return env.DisableOutputValues.Value()
-}
-
-// skipConfirmations returns whether or not confirmation prompts should
-// be skipped. This should be used by pass any requirement that a --yes
-// parameter has been set for non-interactive scenarios.
-//
-// This should NOT be used to bypass protections for destructive
-// operations, such as those that will fail without a --force parameter.
-func skipConfirmations() bool {
-	return env.SkipConfirmations.Value()
-}
 
 // Creates a secrets manager for an existing stack, using the stack to pick defaults if necessary and writing any
 // changes back to the stack's configuration where applicable.

--- a/pkg/cmd/pulumi/util_remote.go
+++ b/pkg/cmd/pulumi/util_remote.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -37,7 +38,7 @@ var disableRemote bool
 
 // remoteSupported returns true if the CLI supports remote deployments.
 func remoteSupported() bool {
-	return !disableRemote && hasExperimentalCommands()
+	return !disableRemote && env.Experimental.Value()
 }
 
 // parseEnv parses a `--remote-env` flag value for `--remote`. A value should be of the form

--- a/pkg/cmd/pulumi/view-trace.go
+++ b/pkg/cmd/pulumi/view-trace.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
@@ -54,7 +55,7 @@ func newViewTraceCmd() *cobra.Command {
 			"webserver to display the trace. By default, this server will listen\n" +
 			"port 8008; the --port flag can be used to change this if necessary.",
 		Args:   cmdutil.ExactArgs(1),
-		Hidden: !hasDebugCommands(),
+		Hidden: !env.DebugCommands.Value(),
 		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			url, err := url.Parse(fmt.Sprintf("http://localhost:%d", port))
 			if err != nil {

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -148,12 +149,12 @@ func newWatchCmd() *cobra.Command {
 				Parallel:                  parallel,
 				Debug:                     debug,
 				Refresh:                   refresh,
-				UseLegacyDiff:             useLegacyDiff(),
-				UseLegacyRefreshDiff:      useLegacyRefreshDiff(),
-				DisableProviderPreview:    disableProviderPreview(),
-				DisableResourceReferences: disableResourceReferences(),
-				DisableOutputValues:       disableOutputValues(),
-				Experimental:              hasExperimentalCommands(),
+				UseLegacyDiff:             env.EnableLegacyDiff.Value(),
+				UseLegacyRefreshDiff:      env.EnableLegacyRefreshDiff.Value(),
+				DisableProviderPreview:    env.DisableProviderPreview.Value(),
+				DisableResourceReferences: env.DisableResourceReferences.Value(),
+				DisableOutputValues:       env.DisableOutputValues.Value(),
+				Experimental:              env.Experimental.Value(),
 			}
 
 			err = s.Watch(ctx, backend.UpdateOperation{


### PR DESCRIPTION
Some of our environment variables have helper functions -- e.g. `skipConfirmations` instead of `env.SkipConfirmations.Value`. We don't define these functions for all variables, nor do we use them consistently for the ones that do have them defined, so this commit removes them. In doing so `util.go` gets a bit smaller again and the dependencies on `sdk/go/common/env` (which we'd like to remove some day) become clearer.