### PR TITLE
Append debug flags after subcommand to account for non global flags like "debug"

### DIFF
--- a/changelog/pending/20241219--auto-go--fix-debug-flag-in-automation-api.yaml
+++ b/changelog/pending/20241219--auto-go--fix-debug-flag-in-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/go
+  description: Fix "debug" flag in automation api

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -370,7 +370,6 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 	bufferSizeHint := len(upOpts.Replace) + len(upOpts.Target) + len(upOpts.PolicyPacks) + len(upOpts.PolicyPackConfigs)
 	sharedArgs := slice.Prealloc[string](bufferSizeHint)
 
-	sharedArgs = debug.AddArgs(&upOpts.DebugLogOpts, sharedArgs)
 	if upOpts.Message != "" {
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--message=%q", upOpts.Message))
 	}
@@ -430,6 +429,8 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 	sharedArgs = append(sharedArgs, s.remoteArgs()...)
 
 	kind, args := constant.ExecKindAutoLocal, []string{"up", "--yes", "--skip-preview"}
+	args = debug.AddArgs(&upOpts.DebugLogOpts, args)
+
 	if program := s.Workspace().Program(); program != nil {
 		server, err := startLanguageRuntimeServer(program)
 		if err != nil {
@@ -720,8 +721,8 @@ func (s *Stack) Refresh(ctx context.Context, opts ...optrefresh.Option) (Refresh
 func refreshOptsToCmd(o *optrefresh.Options, s *Stack, isPreview bool) []string {
 	args := slice.Prealloc[string](len(o.Target))
 
-	args = debug.AddArgs(&o.DebugLogOpts, args)
 	args = append(args, "refresh")
+	args = debug.AddArgs(&o.DebugLogOpts, args)
 	if isPreview {
 		args = append(args, "--preview-only")
 	} else {


### PR DESCRIPTION
Append debug flags after subcommand to account for non global flags like "debug"

Fixes #15305
