### PR TITLE
plugin rm: show unrecognized kind correctly and usage string

### DIFF
--- a/changelog/pending/20250107--cli-plugin--show-plugin-kind-in-plugin-rm-correctly-also-show-the-usage-string-if-the-plugin-type-is-incorrect.yaml
+++ b/changelog/pending/20250107--cli-plugin--show-plugin-kind-in-plugin-rm-correctly-also-show-the-usage-string-if-the-plugin-type-is-incorrect.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/plugin
+  description: Show plugin kind in plugin rm correctly.  Also show the usage string if the plugin type is incorrect

--- a/pkg/cmd/pulumi/plugin/plugin_rm.go
+++ b/pkg/cmd/pulumi/plugin/plugin_rm.go
@@ -64,7 +64,7 @@ func newPluginRmCmd() *cobra.Command {
 			var version *semver.Range
 			if len(args) > 0 {
 				if !apitype.IsPluginKind(args[0]) {
-					return fmt.Errorf("unrecognized plugin kind: %s", kind)
+					return fmt.Errorf("unrecognized plugin kind: %s\n\n%v", args[0], cmd.UsageString())
 				}
 				kind = apitype.PluginKind(args[0])
 			} else if !all {


### PR DESCRIPTION
Currently when the user uses an unrezognized plugin type in `pulumi plugin rm` we currently just show

```
error: unrecognized plugin kind:
```

This is unintuitive, and unintended, as we only check the plugintype after printing the error message.

To further help the user also print the ussage string.

Fixes https://github.com/pulumi/pulumi/issues/18144