### PR TITLE
Fix mypy errors around ResourceOptions and InvokeOptions merge

### DIFF
--- a/changelog/pending/20250129--sdk-python--fix-merge-method-typing.yaml
+++ b/changelog/pending/20250129--sdk-python--fix-merge-method-typing.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/python
+  description: Fix merge method typing for ResourceOptions and Invoke*Options

--- a/sdk/python/lib/pulumi/invoke.py
+++ b/sdk/python/lib/pulumi/invoke.py
@@ -72,20 +72,11 @@ class InvokeOptions:
                URL will be used to service the invocation. This will override the URL sourced from the host package, and
                should be rarely used.
         """
-        # Expose 'merge' on this object as an instance method.
-        # TODO[python/mypy#2427]: mypy disallows method assignment
-        self.merge = self._merge_instance  # type: ignore
-        self.merge.__func__.__doc__ = InvokeOptions.merge.__doc__  # type: ignore
-
         self.parent = parent
         self.provider = provider
         self.version = version
         self.plugin_download_url = plugin_download_url
 
-    def _merge_instance(self, opts: "InvokeOptions") -> "InvokeOptions":
-        return InvokeOptions.merge(self, opts)
-
-    @staticmethod
     def merge(
         opts1: Optional["InvokeOptions"],
         opts2: Optional["InvokeOptions"],
@@ -167,17 +158,6 @@ class InvokeOutputOptions(InvokeOptions):
         )
         self.depends_on = depends_on
 
-        # Expose 'merge' on this object as an instance method.
-        # TODO[python/mypy#2427]: mypy disallows method assignment
-        self.merge = self._merge_instance  # type: ignore
-        self.merge.__func__.__doc__ = InvokeOptions.merge.__doc__  # type: ignore
-
-    def _merge_instance(
-        self, opts: "Union[InvokeOptions, InvokeOutputOptions]"
-    ) -> "InvokeOutputOptions":
-        return InvokeOutputOptions.merge(self, opts)
-
-    @staticmethod
     def merge(
         opts1: Optional[Union["InvokeOptions", "InvokeOutputOptions"]],
         opts2: Optional[Union["InvokeOptions", "InvokeOutputOptions"]],

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -30,6 +30,7 @@ from typing import (
     Tuple,
     TYPE_CHECKING,
     cast,
+    overload,
 )
 from . import _types
 from .runtime import known_types

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -30,7 +30,6 @@ from typing import (
     Tuple,
     TYPE_CHECKING,
     cast,
-    overload,
 )
 from . import _types
 from .runtime import known_types
@@ -537,11 +536,6 @@ class ResourceOptions:
                if specified resource is being deleted as well.
         """
 
-        # Expose 'merge' again this this object, but this time as an instance method.
-        # TODO[python/mypy#2427]: mypy disallows method assignment
-        self.merge = self._merge_instance  # type: ignore
-        self.merge.__func__.__doc__ = ResourceOptions.merge.__doc__  # type: ignore
-
         self.parent = parent
         self.protect = protect
         self.provider = provider
@@ -573,9 +567,6 @@ class ResourceOptions:
                     raise TypeError(
                         f"'depends_on' was passed a value {dep} that was not a Resource."
                     )
-
-    def _merge_instance(self, opts: "ResourceOptions") -> "ResourceOptions":
-        return ResourceOptions.merge(self, opts)
 
     def _depends_on_list(self) -> "Input[List[Input[Resource]]]":
         if self.depends_on is None:
@@ -620,24 +611,7 @@ class ResourceOptions:
         # The fix is to re-assign merge after the copy.
 
         out = copy.copy(self)
-        # Expose 'merge' again this this object, but this time as an instance method.
-        # TODO[python/mypy#2427]: mypy disallows method assignment
-        out.merge = out._merge_instance  # type: ignore
         return out
-
-    @overload
-    @staticmethod
-    def merge(
-        opts1: Optional["ResourceOptions"], opts2: Optional["ResourceOptions"]
-    ) -> "ResourceOptions":
-        ...
-
-    @overload
-    @classmethod
-    def merge(
-        cls, opts2: Optional["ResourceOptions"]
-    ) -> "ResourceOptions":
-        ...
 
     def merge(
         opts1: Optional["ResourceOptions"], opts2: Optional["ResourceOptions"]

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -624,7 +624,20 @@ class ResourceOptions:
         out.merge = out._merge_instance  # type: ignore
         return out
 
+    @overload
     @staticmethod
+    def merge(
+        opts1: Optional["ResourceOptions"], opts2: Optional["ResourceOptions"]
+    ) -> "ResourceOptions":
+        ...
+
+    @overload
+    @classmethod
+    def merge(
+        cls, opts2: Optional["ResourceOptions"]
+    ) -> "ResourceOptions":
+        ...
+
     def merge(
         opts1: Optional["ResourceOptions"], opts2: Optional["ResourceOptions"]
     ) -> "ResourceOptions":

--- a/sdk/python/lib/test/test_resource.py
+++ b/sdk/python/lib/test/test_resource.py
@@ -296,6 +296,15 @@ class MergeResourceOptions(unittest.TestCase):
         assert opts2.protect is True
         opts3 = ResourceOptions.merge(opts2, ResourceOptions())
         assert opts3.protect is True
+        opts4 = opts3.merge(ResourceOptions(retain_on_delete=True))
+        assert opts4.protect is True
+        assert opts4.retain_on_delete is True
+        opts5 = ResourceOptions.merge(None, opts4)
+        assert opts5.protect is True
+        assert opts5.retain_on_delete is True
+        opts6 = ResourceOptions.merge(opts5, None)
+        assert opts6.protect is True
+        assert opts6.retain_on_delete is True
 
 
 # Regression test for https://github.com/pulumi/pulumi/issues/12032


### PR DESCRIPTION
As a consumer, using the class method of merge results in a Pylance/Pyright type error:

![image](https://github.com/user-attachments/assets/e71a5646-9182-4eba-bff5-1e61c19919db)

After making the proposed change locally, the type error is resolved.