### PR TITLE
Break out `config ...` commands into their own package

### DIFF
--- a/pkg/cmd/pulumi/config/config_env.go
+++ b/pkg/cmd/pulumi/config/config_env.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package config
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/config/config_env_add.go
+++ b/pkg/cmd/pulumi/config/config_env_add.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package config
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/config/config_env_init.go
+++ b/pkg/cmd/pulumi/config/config_env_init.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package config
 
 import (
 	"bytes"

--- a/pkg/cmd/pulumi/config/config_env_init_test.go
+++ b/pkg/cmd/pulumi/config/config_env_init_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package config
 
 import (
 	"bytes"

--- a/pkg/cmd/pulumi/config/config_env_ls.go
+++ b/pkg/cmd/pulumi/config/config_env_ls.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,52 +12,45 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package config
 
 import (
 	"context"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
 )
 
-func newConfigEnvRmCmd(parent *configEnvCmd) *cobra.Command {
-	impl := configEnvRmCmd{parent: parent}
+func newConfigEnvLsCmd(parent *configEnvCmd) *cobra.Command {
+	var jsonOut bool
+
+	impl := configEnvLsCmd{parent: parent, jsonOut: &jsonOut}
 
 	cmd := &cobra.Command{
-		Use:   "rm <environment-name>",
-		Short: "Remove environment from a stack",
-		Long:  "Removes an environment from a stack's import list.",
-		Args:  cmdutil.ExactArgs(1),
+		Use:   "ls",
+		Short: "Lists imported environments.",
+		Long:  "Lists the environments imported into a stack's configuration.",
+		Args:  cmdutil.NoArgs,
 		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			parent.initArgs()
 			return impl.run(cmd.Context(), args)
 		}),
 	}
 
-	cmd.Flags().BoolVar(
-		&impl.showSecrets, "show-secrets", false,
-		"Show secret values in plaintext instead of ciphertext")
 	cmd.Flags().BoolVarP(
-		&impl.yes, "yes", "y", false,
-		"True to save changes without prompting")
+		&jsonOut, "json", "j", false,
+		"Emit output as JSON")
 
 	return cmd
 }
 
-type configEnvRmCmd struct {
+type configEnvLsCmd struct {
 	parent *configEnvCmd
 
-	showSecrets bool
-	yes         bool
+	jsonOut *bool
 }
 
-func (cmd *configEnvRmCmd) run(ctx context.Context, args []string) error {
-	return cmd.parent.editStackEnvironment(
-		ctx, cmd.showSecrets, cmd.yes, func(stack *workspace.ProjectStack) error {
-			stack.Environment = stack.Environment.Remove(args[0])
-			return nil
-		})
+func (cmd *configEnvLsCmd) run(ctx context.Context, _ []string) error {
+	return cmd.parent.listStackEnvironments(ctx, *cmd.jsonOut)
 }

--- a/pkg/cmd/pulumi/config/config_env_ls_test.go
+++ b/pkg/cmd/pulumi/config/config_env_ls_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package config
 
 import (
 	"bytes"

--- a/pkg/cmd/pulumi/config/config_env_rm.go
+++ b/pkg/cmd/pulumi/config/config_env_rm.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,45 +12,52 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package config
 
 import (
 	"context"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
 )
 
-func newConfigEnvLsCmd(parent *configEnvCmd) *cobra.Command {
-	var jsonOut bool
-
-	impl := configEnvLsCmd{parent: parent, jsonOut: &jsonOut}
+func newConfigEnvRmCmd(parent *configEnvCmd) *cobra.Command {
+	impl := configEnvRmCmd{parent: parent}
 
 	cmd := &cobra.Command{
-		Use:   "ls",
-		Short: "Lists imported environments.",
-		Long:  "Lists the environments imported into a stack's configuration.",
-		Args:  cmdutil.NoArgs,
+		Use:   "rm <environment-name>",
+		Short: "Remove environment from a stack",
+		Long:  "Removes an environment from a stack's import list.",
+		Args:  cmdutil.ExactArgs(1),
 		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			parent.initArgs()
 			return impl.run(cmd.Context(), args)
 		}),
 	}
 
+	cmd.Flags().BoolVar(
+		&impl.showSecrets, "show-secrets", false,
+		"Show secret values in plaintext instead of ciphertext")
 	cmd.Flags().BoolVarP(
-		&jsonOut, "json", "j", false,
-		"Emit output as JSON")
+		&impl.yes, "yes", "y", false,
+		"True to save changes without prompting")
 
 	return cmd
 }
 
-type configEnvLsCmd struct {
+type configEnvRmCmd struct {
 	parent *configEnvCmd
 
-	jsonOut *bool
+	showSecrets bool
+	yes         bool
 }
 
-func (cmd *configEnvLsCmd) run(ctx context.Context, _ []string) error {
-	return cmd.parent.listStackEnvironments(ctx, *cmd.jsonOut)
+func (cmd *configEnvRmCmd) run(ctx context.Context, args []string) error {
+	return cmd.parent.editStackEnvironment(
+		ctx, cmd.showSecrets, cmd.yes, func(stack *workspace.ProjectStack) error {
+			stack.Environment = stack.Environment.Remove(args[0])
+			return nil
+		})
 }

--- a/pkg/cmd/pulumi/config/config_env_test.go
+++ b/pkg/cmd/pulumi/config/config_env_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package config
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/config/io.go
+++ b/pkg/cmd/pulumi/config/io.go
@@ -1,0 +1,346 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pulumi/esc"
+	"github.com/pulumi/esc/cmd/esc/cli"
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// Attempts to load configuration for the given stack.
+func GetStackConfiguration(
+	ctx context.Context,
+	ssml cmdStack.SecretsManagerLoader,
+	stack backend.Stack,
+	project *workspace.Project,
+) (backend.StackConfiguration, secrets.Manager, error) {
+	return getStackConfigurationWithFallback(ctx, ssml, stack, project, nil)
+}
+
+// GetStackConfigurationOrLatest attempts to load a current stack configuration
+// using getStackConfiguration. If that fails due to not being run within a
+// valid project, the latest configuration from the backend is returned. This is
+// primarily for use in commands like `pulumi destroy`, where it is useful to be
+// able to clean up a stack whose configuration has already been deleted as part
+// of that cleanup.
+func GetStackConfigurationOrLatest(
+	ctx context.Context,
+	ssml cmdStack.SecretsManagerLoader,
+	stack backend.Stack,
+	project *workspace.Project,
+) (backend.StackConfiguration, secrets.Manager, error) {
+	return getStackConfigurationWithFallback(
+		ctx, ssml, stack, project,
+		func(err error) (config.Map, error) {
+			if errors.Is(err, workspace.ErrProjectNotFound) {
+				// This error indicates that we're not being run in a project directory.
+				// We should fallback on the backend.
+				return backend.GetLatestConfiguration(ctx, stack)
+			}
+			return nil, err
+		})
+}
+
+func getStackConfigurationWithFallback(
+	ctx context.Context,
+	ssml cmdStack.SecretsManagerLoader,
+	s backend.Stack,
+	project *workspace.Project,
+	fallbackGetConfig func(err error) (config.Map, error), // optional
+) (backend.StackConfiguration, secrets.Manager, error) {
+	workspaceStack, err := cmdStack.LoadProjectStack(project, s)
+	if err != nil || workspaceStack == nil {
+		if fallbackGetConfig == nil {
+			return backend.StackConfiguration{}, nil, err
+		}
+		// On first run or the latest configuration is unavailable, fallback to check the project's configuration
+		cfg, err := fallbackGetConfig(err)
+		if err != nil {
+			return backend.StackConfiguration{}, nil, fmt.Errorf(
+				"stack configuration could not be loaded from either Pulumi.yaml or the backend: %w", err)
+		}
+		workspaceStack = &workspace.ProjectStack{
+			Config: cfg,
+		}
+	}
+
+	sm, err := getAndSaveSecretsManager(ctx, ssml, s, workspaceStack)
+	if err != nil {
+		return backend.StackConfiguration{}, nil, err
+	}
+
+	config, err := getStackConfigurationFromProjectStack(ctx, s, project, sm, workspaceStack)
+	if err != nil {
+		return backend.StackConfiguration{}, nil, err
+	}
+	return config, sm, nil
+}
+
+func getStackConfigurationFromProjectStack(
+	ctx context.Context,
+	stack backend.Stack,
+	project *workspace.Project,
+	sm secrets.Manager,
+	workspaceStack *workspace.ProjectStack,
+) (backend.StackConfiguration, error) {
+	env, diags, err := openStackEnv(ctx, stack, workspaceStack)
+	if err != nil {
+		return backend.StackConfiguration{}, fmt.Errorf("opening environment: %w", err)
+	}
+	if len(diags) != 0 {
+		printESCDiagnostics(os.Stderr, diags)
+		return backend.StackConfiguration{}, errors.New("opening environment: too many errors")
+	}
+
+	var pulumiEnv esc.Value
+	if env != nil {
+		warnOnNoEnvironmentEffects(os.Stdout, env)
+
+		pulumiEnv = env.Properties["pulumiConfig"]
+
+		_, environ, secrets, err := cli.PrepareEnvironment(env, nil)
+		if err != nil {
+			return backend.StackConfiguration{}, fmt.Errorf("preparing environment: %w", err)
+		}
+		if len(secrets) != 0 {
+			logging.AddGlobalFilter(logging.CreateFilter(secrets, "[secret]"))
+		}
+
+		for _, kvp := range environ {
+			if name, value, ok := strings.Cut(kvp, "="); ok {
+				if err := os.Setenv(name, value); err != nil {
+					return backend.StackConfiguration{}, fmt.Errorf("setting environment variable %v: %w", name, err)
+				}
+			}
+		}
+	}
+
+	// If there are no secrets in the configuration, we should never use the decrypter, so it is safe to return
+	// one which panics if it is used. This provides for some nice UX in the common case (since, for example, building
+	// the correct decrypter for the diy backend would involve prompting for a passphrase)
+	if !needsCrypter(workspaceStack.Config, pulumiEnv) {
+		return backend.StackConfiguration{
+			EnvironmentImports: workspaceStack.Environment.Imports(),
+			Environment:        pulumiEnv,
+			Config:             workspaceStack.Config,
+			Decrypter:          config.NewPanicCrypter(),
+		}, nil
+	}
+
+	crypter, err := sm.Decrypter()
+	if err != nil {
+		return backend.StackConfiguration{}, fmt.Errorf("getting configuration decrypter: %w", err)
+	}
+
+	return backend.StackConfiguration{
+		EnvironmentImports: workspaceStack.Environment.Imports(),
+		Environment:        pulumiEnv,
+		Config:             workspaceStack.Config,
+		Decrypter:          crypter,
+	}, nil
+}
+
+func getAndSaveSecretsManager(
+	ctx context.Context,
+	ssml cmdStack.SecretsManagerLoader,
+	stack backend.Stack,
+	workspaceStack *workspace.ProjectStack,
+) (secrets.Manager, error) {
+	sm, state, err := ssml.GetSecretsManager(ctx, stack, workspaceStack)
+	if err != nil {
+		return nil, fmt.Errorf("get stack secrets manager: %w", err)
+	}
+	if state != cmdStack.SecretsManagerUnchanged {
+		if err = cmdStack.SaveProjectStack(stack, workspaceStack); err != nil && state == cmdStack.SecretsManagerMustSave {
+			return nil, fmt.Errorf("save stack config: %w", err)
+		}
+	}
+	return sm, nil
+}
+
+func needsCrypter(cfg config.Map, env esc.Value) bool {
+	var hasSecrets func(v esc.Value) bool
+	hasSecrets = func(v esc.Value) bool {
+		if v.Secret {
+			return true
+		}
+		switch v := v.Value.(type) {
+		case []esc.Value:
+			for _, v := range v {
+				if hasSecrets(v) {
+					return true
+				}
+			}
+		case map[string]esc.Value:
+			for _, v := range v {
+				if hasSecrets(v) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	return cfg.HasSecureValue() || hasSecrets(env)
+}
+
+func openStackEnv(
+	ctx context.Context,
+	stack backend.Stack,
+	workspaceStack *workspace.ProjectStack,
+) (*esc.Environment, []apitype.EnvironmentDiagnostic, error) {
+	yaml := workspaceStack.EnvironmentBytes()
+	if len(yaml) == 0 {
+		return nil, nil, nil
+	}
+
+	envs, ok := stack.Backend().(backend.EnvironmentsBackend)
+	if !ok {
+		return nil, nil, fmt.Errorf("backend %v does not support environments", stack.Backend().Name())
+	}
+	orgNamer, ok := stack.(interface{ OrgName() string })
+	if !ok {
+		return nil, nil, fmt.Errorf("cannot determine organzation for stack %v", stack.Ref())
+	}
+	orgName := orgNamer.OrgName()
+
+	return envs.OpenYAMLEnvironment(ctx, orgName, yaml, 2*time.Hour)
+}
+
+func copySingleConfigKey(
+	ctx context.Context,
+	ssml cmdStack.SecretsManagerLoader,
+	configKey string,
+	path bool,
+	currentStack backend.Stack,
+	currentProjectStack *workspace.ProjectStack,
+	destinationStack backend.Stack,
+	destinationProjectStack *workspace.ProjectStack,
+) error {
+	var decrypter config.Decrypter
+	key, err := ParseConfigKey(configKey)
+	if err != nil {
+		return fmt.Errorf("invalid configuration key: %w", err)
+	}
+
+	v, ok, err := currentProjectStack.Config.Get(key, path)
+	if err != nil {
+		return err
+	} else if !ok {
+		return fmt.Errorf("configuration key '%s' not found for stack '%s'", PrettyKey(key), currentStack.Ref())
+	}
+
+	if v.Secure() {
+		var err error
+		var state cmdStack.SecretsManagerState
+		if decrypter, state, err = ssml.GetDecrypter(ctx, currentStack, currentProjectStack); err != nil {
+			return fmt.Errorf("could not create a decrypter: %w", err)
+		}
+		contract.Assertf(
+			state == cmdStack.SecretsManagerUnchanged,
+			"We're reading a secure value so the encryption information must be present already",
+		)
+	} else {
+		decrypter = config.NewPanicCrypter()
+	}
+
+	encrypter, _, cerr := ssml.GetEncrypter(ctx, destinationStack, destinationProjectStack)
+	if cerr != nil {
+		return cerr
+	}
+
+	val, err := v.Copy(decrypter, encrypter)
+	if err != nil {
+		return err
+	}
+
+	err = destinationProjectStack.Config.Set(key, val, path)
+	if err != nil {
+		return err
+	}
+
+	return cmdStack.SaveProjectStack(destinationStack, destinationProjectStack)
+}
+
+func parseKeyValuePair(pair string) (config.Key, string, error) {
+	// Split the arg on the first '=' to separate key and value.
+	splitArg := strings.SplitN(pair, "=", 2)
+
+	// Check if the key is wrapped in quote marks and split on the '=' following the wrapping quote.
+	firstChar := string([]rune(pair)[0])
+	if firstChar == "\"" || firstChar == "'" {
+		pair = strings.TrimPrefix(pair, firstChar)
+		splitArg = strings.SplitN(pair, firstChar+"=", 2)
+	}
+
+	if len(splitArg) < 2 {
+		return config.Key{}, "", errors.New("config value must be in the form [key]=[value]")
+	}
+	key, err := ParseConfigKey(splitArg[0])
+	if err != nil {
+		return config.Key{}, "", fmt.Errorf("invalid configuration key: %w", err)
+	}
+
+	value := splitArg[1]
+	return key, value, nil
+}
+
+func ParseConfigKey(key string) (config.Key, error) {
+	// As a convenience, we'll treat any key with no delimiter as if:
+	// <program-name>:<key> had been written instead
+	if !strings.Contains(key, tokens.TokenDelimiter) {
+		proj, err := workspace.DetectProject()
+		if err != nil {
+			return config.Key{}, err
+		}
+
+		return config.ParseKey(fmt.Sprintf("%s:%s", proj.Name, key))
+	}
+
+	return config.ParseKey(key)
+}
+
+func PrettyKey(k config.Key) string {
+	proj, err := workspace.DetectProject()
+	if err != nil {
+		return fmt.Sprintf("%s:%s", k.Namespace(), k.Name())
+	}
+
+	return prettyKeyForProject(k, proj)
+}
+
+func prettyKeyForProject(k config.Key, proj *workspace.Project) string {
+	if k.Namespace() == string(proj.Name) {
+		return k.Name()
+	}
+
+	return fmt.Sprintf("%s:%s", k.Namespace(), k.Name())
+}

--- a/pkg/cmd/pulumi/config/io_test.go
+++ b/pkg/cmd/pulumi/config/io_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package config
 
 import (
 	"context"
@@ -60,7 +60,7 @@ func TestSecretDetection(t *testing.T) {
 func TestGetStackConfigurationDoesNotGetLatestConfiguration(t *testing.T) {
 	t.Parallel()
 	// Don't check return values. Just check that GetLatestConfiguration() is not called.
-	_, _, _ = getStackConfiguration(
+	_, _, _ = GetStackConfiguration(
 		context.Background(),
 		stack.SecretsManagerLoader{},
 		&backend.MockStack{
@@ -89,7 +89,7 @@ func TestGetStackConfigurationOrLatest(t *testing.T) {
 	t.Parallel()
 	// Don't check return values. Just check that GetLatestConfiguration() is called.
 	called := false
-	_, _, _ = getStackConfigurationOrLatest(
+	_, _, _ = GetStackConfigurationOrLatest(
 		context.Background(),
 		stack.SecretsManagerLoader{},
 		&backend.MockStack{

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -213,11 +214,11 @@ func newDestroyCmd() *cobra.Command {
 				return err
 			}
 
-			getConfig := getStackConfiguration
+			getConfig := config.GetStackConfiguration
 			if stackName != "" {
 				// `pulumi destroy --stack <stack>` can be run outside of the project directory.
 				// The config may be missing, fallback on the latest configuration in the backend.
-				getConfig = getStackConfigurationOrLatest
+				getConfig = config.GetStackConfigurationOrLatest
 			}
 			cfg, sm, err := getConfig(ctx, ssml, s, proj)
 			if err != nil {

--- a/pkg/cmd/pulumi/env.go
+++ b/pkg/cmd/pulumi/env.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,16 +15,12 @@
 package main
 
 import (
-	"fmt"
-	"io"
-
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/esc/cmd/esc/cli"
 	escWorkspace "github.com/pulumi/esc/cmd/esc/cli/workspace"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
@@ -40,17 +36,4 @@ func newEnvCmd() *cobra.Command {
 	// Add the `env` command to the root.
 	envCommand := escCLI.Commands()[0]
 	return envCommand
-}
-
-func printESCDiagnostics(out io.Writer, diags []apitype.EnvironmentDiagnostic) {
-	for _, d := range diags {
-		if d.Range != nil {
-			fmt.Fprintf(out, "%v:", d.Range.Environment)
-			if d.Range.Begin.Line != 0 {
-				fmt.Fprintf(out, "%v:%v:", d.Range.Begin.Line, d.Range.Begin.Column)
-			}
-			fmt.Fprintf(out, " ")
-		}
-		fmt.Fprintf(out, "%v\n", d.Summary)
-	}
 }

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
@@ -915,7 +916,7 @@ func newImportCmd() *cobra.Command {
 				}
 			}
 
-			cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
+			cfg, sm, err := config.GetStackConfiguration(ctx, ssml, s, proj)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
@@ -79,7 +80,7 @@ func newLogsCmd() *cobra.Command {
 				return err
 			}
 
-			cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
+			cfg, sm, err := config.GetStackConfiguration(ctx, ssml, s, proj)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	cmdConfig "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -1085,7 +1086,7 @@ func parseConfig(configArray []string, path bool) (config.Map, error) {
 	for _, c := range configArray {
 		kvp := strings.SplitN(c, "=", 2)
 
-		key, err := parseConfigKey(kvp[0])
+		key, err := cmdConfig.ParseConfigKey(kvp[0])
 		if err != nil {
 			return nil, err
 		}
@@ -1122,7 +1123,7 @@ func promptForConfig(
 	// the project name will be prepended.
 	parsedTemplateConfig := make(map[config.Key]workspace.ProjectTemplateConfigValue)
 	for k, v := range templateConfig {
-		parsedKey, parseErr := parseConfigKey(k)
+		parsedKey, parseErr := cmdConfig.ParseConfigKey(k)
 		if parseErr != nil {
 			return nil, parseErr
 		}
@@ -1194,7 +1195,7 @@ func promptForConfig(
 		}
 
 		// Prepare the prompt.
-		promptText := prettyKey(k)
+		promptText := cmdConfig.PrettyKey(k)
 		if templateConfigValue.Description != "" {
 			promptText = templateConfigValue.Description + " (" + promptText + ")"
 		}

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
 	pkgPlan "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/plan"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
@@ -392,7 +393,7 @@ func newPreviewCmd() *cobra.Command {
 				return err
 			}
 
-			cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
+			cfg, sm, err := config.GetStackConfiguration(ctx, ssml, s, proj)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -47,6 +47,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/about"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ai"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/util/tracing"
 	"github.com/pulumi/pulumi/pkg/v3/version"
@@ -315,7 +316,7 @@ func NewPulumiCmd() *cobra.Command {
 			Name: "Stack Management Commands",
 			Commands: []*cobra.Command{
 				newNewCmd(),
-				newConfigCmd(),
+				config.NewConfigCmd(),
 				cmdStack.NewStackCmd(),
 				newConsoleCmd(),
 				newImportCmd(),

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -191,7 +192,7 @@ func newRefreshCmd() *cobra.Command {
 				return err
 			}
 
-			cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
+			cfg, sm, err := config.GetStackConfiguration(ctx, ssml, s, proj)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	cmdConfig "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/plan"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
@@ -126,7 +127,7 @@ func newUpCmd() *cobra.Command {
 			return err
 		}
 
-		cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
+		cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, ssml, s, proj)
 		if err != nil {
 			return fmt.Errorf("getting stack configuration: %w", err)
 		}
@@ -380,7 +381,7 @@ func newUpCmd() *cobra.Command {
 			return err
 		}
 
-		cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
+		cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, ssml, s, proj)
 		if err != nil {
 			return fmt.Errorf("getting stack configuration: %w", err)
 		}
@@ -868,7 +869,7 @@ func isPreconfiguredEmptyStack(
 
 	// Can stackConfig satisfy the config requirements of templateConfig?
 	for templateKey, templateVal := range templateConfig {
-		parsedTemplateKey, parseErr := parseConfigKey(templateKey)
+		parsedTemplateKey, parseErr := cmdConfig.ParseConfigKey(templateKey)
 		if parseErr != nil {
 			contract.IgnoreError(parseErr)
 			return false

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -120,7 +121,7 @@ func newWatchCmd() *cobra.Command {
 				return err
 			}
 
-			cfg, sm, err := getStackConfiguration(ctx, ssml, s, proj)
+			cfg, sm, err := config.GetStackConfiguration(ctx, ssml, s, proj)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}


### PR DESCRIPTION
Continuing with the clean-up of `pkg/cmd/pulumi`, this factors out the `config ...` hierarchy, along with shared functions that are used by other commands for loading configuration.