### PR TITLE
Ignore DependsOn for direct form invokes instead of raising an error

### DIFF
--- a/changelog/pending/20241220--sdk-go--ignore-dependson-for-direct-form-invokes-instead-of-raising-an-error.yaml
+++ b/changelog/pending/20241220--sdk-go--ignore-dependson-for-direct-form-invokes-instead-of-raising-an-error.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Ignore DependsOn for direct form invokes instead of raising an error

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -1407,9 +1407,10 @@ func TestInvokeDependsOn(t *testing.T) {
 	err := RunErr(func(ctx *Context) error {
 		var args DoEchoArgs
 		dep := newTestRes(t, ctx, "dep")
-		opts := DependsOn([]Resource{dep})
+		opt := DependsOn([]Resource{dep})
+		options := mergeInvokeOptions(opt)
 
-		props, deps, err := ctx.invokePackageRaw("pkg:index:doEcho", args, "some-package-ref", opts)
+		props, deps, err := ctx.invokePackageRaw("pkg:index:doEcho", args, "some-package-ref", *options)
 
 		require.NoError(t, err)
 		require.Equal(t, resource.NewStringProperty("hello"), props[resource.PropertyKey("echo")])
@@ -1443,9 +1444,10 @@ func TestInvokeDependsOnInputs(t *testing.T) {
 		var args DoEchoArgs
 		dep := newTestRes(t, ctx, "dep")
 		ro := NewResourceOutput(dep)
-		opts := DependsOnInputs(NewResourceArrayOutput(ro))
+		opt := DependsOnInputs(NewResourceArrayOutput(ro))
+		options := mergeInvokeOptions(opt)
 
-		props, deps, err := ctx.invokePackageRaw("pkg:index:doEcho", args, "some-package-ref", opts)
+		props, deps, err := ctx.invokePackageRaw("pkg:index:doEcho", args, "some-package-ref", *options)
 
 		require.NoError(t, err)
 		require.Equal(t, resource.NewStringProperty("hello"), props[resource.PropertyKey("echo")])
@@ -1458,8 +1460,10 @@ func TestInvokeDependsOnInputs(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestInvokeDependsOnNotAllowed(t *testing.T) {
+func TestInvokeDependsOnIgnored(t *testing.T) {
 	t.Parallel()
+
+	done := make(chan struct{})
 
 	monitor := &testMonitor{
 		CallF: func(args MockCallArgs) (resource.PropertyMap, error) {
@@ -1468,6 +1472,9 @@ func TestInvokeDependsOnNotAllowed(t *testing.T) {
 			}, nil
 		},
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
+			// Wait to resolve the resource until after the invoke has completed.
+			// This lets us test that the invoke did not wait for this resource.
+			<-done
 			return args.Name + "_id", nil, nil
 		},
 	}
@@ -1480,8 +1487,9 @@ func TestInvokeDependsOnNotAllowed(t *testing.T) {
 		opts := DependsOnInputs(NewResourceArrayOutput(ro))
 
 		err := ctx.InvokePackage("pkg:index:doEcho", args, &rv, "some-package-ref", opts)
+		require.NoError(t, err)
 
-		require.ErrorContains(t, err, "DependsOnInputs is not supported for direct form invoke")
+		done <- struct{}{}
 
 		return nil
 	}, WithMocks("project", "stack", monitor))


### PR DESCRIPTION
When we introduced DependsOn for output form invokes in Go, we made it an error to pass this option to direct form invokes. Unfortunately that is not backwards compatible, and users for example pass the same set of options to resources and invokes. Previously this worked without issue, but now this can result in an error.

This also occurs in our SDKs. The Kubernetes SDK has resources that internally call an invoke with the options of the resource.

The solution is to ignore DependsOn in this case, instead of making it an error. This is what we did for Python and Typescript, [for example](https://github.com/pulumi/pulumi/blob/27cf193189a394a6c1f68583149c90fd4bd512e8/sdk/nodejs/runtime/invoke.ts#L88-L92).

Fixes https://github.com/pulumi/pulumi/issues/18087