### PR TITLE
property diff: avoid panic'ing when computed values are present

### DIFF
--- a/changelog/pending/20241223--sdk-go--fix-panic-when-diffing-computed-property-values.yaml
+++ b/changelog/pending/20241223--sdk-go--fix-panic-when-diffing-computed-property-values.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fix panic when diffing computed property values

--- a/sdk/go/common/resource/properties_diff.go
+++ b/sdk/go/common/resource/properties_diff.go
@@ -391,6 +391,15 @@ func (v PropertyValue) DeepEquals(other PropertyValue) bool {
 		return vo.Element.DeepEquals(oo.Element)
 	}
 
+	if v.IsComputed() {
+		if !other.IsComputed() {
+			return false
+		}
+		vc := v.Input().Element
+		oc := other.Input().Element
+		return vc.DeepEquals(oc)
+	}
+
 	// For all other cases, primitives are equal if their values are equal.
 	return v.V == other.V
 }

--- a/sdk/go/common/resource/properties_diff_test.go
+++ b/sdk/go/common/resource/properties_diff_test.go
@@ -370,3 +370,17 @@ func TestMismatchedPropertyValueDiff(t *testing.T) {
 	assert.True(t, s2.DeepEquals(s1))
 	assert.True(t, s1.DeepEquals(s2))
 }
+
+func TestComputedProperyValueDiff(t *testing.T) {
+	t.Parallel()
+
+	a1 := MakeComputed(NewPropertyValue("a"))
+	a2 := MakeComputed(NewPropertyValue("a"))
+	assert.True(t, a1.DeepEquals(a2))
+
+	a3 := MakeComputed(NewPropertyValue("b"))
+	assert.False(t, a1.DeepEquals(a3))
+
+	a4 := NewPropertyValue("a")
+	assert.False(t, a1.DeepEquals(a4))
+}


### PR DESCRIPTION
In property diff we currently don't treat computed values.  This means we're going to try to compare them with `==`, which panics.  Allow computed property values to be diffed correctly.

Fixes https://github.com/pulumi/pulumi/issues/14619