### PR TITLE
Split out more `survey` helpers into `ui`

### DIFF
--- a/pkg/cmd/pulumi/deployment_settings_utils.go
+++ b/pkg/cmd/pulumi/deployment_settings_utils.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -72,19 +73,19 @@ func (promptHandlers) AskForConfirmation(prompt string, color colors.Colorizatio
 func (promptHandlers) PromptUser(msg string, options []string, defaultOption string,
 	colorization colors.Colorization,
 ) string {
-	return promptUser(msg, options, defaultOption, colorization)
+	return ui.PromptUser(msg, options, defaultOption, colorization)
 }
 
 func (promptHandlers) PromptUserSkippable(yes bool, msg string, options []string, defaultOption string,
 	colorization colors.Colorization,
 ) string {
-	return promptUserSkippable(yes, msg, options, defaultOption, colorization)
+	return ui.PromptUserSkippable(yes, msg, options, defaultOption, colorization)
 }
 
 func (promptHandlers) PromptUserMultiSkippable(yes bool, msg string, options []string, defaultOptions []string,
 	colorization colors.Colorization,
 ) []string {
-	return promptUserMultiSkippable(yes, msg, options, defaultOptions, colorization)
+	return ui.PromptUserMultiSkippable(yes, msg, options, defaultOptions, colorization)
 }
 
 func (promptHandlers) PromptForValue(
@@ -188,7 +189,7 @@ func askForConfirmation(prompt string, color colors.Colorization, defaultValue b
 		def = optYes
 	}
 	options := []string{optYes, optNo}
-	response := promptUserSkippable(yes, prompt, options, def, color)
+	response := ui.PromptUserSkippable(yes, prompt, options, def, color)
 	return response == optYes
 }
 

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/diy"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -239,7 +240,7 @@ func chooseAccount(accounts map[string]workspace.Account, opts display.Options) 
 		Message:  message,
 		Options:  acts,
 		PageSize: pageSize,
-	}, &option, surveyIcons(opts.Color)); err != nil {
+	}, &option, ui.SurveyIcons(opts.Color)); err != nil {
 		return "", errors.New("no account selected; please use `pulumi login --interactive` to choose one")
 	}
 

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -730,7 +731,7 @@ func validateProjectName(ctx context.Context, b backend.Backend,
 
 		accept := fmt.Sprintf("Use '%s' anyway", projectName)
 		retry := "Specify a different project name"
-		response := promptUser(prompt, []string{accept, retry}, accept, opts.Color)
+		response := ui.PromptUser(prompt, []string{accept, retry}, accept, opts.Color)
 
 		if response != accept {
 			return errRetry
@@ -939,7 +940,7 @@ func promptRuntimeOptions(ctx *plugin.Context, info *workspace.ProjectRuntimeInf
 				if err := survey.AskOne(&survey.Select{
 					Message: message,
 					Options: choices,
-				}, &response, surveyIcons(opts.Color), nil); err != nil {
+				}, &response, ui.SurveyIcons(opts.Color), nil); err != nil {
 					return nil, err
 				}
 				options[optionPrompt.Key] = choiceMap[response]
@@ -1079,7 +1080,7 @@ func chooseTemplate(templates []workspace.Template, opts display.Options) (works
 		Message:  message,
 		Options:  options,
 		PageSize: pageSize,
-	}, &option, surveyIcons(opts.Color)); err != nil {
+	}, &option, ui.SurveyIcons(opts.Color)); err != nil {
 		return workspace.Template{}, errors.New(chooseTemplateErr)
 	}
 

--- a/pkg/cmd/pulumi/new_ai.go
+++ b/pkg/cmd/pulumi/new_ai.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 )
 
@@ -67,7 +68,7 @@ func runAINew(
 		if err = survey.AskOne(&survey.Select{
 			Message: "Please select a language for your project:",
 			Options: languageOptions,
-		}, &rawLanguageSelect, surveyIcons(opts.Color)); err != nil {
+		}, &rawLanguageSelect, ui.SurveyIcons(opts.Color)); err != nil {
 			return "", err
 		}
 		err = args.aiLanguage.Set(rawLanguageSelect)
@@ -253,7 +254,7 @@ func runAINewPromptStep(
 			Description: func(opt string, _ int) string {
 				return continuePromptOptionsDescriptions[opt]
 			},
-		}, &continueSelection, surveyIcons(opts.Color)); err != nil {
+		}, &continueSelection, ui.SurveyIcons(opts.Color)); err != nil {
 			return "", "", "", "", err
 		}
 		if continueSelection == noSelection {
@@ -284,7 +285,7 @@ func chooseWithAIOrTemplate(opts display.Options) (string, error) {
 		Description: func(opt string, _ int) string {
 			return optionsDescriptionMap[opt]
 		},
-	}, &ai, surveyIcons(opts.Color)); err != nil {
+	}, &ai, ui.SurveyIcons(opts.Color)); err != nil {
 		return "template", err
 	}
 

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -26,6 +26,7 @@ import (
 	surveycore "github.com/AlecAivazis/survey/v2/core"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -273,7 +274,7 @@ func choosePolicyPackTemplate(templates []workspace.PolicyPackTemplate,
 		Message:  message,
 		Options:  options,
 		PageSize: optimalPageSize(optimalPageSizeOpts{nopts: len(options)}),
-	}, &option, surveyIcons(opts.Color)); err != nil {
+	}, &option, ui.SurveyIcons(opts.Color)); err != nil {
 		return workspace.PolicyPackTemplate{}, errors.New(chooseTemplateErr)
 	}
 	return optionToTemplateMap[option], nil

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/edit"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
@@ -112,7 +113,7 @@ func locateStackResource(opts display.Options, snap *deploy.Snapshot, urn resour
 		Message:  prompt,
 		Options:  options,
 		PageSize: optimalPageSize(optimalPageSizeOpts{nopts: len(options)}),
-	}, &option, surveyIcons(opts.Color)); err != nil {
+	}, &option, ui.SurveyIcons(opts.Color)); err != nil {
 		return nil, errors.New("no resource selected")
 	}
 
@@ -167,7 +168,7 @@ func totalStateEdit(ctx context.Context, s backend.Stack, showPrompt bool, opts 
 		prompt += "This command will edit your stack's state directly. Confirm?"
 		if err = survey.AskOne(&survey.Confirm{
 			Message: prompt,
-		}, &confirm, surveyIcons(opts.Color)); err != nil || !confirm {
+		}, &confirm, ui.SurveyIcons(opts.Color)); err != nil || !confirm {
 			return result.FprintBailf(os.Stdout, "confirmation declined")
 		}
 	}
@@ -243,7 +244,7 @@ func getURNFromState(
 	err := survey.AskOne(&survey.Select{
 		Message: prompt,
 		Options: urnList,
-	}, &urn, survey.WithValidator(survey.Required), surveyIcons(cmdutil.GetGlobalColorization()))
+	}, &urn, survey.WithValidator(survey.Required), ui.SurveyIcons(cmdutil.GetGlobalColorization()))
 	if err != nil {
 		return "", err
 	}
@@ -258,7 +259,7 @@ func getNewResourceName() (tokens.QName, error) {
 	var resourceName string
 	err := survey.AskOne(&survey.Input{
 		Message: "Choose a new resource name:",
-	}, &resourceName, surveyIcons(cmdutil.GetGlobalColorization()),
+	}, &resourceName, ui.SurveyIcons(cmdutil.GetGlobalColorization()),
 		survey.WithValidator(func(ans interface{}) error {
 			if tokens.IsQName(ans.(string)) {
 				return nil

--- a/pkg/cmd/pulumi/state_edit.go
+++ b/pkg/cmd/pulumi/state_edit.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -196,7 +197,7 @@ func (cmd *stateEditCmd) Run(ctx context.Context, s backend.Stack) error {
 			}
 		}
 
-		switch response := promptUser(msg, options, edit, cmd.Colorizer); response {
+		switch response := ui.PromptUser(msg, options, edit, cmd.Colorizer); response {
 		case accept:
 			return saveSnapshot(ctx, s, news, false /* force */)
 		case edit:

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/graph"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
@@ -426,7 +427,7 @@ func (cmd *stateMoveCmd) Run(
 			no,
 		}
 
-		switch response := promptUser(msg, options, no, cmdutil.GetGlobalColorization()); response {
+		switch response := ui.PromptUser(msg, options, no, cmdutil.GetGlobalColorization()); response {
 		case yes:
 		// continue
 		case no:

--- a/pkg/cmd/pulumi/state_rename.go
+++ b/pkg/cmd/pulumi/state_rename.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/resource/edit"
@@ -191,7 +192,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 			switch len(args) {
 			case 0: // We got neither the URN nor the name.
 				var snap *deploy.Snapshot
-				err := surveyStack(
+				err := ui.SurveyStack(
 					func() (err error) {
 						urn, err = getURNFromState(ctx, ws, backend.DefaultLoginManager, stack, &snap, "Select a resource to rename:")
 						if err != nil {

--- a/pkg/cmd/pulumi/state_repair.go
+++ b/pkg/cmd/pulumi/state_repair.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/version"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -198,7 +199,7 @@ func (cmd *stateRepairCmd) run(ctx context.Context) error {
 		msg := "This command will edit your stack's state directly. Confirm?"
 		options := []string{yes, no}
 
-		switch response := promptUser(
+		switch response := ui.PromptUser(
 			msg, options, no, cmd.Args.Colorizer,
 			survey.WithStdio(cmd.Stdin, cmd.Stdout, cmd.Stderr),
 		); response {

--- a/pkg/cmd/pulumi/ui/survey.go
+++ b/pkg/cmd/pulumi/ui/survey.go
@@ -1,0 +1,135 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ui
+
+import (
+	survey "github.com/AlecAivazis/survey/v2"
+	surveycore "github.com/AlecAivazis/survey/v2/core"
+	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+)
+
+func SurveyIcons(color colors.Colorization) survey.AskOpt {
+	return survey.WithIcons(func(icons *survey.IconSet) {
+		icons.Question = survey.Icon{}
+		icons.SelectFocus = survey.Icon{Text: color.Colorize(colors.BrightGreen + ">" + colors.Reset)}
+	})
+}
+
+// Ask multiple survey based questions.
+//
+// Ctrl-C will go back in the stack, and valid answers will go forward.
+func SurveyStack(interactions ...func() error) error {
+	for i := 0; i < len(interactions); {
+		err := interactions[i]()
+		switch err {
+		// No error, so go to the next interaction.
+		case nil:
+			i++
+		// We have received an interrupt, so go back to the previous interaction.
+		case terminal.InterruptErr:
+			// If we have received in interrupt at the beginning of the stack,
+			// the user has asked to go back to before the stack. We can't do
+			// that, so we just return the interrupt.
+			if i == 0 {
+				return err
+			}
+			i--
+		// We have received an unexpected error, so return it.
+		default:
+			return err
+		}
+	}
+	return nil
+}
+
+// PromptUserSkippable wraps over promptUser making it skippable through the "yes" parameter
+// commonly being the value of the --yes flag used in each command.
+// If yes is true, defaultValue is returned without prompting.
+func PromptUserSkippable(yes bool, msg string, options []string, defaultOption string,
+	colorization colors.Colorization,
+) string {
+	if yes {
+		return defaultOption
+	}
+	return PromptUser(msg, options, defaultOption, colorization)
+}
+
+// PromptUser prompts the user for a value with a list of options. Hitting enter accepts the
+// default.
+func PromptUser(
+	msg string,
+	options []string,
+	defaultOption string,
+	colorization colors.Colorization,
+	surveyAskOpts ...survey.AskOpt,
+) string {
+	prompt := "\b" + colorization.Colorize(colors.SpecPrompt+msg+colors.Reset)
+	surveycore.DisableColor = true
+
+	allSurveyAskOpts := append(
+		surveyAskOpts,
+		survey.WithIcons(func(icons *survey.IconSet) {
+			icons.Question = survey.Icon{}
+			icons.SelectFocus = survey.Icon{Text: colorization.Colorize(colors.BrightGreen + ">" + colors.Reset)}
+		}),
+	)
+
+	var response string
+	if err := survey.AskOne(&survey.Select{
+		Message: prompt,
+		Options: options,
+		Default: defaultOption,
+	}, &response, allSurveyAskOpts...); err != nil {
+		return ""
+	}
+	return response
+}
+
+// PromptUserMultiSkippable wraps over promptUserMulti making it skippable through the "yes" parameter
+// commonly being the value of the --yes flag used in each command.
+// If yes is true, defaultValue is returned without prompting.
+func PromptUserMultiSkippable(yes bool, msg string, options []string, defaultOptions []string,
+	colorization colors.Colorization,
+) []string {
+	if yes {
+		return defaultOptions
+	}
+	return PromptUserMulti(msg, options, defaultOptions, colorization)
+}
+
+// PromptUserMulti prompts the user for a value with a list of options, allowing to select none or multiple options.
+// defaultOptions is a set of values to be selected by default.
+func PromptUserMulti(msg string, options []string, defaultOptions []string, colorization colors.Colorization) []string {
+	confirmationHint := " (use enter to accept the current selection)"
+
+	prompt := "\b" + colorization.Colorize(colors.SpecPrompt+msg+colors.Reset) + confirmationHint
+
+	surveycore.DisableColor = true
+	surveyIcons := survey.WithIcons(func(icons *survey.IconSet) {
+		icons.Question = survey.Icon{}
+		icons.SelectFocus = survey.Icon{Text: colorization.Colorize(colors.BrightGreen + ">" + colors.Reset)}
+	})
+
+	var response []string
+	if err := survey.AskOne(&survey.MultiSelect{
+		Message: prompt,
+		Options: options,
+		Default: defaultOptions,
+	}, &response, surveyIcons); err != nil {
+		return []string{}
+	}
+	return response
+}


### PR DESCRIPTION
This commit continues pushing more of `pkg/cmd/pulumi/util.go` into better namespaces. This time, it's the turn of several of our `survey` helpers to move to `ui`.