### PR TITLE
Break out the `env` command

### DIFF
--- a/pkg/cmd/pulumi/env/env.go
+++ b/pkg/cmd/pulumi/env/env.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package env
 
 import (
 	"github.com/spf13/cobra"
@@ -24,7 +24,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
-func newEnvCmd() *cobra.Command {
+func NewEnvCmd() *cobra.Command {
 	escCLI := cli.New(&cli.Options{
 		ParentPath:      "pulumi",
 		Colors:          cmdutil.GetGlobalColorization(),

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -53,6 +53,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/console"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/convert"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/deployment"
+	cmdEnv "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/env"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/events"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/install"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/logs"
@@ -357,7 +358,7 @@ func NewPulumiCmd() *cobra.Command {
 		{
 			Name: "Environment Commands",
 			Commands: []*cobra.Command{
-				newEnvCmd(),
+				cmdEnv.NewEnvCmd(),
 			},
 		},
 		{


### PR DESCRIPTION
Continuing with the clean-up of `pkg/cmd/pulumi`, this factors out the `env` command.