### PR TITLE
Revert "Avoid unnecessary Node.js installations"

### DIFF
--- a/changelog/pending/20241213--cli-install--avoid-unnecessary-node-js-installations.yaml
+++ b/changelog/pending/20241213--cli-install--avoid-unnecessary-node-js-installations.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: fix
-  scope: cli/install
-  description: Avoid unnecessary Node.js installations

--- a/changelog/pending/20241220--sdk-nodejs--reverts-18041.yaml
+++ b/changelog/pending/20241220--sdk-nodejs--reverts-18041.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: "Reverts #18041"

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1082,7 +1082,7 @@ func installNodeVersion(cwd string, stdout io.Writer) error {
 		fmt.Fprintf(stdout, "Setting Nodejs version to %s\n", version)
 	}
 	// This is a no-op if the version is already installed
-	installCmd := exec.Command("fnm", "use", version, "--install-if-missing")
+	installCmd := exec.Command("fnm", "install", version, "--progress", "never")
 	out, err := installCmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to install Nodejs version: %v: %s", err, out)

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
@@ -868,6 +868,8 @@ func TestNodeInstall(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("PATH", filepath.Join(tmpDir, "bin"))
 
+	fmt.Println(os.Getenv("PATH"))
+
 	// There's no fnm executable in PATH, installNodeVersion is a no-op
 	stdout := &bytes.Buffer{}
 	err := installNodeVersion(tmpDir, stdout)
@@ -898,6 +900,6 @@ func TestNodeInstall(t *testing.T) {
 	b, err := os.ReadFile(outPath)
 	require.NoError(t, err)
 	commands := strings.Split(strings.TrimSpace(string(b)), "\n")
-	require.Equal(t, "use 20.1.2 --install-if-missing", commands[0])
+	require.Equal(t, "install 20.1.2 --progress never", commands[0])
 	require.Equal(t, "alias 20.1.2 default", commands[1])
 }


### PR DESCRIPTION
Reverts pulumi/pulumi#18041

We can't use `fnm use` in an environment without a persistent shell.