### PR TITLE
Avoid calling invokes with dependencies on unknown resources

### DIFF
--- a/changelog/pending/20250106--sdk-nodejs--avoid-calling-invokes-with-dependencies-on-unknown-resources.yaml
+++ b/changelog/pending/20250106--sdk-nodejs--avoid-calling-invokes-with-dependencies-on-unknown-resources.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Avoid calling invokes with dependencies on unknown resources

--- a/sdk/nodejs/runtime/dependsOn.ts
+++ b/sdk/nodejs/runtime/dependsOn.ts
@@ -85,10 +85,10 @@ export async function gatherExplicitDependencies(
  *
  * @internal
  */
-export async function getAllTransitivelyReferencedResourceURNs(
+export async function getAllTransitivelyReferencedResources(
     resources: Set<Resource>,
     exclude: Set<Resource>,
-): Promise<Set<string>> {
+): Promise<Array<Resource>> {
     const transitivelyReachableResources = await getTransitivelyReferencedChildResourcesOfComponentResources(
         resources,
         exclude,
@@ -98,6 +98,20 @@ export async function getAllTransitivelyReferencedResourceURNs(
     const transitivelyReachableCustomResources = [...transitivelyReachableResources].filter(
         (r) => (CustomResource.isInstance(r) || (r as ComponentResource).__remote) && !exclude.has(r),
     );
+    return transitivelyReachableCustomResources;
+}
+
+/**
+ * Gather all URNs of resources transitively reachable from the given resources,
+ * see `getAllTransitivelyReferencedResources`.
+ *
+ * @internal
+ */
+export async function getAllTransitivelyReferencedResourceURNs(
+    resources: Set<Resource>,
+    exclude: Set<Resource>,
+): Promise<Set<string>> {
+    const transitivelyReachableCustomResources = await getAllTransitivelyReferencedResources(resources, exclude);
     const promises = transitivelyReachableCustomResources.map((r) => r.urn.promise());
     const urns = await Promise.all(promises);
     return new Set<string>(urns);

--- a/sdk/nodejs/tests/runtime/langhost/cases/077.invoke_output_depends_on_unknown_component/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/077.invoke_output_depends_on_unknown_component/index.js
@@ -1,0 +1,22 @@
+// Test the dependsOn invoke option with components
+
+const assert = require("assert");
+const pulumi = require("../../../../../");
+
+class MyResource extends pulumi.CustomResource {
+    constructor(name, opts) {
+        super("test:index:MyResource", name, {}, opts);
+    }
+}
+
+class MyComponent extends pulumi.ComponentResource {
+    constructor(name) {
+        super("test:index:MyComponent", name);
+        const dep = new MyResource("dep", { parent: this });
+    }
+}
+
+const comp = new MyComponent("comp");
+const dependsOn = [comp];
+
+pulumi.runtime.invokeOutput("test:index:echo", {}, { dependsOn });

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -48,7 +48,14 @@ interface RunCase {
     };
     skipRootResourceEndpoints?: boolean;
     showRootResourceRegistration?: boolean;
-    invoke?: (ctx: any, tok: string, args: any, version: string, provider: string) => { failures: any; ret: any };
+    invoke?: (
+        ctx: any,
+        dryrun: boolean,
+        tok: string,
+        args: any,
+        version: string,
+        provider: string,
+    ) => { failures: any; ret: any };
     readResource?: (
         ctx: any,
         t: string,
@@ -357,7 +364,7 @@ describe("rpc", () => {
         invoke: {
             pwd: path.join(base, "009.invoke"),
             expectResourceCount: 0,
-            invoke: (ctx: any, tok: string, args: any, version: string, provider: string) => {
+            invoke: (ctx: any, dryrun: boolean, tok: string, args: any, version: string, provider: string) => {
                 assert.strictEqual(provider, "");
                 assert.strictEqual(tok, "invoke:index:echo");
                 assert.deepStrictEqual(args, {
@@ -1005,7 +1012,7 @@ describe("rpc", () => {
                     props: {},
                 };
             },
-            invoke: (ctx: any, tok: string, args: any, version: string) => {
+            invoke: (ctx: any, dryrun: boolean, tok: string, args: any, version: string) => {
                 switch (tok) {
                     case "invoke:index:doit":
                         assert.strictEqual(version, "0.19.1");
@@ -1287,7 +1294,7 @@ describe("rpc", () => {
             registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any) => {
                 return { urn: makeUrn(t, name), id: name === "p" ? "1" : undefined, props: undefined };
             },
-            invoke: (ctx: any, tok: string, args: any, version: string, provider: string) => {
+            invoke: (ctx: any, dryrun: boolean, tok: string, args: any, version: string, provider: string) => {
                 assert.strictEqual(provider, "pulumi:providers:test::p::1");
                 assert.strictEqual(tok, "test:index:echo");
                 assert.deepStrictEqual(args, {
@@ -1317,7 +1324,7 @@ describe("rpc", () => {
             ) => {
                 return { urn: makeUrn(t, name), id: name === "p" ? "1" : undefined, props: undefined };
             },
-            invoke: (ctx: any, tok: string, args: any, version: string, provider: string) => {
+            invoke: (ctx: any, dryrun: boolean, tok: string, args: any, version: string, provider: string) => {
                 assert.strictEqual(provider, "pulumi:providers:test::p::1");
                 assert.strictEqual(tok, "test:index:echo");
                 assert.deepStrictEqual(args, {
@@ -1336,7 +1343,7 @@ describe("rpc", () => {
             registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any) => {
                 return { urn: makeUrn(t, name), id: name === "p" ? "1" : undefined, props: undefined };
             },
-            invoke: (ctx: any, tok: string, args: any, version: string, provider: string) => {
+            invoke: (ctx: any, dryrun: boolean, tok: string, args: any, version: string, provider: string) => {
                 assert.strictEqual(provider, "pulumi:providers:test::p::1");
                 assert.strictEqual(tok, "test:index:echo");
                 assert.deepStrictEqual(args, {
@@ -1370,7 +1377,7 @@ describe("rpc", () => {
 
                 return { urn: makeUrn(t, name), id: name === "p" ? "1" : undefined, props: undefined };
             },
-            invoke: (ctx: any, tok: string, args: any, version: string, provider: string) => {
+            invoke: (ctx: any, dryrun: boolean, tok: string, args: any, version: string, provider: string) => {
                 assert.strictEqual(provider, "pulumi:providers:test::p::1");
                 assert.strictEqual(tok, "test:index:echo");
                 assert.deepStrictEqual(args, {
@@ -1597,10 +1604,25 @@ describe("rpc", () => {
         invoke_output_depends_on: {
             pwd: path.join(base, "075.invoke_output_depends_on"),
             expectResourceCount: 1,
-            invoke: (ctx: any, tok: string, args: any, version: string, provider: string) => {
+            invoke: (ctx: any, dryrun: boolean, tok: string, args: any, version: string, provider: string) => {
+                if (dryrun) {
+                    assert.fail("invoke should not be called");
+                }
                 assert.strictEqual(tok, "test:index:echo");
                 assert.deepStrictEqual(args, { dependency: { resolved: true } });
                 return { failures: undefined, ret: args };
+            },
+            registerResource: (
+                ctx: any,
+                dryrun: boolean,
+                t: string,
+                name: string,
+                res: any,
+                dependencies?: string[],
+                ...args: any
+            ) => {
+                const id = dryrun ? undefined : name + "_id";
+                return { urn: makeUrn(t, name), id, props: undefined };
             },
         },
         invoke_output_depends_on_non_resource: {
@@ -1619,6 +1641,28 @@ describe("rpc", () => {
                         throw new Error("Unexpected error: " + message);
                     }
                 }
+            },
+        },
+        invoke_output_depends_on_unknown_component: {
+            pwd: path.join(base, "077.invoke_output_depends_on_unknown_component"),
+            expectResourceCount: 2,
+            registerResource: (
+                ctx: any,
+                dryrun: boolean,
+                t: string,
+                name: string,
+                res: any,
+                dependencies?: string[],
+                ...args: any
+            ) => {
+                const id = dryrun ? undefined : name + "_id";
+                return { urn: makeUrn(t, name), id, props: undefined };
+            },
+            invoke: (ctx: any, dryrun: boolean, tok: string, args: any, version: string, provider: string) => {
+                if (dryrun) {
+                    assert.fail("invoke should not be called");
+                }
+                return { failures: undefined, ret: args };
             },
         },
     };
@@ -1651,7 +1695,14 @@ describe("rpc", () => {
                             const req: any = call.request;
                             const args: any = req.getArgs().toJavaScript();
                             const version: string = req.getVersion();
-                            const { failures, ret } = opts.invoke(ctx, req.getTok(), args, version, req.getProvider());
+                            const { failures, ret } = opts.invoke(
+                                ctx,
+                                dryrun,
+                                req.getTok(),
+                                args,
+                                version,
+                                req.getProvider(),
+                            );
                             resp.setFailuresList(failures);
                             resp.setReturn(gstruct.Struct.fromJavaScript(ret));
                         }


### PR DESCRIPTION
Nodejs implementation of #18133

DependsOn for resources is an ordering constraint for register resource calls. If a resource R1 depends on a resource R2, the register resource call for R2 will happen after R1. This is ensured by awaiting the URN for each resource dependency before calling register resource.

For invokes, this causes a problem when running under preview. During preview, register resource immediately returns with the URN, however this does not tell us if the resource "exists".

Instead of waiting for the dependency's URN, we wait for the ID. This tells us that whether a physical resource exists (if the state is in sync), and we can avoid calling the invoke when it is unknown.

The following example fails without this change:
```typescript
import * as pulumi from "@pulumi/pulumi";
import * as gcp from "@pulumi/gcp";

const config = new pulumi.Config()
const billingAccountId = config.require("billing-account")

const billingAccount = gcp.organizations.getBillingAccountOutput({
    billingAccount: billingAccountId
})

const project = new gcp.organizations.Project("project", {
    billingAccount: billingAccount.id,
    name: "project-nodejs",
    autoCreateNetwork: false,
    deletionPolicy: "DELETE",
})

export const zones = gcp.compute.getZonesOutput({
    project: project.projectId,
    region: "us-central1"
}, {
    dependsOn: [project],
})
```