### PR TITLE
fix TestConvertTerraformProviderGo test

### DIFF
--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -1299,7 +1299,7 @@ func TestConvertTerraformProviderGo(t *testing.T) {
 	require.NoError(t, err)
 
 	_, _ = e.RunCommand("pulumi", "plugin", "install", "converter", "terraform")
-	_, _ = e.RunCommand("pulumi", "plugin", "install", "resource", "terraform-provider")
+	_, _ = e.RunCommand("pulumi", "plugin", "install", "resource", "terraform-provider", "0.6.0")
 	_, _ = e.RunCommand("pulumi", "convert", "--from", "terraform", "--language", "go", "--out", "godir")
 
 	assert.True(t, e.PathExists("godir/go.mod"))


### PR DESCRIPTION
The terraform converter relies on v0.6.0 of the resource plugin.  Pin that to fix the test.