### PR TITLE
Improve error messages for wrong stack output types

### DIFF
--- a/changelog/pending/20250115--sdk-go--improve-error-messages-for-wrong-stack-output-types.yaml
+++ b/changelog/pending/20250115--sdk-go--improve-error-messages-for-wrong-stack-output-types.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Improve error messages for wrong stack output types

--- a/sdk/go/pulumi/stack_reference.go
+++ b/sdk/go/pulumi/stack_reference.go
@@ -42,7 +42,7 @@ func (s *StackReference) GetOutput(name StringInput) AnyOutput {
 		ApplyT(func(args []interface{}) (interface{}, error) {
 			n, stack := args[0].(string), args[1].(resource.PropertyMap)
 			if !stack["outputs"].IsObject() {
-				return Any(nil), fmt.Errorf("failed to convert %T to object", stack)
+				return Any(nil), fmt.Errorf("failed to convert stack output %T to object", stack)
 			}
 			outs := stack["outputs"].ObjectValue()
 			v, ok := outs[resource.PropertyKey(n)]


### PR DESCRIPTION
This change rebases the work done by @devnev in #16911, producing better error messages when users of the Go SDK attempt to retrieve stack references that are ill-typed.

Closes #16911