### PR TITLE
Break out the `state ...` command hierarchy

### DIFF
--- a/pkg/cmd/pulumi/cmd/terminal.go
+++ b/pkg/cmd/pulumi/cmd/terminal.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,27 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Terminal detection utilities.
-package main
+package cmd
 
 import "golang.org/x/term"
 
-type optimalPageSizeOpts struct {
-	nopts          int
-	terminalHeight int
+type OptimalPageSizeOpts struct {
+	Nopts          int
+	TerminalHeight int
 }
 
 // Computes how many options to display in a Terminal UI multi-select.
 // Tries to auto-detect and take terminal height into account.
-func optimalPageSize(opts optimalPageSizeOpts) int {
+func OptimalPageSize(opts OptimalPageSizeOpts) int {
 	pageSize := 15
-	if opts.terminalHeight != 0 {
-		pageSize = opts.terminalHeight
+	if opts.TerminalHeight != 0 {
+		pageSize = opts.TerminalHeight
 	} else if _, height, err := term.GetSize(0); err == nil {
 		pageSize = height
 	}
-	if pageSize > opts.nopts {
-		pageSize = opts.nopts
+	if pageSize > opts.Nopts {
+		pageSize = opts.Nopts
 	}
 	const buffer = 5
 	if pageSize > buffer {

--- a/pkg/cmd/pulumi/cmd/terminal_test.go
+++ b/pkg/cmd/pulumi/cmd/terminal_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Terminal detection utilities.
-package main
+package cmd
 
 import (
 	"testing"
@@ -24,9 +24,9 @@ import (
 func TestOptimalPageSize(t *testing.T) {
 	t.Parallel()
 	opt := func(nopts, termHeight int) int {
-		return optimalPageSize(optimalPageSizeOpts{
-			nopts:          nopts,
-			terminalHeight: termHeight,
+		return OptimalPageSize(OptimalPageSizeOpts{
+			Nopts:          nopts,
+			TerminalHeight: termHeight,
 		})
 	}
 

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -231,7 +231,7 @@ func chooseAccount(accounts map[string]workspace.Account, opts display.Options) 
 	sort.Strings(acts)
 
 	nopts := len(acts)
-	pageSize := optimalPageSize(optimalPageSizeOpts{nopts: nopts})
+	pageSize := cmd.OptimalPageSize(cmd.OptimalPageSizeOpts{Nopts: nopts})
 	message := fmt.Sprintf("\rPlease choose an account (%d total):\n", nopts)
 	message = opts.Color.Colorize(colors.SpecPrompt + message + colors.Reset)
 

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -1061,7 +1061,7 @@ func chooseTemplate(templates []workspace.Template, opts display.Options) (works
 
 	options, optionToTemplateMap := templatesToOptionArrayAndMap(templates, true)
 	nopts := len(options)
-	pageSize := optimalPageSize(optimalPageSizeOpts{nopts: nopts})
+	pageSize := cmd.OptimalPageSize(cmd.OptimalPageSizeOpts{Nopts: nopts})
 	message := fmt.Sprintf("\rPlease choose a template (%d total):\n", nopts)
 	message = opts.Color.Colorize(colors.SpecPrompt + message + colors.Reset)
 

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -273,7 +273,7 @@ func choosePolicyPackTemplate(templates []workspace.PolicyPackTemplate,
 	if err := survey.AskOne(&survey.Select{
 		Message:  message,
 		Options:  options,
-		PageSize: optimalPageSize(optimalPageSizeOpts{nopts: len(options)}),
+		PageSize: cmd.OptimalPageSize(cmd.OptimalPageSizeOpts{Nopts: len(options)}),
 	}, &option, ui.SurveyIcons(opts.Color)); err != nil {
 		return workspace.PolicyPackTemplate{}, errors.New(chooseTemplateErr)
 	}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/state"
 	"github.com/pulumi/pulumi/pkg/v3/util/tracing"
 	"github.com/pulumi/pulumi/pkg/v3/version"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -321,7 +322,7 @@ func NewPulumiCmd() *cobra.Command {
 				newConsoleCmd(),
 				newImportCmd(),
 				newRefreshCmd(),
-				newStateCmd(),
+				state.NewStateCmd(),
 				newInstallCmd(),
 			},
 		},

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/state"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
@@ -407,7 +408,7 @@ type editPendingOp = func(op resource.Operation) (*resource.Operation, error)
 func filterMapPendingCreates(
 	ctx context.Context, s backend.Stack, opts display.Options, yes bool, f editPendingOp,
 ) error {
-	return totalStateEdit(ctx, s, yes, opts, func(opts display.Options, snap *deploy.Snapshot) error {
+	return state.TotalStateEdit(ctx, s, yes, opts, func(opts display.Options, snap *deploy.Snapshot) error {
 		var pending []resource.Operation
 		for _, op := range snap.PendingOperations {
 			if op.Resource == nil {

--- a/pkg/cmd/pulumi/state/state.go
+++ b/pkg/cmd/pulumi/state/state.go
@@ -1,0 +1,44 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state
+
+import (
+	"github.com/spf13/cobra"
+
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+func NewStateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "state",
+		Short: "Edit the current stack's state",
+		Long: `Edit the current stack's state
+
+Subcommands of this command can be used to surgically edit parts of a stack's state. These can be useful when
+troubleshooting a stack or when performing specific edits that otherwise would require editing the state file by hand.`,
+		Args: cmdutil.NoArgs,
+	}
+
+	cmd.AddCommand(newStateEditCommand())
+	cmd.AddCommand(newStateDeleteCommand(pkgWorkspace.Instance, cmdBackend.DefaultLoginManager))
+	cmd.AddCommand(newStateUnprotectCommand())
+	cmd.AddCommand(newStateRenameCommand())
+	cmd.AddCommand(newStateUpgradeCommand())
+	cmd.AddCommand(newStateMoveCommand())
+	cmd.AddCommand(newStateRepairCommand())
+	return cmd
+}

--- a/pkg/cmd/pulumi/state/state_delete.go
+++ b/pkg/cmd/pulumi/state/state_delete.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package state
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/state/state_delete_test.go
+++ b/pkg/cmd/pulumi/state/state_delete_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package state
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/state/state_edit.go
+++ b/pkg/cmd/pulumi/state/state_edit.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package state
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/state/state_edit_encoder.go
+++ b/pkg/cmd/pulumi/state/state_edit_encoder.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package state
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/state/state_edit_test.go
+++ b/pkg/cmd/pulumi/state/state_edit_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package state
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/state/state_move.go
+++ b/pkg/cmd/pulumi/state/state_move.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2024, Pulumi Corporation.
+// Copyright 2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package state
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/state/state_move_test.go
+++ b/pkg/cmd/pulumi/state/state_move_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package state
 
 import (
 	"bytes"
@@ -1354,4 +1354,16 @@ func TestMoveLockedBackendRevertsDestination(t *testing.T) {
 		sourceSnapshot.Resources[2].URN)
 	assert.Equal(t, urn.URN("urn:pulumi:sourceStack::test::d:e:f$a:b:c::name2"),
 		sourceSnapshot.Resources[3].URN)
+}
+
+func chdir(t *testing.T, dir string) {
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NoError(t, os.Chdir(dir)) // Set directory
+	t.Cleanup(func() {
+		assert.NoError(t, os.Chdir(cwd)) // Restore directory
+		restoredDir, err := os.Getwd()
+		assert.NoError(t, err)
+		assert.Equal(t, cwd, restoredDir)
+	})
 }

--- a/pkg/cmd/pulumi/state/state_rename.go
+++ b/pkg/cmd/pulumi/state/state_rename.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package state
 
 import (
 	"errors"

--- a/pkg/cmd/pulumi/state/state_rename_test.go
+++ b/pkg/cmd/pulumi/state/state_rename_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package state
 
 import (
 	"testing"

--- a/pkg/cmd/pulumi/state/state_repair.go
+++ b/pkg/cmd/pulumi/state/state_repair.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package state
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/state/state_repair_render.go
+++ b/pkg/cmd/pulumi/state/state_repair_render.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package state
 
 import (
 	"strings"

--- a/pkg/cmd/pulumi/state/state_repair_test.go
+++ b/pkg/cmd/pulumi/state/state_repair_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package state
 
 import (
 	"bytes"

--- a/pkg/cmd/pulumi/state/state_unprotect.go
+++ b/pkg/cmd/pulumi/state/state_unprotect.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package state
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/state/state_upgrade.go
+++ b/pkg/cmd/pulumi/state/state_upgrade.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package state
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/state/state_upgrade_test.go
+++ b/pkg/cmd/pulumi/state/state_upgrade_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package state
 
 import (
 	"bytes"

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/opentracing/opentracing-go"
 
@@ -167,21 +166,4 @@ func installPolicyPackDependencies(ctx context.Context, root string, proj *works
 	}
 
 	return nil
-}
-
-// Format a non-nil error that indicates some arguments are missing for a
-// non-interactive session.
-func missingNonInteractiveArg(args ...string) error {
-	switch len(args) {
-	case 0:
-		panic("cannot create an error message for missing zero args")
-	case 1:
-		return fmt.Errorf("Must supply <%s> unless pulumi is run interactively", args[0])
-	default:
-		for i, s := range args {
-			args[i] = "<" + s + ">"
-		}
-		return fmt.Errorf("Must supply %s and %s unless pulumi is run interactively",
-			strings.Join(args[:len(args)-1], ", "), args[len(args)-1])
-	}
 }


### PR DESCRIPTION
This commit factors the `state ...` command hierarchy into its own `state` subpackage, continuing the clean up of `pkg/cmd/pulumi`.