### PR TITLE
make python auto api tests work with DIY backend

### DIFF
--- a/sdk/python/lib/test/automation/test_errors.py
+++ b/sdk/python/lib/test/automation/test_errors.py
@@ -30,9 +30,6 @@ compilation_error_project = "compilation_error"
 runtime_error_project = "runtime_error"
 
 
-@pytest.mark.skipif(
-    "PULUMI_ACCESS_TOKEN" not in os.environ, reason="PULUMI_ACCESS_TOKEN not set"
-)
 class TestErrors(unittest.TestCase):
     def test_inline_runtime_error_python(self):
         project_name = "inline_runtime_error_python"
@@ -52,7 +49,7 @@ class TestErrors(unittest.TestCase):
                 InlineSourceRuntimeError, inline_error_text, stack.preview
             )
         finally:
-            stack.workspace.remove_stack(stack_name)
+            stack.workspace.remove_stack(stack_name, force=True)
 
     def test_runtime_errors(self):
         for lang in ["python", "go", "dotnet", "javascript", "typescript"]:
@@ -101,7 +98,7 @@ class TestErrors(unittest.TestCase):
                         RuntimeError, "failed with an unhandled exception", stack.up
                     )
             finally:
-                stack.workspace.remove_stack(stack_name)
+                stack.workspace.remove_stack(stack_name, force=True)
 
     def test_compilation_error_go(self):
         stack_name = stack_namer(compilation_error_project)
@@ -114,7 +111,7 @@ class TestErrors(unittest.TestCase):
                 CompilationError, ": syntax error:|: undefined:", stack.up
             )
         finally:
-            stack.workspace.remove_stack(stack_name)
+            stack.workspace.remove_stack(stack_name, force=True)
 
     def test_compilation_error_dotnet(self):
         stack_name = stack_namer(compilation_error_project)
@@ -125,7 +122,7 @@ class TestErrors(unittest.TestCase):
             self.assertRaises(CompilationError, stack.up)
             self.assertRaisesRegex(CompilationError, "Build FAILED.", stack.up)
         finally:
-            stack.workspace.remove_stack(stack_name)
+            stack.workspace.remove_stack(stack_name, force=True)
 
     # This test fails on Windows related to the `subprocess.run` call associated with setting up the environment.
     # Skipping for now.
@@ -144,7 +141,7 @@ class TestErrors(unittest.TestCase):
                 CompilationError, "Unable to compile TypeScript", stack.up
             )
         finally:
-            stack.workspace.remove_stack(stack_name)
+            stack.workspace.remove_stack(stack_name, force=True)
 
 
 def failing_program():

--- a/sdk/python/lib/test/automation/test_isolation.py
+++ b/sdk/python/lib/test/automation/test_isolation.py
@@ -79,9 +79,6 @@ async def async_stack_destroy(stack):
     return stack.destroy()
 
 
-@pytest.mark.skipif(
-    "PULUMI_ACCESS_TOKEN" not in os.environ, reason="PULUMI_ACCESS_TOKEN not set"
-)
 @pytest.mark.asyncio
 async def test_parallel_updates():
     first_stack_name = f"stack-{uuid.uuid4()}"
@@ -112,9 +109,6 @@ async def test_parallel_updates():
     )
 
 
-@pytest.mark.skipif(
-    "PULUMI_ACCESS_TOKEN" not in os.environ, reason="PULUMI_ACCESS_TOKEN not set"
-)
 @pytest.mark.skipif(
     sys.platform == "win32", reason="TODO[pulumi/pulumi#8716] fails on Windows"
 )

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -536,7 +536,9 @@ class TestLocalWorkspace(unittest.TestCase):
 
     def test_tag_methods(self):
         if os.getenv("PULUMI_ACCESS_TOKEN") is None:
-            self.skipTest("Skipping test because tag methods are only supported in the cloud backend.")
+            self.skipTest(
+                "Skipping test because tag methods are only supported in the cloud backend."
+            )
         project_name = "python_test"
         runtime = "python"
         project_settings = ProjectSettings(name=project_name, runtime=runtime)

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -80,9 +80,6 @@ def get_stack(stack_list: List[StackSummary], name: str) -> Optional[StackSummar
     return None
 
 
-@pytest.mark.skipif(
-    "PULUMI_ACCESS_TOKEN" not in os.environ, reason="PULUMI_ACCESS_TOKEN not set"
-)
 class TestLocalWorkspace(unittest.TestCase):
     def test_project_settings(self):
         for ext in extensions:
@@ -538,6 +535,8 @@ class TestLocalWorkspace(unittest.TestCase):
         self.assertEqual(arr.value, '["one","two","three"]')
 
     def test_tag_methods(self):
+        if os.getenv("PULUMI_ACCESS_TOKEN") is None:
+            self.skipTest("Skipping test because tag methods are only supported in the cloud backend.")
         project_name = "python_test"
         runtime = "python"
         project_settings = ProjectSettings(name=project_name, runtime=runtime)

--- a/sdk/python/lib/test/automation/test_utils.py
+++ b/sdk/python/lib/test/automation/test_utils.py
@@ -19,6 +19,8 @@ from pulumi.automation import fully_qualified_stack_name
 
 
 def get_test_org():
+    if os.getenv("PULUMI_ACCESS_TOKEN") is None:
+        return "organization"
     test_org = "moolumi"
     env_var = os.getenv("PULUMI_TEST_ORG")
     if env_var is not None:


### PR DESCRIPTION
Similar to the nodejs automation API tests in
https://github.com/pulumi/pulumi/pull/17393, we also want to be able to run the python tests using the DIY backend, rather than just the cloud backend.  The only changes necessary here are making sure we use the right organization name (which is always "organization" for the DIY backend), and making sure the stacks are removed forcefully (for some reason they seem to think they have resources, even if the up fails with a compilation error).

When PULUMI_ACCESS_TOKEN is set, the tests will still run with the cloud backend.

Making progress towards https://github.com/pulumi/pulumi/pull/17192