### PR TITLE
Log Plugin stdout & stderr as debug (instead of info)

### DIFF
--- a/changelog/pending/20241206--cli-plugin--log-plugin-unstructured-output-to-debug-instead-of-info.yaml
+++ b/changelog/pending/20241206--cli-plugin--log-plugin-unstructured-output-to-debug-instead-of-info.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/plugin
+  description: Log plugin unstructured output to debug instead of info

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -135,8 +135,14 @@ func TestPanickingComponentConfigure(t *testing.T) {
 		Quick:         true,
 		SkipRefresh:   true,
 		NoParallel:    true,
-		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-			assert.Contains(t, stderr.String(), "panic: great sadness\n")
+		ExtraRuntimeValidation: func(t *testing.T, _ integration.RuntimeValidationStackInfo) {
+			const needle = "panic: great sadness\n"
+			haystack := stderr.String()
+			// 2 instances of needle:
+			// - One instance is the returned error.
+			// - Another instance is in the stderr output.
+			assert.Equal(t, 2, strings.Count(haystack, needle),
+				"Expected only two instance of %q in:\n%s", needle, haystack)
 		},
 	})
 }


### PR DESCRIPTION
This commit changes the log level from plugin stdout&stderr to debug, from info. This
change is significant because info is shown by default to users, but debug is not. While
this is a change of plugin aesthetics, it does not effect any runtime behavior. All
plugins, both component providers and custom resource providers, are effected.

> [!IMPORTANT]
> This is a breaking change, in that information which used to be displayed to users will
> now be hidden by default.
>
> We will need to share this change with our users before rolling it out.

The providers team has met and believe that this is the best approach for our
ecosystem. For a full discussion on why this change is necessary, see
[this doc](https://docs.google.com/document/d/1yYrwTwsNoayaIzKyG1l5cl0MjJxiHLsH4NqAvZkQN-I/edit?tab=t.0#heading=h.34v61lg1x4kl).

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2489
Fixes https://github.com/pulumi/pulumi-cloudngfwaws/issues/23
Fixes https://github.com/pulumi/pulumi-ise/issues/9

Taking this change will allow us to revert:
- https://github.com/pulumi/pulumi-databricks/pull/609
- https://github.com/pulumi/pulumi-aws/pull/4650

---

When a provider exists ungracefully, we dump *all* unstructured logs to the user. This
allows providers to output stack traces to users (so they can report them) when a provider
fails. We do not search for `panic` messages to isolate the stack trace, since we cannot
do that effectively in a cross-language way.