### PR TITLE
[programgen/go] Fix importing module names that aren't lower-case

### DIFF
--- a/changelog/pending/20241224--programgen-go--fix-importing-module-names-in-go-programs-that-arent-lower-case.yaml
+++ b/changelog/pending/20241224--programgen-go--fix-importing-module-names-in-go-programs-that-arent-lower-case.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go
+  description: Fix importing module names in Go programs that aren't lower-case

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packagecmd"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
+	gogen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -250,6 +251,11 @@ func runConvert(
 		projectGenerator = generatorWrapper(
 			func(targetDirectory string, proj workspace.Project, program *pcl.Program) error {
 				return javagen.GenerateProject(targetDirectory, proj, program, nil /*localDependencies*/)
+			}, language)
+	case "go":
+		projectGenerator = generatorWrapper(
+			func(targetDirectory string, proj workspace.Project, program *pcl.Program) error {
+				return gogen.GenerateProject(targetDirectory, proj, program, nil)
 			}, language)
 	case "pulumi", "pcl":
 		// No plugin for PCL to install dependencies with

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -37,7 +37,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packagecmd"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
-	gogen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -251,11 +250,6 @@ func runConvert(
 		projectGenerator = generatorWrapper(
 			func(targetDirectory string, proj workspace.Project, program *pcl.Program) error {
 				return javagen.GenerateProject(targetDirectory, proj, program, nil /*localDependencies*/)
-			}, language)
-	case "go":
-		projectGenerator = generatorWrapper(
-			func(targetDirectory string, proj workspace.Project, program *pcl.Program) error {
-				return gogen.GenerateProject(targetDirectory, proj, program, nil)
 			}, language)
 	case "pulumi", "pcl":
 		// No plugin for PCL to install dependencies with

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -943,6 +943,7 @@ func (g *generator) addPulumiImport(pkg, versionPath, mod, name string) {
 	// We do this before we let the user set overrides. That way the user can still have a
 	// module named IndexToken.
 	info, hasInfo := g.getGoPackageInfo(pkg) // We're allowing `info` to be zero-initialized
+	mod = strings.ToLower(mod)
 	importPath := func(mod string) string {
 		importBasePath := fmt.Sprintf("github.com/pulumi/pulumi-%s/sdk%s/go/%s", pkg, versionPath, pkg)
 		if info.ImportBasePath != "" {
@@ -1700,6 +1701,8 @@ func (g *generator) useLookupInvokeForm(token string) bool {
 // getModOrAlias attempts to reconstruct the import statement and check if the imported package
 // is aliased, returning that alias if available.
 func (g *generator) getModOrAlias(pkg, mod, originalMod string) string {
+	mod = strings.ToLower(mod)
+	originalMod = strings.ToLower(originalMod)
 	info, ok := g.getGoPackageInfo(pkg)
 	if !ok {
 		needsAliasing := strings.Contains(mod, "-")
@@ -1710,7 +1713,7 @@ func (g *generator) getModOrAlias(pkg, mod, originalMod string) string {
 			}
 			return moduleAlias
 		}
-		return mod
+		return strings.ToLower(mod)
 	}
 
 	importPath := func(mod string) string {
@@ -1720,15 +1723,15 @@ func (g *generator) getModOrAlias(pkg, mod, originalMod string) string {
 				importedPath := strings.ReplaceAll(info.ImportPathPattern, "{module}", mod)
 				return strings.ReplaceAll(importedPath, "{baseImportPath}", importBasePath)
 			}
-			return fmt.Sprintf("%s/%s", importBasePath, mod)
+			return fmt.Sprintf("%s/%s", importBasePath, strings.ToLower(mod))
 		}
 		return importBasePath
 	}
 
 	if m, ok := info.ModuleToPackage[mod]; ok {
-		mod = m
+		mod = strings.ToLower(m)
 	} else {
-		mod = originalMod
+		mod = strings.ToLower(originalMod)
 	}
 
 	path := importPath(mod)

--- a/tests/testdata/codegen/synthetic-resource-properties-pp/go/synthetic-resource-properties.go
+++ b/tests/testdata/codegen/synthetic-resource-properties-pp/go/synthetic-resource-properties.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"git.example.org/pulumi-synthetic/resourceProperties"
+	"git.example.org/pulumi-synthetic/resourceproperties"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		rt, err := resourceProperties.NewRoot(ctx, "rt", nil)
+		rt, err := resourceproperties.NewRoot(ctx, "rt", nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Description

When importing provider modules in Go programs, we must make sure the module is in lowercase 

Fixes #14845