### PR TITLE
Return when rejecting the InvokeOutput output on error

### DIFF
--- a/changelog/pending/20241211--sdk-go--return-when-resolving-rejecting-the-invokeoutput-output.yaml
+++ b/changelog/pending/20241211--sdk-go--return-when-resolving-rejecting-the-invokeoutput-output.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Return when resolving/rejecting the InvokeOutput output

--- a/changelog/pending/20241211--sdk-go--return-when-resolving-rejecting-the-invokeoutput-output.yaml
+++ b/changelog/pending/20241211--sdk-go--return-when-resolving-rejecting-the-invokeoutput-output.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: sdk/go
-  description: Return when resolving/rejecting the InvokeOutput output
+  description: Return when rejecting the InvokeOutput output on error

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -886,7 +886,6 @@ func (ctx *Context) InvokeOutput(
 			return
 		}
 		internal.ResolveOutput(output, dest.Interface(), known, secret, resourcesToInternal(deps))
-		return
 	}()
 
 	return output

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -875,6 +875,7 @@ func (ctx *Context) InvokeOutput(
 		outProps, deps, err := ctx.invokePackageRaw(tok, args, options.PackageRef, options.InvokeOptions...)
 		if err != nil {
 			internal.RejectOutput(output, err)
+			return
 		}
 
 		dest := reflect.New(output.ElementType()).Elem()
@@ -882,8 +883,10 @@ func (ctx *Context) InvokeOutput(
 		secret, err := unmarshalOutput(ctx, resource.NewObjectProperty(outProps), dest)
 		if err != nil {
 			internal.RejectOutput(output, err)
+			return
 		}
 		internal.ResolveOutput(output, dest.Interface(), known, secret, resourcesToInternal(deps))
+		return
 	}()
 
 	return output

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -645,7 +645,7 @@ func TestInvokeOutput(t *testing.T) {
 
 	err := RunErr(func(ctx *Context) error {
 		outType := AnyOutput{}
-		output := ctx.InvokeOutput("test:invoke:success", &invokeArgs{"will fail"}, outType, InvokeOutputOptions{})
+		output := ctx.InvokeOutput("test:invoke:success", &invokeArgs{"will succeed"}, outType, InvokeOutputOptions{})
 		ctx.Export("output", output)
 		return nil
 	}, WithMocks("project", "stack", mocks))
@@ -653,7 +653,7 @@ func TestInvokeOutput(t *testing.T) {
 
 	err = RunErr(func(ctx *Context) error {
 		outType := AnyOutput{}
-		output := ctx.InvokeOutput("test:invoke:fail", &invokeArgs{"will succeed"}, outType, InvokeOutputOptions{})
+		output := ctx.InvokeOutput("test:invoke:fail", &invokeArgs{"will fail"}, outType, InvokeOutputOptions{})
 		ctx.Export("output", output)
 		return nil
 	}, WithMocks("project", "stack", mocks))

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -16,6 +16,7 @@ package pulumi
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"strings"
 	"testing"
@@ -624,4 +625,38 @@ func TestWithValue(t *testing.T) {
 	assert.Equal(t, nil, testCtx.Value(key))
 	assert.Equal(t, val, newCtx.Value(key))
 	assert.Equal(t, newCtx.state, testCtx.state)
+}
+
+func TestInvokeOutput(t *testing.T) {
+	t.Parallel()
+
+	mocks := &testMonitor{
+		CallF: func(args MockCallArgs) (resource.PropertyMap, error) {
+			if args.Token == "test:invoke:fail" {
+				return nil, errors.New("invoke error")
+			} else {
+				return resource.PropertyMap{"result": resource.NewStringProperty("success!")}, nil
+			}
+		},
+	}
+
+	type invokeArgs struct {
+		Arg string
+	}
+
+	err := RunErr(func(ctx *Context) error {
+		outType := AnyOutput{}
+		output := ctx.InvokeOutput("test:invoke:success", &invokeArgs{"will fail"}, outType, InvokeOutputOptions{})
+		ctx.Export("output", output)
+		return nil
+	}, WithMocks("project", "stack", mocks))
+	require.NoError(t, err)
+
+	err = RunErr(func(ctx *Context) error {
+		outType := AnyOutput{}
+		output := ctx.InvokeOutput("test:invoke:fail", &invokeArgs{"will succeed"}, outType, InvokeOutputOptions{})
+		ctx.Export("output", output)
+		return nil
+	}, WithMocks("project", "stack", mocks))
+	require.ErrorContains(t, err, "invoke error")
 }

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -634,9 +634,8 @@ func TestInvokeOutput(t *testing.T) {
 		CallF: func(args MockCallArgs) (resource.PropertyMap, error) {
 			if args.Token == "test:invoke:fail" {
 				return nil, errors.New("invoke error")
-			} else {
-				return resource.PropertyMap{"result": resource.NewStringProperty("success!")}, nil
 			}
+			return resource.PropertyMap{"result": resource.NewStringProperty("success!")}, nil
 		},
 	}
 


### PR DESCRIPTION
This does not seem to cause any issues because Output guards against double calls, but we should return after rejecting/returning and not rely on output being defensive.
