### PR TITLE
[codegen/dotnet] Emit local dependencies in restore sources deterministically

### DIFF
--- a/changelog/pending/20241212--programgen-dotnet--emit-local-dependencies-in-restore-sources-deterministically.yaml
+++ b/changelog/pending/20241212--programgen-dotnet--emit-local-dependencies-in-restore-sources-deterministically.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/dotnet
+  description: Emit local dependencies in restore sources deterministically

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -28,6 +28,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -2325,10 +2326,8 @@ func genProjectFile(pkg *schema.Package,
 	for _, dep := range localDependencies {
 		folders.Add(path.Dir(dep))
 	}
-	restoreSources := ""
-	if len(folders.ToSlice()) > 0 {
-		restoreSources = strings.Join(folders.ToSlice(), ";")
-	}
+	restoreSources := folders.ToSlice()
+	sort.Strings(restoreSources)
 
 	// Add local package references
 	pkgs := codegen.SortedKeys(localDependencies)
@@ -2366,7 +2365,7 @@ func genProjectFile(pkg *schema.Package,
 		PackageReferences: packageReferences,
 		ProjectReferences: projectReferences,
 		Version:           version,
-		RestoreSources:    restoreSources,
+		RestoreSources:    strings.Join(restoreSources, ";"),
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	mapset "github.com/deckarep/golang-set/v2"
@@ -298,10 +299,14 @@ func GenerateProject(
 	for _, dep := range localDependencies {
 		folders.Add(path.Dir(dep))
 	}
-	if len(folders.ToSlice()) > 0 {
+
+	restoreSources := folders.ToSlice()
+	sort.Strings(restoreSources)
+
+	if len(restoreSources) > 0 {
 		csproj.WriteString(`	<PropertyGroup>
 		<RestoreSources>`)
-		csproj.WriteString(strings.Join(folders.ToSlice(), ";"))
+		csproj.WriteString(strings.Join(restoreSources, ";"))
 		csproj.WriteString(`;$(RestoreSources)</RestoreSources>
 	</PropertyGroup>
 `)


### PR DESCRIPTION
### Description

Required for https://github.com/pulumi/pulumi-dotnet/pull/314 we need the generated restore sources to be emitted deterministically so that the generated code and tests are stable between local and CI runs 