### PR TITLE
Honor opts.PreviewCommandlineFlags in preview after refresh

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1571,6 +1571,9 @@ func (pt *ProgramTester) TestPreviewUpdateAndEdits() error {
 			if pt.opts.JSONOutput {
 				preview = append(preview, "--json")
 			}
+			if pt.opts.PreviewCommandlineFlags != nil {
+				preview = append(preview, pt.opts.PreviewCommandlineFlags...)
+			}
 			if err := pt.runPulumiCommand("pulumi-preview-after-refresh", preview, dir, false); err != nil {
 				return err
 			}


### PR DESCRIPTION
`ProgramTestOptions` has this option:
```go
	// PreviewCommandlineFlags specifies flags to add to the `pulumi preview` command line (e.g. "--color=raw")
	PreviewCommandlineFlags []string
```

However, ProgramTest runs `preview` twice, once before create and then after refresh. The second run ignores `PreviewCommandlineFlags` which I assume was an oversight. This PR fixes that.

The concrete use case is that I was working on a test where the second preview run failed but it didn't tell me why; just "_no changes were expected but changes were proposed_". With this PR I was able to add `UpdateCommandlineFlags:  []string{"--diff"}` to my test and saw the property that changed unexpectedly.