### PR TITLE
Take into account parameterizaiton when loading schema versions

### DIFF
--- a/changelog/pending/20250109--cli--fix-bug-in-paramaterized-provider-version-schemas.yaml
+++ b/changelog/pending/20250109--cli--fix-bug-in-paramaterized-provider-version-schemas.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix bug in paramaterized provider version schemas

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -564,17 +564,21 @@ func generateAndLinkSdksForPackages(
 
 		fmt.Printf("Generated local SDK for package '%s:%s'\n", pkg.Name, pkg.Parameterization.Name)
 
-		// If we don't change the working directory, the workspace instance (when
-		// reading project etc) will not be correct when doing the local sdk
-		// linking, causing errors.
-		//
-		// We must also remember to call returnToStartingDir() to change back to
-		// the original directory after every iteration of the loop and before
-		// returning.
-		returnToStartingDir, err := fsutil.Chdir(convertOutputDirectory)
-		if err != nil {
-			return fmt.Errorf("could not change to output directory: %w", err)
-		}
+		err = func() error {
+			// If we don't change the working directory, the workspace instance (when
+			// reading project etc) will not be correct when doing the local sdk
+			// linking, causing errors.
+			//
+			// We must also remember to call returnToStartingDir() to change back to
+			// the original directory after every iteration of the loop and before
+			// returning.
+			//
+			// func for scope defer
+			returnToStartingDir, err := fsutil.Chdir(convertOutputDirectory)
+			if err != nil {
+				return fmt.Errorf("could not change to output directory: %w", err)
+			}
+			defer returnToStartingDir()
 
 		_, _, err = ws.ReadProject()
 		if err != nil {

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -596,5 +596,3 @@ func generateAndLinkSdksForPackages(
 
 			return err
 
-	return nil
-}

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -580,10 +580,6 @@ func generateAndLinkSdksForPackages(
 			}
 			defer returnToStartingDir()
 
-		_, _, err = ws.ReadProject()
-		if err != nil {
-			returnToStartingDir()
-			return fmt.Errorf("generated root is not a valid pulumi workspace %q: %w", convertOutputDirectory, err)
 			_, _, err = ws.ReadProject()
 			if err != nil {
 				return fmt.Errorf("generated root is not a valid pulumi workspace %q: %w", convertOutputDirectory, err)
@@ -594,9 +590,13 @@ func generateAndLinkSdksForPackages(
 			if err != nil {
 				return fmt.Errorf("failed to link SDK to project: %w", err)
 			}
-			returnToStartingDir()
-			return fmt.Errorf("failed to link SDK to project: %w", err)
-		}
 
+			return nil
+		}()
+		if err != nil {
 			return err
+		}
+	}
 
+	return nil
+}

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -567,6 +567,10 @@ func generateAndLinkSdksForPackages(
 		// If we don't change the working directory, the workspace instance (when
 		// reading project etc) will not be correct when doing the local sdk
 		// linking, causing errors.
+		//
+		// We must also remember to call returnToStartingDir() to change back to
+		// the original directory after every iteration of the loop and before
+		// returning.
 		returnToStartingDir, err := fsutil.Chdir(convertOutputDirectory)
 		if err != nil {
 			return fmt.Errorf("could not change to output directory: %w", err)

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -580,11 +580,16 @@ func generateAndLinkSdksForPackages(
 		if err != nil {
 			returnToStartingDir()
 			return fmt.Errorf("generated root is not a valid pulumi workspace %q: %w", convertOutputDirectory, err)
-		}
+			_, _, err = ws.ReadProject()
+			if err != nil {
+				return fmt.Errorf("generated root is not a valid pulumi workspace %q: %w", convertOutputDirectory, err)
+			}
 
-		sdkRelPath := filepath.Join("sdks", pkg.Parameterization.Name)
-		err = packagecmd.LinkPackage(ws, language, "./", pkgSchema, sdkRelPath)
-		if err != nil {
+			sdkRelPath := filepath.Join("sdks", pkg.Parameterization.Name)
+			err = packagecmd.LinkPackage(ws, language, "./", pkgSchema, sdkRelPath)
+			if err != nil {
+				return fmt.Errorf("failed to link SDK to project: %w", err)
+			}
 			returnToStartingDir()
 			return fmt.Errorf("failed to link SDK to project: %w", err)
 		}

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -594,8 +594,7 @@ func generateAndLinkSdksForPackages(
 			return fmt.Errorf("failed to link SDK to project: %w", err)
 		}
 
-		returnToStartingDir()
-	}
+			return err
 
 	return nil
 }

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -571,18 +571,21 @@ func generateAndLinkSdksForPackages(
 		if err != nil {
 			return fmt.Errorf("could not change to output directory: %w", err)
 		}
-		defer returnToStartingDir()
 
 		_, _, err = ws.ReadProject()
 		if err != nil {
+			returnToStartingDir()
 			return fmt.Errorf("generated root is not a valid pulumi workspace %q: %w", convertOutputDirectory, err)
 		}
 
 		sdkRelPath := filepath.Join("sdks", pkg.Parameterization.Name)
 		err = packagecmd.LinkPackage(ws, language, "./", pkgSchema, sdkRelPath)
 		if err != nil {
+			returnToStartingDir()
 			return fmt.Errorf("failed to link SDK to project: %w", err)
 		}
+
+		returnToStartingDir()
 	}
 
 	return nil

--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -382,7 +382,7 @@ func linkGoPackage(root string, pkg *schema.Package, out string) error {
 		return errors.New("failed to import go language info")
 	}
 
-	gomodFilepath := filepath.Join(out, "go.mod")
+	gomodFilepath := filepath.Join(root, "go.mod")
 	gomodFileContent, err := os.ReadFile(gomodFilepath)
 	if err != nil {
 		return fmt.Errorf("cannot read mod file: %w", err)

--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -382,7 +382,7 @@ func linkGoPackage(root string, pkg *schema.Package, out string) error {
 		return errors.New("failed to import go language info")
 	}
 
-	gomodFilepath := filepath.Join(root, "go.mod")
+	gomodFilepath := filepath.Join(out, "go.mod")
 	gomodFileContent, err := os.ReadFile(gomodFilepath)
 	if err != nil {
 		return fmt.Errorf("cannot read mod file: %w", err)

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -253,9 +253,6 @@ func (l *pluginLoader) loadSchemaBytes(
 		return nil, nil, err
 	}
 	version := descriptor.Version
-	if descriptor.Parameterization != nil {
-		version = &descriptor.Parameterization.Version
-	}
 
 	// If PULUMI_DEBUG_PROVIDERS requested an attach port, skip caching and workspace
 	// interaction and load the schema directly from the given port.

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -253,6 +253,9 @@ func (l *pluginLoader) loadSchemaBytes(
 		return nil, nil, err
 	}
 	version := descriptor.Version
+	if descriptor.Parameterization != nil {
+		version = &descriptor.Parameterization.Version
+	}
 
 	// If PULUMI_DEBUG_PROVIDERS requested an attach port, skip caching and workspace
 	// interaction and load the schema directly from the given port.

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -262,7 +262,7 @@ func (l *pluginLoader) loadSchemaBytes(
 			return nil, nil, fmt.Errorf("Error loading schema from plugin: %w", err)
 		}
 
-		if version == nil && descriptor.Parameterization != nil {
+		if version == nil || descriptor.Parameterization != nil {
 			info, err := provider.GetPluginInfo(ctx)
 			contract.IgnoreError(err) // nonfatal error
 			version = info.Version

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -252,6 +252,12 @@ func (l *pluginLoader) loadSchemaBytes(
 	if err != nil {
 		return nil, nil, err
 	}
+	// note that in the case of parameterization, parameterizing can change in
+	// the schema and expected version, eg in the terraform provider.
+	//
+	// The loader also compares the version against the schema against this, so
+	// they must be updated to be referencing the same semantic package (ie the
+	// parameterized package, see [LoadPackageReferenceV2])
 	version := descriptor.Version
 
 	// If PULUMI_DEBUG_PROVIDERS requested an attach port, skip caching and workspace

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -262,11 +262,12 @@ func (l *pluginLoader) loadSchemaBytes(
 			return nil, nil, fmt.Errorf("Error loading schema from plugin: %w", err)
 		}
 
-		if version == nil {
+		if version == nil && descriptor.Parameterization != nil {
 			info, err := provider.GetPluginInfo(ctx)
 			contract.IgnoreError(err) // nonfatal error
 			version = info.Version
 		}
+
 		return schemaBytes, version, nil
 	}
 
@@ -324,7 +325,7 @@ func (l *pluginLoader) loadSchemaBytes(
 		}
 	}
 
-	if version == nil {
+	if version == nil || descriptor.Parameterization != nil {
 		info, _ := provider.GetPluginInfo(ctx) // nonfatal error
 		version = info.Version
 	}


### PR DESCRIPTION
This fixes it by querying the provider if there is parameterization since versioning can change.

This is causing package references to not be loaded during binding of
PCL and discarded, causing the go language info structure to not be available from the package.

This in turn means that the import codegen logic is incorrect and
produces the wrong path.  This solves the version mismatch error problem
so that does not error out and cause the bad effects.
