### PR TITLE
Break out the `query` command

### DIFF
--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -62,6 +62,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packagecmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/plugin"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/policy"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/query"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/schema"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/state"
@@ -405,7 +406,7 @@ func NewPulumiCmd() *cobra.Command {
 		{
 			Name: "Experimental Commands",
 			Commands: []*cobra.Command{
-				newQueryCmd(),
+				query.NewQueryCmd(),
 				convert.NewConvertCmd(),
 				operations.NewWatchCmd(),
 				logs.NewLogsCmd(),

--- a/pkg/cmd/pulumi/query/query.go
+++ b/pkg/cmd/pulumi/query/query.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package query
 
 import (
 	"context"
@@ -34,7 +34,7 @@ import (
 // intentionally disabling here for cleaner err declaration/assignment.
 //
 //nolint:vetshadow
-func newQueryCmd() *cobra.Command {
+func NewQueryCmd() *cobra.Command {
 	var stackName string
 
 	cmd := &cobra.Command{


### PR DESCRIPTION
Continuing with the clean-up of `pkg/cmd/pulumi`, this factors out the `query` command.