### PR TITLE
Break out the `replay-events` command

### DIFF
--- a/pkg/cmd/pulumi/events/replay.go
+++ b/pkg/cmd/pulumi/events/replay.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package events
 
 import (
 	"encoding/json"
@@ -33,7 +33,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-func newReplayEventsCmd() *cobra.Command {
+func NewReplayEventsCmd() *cobra.Command {
 	var preview bool
 
 	var jsonDisplay bool

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -53,6 +53,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/console"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/convert"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/deployment"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/events"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/install"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/logs"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/newcmd"
@@ -416,7 +417,7 @@ func NewPulumiCmd() *cobra.Command {
 			Commands: []*cobra.Command{
 				trace.NewViewTraceCmd(),
 				trace.NewConvertTraceCmd(),
-				newReplayEventsCmd(),
+				events.NewReplayEventsCmd(),
 			},
 		},
 		// AI Commands relating to specifically the Pulumi AI service


### PR DESCRIPTION
Continuing with the clean-up of `pkg/cmd/pulumi`, this factors out the `replay-events` command.