### PR TITLE
Update dotnet to 3.71.1

### DIFF
--- a/changelog/pending/20241219--sdk-dotnet--update-dotnet-to-3-71-1.yaml
+++ b/changelog/pending/20241219--sdk-dotnet--update-dotnet-to-3-71-1.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/dotnet
+  description: Update dotnet to 3.71.1

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -2372,7 +2372,7 @@ func genProjectFile(pkg *schema.Package,
 		// only add a package reference to Pulumi if we're not referencing a local Pulumi project
 		// which we usually do when testing schemas locally
 		if !referencedLocalPulumiProject {
-			packageReferences["Pulumi"] = "[3.71.0.0,4)"
+			packageReferences["Pulumi"] = "[3.71.1.0,4)"
 		}
 	}
 

--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -378,4 +378,4 @@ const (
 )
 
 // PulumiDotnetSDKVersion is the version of the Pulumi .NET SDK to use in program-gen tests
-const PulumiDotnetSDKVersion = "3.71.0"
+const PulumiDotnetSDKVersion = "3.71.1"

--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -32,7 +32,7 @@ download_release() {
 }
 
 # shellcheck disable=SC2043
-for i in "github.com/pulumi/pulumi-java java" "github.com/pulumi/pulumi-yaml yaml v1.13.0" "github.com/pulumi/pulumi-dotnet dotnet v3.71.0"; do
+for i in "github.com/pulumi/pulumi-java java" "github.com/pulumi/pulumi-yaml yaml v1.13.0" "github.com/pulumi/pulumi-dotnet dotnet v3.71.1"; do
   set -- $i # treat strings in loop as args
   REPO="$1"
   PULUMI_LANG="$2"

--- a/tests/testdata/codegen/assets-and-archives/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/assets-and-archives/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/azure-native-nested-types/dotnet/Pulumi.AzureNative.csproj
+++ b/tests/testdata/codegen/azure-native-nested-types/dotnet/Pulumi.AzureNative.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 

--- a/tests/testdata/codegen/config-variables/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/config-variables/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/cyclic-types/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/cyclic-types/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/dash-named-schema/dotnet/Pulumi.FooBar.csproj
+++ b/tests/testdata/codegen/dash-named-schema/dotnet/Pulumi.FooBar.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
     <PackageReference Include="Pulumi.Aws" Version="4.20" ExcludeAssets="contentFiles" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.7" ExcludeAssets="contentFiles" />
     <PackageReference Include="Pulumi.Random" Version="4.2" ExcludeAssets="contentFiles" />

--- a/tests/testdata/codegen/dashed-import-schema/dotnet/Pulumi.Plant.csproj
+++ b/tests/testdata/codegen/dashed-import-schema/dotnet/Pulumi.Plant.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/functions-secrets/dotnet/Pulumi.Mypkg.csproj
+++ b/tests/testdata/codegen/functions-secrets/dotnet/Pulumi.Mypkg.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/hyphen-url/dotnet/Pulumi.Registrygeoreplication.csproj
+++ b/tests/testdata/codegen/hyphen-url/dotnet/Pulumi.Registrygeoreplication.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
     <PackageReference Include="Pulumi.AzureNative" Version="1.28.*" ExcludeAssets="contentFiles" />
   </ItemGroup>
 

--- a/tests/testdata/codegen/legacy-names/dotnet/Pulumi.Legacy_names.csproj
+++ b/tests/testdata/codegen/legacy-names/dotnet/Pulumi.Legacy_names.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/naming-collisions/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/naming-collisions/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/nested-module-thirdparty/dotnet/Pulumi.FooBar.csproj
+++ b/tests/testdata/codegen/nested-module-thirdparty/dotnet/Pulumi.FooBar.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/output-funcs-edgeorder/dotnet/Pulumi.Myedgeorder.csproj
+++ b/tests/testdata/codegen/output-funcs-edgeorder/dotnet/Pulumi.Myedgeorder.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/output-funcs-tfbridge20/dotnet/Pulumi.Mypkg.csproj
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/dotnet/Pulumi.Mypkg.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/output-funcs/dotnet/Pulumi.Mypkg.csproj
+++ b/tests/testdata/codegen/output-funcs/dotnet/Pulumi.Mypkg.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/plain-and-default/dotnet/Pulumi.FooBar.csproj
+++ b/tests/testdata/codegen/plain-and-default/dotnet/Pulumi.FooBar.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/plain-object-defaults/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/plain-object-defaults/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/plain-object-disable-defaults/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/plain-object-disable-defaults/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/provider-type-schema/dotnet/Pulumi.ProviderType.csproj
+++ b/tests/testdata/codegen/provider-type-schema/dotnet/Pulumi.ProviderType.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/regress-8403/dotnet/Pulumi.Mongodbatlas.csproj
+++ b/tests/testdata/codegen/regress-8403/dotnet/Pulumi.Mongodbatlas.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/regress-node-8110/dotnet/Pulumi.My8110.csproj
+++ b/tests/testdata/codegen/regress-node-8110/dotnet/Pulumi.My8110.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/replace-on-change/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/replace-on-change/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/resource-args-python/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/resource-args-python/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/resource-property-overlap/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/resource-property-overlap/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/secrets/dotnet/Pulumi.Mypkg.csproj
+++ b/tests/testdata/codegen/secrets/dotnet/Pulumi.Mypkg.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/simple-enum-schema/dotnet/Pulumi.Plant.csproj
+++ b/tests/testdata/codegen/simple-enum-schema/dotnet/Pulumi.Plant.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/simple-methods-schema/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-methods-schema/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
     <PackageReference Include="Pulumi.Random" Version="4.2.0" ExcludeAssets="contentFiles" />
   </ItemGroup>
 

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/simple-plain-schema/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-plain-schema/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/simple-resource-schema/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-resource-schema/dotnet/Pulumi.Example.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/simple-resource-with-aliases/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-resource-with-aliases/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/transpiled_examples/cue-random-pp/dotnet/dotnet.csproj
+++ b/tests/testdata/codegen/transpiled_examples/cue-random-pp/dotnet/dotnet.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.66.1" />
+    <PackageReference Include="Pulumi" Version="3.71.1" />
     <PackageReference Include="Pulumi.Random" Version="4.11.2" />
   </ItemGroup>
 

--- a/tests/testdata/codegen/transpiled_examples/getting-started-pp/dotnet/dotnet.csproj
+++ b/tests/testdata/codegen/transpiled_examples/getting-started-pp/dotnet/dotnet.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.66.1" />
+    <PackageReference Include="Pulumi" Version="3.71.1" />
     <PackageReference Include="Pulumi.Aws" Version="4.26.0" />
   </ItemGroup>
 

--- a/tests/testdata/codegen/transpiled_examples/kubernetes-pp/dotnet/dotnet.csproj
+++ b/tests/testdata/codegen/transpiled_examples/kubernetes-pp/dotnet/dotnet.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.66.1" />
+    <PackageReference Include="Pulumi" Version="3.71.1" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.7.2" />
   </ItemGroup>
 

--- a/tests/testdata/codegen/transpiled_examples/random-pp/dotnet/dotnet.csproj
+++ b/tests/testdata/codegen/transpiled_examples/random-pp/dotnet/dotnet.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.66.1" />
+    <PackageReference Include="Pulumi" Version="3.71.1" />
     <PackageReference Include="Pulumi.Random" Version="4.11.2" />
   </ItemGroup>
 

--- a/tests/testdata/codegen/unions-inline/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/unions-inline/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/unions-inside-arrays/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/unions-inside-arrays/dotnet/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/urn-id-properties/dotnet/Pulumi.Urnid.csproj
+++ b/tests/testdata/codegen/urn-id-properties/dotnet/Pulumi.Urnid.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/testdata/codegen/using-shared-types-in-config/dotnet/Pulumi.Credentials.csproj
+++ b/tests/testdata/codegen/using-shared-types-in-config/dotnet/Pulumi.Credentials.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.71.0.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.71.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Also update the minimum required SDK version for codegen to 3.71.1 as it's necessary to be able to use parameterized explicit providers (https://github.com/pulumi/pulumi-dotnet/pull/435).