### PR TITLE
Fix handling of DependencyResource when checking invoke deps

### DIFF
--- a/changelog/pending/20250117--sdk-nodejs-python--fix-handling-of-dependencyresource-when-checking-invoke-deps.yaml
+++ b/changelog/pending/20250117--sdk-nodejs-python--fix-handling-of-dependencyresource-when-checking-invoke-deps.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs,python
+  description: Fix handling of DependencyResource when checking invoke deps

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -266,7 +266,8 @@ async function invokeAsync(
         const expandedDeps = await getAllTransitivelyReferencedResources(resourcesToWaitFor, new Set());
         // Ensure that all resource IDs are known before proceeding.
         for (const dep of expandedDeps.values()) {
-            if (CustomResource.isInstance(dep)) {
+            // DependencyResources inherit from CustomResource, but they don't set the id. Skip them.
+            if (CustomResource.isInstance(dep) && dep.id) {
                 const known = await dep.id.isKnown;
                 if (!known) {
                     return {

--- a/sdk/nodejs/tests/runtime/langhost/cases/077.invoke_output_depends_on_unknown_component/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/077.invoke_output_depends_on_unknown_component/index.js
@@ -17,6 +17,7 @@ class MyComponent extends pulumi.ComponentResource {
 }
 
 const comp = new MyComponent("comp");
-const dependsOn = [comp];
+const remote = new pulumi.DependencyResource("some:urn");
+const dependsOn = [remote, comp];
 
 pulumi.runtime.invokeOutput("test:index:echo", {}, { dependsOn });

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -257,7 +257,9 @@ def _invoke(
         expanded_deps = await rpc._expand_dependencies(resources_to_wait_for, None)
         # Ensure that all resource IDs are known before proceeding.
         for res in expanded_deps.values():
-            if isinstance(res, CustomResource):
+            # DependencyResources inherit from CustomResource, but they don't
+            # set the id. Skip them.
+            if isinstance(res, CustomResource) and res.__dict__.get("id", None):
                 if not await res.id.is_known():
                     return (
                         InvokeResult(None, is_secret=False, is_known=False),


### PR DESCRIPTION
In Python and Node.js, the DependencyResource class inherits from CustomResource, however the `id` is not set for these. Guard against this when validating an invoke’s dependencies.
