### PR TITLE
Break out `up`, `destroy`, and other operations

### DIFF
--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package operations
 
 import (
 	"context"
@@ -47,7 +47,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func newDestroyCmd() *cobra.Command {
+func NewDestroyCmd() *cobra.Command {
 	var debug bool
 	var remove bool
 	var stackName string

--- a/pkg/cmd/pulumi/operations/flags_test.go
+++ b/pkg/cmd/pulumi/operations/flags_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package operations
 
 import (
 	"testing"
@@ -24,8 +24,8 @@ import (
 //nolint:paralleltest // Changes environment variables
 func TestContinueOnErrorEnvVar(t *testing.T) {
 	commands := []func() *cobra.Command{
-		newUpCmd,
-		newDestroyCmd,
+		NewUpCmd,
+		NewDestroyCmd,
 	}
 	testCases := []struct {
 		EnvVarValue string

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package operations
 
 import (
 	"bytes"
@@ -535,7 +535,7 @@ func generateImportedDefinitions(ctx *plugin.Context,
 	}, resources, names)
 }
 
-func newImportCmd() *cobra.Command {
+func NewImportCmd() *cobra.Command {
 	var parentSpec string
 	var providerSpec string
 	var importFilePath string

--- a/pkg/cmd/pulumi/operations/import_test.go
+++ b/pkg/cmd/pulumi/operations/import_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package operations
 
 import (
 	"bytes"

--- a/pkg/cmd/pulumi/operations/io.go
+++ b/pkg/cmd/pulumi/operations/io.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package operations
 
 import (
 	"errors"

--- a/pkg/cmd/pulumi/operations/io_test.go
+++ b/pkg/cmd/pulumi/operations/io_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package operations
 
 import (
 	"testing"

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package operations
 
 import (
 	"bytes"
@@ -243,7 +243,7 @@ func buildImportFile(events <-chan engine.Event) *promise.Promise[importFile] {
 	})
 }
 
-func newPreviewCmd() *cobra.Command {
+func NewPreviewCmd() *cobra.Command {
 	var debug bool
 	var expectNop bool
 	var message string

--- a/pkg/cmd/pulumi/operations/preview_test.go
+++ b/pkg/cmd/pulumi/operations/preview_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package main
+
+package operations
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package operations
 
 import (
 	"context"
@@ -46,7 +46,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func newRefreshCmd() *cobra.Command {
+func NewRefreshCmd() *cobra.Command {
 	var debug bool
 	var expectNop bool
 	var message string

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package operations
 
 import (
 	"context"
@@ -57,7 +57,7 @@ var defaultParallel = int32(runtime.NumCPU()) * 4 //nolint:gosec // NumCPU is an
 // intentionally disabling here for cleaner err declaration/assignment.
 //
 //nolint:vetshadow
-func newUpCmd() *cobra.Command {
+func NewUpCmd() *cobra.Command {
 	var debug bool
 	var expectNop bool
 	var message string

--- a/pkg/cmd/pulumi/operations/up_test.go
+++ b/pkg/cmd/pulumi/operations/up_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package operations
 
 import (
 	"fmt"

--- a/pkg/cmd/pulumi/operations/watch.go
+++ b/pkg/cmd/pulumi/operations/watch.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package operations
 
 import (
 	"context"
@@ -39,7 +39,7 @@ import (
 // intentionally disabling here for cleaner err declaration/assignment.
 //
 //nolint:vetshadow
-func newWatchCmd() *cobra.Command {
+func NewWatchCmd() *cobra.Command {
 	var debug bool
 	var message string
 	var execKind string

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -54,6 +54,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/deployment"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/logs"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/newcmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/operations"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/org"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packagecmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/plugin"
@@ -333,8 +334,8 @@ func NewPulumiCmd() *cobra.Command {
 				config.NewConfigCmd(),
 				cmdStack.NewStackCmd(),
 				console.NewConsoleCmd(),
-				newImportCmd(),
-				newRefreshCmd(),
+				operations.NewImportCmd(),
+				operations.NewRefreshCmd(),
 				state.NewStateCmd(),
 				newInstallCmd(),
 			},
@@ -342,9 +343,9 @@ func NewPulumiCmd() *cobra.Command {
 		{
 			Name: "Deployment Commands",
 			Commands: []*cobra.Command{
-				newUpCmd(),
-				newDestroyCmd(),
-				newPreviewCmd(),
+				operations.NewUpCmd(),
+				operations.NewDestroyCmd(),
+				operations.NewPreviewCmd(),
 				newCancelCmd(),
 			},
 		},
@@ -402,7 +403,7 @@ func NewPulumiCmd() *cobra.Command {
 			Commands: []*cobra.Command{
 				newQueryCmd(),
 				convert.NewConvertCmd(),
-				newWatchCmd(),
+				operations.NewWatchCmd(),
 				logs.NewLogsCmd(),
 			},
 		},


### PR DESCRIPTION
Continuing with the clean-up of `pkg/cmd/pulumi`, this factors out operational commands such as `up`, `destroy`, `refresh`, `import` etc.