### PR TITLE
Break out diagnostic printing functions in `pkg/cmd`

### DIFF
--- a/pkg/cmd/pulumi/diag/diag.go
+++ b/pkg/cmd/pulumi/diag/diag.go
@@ -1,0 +1,31 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diag
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+)
+
+// PrintDiagnostics prints the given diagnostics to the given diagnostic sink.
+func PrintDiagnostics(sink diag.Sink, diagnostics hcl.Diagnostics) {
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Severity == hcl.DiagError {
+			sink.Errorf(diag.Message("", "%s"), diagnostic)
+		} else {
+			sink.Warningf(diag.Message("", "%s"), diagnostic)
+		}
+	}
+}

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -35,6 +35,7 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
+	cmdDiag "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/diag"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
@@ -736,7 +737,7 @@ func newImportCmd() *cobra.Command {
 					return err
 				}
 
-				printDiagnostics(sink, resp.Diagnostics)
+				cmdDiag.PrintDiagnostics(sink, resp.Diagnostics)
 				if resp.Diagnostics.HasErrors() {
 					// If we've got error diagnostics then state conversion failed, we've printed the error above so
 					// just return a plain message here.

--- a/pkg/cmd/pulumi/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/package_gen_sdk.go
@@ -24,6 +24,8 @@ import (
 	"github.com/blang/semver"
 	"github.com/spf13/cobra"
 
+	cmdDiag "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/diag"
+
 	javagen "github.com/pulumi/pulumi-java/pkg/codegen/java"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 
@@ -186,7 +188,7 @@ func genSDK(language, out string, pkg *schema.Package, overlays string, local bo
 
 			// These diagnostics come directly from the converter and so _should_ be user friendly. So we're just
 			// going to print them.
-			printDiagnostics(pCtx.Diag, diags)
+			cmdDiag.PrintDiagnostics(pCtx.Diag, diags)
 			if diags.HasErrors() {
 				// If we've got error diagnostics then package generation failed, we've printed the error above so
 				// just return a plain message here.


### PR DESCRIPTION
Currently we have some shared code for handling diagnostics between commands like `gen-sdk` and `convert`. This commit factors this out into a `diag` subpackage so that these command hierarchies can be split without introducing circular dependencies.