### PR TITLE
Break out the `logs` command

### DIFF
--- a/pkg/cmd/pulumi/logs/logs.go
+++ b/pkg/cmd/pulumi/logs/logs.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package logs
 
 import (
 	"fmt"
@@ -38,7 +38,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func newLogsCmd() *cobra.Command {
+func NewLogsCmd() *cobra.Command {
 	var stackName string
 	var follow bool
 	var since string

--- a/pkg/cmd/pulumi/logs/logs_test.go
+++ b/pkg/cmd/pulumi/logs/logs_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package logs
 
 import (
 	"fmt"

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -50,6 +50,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/deployment"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/logs"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/org"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packagecmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/plugin"
@@ -397,7 +398,7 @@ func NewPulumiCmd() *cobra.Command {
 				newQueryCmd(),
 				newConvertCmd(),
 				newWatchCmd(),
-				newLogsCmd(),
+				logs.NewLogsCmd(),
 			},
 		},
 		// We have a set of options that are useful for developers of pulumi


### PR DESCRIPTION
Continuing with the clean-up of `pkg/cmd/pulumi`, this factors out the `logs` command into its own subpackage.