### PR TITLE
Add a `call` intrinsic to PCL

### DIFF
--- a/changelog/pending/20250109--pkg--add-a-call-intrinsic-to-pcl.yaml
+++ b/changelog/pending/20250109--pkg--add-a-call-intrinsic-to-pcl.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: pkg
+  description: Add a `call` intrinsic to PCL

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -610,7 +610,7 @@ type ObjectTypeFromConfigMetadata = struct {
 }
 
 func annotateObjectTypedConfig(componentName string, typeName string, objectType *model.ObjectType) *model.ObjectType {
-	objectType.Annotations = append(objectType.Annotations, &ObjectTypeFromConfigMetadata{
+	objectType.Annotate(&ObjectTypeFromConfigMetadata{
 		TypeName:      typeName,
 		ComponentName: componentName,
 	})

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -824,14 +824,12 @@ func (g *generator) GenLiteralValueExpression(w io.Writer, expr *model.LiteralVa
 func (g *generator) GenObjectConsExpression(w io.Writer, expr *model.ObjectConsExpression) {
 	switch argType := expr.Type().(type) {
 	case *model.ObjectType:
-		if len(argType.Annotations) > 0 {
-			if configMetadata, ok := argType.Annotations[0].(*ObjectTypeFromConfigMetadata); ok {
-				fullTypeName := fmt.Sprintf("Components.%sArgs.%s",
-					configMetadata.ComponentName,
-					configMetadata.TypeName)
-				g.genObjectConsExpressionWithTypeName(w, expr, fullTypeName, false, nil)
-				return
-			}
+		if configMetadata, ok := model.GetObjectTypeAnnotation[*ObjectTypeFromConfigMetadata](argType); ok {
+			fullTypeName := fmt.Sprintf("Components.%sArgs.%s",
+				configMetadata.ComponentName,
+				configMetadata.TypeName)
+			g.genObjectConsExpressionWithTypeName(w, expr, fullTypeName, false, nil)
+			return
 		}
 	}
 	g.genObjectConsExpression(w, expr, expr.Type())

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -140,7 +140,7 @@ type ObjectTypeFromConfigMetadata = struct {
 }
 
 func annotateObjectTypedConfig(componentName string, typeName string, objectType *model.ObjectType) *model.ObjectType {
-	objectType.Annotations = append(objectType.Annotations, &ObjectTypeFromConfigMetadata{
+	objectType.Annotate(&ObjectTypeFromConfigMetadata{
 		TypeName:      typeName,
 		ComponentName: componentName,
 	})

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -530,11 +530,9 @@ func (g *generator) genLiteralValueExpression(w io.Writer, expr *model.LiteralVa
 func (g *generator) GenObjectConsExpression(w io.Writer, expr *model.ObjectConsExpression) {
 	switch argType := expr.Type().(type) {
 	case *model.ObjectType:
-		if len(argType.Annotations) > 0 {
-			if configMetadata, ok := argType.Annotations[0].(*ObjectTypeFromConfigMetadata); ok {
-				g.genObjectConsExpressionWithTypeName(w, expr, expr.Type(), configMetadata.TypeName)
-				return
-			}
+		if configMetadata, ok := model.GetObjectTypeAnnotation[*ObjectTypeFromConfigMetadata](argType); ok {
+			g.genObjectConsExpressionWithTypeName(w, expr, expr.Type(), configMetadata.TypeName)
+			return
 		}
 	}
 

--- a/pkg/codegen/hcl2/model/type_object.go
+++ b/pkg/codegen/hcl2/model/type_object.go
@@ -47,6 +47,25 @@ func NewObjectType(properties map[string]Type, annotations ...interface{}) *Obje
 	return &ObjectType{Properties: properties, Annotations: annotations}
 }
 
+// Annotate adds annotations to the object type. Annotations may be retrieved by GetObjectTypeAnnotation.
+func (t *ObjectType) Annotate(annotations ...interface{}) {
+	t.Annotations = append(t.Annotations, annotations...)
+}
+
+// GetObjectTypeAnnotation retrieves an annotation of the given type from the object type, if one exists.
+func GetObjectTypeAnnotation[T any](t *ObjectType) (T, bool) {
+	var result T
+	found := false
+	for _, a := range t.Annotations {
+		if v, ok := a.(T); ok {
+			result = v
+			found = true
+			break
+		}
+	}
+	return result, found
+}
+
 // SyntaxNode returns the syntax node for the type. This is always syntax.None.
 func (*ObjectType) SyntaxNode() hclsyntax.Node {
 	return syntax.None

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -207,6 +207,8 @@ func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagno
 	}
 	// Define the invoke function.
 	b.root.DefineFunction(Invoke, model.NewFunction(model.GenericFunctionSignature(b.bindInvokeSignature)))
+	// Define the call function.
+	b.root.DefineFunction(Call, model.NewFunction(model.GenericFunctionSignature(b.bindCallSignature)))
 
 	var diagnostics hcl.Diagnostics
 

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -363,7 +363,11 @@ func (b *binder) bindResourceTypes(node *Resource) hcl.Diagnostics {
 	for _, prop := range properties {
 		outputProperties[prop.Name] = model.NewOutputType(b.schemaTypeToType(prop.Type))
 	}
-	outputType := model.NewObjectType(outputProperties, &schema.ObjectType{Properties: properties})
+	outputType := model.NewObjectType(
+		outputProperties,
+		&resourceAnnotation{node},
+		&schema.ObjectType{Properties: properties},
+	)
 
 	node.InputType, node.OutputType = inputType, outputType
 
@@ -380,6 +384,13 @@ func (b *binder) bindResourceTypes(node *Resource) hcl.Diagnostics {
 	codegen.VisitTypeClosure(properties, findTransitivePackageReferences)
 
 	return diagnostics
+}
+
+// resourceAnnotation is a type that can be used to annotate ObjectTypes that represent resources with their
+// corresponding Resource node. We define a wrapper type that does not implement any interfaces so as to reduce the
+// chance of the annotation being plucked out by an interface-type query by accident.
+type resourceAnnotation struct {
+	node *Resource
 }
 
 type resourceScopes struct {

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -489,15 +489,7 @@ func GetSchemaForType(t model.Type) (schema.Type, bool) {
 		schemaArrayTypes[element] = &schema.ArrayType{ElementType: element}
 		return schemaArrayTypes[element], true
 	case *model.ObjectType:
-		if len(t.Annotations) == 0 {
-			return nil, false
-		}
-		for _, a := range t.Annotations {
-			if t, ok := a.(schema.Type); ok {
-				return t, true
-			}
-		}
-		return nil, false
+		return model.GetObjectTypeAnnotation[schema.Type](t)
 	case *model.OutputType:
 		return GetSchemaForType(t.ElementType)
 	case *model.PromiseType:

--- a/pkg/codegen/pcl/call.go
+++ b/pkg/codegen/pcl/call.go
@@ -1,0 +1,182 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pcl
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+// Call is the name of the PCL `call` intrinsic, which can be used to invoke methods on resources.
+//
+// `call` has the following signature:
+//
+//	call(self, method, args)
+//
+// where `self` is the resource to invoke the method on, `method` is the name of the method to invoke, and `args` is an
+// object containing the arguments to pass to the method.
+const Call = "call"
+
+// bindCallSignature accepts a list of arguments that have been passed to an invocation of the `call` intrinsic and
+// attempts to construct a static function signature that can be used to check them, returning diagnostics if this is
+// not possible.
+func (b *binder) bindCallSignature(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
+	// Call must always be passed three arguments -- a receiver, a string indicating the name of the method to invoke, and
+	// a set of arguments to pass to the method.
+	if len(args) < 3 {
+		var r hcl.Range
+		if len(args) > 0 {
+			r = args[0].SyntaxNode().Range()
+		} else {
+			r = hcl.Range{}
+		}
+		return b.zeroCallSignature(), hcl.Diagnostics{
+			errorf(r, "call must be passed a receiver, method name, and arguments object"),
+		}
+	}
+
+	// We've got the minimum number of arguments. We can start therefore by plucking out the receiver. Since any valid
+	// receiver must be an object type (all resources are typed as objects whose properties are the resource's output
+	// properties), we can query the type's annotations to find the linked resource node. From there we can retrieve the
+	// schema and use this later on to resolve the method, etc.
+	self := args[0]
+	var selfRes *Resource
+	if objectType, ok := self.Type().(*model.ObjectType); ok {
+		if annotation, ok := model.GetObjectTypeAnnotation[*resourceAnnotation](objectType); ok {
+			selfRes = annotation.node
+		}
+	}
+
+	if selfRes == nil {
+		return b.zeroCallSignature(), hcl.Diagnostics{
+			errorf(args[0].SyntaxNode().Range(), "call's receiver must be a single resource"),
+		}
+	}
+
+	// Next we'll grab the method name. This must be a string literal, and can't be e.g. a templated string.
+	template, ok := args[1].(*model.TemplateExpression)
+	if !ok || len(template.Parts) != 1 {
+		return b.zeroCallSignature(), hcl.Diagnostics{
+			errorf(args[1].SyntaxNode().Range(), "call's method name must be a string literal"),
+		}
+	}
+	lit, ok := template.Parts[0].(*model.LiteralValueExpression)
+	if !ok || model.StringType.ConversionFrom(lit.Type()) == model.NoConversion {
+		return b.zeroCallSignature(), hcl.Diagnostics{
+			errorf(args[1].SyntaxNode().Range(), "call's method name must be a string literal"),
+		}
+	}
+
+	// Look up the method in the receiver's method list.
+	methodName := lit.Value.AsString()
+	var method *schema.Method
+	for _, m := range selfRes.Schema.Methods {
+		if m.Name == methodName {
+			method = m
+			break
+		}
+	}
+	if method == nil {
+		return b.zeroCallSignature(), hcl.Diagnostics{errorf(
+			args[1].SyntaxNode().Range(),
+			"resource type %q has no method %q", selfRes.Token, methodName,
+		)}
+	}
+
+	// Construct a signature and return it.
+	sigArgsType, err := b.callArgsType(method.Function)
+	if err != nil {
+		return b.zeroCallSignature(), hcl.Diagnostics{errorf(args[1].SyntaxNode().Range(), "%v", err.Error())}
+	}
+	sig := model.StaticFunctionSignature{
+		Parameters: []model.Parameter{
+			{
+				Name: "self",
+				Type: self.Type(),
+			},
+			{
+				Name: "method",
+				Type: model.StringType,
+			},
+			{
+				Name: "args",
+				Type: sigArgsType,
+			},
+		},
+		ReturnType: b.schemaTypeToType(method.Function.ReturnType),
+	}
+
+	if argsObject, isObjectExpression := args[1].(*model.ObjectConsExpression); isObjectExpression {
+		if method.Function.Inputs != nil {
+			annotateObjectProperties(argsObject.Type(), method.Function.Inputs)
+		}
+	}
+
+	sig.MultiArgumentInputs = method.Function.MultiArgumentInputs
+	return sig, nil
+}
+
+// zeroCallSignature returns a "zero" signature for the `call` intrinsic that can be returned in the event constructing
+// a strongly-typed signature fails. In this signature, the `self` and `args` inputs are dynamically typed, since we
+// have presumably been unable to resolve more accurate types for them.
+func (b *binder) zeroCallSignature() model.StaticFunctionSignature {
+	return model.StaticFunctionSignature{
+		Parameters: []model.Parameter{
+			{
+				Name: "self",
+				Type: model.DynamicType,
+			},
+			{
+				Name: "method",
+				Type: model.StringType,
+			},
+			{
+				Name: "args",
+				Type: model.DynamicType,
+			},
+		},
+		ReturnType: model.DynamicType,
+	}
+}
+
+// callArgsType accepts a function schema and constructs a model.Type for its arguments. As part of this it both
+// validates the presence of the special __self__ argument and removes it from the list of arguments that the `call`
+// intrinsic should expect (since the intrinsic takes self as a separate positional argument).
+func (b *binder) callArgsType(fn *schema.Function) (model.Type, error) {
+	var self *schema.Property
+	args := &schema.ObjectType{Properties: []*schema.Property{}}
+	for _, input := range fn.Inputs.Properties {
+		if input.Name == "__self__" {
+			self = input
+			continue
+		}
+
+		args.Properties = append(args.Properties, input)
+	}
+
+	if self == nil {
+		return nil, fmt.Errorf("method %q has no __self__ input", fn.Token)
+	}
+
+	if len(args.Properties) == 0 {
+		return model.NewOptionalType(model.NewObjectType(map[string]model.Type{})), nil
+	}
+
+	typ := b.schemaTypeToType(args)
+	return typ, nil
+}

--- a/pkg/codegen/pcl/invoke.go
+++ b/pkg/codegen/pcl/invoke.go
@@ -64,7 +64,7 @@ func annotateObjectProperties(modelType model.Type, schemaType schema.Type) {
 			}
 
 			// top-level annotation for the type itself
-			arg.Annotations = append(arg.Annotations, schemaType)
+			arg.Annotate(schemaType)
 			// now for each property, annotate it with the associated type from the schema
 			for propertyName, propertyType := range arg.Properties {
 				if associatedType, ok := schemaProperties[propertyName]; ok {

--- a/pkg/codegen/pcl/invoke.go
+++ b/pkg/codegen/pcl/invoke.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+// Invoke is the name of the PCL `invoke` intrinsic, which can be used to invoke provider functions.
 const Invoke = "invoke"
 
 func getInvokeToken(call *hclsyntax.FunctionCallExpr) (string, hcl.Range, bool) {

--- a/pkg/codegen/pcl/utilities.go
+++ b/pkg/codegen/pcl/utilities.go
@@ -194,11 +194,7 @@ func SortedFunctionParameters(expr *model.FunctionCallExpression) []*schema.Prop
 
 	switch args := expr.Signature.Parameters[1].Type.(type) {
 	case *model.ObjectType:
-		if len(args.Annotations) == 0 {
-			return []*schema.Property{}
-		}
-
-		originalSchemaType, ok := args.Annotations[0].(*schema.ObjectType)
+		originalSchemaType, ok := model.GetObjectTypeAnnotation[*schema.ObjectType](args)
 		if !ok {
 			return []*schema.Property{}
 		}

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -109,6 +109,7 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 		SchemaProvider{"kubernetes", "3.0.0"},
 		SchemaProvider{"aws", "4.37.1"},
 
+		SchemaProvider{"component", "13.3.7"},
 		SchemaProvider{"other", "0.1.0"},
 		SchemaProvider{"synthetic", "1.0.0"},
 		SchemaProvider{"basic-unions", "0.1.0"},

--- a/tests/testdata/codegen/component-13.3.7.json
+++ b/tests/testdata/codegen/component-13.3.7.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://raw.githubusercontent.com/pulumi/pulumi/master/pkg/codegen/schema/pulumi.json",
+  "name": "component",
+  "version": "13.3.7",
+  "functions": {
+    "component:index:Callable/identity": {
+      "description": "The `identity` method of the `Callable` component resource. Returns the component's `value`.",
+      "inputs": {
+        "type": "object",
+        "properties": {
+          "__self__": {
+            "$ref": "#/resources/component:index:Callable",
+            "description": "A reference to the `Callable` component resource."
+          }
+        },
+        "required": [
+          "__self__"
+        ]
+      },
+      "outputs": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "string",
+            "description": "The result of the method call."
+          }
+        },
+        "required": [
+          "result"
+        ]
+      }
+    },
+    "component:index:Callable/prefixed": {
+      "description": "The `prefixed` method of the `Callable` component resource. Accepts a string prefix and returns the component's `value` prefixed with this string.",
+      "inputs": {
+        "type": "object",
+        "properties": {
+          "__self__": {
+            "$ref": "#/resources/component:index:Callable",
+            "description": "A reference to the `Callable` component resource."
+          },
+          "prefix": {
+            "type": "string",
+            "description": "The prefix to add to the component's `value`."
+          }
+        },
+        "required": [
+          "__self__",
+          "prefix"
+        ]
+      },
+      "outputs": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "string",
+            "description": "The result of the method call."
+          }
+        },
+        "required": [
+          "result"
+        ]
+      }
+    }
+  },
+  "resources": {
+    "component:index:Callable": {
+      "isComponent": true,
+      "description": "A component resource that has callable methods.",
+      "inputProperties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "requiredInputs": [
+        "value"
+      ],
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "methods": {
+        "identity": "component:index:Callable/identity",
+        "prefixed": "component:index:Callable/prefixed"
+      }
+    }
+  }
+}


### PR DESCRIPTION
In order for PCL to serve as an authoritative intermediate language for Pulumi programs, it needs to be able to express all the concepts available to a Pulumi program written in a high-level programming language. Put another way, it must be capable of expressing all the functionality exposed by the `ResourceMonitor` interface. Presently, the ability to `Call` methods on component resources is not available in PCL. This change adds a new `call` intrinsic to fix that.

`call` has three required arguments: the receiver (that will become the `__self__` argument under the hood), the method name (that must exist in the resource's `Methods` map in schema), and an object of arguments (whose specifications must appear in the corresponding `Function` in the schema). An example use of `call` might thus look as follows:

```hcl
resource "c" "pkg:index:Callable" {
  ...
}

output "o" {
  value = call(c, "method", { x = 1, y = 2 })
}
```

In order to type check and applications of `call` when binding PCL programs, we use the recently powered-up annotations feature to look up the resource node of the receiver from its expression. With this, we are able to grab the schema and validate the method name and arguments. While we add unit tests for binding programs that use `call`, this change does not extend program generation or the conformance test suite. This will be done in a subsequent set of changes.

Part of fixing pulumi/pulumi-java#262