### PR TITLE
Break out the `login` and `logout` commands

### DIFF
--- a/pkg/cmd/pulumi/auth/login.go
+++ b/pkg/cmd/pulumi/auth/login.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package auth
 
 import (
 	"errors"
@@ -38,7 +38,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func newLoginCmd() *cobra.Command {
+func NewLoginCmd() *cobra.Command {
 	var cloudURL string
 	var defaultOrg string
 	var localMode bool

--- a/pkg/cmd/pulumi/auth/logout.go
+++ b/pkg/cmd/pulumi/auth/logout.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package auth
 
 import (
 	"errors"
@@ -28,7 +28,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func newLogoutCmd() *cobra.Command {
+func NewLogoutCmd() *cobra.Command {
 	var cloudURL string
 	var localMode bool
 	var all bool

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -46,6 +46,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/about"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ai"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/auth"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/deployment"
@@ -350,8 +351,8 @@ func NewPulumiCmd() *cobra.Command {
 		{
 			Name: "Pulumi Cloud Commands",
 			Commands: []*cobra.Command{
-				newLoginCmd(),
-				newLogoutCmd(),
+				auth.NewLoginCmd(),
+				auth.NewLogoutCmd(),
 				whoami.NewWhoAmICmd(),
 				org.NewOrgCmd(),
 				deployment.NewDeploymentCmd(),


### PR DESCRIPTION
Continuing with the clean-up of `pkg/cmd/pulumi`, this factors out the `login` and `logout` commands into an `auth` subpackage.