### PR TITLE
Convert PEP440 local version to semver prerelease in setup.py

### DIFF
--- a/changelog/pending/20250122--sdk-python--support-commits-in-prerelease-versions-of-generated-python-sdks.yaml
+++ b/changelog/pending/20250122--sdk-python--support-commits-in-prerelease-versions-of-generated-python-sdks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Support commits in prerelease versions of generated Python SDKs

--- a/pkg/codegen/python/utilities.py
+++ b/pkg/codegen/python/utilities.py
@@ -85,12 +85,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal/pulumi_alpha/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal/pulumi_alpha/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/pulumi_large/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/pulumi_large/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/pulumi_plain/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/pulumi_plain/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/pulumi_secret/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/pulumi_secret/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/pulumi_simple/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/sdks/old-1.0.0/pulumi_old/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/sdks/old-1.0.0/pulumi_old/_utilities.py
@@ -83,12 +83,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal/pulumi_alpha/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal/pulumi_alpha/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/pulumi_large/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/pulumi_large/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/pulumi_plain/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/pulumi_plain/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/pulumi_secret/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/pulumi_secret/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/pulumi_simple/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal/pulumi_alpha/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal/pulumi_alpha/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pulumi_large/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pulumi_large/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pulumi_plain/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pulumi_plain/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pulumi_secret/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pulumi_secret/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pulumi_simple/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/integration/python/parameterized/sdk/python/pulumi_pkg/_utilities.py
+++ b/tests/integration/python/parameterized/sdk/python/pulumi_pkg/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/assets-and-archives/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/assets-and-archives/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/_utilities.py
+++ b/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/config-variables/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/config-variables/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/cyclic-types/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/cyclic-types/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/_utilities.py
+++ b/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/_utilities.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/different-enum/python/pulumi_plant/_utilities.py
+++ b/tests/testdata/codegen/different-enum/python/pulumi_plant/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/_utilities.py
+++ b/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/enum-reference-python/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/enum-reference-python/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/enum-reference/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/enum-reference/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/external-enum/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/external-enum/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/external-resource-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/external-resource-schema/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/functions-secrets/python/pulumi_mypkg/_utilities.py
+++ b/tests/testdata/codegen/functions-secrets/python/pulumi_mypkg/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/_utilities.py
+++ b/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/_utilities.py
+++ b/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/_utilities.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/_utilities.py
+++ b/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/_utilities.py
+++ b/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/_utilities.py
+++ b/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/nested-module/python/pulumi_foo/_utilities.py
+++ b/tests/testdata/codegen/nested-module/python/pulumi_foo/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/_utilities.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/_utilities.py
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/_utilities.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/_utilities.py
+++ b/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/_utilities.py
+++ b/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/_utilities.py
+++ b/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/_utilities.py
+++ b/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/_utilities.py
+++ b/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/_utilities.py
+++ b/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/_utilities.py
+++ b/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/regress-8403/python/pulumi_mongodbatlas/_utilities.py
+++ b/tests/testdata/codegen/regress-8403/python/pulumi_mongodbatlas/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/regress-node-8110/python/pulumi_my8110/_utilities.py
+++ b/tests/testdata/codegen/regress-node-8110/python/pulumi_my8110/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/_utilities.py
+++ b/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/_utilities.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/regress-py-14012/python/pulumi_foo/_utilities.py
+++ b/tests/testdata/codegen/regress-py-14012/python/pulumi_foo/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/_utilities.py
+++ b/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/_utilities.py
+++ b/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/_utilities.py
+++ b/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/resource-args-python/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/resource-args-python/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/secrets/python/pulumi_mypkg/_utilities.py
+++ b/tests/testdata/codegen/secrets/python/pulumi_mypkg/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/_utilities.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/_utilities.py
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/simple-schema-pyproject/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-schema-pyproject/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/unions-inline/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/unions-inline/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/_utilities.py
+++ b/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 

--- a/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/_utilities.py
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/_utilities.py
@@ -89,12 +89,16 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
+        # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"
+    elif pep440_version.local is not None:
+        # PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease,
+        # PypiVersion in /pkg/codegen/python/utilities.go converts it to a local version. Therefore, we need to
+        # do the reverse conversion here and set the local version as the prerelease tag.
+        prerelease = pep440_version.local
 
-    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
-    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
-    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
-    # their own semver string.
     return SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
 
 


### PR DESCRIPTION
PEP440 only allows a small set of prerelease tags, so when converting an arbitrary prerelease, PypiVersion in `/pkg/codegen/python/utilities.go` converts it to a "local" version with a `+` sign. This PR does the reverse conversion and sets the local version as the prerelease tag.

Resolve https://github.com/pulumi/pulumi/issues/18288