### PR TITLE
Support parameterized packages in `pulumi import`

### DIFF
--- a/changelog/pending/20241212--cli-import--import-can-now-import-resources-defined-in-parameterized-packages.yaml
+++ b/changelog/pending/20241212--cli-import--import-can-now-import-resources-defined-in-parameterized-packages.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/import
+  description: Add support for parameterized packages to `pulumi import`

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -281,6 +281,9 @@ func newDeployment(
 				if imp.PluginChecksums == nil {
 					imp.PluginChecksums = defaultProviderInfo[imp.Type.Package()].Checksums
 				}
+				if imp.Parameterization == nil {
+					imp.Parameterization = defaultProviderInfo[imp.Type.Package()].Parameterization
+				}
 			}
 		}
 

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sort"
+	"slices"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -141,6 +141,15 @@ func (p PackageSet) ToPluginSet() PluginSet {
 		newSet.Add(value.PluginSpec)
 	}
 	return newSet
+}
+
+// Values returns a slice of all of the packages contained within this set.
+func (p PackageSet) Values() []workspace.PackageDescriptor {
+	pkgs := slice.Prealloc[workspace.PackageDescriptor](len(p))
+	for _, value := range p {
+		pkgs = append(pkgs, value)
+	}
+	return pkgs
 }
 
 // A PackageUpdate represents an update from one version of a package to another.
@@ -508,41 +517,48 @@ func installPlugin(
 	return nil
 }
 
-// computeDefaultProviderPlugins computes, for every resource plugin, a mapping from packages to semver versions
-// reflecting the version of a provider that should be used as the "default" resource when registering resources. This
-// function takes two sets of plugins: a set of plugins given to us from the language host and the full set of plugins.
-// If the language host has sent us a non-empty set of plugins, we will use those exclusively to service default
-// provider requests. Otherwise, we will use the full set of plugins, which is the existing behavior today.
+// computeDefaultProviderPackages computes, for every package, a mapping from packages to semver versions reflecting the
+// version of a provider that should be used as the "default" resource when registering resources. This function takes
+// two sets of packages:
 //
-// The justification for favoring language plugins over all else is that, ultimately, it is the language plugin that
-// produces resource registrations and therefore it is the language plugin that should dictate exactly what plugins to
-// use to satisfy a resource registration. SDKs have the opportunity to specify what plugin (pluginDownloadURL and
-// version) they want to use in RegisterResource. If the plugin is left unspecified, we make a best guess effort to
-// infer the version and url that the language plugin actually wants.
+// - a set given to us from the language host; and
+// - the full set of packages.
+//
+// If the language host has sent us a non-empty set of packages, we will use those exclusively to service default
+// provider requests. Otherwise, we will use the full set of packages, which is the existing behavior today.
+//
+// The justification for favoring the language host is that, ultimately, it is the language host that produces resource
+// registrations and therefore it is the language host that should dictate exactly what package to use to satisfy a
+// resource registration. SDKs have the opportunity to specify what plugin (pluginDownloadURL and version) they want to
+// use in RegisterResource. If the plugin is left unspecified, we make a best-guess effort to infer the version and URL
+// that the language host actually wants.
 //
 // Whenever a resource arrives via RegisterResource and does not explicitly specify which provider to use, the engine
 // injects a "default" provider resource that will serve as that resource's provider. This function computes the map
 // that the engine uses to determine which version of a particular provider to load.
 //
-// it is critical that this function be 100% deterministic.
-func computeDefaultProviderPlugins(languagePlugins, allPlugins PluginSet) map[tokens.Package]workspace.PluginSpec {
+// Note: it is critical that this function be 100% deterministic.
+func computeDefaultProviderPackages(
+	languagePackages PackageSet,
+	allPackages PackageSet,
+) map[tokens.Package]workspace.PackageDescriptor {
 	// Language hosts are not required to specify the full set of plugins they depend on. If the set of plugins received
 	// from the language host does not include any resource providers, fall back to the full set of plugins.
 	languageReportedProviderPlugins := false
-	for _, plug := range languagePlugins.Values() {
+	for _, plug := range languagePackages.Values() {
 		if plug.Kind == apitype.ResourcePlugin {
 			languageReportedProviderPlugins = true
 		}
 	}
 
-	sourceSet := languagePlugins
+	sourceSet := languagePackages
 	if !languageReportedProviderPlugins {
 		logging.V(preparePluginLog).Infoln(
 			"computeDefaultProviderPlugins(): language host reported empty set of provider plugins, using all plugins")
-		sourceSet = allPlugins
+		sourceSet = allPackages
 	}
 
-	defaultProviderPlugins := make(map[tokens.Package]workspace.PluginSpec)
+	defaultProviderPlugins := make(map[tokens.Package]workspace.PackageDescriptor)
 
 	// Sort the set of source plugins by version, so that we iterate over the set of plugins in a deterministic order.
 	// Sorting by version gets us two properties:
@@ -553,9 +569,9 @@ func computeDefaultProviderPlugins(languagePlugins, allPlugins PluginSet) map[to
 	//
 	// Despite these properties, the below loop explicitly handles those cases to preserve correct behavior even if the
 	// sort is not functioning properly.
-	sourcePlugins := sourceSet.Values()
-	sort.Sort(workspace.SortedPluginSpec(sourcePlugins))
-	for _, p := range sourcePlugins {
+	sourcePackages := sourceSet.Values()
+	slices.SortFunc(sourcePackages, workspace.SortPackageDescriptors)
+	for _, p := range sourcePackages {
 		logging.V(preparePluginLog).Infof("computeDefaultProviderPlugins(): considering %s", p)
 		if p.Kind != apitype.ResourcePlugin {
 			// Default providers are only relevant for resource plugins.
@@ -564,12 +580,14 @@ func computeDefaultProviderPlugins(languagePlugins, allPlugins PluginSet) map[to
 			continue
 		}
 
-		if seenPlugin, has := defaultProviderPlugins[tokens.Package(p.Name)]; has {
+		name := tokens.Package(p.PackageName())
+
+		if seenPlugin, has := defaultProviderPlugins[name]; has {
 			if seenPlugin.Version == nil {
 				logging.V(preparePluginLog).Infof(
 					"computeDefaultProviderPlugins(): plugin %s selected for package %s (override, previous was nil)",
 					p, p.Name)
-				defaultProviderPlugins[tokens.Package(p.Name)] = p
+				defaultProviderPlugins[name] = p
 				continue
 			}
 
@@ -578,7 +596,7 @@ func computeDefaultProviderPlugins(languagePlugins, allPlugins PluginSet) map[to
 				logging.V(preparePluginLog).Infof(
 					"computeDefaultProviderPlugins(): plugin %s selected for package %s (override, newer than previous %s)",
 					p, p.Name, seenPlugin.Version)
-				defaultProviderPlugins[tokens.Package(p.Name)] = p
+				defaultProviderPlugins[name] = p
 				continue
 			}
 
@@ -589,7 +607,7 @@ func computeDefaultProviderPlugins(languagePlugins, allPlugins PluginSet) map[to
 
 		logging.V(preparePluginLog).Infof(
 			"computeDefaultProviderPlugins(): plugin %s selected for package %s (first seen)", p, p.Name)
-		defaultProviderPlugins[tokens.Package(p.Name)] = p
+		defaultProviderPlugins[name] = p
 	}
 
 	if logging.V(preparePluginLog) {
@@ -599,7 +617,7 @@ func computeDefaultProviderPlugins(languagePlugins, allPlugins PluginSet) map[to
 		}
 	}
 
-	defaultProviderInfo := make(map[tokens.Package]workspace.PluginSpec)
+	defaultProviderInfo := make(map[tokens.Package]workspace.PackageDescriptor)
 	for name, plugin := range defaultProviderPlugins {
 		defaultProviderInfo[name] = plugin
 	}

--- a/pkg/engine/plugins_test.go
+++ b/pkg/engine/plugins_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,20 +35,24 @@ func mustMakeVersion(v string) *semver.Version {
 func TestDefaultProvidersSingle(t *testing.T) {
 	t.Parallel()
 
-	languagePlugins := NewPluginSet()
-	languagePlugins.Add(workspace.PluginSpec{
-		Name:    "aws",
-		Version: mustMakeVersion("0.17.1"),
-		Kind:    apitype.ResourcePlugin,
+	languagePlugins := NewPackageSet()
+	languagePlugins.Add(workspace.PackageDescriptor{
+		PluginSpec: workspace.PluginSpec{
+			Name:    "aws",
+			Version: mustMakeVersion("0.17.1"),
+			Kind:    apitype.ResourcePlugin,
+		},
 	})
-	languagePlugins.Add(workspace.PluginSpec{
-		Name:              "kubernetes",
-		Version:           mustMakeVersion("0.22.0"),
-		Kind:              apitype.ResourcePlugin,
-		PluginDownloadURL: "com.server.url",
+	languagePlugins.Add(workspace.PackageDescriptor{
+		PluginSpec: workspace.PluginSpec{
+			Name:              "kubernetes",
+			Version:           mustMakeVersion("0.22.0"),
+			Kind:              apitype.ResourcePlugin,
+			PluginDownloadURL: "com.server.url",
+		},
 	})
 
-	defaultProviders := computeDefaultProviderPlugins(languagePlugins, NewPluginSet())
+	defaultProviders := computeDefaultProviderPackages(languagePlugins, NewPackageSet())
 	assert.NotNil(t, defaultProviders)
 
 	aws, ok := defaultProviders[tokens.Package("aws")]
@@ -68,19 +72,23 @@ func TestDefaultProvidersSingle(t *testing.T) {
 func TestDefaultProvidersOverrideNoVersion(t *testing.T) {
 	t.Parallel()
 
-	languagePlugins := NewPluginSet()
-	languagePlugins.Add(workspace.PluginSpec{
-		Name:    "aws",
-		Version: mustMakeVersion("0.17.1"),
-		Kind:    apitype.ResourcePlugin,
+	languagePlugins := NewPackageSet()
+	languagePlugins.Add(workspace.PackageDescriptor{
+		PluginSpec: workspace.PluginSpec{
+			Name:    "aws",
+			Version: mustMakeVersion("0.17.1"),
+			Kind:    apitype.ResourcePlugin,
+		},
 	})
-	languagePlugins.Add(workspace.PluginSpec{
-		Name:    "aws",
-		Version: nil,
-		Kind:    apitype.ResourcePlugin,
+	languagePlugins.Add(workspace.PackageDescriptor{
+		PluginSpec: workspace.PluginSpec{
+			Name:    "aws",
+			Version: nil,
+			Kind:    apitype.ResourcePlugin,
+		},
 	})
 
-	defaultProviders := computeDefaultProviderPlugins(languagePlugins, NewPluginSet())
+	defaultProviders := computeDefaultProviderPackages(languagePlugins, NewPackageSet())
 	assert.NotNil(t, defaultProviders)
 	aws, ok := defaultProviders[tokens.Package("aws")]
 	assert.True(t, ok)
@@ -92,24 +100,30 @@ func TestDefaultProvidersOverrideNoVersion(t *testing.T) {
 func TestDefaultProvidersOverrideNewerVersion(t *testing.T) {
 	t.Parallel()
 
-	languagePlugins := NewPluginSet()
-	languagePlugins.Add(workspace.PluginSpec{
-		Name:    "aws",
-		Version: mustMakeVersion("0.17.0"),
-		Kind:    apitype.ResourcePlugin,
+	languagePlugins := NewPackageSet()
+	languagePlugins.Add(workspace.PackageDescriptor{
+		PluginSpec: workspace.PluginSpec{
+			Name:    "aws",
+			Version: mustMakeVersion("0.17.0"),
+			Kind:    apitype.ResourcePlugin,
+		},
 	})
-	languagePlugins.Add(workspace.PluginSpec{
-		Name:    "aws",
-		Version: mustMakeVersion("0.17.1"),
-		Kind:    apitype.ResourcePlugin,
+	languagePlugins.Add(workspace.PackageDescriptor{
+		PluginSpec: workspace.PluginSpec{
+			Name:    "aws",
+			Version: mustMakeVersion("0.17.1"),
+			Kind:    apitype.ResourcePlugin,
+		},
 	})
-	languagePlugins.Add(workspace.PluginSpec{
-		Name:    "aws",
-		Version: mustMakeVersion("0.17.2-dev.1553126336"),
-		Kind:    apitype.ResourcePlugin,
+	languagePlugins.Add(workspace.PackageDescriptor{
+		PluginSpec: workspace.PluginSpec{
+			Name:    "aws",
+			Version: mustMakeVersion("0.17.2-dev.1553126336"),
+			Kind:    apitype.ResourcePlugin,
+		},
 	})
 
-	defaultProviders := computeDefaultProviderPlugins(languagePlugins, NewPluginSet())
+	defaultProviders := computeDefaultProviderPackages(languagePlugins, NewPackageSet())
 	assert.NotNil(t, defaultProviders)
 	aws, ok := defaultProviders[tokens.Package("aws")]
 	assert.True(t, ok)
@@ -121,19 +135,23 @@ func TestDefaultProvidersOverrideNewerVersion(t *testing.T) {
 func TestDefaultProvidersSnapshotOverrides(t *testing.T) {
 	t.Parallel()
 
-	languagePlugins := NewPluginSet()
-	languagePlugins.Add(workspace.PluginSpec{
-		Name: "python",
-		Kind: apitype.LanguagePlugin,
+	languagePlugins := NewPackageSet()
+	languagePlugins.Add(workspace.PackageDescriptor{
+		PluginSpec: workspace.PluginSpec{
+			Name: "python",
+			Kind: apitype.LanguagePlugin,
+		},
 	})
-	snapshotPlugins := NewPluginSet()
-	snapshotPlugins.Add(workspace.PluginSpec{
-		Name:    "aws",
-		Version: mustMakeVersion("0.17.0"),
-		Kind:    apitype.ResourcePlugin,
+	snapshotPlugins := NewPackageSet()
+	snapshotPlugins.Add(workspace.PackageDescriptor{
+		PluginSpec: workspace.PluginSpec{
+			Name:    "aws",
+			Version: mustMakeVersion("0.17.0"),
+			Kind:    apitype.ResourcePlugin,
+		},
 	})
 
-	defaultProviders := computeDefaultProviderPlugins(languagePlugins, snapshotPlugins)
+	defaultProviders := computeDefaultProviderPackages(languagePlugins, snapshotPlugins)
 	assert.NotNil(t, defaultProviders)
 	aws, ok := defaultProviders[tokens.Package("aws")]
 	assert.True(t, ok)
@@ -581,20 +599,24 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 func TestDefaultProviderPluginsSorting(t *testing.T) {
 	t.Parallel()
 	v1 := semver.MustParse("0.0.1-alpha.10")
-	p1 := workspace.PluginSpec{
-		Name:    "foo",
-		Version: &v1,
-		Kind:    apitype.ResourcePlugin,
+	p1 := workspace.PackageDescriptor{
+		PluginSpec: workspace.PluginSpec{
+			Name:    "foo",
+			Version: &v1,
+			Kind:    apitype.ResourcePlugin,
+		},
 	}
 	v2 := semver.MustParse("0.0.1-alpha.10+dirty")
-	p2 := workspace.PluginSpec{
-		Name:    "foo",
-		Version: &v2,
-		Kind:    apitype.ResourcePlugin,
+	p2 := workspace.PackageDescriptor{
+		PluginSpec: workspace.PluginSpec{
+			Name:    "foo",
+			Version: &v2,
+			Kind:    apitype.ResourcePlugin,
+		},
 	}
-	plugins := NewPluginSet(p1, p2)
-	result := computeDefaultProviderPlugins(plugins, plugins)
-	assert.Equal(t, map[tokens.Package]workspace.PluginSpec{
+	plugins := NewPackageSet(p1, p2)
+	result := computeDefaultProviderPackages(plugins, plugins)
+	assert.Equal(t, map[tokens.Package]workspace.PackageDescriptor{
 		"foo": p2,
 	}, result)
 }

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -233,7 +233,7 @@ func installPlugins(
 	ctx context.Context,
 	proj *workspace.Project, pwd, main string, target *deploy.Target, opts *deploymentOptions,
 	plugctx *plugin.Context, returnInstallErrors bool,
-) (PluginSet, map[tokens.Package]workspace.PluginSpec, error) {
+) (PluginSet, map[tokens.Package]workspace.PackageDescriptor, error) {
 	// Before launching the source, ensure that we have all of the plugins that we need in order to proceed.
 	//
 	// There are two places that we need to look for plugins:
@@ -262,7 +262,8 @@ func installPlugins(
 		return nil, nil, err
 	}
 
-	allPlugins := languagePackages.Union(snapshotPackages).ToPluginSet().Deduplicate()
+	allPackages := languagePackages.Union(snapshotPackages)
+	allPlugins := allPackages.ToPluginSet().Deduplicate()
 
 	// If there are any plugins that are not available, we can attempt to install them here.
 	//
@@ -278,7 +279,7 @@ func installPlugins(
 	}
 
 	// Collect the version information for default providers.
-	defaultProviderVersions := computeDefaultProviderPlugins(languagePackages.ToPluginSet(), allPlugins)
+	defaultProviderVersions := computeDefaultProviderPackages(languagePackages, allPackages)
 
 	return allPlugins, defaultProviderVersions, nil
 }

--- a/pkg/resource/deploy/providers/provider.go
+++ b/pkg/resource/deploy/providers/provider.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 type ProviderParameterization struct {
@@ -41,6 +42,15 @@ func NewProviderParameterization(name tokens.Package, version semver.Version, va
 		Version: version,
 		Value:   value,
 	}
+}
+
+// ToProviderParameterization converts a workspace parameterization to a provider parameterization.
+func ToProviderParameterization(parameterization *workspace.Parameterization) *ProviderParameterization {
+	if parameterization == nil {
+		return nil
+	}
+	return NewProviderParameterization(
+		tokens.Package(parameterization.Name), parameterization.Version, parameterization.Value)
 }
 
 // A ProviderRequest is a tuple of an optional semantic version, download server url, parameter, and a package name.

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -96,7 +96,7 @@ type EvalSourceOptions struct {
 func NewEvalSource(
 	plugctx *plugin.Context,
 	runinfo *EvalRunInfo,
-	defaultProviderInfo map[tokens.Package]workspace.PluginSpec,
+	defaultProviderInfo map[tokens.Package]workspace.PackageDescriptor,
 	opts EvalSourceOptions,
 ) Source {
 	return &evalSource{
@@ -108,10 +108,10 @@ func NewEvalSource(
 }
 
 type evalSource struct {
-	plugctx             *plugin.Context                         // the plugin context.
-	runinfo             *EvalRunInfo                            // the directives to use when running the program.
-	defaultProviderInfo map[tokens.Package]workspace.PluginSpec // the default provider versions for this source.
-	opts                EvalSourceOptions                       // options for the evaluation source.
+	plugctx             *plugin.Context                                // the plugin context.
+	runinfo             *EvalRunInfo                                   // the directives to use when running the program.
+	defaultProviderInfo map[tokens.Package]workspace.PackageDescriptor // the default provider versions for this source.
+	opts                EvalSourceOptions                              // options for the evaluation source.
 }
 
 func (src *evalSource) Close() error {
@@ -320,7 +320,7 @@ func (iter *evalSourceIterator) forkRun(
 type defaultProviders struct {
 	// A map of package identifiers to versions, used to disambiguate which plugin to load if no version is provided
 	// by the language host.
-	defaultProviderInfo map[tokens.Package]workspace.PluginSpec
+	defaultProviderInfo map[tokens.Package]workspace.PackageDescriptor
 
 	// A map of ProviderRequest strings to provider references, used to keep track of the set of default providers that
 	// have already been loaded.

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -2076,11 +2076,13 @@ func TestDefaultProviders(t *testing.T) {
 			t.Parallel()
 			v1 := semver.MustParse("0.1.0")
 			d := &defaultProviders{
-				defaultProviderInfo: map[tokens.Package]workspace.PluginSpec{
+				defaultProviderInfo: map[tokens.Package]workspace.PackageDescriptor{
 					tokens.Package("pkg"): {
-						Version:           &v1,
-						PluginDownloadURL: "github://owner/repo",
-						Checksums:         map[string][]byte{"key": []byte("expected-checksum-value")},
+						PluginSpec: workspace.PluginSpec{
+							Version:           &v1,
+							PluginDownloadURL: "github://owner/repo",
+							Checksums:         map[string][]byte{"key": []byte("expected-checksum-value")},
+						},
 					},
 				},
 				config: &configSourceMock{
@@ -3082,7 +3084,7 @@ func TestRegisterResource(t *testing.T) {
 		t.Parallel()
 		rm := &resmon{
 			defaultProviders: &defaultProviders{
-				defaultProviderInfo: map[tokens.Package]workspace.PluginSpec{},
+				defaultProviderInfo: map[tokens.Package]workspace.PackageDescriptor{},
 			},
 		}
 		req := &pulumirpc.RegisterResourceRequest{

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -48,7 +48,7 @@ type QuerySource interface {
 // NewQuerySource creates a `QuerySource` for some target runtime environment specified by
 // `runinfo`, and supported by language plugins provided in `plugctx`.
 func NewQuerySource(cancel context.Context, plugctx *plugin.Context, client BackendClient,
-	runinfo *EvalRunInfo, defaultProviderVersions map[tokens.Package]workspace.PluginSpec,
+	runinfo *EvalRunInfo, defaultProviderVersions map[tokens.Package]workspace.PackageDescriptor,
 	provs ProviderSource,
 ) (QuerySource, error) {
 	// Create a new builtin provider. This provider implements features such as `getStack`.
@@ -205,7 +205,7 @@ func runLangPlugin(src *querySource) error {
 // newQueryResourceMonitor creates a new resource monitor RPC server intended to be used in Pulumi's
 // "query mode".
 func newQueryResourceMonitor(
-	builtins *builtinProvider, defaultProviderInfo map[tokens.Package]workspace.PluginSpec,
+	builtins *builtinProvider, defaultProviderInfo map[tokens.Package]workspace.PackageDescriptor,
 	provs ProviderSource, reg *providers.Registry, plugctx *plugin.Context,
 	providerRegErrChan chan<- error, tracingSpan opentracing.Span, runinfo *EvalRunInfo,
 ) (*queryResmon, error) {


### PR DESCRIPTION
The `pulumi import` command allows users to import existing provider resources into a Pulumi stack, accepting the type of resource to import, a name for the resource that will be created in the stack, and some "ID" that identifies the existing resource in the provider. Historically, the type has been sufficient to infer which provider offers the resource, since package names were in a one-to-one correspondence with plugin names. Now that we support parameterized providers, however, this is no longer the case -- we might wish to import a `random:index/id:Id`, but where the `random` package is a dynamically-bridged instance of the Terraform `random` provider produced by the `terraform-provider` plugin.

This change makes `import` aware of parameterizations by letting it deal with fully-specified package descriptors, as opposed to just plugin specifications. In doing so, `import` can now support importing parameterized resources. That said, it still does not support code generation for such imports (that is, `--generate-code` must be set to `false`) -- this will come in a later change.

Part of #17507