### PR TITLE
Break out remaining commands

### DIFF
--- a/pkg/cmd/pulumi/completion/gen.go
+++ b/pkg/cmd/pulumi/completion/gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package completion
 
 import (
 	"bytes"
@@ -26,8 +26,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
-// newGenCompletionCmd returns a new command that, when run, generates a bash or zsh completion script for the CLI.
-func newGenCompletionCmd(root *cobra.Command) *cobra.Command {
+// NewGenCompletionCmd returns a new command that, when run, generates a bash or zsh completion script for the CLI.
+func NewGenCompletionCmd(root *cobra.Command) *cobra.Command {
 	return &cobra.Command{
 		Use:     "gen-completion <SHELL>",
 		Aliases: []string{"completion"},

--- a/pkg/cmd/pulumi/markdown/gen.go
+++ b/pkg/cmd/pulumi/markdown/gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package markdown
 
 import (
 	"bytes"
@@ -35,9 +35,9 @@ var replaceH2Pattern = regexp.MustCompile(`(?m)^## .*$`)
 // Used to promote the `###` headings to `##` in generated markdown files.
 var h3Pattern = regexp.MustCompile(`(?m)^###\s`)
 
-// newGenMarkdownCmd returns a new command that, when run, generates CLI documentation as Markdown files.
+// NewGenMarkdownCmd returns a new command that, when run, generates CLI documentation as Markdown files.
 // It is hidden by default since it's not commonly used outside of our own build processes.
-func newGenMarkdownCmd(root *cobra.Command) *cobra.Command {
+func NewGenMarkdownCmd(root *cobra.Command) *cobra.Command {
 	return &cobra.Command{
 		Use:    "gen-markdown <DIR>",
 		Args:   cmdutil.ExactArgs(1),

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -49,6 +49,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/auth"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cancel"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/completion"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/console"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/convert"
@@ -57,6 +58,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/events"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/install"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/logs"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/markdown"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/newcmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/operations"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/org"
@@ -390,7 +392,7 @@ func NewPulumiCmd() *cobra.Command {
 			Commands: []*cobra.Command{
 				cmdVersion.NewVersionCmd(),
 				about.NewAboutCmd(),
-				newGenCompletionCmd(cmd),
+				completion.NewGenCompletionCmd(cmd),
 			},
 		},
 
@@ -398,7 +400,7 @@ func NewPulumiCmd() *cobra.Command {
 		{
 			Name: "Hidden Commands",
 			Commands: []*cobra.Command{
-				newGenMarkdownCmd(cmd),
+				markdown.NewGenMarkdownCmd(cmd),
 			},
 		},
 


### PR DESCRIPTION
This commit finishes the clean-up of `pkg/cmd/pulumi`, breaking out the `gen-completion` and `gen-markdown` commands.