### PR TITLE
clarify usage string for --expect-no-changes

### DIFF
--- a/changelog/pending/20241223--cli-engine--clarify-the-usage-string-for-the-expect-no-changes-flag.yaml
+++ b/changelog/pending/20241223--cli-engine--clarify-the-usage-string-for-the-expect-no-changes-flag.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/engine
+  description: Clarify the usage string for the --expect-no-changes flag

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -319,7 +319,7 @@ func NewRefreshCmd() *cobra.Command {
 		"Print detailed debugging output during resource operations")
 	cmd.PersistentFlags().BoolVar(
 		&expectNop, "expect-no-changes", false,
-		"Return an error if any changes occur during this update")
+		"Return an error if any changes occur during this refresh. This check happens after the refresh is applied")
 	cmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -614,7 +614,7 @@ func NewUpCmd() *cobra.Command {
 		"Print detailed debugging output during resource operations")
 	cmd.PersistentFlags().BoolVar(
 		&expectNop, "expect-no-changes", false,
-		"Return an error if any changes occur during this update")
+		"Return an error if any changes occur during this update. This check happens after the update is applied")
 	cmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")


### PR DESCRIPTION
When using --expect-no-changes in pulumi up and pulumi refresh, the CLI applies the changes first, and then checks if there were any later, only erroring out at that point, after having applied the changes.

This is currently not very clear from either the name of the flag, nor the usage string.  Improve the usage string to make this clearer.

We could  potentially also "rename" this flag, by hiding the one with the old name, and introducing a new one doing the same thing, which would be a backwards compatible change.  I couldn't come up with a better name for the flag though (error-on-changes is the best I could come up with, but I don't think it conveys this any better).

Fixes https://github.com/pulumi/pulumi/issues/10967