### PR TITLE
Passthrough unstructured logs from dynamic providers

### DIFF
--- a/changelog/pending/20250115--cli-plugin--passthrough-unstructured-logs-from-dynamic-providers.yaml
+++ b/changelog/pending/20250115--cli-plugin--passthrough-unstructured-logs-from-dynamic-providers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/plugin
+  description: Passthrough unstructured logs from dynamic providers

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -278,7 +278,8 @@ func newPlugin[T any](
 
 	// For now, we will spawn goroutines that will spew STDOUT/STDERR to the relevant diag streams.
 	var sawPolicyModuleNotFoundErr bool
-	if kind == apitype.ResourcePlugin {
+	if kind == apitype.ResourcePlugin && !isDynamicPluginBinary(bin) {
+		logging.Infof("Hiding logs from %q:%q", prefix, bin)
 		plug.unstructuredOutput = &unstructuredOutput{diag: ctx.Diag}
 	}
 	runtrace := func(t io.Reader, streamID streamID, done chan<- bool) {
@@ -604,4 +605,9 @@ func (p *plugin) Close() error {
 	}
 
 	return result
+}
+
+func isDynamicPluginBinary(path string) bool {
+	return strings.HasSuffix(path, "pulumi-resource-pulumi-nodejs") ||
+		strings.HasSuffix(path, "pulumi-resource-pulumi-python")
 }


### PR DESCRIPTION
Adding the ability for structured logs to work correctly in dynamic providers is technically difficult. To maximize the transparency between dynamic providers and Pulumi programs, we have opted in the short term to simply restore `print`/`console.log` functionality to dynamic providers.

Fixes https://github.com/pulumi/pulumi/issues/18249