### PR TITLE
fix race condition in tail better

### DIFF
--- a/sdk/go/common/tail/tail.go
+++ b/sdk/go/common/tail/tail.go
@@ -461,7 +461,7 @@ func (tail *Tail) sendLine(line string) bool {
 		select {
 		case tail.Lines <- &Line{line, tail.lineNum, SeekInfo{Offset: offset}, now, nil}:
 		case <-earlyExitChan:
-			// This is a bit weird here, when a users requests stopAtEof we
+			// This is a bit weird here, when a user requests StopAtEof we
 			// must keep sending all lines. However <-tail.Dying() will return
 			// immediately at this point so depending on the scheduler we may
 			// not have a chance to send the line.  If StopAtEOF is sent, we

--- a/sdk/go/common/tail/tail.go
+++ b/sdk/go/common/tail/tail.go
@@ -454,25 +454,22 @@ func (tail *Tail) sendLine(line string) bool {
 		lines = util.PartitionString(line, tail.MaxLineSize)
 	}
 
-	// This is a bit weird here, when a users requests stopAtEof we
-	// must keep sending all lines however <-tail.Dying() will return
-	// immediately at this point so the select below may not have
-	// chance to send the line if the reader side has is not yet ready.
-	// But if StopAtEOF was not set and it is a "normal" Kill then we
-	// should exit right away still thus the special logic here.
 	earlyExitChan := tail.Dying()
-	if tail.Err() == errStopAtEOF {
-		// Note that receive from a nil channel blocks forever so
-		// below we know it can only take the tail.Lines case.
-		earlyExitChan = nil
-	}
 	for _, line := range lines {
 		tail.lineNum++
 		offset, _ := tail.Tell()
 		select {
 		case tail.Lines <- &Line{line, tail.lineNum, SeekInfo{Offset: offset}, now, nil}:
 		case <-earlyExitChan:
-			return true
+			// This is a bit weird here, when a users requests stopAtEof we
+			// must keep sending all lines. However <-tail.Dying() will return
+			// immediately at this point so depending on the scheduler we may
+			// not have a chance to send the line.  If StopAtEOF is sent, we
+			// continue sending lines, and expect the reader to read them all
+			// to avoid a deadlock.
+			if tail.Err() == errStopAtEOF {
+				tail.Lines <- &Line{line, tail.lineNum, SeekInfo{Offset: offset}, now, nil}
+			}
 		}
 	}
 

--- a/sdk/go/common/tail/tail_test.go
+++ b/sdk/go/common/tail/tail_test.go
@@ -459,7 +459,6 @@ func TestFollowUntilEof(t *testing.T) {
 	tailTest.ReadLinesWithError(tail, []string{"hello", "world"}, false, errStopAtEOF)
 
 	tailTest.RemoveFile(filename)
-	require.ErrorContains(t, tail.Stop(), "stop at eof")
 	tail.Cleanup()
 }
 


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/18044 we vendored the nxadm/tail library and pulled in a couple of changes from upstream to avoid race conditions.

However the changes from upstream were not sufficient. Namely, one of the changes was to try and avoid exiting early if tail is meant to stop at the next EOF.  It did so by setting the earlyExitChan to `nil` if tail was requested to shut down with a stopAtEOF error. However it is possible that stopAtEOF is written to the earlyExitChan after we checked `tail.Err()`, but before we get to the select.

In that case we can still get an early exit on EOF, which we don't want.  Move the check for the stopAtEOF error into the earlyExitChan case. At this point tail.Err() is guaranteed to be set correctly, if the user requested a stop at eof.

Also fix a separate race in the test, where the test called `Stop()` twice, which was incorrect and unnecessary.

(This unflaked the test `TestFollowUntilEof` locally for me. Using `go test -run TestFollowUntilEof\$ -count 10000 .` would fail pretty consistently after a couple of time max.  With this change running it in a loop doesn't seem to break it anymore)

This requires no separate changelog entry since https://github.com/pulumi/pulumi/pull/18044 was not released yet.