### PR TITLE
Allow resource annotations to be publicly queried

### DIFF
--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -365,7 +365,7 @@ func (b *binder) bindResourceTypes(node *Resource) hcl.Diagnostics {
 	}
 	outputType := model.NewObjectType(
 		outputProperties,
-		&resourceAnnotation{node},
+		&ResourceAnnotation{node},
 		&schema.ObjectType{Properties: properties},
 	)
 
@@ -386,10 +386,10 @@ func (b *binder) bindResourceTypes(node *Resource) hcl.Diagnostics {
 	return diagnostics
 }
 
-// resourceAnnotation is a type that can be used to annotate ObjectTypes that represent resources with their
+// ResourceAnnotation is a type that can be used to annotate ObjectTypes that represent resources with their
 // corresponding Resource node. We define a wrapper type that does not implement any interfaces so as to reduce the
 // chance of the annotation being plucked out by an interface-type query by accident.
-type resourceAnnotation struct {
+type ResourceAnnotation struct {
 	node *Resource
 }
 

--- a/pkg/codegen/pcl/call.go
+++ b/pkg/codegen/pcl/call.go
@@ -57,7 +57,7 @@ func (b *binder) bindCallSignature(args []model.Expression) (model.StaticFunctio
 	self := args[0]
 	var selfRes *Resource
 	if objectType, ok := self.Type().(*model.ObjectType); ok {
-		if annotation, ok := model.GetObjectTypeAnnotation[*resourceAnnotation](objectType); ok {
+		if annotation, ok := model.GetObjectTypeAnnotation[*ResourceAnnotation](objectType); ok {
 			selfRes = annotation.node
 		}
 	}


### PR DESCRIPTION
In #18206 we introduced the `call` intrinsic to PCL. As part of making this work, we improved the annotating of PCL expressions with their schema resource types, allowing us to e.g. type-check `call` expressions by traversing the schema attached to a receiver expression. The type we introduced to support these annotations, `resourceAnnotation`, was initially made private, since it was only used within the package. However, in now trying to add `call` to e.g. Java, it's become apparent that it would be valuable to access the annotation from other packages. This change thus makes it public.

The other option here is to always wrap the receiver ("self") in a `__convert` that binds its schema type, but since the annotation is already attached this seems simpler and a bit cleaner. In the long term, we'd ideally tweak how we do code generation so that schema types are readily available throughout the various generation method calls, but right now this isn't currently the case.