### PR TITLE
go automation api support for colorize output

### DIFF
--- a/changelog/pending/20250108--auto-go--add-color-option-to-optdestroy-optpreview-optrefresh-and-optup-packages-to-allow-explicit-configuration-of-output-color.yaml
+++ b/changelog/pending/20250108--auto-go--add-color-option-to-optdestroy-optpreview-optrefresh-and-optup-packages-to-allow-explicit-configuration-of-output-color.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Add `Color` option to `optdestroy`, `optpreview`, `optrefresh`, and `optup` packages to allow explicit configuration of output color.

--- a/sdk/go/auto/optdestroy/optdestroy.go
+++ b/sdk/go/auto/optdestroy/optdestroy.go
@@ -87,6 +87,13 @@ func UserAgent(agent string) Option {
 	})
 }
 
+// Color allows specifying whether to colorize output. Choices are: always, never, raw, auto (default "auto")
+func Color(color string) Option {
+	return optionFunc(func(opts *Options) {
+		opts.Color = color
+	})
+}
+
 // ShowSecrets configures whether to show config secrets when they appear.
 func ShowSecrets(show bool) Option {
 	return optionFunc(func(opts *Options) {

--- a/sdk/go/auto/optpreview/optpreview.go
+++ b/sdk/go/auto/optpreview/optpreview.go
@@ -108,6 +108,13 @@ func UserAgent(agent string) Option {
 	})
 }
 
+// Color allows specifying whether to colorize output. Choices are: always, never, raw, auto (default "auto")
+func Color(color string) Option {
+	return optionFunc(func(opts *Options) {
+		opts.Color = color
+	})
+}
+
 // Plan specifies the path where the update plan should be saved.
 func Plan(path string) Option {
 	return optionFunc(func(opts *Options) {

--- a/sdk/go/auto/optrefresh/optrefresh.go
+++ b/sdk/go/auto/optrefresh/optrefresh.go
@@ -94,6 +94,13 @@ func UserAgent(agent string) Option {
 	})
 }
 
+// Color allows specifying whether to colorize output. Choices are: always, never, raw, auto (default "auto")
+func Color(color string) Option {
+	return optionFunc(func(opts *Options) {
+		opts.Color = color
+	})
+}
+
 // ShowSecrets configures whether to show config secrets when they appear in the config.
 func ShowSecrets(show bool) Option {
 	return optionFunc(func(opts *Options) {

--- a/sdk/go/auto/optup/optup.go
+++ b/sdk/go/auto/optup/optup.go
@@ -108,6 +108,13 @@ func UserAgent(agent string) Option {
 	})
 }
 
+// Color allows specifying whether to colorize output. Choices are: always, never, raw, auto (default "auto")
+func Color(color string) Option {
+	return optionFunc(func(opts *Options) {
+		opts.Color = color
+	})
+}
+
 // Plan specifies the path to an update plan to use for the update.
 func Plan(path string) Option {
 	return optionFunc(func(opts *Options) {


### PR DESCRIPTION
Currently, the Options struct has a field for color, but there is not functions exposed to set this field in go. This change adds the ability to set the color setting for output. optdestroy, optpreview, optrefresh, and optup all have a new function to set the color setting.

To use the new color setting, you can set the color field in the Options struct like the following:

```go
	_, err = s.Up(ctx, stdoutStreamer, optup.Color("always"))
	if err != nil {
		fmt.Printf("Failed to update stack: %v\n\n", err)
		os.Exit(1)
	}
```

Fixes https://github.com/pulumi/pulumi/issues/18183