### PR TITLE
Update golangci-lint

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GOLANGCI_LINT_VERSION: v1.60.3
+  GOLANGCI_LINT_VERSION: v1.62.2
 
 jobs:
   golangci:

--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -449,6 +449,7 @@ type dynamicStackCase struct {
 }
 
 func (c dynamicStackCase) getName() string {
+	//nolint:gosec // resourcePayloadBytes is always positive
 	return fmt.Sprintf("%v_x_%v", c.resourceCount, humanize.Bytes(uint64(c.resourcePayloadBytes)))
 }
 

--- a/pkg/cmd/pulumi/convert-trace.go
+++ b/pkg/cmd/pulumi/convert-trace.go
@@ -494,15 +494,15 @@ func (t *otelTrace) criticalPath(span *otelSpan) (string, time.Duration) {
 		_, duration := t.criticalPath(span)
 		return edge{urn: span.urn, length: duration + span.EndTime().Sub(span.StartTime())}
 	}))
-	var max edge
+	var maximum edge
 	for _, e := range edges {
-		if e.length > max.length {
-			max = e
+		if e.length > maximum.length {
+			maximum = e
 		}
 	}
-	span.criticalDependency = max.urn
-	span.criticalPathLength = &max.length
-	return max.urn, max.length
+	span.criticalDependency = maximum.urn
+	span.criticalPathLength = &maximum.length
+	return maximum.urn, maximum.length
 }
 
 // Extract the start and end times from a trace
@@ -648,6 +648,7 @@ func (t *otelTrace) newSpan(root *appdash.Trace, parent *otelSpan) error {
 
 func (t *otelTrace) getNextSpanID() trace.SpanID {
 	var id trace.SpanID
+	//nolint:gosec // len is always positive
 	binary.BigEndian.PutUint64(id[:], uint64(len(t.spans)+1))
 	return id
 }

--- a/pkg/cmd/pulumi/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin_ls.go
@@ -139,6 +139,7 @@ func formatPluginConsole(plugins []workspace.PluginInfo) error {
 		if plugin.Size == 0 {
 			bytes = naString
 		} else {
+			//nolint:gosec // size is always positive
 			bytes = humanize.Bytes(uint64(plugin.Size))
 		}
 		var installTime string
@@ -158,6 +159,7 @@ func formatPluginConsole(plugins []workspace.PluginInfo) error {
 			Columns: []string{plugin.Name, string(plugin.Kind), version, bytes, installTime, lastUsedTime},
 		})
 
+		//nolint:gosec // size is always positive
 		totalSize += uint64(plugin.Size)
 	}
 

--- a/pkg/codegen/hcl2/model/type_tuple.go
+++ b/pkg/codegen/hcl2/model/type_tuple.go
@@ -152,12 +152,12 @@ func (u *tupleElementUnifier) unify(t *TupleType) {
 	if !u.any {
 		u.elementTypes, u.any, u.conversionKind = append([]Type(nil), t.ElementTypes...), true, SafeConversion
 	} else {
-		min := len(u.elementTypes)
-		if l := len(t.ElementTypes); l < min {
-			min = l
+		minimum := len(u.elementTypes)
+		if l := len(t.ElementTypes); l < minimum {
+			minimum = l
 		}
 
-		for i := 0; i < min; i++ {
+		for i := 0; i < minimum; i++ {
 			element, ck := u.elementTypes[i].unify(t.ElementTypes[i])
 			if ck < u.conversionKind {
 				u.conversionKind = ck
@@ -166,11 +166,11 @@ func (u *tupleElementUnifier) unify(t *TupleType) {
 		}
 
 		if len(u.elementTypes) > len(t.ElementTypes) {
-			for i := min; i < len(u.elementTypes); i++ {
+			for i := minimum; i < len(u.elementTypes); i++ {
 				u.elementTypes[i] = NewOptionalType(u.elementTypes[i])
 			}
 		} else {
-			for _, t := range t.ElementTypes[min:] {
+			for _, t := range t.ElementTypes[minimum:] {
 				u.elementTypes = append(u.elementTypes, NewOptionalType(t))
 			}
 		}

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -616,12 +616,12 @@ func TestPreviewWithPendingOperations(t *testing.T) {
 	const resType = "pkgA:m:typA"
 	urnA := p.NewURN(resType, "resA", "")
 
-	newResource := func(urn resource.URN, id resource.ID, delete bool, dependencies ...resource.URN) *resource.State {
+	newResource := func(urn resource.URN, id resource.ID, del bool, dependencies ...resource.URN) *resource.State {
 		return &resource.State{
 			Type:         urn.Type(),
 			URN:          urn,
 			Custom:       true,
-			Delete:       delete,
+			Delete:       del,
 			ID:           id,
 			Inputs:       resource.PropertyMap{},
 			Outputs:      resource.PropertyMap{},
@@ -670,12 +670,12 @@ func TestRefreshWithPendingOperations(t *testing.T) {
 	const resType = "pkgA:m:typA"
 	urnA := p.NewURN(resType, "resA", "")
 
-	newResource := func(urn resource.URN, id resource.ID, delete bool, dependencies ...resource.URN) *resource.State {
+	newResource := func(urn resource.URN, id resource.ID, del bool, dependencies ...resource.URN) *resource.State {
 		return &resource.State{
 			Type:         urn.Type(),
 			URN:          urn,
 			Custom:       true,
-			Delete:       delete,
+			Delete:       del,
 			ID:           id,
 			Inputs:       resource.PropertyMap{},
 			Outputs:      resource.PropertyMap{},
@@ -737,12 +737,12 @@ func TestRefreshPreservesPendingCreateOperations(t *testing.T) {
 	urnA := p.NewURN(resType, "resA", "")
 	urnB := p.NewURN(resType, "resB", "")
 
-	newResource := func(urn resource.URN, id resource.ID, delete bool, dependencies ...resource.URN) *resource.State {
+	newResource := func(urn resource.URN, id resource.ID, del bool, dependencies ...resource.URN) *resource.State {
 		return &resource.State{
 			Type:         urn.Type(),
 			URN:          urn,
 			Custom:       true,
-			Delete:       delete,
+			Delete:       del,
 			ID:           id,
 			Inputs:       resource.PropertyMap{},
 			Outputs:      resource.PropertyMap{},
@@ -818,12 +818,12 @@ func TestUpdateShowsWarningWithPendingOperations(t *testing.T) {
 	urnA := p.NewURN(resType, "resA", "")
 	urnB := p.NewURN(resType, "resB", "")
 
-	newResource := func(urn resource.URN, id resource.ID, delete bool, dependencies ...resource.URN) *resource.State {
+	newResource := func(urn resource.URN, id resource.ID, del bool, dependencies ...resource.URN) *resource.State {
 		return &resource.State{
 			Type:         urn.Type(),
 			URN:          urn,
 			Custom:       true,
-			Delete:       delete,
+			Delete:       del,
 			ID:           id,
 			Inputs:       resource.PropertyMap{},
 			Outputs:      resource.PropertyMap{},

--- a/pkg/engine/lifecycletest/refresh_legacy_diff_test.go
+++ b/pkg/engine/lifecycletest/refresh_legacy_diff_test.go
@@ -81,12 +81,12 @@ func validateRefreshBasicsWithLegacyDiffCombination(
 
 	p.Options.Targets = deploy.NewUrnTargetsFromUrns(refreshTargets)
 
-	newResource := func(urn resource.URN, id resource.ID, delete bool, dependencies ...resource.URN) *resource.State {
+	newResource := func(urn resource.URN, id resource.ID, del bool, dependencies ...resource.URN) *resource.State {
 		return &resource.State{
 			Type:         urn.Type(),
 			URN:          urn,
 			Custom:       true,
-			Delete:       delete,
+			Delete:       del,
 			ID:           id,
 			Inputs:       resource.PropertyMap{},
 			Outputs:      resource.PropertyMap{},

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -558,12 +558,12 @@ func validateRefreshDeleteCombination(t *testing.T, names []string, targets []st
 
 	p.Options.Targets = deploy.NewUrnTargetsFromUrns(refreshTargets)
 
-	newResource := func(urn resource.URN, id resource.ID, delete bool, dependencies ...resource.URN) *resource.State {
+	newResource := func(urn resource.URN, id resource.ID, del bool, dependencies ...resource.URN) *resource.State {
 		return &resource.State{
 			Type:         urn.Type(),
 			URN:          urn,
 			Custom:       true,
-			Delete:       delete,
+			Delete:       del,
 			ID:           id,
 			Inputs:       resource.PropertyMap{},
 			Outputs:      resource.PropertyMap{},
@@ -726,12 +726,12 @@ func validateRefreshBasicsCombination(t *testing.T, names []string, targets []st
 
 	p.Options.Targets = deploy.NewUrnTargetsFromUrns(refreshTargets)
 
-	newResource := func(urn resource.URN, id resource.ID, delete bool, dependencies ...resource.URN) *resource.State {
+	newResource := func(urn resource.URN, id resource.ID, del bool, dependencies ...resource.URN) *resource.State {
 		return &resource.State{
 			Type:         urn.Type(),
 			URN:          urn,
 			Custom:       true,
-			Delete:       delete,
+			Delete:       del,
 			ID:           id,
 			Inputs:       resource.PropertyMap{},
 			Outputs:      resource.PropertyMap{},
@@ -904,12 +904,12 @@ func TestCanceledRefresh(t *testing.T) {
 	urnB := p.NewURN(resType, "resB", "")
 	urnC := p.NewURN(resType, "resC", "")
 
-	newResource := func(urn resource.URN, id resource.ID, delete bool, dependencies ...resource.URN) *resource.State {
+	newResource := func(urn resource.URN, id resource.ID, del bool, dependencies ...resource.URN) *resource.State {
 		return &resource.State{
 			Type:         urn.Type(),
 			URN:          urn,
 			Custom:       true,
-			Delete:       delete,
+			Delete:       del,
 			ID:           id,
 			Inputs:       resource.PropertyMap{},
 			Outputs:      resource.PropertyMap{},

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -253,7 +253,7 @@ func newSimpleLoader(t *testing.T, pkg, version string, config func(resource.Pro
 	})
 }
 
-func newProviderState(pkg, name, id string, delete bool, inputs resource.PropertyMap) *resource.State {
+func newProviderState(pkg, name, id string, del bool, inputs resource.PropertyMap) *resource.State {
 	typ := MakeProviderType(tokens.Package(pkg))
 	urn := resource.NewURN("test", "test", "", typ, name)
 	if inputs == nil {
@@ -263,7 +263,7 @@ func newProviderState(pkg, name, id string, delete bool, inputs resource.Propert
 		Type:   typ,
 		URN:    urn,
 		Custom: true,
-		Delete: delete,
+		Delete: del,
 		ID:     resource.ID(id),
 		Inputs: inputs,
 	}

--- a/pkg/util/nosleep/darwin.go
+++ b/pkg/util/nosleep/darwin.go
@@ -27,6 +27,7 @@ import (
 
 func keepRunning() DoneFunc {
 	// Run caffeinate to keep the system awake.
+	//nolint:gosec
 	cmd := exec.Command("caffeinate", "-i", "-w", strconv.Itoa(os.Getpid()))
 	// we intentionally ignore the error here.  If we can't keep the system awake we still want to continue.
 	err := cmd.Start()

--- a/sdk/go/auto/cmd.go
+++ b/sdk/go/auto/cmd.go
@@ -114,12 +114,12 @@ func NewPulumiCommand(opts *PulumiCommandOptions) (PulumiCommand, error) {
 		return pulumiCommand{}, fmt.Errorf("failed to run `pulumi version`: %w", err)
 	}
 	currentVersion := strings.TrimSpace(string(out))
-	min := minimumVersion
-	if opts.Version.GT(min) {
-		min = opts.Version
+	minimum := minimumVersion
+	if opts.Version.GT(minimum) {
+		minimum = opts.Version
 	}
 	skipVersionCheck := opts.SkipVersionCheck || env.SkipVersionCheck.Value()
-	version, err := parseAndValidatePulumiVersion(min, currentVersion, skipVersionCheck)
+	version, err := parseAndValidatePulumiVersion(minimum, currentVersion, skipVersionCheck)
 	if err != nil {
 		return pulumiCommand{}, err
 	}

--- a/sdk/go/common/util/cmdutil/args.go
+++ b/sdk/go/common/util/cmdutil/args.go
@@ -75,6 +75,6 @@ func SpecificArgs(argNames []string) cobra.PositionalArgs {
 
 // RangeArgs is the same as cobra.RangeArgs, except it is wrapped with ArgsFunc to provide standard
 // Pulumi error handling.
-func RangeArgs(min int, max int) cobra.PositionalArgs {
-	return ArgsFunc(cobra.RangeArgs(min, max))
+func RangeArgs(minimum int, maximum int) cobra.PositionalArgs {
+	return ArgsFunc(cobra.RangeArgs(minimum, maximum))
 }

--- a/sdk/go/common/util/cmdutil/console.go
+++ b/sdk/go/common/util/cmdutil/console.go
@@ -314,10 +314,3 @@ func (table Table) Render(opts *TableRenderOptions) string {
 	}
 	return result.String()
 }
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -834,7 +834,8 @@ func debugCommand(bin string) (*exec.Cmd, *debugger, error) {
 
 func startDebugging(ctx context.Context, engineClient pulumirpc.EngineClient, dbg *debugger) error {
 	// wait for the debugger to be ready
-	ctx, _ = context.WithTimeoutCause(ctx, 1*time.Minute, errors.New("debugger startup timed out"))
+	ctx, cancel := context.WithTimeoutCause(ctx, 1*time.Minute, errors.New("debugger startup timed out"))
+	defer cancel()
 	err := dbg.WaitForReady(ctx)
 	if err != nil {
 		return err

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -784,7 +784,8 @@ func (c *debugger) WaitForReady(ctx context.Context, pid int) error {
 
 func startDebugging(ctx context.Context, engineClient pulumirpc.EngineClient, cmd *exec.Cmd, dbg *debugger) error {
 	// wait for the debugger to be ready
-	ctx, _ = context.WithTimeoutCause(ctx, 1*time.Minute, errors.New("debugger startup timed out"))
+	ctx, cancel := context.WithTimeoutCause(ctx, 1*time.Minute, errors.New("debugger startup timed out"))
+	defer cancel()
 	err := dbg.WaitForReady(ctx, cmd.Process.Pid)
 	if err != nil {
 		return err


### PR DESCRIPTION
Update to the latest version of golangci-lint.

This flags a couple false positives of int -> uint64 conversions where the argument is always positive. It also started flagging cases where builtin functions like max, min and delete are redefined.
