### PR TITLE
fix racy TestBlockUntilExists test

### DIFF
--- a/sdk/go/common/tail/tail_test.go
+++ b/sdk/go/common/tail/tail_test.go
@@ -434,8 +434,8 @@ func TestBlockUntilExists(t *testing.T) {
 		//nolint:staticcheck
 		break
 	}
+	require.NoError(t, tail.Stop())
 	tailTest.RemoveFile("test.txt")
-	require.ErrorContains(t, tail.Stop(), "no such file or directory")
 	tail.Cleanup()
 }
 


### PR DESCRIPTION
If we remove the file tail is reading before we call `tail.Stop()`, the latter may or may not return an error depending on what state it is in.  Fix this by asserting that there is no error, and removing the file after calling `tail.Stop()`.