### PR TITLE
Update the refresh/destroy warnings for parameterized packages

### DIFF
--- a/changelog/pending/20241212--engine--warn-if-refresh-or-destroy-use-older-parameterized-packages.yaml
+++ b/changelog/pending/20241212--engine--warn-if-refresh-or-destroy-use-older-parameterized-packages.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Warn if `refresh` or `destroy` use older parameterized packages

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -46,27 +46,23 @@ const (
 // PluginSet represents a set of plugins.
 type PluginSet map[string]workspace.PluginSpec
 
+// NewPluginSet creates a new PluginSet from the specified PluginSpecs.
+func NewPluginSet(plugins ...workspace.PluginSpec) PluginSet {
+	var s PluginSet = make(map[string]workspace.PluginSpec, len(plugins))
+	for _, p := range plugins {
+		s.Add(p)
+	}
+	return s
+}
+
 // Add adds a plugin to this plugin set.
 func (p PluginSet) Add(plug workspace.PluginSpec) {
 	p[plug.String()] = plug
 }
 
-// Union returns the union of this pluginSet with another pluginSet.
-func (p PluginSet) Union(other PluginSet) PluginSet {
-	newSet := NewPluginSet()
-	for _, value := range p {
-		newSet.Add(value)
-	}
-	for _, value := range other {
-		newSet.Add(value)
-	}
-	return newSet
-}
-
-// Removes less specific entries.
+// Removes less-specific entries.
 //
-// For example, the plugin aws would be removed if there was an already existing plugin
-// aws-5.4.0.
+// For example, the plugin aws would be removed if there was an already existing plugin aws-5.4.0.
 func (p PluginSet) Deduplicate() PluginSet {
 	existing := map[string]workspace.PluginSpec{}
 	newSet := NewPluginSet()
@@ -100,34 +96,6 @@ func (p PluginSet) Deduplicate() PluginSet {
 	return newSet
 }
 
-// A PluginUpdate represents an update from one version of a plugin to another.
-type PluginUpdate struct {
-	// The old plugin version.
-	Old workspace.PluginSpec
-	// The new plugin version.
-	New workspace.PluginSpec
-}
-
-// UpdatesTo returns a list of PluginUpdates that represent the updates to the argument PluginSet present in this
-// PluginSet. For instance, if the argument contains a plugin P at version 3, and this PluginSet contains the same
-// plugin P (as identified by name and kind) at version 5, this method will return an update where the Old field
-// contains the version 3 instance from the argument and the New field contains the version 5 instance from this
-// PluginSet.
-func (p PluginSet) UpdatesTo(old PluginSet) []PluginUpdate {
-	var updates []PluginUpdate
-	for _, value := range p {
-		for _, otherValue := range old {
-			if value.Name == otherValue.Name && value.Kind == otherValue.Kind {
-				if value.Version != nil && otherValue.Version != nil && value.Version.GT(*otherValue.Version) {
-					updates = append(updates, PluginUpdate{Old: otherValue, New: value})
-				}
-			}
-		}
-	}
-
-	return updates
-}
-
 // Values returns a slice of all of the plugins contained within this set.
 func (p PluginSet) Values() []workspace.PluginSpec {
 	plugins := slice.Prealloc[workspace.PluginSpec](len(p))
@@ -137,13 +105,86 @@ func (p PluginSet) Values() []workspace.PluginSpec {
 	return plugins
 }
 
-// NewPluginSet creates a new empty pluginSet.
-func NewPluginSet(plugins ...workspace.PluginSpec) PluginSet {
-	var s PluginSet = make(map[string]workspace.PluginSpec, len(plugins))
-	for _, p := range plugins {
+// PackageSet represents a set of packages.
+type PackageSet map[string]workspace.PackageDescriptor
+
+// NewPackageSet creates a new PackageSet from the specified PackageDescriptors.
+func NewPackageSet(pkgs ...workspace.PackageDescriptor) PackageSet {
+	var s PackageSet = make(map[string]workspace.PackageDescriptor, len(pkgs))
+	for _, p := range pkgs {
 		s.Add(p)
 	}
 	return s
+}
+
+// Add adds a package to this package set.
+func (p PackageSet) Add(pkg workspace.PackageDescriptor) {
+	p[pkg.String()] = pkg
+}
+
+// Union returns the union of this PackageSet with another PackageSet.
+func (p PackageSet) Union(other PackageSet) PackageSet {
+	newSet := NewPackageSet()
+	for _, value := range p {
+		newSet.Add(value)
+	}
+	for _, value := range other {
+		newSet.Add(value)
+	}
+	return newSet
+}
+
+// ToPluginSet converts this PackageSet to a PluginSet by discarding all parameterization information.
+func (p PackageSet) ToPluginSet() PluginSet {
+	newSet := NewPluginSet()
+	for _, value := range p {
+		newSet.Add(value.PluginSpec)
+	}
+	return newSet
+}
+
+// A PackageUpdate represents an update from one version of a package to another.
+type PackageUpdate struct {
+	// The old package version.
+	Old workspace.PackageDescriptor
+	// The new package version.
+	New workspace.PackageDescriptor
+}
+
+// UpdatesTo returns a list of PackageUpdates that represent the updates to the argument PackageSet present in this
+// PackageSet. For instance, if the argument contains a package P at version 3, and this PackageSet contains the same
+// package P (as identified by name and kind) at version 5, this method will return an update where the Old field
+// contains the version 3 instance from the argument and the New field contains the version 5 instance from this
+// PackageSet. This also considers parameterization information, so a parameterized package P at version 3 will be
+// considered different from a parameterized package P at version 5 even if the base plugin is the same.
+func (p PackageSet) UpdatesTo(old PackageSet) []PackageUpdate {
+	var updates []PackageUpdate
+	for _, value := range p {
+		for _, otherValue := range old {
+			// This is comparing _package_ names. i.e. the plugin name if parameterization is nil, or the parameterization
+			// name if it's present. This means that, if we see a package `aws v1.2.3`, and a parameterized package `aws
+			// v1.2.4 (base: terraform-provider)`, say, we _will_ consider the latter an update of the former, since there can
+			// only really be one instance of a package name in a Pulumi program.
+
+			name := value.PackageName()
+			otherName := otherValue.PackageName()
+
+			namesAndKindsEqual := name == otherName && value.Kind == otherValue.Kind
+
+			if namesAndKindsEqual {
+				version := value.PackageVersion()
+				otherVersion := otherValue.PackageVersion()
+
+				// If both versions have been explicitly specified, we can compare them. If one is missing, we don't have enough
+				// information to work out if one is a later version of the other.
+				if version != nil && otherVersion != nil && version.GT(*otherVersion) {
+					updates = append(updates, PackageUpdate{Old: otherValue, New: value})
+				}
+			}
+		}
+	}
+
+	return updates
 }
 
 // GetRequiredPlugins lists a full set of plugins that will be required by the given program.
@@ -192,45 +233,46 @@ func GetRequiredPlugins(
 	return plugins, nil
 }
 
-// gatherPluginsFromProgram inspects the given program and returns the set of plugins that the program requires to
+// gatherPackagesFromProgram inspects the given program and returns the set of packages that the program requires to
 // function. If the language host does not support this operation, the empty set is returned.
-func gatherPluginsFromProgram(plugctx *plugin.Context, runtime string, prog plugin.ProgramInfo) (PluginSet, error) {
-	logging.V(preparePluginLog).Infof("gatherPluginsFromProgram(): gathering plugins from language host")
-	set := NewPluginSet()
+func gatherPackagesFromProgram(plugctx *plugin.Context, runtime string, info plugin.ProgramInfo) (PackageSet, error) {
+	logging.V(preparePluginLog).Infof("gatherPackagesFromProgram(): gathering plugins from language host")
 
-	langhostPlugins, err := GetRequiredPlugins(plugctx.Host, runtime, prog)
-	if err != nil {
-		return set, err
+	lang, err := plugctx.Host.LanguageRuntime(runtime, info)
+	if lang == nil || err != nil {
+		return nil, fmt.Errorf("failed to load language plugin %s: %w", runtime, err)
 	}
-	for _, plug := range langhostPlugins {
-		// Ignore language plugins
-		if plug.Kind == apitype.LanguagePlugin {
-			continue
-		}
 
+	pkgs, err := lang.GetRequiredPackages(info)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover package requirements: %w", err)
+	}
+
+	set := NewPackageSet()
+	for _, pkg := range pkgs {
 		logging.V(preparePluginLog).Infof(
-			"gatherPluginsFromProgram(): plugin %s %s (%s) is required by language host",
-			plug.Name, plug.Version, plug.PluginDownloadURL)
-		set.Add(plug)
+			"gatherPackagesFromProgram(): package %s (%s) is required by language host",
+			pkg.String(), pkg.PluginDownloadURL)
+		set.Add(pkg)
 	}
 	return set, nil
 }
 
-// gatherPluginsFromSnapshot inspects the snapshot associated with the given Target and returns the set of plugins
-// required to operate on the snapshot. The set of plugins is derived from first-class providers saved in the snapshot
+// gatherPackagesFromSnapshot inspects the snapshot associated with the given Target and returns the set of packages
+// required to operate on the snapshot. The set of packages is derived from first-class providers saved in the snapshot
 // and the plugins specified in the deployment manifest.
-func gatherPluginsFromSnapshot(plugctx *plugin.Context, target *deploy.Target) (PluginSet, error) {
-	logging.V(preparePluginLog).Infof("gatherPluginsFromSnapshot(): gathering plugins from snapshot")
-	set := NewPluginSet()
+func gatherPackagesFromSnapshot(plugctx *plugin.Context, target *deploy.Target) (PackageSet, error) {
+	logging.V(preparePluginLog).Infof("gatherPackagesFromSnapshot(): gathering plugins from snapshot")
+	set := NewPackageSet()
 	if target == nil || target.Snapshot == nil {
-		logging.V(preparePluginLog).Infof("gatherPluginsFromSnapshot(): no snapshot available, skipping")
+		logging.V(preparePluginLog).Infof("gatherPackagesFromSnapshot(): no snapshot available, skipping")
 		return set, nil
 	}
 	for _, res := range target.Snapshot.Resources {
 		urn := res.URN
 		if !providers.IsProviderType(urn.Type()) {
 			logging.V(preparePluginVerboseLog).Infof(
-				"gatherPluginsFromSnapshot(): skipping %q, not a provider", urn)
+				"gatherPackagesFromSnapshot(): skipping %q, not a provider", urn)
 			continue
 		}
 		pkg := providers.GetProviderPackage(urn.Type())
@@ -251,15 +293,30 @@ func gatherPluginsFromSnapshot(plugctx *plugin.Context, target *deploy.Target) (
 		if err != nil {
 			return set, err
 		}
+		parameterization, err := providers.GetProviderParameterization(pkg, res.Inputs)
+		if err != nil {
+			return set, err
+		}
+		var packageParameterization *workspace.Parameterization
+		if parameterization != nil {
+			packageParameterization = &workspace.Parameterization{
+				Name:    string(parameterization.Name),
+				Version: parameterization.Version,
+				Value:   parameterization.Value,
+			}
+		}
 
 		logging.V(preparePluginLog).Infof(
-			"gatherPluginsFromSnapshot(): plugin %s %s is required by first-class provider %q", name, version, urn)
-		set.Add(workspace.PluginSpec{
-			Name:              name.String(),
-			Kind:              apitype.ResourcePlugin,
-			Version:           version,
-			PluginDownloadURL: downloadURL,
-			Checksums:         checksums,
+			"gatherPackagesFromSnapshot(): package %s %s is required by first-class provider %q", name, version, urn)
+		set.Add(workspace.PackageDescriptor{
+			PluginSpec: workspace.PluginSpec{
+				Name:              name.String(),
+				Kind:              apitype.ResourcePlugin,
+				Version:           version,
+				PluginDownloadURL: downloadURL,
+				Checksums:         checksums,
+			},
+			Parameterization: packageParameterization,
 		})
 	}
 	return set, nil

--- a/pkg/engine/plugins_test.go
+++ b/pkg/engine/plugins_test.go
@@ -196,189 +196,367 @@ func TestPluginSetDeduplicate(t *testing.T) {
 	}
 }
 
-func TestPluginSetUpdatesTo(t *testing.T) {
+func TestPackageSetUpdatesTo(t *testing.T) {
 	t.Parallel()
 
 	// Arrange.
 	cases := []struct {
 		name     string
-		olds     PluginSet
-		news     PluginSet
-		expected []PluginUpdate
+		olds     PackageSet
+		news     PackageSet
+		expected []PackageUpdate
 	}{
 		{
 			name:     "Both empty",
-			olds:     NewPluginSet(),
-			news:     NewPluginSet(),
+			olds:     NewPackageSet(),
+			news:     NewPackageSet(),
 			expected: nil,
 		},
 		{
 			name: "Olds empty",
-			olds: NewPluginSet(),
-			news: NewPluginSet(workspace.PluginSpec{
-				Name:    "foo",
-				Version: &semver.Version{Major: 1},
+			olds: NewPackageSet(),
+			news: NewPackageSet(workspace.PackageDescriptor{
+				PluginSpec: workspace.PluginSpec{
+					Name:    "foo",
+					Kind:    apitype.ResourcePlugin,
+					Version: &semver.Version{Major: 1},
+				},
 			}),
 			expected: nil,
 		},
 		{
 			name: "News empty",
-			olds: NewPluginSet(workspace.PluginSpec{
-				Name:    "foo",
-				Version: &semver.Version{Major: 1},
+			olds: NewPackageSet(workspace.PackageDescriptor{
+				PluginSpec: workspace.PluginSpec{
+					Name:    "foo",
+					Kind:    apitype.ResourcePlugin,
+					Version: &semver.Version{Major: 1},
+				},
 			}),
-			news:     NewPluginSet(),
+			news:     NewPackageSet(),
 			expected: nil,
 		},
 		{
 			name: "No matches by name",
-			olds: NewPluginSet(workspace.PluginSpec{
-				Name:    "foo",
-				Version: &semver.Version{Major: 1},
+			olds: NewPackageSet(workspace.PackageDescriptor{
+				PluginSpec: workspace.PluginSpec{
+					Name:    "foo",
+					Kind:    apitype.ResourcePlugin,
+					Version: &semver.Version{Major: 1},
+				},
 			}),
-			news: NewPluginSet(workspace.PluginSpec{
-				Name:    "bar",
-				Version: &semver.Version{Major: 1},
+			news: NewPackageSet(workspace.PackageDescriptor{
+				PluginSpec: workspace.PluginSpec{
+					Name:    "bar",
+					Kind:    apitype.ResourcePlugin,
+					Version: &semver.Version{Major: 1},
+				},
 			}),
 			expected: nil,
 		},
 		{
 			name: "No matches by kind",
-			olds: NewPluginSet(workspace.PluginSpec{
-				Name:    "foo",
-				Kind:    apitype.ResourcePlugin,
-				Version: &semver.Version{Major: 1},
+			olds: NewPackageSet(workspace.PackageDescriptor{
+				PluginSpec: workspace.PluginSpec{
+					Name:    "foo",
+					Kind:    apitype.ResourcePlugin,
+					Version: &semver.Version{Major: 1},
+				},
 			}),
-			news: NewPluginSet(workspace.PluginSpec{
-				Name:    "foo",
-				Kind:    apitype.AnalyzerPlugin,
-				Version: &semver.Version{Major: 1},
+			news: NewPackageSet(workspace.PackageDescriptor{
+				PluginSpec: workspace.PluginSpec{
+					Name:    "foo",
+					Kind:    apitype.AnalyzerPlugin,
+					Version: &semver.Version{Major: 1},
+				},
 			}),
 			expected: nil,
 		},
 		{
 			name: "Matches with no updates (equal)",
-			olds: NewPluginSet(workspace.PluginSpec{
-				Name:    "foo",
-				Kind:    apitype.ResourcePlugin,
-				Version: &semver.Version{Major: 1},
+			olds: NewPackageSet(workspace.PackageDescriptor{
+				PluginSpec: workspace.PluginSpec{
+					Name:    "foo",
+					Kind:    apitype.ResourcePlugin,
+					Version: &semver.Version{Major: 1},
+				},
 			}),
-			news: NewPluginSet(workspace.PluginSpec{
-				Name:    "foo",
-				Kind:    apitype.ResourcePlugin,
-				Version: &semver.Version{Major: 1},
+			news: NewPackageSet(workspace.PackageDescriptor{
+				PluginSpec: workspace.PluginSpec{
+					Name:    "foo",
+					Kind:    apitype.ResourcePlugin,
+					Version: &semver.Version{Major: 1},
+				},
 			}),
 			expected: nil,
 		},
 		{
 			name: "Matches with no updates (news has an older version)",
-			olds: NewPluginSet(workspace.PluginSpec{
-				Name:    "foo",
-				Kind:    apitype.ResourcePlugin,
-				Version: &semver.Version{Major: 2},
+			olds: NewPackageSet(workspace.PackageDescriptor{
+				PluginSpec: workspace.PluginSpec{
+					Name:    "foo",
+					Kind:    apitype.ResourcePlugin,
+					Version: &semver.Version{Major: 2},
+				},
 			}),
-			news: NewPluginSet(workspace.PluginSpec{
-				Name:    "foo",
-				Kind:    apitype.ResourcePlugin,
-				Version: &semver.Version{Major: 1},
+			news: NewPackageSet(workspace.PackageDescriptor{
+				PluginSpec: workspace.PluginSpec{
+					Name:    "foo",
+					Kind:    apitype.ResourcePlugin,
+					Version: &semver.Version{Major: 1},
+				},
 			}),
 			expected: nil,
 		},
 		{
 			name: "Matches with one update",
-			olds: NewPluginSet(
-				workspace.PluginSpec{
-					Name:    "foo",
-					Kind:    apitype.ResourcePlugin,
-					Version: &semver.Version{Major: 1},
-				},
-				workspace.PluginSpec{
-					Name:    "bar",
-					Kind:    apitype.ResourcePlugin,
-					Version: &semver.Version{Major: 1},
-				},
-			),
-			news: NewPluginSet(
-				workspace.PluginSpec{
-					Name:    "foo",
-					Kind:    apitype.ResourcePlugin,
-					Version: &semver.Version{Major: 2},
-				},
-			),
-			expected: []PluginUpdate{
-				{
-					Old: workspace.PluginSpec{
+			olds: NewPackageSet(
+				workspace.PackageDescriptor{
+					PluginSpec: workspace.PluginSpec{
 						Name:    "foo",
 						Kind:    apitype.ResourcePlugin,
 						Version: &semver.Version{Major: 1},
 					},
-					New: workspace.PluginSpec{
+				},
+				workspace.PackageDescriptor{
+					PluginSpec: workspace.PluginSpec{
+						Name:    "bar",
+						Kind:    apitype.ResourcePlugin,
+						Version: &semver.Version{Major: 1},
+					},
+				},
+			),
+			news: NewPackageSet(
+				workspace.PackageDescriptor{
+					PluginSpec: workspace.PluginSpec{
 						Name:    "foo",
 						Kind:    apitype.ResourcePlugin,
 						Version: &semver.Version{Major: 2},
+					},
+				},
+			),
+			expected: []PackageUpdate{
+				{
+					Old: workspace.PackageDescriptor{
+						PluginSpec: workspace.PluginSpec{
+							Name:    "foo",
+							Kind:    apitype.ResourcePlugin,
+							Version: &semver.Version{Major: 1},
+						},
+					},
+					New: workspace.PackageDescriptor{
+						PluginSpec: workspace.PluginSpec{
+							Name:    "foo",
+							Kind:    apitype.ResourcePlugin,
+							Version: &semver.Version{Major: 2},
+						},
 					},
 				},
 			},
 		},
 		{
 			name: "Matches with multiple updates",
-			olds: NewPluginSet(
-				workspace.PluginSpec{
-					Name:    "foo",
-					Kind:    apitype.ResourcePlugin,
-					Version: &semver.Version{Major: 1},
-				},
-				workspace.PluginSpec{
-					Name:    "bar",
-					Kind:    apitype.ResourcePlugin,
-					Version: &semver.Version{Major: 2},
-				},
-				workspace.PluginSpec{
-					Name:    "baz",
-					Kind:    apitype.AnalyzerPlugin,
-					Version: &semver.Version{Major: 3},
-				},
-			),
-			news: NewPluginSet(
-				workspace.PluginSpec{
-					Name:    "foo",
-					Kind:    apitype.ResourcePlugin,
-					Version: &semver.Version{Major: 2},
-				},
-				workspace.PluginSpec{
-					Name:    "bar",
-					Kind:    apitype.ResourcePlugin,
-					Version: &semver.Version{Major: 2},
-				},
-				workspace.PluginSpec{
-					Name:    "baz",
-					Kind:    apitype.AnalyzerPlugin,
-					Version: &semver.Version{Major: 4},
-				},
-			),
-			expected: []PluginUpdate{
-				{
-					Old: workspace.PluginSpec{
+			olds: NewPackageSet(
+				workspace.PackageDescriptor{
+					PluginSpec: workspace.PluginSpec{
 						Name:    "foo",
 						Kind:    apitype.ResourcePlugin,
 						Version: &semver.Version{Major: 1},
 					},
-					New: workspace.PluginSpec{
+				},
+				workspace.PackageDescriptor{
+					PluginSpec: workspace.PluginSpec{
+						Name:    "bar",
+						Kind:    apitype.ResourcePlugin,
+						Version: &semver.Version{Major: 2},
+					},
+				},
+				workspace.PackageDescriptor{
+					PluginSpec: workspace.PluginSpec{
+						Name:    "baz",
+						Kind:    apitype.AnalyzerPlugin,
+						Version: &semver.Version{Major: 3},
+					},
+				},
+			),
+			news: NewPackageSet(
+				workspace.PackageDescriptor{
+					PluginSpec: workspace.PluginSpec{
 						Name:    "foo",
 						Kind:    apitype.ResourcePlugin,
 						Version: &semver.Version{Major: 2},
 					},
 				},
-				{
-					Old: workspace.PluginSpec{
-						Name:    "baz",
-						Kind:    apitype.AnalyzerPlugin,
-						Version: &semver.Version{Major: 3},
+				workspace.PackageDescriptor{
+					PluginSpec: workspace.PluginSpec{
+						Name:    "bar",
+						Kind:    apitype.ResourcePlugin,
+						Version: &semver.Version{Major: 2},
 					},
-					New: workspace.PluginSpec{
+				},
+				workspace.PackageDescriptor{
+					PluginSpec: workspace.PluginSpec{
 						Name:    "baz",
 						Kind:    apitype.AnalyzerPlugin,
 						Version: &semver.Version{Major: 4},
+					},
+				},
+			),
+			expected: []PackageUpdate{
+				{
+					Old: workspace.PackageDescriptor{
+						PluginSpec: workspace.PluginSpec{
+							Name:    "foo",
+							Kind:    apitype.ResourcePlugin,
+							Version: &semver.Version{Major: 1},
+						},
+					},
+
+					New: workspace.PackageDescriptor{
+						PluginSpec: workspace.PluginSpec{
+							Name:    "foo",
+							Kind:    apitype.ResourcePlugin,
+							Version: &semver.Version{Major: 2},
+						},
+					},
+				},
+				{
+					Old: workspace.PackageDescriptor{
+						PluginSpec: workspace.PluginSpec{
+							Name:    "baz",
+							Kind:    apitype.AnalyzerPlugin,
+							Version: &semver.Version{Major: 3},
+						},
+					},
+					New: workspace.PackageDescriptor{
+						PluginSpec: workspace.PluginSpec{
+							Name:    "baz",
+							Kind:    apitype.AnalyzerPlugin,
+							Version: &semver.Version{Major: 4},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Base plugin and parameterized package",
+			olds: NewPackageSet(workspace.PackageDescriptor{
+				PluginSpec: workspace.PluginSpec{
+					Name:    "foo",
+					Kind:    apitype.ResourcePlugin,
+					Version: &semver.Version{Major: 1},
+				},
+			}),
+			news: NewPackageSet(workspace.PackageDescriptor{
+				PluginSpec: workspace.PluginSpec{
+					Name:    "foo",
+					Kind:    apitype.ResourcePlugin,
+					Version: &semver.Version{Major: 2},
+				},
+				Parameterization: &workspace.Parameterization{
+					Name:    "bar",
+					Version: semver.Version{Major: 2},
+					Value:   []byte("data"),
+				},
+			}),
+			expected: nil,
+		},
+		{
+			name: "Parameterized package update",
+			olds: NewPackageSet(workspace.PackageDescriptor{
+				PluginSpec: workspace.PluginSpec{
+					Name:    "foo",
+					Kind:    apitype.ResourcePlugin,
+					Version: &semver.Version{Major: 1},
+				},
+				Parameterization: &workspace.Parameterization{
+					Name:    "bar",
+					Version: semver.Version{Major: 1},
+					Value:   []byte("data"),
+				},
+			}),
+			news: NewPackageSet(workspace.PackageDescriptor{
+				PluginSpec: workspace.PluginSpec{
+					Name:    "foo",
+					Kind:    apitype.ResourcePlugin,
+					Version: &semver.Version{Major: 1},
+				},
+				Parameterization: &workspace.Parameterization{
+					Name:    "bar",
+					Version: semver.Version{Major: 2},
+					Value:   []byte("data"),
+				},
+			}),
+			expected: []PackageUpdate{
+				{
+					Old: workspace.PackageDescriptor{
+						PluginSpec: workspace.PluginSpec{
+							Name:    "foo",
+							Kind:    apitype.ResourcePlugin,
+							Version: &semver.Version{Major: 1},
+						},
+						Parameterization: &workspace.Parameterization{
+							Name:    "bar",
+							Version: semver.Version{Major: 1},
+							Value:   []byte("data"),
+						},
+					},
+					New: workspace.PackageDescriptor{
+						PluginSpec: workspace.PluginSpec{
+							Name:    "foo",
+							Kind:    apitype.ResourcePlugin,
+							Version: &semver.Version{Major: 1},
+						},
+						Parameterization: &workspace.Parameterization{
+							Name:    "bar",
+							Version: semver.Version{Major: 2},
+							Value:   []byte("data"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Non-parameterized to parameterized package update",
+			olds: NewPackageSet(workspace.PackageDescriptor{
+				PluginSpec: workspace.PluginSpec{
+					Name:    "foo",
+					Kind:    apitype.ResourcePlugin,
+					Version: &semver.Version{Major: 1},
+				},
+			}),
+			news: NewPackageSet(workspace.PackageDescriptor{
+				PluginSpec: workspace.PluginSpec{
+					Name:    "base",
+					Kind:    apitype.ResourcePlugin,
+					Version: &semver.Version{Major: 1},
+				},
+				Parameterization: &workspace.Parameterization{
+					Name:    "foo",
+					Version: semver.Version{Major: 2},
+					Value:   []byte("data"),
+				},
+			}),
+			expected: []PackageUpdate{
+				{
+					Old: workspace.PackageDescriptor{
+						PluginSpec: workspace.PluginSpec{
+							Name:    "foo",
+							Kind:    apitype.ResourcePlugin,
+							Version: &semver.Version{Major: 1},
+						},
+					},
+					New: workspace.PackageDescriptor{
+						PluginSpec: workspace.PluginSpec{
+							Name:    "base",
+							Kind:    apitype.ResourcePlugin,
+							Version: &semver.Version{Major: 1},
+						},
+						Parameterization: &workspace.Parameterization{
+							Name:    "foo",
+							Version: semver.Version{Major: 2},
+							Value:   []byte("data"),
+						},
 					},
 				},
 			},

--- a/pkg/resource/deploy/providers/provider.go
+++ b/pkg/resource/deploy/providers/provider.go
@@ -26,20 +26,20 @@ import (
 
 type ProviderParameterization struct {
 	// The name of the parametrized package.
-	name tokens.Package
+	Name tokens.Package
 	// The version of the parametrized package.
-	version semver.Version
+	Version semver.Version
 	// The value of the parameter.
-	value []byte
+	Value []byte
 }
 
 // NewProviderParameterization constructs a new provider parameterization.
 func NewProviderParameterization(name tokens.Package, version semver.Version, value []byte,
 ) *ProviderParameterization {
 	return &ProviderParameterization{
-		name:    name,
-		version: version,
-		value:   value,
+		Name:    name,
+		Version: version,
+		Value:   value,
 	}
 }
 
@@ -100,7 +100,7 @@ func (p ProviderRequest) Version() *semver.Version {
 // Package returns this provider request's package.
 func (p ProviderRequest) Package() tokens.Package {
 	if p.parameterization != nil {
-		return p.parameterization.name
+		return p.parameterization.Name
 	}
 	return p.name
 }
@@ -127,7 +127,7 @@ func (p ProviderRequest) DefaultName() string {
 
 	var v *semver.Version
 	if p.parameterization != nil {
-		v = &p.parameterization.version
+		v = &p.parameterization.Version
 	} else {
 		v = p.version
 	}
@@ -158,7 +158,7 @@ func (p ProviderRequest) DefaultName() string {
 func (p ProviderRequest) String() string {
 	var version string
 	if p.parameterization != nil {
-		version = "-" + p.parameterization.version.String()
+		version = "-" + p.parameterization.Version.String()
 	} else if p.version != nil {
 		version = "-" + p.version.String()
 	}

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -219,10 +219,10 @@ func SetProviderParameterization(inputs resource.PropertyMap, value *ProviderPar
 	// SetVersion will have written the base plugin version to inputs["version"], if we're parameterized we need to move
 	// it, and replace it with our package version.
 	internalInputs[versionKey] = inputs[versionKey]
-	inputs[versionKey] = resource.NewStringProperty(value.version.String())
+	inputs[versionKey] = resource.NewStringProperty(value.Version.String())
 	// We don't write name here because we can reconstruct that from the providers type token
 	internalInputs[parameterizationKey] = resource.NewStringProperty(
-		base64.StdEncoding.EncodeToString(value.value))
+		base64.StdEncoding.EncodeToString(value.Value))
 }
 
 // GetProviderParameterization fetches and parses a provider parameterization from the given property map. If the
@@ -259,9 +259,9 @@ func GetProviderParameterization(name tokens.Package, inputs resource.PropertyMa
 	}
 
 	return &ProviderParameterization{
-		name:    name,
-		version: sv,
-		value:   bytes,
+		Name:    name,
+		Version: sv,
+		Value:   bytes,
 	}, nil
 }
 
@@ -355,16 +355,16 @@ func loadParameterizedProvider(
 	if parameter != nil {
 		resp, err := provider.Parameterize(context.TODO(), plugin.ParameterizeRequest{
 			Parameters: &plugin.ParameterizeValue{
-				Name:    string(parameter.name),
-				Version: parameter.version,
-				Value:   parameter.value,
+				Name:    string(parameter.Name),
+				Version: parameter.Version,
+				Value:   parameter.Value,
 			},
 		})
 		if err != nil {
 			return nil, err
 		}
-		if resp.Name != string(parameter.name) {
-			return nil, fmt.Errorf("parameterize response name %q does not match expected package %q", resp.Name, parameter.name)
+		if resp.Name != string(parameter.Name) {
+			return nil, fmt.Errorf("parameterize response name %q does not match expected package %q", resp.Name, parameter.Name)
 		}
 	}
 	return provider, nil

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -810,6 +810,37 @@ type PackageDescriptor struct {
 	Parameterization *Parameterization
 }
 
+// PackageName returns the name of the package.
+func (pd PackageDescriptor) PackageName() string {
+	if pd.Parameterization != nil {
+		return pd.Parameterization.Name
+	}
+	return pd.PluginSpec.Name
+}
+
+// PackageVersion returns the version of the package.
+func (pd PackageDescriptor) PackageVersion() *semver.Version {
+	if pd.Parameterization != nil {
+		return &pd.Parameterization.Version
+	}
+	return pd.PluginSpec.Version
+}
+
+func (pd PackageDescriptor) String() string {
+	name := pd.PluginSpec.Name
+	version := pd.PluginSpec.Version
+	if pd.Parameterization != nil {
+		name = pd.Parameterization.Name
+		version = &pd.Parameterization.Version
+	}
+
+	var v string
+	if version != nil {
+		v = fmt.Sprintf("-%s", version)
+	}
+	return name + v
+}
+
 // A Parameterization may be applied to a supporting plugin to yield a package.
 type Parameterization struct {
 	// The name of the package that will be produced by the parameterization.


### PR DESCRIPTION
This updates the warnings added by https://github.com/pulumi/pulumi/pull/12196 to also warn about updates to parameterized packages, not just plugins. 

Before this the warning would kick in if the underlying parameterised plugin was updated (e.g. terraform-provider went from 0.3.0 to 0.3.1) but it wouldn't warn if the user had regenerated the parameterised package (e.g hashicorp/random 3.6.0 to hashicorp/random 3.6.3). This change fixes it so the later will now print the expected warning.

It also fixes it so the warning refers to the package name, not the plugin name (i.e. in the above terraform random example we print 'random 3.6.3' not 'terraform-provider 0.3.1').

Part of https://github.com/pulumi/pulumi/issues/17507