### PR TITLE
Fix nil access violation in plugin.Close

### DIFF
--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -554,11 +554,13 @@ func buildPluginArguments(opts pluginArgumentOptions) []string {
 }
 
 func (p *plugin) Close() error {
-	// Something has gone wrong with the plugin if it is not ready to handle requests
-	// and we have not yet shut it down.
-	pluginCrashed := p.Conn.GetState() != connectivity.Ready
+	pluginCrashed := true
 
 	if p.Conn != nil {
+		// Something has gone wrong with the plugin if it is not ready to handle requests and we have not yet
+		// shut it down.
+		pluginCrashed = p.Conn.GetState() != connectivity.Ready
+
 		contract.IgnoreClose(p.Conn)
 	}
 


### PR DESCRIPTION
Noticed this while doing some tests with a new provider that was crashing on startup. `plugin.Close` can get called before `Conn` is set, leading to a nil access violation trying to get the connection state.