### PR TITLE
Allow specifying a version with `pulumi convert --from=<plugin>@<version>`

### DIFF
--- a/changelog/pending/20250110--cli--allow-specifying-a-version-with-pulumi-convert-from-plugin-at-version.yaml
+++ b/changelog/pending/20250110--cli--allow-specifying-a-version-with-pulumi-convert-from-plugin-at-version.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Allow specifying a version with `pulumi convert --from=<plugin>@<version>`


### PR DESCRIPTION
This uses the same syntax for `<plugin>@<version>` as is used in `pulumi package get-schema <plugin@version|file>`.

This is motivated by the way the bridge shells out to the converter for example conversion. We would like to move away from ambient plugins to hermetic builds.