### PR TITLE
Break out the `install` command

### DIFF
--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package install
 
 import (
 	"errors"
@@ -34,7 +34,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func newInstallCmd() *cobra.Command {
+func NewInstallCmd() *cobra.Command {
 	var reinstall bool
 	var noPlugins, noDependencies bool
 	var useLanguageVersionTools bool

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -53,6 +53,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/console"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/convert"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/deployment"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/install"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/logs"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/newcmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/operations"
@@ -338,7 +339,7 @@ func NewPulumiCmd() *cobra.Command {
 				operations.NewImportCmd(),
 				operations.NewRefreshCmd(),
 				state.NewStateCmd(),
-				newInstallCmd(),
+				install.NewInstallCmd(),
 			},
 		},
 		{


### PR DESCRIPTION
Continuing with the clean-up of `pkg/cmd/pulumi`, this factors out the `install` command.