### PR TITLE
Support codegen for parameterised imports

### DIFF
--- a/changelog/pending/20241212--cli-import--import-can-now-import-resources-from-parameterized-providers.yaml
+++ b/changelog/pending/20241212--cli-import--import-can-now-import-resources-from-parameterized-providers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/import
+  description: Import can now import resources from parameterized providers

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -516,22 +516,31 @@ func generateImportedDefinitions(ctx *plugin.Context,
 	}
 
 	loader := schema.NewPluginLoader(ctx.Host)
-	return true, importer.GenerateLanguageDefinitions(out, loader, func(w io.Writer, p *pcl.Program) error {
-		files, _, err := programGenerator(p, loader)
-		if err != nil {
-			return err
-		}
+	err := importer.GenerateLanguageDefinitions(
+		out,
+		loader,
+		func(w io.Writer, p *pcl.Program) error {
+			files, _, err := programGenerator(p, loader)
+			if err != nil {
+				return err
+			}
 
-		var contents []byte
-		for _, v := range files {
-			contents = v
-		}
+			var contents []byte
+			for _, v := range files {
+				contents = v
+			}
 
-		if _, err := w.Write(contents); err != nil {
-			return err
-		}
-		return nil
-	}, resources, names)
+			if _, err := w.Write(contents); err != nil {
+				return err
+			}
+			return nil
+		},
+		resources,
+		snap.Resources,
+		names,
+	)
+
+	return true, err
 }
 
 func NewImportCmd() *cobra.Command {

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -15,6 +15,7 @@
 package importer
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -44,9 +45,14 @@ type PathedLiteralValue struct {
 	ExpressionReference *model.ScopeTraversalExpression
 }
 
+// ImportState tracks the state of an import process.
 type ImportState struct {
 	Names               NameTable
 	PathedLiteralValues []PathedLiteralValue
+
+	// A snapshot of the resources in the Pulumi program that new resources are being imported to. This is used to resolve
+	// references to packages providers.
+	Snapshot []*resource.State
 }
 
 // filterReferences filters out self-references from the import state so that if a resource has a property
@@ -65,6 +71,7 @@ func filterReferences(resourceName string, importState ImportState) ImportState 
 	return ImportState{
 		Names:               importState.Names,
 		PathedLiteralValues: withoutDuplicates,
+		Snapshot:            importState.Snapshot,
 	}
 }
 
@@ -73,19 +80,72 @@ func GenerateHCL2Definition(
 	loader schema.Loader,
 	state *resource.State,
 	importState ImportState,
-) (*model.Block, error) {
-	// TODO: pull the package version from the resource's provider
-	pkg, err := schema.LoadPackageReference(loader, string(state.Type.Package()), nil)
+) (*model.Block, *schema.PackageDescriptor, error) {
+	// First up, we'll need to load the appropriate package for this resource. We'll do this by grabbing the resource's
+	// provider reference and looking up that provider resource in the current program snapshot. From there, we can build
+	// a package descriptor and load the package and its schema.
+	providerRef, err := providers.ParseReference(state.Provider)
 	if err != nil {
-		return nil, err
+		return nil, nil, fmt.Errorf("parse resource provider reference: %w", err)
 	}
 
+	var provider *resource.State
+	for _, s := range importState.Snapshot {
+		if s.URN == providerRef.URN() && s.ID == providerRef.ID() {
+			provider = s
+			break
+		}
+	}
+	if provider == nil {
+		return nil, nil, fmt.Errorf("provider %v not found in snapshot", providerRef)
+	}
+
+	packageName := state.Type.Package()
+	pluginName, err := providers.GetProviderName(packageName, provider.Inputs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get provider name: %w", err)
+	}
+	pluginVersion, err := providers.GetProviderVersion(provider.Inputs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get provider version: %w", err)
+	}
+	downloadURL, err := providers.GetProviderDownloadURL(provider.Inputs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get provider version: %w", err)
+	}
+	var parameterization *schema.ParameterizationDescriptor
+	parameters, err := providers.GetProviderParameterization(packageName, provider.Inputs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get provider parameterization: %w", err)
+	}
+	if parameters != nil {
+		parameterization = &schema.ParameterizationDescriptor{
+			Name:    string(parameters.Name),
+			Version: parameters.Version,
+			Value:   parameters.Value,
+		}
+	}
+
+	pkgDesc := &schema.PackageDescriptor{
+		Name:             string(pluginName),
+		Version:          pluginVersion,
+		DownloadURL:      downloadURL,
+		Parameterization: parameterization,
+	}
+
+	pkg, err := schema.LoadPackageReferenceV2(context.TODO(), loader, pkgDesc)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading package '%v': %w", pkgDesc, err)
+	}
+
+	// With the package loaded, we can get the full resource schema and use that to generate an appropriate HCL2
+	// definition.
 	r, ok, err := pkg.Resources().Get(string(state.Type))
 	if err != nil {
-		return nil, fmt.Errorf("loading resource '%v': %w", state.Type, err)
+		return nil, nil, fmt.Errorf("loading resource '%v': %w", state.Type, err)
 	}
 	if !ok {
-		return nil, fmt.Errorf("unknown resource type '%v'", r)
+		return nil, nil, fmt.Errorf("unknown resource type '%v'", r)
 	}
 
 	var items []model.BodyItem
@@ -118,7 +178,7 @@ func GenerateHCL2Definition(
 		input := state.Inputs[resource.PropertyKey(p.Name)]
 		x, err := generatePropertyValue(p, input, importStateContext, onReferenceFound)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if x != nil {
 			items = append(items, &model.Attribute{
@@ -130,7 +190,7 @@ func GenerateHCL2Definition(
 
 	resourceOptions, err := makeResourceOptions(state, importState.Names, addedReferences)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if resourceOptions != nil {
 		items = append(items, resourceOptions)
@@ -144,7 +204,7 @@ func GenerateHCL2Definition(
 		Body: &model.Body{
 			Items: items,
 		},
-	}, nil
+	}, pkgDesc, nil
 }
 
 func newVariableReference(name string) model.Expression {

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -258,11 +258,33 @@ func TestGenerateHCL2Definition(t *testing.T) {
 				t.Fatal()
 			}
 
-			importState := ImportState{
-				Names: names,
+			snapshot := []*resource.State{
+				{
+					ID:     "123",
+					Custom: true,
+					Type:   "pulumi:providers:aws",
+					URN:    "urn:pulumi:stack::project::pulumi:providers:aws::default_123",
+				},
+				{
+					ID:     "123",
+					Custom: true,
+					Type:   "pulumi:providers:random",
+					URN:    "urn:pulumi:stack::project::pulumi:providers:random::default_123",
+				},
+				{
+					ID:     "id",
+					Custom: true,
+					Type:   "pulumi:providers:pkg",
+					URN:    "urn:pulumi:stack::project::pulumi:providers:pkg::provider",
+				},
 			}
 
-			block, err := GenerateHCL2Definition(loader, state, importState)
+			importState := ImportState{
+				Names:    names,
+				Snapshot: snapshot,
+			}
+
+			block, _, err := GenerateHCL2Definition(loader, state, importState)
 			if !assert.NoError(t, err) {
 				t.Fatal()
 			}
@@ -293,7 +315,9 @@ func TestGenerateHCL2Definition(t *testing.T) {
 			assert.Equal(t, state.Type, actualState.Type)
 			assert.Equal(t, state.URN, actualState.URN)
 			assert.Equal(t, state.Parent, actualState.Parent)
-			assert.Equal(t, state.Provider, actualState.Provider)
+			if !strings.Contains(state.Provider, "::default_") {
+				assert.Equal(t, state.Provider, actualState.Provider)
+			}
 			assert.Equal(t, state.Protect, actualState.Protect)
 			if !assert.True(t, actualState.Inputs.DeepEquals(state.Inputs)) {
 				actual, err := stack.SerializeResource(context.Background(), actualState, config.NopEncrypter, false)
@@ -317,12 +341,22 @@ func TestGenerateHCL2DefinitionsWithDependantResources(t *testing.T) {
 	t.Parallel()
 	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
 
+	snapshot := []*resource.State{
+		{
+			ID:     "123",
+			Custom: true,
+			Type:   "pulumi:providers:aws",
+			URN:    "urn:pulumi:stack::project::pulumi:providers:aws::default_123",
+		},
+	}
+
 	resources := []apitype.ResourceV3{
 		{
-			URN:    "urn:pulumi:stack::project::aws:s3/bucket:Bucket::exampleBucket",
-			ID:     "provider-generated-bucket-id-abc123",
-			Custom: true,
-			Type:   "aws:s3/bucket:Bucket",
+			URN:      "urn:pulumi:stack::project::aws:s3/bucket:Bucket::exampleBucket",
+			ID:       "provider-generated-bucket-id-abc123",
+			Custom:   true,
+			Type:     "aws:s3/bucket:Bucket",
+			Provider: fmt.Sprintf("%s::%s", snapshot[0].URN, snapshot[0].ID),
 		},
 		{
 			URN:    "urn:pulumi:stack::project::aws:s3/bucketObject:BucketObject::exampleBucketObject",
@@ -334,6 +368,7 @@ func TestGenerateHCL2DefinitionsWithDependantResources(t *testing.T) {
 				"bucket":       "provider-generated-bucket-id-abc123",
 				"storageClass": "STANDARD",
 			},
+			Provider: fmt.Sprintf("%s::%s", snapshot[0].URN, snapshot[0].ID),
 		},
 	}
 
@@ -346,11 +381,11 @@ func TestGenerateHCL2DefinitionsWithDependantResources(t *testing.T) {
 		states = append(states, state)
 	}
 
-	importState := createImportState(states, names)
+	importState := createImportState(states, snapshot, names)
 
 	var hcl2Text strings.Builder
 	for i, state := range states {
-		hcl2Def, err := GenerateHCL2Definition(loader, state, importState)
+		hcl2Def, _, err := GenerateHCL2Definition(loader, state, importState)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -381,22 +416,33 @@ func TestGenerateHCL2DefinitionsWithDependantResourcesUsingNameOrArnProperty(t *
 	t.Parallel()
 	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
 
+	snapshot := []*resource.State{
+		{
+			ID:     "123",
+			Custom: true,
+			Type:   "pulumi:providers:aws",
+			URN:    "urn:pulumi:stack::project::pulumi:providers:aws::default_123",
+		},
+	}
+
 	resources := []apitype.ResourceV3{
 		{
-			URN:    "urn:pulumi:stack::project::aws:s3/bucket:Bucket::exampleBucket",
-			ID:     "provider-generated-bucket-id-abc123",
-			Custom: true,
-			Type:   "aws:s3/bucket:Bucket",
+			Provider: fmt.Sprintf("%s::%s", snapshot[0].URN, snapshot[0].ID),
+			URN:      "urn:pulumi:stack::project::aws:s3/bucket:Bucket::exampleBucket",
+			ID:       "provider-generated-bucket-id-abc123",
+			Custom:   true,
+			Type:     "aws:s3/bucket:Bucket",
 			Outputs: map[string]interface{}{
 				"name": "bucketName-12345",
 				"arn":  "arn:aws:s3:bucket-12345",
 			},
 		},
 		{
-			URN:    "urn:pulumi:stack::project::aws:s3/bucketObject:BucketObject::exampleBucketObject",
-			ID:     "provider-generated-bucket-object-id-abc123",
-			Custom: true,
-			Type:   "aws:s3/bucketObject:BucketObject",
+			Provider: fmt.Sprintf("%s::%s", snapshot[0].URN, snapshot[0].ID),
+			URN:      "urn:pulumi:stack::project::aws:s3/bucketObject:BucketObject::exampleBucketObject",
+			ID:       "provider-generated-bucket-object-id-abc123",
+			Custom:   true,
+			Type:     "aws:s3/bucketObject:BucketObject",
 			Inputs: map[string]interface{}{
 				// this will be replaced with a reference to exampleBucket.name in the generated code
 				"bucket":       "bucketName-12345",
@@ -404,10 +450,11 @@ func TestGenerateHCL2DefinitionsWithDependantResourcesUsingNameOrArnProperty(t *
 			},
 		},
 		{
-			URN:    "urn:pulumi:stack::project::aws:s3/bucketObject:BucketObject::exampleBucketObjectUsingArn",
-			ID:     "provider-generated-bucket-object-id-abc123",
-			Custom: true,
-			Type:   "aws:s3/bucketObject:BucketObject",
+			Provider: fmt.Sprintf("%s::%s", snapshot[0].URN, snapshot[0].ID),
+			URN:      "urn:pulumi:stack::project::aws:s3/bucketObject:BucketObject::exampleBucketObjectUsingArn",
+			ID:       "provider-generated-bucket-object-id-abc123",
+			Custom:   true,
+			Type:     "aws:s3/bucketObject:BucketObject",
 			Inputs: map[string]interface{}{
 				// this will be replaced with a reference to exampleBucket.arn in the generated code
 				"bucket":       "arn:aws:s3:bucket-12345",
@@ -425,11 +472,11 @@ func TestGenerateHCL2DefinitionsWithDependantResourcesUsingNameOrArnProperty(t *
 		states = append(states, state)
 	}
 
-	importState := createImportState(states, names)
+	importState := createImportState(states, snapshot, names)
 
 	var hcl2Text strings.Builder
 	for i, state := range states {
-		hcl2Def, err := GenerateHCL2Definition(loader, state, importState)
+		hcl2Def, _, err := GenerateHCL2Definition(loader, state, importState)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -466,24 +513,36 @@ func TestGenerateHCL2DefinitionsWithAmbiguousReferencesMaintainsLiteralValue(t *
 	t.Parallel()
 	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
 
+	snapshot := []*resource.State{
+		{
+			ID:     "123",
+			Custom: true,
+			Type:   "pulumi:providers:aws",
+			URN:    "urn:pulumi:stack::project::pulumi:providers:aws::default_123",
+		},
+	}
+
 	resources := []apitype.ResourceV3{
 		{
-			URN:    "urn:pulumi:stack::project::aws:s3/bucket:Bucket::firstBucket",
-			ID:     "provider-generated-bucket-id-abc123",
-			Custom: true,
-			Type:   "aws:s3/bucket:Bucket",
+			Provider: fmt.Sprintf("%s::%s", snapshot[0].URN, snapshot[0].ID),
+			URN:      "urn:pulumi:stack::project::aws:s3/bucket:Bucket::firstBucket",
+			ID:       "provider-generated-bucket-id-abc123",
+			Custom:   true,
+			Type:     "aws:s3/bucket:Bucket",
 		},
 		{
-			URN:    "urn:pulumi:stack::project::aws:s3/bucket:Bucket::secondBucket",
-			ID:     "provider-generated-bucket-id-abc123",
-			Custom: true,
-			Type:   "aws:s3/bucket:Bucket",
+			Provider: fmt.Sprintf("%s::%s", snapshot[0].URN, snapshot[0].ID),
+			URN:      "urn:pulumi:stack::project::aws:s3/bucket:Bucket::secondBucket",
+			ID:       "provider-generated-bucket-id-abc123",
+			Custom:   true,
+			Type:     "aws:s3/bucket:Bucket",
 		},
 		{
-			URN:    "urn:pulumi:stack::project::aws:s3/bucketObject:BucketObject::exampleBucketObject",
-			ID:     "provider-generated-bucket-object-id-abc123",
-			Custom: true,
-			Type:   "aws:s3/bucketObject:BucketObject",
+			Provider: fmt.Sprintf("%s::%s", snapshot[0].URN, snapshot[0].ID),
+			URN:      "urn:pulumi:stack::project::aws:s3/bucketObject:BucketObject::exampleBucketObject",
+			ID:       "provider-generated-bucket-object-id-abc123",
+			Custom:   true,
+			Type:     "aws:s3/bucketObject:BucketObject",
 			Inputs: map[string]interface{}{
 				// this will *NOT* be replaced with a reference to either firstBucket.id or secondBucket.id
 				// because both have the same ID and it would be ambiguous
@@ -502,11 +561,11 @@ func TestGenerateHCL2DefinitionsWithAmbiguousReferencesMaintainsLiteralValue(t *
 		states = append(states, state)
 	}
 
-	importState := createImportState(states, names)
+	importState := createImportState(states, snapshot, names)
 
 	var hcl2Text strings.Builder
 	for i, state := range states {
-		hcl2Def, err := GenerateHCL2Definition(loader, state, importState)
+		hcl2Def, _, err := GenerateHCL2Definition(loader, state, importState)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -541,12 +600,22 @@ func TestGenerateHCL2DefinitionsDoesNotMakeSelfReferences(t *testing.T) {
 	t.Parallel()
 	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
 
+	snapshot := []*resource.State{
+		{
+			ID:     "123",
+			Custom: true,
+			Type:   "pulumi:providers:aws",
+			URN:    "urn:pulumi:stack::project::pulumi:providers:aws::default_123",
+		},
+	}
+
 	resources := []apitype.ResourceV3{
 		{
-			URN:    "urn:pulumi:stack::project::aws:s3/bucketObject:BucketObject::exampleBucketObject",
-			ID:     "provider-generated-bucket-object-id-abc123",
-			Custom: true,
-			Type:   "aws:s3/bucketObject:BucketObject",
+			Provider: fmt.Sprintf("%s::%s", snapshot[0].URN, snapshot[0].ID),
+			URN:      "urn:pulumi:stack::project::aws:s3/bucketObject:BucketObject::exampleBucketObject",
+			ID:       "provider-generated-bucket-object-id-abc123",
+			Custom:   true,
+			Type:     "aws:s3/bucketObject:BucketObject",
 			Inputs: map[string]interface{}{
 				// this literal value will stay as is since it shouldn't self-reference the bucket object itself
 				"bucket":       "provider-generated-bucket-object-id-abc123",
@@ -564,11 +633,11 @@ func TestGenerateHCL2DefinitionsDoesNotMakeSelfReferences(t *testing.T) {
 		states = append(states, state)
 	}
 
-	importState := createImportState(states, names)
+	importState := createImportState(states, snapshot, names)
 
 	var hcl2Text strings.Builder
 	for i, state := range states {
-		hcl2Def, err := GenerateHCL2Definition(loader, state, importState)
+		hcl2Def, _, err := GenerateHCL2Definition(loader, state, importState)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/importer/testdata/cases.json
+++ b/pkg/importer/testdata/cases.json
@@ -1,6 +1,7 @@
 {
     "resources": [
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:autoscaling/group:Group::Group",
 			"custom": true,
 			"type": "aws:autoscaling/group:Group",
@@ -25,6 +26,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:cloudformation/stack:Stack::Stack",
 			"custom": true,
 			"type": "aws:cloudformation/stack:Stack",
@@ -34,6 +36,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:cloudwatch/dashboard:Dashboard::Dashboard",
 			"custom": true,
 			"type": "aws:cloudwatch/dashboard:Dashboard",
@@ -43,6 +46,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:cloudwatch/logGroup:LogGroup::LogGroup",
 			"custom": true,
 			"type": "aws:cloudwatch/logGroup:LogGroup",
@@ -52,6 +56,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:cloudwatch/logMetricFilter:LogMetricFilter::LogMetricFilter",
 			"custom": true,
 			"type": "aws:cloudwatch/logMetricFilter:LogMetricFilter",
@@ -67,6 +72,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:cloudwatch/metricAlarm:MetricAlarm::MetricAlarm",
 			"custom": true,
 			"type": "aws:cloudwatch/metricAlarm:MetricAlarm",
@@ -91,6 +97,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:cloudwatch/metricAlarm:MetricAlarm::MetricAlarm",
 			"custom": true,
 			"type": "aws:cloudwatch/metricAlarm:MetricAlarm",
@@ -115,6 +122,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:cloudwatch/metricAlarm:MetricAlarm::MetricAlarm",
 			"custom": true,
 			"type": "aws:cloudwatch/metricAlarm:MetricAlarm",
@@ -139,6 +147,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:cloudwatch/metricAlarm:MetricAlarm::MetricAlarm",
 			"custom": true,
 			"type": "aws:cloudwatch/metricAlarm:MetricAlarm",
@@ -164,6 +173,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:cloudwatch/metricAlarm:MetricAlarm::MetricAlarm",
 			"custom": true,
 			"type": "aws:cloudwatch/metricAlarm:MetricAlarm",
@@ -185,6 +195,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ec2/eip:Eip::Eip",
 			"custom": true,
 			"type": "aws:ec2/eip:Eip",
@@ -193,6 +204,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ec2/flowLog:FlowLog::FlowLog",
 			"custom": true,
 			"type": "aws:ec2/flowLog:FlowLog",
@@ -206,6 +218,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ec2/internetGateway:InternetGateway::InternetGateway",
 			"custom": true,
 			"type": "aws:ec2/internetGateway:InternetGateway",
@@ -214,6 +227,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ec2/launchConfiguration:LaunchConfiguration::LaunchConfiguration",
 			"custom": true,
 			"type": "aws:ec2/launchConfiguration:LaunchConfiguration",
@@ -245,6 +259,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ec2/launchConfiguration:LaunchConfiguration::LaunchConfiguration",
 			"custom": true,
 			"type": "aws:ec2/launchConfiguration:LaunchConfiguration",
@@ -261,6 +276,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ec2/natGateway:NatGateway::NatGateway",
 			"custom": true,
 			"type": "aws:ec2/natGateway:NatGateway",
@@ -270,6 +286,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ec2/routeTable:RouteTable::RouteTable",
 			"custom": true,
 			"type": "aws:ec2/routeTable:RouteTable",
@@ -284,6 +301,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ec2/routeTableAssociation:RouteTableAssociation::RouteTableAssociation",
 			"custom": true,
 			"type": "aws:ec2/routeTableAssociation:RouteTableAssociation",
@@ -293,6 +311,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ec2/securityGroup:SecurityGroup::SecurityGroup",
 			"custom": true,
 			"type": "aws:ec2/securityGroup:SecurityGroup",
@@ -326,6 +345,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ec2/securityGroup:SecurityGroup::SecurityGroup",
 			"custom": true,
 			"type": "aws:ec2/securityGroup:SecurityGroup",
@@ -368,6 +388,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ec2/securityGroup:SecurityGroup::SecurityGroup",
 			"custom": true,
 			"type": "aws:ec2/securityGroup:SecurityGroup",
@@ -410,6 +431,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ec2/securityGroup:SecurityGroup::SecurityGroup",
 			"custom": true,
 			"type": "aws:ec2/securityGroup:SecurityGroup",
@@ -441,6 +463,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ec2/subnet:Subnet::Subnet",
 			"custom": true,
 			"type": "aws:ec2/subnet:Subnet",
@@ -453,6 +476,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ec2/subnet:Subnet::Subnet",
 			"custom": true,
 			"type": "aws:ec2/subnet:Subnet",
@@ -465,6 +489,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ec2/vpc:Vpc::Vpc",
 			"custom": true,
 			"type": "aws:ec2/vpc:Vpc",
@@ -473,6 +498,7 @@
             }
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ec2/vpc:Vpc::Vpc",
 			"custom": true,
 			"type": "aws:ec2/vpc:Vpc",
@@ -489,6 +515,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ecs/cluster:Cluster::Cluster",
 			"custom": true,
 			"type": "aws:ecs/cluster:Cluster",
@@ -497,6 +524,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ecs/service:Service::Service",
 			"custom": true,
 			"type": "aws:ecs/service:Service",
@@ -527,6 +555,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:ecs/taskDefinition:TaskDefinition::TaskDefinition",
 			"custom": true,
 			"type": "aws:ecs/taskDefinition:TaskDefinition",
@@ -538,6 +567,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:elasticloadbalancingv2/listener:Listener::Listener",
 			"custom": true,
 			"type": "aws:elasticloadbalancingv2/listener:Listener",
@@ -560,6 +590,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:elasticloadbalancingv2/listener:Listener::Listener",
 			"custom": true,
 			"type": "aws:elasticloadbalancingv2/listener:Listener",
@@ -580,6 +611,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:elasticloadbalancingv2/listenerRule:ListenerRule::ListenerRule",
 			"custom": true,
 			"type": "aws:elasticloadbalancingv2/listenerRule:ListenerRule",
@@ -609,6 +641,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:elasticloadbalancingv2/loadBalancer:LoadBalancer::LoadBalancer",
 			"custom": true,
 			"type": "aws:elasticloadbalancingv2/loadBalancer:LoadBalancer",
@@ -636,6 +669,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:elasticloadbalancingv2/targetGroup:TargetGroup::TargetGroup",
 			"custom": true,
 			"type": "aws:elasticloadbalancingv2/targetGroup:TargetGroup",
@@ -663,6 +697,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:elasticloadbalancingv2/targetGroup:TargetGroup::TargetGroup",
 			"custom": true,
 			"type": "aws:elasticloadbalancingv2/targetGroup:TargetGroup",
@@ -679,6 +714,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:iam/instanceProfile:InstanceProfile::InstanceProfile",
 			"custom": true,
 			"type": "aws:iam/instanceProfile:InstanceProfile",
@@ -689,6 +725,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:iam/role:Role::Role",
 			"custom": true,
 			"type": "aws:iam/role:Role",
@@ -701,6 +738,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:iam/rolePolicy:RolePolicy::RolePolicy",
 			"custom": true,
 			"type": "aws:iam/rolePolicy:RolePolicy",
@@ -711,6 +749,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:iam/rolePolicyAttachment:RolePolicyAttachment::RolePolicyAttachment",
 			"custom": true,
 			"type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
@@ -720,6 +759,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:iam/serviceLinkedRole:ServiceLinkedRole::ServiceLinkedRole",
 			"custom": true,
 			"type": "aws:iam/serviceLinkedRole:ServiceLinkedRole",
@@ -728,6 +768,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:kms/key:Key::Key",
 			"custom": true,
 			"type": "aws:kms/key:Key",
@@ -740,6 +781,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:rds/cluster:Cluster::Cluster",
 			"custom": true,
 			"type": "aws:rds/cluster:Cluster",
@@ -764,6 +806,7 @@
 			"protect": true
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:rds/clusterInstance:ClusterInstance::ClusterInstance",
 			"custom": true,
 			"type": "aws:rds/clusterInstance:ClusterInstance",
@@ -781,6 +824,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:rds/parameterGroup:ParameterGroup::ParameterGroup",
 			"custom": true,
 			"type": "aws:rds/parameterGroup:ParameterGroup",
@@ -818,6 +862,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:rds/subnetGroup:SubnetGroup::SubnetGroup",
 			"custom": true,
 			"type": "aws:rds/subnetGroup:SubnetGroup",
@@ -831,6 +876,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:route53/record:Record::Record",
 			"custom": true,
 			"type": "aws:route53/record:Record",
@@ -848,6 +894,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:route53/record:Record::Record",
 			"custom": true,
 			"type": "aws:route53/record:Record",
@@ -862,11 +909,13 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:route53/zone:Zone::Zone",
 			"custom": true,
 			"type": "aws:route53/zone:Zone"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:s3/bucket:Bucket::Bucket",
 			"custom": true,
 			"type": "aws:s3/bucket:Bucket",
@@ -878,6 +927,7 @@
 			"protect": true
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:s3/bucket:Bucket::Bucket",
 			"custom": true,
 			"type": "aws:s3/bucket:Bucket",
@@ -905,6 +955,7 @@
 			"protect": true
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::aws:s3/bucketPolicy:BucketPolicy::BucketPolicy",
 			"custom": true,
 			"type": "aws:s3/bucketPolicy:BucketPolicy",
@@ -914,12 +965,14 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:acm/certificate:Certificate::Certificate",
 			"custom": true,
 			"type": "aws:acm/certificate:Certificate",
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:cloudwatch/eventRule:EventRule::EventRule",
 			"custom": true,
 			"type": "aws:cloudwatch/eventRule:EventRule",
@@ -932,6 +985,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:cloudwatch/eventTarget:EventTarget::EventTarget",
 			"custom": true,
 			"type": "aws:cloudwatch/eventTarget:EventTarget",
@@ -959,6 +1013,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:cloudwatch/logGroup:LogGroup::LogGroup",
 			"custom": true,
 			"type": "aws:cloudwatch/logGroup:LogGroup",
@@ -969,6 +1024,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:cloudwatch/metricAlarm:MetricAlarm::MetricAlarm",
 			"custom": true,
 			"type": "aws:cloudwatch/metricAlarm:MetricAlarm",
@@ -995,6 +1051,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:ec2/securityGroup:SecurityGroup::SecurityGroup",
 			"custom": true,
 			"type": "aws:ec2/securityGroup:SecurityGroup",
@@ -1007,12 +1064,14 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:ec2/securityGroup:SecurityGroup::SecurityGroup",
 			"custom": true,
 			"type": "aws:ec2/securityGroup:SecurityGroup",
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:ec2/securityGroupRule:SecurityGroupRule::SecurityGroupRule",
 			"custom": true,
 			"type": "aws:ec2/securityGroupRule:SecurityGroupRule",
@@ -1031,6 +1090,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:ec2/securityGroupRule:SecurityGroupRule::SecurityGroupRule",
 			"custom": true,
 			"type": "aws:ec2/securityGroupRule:SecurityGroupRule",
@@ -1048,6 +1108,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:ec2/securityGroupRule:SecurityGroupRule::SecurityGroupRule",
 			"custom": true,
 			"type": "aws:ec2/securityGroupRule:SecurityGroupRule",
@@ -1066,6 +1127,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:ec2/securityGroupRule:SecurityGroupRule::SecurityGroupRule",
 			"custom": true,
 			"type": "aws:ec2/securityGroupRule:SecurityGroupRule",
@@ -1080,6 +1142,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:ecr/lifecyclePolicy:LifecyclePolicy::LifecyclePolicy",
 			"custom": true,
 			"type": "aws:ecr/lifecyclePolicy:LifecyclePolicy",
@@ -1090,6 +1153,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:ecr/repository:Repository::Repository",
 			"custom": true,
 			"type": "aws:ecr/repository:Repository",
@@ -1100,6 +1164,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:ecs/cluster:Cluster::Cluster",
 			"custom": true,
 			"type": "aws:ecs/cluster:Cluster",
@@ -1109,6 +1174,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:ecs/service:Service::Service",
 			"custom": true,
 			"type": "aws:ecs/service:Service",
@@ -1143,6 +1209,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:ecs/service:Service::Service",
 			"custom": true,
 			"type": "aws:ecs/service:Service",
@@ -1178,6 +1245,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:ecs/taskDefinition:TaskDefinition::TaskDefinition",
 			"custom": true,
 			"type": "aws:ecs/taskDefinition:TaskDefinition",
@@ -1196,6 +1264,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:ecs/taskDefinition:TaskDefinition::TaskDefinition",
 			"custom": true,
 			"type": "aws:ecs/taskDefinition:TaskDefinition",
@@ -1226,6 +1295,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:elasticsearch/domain:Domain::Domain",
 			"custom": true,
 			"type": "aws:elasticsearch/domain:Domain",
@@ -1263,6 +1333,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:iam/policy:Policy::Policy",
 			"custom": true,
 			"type": "aws:iam/policy:Policy",
@@ -1275,6 +1346,7 @@
 			"protect": true
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:iam/policyAttachment:PolicyAttachment::PolicyAttachment",
 			"custom": true,
 			"type": "aws:iam/policyAttachment:PolicyAttachment",
@@ -1289,6 +1361,7 @@
 			"protect": true
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:iam/role:Role::Role",
 			"custom": true,
 			"type": "aws:iam/role:Role",
@@ -1302,6 +1375,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:iam/role:Role::Role",
 			"custom": true,
 			"type": "aws:iam/role:Role",
@@ -1316,6 +1390,7 @@
 			"protect": true
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:iam/rolePolicy:RolePolicy::RolePolicy",
 			"custom": true,
 			"type": "aws:iam/rolePolicy:RolePolicy",
@@ -1327,6 +1402,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:iam/rolePolicyAttachment:RolePolicyAttachment::RolePolicyAttachment",
 			"custom": true,
 			"type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
@@ -1337,6 +1413,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:lambda/function:Function::Function",
 			"custom": true,
 			"type": "aws:lambda/function:Function",
@@ -1354,6 +1431,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:lambda/permission:Permission::Permission",
 			"custom": true,
 			"type": "aws:lambda/permission:Permission",
@@ -1367,6 +1445,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:lb/listener:Listener::Listener",
 			"custom": true,
 			"type": "aws:lb/listener:Listener",
@@ -1386,6 +1465,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:lb/listener:Listener::Listener",
 			"custom": true,
 			"type": "aws:lb/listener:Listener",
@@ -1403,6 +1483,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:lb/loadBalancer:LoadBalancer::LoadBalancer",
 			"custom": true,
 			"type": "aws:lb/loadBalancer:LoadBalancer",
@@ -1431,6 +1512,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:lb/loadBalancer:LoadBalancer::LoadBalancer",
 			"custom": true,
 			"type": "aws:lb/loadBalancer:LoadBalancer",
@@ -1459,6 +1541,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:lb/targetGroup:TargetGroup::TargetGroup",
 			"custom": true,
 			"type": "aws:lb/targetGroup:TargetGroup",
@@ -1491,6 +1574,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:lb/targetGroup:TargetGroup::TargetGroup",
 			"custom": true,
 			"type": "aws:lb/targetGroup:TargetGroup",
@@ -1528,6 +1612,7 @@
 			"provider": "urn:pulumi:stack::project::pulumi:providers:pkg::provider::id"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:sns/topic:Topic::Topic",
 			"custom": true,
 			"type": "aws:sns/topic:Topic",
@@ -1537,6 +1622,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:aws::default_123::123",
 			"urn": "urn:pulumi:stack::project::my$aws:sns/topicSubscription:TopicSubscription::TopicSubscription",
 			"custom": true,
 			"type": "aws:sns/topicSubscription:TopicSubscription",
@@ -1551,6 +1637,7 @@
 			"parent": "urn:pulumi:stack::project::my::parent::parent"
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:random::default_123::123",
 			"urn": "urn:pulumi:stack::project::random:index/randomId:RandomId::RandomId",
 			"custom": true,
 			"type": "random:index/randomId:RandomId",
@@ -1560,6 +1647,7 @@
 			}
 		},
 		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:random::default_123::123",
 			"urn": "urn:pulumi:stack::project::random:index/randomId:RandomId::strange logical name",
 			"custom": true,
 			"type": "random:index/randomId:RandomId",


### PR DESCRIPTION
Follow on PR to https://github.com/pulumi/pulumi/pull/18038. This adds support to the import code generator to support resources from parameterized packages.

This requires two things. Firstly we need the whole state when generating code so we can look up providers (there was a very old TODO comment that we should have been doing this anyway so we used the correct package versions). Looking up the provider means we can pull all the package information off it to look up the schema correctly.

We also emit that package information to the generated PCL as `package` blocks, so that the language code generator also has full access to the package information so it can correctly load schemas inside its GenerateProgram call.

Part of https://github.com/pulumi/pulumi/issues/17507