### PR TITLE
Add continue on error to pulumi preview

### DIFF
--- a/changelog/pending/20250115--engine--add-continueonerror-to-pulumi-preview-and-make-deletion-of-protected-present-as-warnings.yaml
+++ b/changelog/pending/20250115--engine--add-continueonerror-to-pulumi-preview-and-make-deletion-of-protected-present-as-warnings.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Add ContinueOnError to pulumi preview and make deletion of protected present as warnings

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -275,6 +275,7 @@ func NewPreviewCmd() *cobra.Command {
 	var showReads bool
 	var suppressOutputs bool
 	var suppressProgress bool
+	var continueOnError bool
 	var suppressPermalink string
 	var targets []string
 	var replaces []string
@@ -466,6 +467,7 @@ func NewPreviewCmd() *cobra.Command {
 					// experimental mode to just get more testing of it.
 					GeneratePlan:   env.Experimental.Value() || planFilePath != "",
 					Experimental:   env.Experimental.Value(),
+					ContinueOnError: continueOnError,
 					AttachDebugger: attachDebugger,
 					Autonamer:      autonamer,
 				},
@@ -650,6 +652,10 @@ func NewPreviewCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&suppressProgress, "suppress-progress", false,
 		"Suppress display of periodic progress dots")
+	cmd.PersistentFlags().BoolVar(
+		&continueOnError, "continue-on-error", env.ContinueOnError.Value(),
+		"Continue updating resources even if an error is encountered "+
+			"(can also be set with PULUMI_CONTINUE_ON_ERROR environment variable)")
 	cmd.PersistentFlags().StringVar(
 		&suppressPermalink, "suppress-permalink", "",
 		"Suppress display of the state permalink")

--- a/pkg/engine/update_test.go
+++ b/pkg/engine/update_test.go
@@ -91,6 +91,7 @@ func TestDeletingComponentResourceProducesResourceOutputsEvent(t *testing.T) {
 	err := acts.OnResourceStepPost(
 		&mockSnapshotMutation{}, step, resource.StatusOK,
 		nil, /* err */
+		false,
 	)
 	require.NoError(t, err)
 

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -214,7 +214,7 @@ func (t *UrnTargets) addLiteral(urn resource.URN) {
 // StepExecutorEvents is an interface that can be used to hook resource lifecycle events.
 type StepExecutorEvents interface {
 	OnResourceStepPre(step Step) (interface{}, error)
-	OnResourceStepPost(ctx interface{}, step Step, status resource.Status, err error) error
+	OnResourceStepPost(ctx interface{}, step Step, status resource.Status, err error, errorsAsWarnings bool) error
 	OnResourceOutputs(step Step) error
 }
 

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -493,7 +493,8 @@ func (se *stepExecutor) executeStep(workerID int, step Step) error {
 	}
 
 	if events != nil {
-		if postErr := events.OnResourceStepPost(payload, step, status, err); postErr != nil {
+		errorsAsWarnings := se.deployment.opts.DryRun && se.deployment.opts.ContinueOnError
+		if postErr := events.OnResourceStepPost(payload, step, status, err, errorsAsWarnings); postErr != nil {
 			se.log(workerID, "step %v on %v failed post-resource step: %v", step.Op(), step.URN(), postErr)
 			return fmt.Errorf("post-step event returned an error: %w", postErr)
 		}

--- a/pkg/resource/deploy/step_executor_test.go
+++ b/pkg/resource/deploy/step_executor_test.go
@@ -57,7 +57,7 @@ func (e *mockRegisterResourceOutputsEvent) Done() {}
 
 type mockEvents struct {
 	OnResourceStepPreF   func(step Step) (interface{}, error)
-	OnResourceStepPostF  func(ctx interface{}, step Step, status resource.Status, err error) error
+	OnResourceStepPostF  func(ctx interface{}, step Step, status resource.Status, err error, errorsAsWarnings bool) error
 	OnResourceOutputsF   func(step Step) error
 	OnPolicyViolationF   func(resource.URN, plugin.AnalyzeDiagnostic)
 	OnPolicyRemediationF func(resource.URN, plugin.Remediation, resource.PropertyMap, resource.PropertyMap)
@@ -70,9 +70,15 @@ func (e *mockEvents) OnResourceStepPre(step Step) (interface{}, error) {
 	panic("unimplemented")
 }
 
-func (e *mockEvents) OnResourceStepPost(ctx interface{}, step Step, status resource.Status, err error) error {
+func (e *mockEvents) OnResourceStepPost(
+	ctx interface{},
+	step Step,
+	status resource.Status,
+	err error,
+	errorsAsWarnings bool,
+) error {
 	if e.OnResourceStepPostF != nil {
-		return e.OnResourceStepPostF(ctx, step, status, err)
+		return e.OnResourceStepPostF(ctx, step, status, err, errorsAsWarnings)
 	}
 	panic("unimplemented")
 }
@@ -201,7 +207,7 @@ func TestStepExecutor(t *testing.T) {
 							return nil, nil
 						},
 						OnResourceStepPostF: func(
-							ctx interface{}, step Step, status resource.Status, err error,
+							ctx interface{}, step Step, status resource.Status, err error, errorsAsWarnings bool,
 						) error {
 							return expectedErr
 						},

--- a/sdk/go/common/diag/errors.go
+++ b/sdk/go/common/diag/errors.go
@@ -45,6 +45,14 @@ func GetPreviewFailedError(urn resource.URN) *Diag {
 	return newError(urn, 2005, "Preview failed: %v")
 }
 
+// GetPreviewWarningError returns a diagnostic that indicates a warning occurred during preview.
+// This is useful when an error is swallowed such as when previewing something
+// that would actually fail in an update, but has no error in a preview. (eg
+// removing a protected resource).
+func GetPreviewWarningError(urn resource.URN) *Diag {
+	return newError(urn, 2005, "Preview warning, would fail on update: %v")
+}
+
 func GetBadProviderError(urn resource.URN) *Diag {
 	return newError(urn, 2006, "bad provider reference '%v' for resource '%v': %v")
 }


### PR DESCRIPTION
This also will cause the CLI to exit with code 0 when this flag is set,
even if there is an error deleting a resource due to failed
performDelete of a resource.

The second commit changes that it so that it now says "Preview warning, would fail on update". Instead of "error" in the diagnostic.
this is so CI/CD pipelines or users don't think a preview failed, but it does let them know when they run this same `pulumi up` it will fail to delete the protected resource.

Related #12195 

Fixes #18103
