### PR TITLE
Unflake TestRunCanceled

### DIFF
--- a/sdk/go/auto/testdata/slow/main.go
+++ b/sdk/go/auto/testdata/slow/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -8,6 +9,7 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
+		os.WriteFile("ready", []byte("✅"), 0644)
 		time.Sleep(10 * time.Second)
 		return nil
 	})


### PR DESCRIPTION
If this test takes more than 2 seconds to start the pulumi operation it fails. Instead of relying on timing, have the test program write a sentinel file that we look for. This lets us reliably wait for the correct test conditions, even on overlaoded GHA runners.
