### PR TITLE
[sdkgen/dotnet] Compute restore sources from local dependencies and referenced packages

### DIFF
--- a/changelog/pending/20241213--sdkgen-dotnet--compute-restore-sources-from-local-dependencies-and-referenced-packages.yaml
+++ b/changelog/pending/20241213--sdkgen-dotnet--compute-restore-sources-from-local-dependencies-and-referenced-packages.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/dotnet
+  description: Compute restore sources from local dependencies and referenced packages

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -2277,48 +2277,7 @@ func genPackageMetadata(pkg *schema.Package,
 	}
 
 	// compute referenced packages in the schema
-	var referencedPackages []string
-
-	visitor := func(t schema.Type) {
-		if rt, ok := t.(*schema.ResourceType); ok && rt.Resource != nil {
-			referencedPackageName := rt.Resource.PackageReference.Name()
-			if referencedPackageName != pkg.Name {
-				referencedPackages = append(referencedPackages, referencedPackageName)
-			}
-		}
-
-		if objectType, ok := t.(*schema.ObjectType); ok {
-			referencedPackageName := objectType.PackageReference.Name()
-			if referencedPackageName != pkg.Name {
-				referencedPackages = append(referencedPackages, referencedPackageName)
-			}
-		}
-
-		if et, ok := t.(*schema.EnumType); ok {
-			referencedPackageName := et.PackageReference.Name()
-			if referencedPackageName != pkg.Name {
-				referencedPackages = append(referencedPackages, referencedPackageName)
-			}
-		}
-	}
-
-	for _, resource := range pkg.Resources {
-		codegen.VisitTypeClosure(resource.InputProperties, visitor)
-		codegen.VisitTypeClosure(resource.Properties, visitor)
-	}
-
-	for _, function := range pkg.Functions {
-		if function.Inputs != nil {
-			codegen.VisitTypeClosure(function.Inputs.Properties, visitor)
-		}
-		if function.Outputs != nil {
-			codegen.VisitTypeClosure(function.Outputs.Properties, visitor)
-		}
-	}
-
-	for _, t := range pkg.Types {
-		codegen.VisitType(t, visitor)
-	}
+	referencedPackages := codegen.PackageReferences(pkg)
 
 	for pkg, path := range localDependencies {
 		// if a local dependency is package refenced in the schema,

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -2283,7 +2283,7 @@ func genPackageMetadata(pkg *schema.Package,
 		// if a local dependency is package refenced in the schema,
 		// we add it to the local packages
 		for _, referencedPackage := range referencedPackages {
-			if pkg == referencedPackage {
+			if pkg == referencedPackage.Name() {
 				localPackages[pkg] = path
 			}
 		}

--- a/pkg/codegen/utilities_test.go
+++ b/pkg/codegen/utilities_test.go
@@ -63,7 +63,7 @@ func TestResolvingPackageReferences(t *testing.T) {
 	// ensure that package references return aws because awsx depends on aws
 	references := PackageReferences(pkg)
 	require.Equal(t, 1, len(references))
-	assert.Equal(t, "aws", references[0])
+	assert.Equal(t, "aws", references[0].Name())
 }
 
 func TestStringSetContains(t *testing.T) {

--- a/pkg/codegen/utilities_test.go
+++ b/pkg/codegen/utilities_test.go
@@ -15,11 +15,56 @@
 package codegen
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
+
+func readSchemaFile(file string) (pkgSpec schema.PackageSpec) {
+	// Read in, decode, and import the schema.
+	schemaBytes, err := os.ReadFile(filepath.Join("testing", "test", "testdata", file))
+	if err != nil {
+		panic(err)
+	}
+
+	if strings.HasSuffix(file, ".json") {
+		if err = json.Unmarshal(schemaBytes, &pkgSpec); err != nil {
+			panic(err)
+		}
+	} else if strings.HasSuffix(file, ".yaml") || strings.HasSuffix(file, ".yml") {
+		if err = yaml.Unmarshal(schemaBytes, &pkgSpec); err != nil {
+			panic(err)
+		}
+	} else {
+		panic("unknown schema file extension while parsing " + file)
+	}
+
+	return pkgSpec
+}
+
+func TestResolvingPackageReferences(t *testing.T) {
+	t.Parallel()
+
+	testdataPath := filepath.Join("testing", "test", "testdata")
+	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	pkgSpec := readSchemaFile("awsx-1.0.0-beta.5.json")
+	pkg, diags, err := schema.BindSpec(pkgSpec, loader)
+	require.NotNil(t, pkg)
+	require.NoError(t, err)
+	require.Empty(t, diags)
+	// ensure that package references return aws because awsx depends on aws
+	references := PackageReferences(pkg)
+	require.Equal(t, 1, len(references))
+	assert.Equal(t, "aws", references[0])
+}
 
 func TestStringSetContains(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
When emitting the restore sources from local dependencies in .NET which are local nuget packages, we should only add the relevant ones:
 - `pulumi` core sdk if it is part of the local dependencies
 - any other package that is referenced by the schema and is also part of the local dependencies

Replaces #18035 

Required for https://github.com/pulumi/pulumi-dotnet/pull/314