### PR TITLE
Enable Autonaming Configuration in non-experimental mode

### DIFF
--- a/changelog/pending/20250113--cli--enable-autonaming-configuration-in-non-experimental-mode.yaml
+++ b/changelog/pending/20250113--cli--enable-autonaming-configuration-in-non-experimental-mode.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Enable Autonaming Configuration in non-experimental mode

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -443,12 +443,9 @@ func NewPreviewCmd() *cobra.Command {
 				return err
 			}
 
-			var autonamer autonaming.Autonamer
-			if env.Experimental.Value() {
-				autonamer, err = autonaming.ParseAutonamingConfig(autonamingStackContext(proj, s), cfg.Config, decrypter)
-				if err != nil {
-					return fmt.Errorf("getting autonaming config: %w", err)
-				}
+			autonamer, err := autonaming.ParseAutonamingConfig(autonamingStackContext(proj, s), cfg.Config, decrypter)
+			if err != nil {
+				return fmt.Errorf("getting autonaming config: %w", err)
 			}
 
 			opts := backend.UpdateOptions{

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -176,12 +176,9 @@ func NewUpCmd() *cobra.Command {
 			return err
 		}
 
-		var autonamer autonaming.Autonamer
-		if env.Experimental.Value() {
-			autonamer, err = autonaming.ParseAutonamingConfig(autonamingStackContext(proj, s), cfg.Config, decrypter)
-			if err != nil {
-				return fmt.Errorf("getting autonaming config: %w", err)
-			}
+		autonamer, err := autonaming.ParseAutonamingConfig(autonamingStackContext(proj, s), cfg.Config, decrypter)
+		if err != nil {
+			return fmt.Errorf("getting autonaming config: %w", err)
 		}
 
 		opts.Engine = engine.UpdateOptions{

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2293,30 +2293,20 @@ func TestLogDebugNode(t *testing.T) {
 //nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestAutonaming(t *testing.T) {
 	testCases := []struct {
-		name         string
-		experimental bool
-		autoName     string
-		config       map[string]string
+		name     string
+		autoName string
+		config   map[string]string
 	}{
 		{
 			name:     "no autonaming configured",
 			autoName: "default-name",
 		},
 		{
-			name: "autonaming ignored in non-experimental mode",
-			config: map[string]string{
-				"pulumi:autonaming.mode": "verbatim",
-			},
-			experimental: false,
-			autoName:     "default-name",
-		},
-		{
 			name: "autonaming configured globally to verbatim",
 			config: map[string]string{
 				"pulumi:autonaming.mode": "verbatim",
 			},
-			experimental: true,
-			autoName:     "test1",
+			autoName: "test1",
 		},
 		{
 			name: "autonaming configured on provider to a pattern",
@@ -2324,8 +2314,7 @@ func TestAutonaming(t *testing.T) {
 				"pulumi:autonaming.providers.testprovider.pattern": "${config.foo}-${name}",
 				"foo": "bar",
 			},
-			experimental: true,
-			autoName:     "bar-test1",
+			autoName: "bar-test1",
 		},
 	}
 
@@ -2336,9 +2325,6 @@ func TestAutonaming(t *testing.T) {
 			orderedConfig = append(orderedConfig, integration.ConfigValue{Key: k, Value: v, Path: true})
 		}
 		env := []string{}
-		if tc.experimental {
-			env = append(env, "PULUMI_EXPERIMENTAL=1")
-		}
 		t.Run(tc.name, func(t *testing.T) {
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
 				Dir:           "autonaming",


### PR DESCRIPTION
https://github.com/pulumi/pulumi/pull/17916 introduced auto-naming configuration behind PULUMI_EXPERIMENTAL flag. This PR removes that experimental requirement so that the feature becomes available by default. Blog post in https://github.com/pulumi/docs/pull/13763.