### PR TITLE
Only return providers from gatherPluginsFromProgram

### DIFF
--- a/cmd/pulumi-test-language/test_host.go
+++ b/cmd/pulumi-test-language/test_host.go
@@ -124,9 +124,7 @@ func (h *testHost) LanguageRuntime(runtime string, info plugin.ProgramInfo) (plu
 func (h *testHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plugin.Flags) error {
 	// EnsurePlugins will be called with the result of GetRequiredPlugins, so we can use this to check
 	// that that returned the expected plugins (with expected versions).
-	expected := mapset.NewSet(
-		fmt.Sprintf("language-%s@<nil>", h.runtimeName),
-	)
+	expected := mapset.NewSet[string]()
 	for _, provider := range h.providers {
 		pkg := provider.Pkg()
 		version, err := getProviderVersion(provider)

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -203,8 +203,8 @@ func gatherPluginsFromProgram(plugctx *plugin.Context, runtime string, prog plug
 		return set, err
 	}
 	for _, plug := range langhostPlugins {
-		// Ignore language plugins named "client".
-		if plug.Name == clientRuntimeName && plug.Kind == apitype.LanguagePlugin {
+		// Ignore language plugins
+		if plug.Kind == apitype.LanguagePlugin {
 			continue
 		}
 


### PR DESCRIPTION
gatherPluginsFromProgram historically would return the language plugin as well as provider plugins. Nothing in the system made use of that language plugin, and making this function just return providers makes it a lot clearer on changing this to return "packages" rather than "plugins" for parameterization support.