### PR TITLE
Fix infinite looping of calls of pulumi program when missing inline program

### DIFF
--- a/changelog/pending/20241220--auto-go--return-error-if-no-inline-program-specified.yaml
+++ b/changelog/pending/20241220--auto-go--return-error-if-no-inline-program-specified.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/go
+  description: Return error if no inline program specified

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -1357,6 +1357,9 @@ func NewStackInlineSource(
 	opts ...LocalWorkspaceOption,
 ) (Stack, error) {
 	var stack Stack
+	if program == nil {
+		return stack, errors.New("program must be specified")
+	}
 	opts = append(opts, Program(program))
 
 	proj, err := getProjectSettings(ctx, projectName, opts)
@@ -1388,6 +1391,9 @@ func UpsertStackInlineSource(
 	opts ...LocalWorkspaceOption,
 ) (Stack, error) {
 	var stack Stack
+	if program == nil {
+		return stack, errors.New("program must be specified")
+	}
 	opts = append(opts, Program(program))
 
 	proj, err := getProjectSettings(ctx, projectName, opts)
@@ -1418,6 +1424,9 @@ func SelectStackInlineSource(
 	opts ...LocalWorkspaceOption,
 ) (Stack, error) {
 	var stack Stack
+	if program == nil {
+		return stack, errors.New("program must be specified")
+	}
 	opts = append(opts, Program(program))
 
 	proj, err := getProjectSettings(ctx, projectName, opts)

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -966,6 +966,24 @@ func TestNewStackInlineSource(t *testing.T) {
 	assert.Equal(t, "succeeded", dRes.Summary.Result)
 }
 
+func TestInlineSourceFamilyReturnsErrorWhenNil(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	sName := ptesting.RandomStackName()
+	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
+
+	// initialize
+	_, err := NewStackInlineSource(ctx, stackName, pName, nil)
+	assert.ErrorContains(t, err, "program must be specified")
+
+	_, err = UpsertStackInlineSource(ctx, stackName, pName, nil)
+	assert.ErrorContains(t, err, "program must be specified")
+
+	_, err = SelectStackInlineSource(ctx, stackName, pName, nil)
+	assert.ErrorContains(t, err, "program must be specified")
+}
+
 func TestStackLifecycleInlineProgramRemoveWithoutDestroy(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The fix is described by Fraser here: https://github.com/pulumi/pulumi/issues/15877#issuecomment-2076785682

In summary the program uses the current directory as the project directory to run instead of an inline program when one is not specified. This causes pulumi up to be invoked in the current directory (again), potentially causing an infinite loop.

Fixes #15877