### PR TITLE
Move pyright configuration into pyproject.toml

### DIFF
--- a/changelog/pending/20241227--sdk-python--move-pyright-configuration-into-pyproject-toml.yaml
+++ b/changelog/pending/20241227--sdk-python--move-pyright-configuration-into-pyproject-toml.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/python
+  description: Move pyright configuration into pyproject.toml

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -996,6 +996,7 @@ func (host *pythonLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 		}
 		typecheckerCmd.Stdout = os.Stdout
 		typecheckerCmd.Stderr = os.Stderr
+		typecheckerCmd.Dir = req.Info.ProgramDirectory
 		err = checkForPackage(ctx, typechecker, opts)
 		if err != nil {
 			var installError *NotInstalledError

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -64,3 +64,9 @@ core-metadata-version = "2.3"
 # This ensures that the version for pulumi in uv.lock is updated when the
 # version from _version changes.
 upgrade-package = ["pulumi"]
+
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+include = ["lib/test_types"]
+strict = ["lib/test_types"]

--- a/sdk/python/pyrightconfig.json
+++ b/sdk/python/pyrightconfig.json
@@ -1,9 +1,0 @@
-{
-  "venvPath": ".venv",
-  "include": [
-    "lib/test_types"
-  ],
-  "strict": [
-    "lib/test_types",
-  ],
-}


### PR DESCRIPTION
Now that we have a pyproject.toml, we can move the configuration for most python tools there, instead of having separate files for each tool.