### PR TITLE
Skip TestPackageAddGoParameterized

### DIFF
--- a/changelog/pending/20241216--sdkgen-go--skip-testpackageaddgoparameterized.yaml
+++ b/changelog/pending/20241216--sdkgen-go--skip-testpackageaddgoparameterized.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdkgen/go
+  description: Skip TestPackageAddGoParameterized

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -1255,6 +1255,7 @@ func TestPackageAddGo(t *testing.T) {
 
 //nolint:paralleltest // mutates environment
 func TestPackageAddGoParameterized(t *testing.T) {
+	t.Skip("mod replace is wrong after pulumi-terraform-provider release https://github.com/pulumi/pulumi/issues/18048")
 	e := ptesting.NewEnvironment(t)
 
 	var err error


### PR DESCRIPTION
This test is failing after 0.4.0 of pulumi-terraform-provider was released

Unskipping tracked in https://github.com/pulumi/pulumi/issues/18048