### PR TITLE
Break out the `stack ...` command hierarchy

### DIFF
--- a/pkg/cmd/pulumi/cancel.go
+++ b/pkg/cmd/pulumi/cancel.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -78,7 +79,7 @@ func newCancelCmd() *cobra.Command {
 			// Ensure the user really wants to do this.
 			stackName := s.Ref().Name().String()
 			prompt := fmt.Sprintf("This will irreversibly cancel the currently running update for '%s'!", stackName)
-			if cmdutil.Interactive() && (!yes && !confirmPrompt(prompt, stackName, opts)) {
+			if cmdutil.Interactive() && (!yes && !ui.ConfirmPrompt(prompt, stackName, opts)) {
 				return result.FprintBailf(os.Stdout, "confirmation declined")
 			}
 

--- a/pkg/cmd/pulumi/config_test.go
+++ b/pkg/cmd/pulumi/config_test.go
@@ -427,7 +427,7 @@ func TestCopyConfig(t *testing.T) {
 		err := yaml.Unmarshal([]byte("environment:\n  - test2"), &destinationProjectStack)
 		require.NoError(t, err)
 
-		requiresSaving, err := copyEntireConfigMap(
+		requiresSaving, err := stack.CopyEntireConfigMap(
 			context.Background(),
 			stack.SecretsManagerLoader{},
 			sourceStack,

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -814,7 +814,7 @@ func promptAndCreateStack(ctx context.Context, ws pkgWorkspace.Context, b backen
 		if err != nil {
 			return nil, err
 		}
-		s, err := stackInit(ctx, ws, b, stackName, root, setCurrent, secretsProvider)
+		s, err := cmdStack.InitStack(ctx, ws, b, stackName, root, setCurrent, secretsProvider)
 		if err != nil {
 			return nil, err
 		}
@@ -836,7 +836,7 @@ func promptAndCreateStack(ctx context.Context, ws pkgWorkspace.Context, b backen
 		if err != nil {
 			return nil, err
 		}
-		s, err := stackInit(ctx, ws, b, formattedStackName, root, setCurrent, secretsProvider)
+		s, err := cmdStack.InitStack(ctx, ws, b, formattedStackName, root, setCurrent, secretsProvider)
 		if err != nil {
 			if !yes {
 				// Let the user know about the error and loop around to try again.
@@ -847,18 +847,6 @@ func promptAndCreateStack(ctx context.Context, ws pkgWorkspace.Context, b backen
 		}
 		return s, nil
 	}
-}
-
-// stackInit creates the stack.
-func stackInit(
-	ctx context.Context, ws pkgWorkspace.Context, b backend.Backend, stackName string,
-	root string, setCurrent bool, secretsProvider string,
-) (backend.Stack, error) {
-	stackRef, err := b.ParseStackReference(stackName)
-	if err != nil {
-		return nil, err
-	}
-	return cmdStack.CreateStack(ctx, ws, b, stackRef, root, nil, setCurrent, secretsProvider)
 }
 
 // saveConfig saves the config for the stack.

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// mockBackendInstance sets the backendInstance for the test and cleans it up after.
+// mockBackendInstance sets the backend instance for the test and cleans it up after.
 func mockBackendInstance(t *testing.T, b backend.Backend) {
 	t.Cleanup(func() {
 		cmdBackend.BackendInstance = nil

--- a/pkg/cmd/pulumi/plugin_rm.go
+++ b/pkg/cmd/pulumi/plugin_rm.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -113,7 +114,7 @@ func newPluginRmCmd() *cobra.Command {
 				for _, del := range deletes {
 					fmt.Printf("    %s %s\n", del.Kind, del.String())
 				}
-				if !confirmPrompt("", "yes", opts) {
+				if !ui.ConfirmPrompt("", "yes", opts) {
 					return nil
 				}
 			}

--- a/pkg/cmd/pulumi/policy_rm.go
+++ b/pkg/cmd/pulumi/policy_rm.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
@@ -57,7 +58,7 @@ func newPolicyRmCmd() *cobra.Command {
 			}
 
 			prompt := fmt.Sprintf("This will permanently remove the '%s' policy!", args[0])
-			if !yes && !confirmPrompt(prompt, args[0], opts) {
+			if !yes && !ui.ConfirmPrompt(prompt, args[0], opts) {
 				return result.FprintBailf(os.Stdout, "confirmation declined")
 			}
 

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -43,17 +42,16 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
-	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/about"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ai"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/util/tracing"
 	"github.com/pulumi/pulumi/pkg/v3/version"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -318,7 +316,7 @@ func NewPulumiCmd() *cobra.Command {
 			Commands: []*cobra.Command{
 				newNewCmd(),
 				newConfigCmd(),
-				newStackCmd(),
+				cmdStack.NewStackCmd(),
 				newConsoleCmd(),
 				newImportCmd(),
 				newRefreshCmd(),
@@ -782,30 +780,4 @@ func isDevVersion(s semver.Version) bool {
 
 	devRegex := regexp.MustCompile(`\d*-g[0-9a-f]*$`)
 	return !s.Pre[0].IsNum && devRegex.MatchString(s.Pre[0].VersionStr)
-}
-
-func confirmPrompt(prompt string, name string, opts display.Options) bool {
-	out := opts.Stdout
-	if out == nil {
-		out = os.Stdout
-	}
-	in := opts.Stdin
-	if in == nil {
-		in = os.Stdin
-	}
-
-	if prompt != "" {
-		fmt.Fprint(out,
-			opts.Color.Colorize(
-				fmt.Sprintf("%s%s%s\n", colors.SpecAttention, prompt, colors.Reset)))
-	}
-
-	fmt.Fprint(out,
-		opts.Color.Colorize(
-			fmt.Sprintf("%sPlease confirm that this is what you'd like to do by typing `%s%s%s`:%s ",
-				colors.SpecAttention, colors.SpecPrompt, name, colors.SpecAttention, colors.Reset)))
-
-	reader := bufio.NewReader(in)
-	line, _ := reader.ReadString('\n')
-	return strings.TrimSpace(line) == name
 }

--- a/pkg/cmd/pulumi/stack/io.go
+++ b/pkg/cmd/pulumi/stack/io.go
@@ -24,6 +24,7 @@ import (
 
 	survey "github.com/AlecAivazis/survey/v2"
 	surveycore "github.com/AlecAivazis/survey/v2/core"
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -31,10 +32,13 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/version"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -309,6 +313,18 @@ func ChooseStack(ctx context.Context, ws pkgWorkspace.Context,
 	return stack, nil
 }
 
+// InitStack creates the stack.
+func InitStack(
+	ctx context.Context, ws pkgWorkspace.Context, b backend.Backend, stackName string,
+	root string, setCurrent bool, secretsProvider string,
+) (backend.Stack, error) {
+	stackRef, err := b.ParseStackReference(stackName)
+	if err != nil {
+		return nil, err
+	}
+	return CreateStack(ctx, ws, b, stackRef, root, nil, setCurrent, secretsProvider)
+}
+
 // CreateStack creates a stack with the given name, and optionally selects it as the current.
 func CreateStack(ctx context.Context, ws pkgWorkspace.Context,
 	b backend.Backend, stackRef backend.StackReference,
@@ -376,4 +392,136 @@ func CreateStack(ctx context.Context, ws pkgWorkspace.Context,
 	}
 
 	return stack, nil
+}
+
+func CopyEntireConfigMap(
+	ctx context.Context,
+	ssml SecretsManagerLoader,
+	currentStack backend.Stack,
+	currentProjectStack *workspace.ProjectStack,
+	destinationStack backend.Stack,
+	destinationProjectStack *workspace.ProjectStack,
+) (bool, error) {
+	var decrypter config.Decrypter
+	currentConfig := currentProjectStack.Config
+	currentEnvironments := currentProjectStack.Environment
+
+	if currentConfig.HasSecureValue() {
+		dec, state, decerr := ssml.GetDecrypter(ctx, currentStack, currentProjectStack)
+		if decerr != nil {
+			return false, decerr
+		}
+		contract.Assertf(
+			state == SecretsManagerUnchanged,
+			"We're reading a secure value so the encryption information must be present already",
+		)
+		decrypter = dec
+	} else {
+		decrypter = config.NewPanicCrypter()
+	}
+
+	encrypter, _, cerr := ssml.GetEncrypter(ctx, destinationStack, destinationProjectStack)
+	if cerr != nil {
+		return false, cerr
+	}
+
+	newProjectConfig, err := currentConfig.Copy(decrypter, encrypter)
+	if err != nil {
+		return false, err
+	}
+
+	var requiresSaving bool
+	for key, val := range newProjectConfig {
+		err = destinationProjectStack.Config.Set(key, val, false)
+		if err != nil {
+			return false, err
+		}
+		requiresSaving = true
+	}
+
+	if currentEnvironments != nil && len(currentEnvironments.Imports()) > 0 {
+		destinationProjectStack.Environment = currentEnvironments
+		requiresSaving = true
+	}
+
+	return requiresSaving, nil
+}
+
+func SaveSnapshot(ctx context.Context, s backend.Stack, snapshot *deploy.Snapshot, force bool) error {
+	stackName := s.Ref().Name()
+	var result error
+	for _, res := range snapshot.Resources {
+		if res.URN.Stack() != stackName.Q() {
+			msg := fmt.Sprintf("resource '%s' is from a different stack (%s != %s)",
+				res.URN, res.URN.Stack(), stackName)
+			if force {
+				// If --force was passed, just issue a warning and proceed anyway.
+				// Note: we could associate this diagnostic with the resource URN
+				// we have.  However, this sort of message seems to be better as
+				// something associated with the stack as a whole.
+				cmdutil.Diag().Warningf(diag.Message("" /*urn*/, msg))
+			} else {
+				// Otherwise, gather up an error so that we can quit before doing damage.
+				result = multierror.Append(result, errors.New(msg))
+			}
+		}
+	}
+	// Validate the stack. If --force was passed, issue an error if validation fails. Otherwise, issue a warning.
+	if !backend.DisableIntegrityChecking {
+		if err := snapshot.VerifyIntegrity(); err != nil {
+			msg := fmt.Sprintf("state file contains errors: %v", err)
+			if force {
+				cmdutil.Diag().Warningf(diag.Message("", msg))
+			} else {
+				result = multierror.Append(result, errors.New(msg))
+			}
+		}
+	}
+	if result != nil {
+		return multierror.Append(result,
+			errors.New("importing this file could be dangerous; rerun with --force to proceed anyway"))
+	}
+
+	// Explicitly clear-out any pending operations.
+	if snapshot.PendingOperations != nil {
+		for _, op := range snapshot.PendingOperations {
+			msg := fmt.Sprintf(
+				"removing pending operation '%s' on '%s' from snapshot", op.Type, op.Resource.URN)
+			cmdutil.Diag().Warningf(diag.Message(op.Resource.URN, msg))
+		}
+
+		snapshot.PendingOperations = nil
+	}
+	sdp, err := stack.SerializeDeployment(ctx, snapshot, false /* showSecrets */)
+	if err != nil {
+		return fmt.Errorf("constructing deployment for upload: %w", err)
+	}
+
+	bytes, err := json.Marshal(sdp)
+	if err != nil {
+		return err
+	}
+
+	dep := apitype.UntypedDeployment{
+		Version:    apitype.DeploymentSchemaVersionCurrent,
+		Deployment: bytes,
+	}
+
+	// Now perform the deployment.
+	if err = s.ImportDeployment(ctx, &dep); err != nil {
+		return fmt.Errorf("could not import deployment: %w", err)
+	}
+	return nil
+}
+
+func checkDeploymentVersionError(err error, stackName string) error {
+	switch err {
+	case stack.ErrDeploymentSchemaVersionTooOld:
+		return fmt.Errorf("the stack '%s' is too old to be used by this version of the Pulumi CLI",
+			stackName)
+	case stack.ErrDeploymentSchemaVersionTooNew:
+		return fmt.Errorf("the stack '%s' is newer than what this version of the Pulumi CLI understands. "+
+			"Please update your version of the Pulumi CLI", stackName)
+	}
+	return fmt.Errorf("could not deserialize deployment: %w", err)
 }

--- a/pkg/cmd/pulumi/stack/stack.go
+++ b/pkg/cmd/pulumi/stack/stack.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package stack
 
 import (
 	"context"
@@ -30,7 +30,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
-	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
@@ -49,7 +48,7 @@ type stackArgs struct {
 	fullyQualifyStackNames bool
 }
 
-func newStackCmd() *cobra.Command {
+func NewStackCmd() *cobra.Command {
 	var stackName string
 	args := stackArgs{}
 
@@ -69,12 +68,12 @@ func newStackCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := cmdStack.RequireStack(
+			s, err := RequireStack(
 				ctx,
 				ws,
 				cmdBackend.DefaultLoginManager,
 				stackName,
-				cmdStack.OfferNew,
+				OfferNew,
 				opts,
 			)
 			if err != nil {
@@ -200,7 +199,7 @@ func runStack(ctx context.Context, s backend.Stack, out io.Writer, args stackArg
 		}
 
 		if args.showSecrets {
-			log3rdPartySecretsProviderDecryptionEvent(ctx, s, "", "pulumi stack")
+			Log3rdPartySecretsProviderDecryptionEvent(ctx, s, "", "pulumi stack")
 		}
 	}
 

--- a/pkg/cmd/pulumi/stack/stack_change_secrets_provider_test.go
+++ b/pkg/cmd/pulumi/stack/stack_change_secrets_provider_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package stack
 
 import (
 	"bytes"
@@ -288,4 +288,16 @@ runtime: mock
 	val, err := cfgValue.Value(passphraseDecrypter)
 	require.NoError(t, err)
 	assert.Equal(t, "bar", val)
+}
+
+func chdir(t *testing.T, dir string) {
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NoError(t, os.Chdir(dir)) // Set directory
+	t.Cleanup(func() {
+		assert.NoError(t, os.Chdir(cwd)) // Restore directory
+		restoredDir, err := os.Getwd()
+		assert.NoError(t, err)
+		assert.Equal(t, cwd, restoredDir)
+	})
 }

--- a/pkg/cmd/pulumi/stack/stack_export.go
+++ b/pkg/cmd/pulumi/stack/stack_export.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package stack
 
 import (
 	"encoding/json"
@@ -22,7 +22,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
-	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/spf13/cobra"
@@ -56,12 +55,12 @@ func newStackExportCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack and export its deployment
-			s, err := cmdStack.RequireStack(
+			s, err := RequireStack(
 				ctx,
 				ws,
 				cmdBackend.DefaultLoginManager,
 				stackName,
-				cmdStack.LoadOnly,
+				LoadOnly,
 				opts,
 			)
 			if err != nil {
@@ -122,7 +121,7 @@ func newStackExportCmd() *cobra.Command {
 					Deployment: data,
 				}
 
-				log3rdPartySecretsProviderDecryptionEvent(ctx, s, "", "pulumi stack export")
+				Log3rdPartySecretsProviderDecryptionEvent(ctx, s, "", "pulumi stack export")
 			}
 
 			// Write the deployment.

--- a/pkg/cmd/pulumi/stack/stack_graph.go
+++ b/pkg/cmd/pulumi/stack/stack_graph.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package stack
 
 import (
 	"fmt"
@@ -22,7 +22,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
-	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/graph"
 	"github.com/pulumi/pulumi/pkg/v3/graph/dotconv"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -75,12 +74,12 @@ func newStackGraphCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := cmdStack.RequireStack(
+			s, err := RequireStack(
 				ctx,
 				ws,
 				backend.DefaultLoginManager,
 				cmdOpts.stackName,
-				cmdStack.LoadOnly,
+				LoadOnly,
 				opts,
 			)
 			if err != nil {

--- a/pkg/cmd/pulumi/stack/stack_graph_test.go
+++ b/pkg/cmd/pulumi/stack/stack_graph_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package stack
 
 import (
 	"bytes"

--- a/pkg/cmd/pulumi/stack/stack_init_test.go
+++ b/pkg/cmd/pulumi/stack/stack_init_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package stack
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/stack/stack_ls.go
+++ b/pkg/cmd/pulumi/stack/stack_ls.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package stack
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/stack/stack_ls_test.go
+++ b/pkg/cmd/pulumi/stack/stack_ls_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package stack
 
 import (
 	"bytes"

--- a/pkg/cmd/pulumi/stack/stack_output.go
+++ b/pkg/cmd/pulumi/stack/stack_output.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package stack
 
 import (
 	"context"
@@ -31,7 +31,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
-	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
@@ -82,7 +81,7 @@ type stackOutputCmd struct {
 	// from tests.
 	requireStack func(
 		ctx context.Context, ws pkgWorkspace.Context, lm cmdBackend.LoginManager,
-		name string, lopt cmdStack.LoadOption, opts display.Options,
+		name string, lopt LoadOption, opts display.Options,
 	) (backend.Stack, error)
 
 	Stdout io.Writer // defaults to os.Stdout
@@ -93,7 +92,7 @@ func (cmd *stackOutputCmd) Run(ctx context.Context, args []string) error {
 		Color: cmdutil.GetGlobalColorization(),
 	}
 
-	requireStack := cmdStack.RequireStack
+	requireStack := RequireStack
 	if cmd.requireStack != nil {
 		requireStack = cmd.requireStack
 	}
@@ -129,7 +128,7 @@ func (cmd *stackOutputCmd) Run(ctx context.Context, args []string) error {
 		cmd.ws,
 		cmdBackend.DefaultLoginManager,
 		cmd.stackName,
-		cmdStack.LoadOnly,
+		LoadOnly,
 		opts,
 	)
 	if err != nil {
@@ -166,7 +165,7 @@ func (cmd *stackOutputCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	if cmd.showSecrets {
-		log3rdPartySecretsProviderDecryptionEvent(ctx, s, "", "pulumi stack output")
+		Log3rdPartySecretsProviderDecryptionEvent(ctx, s, "", "pulumi stack output")
 	}
 
 	return nil

--- a/pkg/cmd/pulumi/stack/stack_output_fuzz_test.go
+++ b/pkg/cmd/pulumi/stack/stack_output_fuzz_test.go
@@ -15,7 +15,7 @@
 //go:build go1.18
 // +build go1.18
 
-package main
+package stack
 
 import (
 	"bytes"

--- a/pkg/cmd/pulumi/stack/stack_output_test.go
+++ b/pkg/cmd/pulumi/stack/stack_output_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package stack
 
 import (
 	"bytes"
@@ -25,7 +25,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
-	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -112,7 +111,7 @@ func TestStackOutputCmd_plainText(t *testing.T) {
 				},
 			}
 			requireStack := func(context.Context, pkgWorkspace.Context, cmdBackend.LoginManager,
-				string, stack.LoadOption, display.Options,
+				string, LoadOption, display.Options,
 			) (backend.Stack, error) {
 				return &backend.MockStack{
 					SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
@@ -224,7 +223,7 @@ func TestStackOutputCmd_json(t *testing.T) {
 				},
 			}
 			requireStack := func(context.Context, pkgWorkspace.Context, cmdBackend.LoginManager,
-				string, stack.LoadOption, display.Options,
+				string, LoadOption, display.Options,
 			) (backend.Stack, error) {
 				return &backend.MockStack{
 					SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
@@ -346,7 +345,7 @@ func TestStackOutputCmd_shell(t *testing.T) {
 				},
 			}
 			requireStack := func(context.Context, pkgWorkspace.Context, cmdBackend.LoginManager,
-				string, stack.LoadOption, display.Options,
+				string, LoadOption, display.Options,
 			) (backend.Stack, error) {
 				return &backend.MockStack{
 					SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
@@ -384,7 +383,7 @@ func TestStackOutputCmd_jsonAndShellConflict(t *testing.T) {
 
 	cmd := stackOutputCmd{
 		requireStack: func(
-			context.Context, pkgWorkspace.Context, cmdBackend.LoginManager, string, stack.LoadOption, display.Options,
+			context.Context, pkgWorkspace.Context, cmdBackend.LoginManager, string, LoadOption, display.Options,
 		) (backend.Stack, error) {
 			t.Fatal("This function should not be called")
 			return nil, errors.New("should not be called")

--- a/pkg/cmd/pulumi/stack/stack_rename.go
+++ b/pkg/cmd/pulumi/stack/stack_rename.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package stack
 
 import (
 	"fmt"
@@ -25,7 +25,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
-	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -56,12 +55,12 @@ func newStackRenameCmd() *cobra.Command {
 			}
 
 			// Look up the stack to be moved, and find the path to the project file's location.
-			s, err := cmdStack.RequireStack(
+			s, err := RequireStack(
 				ctx,
 				ws,
 				backend.DefaultLoginManager,
 				stack,
-				cmdStack.LoadOnly,
+				LoadOnly,
 				opts,
 			)
 			if err != nil {

--- a/pkg/cmd/pulumi/stack/stack_rm.go
+++ b/pkg/cmd/pulumi/stack/stack_rm.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package stack
 
 import (
 	"errors"
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 
@@ -28,7 +29,6 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
-	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -68,12 +68,12 @@ func newStackRmCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := cmdStack.RequireStack(
+			s, err := RequireStack(
 				ctx,
 				ws,
 				backend.DefaultLoginManager,
 				stack,
-				cmdStack.LoadOnly,
+				LoadOnly,
 				opts,
 			)
 			if err != nil {
@@ -82,7 +82,7 @@ func newStackRmCmd() *cobra.Command {
 
 			// Ensure the user really wants to do this.
 			prompt := fmt.Sprintf("This will permanently remove the '%s' stack!", s.Ref())
-			if !yes && !confirmPrompt(prompt, s.Ref().String(), opts) {
+			if !yes && !ui.ConfirmPrompt(prompt, s.Ref().String(), opts) {
 				return result.FprintBailf(os.Stdout, "confirmation declined")
 			}
 

--- a/pkg/cmd/pulumi/stack/stack_select.go
+++ b/pkg/cmd/pulumi/stack/stack_select.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package stack
 
 import (
 	"errors"
@@ -24,7 +24,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
-	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -88,7 +87,7 @@ func newStackSelectCmd() *cobra.Command {
 				}
 				// If create flag was passed and stack was not found, create it and select it.
 				if create && stack != "" {
-					s, err := stackInit(ctx, ws, b, stack, root, false, secretsProvider)
+					s, err := InitStack(ctx, ws, b, stack, root, false, secretsProvider)
 					if err != nil {
 						return err
 					}
@@ -99,11 +98,11 @@ func newStackSelectCmd() *cobra.Command {
 			}
 
 			// If no stack was given, prompt the user to select a name from the available ones.
-			stack, err := cmdStack.ChooseStack(
+			stack, err := ChooseStack(
 				ctx,
 				ws,
 				b,
-				cmdStack.OfferNew|cmdStack.SetCurrent,
+				OfferNew|SetCurrent,
 				opts,
 			)
 			if err != nil {

--- a/pkg/cmd/pulumi/stack/stack_tag.go
+++ b/pkg/cmd/pulumi/stack/stack_tag.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package stack
 
 import (
 	"fmt"
@@ -24,7 +24,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
-	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -71,12 +70,12 @@ func newStackTagGetCmd(stack *string) *cobra.Command {
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := cmdStack.RequireStack(
+			s, err := RequireStack(
 				ctx,
 				ws,
 				cmdBackend.DefaultLoginManager,
 				*stack,
-				cmdStack.LoadOnly,
+				LoadOnly,
 				opts,
 			)
 			if err != nil {
@@ -112,12 +111,12 @@ func newStackTagLsCmd(stack *string) *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := cmdStack.RequireStack(
+			s, err := RequireStack(
 				ctx,
 				ws,
 				cmdBackend.DefaultLoginManager,
 				*stack,
-				cmdStack.SetCurrent,
+				SetCurrent,
 				opts,
 			)
 			if err != nil {
@@ -177,12 +176,12 @@ func newStackTagRmCmd(stack *string) *cobra.Command {
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := cmdStack.RequireStack(
+			s, err := RequireStack(
 				ctx,
 				ws,
 				cmdBackend.DefaultLoginManager,
 				*stack,
-				cmdStack.SetCurrent,
+				SetCurrent,
 				opts,
 			)
 			if err != nil {
@@ -216,12 +215,12 @@ func newStackTagSetCmd(stack *string) *cobra.Command {
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := cmdStack.RequireStack(
+			s, err := RequireStack(
 				ctx,
 				ws,
 				cmdBackend.DefaultLoginManager,
 				*stack,
-				cmdStack.SetCurrent,
+				SetCurrent,
 				opts,
 			)
 			if err != nil {

--- a/pkg/cmd/pulumi/stack/stack_test.go
+++ b/pkg/cmd/pulumi/stack/stack_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2013, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package stack
 
 import (
 	"bytes"
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/assert"
 )
@@ -120,4 +121,12 @@ func TestStringifyOutput(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// mockBackendInstance sets the backend instance for the test and cleans it up after.
+func mockBackendInstance(t *testing.T, b backend.Backend) {
+	t.Cleanup(func() {
+		cmdBackend.BackendInstance = nil
+	})
+	cmdBackend.BackendInstance = b
 }

--- a/pkg/cmd/pulumi/stack/stack_unselect.go
+++ b/pkg/cmd/pulumi/stack/stack_unselect.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package stack
 
 import (
 	"fmt"

--- a/pkg/cmd/pulumi/state_edit.go
+++ b/pkg/cmd/pulumi/state_edit.go
@@ -207,7 +207,7 @@ func (cmd *stateEditCmd) Run(ctx context.Context, s backend.Stack) error {
 
 		switch response := ui.PromptUser(msg, options, edit, cmd.Colorizer); response {
 		case accept:
-			return saveSnapshot(ctx, s, news, false /* force */)
+			return cmdStack.SaveSnapshot(ctx, s, news, false /* force */)
 		case edit:
 			continue
 		case reset:

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -454,18 +454,18 @@ This is a bug! We would appreciate a report: https://github.com/pulumi/pulumi/is
 	// We're saving the destination snapshot first, so that if saving a snapshot fails
 	// the resources will always still be tracked.  If the source snapshot fails the user
 	// will have to manually remove the resources from the source stack.
-	err = saveSnapshot(ctx, dest, destSnapshot, false)
+	err = cmdStack.SaveSnapshot(ctx, dest, destSnapshot, false)
 	if err != nil {
 		return fmt.Errorf(`failed to save destination snapshot: %w
 
 None of the resources have been moved, it is safe to try again`, err)
 	}
 
-	err = saveSnapshot(ctx, source, sourceSnapshot, false)
+	err = cmdStack.SaveSnapshot(ctx, source, sourceSnapshot, false)
 	if err != nil {
 		// Try to restore the destination snapshot to its original state
 		destSnapshot.Resources = originalDestResources
-		errDest := saveSnapshot(ctx, dest, destSnapshot, false)
+		errDest := cmdStack.SaveSnapshot(ctx, dest, destSnapshot, false)
 		if errDest != nil {
 			var deleteCommands string
 			// Iterate over the resources in reverse order, so resources with no dependencies will be deleted first.

--- a/pkg/cmd/pulumi/state_upgrade.go
+++ b/pkg/cmd/pulumi/state_upgrade.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/diy"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -117,7 +118,7 @@ func (cmd *stateUpgradeCmd) Run(ctx context.Context) error {
 	prompt := "This will upgrade the current backend to the latest supported version.\n" +
 		"Older versions of Pulumi will not be able to read the new format.\n" +
 		"Are you sure you want to proceed?"
-	if !cmd.yes && !confirmPrompt(prompt, "yes", dopts) {
+	if !cmd.yes && !ui.ConfirmPrompt(prompt, "yes", dopts) {
 		fmt.Fprintln(cmd.Stdout, "Upgrade cancelled")
 		return nil
 	}

--- a/pkg/cmd/pulumi/ui/survey.go
+++ b/pkg/cmd/pulumi/ui/survey.go
@@ -15,8 +15,10 @@
 package ui
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	survey "github.com/AlecAivazis/survey/v2"
@@ -223,4 +225,30 @@ func PromptUserMulti(msg string, options []string, defaultOptions []string, colo
 		return []string{}
 	}
 	return response
+}
+
+func ConfirmPrompt(prompt string, name string, opts display.Options) bool {
+	out := opts.Stdout
+	if out == nil {
+		out = os.Stdout
+	}
+	in := opts.Stdin
+	if in == nil {
+		in = os.Stdin
+	}
+
+	if prompt != "" {
+		fmt.Fprint(out,
+			opts.Color.Colorize(
+				fmt.Sprintf("%s%s%s\n", colors.SpecAttention, prompt, colors.Reset)))
+	}
+
+	fmt.Fprint(out,
+		opts.Color.Colorize(
+			fmt.Sprintf("%sPlease confirm that this is what you'd like to do by typing `%s%s%s`:%s ",
+				colors.SpecAttention, colors.SpecPrompt, name, colors.SpecAttention, colors.Reset)))
+
+	reader := bufio.NewReader(in)
+	line, _ := reader.ReadString('\n')
+	return strings.TrimSpace(line) == name
 }


### PR DESCRIPTION
This commit breaks out the `stack ...` command hierarchy into its own subpackage, continuing the clean up of `pkg/cmd/pulumi`.