### PR TITLE
Break out the `whoami ...` command hierarchy

### DIFF
--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -53,6 +53,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packagecmd"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/state"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/whoami"
 	"github.com/pulumi/pulumi/pkg/v3/util/tracing"
 	"github.com/pulumi/pulumi/pkg/v3/version"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -349,7 +350,7 @@ func NewPulumiCmd() *cobra.Command {
 			Commands: []*cobra.Command{
 				newLoginCmd(),
 				newLogoutCmd(),
-				newWhoAmICmd(),
+				whoami.NewWhoAmICmd(),
 				org.NewOrgCmd(),
 				deployment.NewDeploymentCmd(),
 			},

--- a/pkg/cmd/pulumi/whoami/whoami.go
+++ b/pkg/cmd/pulumi/whoami/whoami.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package whoami
 
 import (
 	"context"
@@ -33,7 +33,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newWhoAmICmd() *cobra.Command {
+func NewWhoAmICmd() *cobra.Command {
 	var whocmd whoAmICmd
 	cmd := &cobra.Command{
 		Use:   "whoami",
@@ -102,7 +102,7 @@ func (cmd *whoAmICmd) Run(ctx context.Context) error {
 	}
 
 	if cmd.jsonOut {
-		return ui.FprintJSON(cmd.Stdout, WhoAmIJSON{
+		return ui.FprintJSON(cmd.Stdout, whoAmIJSON{
 			User:             name,
 			Organizations:    orgs,
 			URL:              b.URL(),
@@ -133,8 +133,8 @@ func (cmd *whoAmICmd) Run(ctx context.Context) error {
 	return nil
 }
 
-// WhoAmIJSON is the shape of the --json output of this command.
-type WhoAmIJSON struct {
+// whoAmIJSON is the shape of the --json output of this command.
+type whoAmIJSON struct {
 	User             string                      `json:"user"`
 	Organizations    []string                    `json:"organizations,omitempty"`
 	URL              string                      `json:"url"`

--- a/pkg/cmd/pulumi/whoami/whoami_test.go
+++ b/pkg/cmd/pulumi/whoami/whoami_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package whoami
 
 import (
 	"bytes"


### PR DESCRIPTION
Continuing with the clean-up of `pkg/cmd/pulumi`, this factors out the `whoami ...` hierarchy.