### PR TITLE
run all integration tests on all platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,6 @@ jobs:
               generate-matrix \
               --kind acceptance-test \
               "$CODEGEN_TESTS_FLAG" \
-              --tags all xplatform_acceptance \
               --platform windows-latest \
               --version-set current \
               --partition-module pkg 1 \
@@ -208,7 +207,6 @@ jobs:
               generate-matrix \
               --kind acceptance-test \
               "$CODEGEN_TESTS_FLAG" \
-              --tags all xplatform_acceptance \
               --platform macos-latest \
               --version-set current \
               --partition-module pkg 1 \


### PR DESCRIPTION
We currently exclude some integration tests on windows and macos. This is (probably) done as an optimization to save some compute time on these platform.  However we should have enough CI capacity to run these tests everywhere, and it's better to spend that capacity, rather than spend brain time to try and figure out what needs to be run cross platform and what doesn't.