### PR TITLE
Abstract time formatting in `pkg/cmd/pulumi`

### DIFF
--- a/pkg/cmd/pulumi/cmd/time.go
+++ b/pkg/cmd/pulumi/cmd/time.go
@@ -1,0 +1,30 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"time"
+)
+
+// We use RFC 5424 timestamps with millisecond precision for displaying time stamps on log entries. Go does not
+// pre-define a format string for this format, though it is similar to time.RFC3339Nano.
+//
+// See https://tools.ietf.org/html/rfc5424#section-6.2.3.
+const timeFormat = "2006-01-02T15:04:05.000Z07:00"
+
+// FormatTime formats the given time.Time according to RFC 5424, with millisecond precision.
+func FormatTime(t time.Time) string {
+	return t.Format(timeFormat)
+}

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -37,12 +37,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-// We use RFC 5424 timestamps with millisecond precision for displaying time stamps on log entries. Go does not
-// pre-define a format string for this format, though it is similar to time.RFC3339Nano.
-//
-// See https://tools.ietf.org/html/rfc5424#section-6.2.3.
-const timeFormat = "2006-01-02T15:04:05.000Z07:00"
-
 func newLogsCmd() *cobra.Command {
 	var stackName string
 	var follow bool
@@ -59,8 +53,8 @@ func newLogsCmd() *cobra.Command {
 			"provider. For example, for AWS resources, the `pulumi logs` command will query\n" +
 			"CloudWatch Logs for log data relevant to resources in a stack.\n",
 		Args: cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+		Run: cmd.RunCmdFunc(func(cobraCmd *cobra.Command, args []string) error {
+			ctx := cobraCmd.Context()
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 			ws := pkgWorkspace.Instance
 			opts := display.Options{
@@ -126,7 +120,7 @@ func newLogsCmd() *cobra.Command {
 				fmt.Printf(
 					opts.Color.Colorize(colors.BrightMagenta+"Collecting logs for stack %s since %s.\n\n"+colors.Reset),
 					s.Ref().String(),
-					startTime.Format(timeFormat),
+					cmd.FormatTime(*startTime),
 				)
 			}
 
@@ -156,7 +150,7 @@ func newLogsCmd() *cobra.Command {
 
 							entries = append(entries, logEntryJSON{
 								ID:        logEntry.ID,
-								Timestamp: eventTime.UTC().Format(timeFormat),
+								Timestamp: cmd.FormatTime(eventTime.UTC()),
 								Message:   logEntry.Message,
 							})
 
@@ -174,14 +168,14 @@ func newLogsCmd() *cobra.Command {
 						if !jsonOut {
 							fmt.Printf(
 								"%30.30s[%30.30s] %v\n",
-								eventTime.Format(timeFormat),
+								cmd.FormatTime(eventTime),
 								logEntry.ID,
 								strings.TrimRight(logEntry.Message, "\n"),
 							)
 						} else {
 							err = ui.PrintJSON(logEntryJSON{
 								ID:        logEntry.ID,
-								Timestamp: eventTime.UTC().Format(timeFormat),
+								Timestamp: cmd.FormatTime(eventTime.UTC()),
 								Message:   logEntry.Message,
 							})
 							if err != nil {

--- a/pkg/cmd/pulumi/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin_ls.go
@@ -114,11 +114,11 @@ func formatPluginsJSON(plugins []workspace.PluginInfo) error {
 		}
 
 		if !plugin.InstallTime.IsZero() {
-			jsonPluginInfo[idx].InstallTime = makeStringRef(plugin.InstallTime.UTC().Format(timeFormat))
+			jsonPluginInfo[idx].InstallTime = makeStringRef(cmd.FormatTime(plugin.InstallTime.UTC()))
 		}
 
 		if !plugin.LastUsedTime.IsZero() {
-			jsonPluginInfo[idx].LastUsedTime = makeStringRef(plugin.LastUsedTime.UTC().Format(timeFormat))
+			jsonPluginInfo[idx].LastUsedTime = makeStringRef(cmd.FormatTime(plugin.LastUsedTime.UTC()))
 		}
 	}
 

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -155,7 +155,7 @@ func displayUpdatesJSON(updates []backend.UpdateInfo, decrypter config.Decrypter
 		info := updateInfoJSON{
 			Version:     update.Version,
 			Kind:        string(update.Kind),
-			StartTime:   time.Unix(update.StartTime, 0).UTC().Format(timeFormat),
+			StartTime:   cmd.FormatTime(time.Unix(update.StartTime, 0).UTC()),
 			Message:     update.Message,
 			Environment: update.Environment,
 		}
@@ -187,7 +187,7 @@ func displayUpdatesJSON(updates []backend.UpdateInfo, decrypter config.Decrypter
 		}
 		info.Result = string(update.Result)
 		if update.Result != backend.InProgressResult {
-			info.EndTime = makeStringRef(time.Unix(update.EndTime, 0).UTC().Format(timeFormat))
+			info.EndTime = makeStringRef(cmd.FormatTime(time.Unix(update.EndTime, 0).UTC()))
 			resourceChanges := make(map[string]int)
 			for k, v := range update.ResourceChanges {
 				resourceChanges[string(k)] = v

--- a/pkg/cmd/pulumi/stack_ls.go
+++ b/pkg/cmd/pulumi/stack_ls.go
@@ -240,7 +240,7 @@ func formatStackSummariesJSON(
 					updateInProgress := false
 					summaryJSON.UpdateInProgress = &updateInProgress
 				}
-				summaryJSON.LastUpdate = summary.LastUpdate().UTC().Format(timeFormat)
+				summaryJSON.LastUpdate = cmd.FormatTime(summary.LastUpdate().UTC())
 			}
 		}
 


### PR DESCRIPTION
Presently, a shared `timeFormat` is used in several places in `pkg/cmd/pulumi` to format timestamps using the `time.Time.Format` method. This commit pulls this functionality into a `cmdTime` subpackage so that we don't need the shared variable and resulting duplication.