### PR TITLE
upgrade go toolchain to 1.22

### DIFF
--- a/.github/workflows/cron-direct-build.yml
+++ b/.github/workflows/cron-direct-build.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Build
         shell: bash
         run: GOPROXY=direct make build
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Build
         shell: bash
         run: |

--- a/changelog/pending/20250117--cli--update-go-mod-to-require-go1-22.yaml
+++ b/changelog/pending/20250117--cli--update-go-mod-to-require-go1-22.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Update go.mod to require go1.22

--- a/cmd/pulumi-test-language/go.mod
+++ b/cmd/pulumi-test-language/go.mod
@@ -2,8 +2,6 @@ module github.com/pulumi/pulumi/cmd/pulumi-test-language
 
 go 1.22
 
-toolchain go1.22.1
-
 replace github.com/pulumi/pulumi/sdk/v3 => ../../sdk
 
 replace github.com/pulumi/pulumi/pkg/v3 => ../../pkg

--- a/cmd/pulumi-test-language/go.mod
+++ b/cmd/pulumi-test-language/go.mod
@@ -1,6 +1,8 @@
 module github.com/pulumi/pulumi/cmd/pulumi-test-language
 
-go 1.21
+go 1.22
+
+toolchain go1.22.1
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../../sdk
 

--- a/developer-docs/go.mod
+++ b/developer-docs/go.mod
@@ -2,8 +2,6 @@ module github.com/pulumi/pulumi/developer-docs
 
 go 1.22
 
-toolchain go1.22.1
-
 replace github.com/pulumi/pulumi/sdk/v3 => ../sdk
 
 require (

--- a/developer-docs/go.mod
+++ b/developer-docs/go.mod
@@ -1,6 +1,8 @@
 module github.com/pulumi/pulumi/developer-docs
 
-go 1.21
+go 1.22
+
+toolchain go1.22.1
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../sdk
 

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/pkg/v3
 
-go 1.21
+go 1.22
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../sdk
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/sdk/v3
 
-go 1.21
+go 1.22
 
 replace golang.org/x/text => golang.org/x/text v0.3.8
 

--- a/sdk/go/pulumi-language-go/go.mod
+++ b/sdk/go/pulumi-language-go/go.mod
@@ -1,6 +1,8 @@
 module github.com/pulumi/pulumi/sdk/go/pulumi-language-go/v3
 
-go 1.21
+go 1.22
+
+toolchain go1.22.1
 
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/sdk/go/pulumi-language-go/go.mod
+++ b/sdk/go/pulumi-language-go/go.mod
@@ -2,8 +2,6 @@ module github.com/pulumi/pulumi/sdk/go/pulumi-language-go/v3
 
 go 1.22
 
-toolchain go1.22.1
-
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e
 	github.com/pulumi/pulumi/pkg/v3 => ../../../pkg

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
@@ -1,6 +1,8 @@
 module github.com/pulumi/pulumi/sdk/nodejs/cmd/pulumi-language-nodejs/v3
 
-go 1.21
+go 1.22
+
+toolchain go1.22.1
 
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
@@ -2,8 +2,6 @@ module github.com/pulumi/pulumi/sdk/nodejs/cmd/pulumi-language-nodejs/v3
 
 go 1.22
 
-toolchain go1.22.1
-
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e
 	github.com/pulumi/pulumi/pkg/v3 => ../../../../pkg

--- a/sdk/python/cmd/pulumi-language-python/go.mod
+++ b/sdk/python/cmd/pulumi-language-python/go.mod
@@ -1,6 +1,8 @@
 module github.com/pulumi/pulumi/sdk/python/cmd/pulumi-language-python/v3
 
-go 1.21
+go 1.22
+
+toolchain go1.22.1
 
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/sdk/python/cmd/pulumi-language-python/go.mod
+++ b/sdk/python/cmd/pulumi-language-python/go.mod
@@ -2,8 +2,6 @@ module github.com/pulumi/pulumi/sdk/python/cmd/pulumi-language-python/v3
 
 go 1.22
 
-toolchain go1.22.1
-
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e
 	github.com/pulumi/pulumi/pkg/v3 => ../../../../pkg

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -2,8 +2,6 @@ module github.com/pulumi/pulumi/tests
 
 go 1.22
 
-toolchain go1.22.1
-
 replace (
 	github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.5.0
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,8 @@
 module github.com/pulumi/pulumi/tests
 
-go 1.21
+go 1.22
+
+toolchain go1.22.1
 
 replace (
 	github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.5.0

--- a/tests/integration/construct_component_configure_provider/testcomponent-go/go.mod
+++ b/tests/integration/construct_component_configure_provider/testcomponent-go/go.mod
@@ -1,6 +1,8 @@
 module github.com/pulumi/pulumi/tests/integration/construct_component_configure_provider/testcomponent-go
 
-go 1.21
+go 1.22
+
+toolchain go1.22.1
 
 require (
 	github.com/blang/semver v3.5.1+incompatible

--- a/tests/integration/construct_component_configure_provider/testcomponent-go/go.mod
+++ b/tests/integration/construct_component_configure_provider/testcomponent-go/go.mod
@@ -2,8 +2,6 @@ module github.com/pulumi/pulumi/tests/integration/construct_component_configure_
 
 go 1.22
 
-toolchain go1.22.1
-
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/pulumi/pulumi-tls/sdk/v4 v4.10.0

--- a/tests/integration/construct_component_provider_propagation/go/go.mod
+++ b/tests/integration/construct_component_provider_propagation/go/go.mod
@@ -2,8 +2,6 @@ module github.com/pulumi/pulumi/tests/construct_component_provider_propagation
 
 go 1.22
 
-toolchain go1.22.1
-
 replace github.com/pulumi/pulumi/sdk/v3 => ../../../../sdk
 
 require github.com/pulumi/pulumi/sdk/v3 v3.98.0

--- a/tests/integration/construct_component_provider_propagation/go/go.mod
+++ b/tests/integration/construct_component_provider_propagation/go/go.mod
@@ -1,6 +1,8 @@
 module github.com/pulumi/pulumi/tests/construct_component_provider_propagation
 
-go 1.21
+go 1.22
+
+toolchain go1.22.1
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../../../../sdk
 

--- a/tests/integration/construct_component_resource_options/go/go.mod
+++ b/tests/integration/construct_component_resource_options/go/go.mod
@@ -1,6 +1,8 @@
 module github.com/pulumi/pulumi/tests/construct_component_resource_options
 
-go 1.21
+go 1.22
+
+toolchain go1.22.1
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../../../../sdk
 

--- a/tests/integration/construct_component_resource_options/go/go.mod
+++ b/tests/integration/construct_component_resource_options/go/go.mod
@@ -2,8 +2,6 @@ module github.com/pulumi/pulumi/tests/construct_component_resource_options
 
 go 1.22
 
-toolchain go1.22.1
-
 replace github.com/pulumi/pulumi/sdk/v3 => ../../../../sdk
 
 replace github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/tests/integration/construct_nested_component/go/go.mod
+++ b/tests/integration/construct_nested_component/go/go.mod
@@ -2,8 +2,6 @@ module github.com/pulumi/pulumi/tests/construct_nested_component
 
 go 1.22
 
-toolchain go1.22.1
-
 require github.com/pulumi/pulumi/sdk/v3 v3.98.0
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../../../../sdk

--- a/tests/integration/construct_nested_component/go/go.mod
+++ b/tests/integration/construct_nested_component/go/go.mod
@@ -1,6 +1,8 @@
 module github.com/pulumi/pulumi/tests/construct_nested_component
 
-go 1.21
+go 1.22
+
+toolchain go1.22.1
 
 require github.com/pulumi/pulumi/sdk/v3 v3.98.0
 


### PR DESCRIPTION
We officially support the two latest releases of Go.  In https://github.com/pulumi/pulumi/pull/17827, we started using tar.AddFS, which was introduced in Go 1.22.  Since Go 1.23 is already out, we can drop support for Go 1.21, and reflect that in our go.mod files.

Fixes https://github.com/pulumi/pulumi/issues/18273