### PR TITLE
unflake unhandledInterrupt test

### DIFF
--- a/sdk/go/common/util/cmdutil/term_test.go
+++ b/sdk/go/common/util/cmdutil/term_test.go
@@ -285,7 +285,7 @@ func TestTerminate_unhandledInterrupt(t *testing.T) {
 			go func() {
 				defer close(done)
 
-				ok, err := TerminateProcessGroup(cmd.Process, 200*time.Millisecond)
+				ok, err := TerminateProcessGroup(cmd.Process, 400*time.Millisecond)
 				assert.True(t, ok, "child process did not exit gracefully")
 				assert.Error(t, err, "child process should have exited with an error")
 			}()
@@ -294,7 +294,7 @@ func TestTerminate_unhandledInterrupt(t *testing.T) {
 			case <-done:
 				// continue
 
-			case <-time.After(200 * time.Millisecond):
+			case <-time.After(500 * time.Millisecond):
 				// Took too long to kill the child process.
 				t.Fatal("Took too long to kill child process")
 			}


### PR DESCRIPTION
It looks like python is occasionally slow in CI, so allow some extra time for it to shut down to hopefully fix the flake.

Also make the "Took too long to kill child process" case take a little longer, so we can actually observe what happens in TerminateProcessGroup and the following asserts, rather than shutting the test down.  The test is still correct, as if we're hitting the 400ms timeout the first assert in the goroutine will trigger.

Fixes https://github.com/pulumi/pulumi/issues/18074