### PR TITLE
retry deletes in a bucket if they fail

### DIFF
--- a/changelog/pending/20241217--backend-diy--retry-deletes-of-lock-files-if-they-fail.yaml
+++ b/changelog/pending/20241217--backend-diy--retry-deletes-of-lock-files-if-they-fail.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/diy
+  description: Retry deletes of lock files if they fail


### PR DESCRIPTION
Cloud infrastructure can occasionally hiccup.  This can be noticable when we try to delete a lock file from a bucket, and the delete fails. In that case we currently just error out, making the user to a `pulumi cancel` later.

We can do better here and actually retry the delete a few times with backoff.  This should work around temporary hiccups.  Deletes are an operation that should always be safe to retry, as even if an earlier request goes through, the object can't be deleted twice.

Fixes https://github.com/pulumi/pulumi/issues/17876