### PR TITLE
Don't pass plugin.Host and plugin.Context to NewProviderFromPath

### DIFF
--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -748,12 +748,8 @@ func ProviderFromSource(packageSource string) (plugin.Provider, error) {
 	// No file separators, so we try to look up the schema
 	// On unix, these checks are identical. On windows, filepath.Separator is '\\'
 	if !strings.ContainsRune(descriptor.Name, filepath.Separator) && !strings.ContainsRune(descriptor.Name, '/') {
-		host, err := plugin.NewDefaultHost(pCtx, nil, false, nil, nil, nil, "")
-		if err != nil {
-			return nil, err
-		}
 		// We assume this was a plugin and not a path, so load the plugin.
-		provider, err := host.Provider(descriptor)
+		provider, err := pCtx.Host.Provider(descriptor)
 		if err != nil {
 			// There is an executable with the same name, so suggest that
 			if info, statErr := os.Stat(descriptor.Name); statErr == nil && isExecutable(info) {
@@ -767,7 +763,7 @@ func ProviderFromSource(packageSource string) (plugin.Provider, error) {
 			}
 
 			log := func(sev diag.Severity, msg string) {
-				host.Log(sev, "", msg, 0)
+				pCtx.Host.Log(sev, "", msg, 0)
 			}
 
 			_, err = pkgWorkspace.InstallPlugin(pCtx.Base(), descriptor.PluginSpec, log)
@@ -775,7 +771,7 @@ func ProviderFromSource(packageSource string) (plugin.Provider, error) {
 				return nil, err
 			}
 
-			p, err := host.Provider(descriptor)
+			p, err := pCtx.Host.Provider(descriptor)
 			if err != nil {
 				return nil, err
 			}
@@ -804,12 +800,7 @@ func ProviderFromSource(packageSource string) (plugin.Provider, error) {
 		}
 	}
 
-	host, err := plugin.NewDefaultHost(pCtx, nil, false, nil, nil, nil, "")
-	if err != nil {
-		return nil, err
-	}
-
-	p, err := plugin.NewProviderFromPath(host, pCtx, packageSource)
+	p, err := plugin.NewProviderFromPath(pCtx, packageSource)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/integration/run_plugin/go/main.go
+++ b/tests/integration/run_plugin/go/main.go
@@ -22,17 +22,16 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-func testProvider(ctx context.Context, host plugin.Host, pCtx *plugin.Context, name string) error {
+func testProvider(ctx context.Context, pCtx *plugin.Context, name string) error {
 	providerLocation := filepath.Join("..", name)
 	// NewProviderFromPath requires a "binary", so we use a fake one. It then uses the directory for
 	// that to run the plugin.
 	fakeProviderBinary := filepath.Join(providerLocation, "pulumi-bin")
-	prov, err := plugin.NewProviderFromPath(host, pCtx, fakeProviderBinary)
+	prov, err := plugin.NewProviderFromPath(pCtx, fakeProviderBinary)
 	if err != nil {
 		return err
 	}
@@ -67,22 +66,18 @@ func main() {
 		if err != nil {
 			return err
 		}
-		host, err := plugin.NewDefaultHost(pCtx, nil, false, nil, nil, nil, tokens.PackageName("test"))
+
+		err = testProvider(ctx.Context(), pCtx, "provider-nodejs")
 		if err != nil {
 			return err
 		}
 
-		err = testProvider(ctx.Context(), host, pCtx, "provider-nodejs")
+		err = testProvider(ctx.Context(), pCtx, "provider-go")
 		if err != nil {
 			return err
 		}
 
-		err = testProvider(ctx.Context(), host, pCtx, "provider-go")
-		if err != nil {
-			return err
-		}
-
-		err = testProvider(ctx.Context(), host, pCtx, "provider-python")
+		err = testProvider(ctx.Context(), pCtx, "provider-python")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
`plugin.Context` already has a `Host` so there's no need to pass both values through to `NewProviderFromPath`.