### PR TITLE
[sdk/nodejs] Add getSchema to Provider interface

### DIFF
--- a/changelog/pending/20241206--sdk-nodejs--add-getschema-to-provider-interface.yaml
+++ b/changelog/pending/20241206--sdk-nodejs--add-getschema-to-provider-interface.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Add getSchema to Provider interface

--- a/sdk/nodejs/provider/provider.ts
+++ b/sdk/nodejs/provider/provider.ts
@@ -187,6 +187,14 @@ export interface Provider {
     schema?: string;
 
     /**
+     * Gets the JSON-encoded schema for this provider's package.
+     * Implementations can lazily load or generate the schema when needed.
+     *
+     * @returns A promise that resolves to the JSON-encoded schema string.
+     */
+    getSchema?: () => Promise<string>;
+
+    /**
      * Validates that the given property bag is valid for a resource of the
      * given type.
      *

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -88,10 +88,26 @@ class Server implements grpc.UntypedServiceImplementation {
         const req: any = call.request;
         if (req.getVersion() !== 0) {
             callback(new Error(`unsupported schema version ${req.getVersion()}`), undefined);
+            return;
         }
+
         const resp: any = new provproto.GetSchemaResponse();
-        resp.setSchema(this.provider.schema || "{}");
-        callback(undefined, resp);
+
+        if (this.provider.schema) {
+            resp.setSchema(this.provider.schema);
+            callback(undefined, resp);
+        } else if (this.provider.getSchema) {
+            this.provider
+                .getSchema()
+                .then((schema) => {
+                    resp.setSchema(schema);
+                    callback(undefined, resp);
+                })
+                .catch((err) => callback(err, undefined));
+        } else {
+            resp.setSchema("{}");
+            callback(undefined, resp);
+        }
     }
 
     // Config methods


### PR DESCRIPTION
Originally implemented in https://github.com/pulumi/pulumi/pull/6892, node's Provider interface has a `schema` property of type string. As such, it's required to be set unconditionally at provider class instantiation, not loaded dynamically on demand. This puts an unneeded burden on provider startup to load or calculate the entire schema even though it may never be needed.

This PR adds a `getSchema?: () => Promise<string>;` method in line with gRPC interface functionality. `schema` is still present for backwards compatibility. The server will use `schema` if it's defined, or `getSchema` if not.