### PR TITLE
Support `--clear-pending-creates` for `refresh` command in Go Automation API.

### DIFF
--- a/changelog/pending/20241222--auto-go--support-clear-pending-creates-to-go-automation-api-previewrefresh-and-refresh.yaml
+++ b/changelog/pending/20241222--auto-go--support-clear-pending-creates-to-go-automation-api-previewrefresh-and-refresh.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Support --clear-pending-creates for refresh command in Go Automation API for preview refresh and refresh operations.

--- a/sdk/go/auto/optrefresh/optrefresh.go
+++ b/sdk/go/auto/optrefresh/optrefresh.go
@@ -38,6 +38,13 @@ func ExpectNoChanges() Option {
 	})
 }
 
+// ClearPendingCreates will cause the refresh to drop all pending creates from the state
+func ClearPendingCreates() Option {
+	return optionFunc(func(opts *Options) {
+		opts.ClearPendingCreates = true
+	})
+}
+
 // Message (optional) to associate with the refresh operation
 func Message(message string) Option {
 	return optionFunc(func(opts *Options) {
@@ -131,7 +138,9 @@ type Options struct {
 	Message string
 	// Return an error if any changes occur during this preview
 	ExpectNoChanges bool
-	// Specify an exclusive list of resource URNs to re
+	// Clear all pending creates, dropping them from the state
+	ClearPendingCreates bool
+	// Specify an exclusive of resource URNs to refresh
 	Target []string
 	// ProgressStreams allows specifying one or more io.Writers to redirect incremental refresh stdout
 	ProgressStreams []io.Writer

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -734,6 +734,9 @@ func refreshOptsToCmd(o *optrefresh.Options, s *Stack, isPreview bool) []string 
 	if o.ExpectNoChanges {
 		args = append(args, "--expect-no-changes")
 	}
+	if o.ClearPendingCreates {
+		args = append(args, "--clear-pending-creates")
+	}
 	for _, tURN := range o.Target {
 		args = append(args, "--target="+tURN)
 	}

--- a/sdk/go/auto/stack_test.go
+++ b/sdk/go/auto/stack_test.go
@@ -224,3 +224,25 @@ func TestRefreshOptsConfigFile(t *testing.T) {
 	configFilePath := filepath.Join(stack.workspace.WorkDir(), "test.yaml")
 	assert.Contains(t, args, "--config-file="+configFilePath)
 }
+
+func TestRefreshOptsClearPendingCreates(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	sName := ptesting.RandomStackName()
+	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
+	pDir := filepath.Join(".", "test", "testproj")
+
+	stack, err := NewStackLocalSource(ctx, stackName, pDir)
+	require.NoError(t, err)
+
+	args := refreshOptsToCmd(
+		&optrefresh.Options{
+			ClearPendingCreates: true,
+		},
+		&stack,
+		true,
+	)
+
+	assert.Contains(t, args, "--clear-pending-creates")
+}


### PR DESCRIPTION
Further fulfills #11336.

