### PR TITLE
Break out `*-trace` commands

### DIFF
--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -54,6 +54,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/plugin"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/state"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/trace"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/whoami"
 	"github.com/pulumi/pulumi/pkg/v3/util/tracing"
 	"github.com/pulumi/pulumi/pkg/v3/version"
@@ -403,8 +404,8 @@ func NewPulumiCmd() *cobra.Command {
 		{
 			Name: "Developer Commands",
 			Commands: []*cobra.Command{
-				newViewTraceCmd(),
-				newConvertTraceCmd(),
+				trace.NewViewTraceCmd(),
+				trace.NewConvertTraceCmd(),
 				newReplayEventsCmd(),
 			},
 		},

--- a/pkg/cmd/pulumi/trace/convert.go
+++ b/pkg/cmd/pulumi/trace/convert.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package trace
 
 import (
 	"context"
@@ -701,7 +701,7 @@ func exportTraceToOtel(querier appdash.Queryer, ignoreLogSpans bool) error {
 	return exporter.Shutdown(context.Background())
 }
 
-func newConvertTraceCmd() *cobra.Command {
+func NewConvertTraceCmd() *cobra.Command {
 	var otel bool
 	var ignoreLogSpans bool
 	var quantum time.Duration

--- a/pkg/cmd/pulumi/trace/io.go
+++ b/pkg/cmd/pulumi/trace/io.go
@@ -1,0 +1,32 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"io"
+	"os"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+func readTrace(path string, store io.ReaderFrom) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer contract.IgnoreClose(f)
+	_, err = store.ReadFrom(f)
+	return err
+}

--- a/pkg/cmd/pulumi/trace/view.go
+++ b/pkg/cmd/pulumi/trace/view.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package trace
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
-	"os"
 
 	"github.com/pulumi/appdash"
 	"github.com/pulumi/appdash/traceapp"
@@ -28,20 +26,9 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-func readTrace(path string, store io.ReaderFrom) error {
-	f, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer contract.IgnoreClose(f)
-	_, err = store.ReadFrom(f)
-	return err
-}
-
-func newViewTraceCmd() *cobra.Command {
+func NewViewTraceCmd() *cobra.Command {
 	var port int
 	cmd := &cobra.Command{
 		Use:   "view-trace [trace-file]",


### PR DESCRIPTION
Continuing with the clean-up of `pkg/cmd/pulumi`, this factors out the `convert-trace` and `view-trace` commands into a `trace` subpackage.