### PR TITLE
Fix callbackserver shutdown

### DIFF
--- a/changelog/pending/20250108--sdk-python--fix-callbackserver-shutdown.yaml
+++ b/changelog/pending/20250108--sdk-python--fix-callbackserver-shutdown.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix callbackserver shutdown

--- a/sdk/python/lib/pulumi/runtime/_callbacks.py
+++ b/sdk/python/lib/pulumi/runtime/_callbacks.py
@@ -82,7 +82,7 @@ class _CallbackServicer(callback_pb2_grpc.CallbacksServicer):
     @classmethod
     async def shutdown(cls):
         for servicer in cls._servicers:
-            await servicer._server.stop(grace=0)
+            await servicer._server.wait_for_termination(timeout=0)
 
     # aio handles this being async but the pyi typings don't expect it.
     async def Invoke(

--- a/tests/integration/python/excepthook/.gitignore
+++ b/tests/integration/python/excepthook/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+/.pulumi/
+/dist/
+/*.egg-info
+venv/

--- a/tests/integration/python/excepthook/Pulumi.yaml
+++ b/tests/integration/python/excepthook/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: pulumi-excepthook-bad-log
+description: A test case for https://github.com/pulumi/pulumi/issues/18176
+runtime:
+  name: python
+  options:
+    toolchain: pip
+    virtualenv: venv

--- a/tests/integration/python/excepthook/__main__.py
+++ b/tests/integration/python/excepthook/__main__.py
@@ -1,0 +1,21 @@
+# Copyright 2024, Pulumi Corporation.  All rights reserved.
+
+import pulumi
+import pulumi_random as random
+
+
+def transform(args):
+    return pulumi.ResourceTransformResult(
+        props=args.props,
+        opts=args.opts,
+    )
+
+
+random.RandomInteger(
+    "test",
+    max=999,
+    min=100,
+    opts=pulumi.ResourceOptions(
+        transforms=[transform],
+    ),
+)

--- a/tests/integration/python/excepthook/requirements.txt
+++ b/tests/integration/python/excepthook/requirements.txt
@@ -1,0 +1,1 @@
+pulumi_random


### PR DESCRIPTION
When using transforms, we spin up a GRPC server within the Python runtime to run the transforms. During shutdown of the Python runtime, this server would print errors when running in Python 3.12 or higher.

By using the [wait_for_termination](https://grpc.github.io/grpc/python/grpc_asyncio.html#grpc.aio.Server.wait_for_termination) instead of [stop](https://grpc.github.io/grpc/python/grpc_asyncio.html#grpc.aio.Server.stop) we avoid these errors.

Fixes https://github.com/pulumi/pulumi/issues/18176