### PR TITLE
allow setting the type of the config value in pulumi config set

### DIFF
--- a/changelog/pending/20250122--cli-config--introduce-type-flag-for-config-set.yaml
+++ b/changelog/pending/20250122--cli-config--introduce-type-flag-for-config-set.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/config
+  description: Introduce `--type` flag for `config set`

--- a/pkg/cmd/pulumi/config/config_test.go
+++ b/pkg/cmd/pulumi/config/config_test.go
@@ -91,3 +91,109 @@ func TestConfigSet(t *testing.T) {
 		})
 	}
 }
+
+//nolint:paralleltest // changes global ConfigFile variable
+func TestConfigSetTypes(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name     string
+		args     []string
+		expected string
+		typ      string
+		path     bool
+	}{
+		{
+			name:     "toplevel bool",
+			args:     []string{"testProject:test", "true"},
+			typ:      "bool",
+			expected: "config:\n  testProject:test: true\n",
+		},
+		{
+			name:     "toplevel int",
+			args:     []string{"testProject:test", "123"},
+			typ:      "int",
+			expected: "config:\n  testProject:test: 123\n",
+		},
+		{
+			name:     "toplevel float",
+			args:     []string{"testProject:test", "123.456"},
+			typ:      "float",
+			expected: "config:\n  testProject:test: 123.456\n",
+		},
+		{
+			name:     "toplevel string",
+			args:     []string{"testProject:test", "123"},
+			typ:      "string",
+			expected: "config:\n  testProject:test: \"123\"\n",
+		},
+		{
+			name:     "path'd bool",
+			args:     []string{"testProject:test[0]", "true"},
+			typ:      "bool",
+			expected: "config:\n  testProject:test:\n    - true\n",
+			path:     true,
+		},
+		{
+			name:     "path'd int",
+			args:     []string{"testProject:test[0]", "123"},
+			typ:      "int",
+			expected: "config:\n  testProject:test:\n    - 123\n",
+			path:     true,
+		},
+		{
+			name:     "path'd float",
+			args:     []string{"testProject:test[0]", "123.456"},
+			typ:      "float",
+			expected: "config:\n  testProject:test:\n    - 123.456\n",
+			path:     true,
+		},
+		{
+			name:     "path'd string",
+			args:     []string{"testProject:test[0]", "123"},
+			typ:      "string",
+			expected: "config:\n  testProject:test:\n    - \"123\"\n",
+			path:     true,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run("", func(t *testing.T) {
+			project := workspace.Project{
+				Name: "testProject",
+			}
+
+			s := backend.MockStack{
+				RefF: func() backend.StackReference {
+					return &backend.MockStackReference{
+						NameV: tokens.MustParseStackName("testStack"),
+					}
+				},
+			}
+
+			configSetCmd := &configSetCmd{
+				Path: c.path,
+				Type: c.typ,
+				LoadProjectStack: func(project *workspace.Project, _ backend.Stack) (*workspace.ProjectStack, error) {
+					return workspace.LoadProjectStackBytes(project, []byte{}, "Pulumi.stack.yaml", encoding.YAML)
+				},
+			}
+
+			tmpdir := t.TempDir()
+			stack.ConfigFile = filepath.Join(tmpdir, "Pulumi.stack.yaml")
+			defer func() {
+				stack.ConfigFile = ""
+			}()
+
+			err := configSetCmd.Run(ctx, c.args, &project, &s)
+			require.NoError(t, err)
+
+			// verify the config was set
+			data, err := os.ReadFile(stack.ConfigFile)
+			require.NoError(t, err)
+
+			require.Equal(t, c.expected, string(data))
+		})
+	}
+}

--- a/pkg/cmd/pulumi/config/config_test.go
+++ b/pkg/cmd/pulumi/config/config_test.go
@@ -39,15 +39,36 @@ func TestConfigSet(t *testing.T) {
 		path     bool
 	}{
 		{
+			name:     "toplevel bool",
+			args:     []string{"testProject:test", "true"},
+			expected: "config:\n  testProject:test: \"true\"\n",
+		},
+		{
 			name:     "toplevel int",
 			args:     []string{"testProject:test", "123"},
 			expected: "config:\n  testProject:test: \"123\"\n",
-			path:     false,
+		},
+		{
+			name:     "toplevel float",
+			args:     []string{"testProject:test", "123.456"},
+			expected: "config:\n  testProject:test: \"123.456\"\n",
+		},
+		{
+			name:     "path'd bool",
+			args:     []string{"testProject:test[0]", "true"},
+			expected: "config:\n  testProject:test:\n    - true\n",
+			path:     true,
 		},
 		{
 			name:     "path'd int",
 			args:     []string{"testProject:test[0]", "123"},
 			expected: "config:\n  testProject:test:\n    - 123\n",
+			path:     true,
+		},
+		{
+			name:     "path'd float",
+			args:     []string{"testProject:test[0]", "123.456"},
+			expected: "config:\n  testProject:test:\n    - \"123.456\"\n",
 			path:     true,
 		},
 	}


### PR DESCRIPTION
Config values in `pulumi config set` are marshalled according to certain rules (everything on the top level is a string), and for paths, true/false becomes a boolean, integers not starting with a 0 become integers and everything else becomes strings.

This leaves floats out, and someone might want to store a number or a bool as a string instead.  Add a `--type` flag to pulumi config set to force the type.  This type also applies to top level config elements.

Fixes https://github.com/pulumi/pulumi/issues/5442