### PR TITLE
Fix hang on error when using uv on Windows

### DIFF
--- a/changelog/pending/20241216--sdk-python--fix-hang-on-error-when-using-uv-on-windows.yaml
+++ b/changelog/pending/20241216--sdk-python--fix-hang-on-error-when-using-uv-on-windows.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix hang on error when using uv on Windows

--- a/sdk/python/toolchain/toolchain.go
+++ b/sdk/python/toolchain/toolchain.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
@@ -116,6 +117,43 @@ func ResolveToolchain(options PythonOptions) (Toolchain, error) {
 		return newUv(options.Root, options.Virtualenv)
 	}
 	return newPip(options.Root, options.Virtualenv)
+}
+
+// ActivateVirtualEnv takes an array of environment variables (same format as os.Environ()) and path to
+// a virtual environment directory, and returns a new "activated" array with the virtual environment's
+// "bin" dir ("Scripts" on Windows) prepended to the `PATH` environment variable, the `VIRTUAL_ENV`
+// variable set to the path, and the `PYTHONHOME` variable removed.
+func ActivateVirtualEnv(environ []string, virtualEnvDir string) []string {
+	virtualEnvBin := filepath.Join(virtualEnvDir, virtualEnvBinDirName())
+	var hasPath bool
+	var result []string
+	for _, env := range environ {
+		split := strings.SplitN(env, "=", 2)
+		contract.Assertf(len(split) == 2, "unexpected environment variable: %q", env)
+		key, value := split[0], split[1]
+
+		// Case-insensitive compare, as Windows will normally be "Path", not "PATH".
+		if strings.EqualFold(key, "PATH") {
+			hasPath = true
+			// Prepend the virtual environment bin directory to PATH so any calls to run
+			// python or pip will use the binaries in the virtual environment.
+			path := fmt.Sprintf("%s=%s%s%s", key, virtualEnvBin, string(os.PathListSeparator), value)
+			result = append(result, path)
+		} else if strings.EqualFold(key, "PYTHONHOME") {
+			// Skip PYTHONHOME to "unset" this value.
+		} else if strings.EqualFold(key, "VIRTUAL_ENV") {
+			// Skip VIRTUAL_ENV, we always set this to `virtualEnvDir`
+		} else {
+			result = append(result, env)
+		}
+	}
+	if !hasPath {
+		path := "PATH=" + virtualEnvBin
+		result = append(result, path)
+	}
+	virtualEnv := "VIRTUAL_ENV=" + virtualEnvDir
+	result = append(result, virtualEnv)
+	return result
 }
 
 func virtualEnvBinDirName() string {

--- a/sdk/python/toolchain/uv.go
+++ b/sdk/python/toolchain/uv.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/blang/semver"
@@ -214,11 +215,33 @@ func (u *uv) ListPackages(ctx context.Context, transitive bool) ([]PythonPackage
 }
 
 func (u *uv) Command(ctx context.Context, args ...string) (*exec.Cmd, error) {
-	return u.uvCommand(ctx, "", false, nil, nil, append([]string{"run", "python"}, args...)...), nil
+	// Note that we do not use `uv run python` here because this results in a
+	// process tree of `python-language-runtime -> uv -> python`. This is
+	// problematic because on error we kill the plugin and its children, but not
+	// the children of the children. On macOS and Linux, when uv is killed, it
+	// kills its children, so we have no problem here. On Windows however, it
+	// does not, and we end up with an orphaned Python process that's
+	// busy-waiting in the eventloop and never exits.
+	var cmd *exec.Cmd
+	name := "python"
+	if runtime.GOOS == windows {
+		name = name + ".exe"
+	}
+	cmdPath := filepath.Join(u.virtualenvPath, virtualEnvBinDirName(), name)
+	if needsPythonShim(cmdPath) {
+		shimCmd := fmt.Sprintf(pythonShimCmdFormat, name)
+		cmd = exec.CommandContext(ctx, shimCmd, args...)
+	} else {
+		cmd = exec.CommandContext(ctx, cmdPath, args...)
+	}
+	cmd.Env = ActivateVirtualEnv(os.Environ(), u.virtualenvPath)
+	cmd.Dir = u.root
+	return cmd, nil
 }
 
 func (u *uv) ModuleCommand(ctx context.Context, module string, args ...string) (*exec.Cmd, error) {
-	return u.uvCommand(ctx, "", false, nil, nil, append([]string{"run", "--module"}, args...)...), nil
+	moduleArgs := append([]string{"-m", module}, args...)
+	return u.Command(ctx, moduleArgs...)
 }
 
 func (u *uv) About(ctx context.Context) (Info, error) {

--- a/sdk/python/toolchain/uv.go
+++ b/sdk/python/toolchain/uv.go
@@ -234,7 +234,7 @@ func (u *uv) Command(ctx context.Context, args ...string) (*exec.Cmd, error) {
 	} else {
 		cmd = exec.CommandContext(ctx, cmdPath, args...)
 	}
-	cmd.Env = ActivateVirtualEnv(os.Environ(), u.virtualenvPath)
+	cmd.Env = ActivateVirtualEnv(cmd.Environ(), u.virtualenvPath)
 	cmd.Dir = u.root
 	return cmd, nil
 }

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -752,4 +753,34 @@ package-mode = false
 pulumi = ">=3.0.0,<4.0.0"
 python = "^3.9"
 `, string(b))
+}
+
+// Regression test for https://github.com/pulumi/pulumi/issues/17877
+//
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestUvWindowsError(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+
+	// This test will hang on Windows without the fix for https://github.com/pulumi/pulumi/issues/17877
+	done := make(chan struct{})
+	var stdout string
+	go func() {
+		e.ImportDirectory(filepath.Join("python", "uv-with-error"))
+		e.RunCommand("pulumi", "install")
+		e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+		e.RunCommand("pulumi", "stack", "init", ptesting.RandomStackName())
+		stdout, _ = e.RunCommandExpectError("pulumi", "preview")
+
+		done <- struct{}{}
+	}()
+	select {
+	case <-done:
+		require.Contains(t, stdout, "Duplicate resource URN")
+	case <-time.After(3 * time.Minute):
+		t.Fatal("Timed out waiting for TestUvWindowsError")
+	}
 }

--- a/tests/integration/python/uv-with-error/Pulumi.yaml
+++ b/tests/integration/python/uv-with-error/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: pulumi-python-uv
+description: A Python project that uses the uv toolchain.
+runtime:
+  name: python
+  options:
+    toolchain: uv
+    virtualenv: my-venv

--- a/tests/integration/python/uv-with-error/__main__.py
+++ b/tests/integration/python/uv-with-error/__main__.py
@@ -1,0 +1,8 @@
+# Copyright 2024, Pulumi Corporation.  All rights reserved.
+
+import pulumi_random as random
+
+r = random.RandomString("random", length=16)
+
+# This will fail because the name is already used
+r2 = random.RandomString("random", length=16)

--- a/tests/integration/python/uv-with-error/pyproject.toml
+++ b/tests/integration/python/uv-with-error/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "uv"
+version = "0.1.0"
+description = "A Python project with an error that uses the uv toolchain."
+requires-python = ">=3.9"
+dependencies = ["pulumi>=3.0.0,<4.0.0", "pulumi-random>=4.0.0,<5.0.0"]


### PR DESCRIPTION
When using uv we were running Python as `uv run python`, since that conveniently
handles the virtualenv for us. This results in a process tree of
`python-language-runtime -> uv -> python`. This is problematic because on error
we kill the plugin and its children, but not the children of the children. On
macOS and Linux, when uv is killed, it kills its children, so we have no problem
here. On Windows however, it does not, and we end up with an orphaned Python
process that's busy-waiting in the eventloop and never exits.

To avoid this issue, we run Python the same way as we do when using Poetry or Pip.

Fixes https://github.com/pulumi/pulumi/issues/17877