### PR TITLE
Wait for resources in the input property dependencies

### DIFF
--- a/changelog/pending/20250109--sdk-nodejs-python--wait-for-resource-in-the-input-property-dependencies.yaml
+++ b/changelog/pending/20250109--sdk-nodejs-python--wait-for-resource-in-the-input-property-dependencies.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs,python
+  description: Wait for resource in the input property dependencies

--- a/sdk/nodejs/tests/runtime/langhost/cases/078.invoke_output_input_dependencies/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/078.invoke_output_input_dependencies/index.js
@@ -1,0 +1,21 @@
+// Test the dependsOn invoke option with components
+
+const assert = require("assert");
+const pulumi = require("../../../../../");
+
+class MyResource extends pulumi.CustomResource {
+    constructor(name, opts) {
+        super("test:index:MyResource", name, {}, opts);
+    }
+}
+
+const dep = new MyResource("dep");
+
+const argWithResourceDependency = new pulumi.Output(
+    new Set([dep]),
+    Promise.resolve(0),
+    Promise.resolve(true), // isKnown
+    Promise.resolve(false), // isSecret
+);
+
+pulumi.runtime.invokeOutput("test:index:echo", { argWithResourceDependency });

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -1665,6 +1665,28 @@ describe("rpc", () => {
                 return { failures: undefined, ret: args };
             },
         },
+        invoke_output_input_dependencies: {
+            pwd: path.join(base, "078.invoke_output_input_dependencies"),
+            expectResourceCount: 1,
+            registerResource: (
+                ctx: any,
+                dryrun: boolean,
+                t: string,
+                name: string,
+                res: any,
+                dependencies?: string[],
+                ...args: any
+            ) => {
+                const id = dryrun ? undefined : name + "_id";
+                return { urn: makeUrn(t, name), id, props: undefined };
+            },
+            invoke: (ctx: any, dryrun: boolean, tok: string, args: any, version: string, provider: string) => {
+                if (dryrun) {
+                    assert.fail("invoke should not be called");
+                }
+                return { failures: undefined, ret: args };
+            },
+        },
     };
 
     for (const casename of Object.keys(cases)) {


### PR DESCRIPTION
Besides the explicitly provided resources from the `dependsOn` option, we need to also take into account the resource dependencies from the invoke’s arguments.
