### PR TITLE
don't make backups if the object doesn't exist

### DIFF
--- a/pkg/backend/diy/state.go
+++ b/pkg/backend/diy/state.go
@@ -337,7 +337,7 @@ func (b *diyBackend) removeStack(ctx context.Context, ref *diyBackendReference) 
 // backupTarget makes a backup of an existing file, in preparation for writing a new one.
 func backupTarget(ctx context.Context, bucket Bucket, file string, keepOriginal bool) string {
 	contract.Requiref(file != "", "file", "must not be empty")
-	if ok, err := bucket.Exists(ctx, file); !ok && err == nil {
+	if exists, err := bucket.Exists(ctx, file); !exists && err == nil {
 		logging.V(5).Infof("file %s does not exist, skipping backup", file)
 		return ""
 	}

--- a/pkg/backend/diy/state.go
+++ b/pkg/backend/diy/state.go
@@ -337,6 +337,10 @@ func (b *diyBackend) removeStack(ctx context.Context, ref *diyBackendReference) 
 // backupTarget makes a backup of an existing file, in preparation for writing a new one.
 func backupTarget(ctx context.Context, bucket Bucket, file string, keepOriginal bool) string {
 	contract.Requiref(file != "", "file", "must not be empty")
+	if ok, err := bucket.Exists(ctx, file); !ok && err == nil {
+		logging.V(5).Infof("file %s does not exist, skipping backup", file)
+		return ""
+	}
 	bck := file + ".bak"
 
 	err := bucket.Copy(ctx, bck, file, nil)


### PR DESCRIPTION
We're currently trying to backup files unconditonally in this function.  However the file doesn't necessarily exist when we call it (by design).

In the future we want to introduce retries for at least the bucket.Delete function, so calling that on a file that doesn't exist would slow down the process.  It really only makes sense to create a backup if the file does actually exist, so do that.  If we get an error back from the exists function we still go ahead and try to create the backup anyway.

This needs to be merged before https://github.com/pulumi/pulumi/pull/18059