### PR TITLE
`pulumi package gen-sdk`: Write where the SDK was generated to

### DIFF
--- a/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
@@ -85,9 +85,15 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 						return err
 					}
 				}
+				fmt.Fprintf(os.Stderr, "SDKs have been written to %s", out)
 				return nil
 			}
-			return genSDK(language, out, pkg, overlays, local)
+			err = genSDK(language, out, pkg, overlays, local)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "SDKs have been written to %s", filepath.Join(out, language))
+			return nil
 		}),
 	}
 	cmd.Flags().StringVarP(&language, "language", "", "all",

--- a/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
@@ -92,7 +92,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(os.Stderr, "SDKs have been written to %s", filepath.Join(out, language))
+			fmt.Fprintf(os.Stderr, "SDK has been written to %s", filepath.Join(out, language))
 			return nil
 		}),
 	}


### PR DESCRIPTION
This is a small UX improvement:

Before:

```
𝛌 pulumi package gen-sdk --language typescript terraform-provider registry.opentofu.org/Azure/alz 0.11.1
Downloading provider: terraform-provider
```

After:

```
𝛌 pulumi package gen-sdk --language typescript terraform-provider registry.opentofu.org/Azure/alz 0.11.1
Downloading provider: terraform-provider
SDKs have been written to ./sdk
```