### PR TITLE
Use LoadPackageV2 in loader server

### DIFF
--- a/changelog/pending/20241212--engine--change-loader-server-to-use-package-load-v2-so-it-can-include-paramaterization.yaml
+++ b/changelog/pending/20241212--engine--change-loader-server-to-use-package-load-v2-so-it-can-include-paramaterization.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: change loader server to use package load v2 so it can include paramaterization


### PR DESCRIPTION
This change is required to support parameterization of providers.

It is part of the work required for pulumi/pulumi#18019
