### PR TITLE
Clean up and test PCL object type annotations

### DIFF
--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -610,7 +610,7 @@ type ObjectTypeFromConfigMetadata = struct {
 }
 
 func annotateObjectTypedConfig(componentName string, typeName string, objectType *model.ObjectType) *model.ObjectType {
-	objectType.Annotations = append(objectType.Annotations, &ObjectTypeFromConfigMetadata{
+	objectType.Annotate(&ObjectTypeFromConfigMetadata{
 		TypeName:      typeName,
 		ComponentName: componentName,
 	})

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -824,14 +824,12 @@ func (g *generator) GenLiteralValueExpression(w io.Writer, expr *model.LiteralVa
 func (g *generator) GenObjectConsExpression(w io.Writer, expr *model.ObjectConsExpression) {
 	switch argType := expr.Type().(type) {
 	case *model.ObjectType:
-		if len(argType.Annotations) > 0 {
-			if configMetadata, ok := argType.Annotations[0].(*ObjectTypeFromConfigMetadata); ok {
-				fullTypeName := fmt.Sprintf("Components.%sArgs.%s",
-					configMetadata.ComponentName,
-					configMetadata.TypeName)
-				g.genObjectConsExpressionWithTypeName(w, expr, fullTypeName, false, nil)
-				return
-			}
+		if configMetadata, ok := model.GetObjectTypeAnnotation[*ObjectTypeFromConfigMetadata](argType); ok {
+			fullTypeName := fmt.Sprintf("Components.%sArgs.%s",
+				configMetadata.ComponentName,
+				configMetadata.TypeName)
+			g.genObjectConsExpressionWithTypeName(w, expr, fullTypeName, false, nil)
+			return
 		}
 	}
 	g.genObjectConsExpression(w, expr, expr.Type())

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -140,7 +140,7 @@ type ObjectTypeFromConfigMetadata = struct {
 }
 
 func annotateObjectTypedConfig(componentName string, typeName string, objectType *model.ObjectType) *model.ObjectType {
-	objectType.Annotations = append(objectType.Annotations, &ObjectTypeFromConfigMetadata{
+	objectType.Annotate(&ObjectTypeFromConfigMetadata{
 		TypeName:      typeName,
 		ComponentName: componentName,
 	})

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -530,11 +530,9 @@ func (g *generator) genLiteralValueExpression(w io.Writer, expr *model.LiteralVa
 func (g *generator) GenObjectConsExpression(w io.Writer, expr *model.ObjectConsExpression) {
 	switch argType := expr.Type().(type) {
 	case *model.ObjectType:
-		if len(argType.Annotations) > 0 {
-			if configMetadata, ok := argType.Annotations[0].(*ObjectTypeFromConfigMetadata); ok {
-				g.genObjectConsExpressionWithTypeName(w, expr, expr.Type(), configMetadata.TypeName)
-				return
-			}
+		if configMetadata, ok := model.GetObjectTypeAnnotation[*ObjectTypeFromConfigMetadata](argType); ok {
+			g.genObjectConsExpressionWithTypeName(w, expr, expr.Type(), configMetadata.TypeName)
+			return
 		}
 	}
 

--- a/pkg/codegen/hcl2/model/type_object.go
+++ b/pkg/codegen/hcl2/model/type_object.go
@@ -47,6 +47,25 @@ func NewObjectType(properties map[string]Type, annotations ...interface{}) *Obje
 	return &ObjectType{Properties: properties, Annotations: annotations}
 }
 
+// Annotate adds annotations to the object type. Annotations may be retrieved by GetObjectTypeAnnotation.
+func (t *ObjectType) Annotate(annotations ...interface{}) {
+	t.Annotations = append(t.Annotations, annotations...)
+}
+
+// GetObjectTypeAnnotation retrieves an annotation of the given type from the object type, if one exists.
+func GetObjectTypeAnnotation[T any](t *ObjectType) (T, bool) {
+	var result T
+	found := false
+	for _, a := range t.Annotations {
+		if v, ok := a.(T); ok {
+			result = v
+			found = true
+			break
+		}
+	}
+	return result, found
+}
+
 // SyntaxNode returns the syntax node for the type. This is always syntax.None.
 func (*ObjectType) SyntaxNode() hclsyntax.Node {
 	return syntax.None

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -489,15 +489,7 @@ func GetSchemaForType(t model.Type) (schema.Type, bool) {
 		schemaArrayTypes[element] = &schema.ArrayType{ElementType: element}
 		return schemaArrayTypes[element], true
 	case *model.ObjectType:
-		if len(t.Annotations) == 0 {
-			return nil, false
-		}
-		for _, a := range t.Annotations {
-			if t, ok := a.(schema.Type); ok {
-				return t, true
-			}
-		}
-		return nil, false
+		return model.GetObjectTypeAnnotation[schema.Type](t)
 	case *model.OutputType:
 		return GetSchemaForType(t.ElementType)
 	case *model.PromiseType:

--- a/pkg/codegen/pcl/invoke.go
+++ b/pkg/codegen/pcl/invoke.go
@@ -64,7 +64,7 @@ func annotateObjectProperties(modelType model.Type, schemaType schema.Type) {
 			}
 
 			// top-level annotation for the type itself
-			arg.Annotations = append(arg.Annotations, schemaType)
+			arg.Annotate(schemaType)
 			// now for each property, annotate it with the associated type from the schema
 			for propertyName, propertyType := range arg.Properties {
 				if associatedType, ok := schemaProperties[propertyName]; ok {

--- a/pkg/codegen/pcl/utilities.go
+++ b/pkg/codegen/pcl/utilities.go
@@ -194,11 +194,7 @@ func SortedFunctionParameters(expr *model.FunctionCallExpression) []*schema.Prop
 
 	switch args := expr.Signature.Parameters[1].Type.(type) {
 	case *model.ObjectType:
-		if len(args.Annotations) == 0 {
-			return []*schema.Property{}
-		}
-
-		originalSchemaType, ok := args.Annotations[0].(*schema.ObjectType)
+		originalSchemaType, ok := model.GetObjectTypeAnnotation[*schema.ObjectType](args)
 		if !ok {
 			return []*schema.Property{}
 		}


### PR DESCRIPTION
In our model of PCL based on HCL syntax, we define a number of types according to Pulumi's type system. Among these is `ObjectType`, the type of objects of the form `{ k_1: t_1, ..., k_n: t_n }`, where each key `k_i` maps to a nested type `t_i`. Object types crop up all over the place -- as sets of resource input properties, resource outputs themselves, and as arguments to function calls, for instance.

Because object types are so prevalent, it is often useful to be able to link them to metadata about their intended use. For instance, in code generation, we might like to know if an object type corresponds to a "bare" object literal or an instance of some named class. To this end, object types support _annotations_, and such annotations are used in e.g. .Net and Python codegen as hinted above.

In preparation for making wider use of annotations (e.g. for adding `call` to PCL, which requires us to know about expressions' linked resource types), this change cleans up the interface for working with annotations and adds a number of test cases. Additionally, code that is likely currently brittle due to only checking the first of a set of annotations (see the various uses of `[0]` in the diff) has been made more robust, possibly fixing some rare bugs/edge cases.

Working towards closing pulumi/pulumi-java#262