### PR TITLE
Move getAllTransitivelyReferencedResourceURNs to dependsOn

### DIFF
--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -35,7 +35,7 @@ import {
     ResourceOptions,
     URN,
 } from "../resource";
-import { gatherExplicitDependencies } from "./dependsOn";
+import { gatherExplicitDependencies, getAllTransitivelyReferencedResourceURNs } from "./dependsOn";
 import { debuggablePromise, debugPromiseLeaks } from "./debuggable";
 import { invoke } from "./invoke";
 import { getStore } from "./state";
@@ -977,99 +977,6 @@ export async function prepareResource(
 function addAll<T>(to: Set<T>, from: Set<T>) {
     for (const val of from) {
         to.add(val);
-    }
-}
-
-/**
- * @internal
- */
-export async function getAllTransitivelyReferencedResourceURNs(
-    resources: Set<Resource>,
-    exclude: Set<Resource>,
-): Promise<Set<string>> {
-    // Go through 'resources', but transitively walk through **Component** resources, collecting any
-    // of their child resources.  This way, a Component acts as an aggregation really of all the
-    // reachable resources it parents.  This walking will stop when it hits custom resources.
-    //
-    // This function also terminates at remote components, whose children are not known to the Node SDK directly.
-    // Remote components will always wait on all of their children, so ensuring we return the remote component
-    // itself here and waiting on it will accomplish waiting on all of it's children regardless of whether they
-    // are returned explicitly here.
-    //
-    // In other words, if we had:
-    //
-    //                  Comp1
-    //              /     |     \
-    //          Cust1   Comp2  Remote1
-    //                  /   \       \
-    //              Cust2   Cust3  Comp3
-    //              /                 \
-    //          Cust4                Cust5
-    //
-    // Then the transitively reachable resources of Comp1 will be [Cust1, Cust2, Cust3, Remote1].
-    // It will *not* include:
-    // * Cust4 because it is a child of a custom resource
-    // * Comp2 because it is a non-remote component resource
-    // * Comp3 and Cust5 because Comp3 is a child of a remote component resource
-
-    // To do this, first we just get the transitively reachable set of resources (not diving
-    // into custom resources).  In the above picture, if we start with 'Comp1', this will be
-    // [Comp1, Cust1, Comp2, Cust2, Cust3]
-    const transitivelyReachableResources = await getTransitivelyReferencedChildResourcesOfComponentResources(
-        resources,
-        exclude,
-    );
-
-    // Then we filter to only include Custom and Remote resources.
-    const transitivelyReachableCustomResources = [...transitivelyReachableResources].filter(
-        (r) => (CustomResource.isInstance(r) || (r as ComponentResource).__remote) && !exclude.has(r),
-    );
-    const promises = transitivelyReachableCustomResources.map((r) => r.urn.promise());
-    const urns = await Promise.all(promises);
-    return new Set<string>(urns);
-}
-
-/**
- * Recursively walk the resources passed in, returning them and all resources
- * reachable from {@link Resource.__childResources} through any **component**
- * resources we encounter.
- */
-async function getTransitivelyReferencedChildResourcesOfComponentResources(
-    resources: Set<Resource>,
-    exclude: Set<Resource>,
-) {
-    // Recursively walk the dependent resources through their children, adding them to the result set.
-    const result = new Set<Resource>();
-    await addTransitivelyReferencedChildResourcesOfComponentResources(resources, exclude, result);
-    return result;
-}
-
-async function addTransitivelyReferencedChildResourcesOfComponentResources(
-    resources: Set<Resource> | undefined,
-    exclude: Set<Resource>,
-    result: Set<Resource>,
-) {
-    if (resources) {
-        for (const resource of resources) {
-            if (!result.has(resource)) {
-                result.add(resource);
-
-                if (ComponentResource.isInstance(resource)) {
-                    // Skip including children of a resource in the excluded set to avoid depending on
-                    // children that haven't been registered yet.
-                    if (exclude.has(resource)) {
-                        continue;
-                    }
-
-                    // This await is safe even if __isConstructed is undefined. Ensure that the
-                    // resource has completely finished construction.  That way all parent/child
-                    // relationships will have been setup.
-                    await resource.__data;
-                    const children = resource.__childResources;
-                    addTransitivelyReferencedChildResourcesOfComponentResources(children, exclude, result);
-                }
-            }
-        }
     }
 }
 

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -18,7 +18,7 @@ import * as log from "../log";
 import { getAllResources, Input, Inputs, isUnknown, Output, unknown } from "../output";
 import { ComponentResource, CustomResource, DependencyResource, ProviderResource, Resource } from "../resource";
 import { debuggablePromise, debugPromiseLeaks, errorString } from "./debuggable";
-import { getAllTransitivelyReferencedResourceURNs } from "./resource";
+import { getAllTransitivelyReferencedResourceURNs } from "./dependsOn";
 import { excessiveDebugOutput, isDryRun } from "./settings";
 import { getStore, getResourcePackages, getResourceModules } from "./state";
 


### PR DESCRIPTION
This PR has no functional changes. We want to use this function in invokes, move it to the dependsOn package in preparation of that.