### PR TITLE
[engine/refresh] Skip acquiring program packages during refresh when running inline automation programs

### DIFF
--- a/changelog/pending/20250117--engine--skip-acquiring-program-packages-during-refresh-when-running-inline-automation-programs.yaml
+++ b/changelog/pending/20250117--engine--skip-acquiring-program-packages-during-refresh-when-running-inline-automation-programs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Skip acquiring program packages during refresh when running inline automation programs

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -288,6 +288,7 @@ func NewRefreshCmd() *cobra.Command {
 				DisableOutputValues:       env.DisableOutputValues.Value(),
 				Targets:                   deploy.NewUrnTargets(targetUrns),
 				Experimental:              env.Experimental.Value(),
+				ExecKind:                  execKind,
 			}
 
 			changes, err := s.Refresh(ctx, backend.UpdateOperation{

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -252,6 +252,7 @@ func gatherPackagesFromProgram(plugctx *plugin.Context, runtime string, info plu
 		return nil, fmt.Errorf("failed to load language plugin %s: %w", runtime, err)
 	}
 
+	defer lang.Close()
 	pkgs, err := lang.GetRequiredPackages(info)
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover package requirements: %w", err)

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -252,7 +252,6 @@ func gatherPackagesFromProgram(plugctx *plugin.Context, runtime string, info plu
 		return nil, fmt.Errorf("failed to load language plugin %s: %w", runtime, err)
 	}
 
-	defer lang.Close()
 	pkgs, err := lang.GetRequiredPackages(info)
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover package requirements: %w", err)

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/constant"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -82,7 +83,7 @@ func newRefreshSource(
 	// we'll populate an empty set of program plugins.
 
 	var programPackages PackageSet
-	if plugctx.Root != "" {
+	if plugctx.Root != "" && opts.ExecKind != constant.ExecKindAutoInline {
 		runtime := proj.Runtime.Name()
 		programInfo := plugin.NewProgramInfo(
 			/* rootDirectory */ plugctx.Root,

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -178,6 +178,9 @@ type UpdateOptions struct {
 
 	// Autonamer can resolve user's preference for custom autonaming options for a given resource.
 	Autonamer autonaming.Autonamer
+
+	// The execution kind of the operation.
+	ExecKind string
 }
 
 // HasChanges returns true if there are any non-same changes in the resulting summary.


### PR DESCRIPTION
### Description

When https://github.com/pulumi/pulumi/pull/12196 was added to Pulumi CLI v3.143.0+ it made it such that when performing a `refresh`, the CLI would gather the dependencies of the program, compare them against the dependencies from the state/snapshot and warn if there are mismatches. To gather the dependencies of the program, the CLI would spin up a language plugin and call `GetRequiredPackages()` to get the set of dependencies. This usually works fine, however the PR does not account for _inline_ automation API programs where the language host isn't usually involved or needed to begin with.

This I believe is the root cause of https://github.com/pulumi/pulumi-dotnet/issues/443: a user that runs their standalone dotnet binaries with inline programs (in an environment without `dotnet` in the PATH) now sees errors reported by the dotnet language host that the `dotnet` executable is missing whereas previously it wasn't needed. 

Furthermore, although the "missing `dotnet`" errors are benign and don't cause refresh to fail or stop executing, the issue suggested that the language host plugin isn't gracefully shutting down, causing a panic (see issue details).

This PR attempts to address the issue by:
 - Skipping the gathering of program dependencies when we are running an inline automation program 
 - ~Calling `defer lang.Close()` on the language host when acquiring the program dependencies for a graceful shutdown~
