### PR TITLE
Avoid calling invokes with dependencies on unknown resources

### DIFF
--- a/changelog/pending/20250103--sdk-python--avoid-calling-invokes-with-dependencies-on-unknown-resources.yaml
+++ b/changelog/pending/20250103--sdk-python--avoid-calling-invokes-with-dependencies-on-unknown-resources.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Avoid calling invokes with dependencies on unknown resources

--- a/sdk/python/lib/pulumi/runtime/_depends_on.py
+++ b/sdk/python/lib/pulumi/runtime/_depends_on.py
@@ -61,4 +61,5 @@ async def _resolve_depends_on_urns(
 
     all_deps = await _resolve_depends_on(depends_on)
 
-    return await _expand_dependencies(all_deps, from_resource)
+    expanded = await _expand_dependencies(all_deps, from_resource)
+    return set(expanded.keys())

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -257,9 +257,7 @@ def _invoke(
             # an unknown result.
             for res in expanded_deps.values():
                 if isinstance(res, CustomResource):
-                    if await res.id.is_known():
-                        await res.id.future()
-                    else:
+                    if not await res.id.is_known():
                         return (
                             InvokeResult(None, is_secret=False, is_known=False),
                             None,

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -237,7 +237,8 @@ async def prepare_resource(
     dependencies: Set[str] = set(explicit_urn_dependencies)
     property_dependencies: Dict[str, List[str]] = {}
     for key, deps in property_dependencies_resources.items():
-        urns = await _expand_dependencies(deps, from_resource=res)
+        expanded_deps = await _expand_dependencies(deps, from_resource=res)
+        urns = set(expanded_deps.keys())
         dependencies |= urns
         property_dependencies[key] = list(urns)
 

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -335,11 +335,11 @@ async def _expand_dependencies(
     _expand_dependencies expands the given iterable of Resources into a map of URN -> Resource
     """
 
-    urns: dict[str, "Resource"] = {}
+    expanded_deps: dict[str, "Resource"] = {}
     for d in deps:
-        await _add_dependency(urns, d, from_resource)
+        await _add_dependency(expanded_deps, d, from_resource)
 
-    return urns
+    return expanded_deps
 
 
 async def serialize_property(

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -251,7 +251,7 @@ async def serialize_properties(
 
 
 async def _add_dependency(
-    deps: Set[str], res: "Resource", from_resource: Optional["Resource"]
+    deps: dict[str, "Resource"], res: "Resource", from_resource: Optional["Resource"]
 ):
     """
     _add_dependency adds a dependency on the given resource to the set of deps.
@@ -325,17 +325,17 @@ async def _add_dependency(
         else:
             urn = await res.urn.future()
             if urn:
-                deps.add(urn)
+                deps[urn] = res
 
 
 async def _expand_dependencies(
     deps: Iterable["Resource"], from_resource: Optional["Resource"]
-) -> Set[str]:
+) -> dict[str, "Resource"]:
     """
-    _expand_dependencies expands the given iterable of Resources into a set of URNs.
+    _expand_dependencies expands the given iterable of Resources into a map of URN -> Resource
     """
 
-    urns: Set[str] = set()
+    urns: dict[str, "Resource"] = {}
     for d in deps:
         await _add_dependency(urns, d, from_resource)
 

--- a/sdk/python/lib/test/test_invoke.py
+++ b/sdk/python/lib/test/test_invoke.py
@@ -14,13 +14,26 @@
 
 import pytest
 
-from typing import Awaitable, Optional, Union
+from typing import Any, Optional, Union
 from concurrent.futures import ThreadPoolExecutor
 import asyncio
 import time
 
 import pulumi
 from pulumi import InvokeOptions, InvokeOutputOptions
+from pulumi.output import UNKNOWN
+from pulumi.resource import Resource
+
+
+def unknown() -> pulumi.Output[Any]:
+    is_known_fut: asyncio.Future[bool] = asyncio.Future()
+    is_secret_fut: asyncio.Future[bool] = asyncio.Future()
+    is_known_fut.set_result(False)
+    is_secret_fut.set_result(False)
+
+    value_fut: asyncio.Future[Any] = asyncio.Future()
+    value_fut.set_result(pulumi.UNKNOWN)
+    return pulumi.Output(set(), value_fut, is_known_fut, is_secret_fut)
 
 
 class MyMocks(pulumi.runtime.Mocks):
@@ -34,6 +47,11 @@ class MyMocks(pulumi.runtime.Mocks):
 class MockResource(pulumi.CustomResource):
     def __init__(self, name: str, opts: Optional[pulumi.ResourceOptions] = None):
         super().__init__("python:test:MockResource", name, {}, opts)
+
+
+class MockComponentResource(pulumi.ComponentResource):
+    def __init__(self, name: str, opts: Optional[pulumi.ResourceOptions] = None):
+        super().__init__("python:test:MockComponentResource", name, {}, opts)
 
 
 @pytest.mark.parametrize(
@@ -132,6 +150,49 @@ async def test_invoke_depends_on() -> None:
             assert invoke_result == {"result": "mock"}
 
         return o.apply(check)
+
+
+@pulumi.runtime.test
+async def test_invoke_depends_on_component() -> None:
+    pulumi.runtime.mocks.set_mocks(MyMocks())
+
+    dep = MockComponentResource(name="c")
+    MockResource(name="r", opts=pulumi.ResourceOptions(parent=dep))
+
+    opts = pulumi.InvokeOutputOptions(depends_on=[dep])
+    o = pulumi.runtime.invoke_output("test::MyFunction", {}, opts)
+    v = await o.future()
+    assert v == {"result": "mock"}
+    deps = await o.resources()
+    assert len(deps) == 1
+    assert deps == {dep}
+
+
+@pulumi.runtime.test
+async def test_invoke_depends_on_unknown() -> None:
+    pulumi.runtime.mocks.set_mocks(MyMocks())
+
+    dep = MockResource(name="dep")
+    dep.__dict__["id"] = unknown()
+
+    opts = pulumi.InvokeOutputOptions(depends_on=[dep])
+    o = pulumi.runtime.invoke_output("test::MyFunction", {}, opts)
+    k = await o.is_known()
+    assert k == False
+
+
+@pulumi.runtime.test
+async def test_invoke_depends_on_unknown_component_child() -> None:
+    pulumi.runtime.mocks.set_mocks(MyMocks())
+
+    comp = MockComponentResource(name="c")
+    dep = MockResource(name="dep", opts=pulumi.ResourceOptions(parent=comp))
+    dep.__dict__["id"] = unknown()
+
+    opts = pulumi.InvokeOutputOptions(depends_on=[comp])
+    o = pulumi.runtime.invoke_output("test::MyFunction", {}, opts)
+    k = await o.is_known()
+    assert k == False
 
 
 @pytest.mark.parametrize(

--- a/sdk/python/lib/test/test_invoke.py
+++ b/sdk/python/lib/test/test_invoke.py
@@ -30,7 +30,6 @@ def unknown() -> pulumi.Output[Any]:
     is_secret_fut: asyncio.Future[bool] = asyncio.Future()
     is_known_fut.set_result(False)
     is_secret_fut.set_result(False)
-
     value_fut: asyncio.Future[Any] = asyncio.Future()
     value_fut.set_result(pulumi.UNKNOWN)
     return pulumi.Output(set(), value_fut, is_known_fut, is_secret_fut)


### PR DESCRIPTION
Python implementation of https://github.com/pulumi/pulumi/pull/18133

DependsOn for resources is an ordering constraint for register resource calls. If a resource R1 depends on a resource R2, the register resource call for R2 will happen after R1. This is ensured by awaiting the URN for each resource dependency before calling register resource.

For invokes, this causes a problem when running under preview. During preview, register resource immediately returns with the URN, however this does not tell us if the resource "exists".

Instead of waiting for the dependency's URN, we wait for the ID. This tells us that whether a physical resource exists (if the state is in sync), and we can avoid calling the invoke when it is unknown.

The following example fails without this change:
```python
import pulumi
from pulumi_gcp import organizations, compute

config = pulumi.Config()
billing_account = config.require("billing-account")

project = organizations.Project(
    "project",
    name="project-1234-banana",
    billing_account=billing_account,
    auto_create_network=False,
    deletion_policy="DELETE",
)

zones = compute.get_zones_output(
    region="us-central1",
    project=project.project_id,
    status="UP",
    opts=pulumi.InvokeOutputOptions(depends_on=[project]),
)
pulumi.export("zones", zones)
```
