### PR TITLE
add hide lifecycletest testdata in diffs by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+pkg/engine/lifecycletest/testdata/** linguist-generated=true


### PR DESCRIPTION
These files show up in PRs all the time, and clutter PRs making them harder to read.  According to
https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github, we can use this gitattribute to make them not show up in diffs (which I think means they are collapsed in PR reviews).