### PR TITLE
Avoid unnecessary Node.js installations

### DIFF
--- a/changelog/pending/20241213--cli-install--avoid-unnecessary-node-js-installations.yaml
+++ b/changelog/pending/20241213--cli-install--avoid-unnecessary-node-js-installations.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/install
+  description: Avoid unnecessary Node.js installations

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1082,7 +1082,7 @@ func installNodeVersion(cwd string, stdout io.Writer) error {
 		fmt.Fprintf(stdout, "Setting Nodejs version to %s\n", version)
 	}
 	// This is a no-op if the version is already installed
-	installCmd := exec.Command("fnm", "install", version, "--progress", "never")
+	installCmd := exec.Command("fnm", "use", version, "--install-if-missing")
 	out, err := installCmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to install Nodejs version: %v: %s", err, out)

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
@@ -868,8 +868,6 @@ func TestNodeInstall(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("PATH", filepath.Join(tmpDir, "bin"))
 
-	fmt.Println(os.Getenv("PATH"))
-
 	// There's no fnm executable in PATH, installNodeVersion is a no-op
 	stdout := &bytes.Buffer{}
 	err := installNodeVersion(tmpDir, stdout)
@@ -900,6 +898,6 @@ func TestNodeInstall(t *testing.T) {
 	b, err := os.ReadFile(outPath)
 	require.NoError(t, err)
 	commands := strings.Split(strings.TrimSpace(string(b)), "\n")
-	require.Equal(t, "install 20.1.2 --progress never", commands[0])
+	require.Equal(t, "use 20.1.2 --install-if-missing", commands[0])
 	require.Equal(t, "alias 20.1.2 default", commands[1])
 }


### PR DESCRIPTION
When running `pulumi install --use-language-version-tools`, and `fnm` is installed on the system, we will automatically install the Node.js version specified in `.nvmrc` or `.node-version`.

When the file does not specify the full version, for example `22`, we would always install the latest release of Node.js 22, even if another point release of Node.js 22 is already present on the system. This is unnecessary, and we should use the available version.

This mostly affects Pulumi Deployments, where this installation flag is used by default. Whenever we release a new version of Pulumi, we also release new versions of the docker containers. These containers include the latest version of Node.js (22, and other versions) at the time of release, so the pre-installed version is usually very recent. However if a new Node.js version is released after our release, deployments that specify a Node.js version will always install that.

By using `fnm use ${VERSION} --install-if-missing`, we prefer the pre-installed version, and only install new Node.js versions if the fnm version matching can not be satisfied by any of the pre-installed versions.
