### PR TITLE
Document provider Diff response requirements

### DIFF
--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -18,7 +18,7 @@
 1921230328 1269 proto/pulumi/errors.proto
 2888070731 13849 proto/pulumi/language.proto
 1674803920 2966 proto/pulumi/plugin.proto
-1835085438 56519 proto/pulumi/provider.proto
+136291163 56902 proto/pulumi/provider.proto
 940215571 17847 proto/pulumi/resource.proto
 607478140 1008 proto/pulumi/source.proto
 3670315643 2603 proto/pulumi/testing/language.proto

--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -18,7 +18,7 @@
 1921230328 1269 proto/pulumi/errors.proto
 2888070731 13849 proto/pulumi/language.proto
 1674803920 2966 proto/pulumi/plugin.proto
-136291163 56902 proto/pulumi/provider.proto
+1142872678 57051 proto/pulumi/provider.proto
 940215571 17847 proto/pulumi/resource.proto
 607478140 1008 proto/pulumi/source.proto
 3670315643 2603 proto/pulumi/testing/language.proto

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -96,6 +96,8 @@ service ResourceProvider {
     // thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
     // Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
     // AWS access key, should almost certainly not.
+    //
+    // Implementations must satisfy the invariants documented on `DiffResponse`.
     rpc DiffConfig(DiffRequest) returns (DiffResponse) {}
 
     // `Configure` is the final stage in configuring a provider instance. Callers may supply two sets of data:
@@ -153,12 +155,7 @@ service ResourceProvider {
     // difference (if any) between them. `Diff` should only be called with values that have at some point been validated
     // by a [](pulumirpc.ResourceProvider.Check) call.
     //
-    // The provider's response must satisfy the following invariants:
-    //
-    // * For each top-level key in Diff there is at least one matching property path, starting at that key, in DetailedDiff.
-    // * For each entry in DetailedDiff, its top-level property is in Diff.
-    // * Diff does not contain duplicates.
-    // * DetailedDiff does not contain duplicate keys.
+    // Implementations must satisfy the invariants documented on `DiffResponse`.
     rpc Diff(DiffRequest) returns (DiffResponse) {}
 
     // `Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a
@@ -654,6 +651,13 @@ message PropertyDiff {
 //   granular view of the changes that have occurred. Detailed diffs are designed to allow providers to control
 //   precisely which field names are displayed as responsible for a change, and to signal more accurately what kind of
 //   change occurred (e.g. a field was added, deleted or updated).
+//
+// The response must satisfy the following invariants:
+//
+// * For each top-level key in `diff` there is at least one matching property path, starting at that key, in `detailedDiff`.
+// * For each entry in `detailedDiff`, its top-level property is in `diff`.
+// * `diff` does not contain duplicates.
+// * `detailedDiff` does not contain duplicate keys.
 message DiffResponse {
     // A set of properties which have changed and whose changes require the resource being diffed to be replaced. The
     // caller should replace the resource if this set is non-empty, or if any of the properties specified in

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -155,8 +155,8 @@ service ResourceProvider {
     //
     // The provider's response must satisfy the following invariants:
     //
-    // * All keys in Diff appear in DetailedDiff.
-    // * All keys in DetailedDiff appear in Diff.
+    // * For each top-level key in Diff there is at least one matching property path, starting at that key, in DetailedDiff.
+    // * For each entry in DetailedDiff, its top-level property is in Diff.
     // * Diff does not contain duplicates.
     // * DetailedDiff does not contain duplicate keys.
     rpc Diff(DiffRequest) returns (DiffResponse) {}

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -152,6 +152,13 @@ service ResourceProvider {
     // `Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
     // difference (if any) between them. `Diff` should only be called with values that have at some point been validated
     // by a [](pulumirpc.ResourceProvider.Check) call.
+    //
+    // The provider's response must satisfy the following invariants:
+    //
+    // * All keys in Diff appear in DetailedDiff.
+    // * All keys in DetailedDiff appear in Diff.
+    // * Diff does not contain duplicates.
+    // * DetailedDiff does not contain duplicate keys.
     rpc Diff(DiffRequest) returns (DiffResponse) {}
 
     // `Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a

--- a/sdk/nodejs/proto/provider_grpc_pb.js
+++ b/sdk/nodejs/proto/provider_grpc_pb.js
@@ -595,6 +595,13 @@ check: {
   // `Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
 // difference (if any) between them. `Diff` should only be called with values that have at some point been validated
 // by a [](pulumirpc.ResourceProvider.Check) call.
+//
+// The provider's response must satisfy the following invariants:
+//
+// * For each top-level key in Diff there is at least one matching property path, starting at that key, in DetailedDiff.
+// * For each entry in DetailedDiff, its top-level property is in Diff.
+// * Diff does not contain duplicates.
+// * DetailedDiff does not contain duplicate keys.
 diff: {
     path: '/pulumirpc.ResourceProvider/Diff',
     requestStream: false,

--- a/sdk/nodejs/proto/provider_grpc_pb.js
+++ b/sdk/nodejs/proto/provider_grpc_pb.js
@@ -485,6 +485,8 @@ checkConfig: {
 // thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
 // Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
 // AWS access key, should almost certainly not.
+//
+// Implementations must satisfy the invariants documented on `DiffResponse`.
 diffConfig: {
     path: '/pulumirpc.ResourceProvider/DiffConfig',
     requestStream: false,
@@ -596,12 +598,7 @@ check: {
 // difference (if any) between them. `Diff` should only be called with values that have at some point been validated
 // by a [](pulumirpc.ResourceProvider.Check) call.
 //
-// The provider's response must satisfy the following invariants:
-//
-// * For each top-level key in Diff there is at least one matching property path, starting at that key, in DetailedDiff.
-// * For each entry in DetailedDiff, its top-level property is in Diff.
-// * Diff does not contain duplicates.
-// * DetailedDiff does not contain duplicate keys.
+// Implementations must satisfy the invariants documented on `DiffResponse`.
 diff: {
     path: '/pulumirpc.ResourceProvider/Diff',
     requestStream: false,

--- a/sdk/proto/go/provider.pb.go
+++ b/sdk/proto/go/provider.pb.go
@@ -1624,6 +1624,13 @@ func (x *PropertyDiff) GetInputDiff() bool {
 //   granular view of the changes that have occurred. Detailed diffs are designed to allow providers to control
 //   precisely which field names are displayed as responsible for a change, and to signal more accurately what kind of
 //   change occurred (e.g. a field was added, deleted or updated).
+//
+// The response must satisfy the following invariants:
+//
+// * For each top-level key in `diff` there is at least one matching property path, starting at that key, in `detailedDiff`.
+// * For each entry in `detailedDiff`, its top-level property is in `diff`.
+// * `diff` does not contain duplicates.
+// * `detailedDiff` does not contain duplicate keys.
 type DiffResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/sdk/proto/go/provider_grpc.pb.go
+++ b/sdk/proto/go/provider_grpc.pb.go
@@ -88,6 +88,8 @@ type ResourceProviderClient interface {
 	// thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
 	// Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
 	// AWS access key, should almost certainly not.
+	//
+	// Implementations must satisfy the invariants documented on `DiffResponse`.
 	DiffConfig(ctx context.Context, in *DiffRequest, opts ...grpc.CallOption) (*DiffResponse, error)
 	// `Configure` is the final stage in configuring a provider instance. Callers may supply two sets of data:
 	//
@@ -139,12 +141,7 @@ type ResourceProviderClient interface {
 	// difference (if any) between them. `Diff` should only be called with values that have at some point been validated
 	// by a [](pulumirpc.ResourceProvider.Check) call.
 	//
-	// The provider's response must satisfy the following invariants:
-	//
-	// * For each top-level key in Diff there is at least one matching property path, starting at that key, in DetailedDiff.
-	// * For each entry in DetailedDiff, its top-level property is in Diff.
-	// * Diff does not contain duplicates.
-	// * DetailedDiff does not contain duplicate keys.
+	// Implementations must satisfy the invariants documented on `DiffResponse`.
 	Diff(ctx context.Context, in *DiffRequest, opts ...grpc.CallOption) (*DiffResponse, error)
 	// `Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a
 	// provider-assigned ID for the resource as well as the output properties that arose from the creation properties.
@@ -488,6 +485,8 @@ type ResourceProviderServer interface {
 	// thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
 	// Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
 	// AWS access key, should almost certainly not.
+	//
+	// Implementations must satisfy the invariants documented on `DiffResponse`.
 	DiffConfig(context.Context, *DiffRequest) (*DiffResponse, error)
 	// `Configure` is the final stage in configuring a provider instance. Callers may supply two sets of data:
 	//
@@ -539,12 +538,7 @@ type ResourceProviderServer interface {
 	// difference (if any) between them. `Diff` should only be called with values that have at some point been validated
 	// by a [](pulumirpc.ResourceProvider.Check) call.
 	//
-	// The provider's response must satisfy the following invariants:
-	//
-	// * For each top-level key in Diff there is at least one matching property path, starting at that key, in DetailedDiff.
-	// * For each entry in DetailedDiff, its top-level property is in Diff.
-	// * Diff does not contain duplicates.
-	// * DetailedDiff does not contain duplicate keys.
+	// Implementations must satisfy the invariants documented on `DiffResponse`.
 	Diff(context.Context, *DiffRequest) (*DiffResponse, error)
 	// `Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a
 	// provider-assigned ID for the resource as well as the output properties that arose from the creation properties.

--- a/sdk/proto/go/provider_grpc.pb.go
+++ b/sdk/proto/go/provider_grpc.pb.go
@@ -138,6 +138,13 @@ type ResourceProviderClient interface {
 	// `Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
 	// difference (if any) between them. `Diff` should only be called with values that have at some point been validated
 	// by a [](pulumirpc.ResourceProvider.Check) call.
+	//
+	// The provider's response must satisfy the following invariants:
+	//
+	// * For each top-level key in Diff there is at least one matching property path, starting at that key, in DetailedDiff.
+	// * For each entry in DetailedDiff, its top-level property is in Diff.
+	// * Diff does not contain duplicates.
+	// * DetailedDiff does not contain duplicate keys.
 	Diff(ctx context.Context, in *DiffRequest, opts ...grpc.CallOption) (*DiffResponse, error)
 	// `Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a
 	// provider-assigned ID for the resource as well as the output properties that arose from the creation properties.
@@ -531,6 +538,13 @@ type ResourceProviderServer interface {
 	// `Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
 	// difference (if any) between them. `Diff` should only be called with values that have at some point been validated
 	// by a [](pulumirpc.ResourceProvider.Check) call.
+	//
+	// The provider's response must satisfy the following invariants:
+	//
+	// * For each top-level key in Diff there is at least one matching property path, starting at that key, in DetailedDiff.
+	// * For each entry in DetailedDiff, its top-level property is in Diff.
+	// * Diff does not contain duplicates.
+	// * DetailedDiff does not contain duplicate keys.
 	Diff(context.Context, *DiffRequest) (*DiffResponse, error)
 	// `Create` provisions a new instance of the specified [(custom) resource](custom-resources). It returns a
 	// provider-assigned ID for the resource as well as the output properties that arose from the creation properties.

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
@@ -970,6 +970,13 @@ class DiffResponse(google.protobuf.message.Message):
       granular view of the changes that have occurred. Detailed diffs are designed to allow providers to control
       precisely which field names are displayed as responsible for a change, and to signal more accurately what kind of
       change occurred (e.g. a field was added, deleted or updated).
+
+    The response must satisfy the following invariants:
+
+    * For each top-level key in `diff` there is at least one matching property path, starting at that key, in `detailedDiff`.
+    * For each entry in `detailedDiff`, its top-level property is in `diff`.
+    * `diff` does not contain duplicates.
+    * `detailedDiff` does not contain duplicate keys.
     """
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
@@ -300,6 +300,13 @@ class ResourceProviderServicer(object):
         """`Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
         difference (if any) between them. `Diff` should only be called with values that have at some point been validated
         by a [](pulumirpc.ResourceProvider.Check) call.
+
+        The provider's response must satisfy the following invariants:
+
+        * For each top-level key in Diff there is at least one matching property path, starting at that key, in DetailedDiff.
+        * For each entry in DetailedDiff, its top-level property is in Diff.
+        * Diff does not contain duplicates.
+        * DetailedDiff does not contain duplicate keys.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
@@ -220,6 +220,8 @@ class ResourceProviderServicer(object):
         thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
         Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
         AWS access key, should almost certainly not.
+
+        Implementations must satisfy the invariants documented on `DiffResponse`.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -301,12 +303,7 @@ class ResourceProviderServicer(object):
         difference (if any) between them. `Diff` should only be called with values that have at some point been validated
         by a [](pulumirpc.ResourceProvider.Check) call.
 
-        The provider's response must satisfy the following invariants:
-
-        * For each top-level key in Diff there is at least one matching property path, starting at that key, in DetailedDiff.
-        * For each entry in DetailedDiff, its top-level property is in Diff.
-        * Diff does not contain duplicates.
-        * DetailedDiff does not contain duplicate keys.
+        Implementations must satisfy the invariants documented on `DiffResponse`.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
@@ -116,6 +116,8 @@ class ResourceProviderStub:
     thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
     Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
     AWS access key, should almost certainly not.
+
+    Implementations must satisfy the invariants documented on `DiffResponse`.
     """
     Configure: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.ConfigureRequest,
@@ -189,12 +191,7 @@ class ResourceProviderStub:
     difference (if any) between them. `Diff` should only be called with values that have at some point been validated
     by a [](pulumirpc.ResourceProvider.Check) call.
 
-    The provider's response must satisfy the following invariants:
-
-    * For each top-level key in Diff there is at least one matching property path, starting at that key, in DetailedDiff.
-    * For each entry in DetailedDiff, its top-level property is in Diff.
-    * Diff does not contain duplicates.
-    * DetailedDiff does not contain duplicate keys.
+    Implementations must satisfy the invariants documented on `DiffResponse`.
     """
     Create: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.CreateRequest,
@@ -386,6 +383,8 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         thus be reserved for changes to configuration properties that are guaranteed to make old resources unmanageable.
         Changes to an AWS region, for example, will almost certainly require a provider replacement, but changes to an
         AWS access key, should almost certainly not.
+
+        Implementations must satisfy the invariants documented on `DiffResponse`.
         """
     
     def Configure(
@@ -471,12 +470,7 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         difference (if any) between them. `Diff` should only be called with values that have at some point been validated
         by a [](pulumirpc.ResourceProvider.Check) call.
 
-        The provider's response must satisfy the following invariants:
-
-        * For each top-level key in Diff there is at least one matching property path, starting at that key, in DetailedDiff.
-        * For each entry in DetailedDiff, its top-level property is in Diff.
-        * Diff does not contain duplicates.
-        * DetailedDiff does not contain duplicate keys.
+        Implementations must satisfy the invariants documented on `DiffResponse`.
         """
     
     def Create(

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
@@ -188,6 +188,13 @@ class ResourceProviderStub:
     """`Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
     difference (if any) between them. `Diff` should only be called with values that have at some point been validated
     by a [](pulumirpc.ResourceProvider.Check) call.
+
+    The provider's response must satisfy the following invariants:
+
+    * For each top-level key in Diff there is at least one matching property path, starting at that key, in DetailedDiff.
+    * For each entry in DetailedDiff, its top-level property is in Diff.
+    * Diff does not contain duplicates.
+    * DetailedDiff does not contain duplicate keys.
     """
     Create: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.CreateRequest,
@@ -463,6 +470,13 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         """`Diff` compares an existing ("old") set of resource properties with a new set of properties and computes the
         difference (if any) between them. `Diff` should only be called with values that have at some point been validated
         by a [](pulumirpc.ResourceProvider.Check) call.
+
+        The provider's response must satisfy the following invariants:
+
+        * For each top-level key in Diff there is at least one matching property path, starting at that key, in DetailedDiff.
+        * For each entry in DetailedDiff, its top-level property is in Diff.
+        * Diff does not contain duplicates.
+        * DetailedDiff does not contain duplicate keys.
         """
     
     def Create(


### PR DESCRIPTION
Resolves #17612 - we had two incidents caused by a mismatch of expectations between the engine and a provider on how `Diff` should behave exactly.

In a way a follow-up to #17683.