### PR TITLE
Revert "Fix infinite looping of calls of pulumi program when missing inline program (#18086)"

### DIFF
--- a/changelog/pending/20250110--auto-go--fix-rejection-of-nil-inline-programs-in-the-go-automation-api.yaml
+++ b/changelog/pending/20250110--auto-go--fix-rejection-of-nil-inline-programs-in-the-go-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/go
+  description: Fix rejection of `nil` inline programs in the Go automation API

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -1357,9 +1357,6 @@ func NewStackInlineSource(
 	opts ...LocalWorkspaceOption,
 ) (Stack, error) {
 	var stack Stack
-	if program == nil {
-		return stack, errors.New("program must be specified")
-	}
 	opts = append(opts, Program(program))
 
 	proj, err := getProjectSettings(ctx, projectName, opts)
@@ -1391,9 +1388,6 @@ func UpsertStackInlineSource(
 	opts ...LocalWorkspaceOption,
 ) (Stack, error) {
 	var stack Stack
-	if program == nil {
-		return stack, errors.New("program must be specified")
-	}
 	opts = append(opts, Program(program))
 
 	proj, err := getProjectSettings(ctx, projectName, opts)
@@ -1424,9 +1418,6 @@ func SelectStackInlineSource(
 	opts ...LocalWorkspaceOption,
 ) (Stack, error) {
 	var stack Stack
-	if program == nil {
-		return stack, errors.New("program must be specified")
-	}
 	opts = append(opts, Program(program))
 
 	proj, err := getProjectSettings(ctx, projectName, opts)

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -966,24 +966,6 @@ func TestNewStackInlineSource(t *testing.T) {
 	assert.Equal(t, "succeeded", dRes.Summary.Result)
 }
 
-func TestInlineSourceFamilyReturnsErrorWhenNil(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	sName := ptesting.RandomStackName()
-	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
-
-	// initialize
-	_, err := NewStackInlineSource(ctx, stackName, pName, nil)
-	assert.ErrorContains(t, err, "program must be specified")
-
-	_, err = UpsertStackInlineSource(ctx, stackName, pName, nil)
-	assert.ErrorContains(t, err, "program must be specified")
-
-	_, err = SelectStackInlineSource(ctx, stackName, pName, nil)
-	assert.ErrorContains(t, err, "program must be specified")
-}
-
 func TestStackLifecycleInlineProgramRemoveWithoutDestroy(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This reverts commit 119057414d3598fbab20b7878558baf8f29602a5. Introduced in #18086, this commit introduced a check for `nil` inline programs when running Go automation API functions, which fixed the original issue but has unfortunately created a breaking change in cases where there is a legitimate need to pass a `nil` program (such as to a `destroy` operation).

Fixes #18213
Reopens #15877