### PR TITLE
Break out the `plugin ...` command hierarchy

### DIFF
--- a/pkg/cmd/pulumi/plugin/plugin.go
+++ b/pkg/cmd/pulumi/plugin/plugin.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package plugin
 
 import (
 	"github.com/spf13/cobra"
@@ -25,7 +25,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func newPluginCmd() *cobra.Command {
+func NewPluginCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "plugin",
 		Short: "Manage language and resource provider plugins",

--- a/pkg/cmd/pulumi/plugin/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package plugin
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/plugin/plugin_install_test.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package plugin
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/plugin/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin/plugin_ls.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package plugin
 
 import (
 	"fmt"

--- a/pkg/cmd/pulumi/plugin/plugin_rm.go
+++ b/pkg/cmd/pulumi/plugin/plugin_rm.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package plugin
 
 import (
 	"errors"

--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package plugin
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -51,6 +51,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/deployment"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/org"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packagecmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/plugin"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/state"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/whoami"
@@ -364,7 +365,7 @@ func NewPulumiCmd() *cobra.Command {
 		{
 			Name: "Plugin Commands",
 			Commands: []*cobra.Command{
-				newPluginCmd(),
+				plugin.NewPluginCmd(),
 				newSchemaCmd(),
 				packagecmd.NewPackageCmd(),
 			},


### PR DESCRIPTION
Continuing with the clean-up of `pkg/cmd/pulumi`, this factors out the `plugin ...` hierarchy.