### PR TITLE
Fix `pulumi import` for paramaterized providers.

### DIFF
--- a/changelog/pending/20250116--cli-import--fix-paramaterized-providers-not-being-loaded-correctly-on-import.yaml
+++ b/changelog/pending/20250116--cli-import--fix-paramaterized-providers-not-being-loaded-correctly-on-import.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/import
+  description: Fix paramaterized providers not being loaded correctly on import

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -283,6 +283,7 @@ func newDeployment(
 				}
 				if imp.Parameterization == nil {
 					imp.Parameterization = defaultProviderInfo[imp.Type.Package()].Parameterization
+					imp.BaseProviderName = defaultProviderInfo[imp.Type.Package()].Name
 				}
 			}
 		}

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -46,7 +46,8 @@ type Import struct {
 	Protect           bool                        // Whether to mark the resource as protected after import
 	Properties        []string                    // Which properties to include (Defaults to required properties)
 	Parameterization  *workspace.Parameterization // The parameterization to use for the resource, if any.
-	BaseProviderName      string                      // If the provider is parameterized, the base (unparameterized) provider name.
+	// If the provider is parameterized, the base (unparameterized) provider name.
+	BaseProviderName string
 
 	// True if this import should create an empty component resource. ID must not be set if this is used.
 	Component bool

--- a/pkg/resource/deploy/import_test.go
+++ b/pkg/resource/deploy/import_test.go
@@ -211,3 +211,77 @@ func TestImporter(t *testing.T) {
 		})
 	})
 }
+
+func TestImporterParameterizedProvider(t *testing.T) {
+	t.Parallel()
+	t.Run("ensure provider is called correctly with Parameterization", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		version := semver.MustParse("1.0.0")
+		mockProvider := plugin.MockProvider{
+			ParameterizeF: func(ctx context.Context, paramReq plugin.ParameterizeRequest) (plugin.ParameterizeResponse, error) {
+				pValue, ok := paramReq.Parameters.(*plugin.ParameterizeValue)
+				assert.True(t, ok)
+				assert.Equal(t, pValue, &plugin.ParameterizeValue{
+					Name:    "ParameterizationName",
+					Version: semver.MustParse("1.2.3"),
+					Value:   []byte("parameterization-value"),
+				})
+				return plugin.ParameterizeResponse{
+					Name:    "ParameterizationName",
+					Version: semver.MustParse("1.2.3"),
+				}, nil
+			},
+			CloseF: func() error {
+				return nil
+			},
+			CheckConfigF: func(context.Context, plugin.CheckConfigRequest) (plugin.CheckConfigResponse, error) {
+				return plugin.CheckConfigResponse{}, nil
+			},
+		}
+		i := &importer{
+			executor: &stepExecutor{
+				ctx: ctx,
+			},
+			deployment: &Deployment{
+				goals: &gsync.Map[urn.URN, *resource.Goal]{},
+				ctx:   &plugin.Context{Diag: &deploytest.NoopSink{}},
+				target: &Target{
+					Name: tokens.MustParseStackName("stack-name"),
+				},
+				source: &nullSource{},
+				providers: providers.NewRegistry(&mockHost{
+					ProviderF: func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
+						assert.Equal(t, "foo", descriptor.Name)
+						assert.Equal(t, "1.0.0", descriptor.Version.String())
+						return &mockProvider, nil
+					},
+					CloseProviderF: func(provider plugin.Provider) error {
+						return nil
+					},
+				}, true, nil),
+				imports: []Import{
+					{
+						Version:           &version,
+						PluginDownloadURL: "download-url",
+						PluginChecksums: map[string][]byte{
+							"a": {},
+							"b": {},
+							"c": {},
+						},
+						Type:             "ParameterizationName:bar:Bar",
+						BaseProviderName: "foo",
+						Parameterization: &workspace.Parameterization{
+							Name:    "ParameterizationName",
+							Version: semver.MustParse("1.2.3"),
+							Value:   []byte("parameterization-value"),
+						},
+					},
+				},
+			},
+		}
+		_, _, err := i.registerProviders(context.Background())
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Previously pulumi would not take into account base provider or set
paramaterization information in the ProperyMap.

This adds these both in so the correct provider is chosen and configured
for imports.
