### PR TITLE
Break out the `deployment ...` command hierarchy

### DIFF
--- a/pkg/cmd/pulumi/deployment/deployment.go
+++ b/pkg/cmd/pulumi/deployment/deployment.go
@@ -1,0 +1,47 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func NewDeploymentCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		// This is temporarily hidden while we iterate over the new set of commands,
+		// we will remove before releasing these new set of features.
+		Hidden: true,
+		Use:    "deployment",
+		Short:  "Manage stack deployments on Pulumi Cloud",
+		Long: "Manage stack deployments on Pulumi Cloud.\n" +
+			"\n" +
+			"Use this command to trigger deployment jobs and manage deployment settings.",
+		Args: cmdutil.NoArgs,
+		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		}),
+	}
+
+	cmd.PersistentFlags().StringVar(
+		&stackDeploymentConfigFile, "config-file", "",
+		"Override the file name where the deployment settings are specified. Default is Pulumi.[stack].deploy.yaml")
+
+	cmd.AddCommand(newDeploymentSettingsCmd())
+	cmd.AddCommand(newDeploymentRunCmd())
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/deployment/deployment_run.go
+++ b/pkg/cmd/pulumi/deployment/deployment_run.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package deployment
 
 import (
 	"errors"
@@ -96,12 +96,12 @@ func newDeploymentRunCmd() *cobra.Command {
 				return errResult
 			}
 
-			return runDeployment(ctx, ws, cmd, display, operation, s.Ref().FullyQualifiedName().String(), url, remoteArgs)
+			return RunDeployment(ctx, ws, cmd, display, operation, s.Ref().FullyQualifiedName().String(), url, remoteArgs)
 		}),
 	}
 
 	// Remote flags
-	remoteArgs.applyFlagsForDeploymentCommand(cmd)
+	remoteArgs.ApplyFlagsForDeploymentCommand(cmd)
 
 	cmd.PersistentFlags().BoolVar(
 		&suppressPermalink, "suppress-permalink", false,

--- a/pkg/cmd/pulumi/deployment/deployment_settings_config.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package deployment
 
 import (
 	"context"
@@ -56,32 +56,6 @@ const (
 )
 
 var errAbortCmd = errors.New("abort")
-
-func newDeploymentCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		// This is temporarily hidden while we iterate over the new set of commands,
-		// we will remove before releasing these new set of features.
-		Hidden: true,
-		Use:    "deployment",
-		Short:  "Manage stack deployments on Pulumi Cloud",
-		Long: "Manage stack deployments on Pulumi Cloud.\n" +
-			"\n" +
-			"Use this command to trigger deployment jobs and manage deployment settings.",
-		Args: cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
-			return cmd.Help()
-		}),
-	}
-
-	cmd.PersistentFlags().StringVar(
-		&stackDeploymentConfigFile, "config-file", "",
-		"Override the file name where the deployment settings are specified. Default is Pulumi.[stack].deploy.yaml")
-
-	cmd.AddCommand(newDeploymentSettingsCmd())
-	cmd.AddCommand(newDeploymentRunCmd())
-
-	return cmd
-}
 
 func newDeploymentSettingsCmd() *cobra.Command {
 	cmd := &cobra.Command{

--- a/pkg/cmd/pulumi/deployment/deployment_settings_config_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_config_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package deployment
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/deployment/deployment_settings_ops.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_ops.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package deployment
 
 import (
 	"errors"

--- a/pkg/cmd/pulumi/deployment/deployment_settings_utils.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_utils.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package deployment
 
 import (
 	"errors"

--- a/pkg/cmd/pulumi/deployment/deployment_settings_utils_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_utils_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package deployment
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/deployment/remote.go
+++ b/pkg/cmd/pulumi/deployment/remote.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package deployment
 
 import (
 	"context"
@@ -36,8 +36,8 @@ import (
 // support remote deployments.
 var disableRemote bool
 
-// remoteSupported returns true if the CLI supports remote deployments.
-func remoteSupported() bool {
+// RemoteSupported returns true if the CLI supports remote deployments.
+func RemoteSupported() bool {
 	return !disableRemote && env.Experimental.Value()
 }
 
@@ -57,8 +57,8 @@ func parseEnv(input string) (string, string, error) {
 	return name, value, nil
 }
 
-// validateUnsupportedRemoteFlags returns an error if any unsupported flags are set when --remote is set.
-func validateUnsupportedRemoteFlags(
+// ValidateUnsupportedRemoteFlags returns an error if any unsupported flags are set when --remote is set.
+func ValidateUnsupportedRemoteFlags(
 	expectNop bool,
 	configArray []string,
 	configPath bool,
@@ -154,183 +154,182 @@ func validateUnsupportedRemoteFlags(
 
 // Flags for remote operations.
 type RemoteArgs struct {
-	remote                   bool
-	inheritSettings          bool
-	suppressStreamLogs       bool
-	envVars                  []string
-	secretEnvVars            []string
-	preRunCommands           []string
-	skipInstallDependencies  bool
-	gitBranch                string
-	gitCommit                string
-	gitRepoDir               string
-	gitAuthAccessToken       string
-	gitAuthSSHPrivateKey     string
-	gitAuthSSHPrivateKeyPath string
-	gitAuthPassword          string
-	gitAuthUsername          string
-	executorImage            string
-	executorImageUsername    string
-	executorImagePassword    string
-	agentPoolID              string
+	Remote                   bool
+	InheritSettings          bool
+	SuppressStreamLogs       bool
+	EnvVars                  []string
+	SecretEnvVars            []string
+	PreRunCommands           []string
+	SkipInstallDependencies  bool
+	GitBranch                string
+	GitCommit                string
+	GitRepoDir               string
+	GitAuthAccessToken       string
+	GitAuthSSHPrivateKey     string
+	GitAuthSSHPrivateKeyPath string
+	GitAuthPassword          string
+	GitAuthUsername          string
+	ExecutorImage            string
+	ExecutorImageUsername    string
+	ExecutorImagePassword    string
+	AgentPoolID              string
 }
 
-func (r *RemoteArgs) applyFlagsForDeploymentCommand(cmd *cobra.Command) {
+func (r *RemoteArgs) ApplyFlagsForDeploymentCommand(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(
-		&r.inheritSettings, "inherit-settings", true,
+		&r.InheritSettings, "inherit-settings", true,
 		"Inherit deployment settings from the current stack")
 	cmd.PersistentFlags().BoolVar(
-		&r.suppressStreamLogs, "suppress-stream-logs", true,
+		&r.SuppressStreamLogs, "suppress-stream-logs", true,
 		"Suppress log streaming of the deployment job")
 	cmd.PersistentFlags().StringArrayVar(
-		&r.envVars, "env", []string{},
+		&r.EnvVars, "env", []string{},
 		"Environment variables to use in the remote operation of the form NAME=value "+
 			"(e.g. `--env FOO=bar`)")
 	cmd.PersistentFlags().StringArrayVar(
-		&r.secretEnvVars, "env-secret", []string{},
+		&r.SecretEnvVars, "env-secret", []string{},
 		"Environment variables with secret values to use in the remote operation of the form "+
 			"NAME=secretvalue (e.g. `--env FOO=secret`)")
 	cmd.PersistentFlags().StringArrayVar(
-		&r.preRunCommands, "pre-run-command", []string{},
+		&r.PreRunCommands, "pre-run-command", []string{},
 		"Commands to run before the remote operation")
 	cmd.PersistentFlags().BoolVar(
-		&r.skipInstallDependencies, "skip-install-dependencies", false,
+		&r.SkipInstallDependencies, "skip-install-dependencies", false,
 		"Whether to skip the default dependency installation step")
 	cmd.PersistentFlags().StringVar(
-		&r.gitBranch, "git-branch", "",
+		&r.GitBranch, "git-branch", "",
 		"Git branch to deploy; this is mutually exclusive with --git-commit; "+
 			"either value needs to be specified")
 	cmd.PersistentFlags().StringVar(
-		&r.gitCommit, "git-commit", "",
+		&r.GitCommit, "git-commit", "",
 		"Git commit hash of the commit to deploy (if used, HEAD will be in detached mode); "+
 			"this is mutually exclusive with --git-branch; either value needs to be specified")
 	cmd.PersistentFlags().StringVar(
-		&r.gitRepoDir, "git-repo-dir", "",
+		&r.GitRepoDir, "git-repo-dir", "",
 		"The directory to work from in the project's source repository "+
 			"where Pulumi.yaml is located; used when Pulumi.yaml is not in the project source root")
 	cmd.PersistentFlags().StringVar(
-		&r.gitAuthAccessToken, "git-auth-access-token", "",
+		&r.GitAuthAccessToken, "git-auth-access-token", "",
 		"Git personal access token")
 	cmd.PersistentFlags().StringVar(
-		&r.gitAuthSSHPrivateKey, "git-auth-ssh-private-key", "",
+		&r.GitAuthSSHPrivateKey, "git-auth-ssh-private-key", "",
 		"Git SSH private key; use --git-auth-password for the password, if needed")
 	cmd.PersistentFlags().StringVar(
-		&r.gitAuthSSHPrivateKeyPath, "git-auth-ssh-private-key-path", "",
+		&r.GitAuthSSHPrivateKeyPath, "git-auth-ssh-private-key-path", "",
 		"Git SSH private key path; use --git-auth-password for the password, if needed")
 	cmd.PersistentFlags().StringVar(
-		&r.gitAuthPassword, "git-auth-password", "",
+		&r.GitAuthPassword, "git-auth-password", "",
 		"Git password; for use with username or with an SSH private key")
 	cmd.PersistentFlags().StringVar(
-		&r.gitAuthUsername, "git-auth-username", "",
+		&r.GitAuthUsername, "git-auth-username", "",
 		"Git username")
 	cmd.PersistentFlags().StringVar(
-		&r.executorImage, "executor-image", "",
+		&r.ExecutorImage, "executor-image", "",
 		"The Docker image to use for the executor")
 	cmd.PersistentFlags().StringVar(
-		&r.executorImageUsername, "executor-image-username", "",
+		&r.ExecutorImageUsername, "executor-image-username", "",
 		"The username for the credentials with access to the Docker image to use for the executor")
 	cmd.PersistentFlags().StringVar(
-		&r.executorImagePassword, "executor-image-password", "",
+		&r.ExecutorImagePassword, "executor-image-password", "",
 		"The password for the credentials with access to the Docker image to use for the executor")
 	cmd.PersistentFlags().StringVar(
-		&r.agentPoolID, "agent-pool-id", "",
+		&r.AgentPoolID, "agent-pool-id", "",
 		"The agent pool to use to run the deployment job. When empty, the Pulumi Cloud shared queue "+
 			"will be used.")
 }
 
 // Add flags to support remote operations
-func (r *RemoteArgs) applyFlags(cmd *cobra.Command) {
-	if !remoteSupported() {
+func (r *RemoteArgs) ApplyFlags(cmd *cobra.Command) {
+	if !RemoteSupported() {
 		return
 	}
 
 	cmd.PersistentFlags().BoolVar(
-		&r.remote, "remote", false,
+		&r.Remote, "remote", false,
 		"[EXPERIMENTAL] Run the operation remotely")
 	cmd.PersistentFlags().BoolVar(
-		&r.suppressStreamLogs, "suppress-stream-logs", false,
+		&r.SuppressStreamLogs, "suppress-stream-logs", false,
 		"[EXPERIMENTAL] Suppress log streaming of the deployment job")
 	cmd.PersistentFlags().BoolVar(
-		&r.inheritSettings, "remote-inherit-settings", false,
+		&r.InheritSettings, "remote-inherit-settings", false,
 		"[EXPERIMENTAL] Inherit deployment settings from the current stack")
 	cmd.PersistentFlags().StringArrayVar(
-		&r.envVars, "remote-env", []string{},
+		&r.EnvVars, "remote-env", []string{},
 		"[EXPERIMENTAL] Environment variables to use in the remote operation of the form NAME=value "+
 			"(e.g. `--remote-env FOO=bar`)")
 	cmd.PersistentFlags().StringArrayVar(
-		&r.secretEnvVars, "remote-env-secret", []string{},
+		&r.SecretEnvVars, "remote-env-secret", []string{},
 		"[EXPERIMENTAL] Environment variables with secret values to use in the remote operation of the form "+
 			"NAME=secretvalue (e.g. `--remote-env FOO=secret`)")
 	cmd.PersistentFlags().StringArrayVar(
-		&r.preRunCommands, "remote-pre-run-command", []string{},
+		&r.PreRunCommands, "remote-pre-run-command", []string{},
 		"[EXPERIMENTAL] Commands to run before the remote operation")
 	cmd.PersistentFlags().BoolVar(
-		&r.skipInstallDependencies, "remote-skip-install-dependencies", false,
+		&r.SkipInstallDependencies, "remote-skip-install-dependencies", false,
 		"[EXPERIMENTAL] Whether to skip the default dependency installation step")
 	cmd.PersistentFlags().StringVar(
-		&r.gitBranch, "remote-git-branch", "",
+		&r.GitBranch, "remote-git-branch", "",
 		"[EXPERIMENTAL] Git branch to deploy; this is mutually exclusive with --remote-git-commit; "+
 			"either value needs to be specified")
 	cmd.PersistentFlags().StringVar(
-		&r.gitCommit, "remote-git-commit", "",
+		&r.GitCommit, "remote-git-commit", "",
 		"[EXPERIMENTAL] Git commit hash of the commit to deploy (if used, HEAD will be in detached mode); "+
 			"this is mutually exclusive with --remote-git-branch; either value needs to be specified")
 	cmd.PersistentFlags().StringVar(
-		&r.gitRepoDir, "remote-git-repo-dir", "",
+		&r.GitRepoDir, "remote-git-repo-dir", "",
 		"[EXPERIMENTAL] The directory to work from in the project's source repository "+
 			"where Pulumi.yaml is located; used when Pulumi.yaml is not in the project source root")
 	cmd.PersistentFlags().StringVar(
-		&r.gitAuthAccessToken, "remote-git-auth-access-token", "",
+		&r.GitAuthAccessToken, "remote-git-auth-access-token", "",
 		"[EXPERIMENTAL] Git personal access token")
 	cmd.PersistentFlags().StringVar(
-		&r.gitAuthSSHPrivateKey, "remote-git-auth-ssh-private-key", "",
+		&r.GitAuthSSHPrivateKey, "remote-git-auth-ssh-private-key", "",
 		"[EXPERIMENTAL] Git SSH private key; use --remote-git-auth-password for the password, if needed")
 	cmd.PersistentFlags().StringVar(
-		&r.gitAuthSSHPrivateKeyPath, "remote-git-auth-ssh-private-key-path", "",
+		&r.GitAuthSSHPrivateKeyPath, "remote-git-auth-ssh-private-key-path", "",
 		"[EXPERIMENTAL] Git SSH private key path; use --remote-git-auth-password for the password, if needed")
 	cmd.PersistentFlags().StringVar(
-		&r.gitAuthPassword, "remote-git-auth-password", "",
+		&r.GitAuthPassword, "remote-git-auth-password", "",
 		"[EXPERIMENTAL] Git password; for use with username or with an SSH private key")
 	cmd.PersistentFlags().StringVar(
-		&r.gitAuthUsername, "remote-git-auth-username", "",
+		&r.GitAuthUsername, "remote-git-auth-username", "",
 		"[EXPERIMENTAL] Git username")
 	cmd.PersistentFlags().StringVar(
-		&r.executorImage, "remote-executor-image", "",
+		&r.ExecutorImage, "remote-executor-image", "",
 		"[EXPERIMENTAL] The Docker image to use for the executor")
 	cmd.PersistentFlags().StringVar(
-		&r.executorImageUsername, "remote-executor-image-username", "",
+		&r.ExecutorImageUsername, "remote-executor-image-username", "",
 		"[EXPERIMENTAL] The username for the credentials with access to the Docker image to use for the executor")
 	cmd.PersistentFlags().StringVar(
-		&r.executorImagePassword, "remote-executor-image-password", "",
+		&r.ExecutorImagePassword, "remote-executor-image-password", "",
 		"[EXPERIMENTAL] The password for the credentials with access to the Docker image to use for the executor")
 	cmd.PersistentFlags().StringVar(
-		&r.agentPoolID, "remote-agent-pool-id", "",
+		&r.AgentPoolID, "remote-agent-pool-id", "",
 		"[EXPERIMENTAL] The agent pool to use to run the deployment job. When empty, the Pulumi Cloud shared queue "+
 			"will be used.")
 }
 
-func validateRemoteDeploymentFlags(url string, args RemoteArgs) error {
-	// Validate args.
-	if url == "" && !args.inheritSettings {
+func ValidateRemoteDeploymentFlags(url string, args RemoteArgs) error {
+	if url == "" && !args.InheritSettings {
 		return errors.New("the url arg must be specified if not passing --remote-inherit-settings")
 	}
-	if args.gitBranch != "" && args.gitCommit != "" {
+	if args.GitBranch != "" && args.GitCommit != "" {
 		return errors.New("`--remote-git-branch` and `--remote-git-commit` cannot both be specified")
 	}
-	if args.gitBranch == "" && args.gitCommit == "" && !args.inheritSettings {
+	if args.GitBranch == "" && args.GitCommit == "" && !args.InheritSettings {
 		return errors.New("either `--remote-git-branch` or `--remote-git-commit` is required " +
 			"if not passing --remote-inherit-settings")
 	}
-	if args.gitAuthSSHPrivateKey != "" && args.gitAuthSSHPrivateKeyPath != "" {
+	if args.GitAuthSSHPrivateKey != "" && args.GitAuthSSHPrivateKeyPath != "" {
 		return errors.New("`--remote-git-auth-ssh-private-key` and " +
 			"`--remote-git-auth-ssh-private-key-path` cannot both be specified")
 	}
-	if args.executorImage == "" && (args.executorImageUsername != "" || args.executorImagePassword != "") {
+	if args.ExecutorImage == "" && (args.ExecutorImageUsername != "" || args.ExecutorImagePassword != "") {
 		return errors.New("`--remote-executor-image-username` and `--remote-executor-image-password` " +
 			"cannot be specified without `--remote-executor-image`")
 	}
-	if (args.executorImagePassword != "" && args.executorImageUsername == "") ||
-		(args.executorImageUsername != "" && args.executorImagePassword == "") {
+	if (args.ExecutorImagePassword != "" && args.ExecutorImageUsername == "") ||
+		(args.ExecutorImageUsername != "" && args.ExecutorImagePassword == "") {
 		return errors.New("`--remote-executor-image-username` and `--remote-executor-image-password` " +
 			"must both be specified")
 	}
@@ -339,27 +338,26 @@ func validateRemoteDeploymentFlags(url string, args RemoteArgs) error {
 }
 
 func validateDeploymentFlags(url string, args RemoteArgs) error {
-	// Validate args.
-	if url == "" && !args.inheritSettings {
+	if url == "" && !args.InheritSettings {
 		return errors.New("the url arg must be specified if not passing --inherit-settings")
 	}
-	if args.gitBranch != "" && args.gitCommit != "" {
+	if args.GitBranch != "" && args.GitCommit != "" {
 		return errors.New("`--git-branch` and `--git-commit` cannot both be specified")
 	}
-	if args.gitBranch == "" && args.gitCommit == "" && !args.inheritSettings {
+	if args.GitBranch == "" && args.GitCommit == "" && !args.InheritSettings {
 		return errors.New("either `--git-branch` or `--git-commit` is required " +
 			"if not passing --inherit-settings")
 	}
-	if args.gitAuthSSHPrivateKey != "" && args.gitAuthSSHPrivateKeyPath != "" {
+	if args.GitAuthSSHPrivateKey != "" && args.GitAuthSSHPrivateKeyPath != "" {
 		return errors.New("`--git-auth-ssh-private-key` and " +
 			"`--git-auth-ssh-private-key-path` cannot both be specified")
 	}
-	if args.executorImage == "" && (args.executorImageUsername != "" || args.executorImagePassword != "") {
+	if args.ExecutorImage == "" && (args.ExecutorImageUsername != "" || args.ExecutorImagePassword != "") {
 		return errors.New("`--executor-image-username` and `--executor-image-password` " +
 			"cannot be specified without `--executor-image`")
 	}
-	if (args.executorImagePassword != "" && args.executorImageUsername == "") ||
-		(args.executorImageUsername != "" && args.executorImagePassword == "") {
+	if (args.ExecutorImagePassword != "" && args.ExecutorImageUsername == "") ||
+		(args.ExecutorImageUsername != "" && args.ExecutorImagePassword == "") {
 		return errors.New("`--executor-image-username` and `--executor-image-password` " +
 			"must both be specified")
 	}
@@ -367,30 +365,30 @@ func validateDeploymentFlags(url string, args RemoteArgs) error {
 	return nil
 }
 
-// runDeployment kicks off a remote deployment.
-func runDeployment(ctx context.Context, ws pkgWorkspace.Context, cmd *cobra.Command, opts display.Options,
+// RunDeployment kicks off a remote deployment.
+func RunDeployment(ctx context.Context, ws pkgWorkspace.Context, cmd *cobra.Command, opts display.Options,
 	operation apitype.PulumiOperation, stack, url string, args RemoteArgs,
 ) error {
 	// Parse and validate the environment args.
 	env := map[string]apitype.SecretValue{}
-	for i, e := range append(args.envVars, args.secretEnvVars...) {
+	for i, e := range append(args.EnvVars, args.SecretEnvVars...) {
 		name, value, err := parseEnv(e)
 		if err != nil {
 			return err
 		}
 		env[name] = apitype.SecretValue{
 			Value:  value,
-			Secret: i >= len(args.envVars),
+			Secret: i >= len(args.EnvVars),
 		}
 	}
 
 	// Read the SSH Private Key from the path, if necessary.
-	sshPrivateKey := args.gitAuthSSHPrivateKey
-	if args.gitAuthSSHPrivateKeyPath != "" {
-		key, err := os.ReadFile(args.gitAuthSSHPrivateKeyPath)
+	sshPrivateKey := args.GitAuthSSHPrivateKey
+	if args.GitAuthSSHPrivateKeyPath != "" {
+		key, err := os.ReadFile(args.GitAuthSSHPrivateKeyPath)
 		if err != nil {
 			return fmt.Errorf(
-				"reading SSH private key path %q: %w", args.gitAuthSSHPrivateKeyPath, err)
+				"reading SSH private key path %q: %w", args.GitAuthSSHPrivateKeyPath, err)
 		}
 		sshPrivateKey = string(key)
 	}
@@ -419,68 +417,68 @@ func runDeployment(ctx context.Context, ws pkgWorkspace.Context, cmd *cobra.Comm
 	}
 
 	var gitAuth *apitype.GitAuthConfig
-	if args.gitAuthAccessToken != "" || sshPrivateKey != "" || args.gitAuthPassword != "" ||
-		args.gitAuthUsername != "" {
+	if args.GitAuthAccessToken != "" || sshPrivateKey != "" || args.GitAuthPassword != "" ||
+		args.GitAuthUsername != "" {
 		gitAuth = &apitype.GitAuthConfig{}
 		switch {
-		case args.gitAuthAccessToken != "":
-			gitAuth.PersonalAccessToken = &apitype.SecretValue{Value: args.gitAuthAccessToken, Secret: true}
+		case args.GitAuthAccessToken != "":
+			gitAuth.PersonalAccessToken = &apitype.SecretValue{Value: args.GitAuthAccessToken, Secret: true}
 
 		case sshPrivateKey != "":
 			sshAuth := &apitype.SSHAuth{
 				SSHPrivateKey: apitype.SecretValue{Value: sshPrivateKey, Secret: true},
 			}
-			if args.gitAuthPassword != "" {
-				sshAuth.Password = &apitype.SecretValue{Value: args.gitAuthPassword, Secret: true}
+			if args.GitAuthPassword != "" {
+				sshAuth.Password = &apitype.SecretValue{Value: args.GitAuthPassword, Secret: true}
 			}
 			gitAuth.SSHAuth = sshAuth
 
-		case args.gitAuthUsername != "":
-			basicAuth := &apitype.BasicAuth{UserName: apitype.SecretValue{Value: args.gitAuthUsername, Secret: true}}
-			if args.gitAuthPassword != "" {
-				basicAuth.Password = apitype.SecretValue{Value: args.gitAuthPassword, Secret: true}
+		case args.GitAuthUsername != "":
+			basicAuth := &apitype.BasicAuth{UserName: apitype.SecretValue{Value: args.GitAuthUsername, Secret: true}}
+			if args.GitAuthPassword != "" {
+				basicAuth.Password = apitype.SecretValue{Value: args.GitAuthPassword, Secret: true}
 			}
 			gitAuth.BasicAuth = basicAuth
 		}
 	}
 
 	var executorImage *apitype.DockerImage
-	if args.executorImage != "" {
+	if args.ExecutorImage != "" {
 		executorImage = &apitype.DockerImage{
-			Reference: args.executorImage,
+			Reference: args.ExecutorImage,
 		}
 	}
-	if args.executorImageUsername != "" && args.executorImagePassword != "" {
+	if args.ExecutorImageUsername != "" && args.ExecutorImagePassword != "" {
 		if executorImage.Credentials == nil {
 			executorImage.Credentials = &apitype.DockerImageCredentials{}
 		}
-		executorImage.Credentials.Username = args.executorImageUsername
-		executorImage.Credentials.Password = apitype.SecretValue{Value: args.executorImagePassword, Secret: true}
+		executorImage.Credentials.Username = args.ExecutorImageUsername
+		executorImage.Credentials.Password = apitype.SecretValue{Value: args.ExecutorImagePassword, Secret: true}
 	}
 
 	var operationOptions *apitype.OperationContextOptions
-	if args.skipInstallDependencies {
+	if args.SkipInstallDependencies {
 		operationOptions = &apitype.OperationContextOptions{
-			SkipInstallDependencies: args.skipInstallDependencies,
+			SkipInstallDependencies: args.SkipInstallDependencies,
 		}
 	}
 
 	var sourceContext *apitype.SourceContext
-	if url != "" || args.gitBranch != "" || args.gitCommit != "" || args.gitRepoDir != "" || gitAuth != nil {
+	if url != "" || args.GitBranch != "" || args.GitCommit != "" || args.GitRepoDir != "" || gitAuth != nil {
 		sourceContext = &apitype.SourceContext{
 			Git: &apitype.SourceContextGit{},
 		}
 		if url != "" {
 			sourceContext.Git.RepoURL = url
 		}
-		if args.gitBranch != "" {
-			sourceContext.Git.Branch = args.gitBranch
+		if args.GitBranch != "" {
+			sourceContext.Git.Branch = args.GitBranch
 		}
-		if args.gitCommit != "" {
-			sourceContext.Git.Commit = args.gitCommit
+		if args.GitCommit != "" {
+			sourceContext.Git.Commit = args.GitCommit
 		}
-		if args.gitRepoDir != "" {
-			sourceContext.Git.RepoDir = args.gitRepoDir
+		if args.GitRepoDir != "" {
+			sourceContext.Git.RepoDir = args.GitRepoDir
 		}
 		if gitAuth != nil {
 			sourceContext.Git.GitAuth = gitAuth
@@ -489,17 +487,17 @@ func runDeployment(ctx context.Context, ws pkgWorkspace.Context, cmd *cobra.Comm
 
 	// we have a custom marshaller for CreateDeploymentRequest, to handle semantics around
 	// defined/undefined/null values on AgentPoolID
-	agentPoolID := apitype.AgentPoolIDMarshaller(args.agentPoolID)
+	agentPoolID := apitype.AgentPoolIDMarshaller(args.AgentPoolID)
 
 	req := apitype.CreateDeploymentRequest{
 		Op:              operation,
-		InheritSettings: args.inheritSettings,
+		InheritSettings: args.InheritSettings,
 		Executor: &apitype.ExecutorContext{
 			ExecutorImage: executorImage,
 		},
 		Source: sourceContext,
 		Operation: &apitype.OperationContext{
-			PreRunCommands:       args.preRunCommands,
+			PreRunCommands:       args.PreRunCommands,
 			EnvironmentVariables: env,
 			Options:              operationOptions,
 		},
@@ -510,7 +508,7 @@ func runDeployment(ctx context.Context, ws pkgWorkspace.Context, cmd *cobra.Comm
 	// to "automation-api".
 	// In the future, we may want to expose initiating deployments from the CLI, in which case we would need to
 	// pass this value in from the CLI as a flag or environment variable.
-	err = cb.RunDeployment(ctx, stackRef, req, opts, "automation-api" /*deploymentInitiator*/, args.suppressStreamLogs)
+	err = cb.RunDeployment(ctx, stackRef, req, opts, "automation-api" /*deploymentInitiator*/, args.SuppressStreamLogs)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/deployment/remote_test.go
+++ b/pkg/cmd/pulumi/deployment/remote_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package deployment
 
 import (
 	"testing"

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -29,6 +29,7 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/deployment"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -56,7 +57,7 @@ func newDestroyCmd() *cobra.Command {
 	var execAgent string
 
 	// Flags for remote operations.
-	remoteArgs := RemoteArgs{}
+	remoteArgs := deployment.RemoteArgs{}
 
 	// Flags for engine.UpdateOptions.
 	var jsonDisplay bool
@@ -79,7 +80,7 @@ func newDestroyCmd() *cobra.Command {
 	var continueOnError bool
 
 	use, cmdArgs := "destroy", cmdutil.NoArgs
-	if remoteSupported() {
+	if deployment.RemoteSupported() {
 		use, cmdArgs = "destroy [url]", cmdutil.MaximumNArgs(1)
 	}
 
@@ -109,7 +110,7 @@ func newDestroyCmd() *cobra.Command {
 			ws := pkgWorkspace.Instance
 
 			// Remote implies we're skipping previews.
-			if remoteArgs.remote {
+			if remoteArgs.Remote {
 				skipPreview = true
 			}
 
@@ -152,8 +153,8 @@ func newDestroyCmd() *cobra.Command {
 				opts.Display.SuppressPermalink = false
 			}
 
-			if remoteArgs.remote {
-				err = validateUnsupportedRemoteFlags(false, nil, false, "", jsonDisplay, nil,
+			if remoteArgs.Remote {
+				err = deployment.ValidateUnsupportedRemoteFlags(false, nil, false, "", jsonDisplay, nil,
 					nil, refresh, showConfig, false, showReplacementSteps, showSames, false,
 					suppressOutputs, "default", targets, nil, nil,
 					targetDependents, "", cmdStack.ConfigFile)
@@ -166,11 +167,11 @@ func newDestroyCmd() *cobra.Command {
 					url = args[0]
 				}
 
-				if errResult := validateRemoteDeploymentFlags(url, remoteArgs); errResult != nil {
+				if errResult := deployment.ValidateRemoteDeploymentFlags(url, remoteArgs); errResult != nil {
 					return errResult
 				}
 
-				return runDeployment(ctx, ws, cmd, opts.Display, apitype.Destroy, stackName, url, remoteArgs)
+				return deployment.RunDeployment(ctx, ws, cmd, opts.Display, apitype.Destroy, stackName, url, remoteArgs)
 			}
 
 			isDIYBackend, err := cmdBackend.IsDIYBackend(ws, opts.Display)
@@ -412,7 +413,7 @@ func newDestroyCmd() *cobra.Command {
 		"Automatically approve and perform the destroy after previewing it")
 
 	// Remote flags
-	remoteArgs.applyFlags(cmd)
+	remoteArgs.ApplyFlags(cmd)
 
 	if env.DebugCommands.Value() {
 		cmd.PersistentFlags().StringVar(

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -29,6 +29,7 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/deployment"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
 	pkgPlan "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/plan"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
@@ -257,7 +258,7 @@ func newPreviewCmd() *cobra.Command {
 	var showSecrets bool
 
 	// Flags for remote operations.
-	remoteArgs := RemoteArgs{}
+	remoteArgs := deployment.RemoteArgs{}
 
 	// Flags for engine.UpdateOptions.
 	var jsonDisplay bool
@@ -282,7 +283,7 @@ func newPreviewCmd() *cobra.Command {
 	var attachDebugger bool
 
 	use, cmdArgs := "preview", cmdutil.NoArgs
-	if remoteSupported() {
+	if deployment.RemoteSupported() {
 		use, cmdArgs = "preview [url]", cmdutil.MaximumNArgs(1)
 	}
 
@@ -336,8 +337,8 @@ func newPreviewCmd() *cobra.Command {
 				displayOpts.SuppressPermalink = false
 			}
 
-			if remoteArgs.remote {
-				err := validateUnsupportedRemoteFlags(expectNop, configArray, configPath, client, jsonDisplay,
+			if remoteArgs.Remote {
+				err := deployment.ValidateUnsupportedRemoteFlags(expectNop, configArray, configPath, client, jsonDisplay,
 					policyPackPaths, policyPackConfigPaths, refresh, showConfig, showPolicyRemediations,
 					showReplacementSteps, showSames, showReads, suppressOutputs, "default", &targets, replaces,
 					targetReplaces, targetDependents, planFilePath, cmdStack.ConfigFile)
@@ -350,11 +351,11 @@ func newPreviewCmd() *cobra.Command {
 					url = args[0]
 				}
 
-				if errResult := validateRemoteDeploymentFlags(url, remoteArgs); errResult != nil {
+				if errResult := deployment.ValidateRemoteDeploymentFlags(url, remoteArgs); errResult != nil {
 					return errResult
 				}
 
-				return runDeployment(ctx, ws, cmd, displayOpts, apitype.Preview, stackName, url, remoteArgs)
+				return deployment.RunDeployment(ctx, ws, cmd, displayOpts, apitype.Preview, stackName, url, remoteArgs)
 			}
 
 			isDIYBackend, err := cmdBackend.IsDIYBackend(ws, displayOpts)
@@ -661,7 +662,7 @@ func newPreviewCmd() *cobra.Command {
 		"Enable the ability to attach a debugger to the program being executed")
 
 	// Remote flags
-	remoteArgs.applyFlags(cmd)
+	remoteArgs.ApplyFlags(cmd)
 
 	if env.DebugCommands.Value() {
 		cmd.PersistentFlags().StringVar(

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -48,6 +48,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ai"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/deployment"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/org"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packagecmd"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
@@ -350,7 +351,7 @@ func NewPulumiCmd() *cobra.Command {
 				newLogoutCmd(),
 				newWhoAmICmd(),
 				org.NewOrgCmd(),
-				newDeploymentCmd(),
+				deployment.NewDeploymentCmd(),
 			},
 		},
 		{

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -30,6 +30,7 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/deployment"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/state"
@@ -54,7 +55,7 @@ func newRefreshCmd() *cobra.Command {
 	var stackName string
 
 	// Flags for remote operations.
-	remoteArgs := RemoteArgs{}
+	remoteArgs := deployment.RemoteArgs{}
 
 	// Flags for engine.UpdateOptions.
 	var jsonDisplay bool
@@ -78,7 +79,7 @@ func newRefreshCmd() *cobra.Command {
 	var importPendingCreates *[]string
 
 	use, cmdArgs := "refresh", cmdutil.NoArgs
-	if remoteSupported() {
+	if deployment.RemoteSupported() {
 		use, cmdArgs = "refresh [url]", cmdutil.MaximumNArgs(1)
 	}
 
@@ -101,7 +102,7 @@ func newRefreshCmd() *cobra.Command {
 			ws := pkgWorkspace.Instance
 
 			// Remote implies we're skipping previews.
-			if remoteArgs.remote {
+			if remoteArgs.Remote {
 				skipPreview = true
 			}
 
@@ -144,8 +145,8 @@ func newRefreshCmd() *cobra.Command {
 				opts.Display.SuppressPermalink = false
 			}
 
-			if remoteArgs.remote {
-				err = validateUnsupportedRemoteFlags(expectNop, nil, false, "", jsonDisplay, nil,
+			if remoteArgs.Remote {
+				err = deployment.ValidateUnsupportedRemoteFlags(expectNop, nil, false, "", jsonDisplay, nil,
 					nil, "", showConfig, false, showReplacementSteps, showSames, false,
 					suppressOutputs, "default", targets, nil, nil,
 					false, "", cmdStack.ConfigFile)
@@ -158,11 +159,11 @@ func newRefreshCmd() *cobra.Command {
 					url = args[0]
 				}
 
-				if errResult := validateRemoteDeploymentFlags(url, remoteArgs); errResult != nil {
+				if errResult := deployment.ValidateRemoteDeploymentFlags(url, remoteArgs); errResult != nil {
 					return errResult
 				}
 
-				return runDeployment(ctx, ws, cmd, opts.Display, apitype.Refresh, stackName, url, remoteArgs)
+				return deployment.RunDeployment(ctx, ws, cmd, opts.Display, apitype.Refresh, stackName, url, remoteArgs)
 			}
 
 			isDIYBackend, err := cmdBackend.IsDIYBackend(ws, opts.Display)
@@ -382,7 +383,7 @@ func newRefreshCmd() *cobra.Command {
 		"A list of form [[URN ID]...] describing the provider IDs of pending creates")
 
 	// Remote flags
-	remoteArgs.applyFlags(cmd)
+	remoteArgs.ApplyFlags(cmd)
 
 	if env.DebugCommands.Value() {
 		cmd.PersistentFlags().StringVar(

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -29,6 +29,7 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	cmdConfig "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/deployment"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/plan"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
@@ -68,7 +69,7 @@ func newUpCmd() *cobra.Command {
 	var client string
 
 	// Flags for remote operations.
-	remoteArgs := RemoteArgs{}
+	remoteArgs := deployment.RemoteArgs{}
 
 	// Flags for engine.UpdateOptions.
 	var jsonDisplay bool
@@ -497,7 +498,7 @@ func newUpCmd() *cobra.Command {
 			ws := pkgWorkspace.Instance
 
 			// Remote implies we're skipping previews.
-			if remoteArgs.remote {
+			if remoteArgs.Remote {
 				skipPreview = true
 			}
 
@@ -549,8 +550,8 @@ func newUpCmd() *cobra.Command {
 				opts.Display.SuppressPermalink = false
 			}
 
-			if remoteArgs.remote {
-				err = validateUnsupportedRemoteFlags(expectNop, configArray, path, client, jsonDisplay, policyPackPaths,
+			if remoteArgs.Remote {
+				err = deployment.ValidateUnsupportedRemoteFlags(expectNop, configArray, path, client, jsonDisplay, policyPackPaths,
 					policyPackConfigPaths, refresh, showConfig, showPolicyRemediations, showReplacementSteps, showSames,
 					showReads, suppressOutputs, secretsProvider, &targets, replaces, targetReplaces,
 					targetDependents, planFilePath, cmdStack.ConfigFile)
@@ -563,11 +564,11 @@ func newUpCmd() *cobra.Command {
 					url = args[0]
 				}
 
-				if err = validateRemoteDeploymentFlags(url, remoteArgs); err != nil {
+				if err = deployment.ValidateRemoteDeploymentFlags(url, remoteArgs); err != nil {
 					return err
 				}
 
-				return runDeployment(ctx, ws, cmd, opts.Display, apitype.Update, stackName, url, remoteArgs)
+				return deployment.RunDeployment(ctx, ws, cmd, opts.Display, apitype.Update, stackName, url, remoteArgs)
 			}
 
 			isDIYBackend, err := cmdBackend.IsDIYBackend(ws, opts.Display)
@@ -730,7 +731,7 @@ func newUpCmd() *cobra.Command {
 	}
 
 	// Remote flags
-	remoteArgs.applyFlags(cmd)
+	remoteArgs.ApplyFlags(cmd)
 
 	if env.DebugCommands.Value() {
 		cmd.PersistentFlags().StringVar(


### PR DESCRIPTION
Continuing with the clean-up of `pkg/cmd/pulumi`, this factors out the `deployment ...` hierarchy.