### PR TITLE
reenable concurrent update test

### DIFF
--- a/sdk/go/auto/errors_test.go
+++ b/sdk/go/auto/errors_test.go
@@ -102,7 +102,6 @@ func TestConcurrentUpdateError(t *testing.T) {
 func TestInlineConcurrentUpdateError(t *testing.T) {
 	t.Parallel()
 
-	t.Skip("disabled, see https://github.com/pulumi/pulumi/issues/5312")
 	ctx := context.Background()
 	pName := "inline_conflict_error"
 	sName := ptesting.RandomStackName()
@@ -110,7 +109,7 @@ func TestInlineConcurrentUpdateError(t *testing.T) {
 
 	// initialize
 	s, err := NewStackInlineSource(ctx, stackName, pName, func(ctx *pulumi.Context) error {
-		time.Sleep(1 * time.Second)
+		time.Sleep(5 * time.Second)
 		ctx.Export("exp_static", pulumi.String("foo"))
 		return nil
 	})


### PR DESCRIPTION
Make the same changes as https://github.com/pulumi/pulumi/pull/7609 to reenable this inline test.  I noticed this test still being skipped, while https://github.com/pulumi/pulumi/issues/5312 was closed.  Since I don't recall any issues with TestConcurrentUpdateError, we can assume the same fix works for the inline version of the test as well.