### PR TITLE
return a meaningful error when getting a zip template fails

### DIFF
--- a/changelog/pending/20241220--cli-new--provide-a-better-error-message-when-pulumi-new-ai-generates-a-program-with-errors.yaml
+++ b/changelog/pending/20241220--cli-new--provide-a-better-error-message-when-pulumi-new-ai-generates-a-program-with-errors.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Provide a better error message when pulumi new --ai generates a program with errors

--- a/sdk/go/common/workspace/templates_zip.go
+++ b/sdk/go/common/workspace/templates_zip.go
@@ -162,6 +162,9 @@ func RetrieveZIPTemplateFolder(templateURL *url.URL, tempDir string) (string, er
 	if err != nil {
 		return "", err
 	}
+	if packageResponse.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to download template: %s\n%s", packageResponse.Status, string(packageResponseBody))
+	}
 	archive, err := zip.NewReader(bytes.NewReader(packageResponseBody), int64(len(packageResponseBody)))
 	if err != nil {
 		return "", err

--- a/sdk/go/common/workspace/templates_zip_test.go
+++ b/sdk/go/common/workspace/templates_zip_test.go
@@ -185,6 +185,18 @@ func TestRetrieveZIPTemplates_SucceedsWhenPulumiYAMLIsPresent(t *testing.T) {
 	}
 }
 
+func TestRetrieveZIPTemplates_ReturnsMeaningfulErrorOn5xx(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusInternalServerError)
+		rw.Write([]byte("Missing , or : between flow sequence items at line 30, column 20"))
+	}))
+
+	_, err := retrieveZIPTemplates(server.URL)
+
+	assert.ErrorContains(t, err, "failed to download template: 500 Internal Server Error\n"+
+		"Missing , or : between flow sequence items at line 30, column 20")
+}
+
 // Returns a new test HTTP server that responds to requests according to the supplied map. Keys in the map correspond to
 // paths, while values are slices whose values correspond to filenames that should be present in the ZIP file served at
 // that path.

--- a/sdk/go/common/workspace/templates_zip_test.go
+++ b/sdk/go/common/workspace/templates_zip_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSanitizeArchivePath(t *testing.T) {
@@ -186,9 +187,12 @@ func TestRetrieveZIPTemplates_SucceedsWhenPulumiYAMLIsPresent(t *testing.T) {
 }
 
 func TestRetrieveZIPTemplates_ReturnsMeaningfulErrorOn5xx(t *testing.T) {
+	t.Parallel()
+
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusInternalServerError)
-		rw.Write([]byte("Missing , or : between flow sequence items at line 30, column 20"))
+		_, err := rw.Write([]byte("Missing , or : between flow sequence items at line 30, column 20"))
+		require.NoError(t, err)
 	}))
 
 	_, err := retrieveZIPTemplates(server.URL)


### PR DESCRIPTION
When trying to download a ZIP (e.g. for an AI response in pulumi new), we currently don't check the response code, and just feed whatever we are getting from the server into the zip parser.  The AI at the same time response with a 500 if the program it generated is not valid, which is always a possibility with LLMs.

This results in confusing error messages when the AI fails to generate a correct program: "error: failed to retrieve zip archive: zip: not a valid zip file".

We can do better here, and check the error code.  Helpfully Pulumi AI also tells us what is wrong in the response body, so we can include that in the error message.

This results in an error message like (in a failing example I tried):

```
error: failed to retrieve zip archive: failed to download template: 500 Internal Server Error
Missing , or : between flow sequence items at line 30, column 20:

      subnetIDs: [${subnet1.id}]
                   ^
```

This can help the user refine the prompt, and gives them at least a bit more information on why the AI generation failed.

Fixes https://github.com/pulumi/pulumi/issues/15644