### PR TITLE
Re-add `l2-map-keys` and `l2-provider-grpc-config`

### DIFF
--- a/cmd/pulumi-test-language/tests/l2_map_keys.go
+++ b/cmd/pulumi-test-language/tests/l2_map_keys.go
@@ -1,0 +1,193 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	LanguageTests["l2-map-keys"] = LanguageTest{
+		Providers: []plugin.Provider{
+			&providers.PrimitiveProvider{}, &providers.PrimitiveRefProvider{},
+			&providers.RefRefProvider{}, &providers.PlainProvider{},
+		},
+		Runs: []TestRun{
+			{
+				Assert: func(l *L,
+					projectDirectory string, err error,
+					snap *deploy.Snapshot, changes display.ResourceChanges,
+				) {
+					RequireStackResource(l, err, changes)
+
+					require.Len(l, snap.Resources, 9, "expected 9 resources in snapshot")
+
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:primitive")
+					primResource := RequireSingleResource(l, snap.Resources, "primitive:index:Resource")
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:primitive-ref")
+					refResource := RequireSingleResource(l, snap.Resources, "primitive-ref:index:Resource")
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:ref-ref")
+					rrefResource := RequireSingleResource(l, snap.Resources, "ref-ref:index:Resource")
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:plain")
+					plainResource := RequireSingleResource(l, snap.Resources, "plain:index:Resource")
+
+					want := resource.NewPropertyMapFromMap(map[string]any{
+						"boolean":     false,
+						"float":       2.17,
+						"integer":     -12,
+						"string":      "Goodbye",
+						"numberArray": []interface{}{0, 1},
+						"booleanMap": map[string]interface{}{
+							"my key": false,
+							"my.key": true,
+							"my-key": false,
+							"my_key": true,
+							"MY_KEY": false,
+							"myKey":  true,
+						},
+					})
+					assert.Equal(l, want, primResource.Inputs, "expected inputs to be %v", want)
+					assert.Equal(l, primResource.Inputs, primResource.Outputs, "expected inputs and outputs to match")
+
+					want = resource.NewPropertyMapFromMap(map[string]any{
+						"data": resource.NewPropertyMapFromMap(map[string]any{
+							"boolean":   false,
+							"float":     2.17,
+							"integer":   -12,
+							"string":    "Goodbye",
+							"boolArray": []interface{}{false, true},
+							"stringMap": map[string]interface{}{
+								"my key": "one",
+								"my.key": "two",
+								"my-key": "three",
+								"my_key": "four",
+								"MY_KEY": "five",
+								"myKey":  "six",
+							},
+						}),
+					})
+					assert.Equal(l, want, refResource.Inputs, "expected inputs to be %v", want)
+					assert.Equal(l, refResource.Inputs, refResource.Outputs, "expected inputs and outputs to match")
+
+					want = resource.NewPropertyMapFromMap(map[string]any{
+						"data": resource.NewPropertyMapFromMap(map[string]any{
+							"innerData": resource.NewPropertyMapFromMap(map[string]any{
+								"boolean":   false,
+								"float":     -2.17,
+								"integer":   123,
+								"string":    "Goodbye",
+								"boolArray": []interface{}{},
+								"stringMap": map[string]interface{}{
+									"my key": "one",
+									"my.key": "two",
+									"my-key": "three",
+									"my_key": "four",
+									"MY_KEY": "five",
+									"myKey":  "six",
+								},
+							}),
+							"boolean":   true,
+							"float":     4.5,
+							"integer":   1024,
+							"string":    "Hello",
+							"boolArray": []interface{}{},
+							"stringMap": map[string]interface{}{
+								"my key": "one",
+								"my.key": "two",
+								"my-key": "three",
+								"my_key": "four",
+								"MY_KEY": "five",
+								"myKey":  "six",
+							},
+						}),
+					})
+					assert.Equal(l, want, rrefResource.Inputs, "expected inputs to be %v", want)
+					assert.Equal(l, rrefResource.Inputs, rrefResource.Outputs, "expected inputs and outputs to match")
+
+					want = resource.NewPropertyMapFromMap(map[string]any{
+						"data": resource.NewPropertyMapFromMap(map[string]any{
+							"innerData": resource.NewPropertyMapFromMap(map[string]any{
+								"boolean":   false,
+								"float":     2.17,
+								"integer":   -12,
+								"string":    "Goodbye",
+								"boolArray": []interface{}{false, true},
+								"stringMap": map[string]interface{}{
+									"my key": "one",
+									"my.key": "two",
+									"my-key": "three",
+									"my_key": "four",
+									"MY_KEY": "five",
+									"myKey":  "six",
+								},
+							}),
+							"boolean":   true,
+							"float":     4.5,
+							"integer":   1024,
+							"string":    "Hello",
+							"boolArray": []interface{}{true, false},
+							"stringMap": map[string]interface{}{
+								"my key": "one",
+								"my.key": "two",
+								"my-key": "three",
+								"my_key": "four",
+								"MY_KEY": "five",
+								"myKey":  "six",
+							},
+						}),
+						"nonPlainData": resource.NewPropertyMapFromMap(map[string]any{
+							"innerData": resource.NewPropertyMapFromMap(map[string]any{
+								"boolean":   false,
+								"float":     2.17,
+								"integer":   -12,
+								"string":    "Goodbye",
+								"boolArray": []interface{}{false, true},
+								"stringMap": map[string]interface{}{
+									"my key": "one",
+									"my.key": "two",
+									"my-key": "three",
+									"my_key": "four",
+									"MY_KEY": "five",
+									"myKey":  "six",
+								},
+							}),
+							"boolean":   true,
+							"float":     4.5,
+							"integer":   1024,
+							"string":    "Hello",
+							"boolArray": []interface{}{true, false},
+							"stringMap": map[string]interface{}{
+								"my key": "one",
+								"my.key": "two",
+								"my-key": "three",
+								"my_key": "four",
+								"MY_KEY": "five",
+								"myKey":  "six",
+							},
+						}),
+					})
+					assert.Equal(l, want, plainResource.Inputs, "expected inputs to be %v", want)
+					assert.Equal(l, plainResource.Inputs, plainResource.Outputs, "expected inputs and outputs to match")
+				},
+			},
+		},
+	}
+}

--- a/cmd/pulumi-test-language/tests/l2_provider_grpc_config.go
+++ b/cmd/pulumi-test-language/tests/l2_provider_grpc_config.go
@@ -1,0 +1,138 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	LanguageTests["l2-provider-grpc-config"] = LanguageTest{
+		Providers: []plugin.Provider{&providers.ConfigGrpcProvider{}},
+		Runs: []TestRun{
+			{
+				Assert: func(l *L,
+					projectDirectory string, err error,
+					snap *deploy.Snapshot, changes display.ResourceChanges,
+				) {
+					g := &grpcTestContext{l: l, s: snap}
+
+					r := g.CheckConfigReq("config")
+					assert.Equal(l, "", r.News.Fields["string1"].AsInterface(), "string1")
+					assert.Equal(l, "x", r.News.Fields["string2"].AsInterface(), "string2")
+					assert.Equal(l, "{}", r.News.Fields["string3"].AsInterface(), "string3")
+					AssertEqualOrJSONEncoded(l, float64(0), r.News.Fields["int1"].AsInterface(), "int1")
+					AssertEqualOrJSONEncoded(l, float64(42), r.News.Fields["int2"].AsInterface(), "int2")
+					AssertEqualOrJSONEncoded(l, float64(0), r.News.Fields["num1"].AsInterface(), "num1")
+					AssertEqualOrJSONEncoded(l, float64(42.42), r.News.Fields["num2"].AsInterface(), "num2")
+					AssertEqualOrJSONEncoded(l, true, r.News.Fields["bool1"].AsInterface(), "bool1")
+					AssertEqualOrJSONEncoded(l, false, r.News.Fields["bool2"].AsInterface(), "bool2")
+					AssertEqualOrJSONEncoded(l, []any{}, r.News.Fields["listString1"].AsInterface(), "listString1")
+					AssertEqualOrJSONEncoded(l, []any{"", "foo"}, r.News.Fields["listString2"].AsInterface(), "listString2")
+					AssertEqualOrJSONEncoded(l,
+						[]any{float64(1), float64(2)},
+						r.News.Fields["listInt1"].AsInterface(), "listInt1")
+
+					AssertEqualOrJSONEncoded(l, map[string]any{}, r.News.Fields["mapString1"].AsInterface(), "mapString1")
+
+					AssertEqualOrJSONEncoded(l,
+						map[string]any{"key1": "value1", "key2": "value2"},
+						r.News.Fields["mapString2"].AsInterface(), "mapString2")
+
+					AssertEqualOrJSONEncoded(l,
+						map[string]any{"key1": float64(0), "key2": float64(42)},
+						r.News.Fields["mapInt1"].AsInterface(), "mapInt1")
+
+					AssertEqualOrJSONEncoded(l, map[string]any{}, r.News.Fields["objString1"].AsInterface(), "objString1")
+
+					AssertEqualOrJSONEncoded(l, map[string]any{"x": "x-value"},
+						r.News.Fields["objString2"].AsInterface(), "objString2")
+
+					AssertEqualOrJSONEncoded(l,
+						map[string]any{"x": float64(42)},
+						r.News.Fields["objInt1"].AsInterface(), "objInt1")
+
+					// Check what schemaprov received in ConfigureRequest.
+					c := g.ConfigureReq("config")
+					assert.Equal(l, "", c.Args.Fields["string1"].AsInterface(), "string1")
+					assert.Equal(l, "x", c.Args.Fields["string2"].AsInterface(), "string2")
+					assert.Equal(l, "{}", c.Args.Fields["string3"].AsInterface(), "string3")
+					AssertEqualOrJSONEncoded(l, float64(0), c.Args.Fields["int1"].AsInterface(), "int1")
+					AssertEqualOrJSONEncoded(l, float64(42), c.Args.Fields["int2"].AsInterface(), "int2")
+					AssertEqualOrJSONEncoded(l, float64(0), c.Args.Fields["num1"].AsInterface(), "num1")
+					AssertEqualOrJSONEncoded(l, float64(42.42), c.Args.Fields["num2"].AsInterface(), "num2")
+					AssertEqualOrJSONEncoded(l, true, c.Args.Fields["bool1"].AsInterface(), "bool1")
+					AssertEqualOrJSONEncoded(l, false, c.Args.Fields["bool2"].AsInterface(), "bool2")
+					AssertEqualOrJSONEncoded(l, []any{}, c.Args.Fields["listString1"].AsInterface(), "listString1")
+					AssertEqualOrJSONEncoded(l, []any{"", "foo"}, c.Args.Fields["listString2"].AsInterface(), "listString2")
+					AssertEqualOrJSONEncoded(l,
+						[]any{float64(1), float64(2)},
+						c.Args.Fields["listInt1"].AsInterface(), "listInt1")
+
+					AssertEqualOrJSONEncoded(l, map[string]any{}, c.Args.Fields["mapString1"].AsInterface(), "mapString1")
+
+					AssertEqualOrJSONEncoded(l,
+						map[string]any{"key1": "value1", "key2": "value2"},
+						c.Args.Fields["mapString2"].AsInterface(), "mapString2")
+
+					AssertEqualOrJSONEncoded(l,
+						map[string]any{"key1": float64(0), "key2": float64(42)},
+						c.Args.Fields["mapInt1"].AsInterface(), "mapInt1")
+
+					AssertEqualOrJSONEncoded(l, map[string]any{}, c.Args.Fields["objString1"].AsInterface(), "objString1")
+
+					AssertEqualOrJSONEncoded(l, map[string]any{"x": "x-value"},
+						c.Args.Fields["objString2"].AsInterface(), "objString2")
+
+					AssertEqualOrJSONEncoded(l,
+						map[string]any{"x": float64(42)},
+						c.Args.Fields["objInt1"].AsInterface(), "objInt1")
+
+					v := c.GetVariables()
+					assert.Equal(l, "", v["config-grpc:config:string1"], "string1")
+					assert.Equal(l, "x", v["config-grpc:config:string2"], "string2")
+					assert.Equal(l, "{}", v["config-grpc:config:string3"], "string3")
+					assert.Equal(l, "0", v["config-grpc:config:int1"], "int1")
+					assert.Equal(l, "42", v["config-grpc:config:int2"], "int2")
+					assert.Equal(l, "0", v["config-grpc:config:num1"], "num1")
+					assert.Equal(l, "42.42", v["config-grpc:config:num2"], "num2")
+					assert.Equal(l, "true", v["config-grpc:config:bool1"], "bool1")
+					assert.Equal(l, "false", v["config-grpc:config:bool2"], "bool2")
+					assert.JSONEq(l, "[]", v["config-grpc:config:listString1"], "listString1")
+					assert.JSONEq(l, "[\"\",\"foo\"]", v["config-grpc:config:listString2"], "listString2")
+					assert.JSONEq(l, "[1,2]", v["config-grpc:config:listInt1"], "listInt1")
+					assert.JSONEq(l, "{}", v["config-grpc:config:mapString1"], "mapString1")
+					assert.JSONEq(l, "{\"key1\":\"value1\",\"key2\":\"value2\"}", v["config-grpc:config:mapString2"], "mapString2")
+					assert.JSONEq(l, "{\"key1\":0,\"key2\":42}", v["config-grpc:config:mapInt1"], "mapInt1")
+					assert.JSONEq(l, "{}", v["config-grpc:config:objString1"], "objString1")
+					assert.JSONEq(l, "{\"x\":\"x-value\"}", v["config-grpc:config:objString2"], "objString2")
+					assert.JSONEq(l, "{\"x\":42}", v["config-grpc:config:objInt1"], "objInt1")
+
+					AssertNoSecretLeaks(l, snap, AssertNoSecretLeaksOpts{
+						// ConfigFetcher is a test helper that retains secret material in its
+						// state by design, and should not be part of the check.
+						IgnoreResourceTypes: []tokens.Type{"config-grpc:index:ConfigFetcher"},
+						Secrets:             []string{"SECRET", "SECRET2"},
+					})
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
These got lost during the reorganisation of conformance tests, possibly due to a bad merge conflict, so this puts them back.