### PR TITLE
return a more meaningful message for new --language

### DIFF
--- a/changelog/pending/20241220--cli-new--provide-a-more-meaningful-message-for-the-language-flag.yaml
+++ b/changelog/pending/20241220--cli-new--provide-a-more-meaningful-message-for-the-language-flag.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Provide a more meaningful message for the --language flag

--- a/pkg/cmd/pulumi/newcmd/new.go
+++ b/pkg/cmd/pulumi/newcmd/new.go
@@ -180,6 +180,13 @@ func runNew(ctx context.Context, args newArgs) error {
 		if aiOrTemplate == "ai" {
 			checkedBackend, ok := b.(httpstate.Backend)
 			if !ok {
+				if args.aiLanguage != "" {
+					return errors.New(
+						"--language is used to generate a template with Pulumi AI. " +
+							"Please log in to Pulumi Cloud to use Pulumi AI.\n" +
+							"Use --template to create a project from a template, " +
+							"or no flags to choose one interactively.")
+				}
 				return errors.New("please log in to Pulumi Cloud to use Pulumi AI")
 			}
 			conversationURL, err := runAINew(ctx, args, opts, checkedBackend)

--- a/pkg/cmd/pulumi/newcmd/new.go
+++ b/pkg/cmd/pulumi/newcmd/new.go
@@ -180,7 +180,7 @@ func runNew(ctx context.Context, args newArgs) error {
 		if aiOrTemplate == "ai" {
 			checkedBackend, ok := b.(httpstate.Backend)
 			if !ok {
-				if args.aiLanguage != "" {
+				if args.aiLanguage != "" && args.aiPrompt == "" {
 					return errors.New(
 						"--language is used to generate a template with Pulumi AI. " +
 							"Please log in to Pulumi Cloud to use Pulumi AI.\n" +


### PR DESCRIPTION
The `--language` flag in `pulumi new` implies using Pulumi AI.
However this is not super clear for users, so let's return a better
error message that points users in the right direction, to either log
in to Pulumi Cloud to be able to use Pulumi AI, or use a different flag.

Fixes https://github.com/pulumi/pulumi/issues/15003