### PR TITLE
Avoid unnecessary Node.js installations

### DIFF
--- a/changelog/pending/20250118--sdk-nodejs--avoid-unnecessary-node-js-installations.yaml
+++ b/changelog/pending/20250118--sdk-nodejs--avoid-unnecessary-node-js-installations.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Avoid unnecessary Node.js installations

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
@@ -874,14 +874,19 @@ func TestNodeInstall(t *testing.T) {
 		t.Skip()
 	}
 	tmpDir := t.TempDir()
+	path := os.Getenv("PATH")
+
+	// Set path to *only* $TMPDIR/bin so that no `fnm` executable can not be found
+	// until after we write our mock.
 	t.Setenv("PATH", filepath.Join(tmpDir, "bin"))
 
-	fmt.Println(os.Getenv("PATH"))
-
-	// There's no fnm executable in PATH, installNodeVersion is a no-op
+	// There's no fnm executable in PATH, installNodeVersion returns an error
 	stdout := &bytes.Buffer{}
 	err := installNodeVersion(tmpDir, stdout)
 	require.ErrorIs(t, err, errFnmNotFound)
+
+	// Restore the original PATH and prepend $TMPDIR/bin to it.
+	t.Setenv("PATH", filepath.Join(tmpDir, "bin")+":"+path)
 
 	// Add a mock fnm executable to $tmp/bin. For each execution, the mock fnm executable will
 	// append a line with its arguments to a file. We read back the file to verify that it was
@@ -899,15 +904,30 @@ func TestNodeInstall(t *testing.T) {
 	require.Error(t, err, errVersionFileNotFound)
 
 	// Create a .node-version file
-	// The mock fnm executable should be called with a command to install the requested version,
-	// and a command to set the default version to this version.
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".node-version"), []byte("20.1.2"), 0o600))
+
+	t.Setenv("FNM_MULTISHELL_PATH", "")
 	stdout = &bytes.Buffer{}
 	err = installNodeVersion(tmpDir, stdout)
 	require.NoError(t, err)
 	b, err := os.ReadFile(outPath)
 	require.NoError(t, err)
 	commands := strings.Split(strings.TrimSpace(string(b)), "\n")
-	require.Equal(t, "install 20.1.2 --progress never", commands[0])
+	require.Equal(t, "env --shell bash", commands[0])
+	require.Equal(t, "use 20.1.2 --install-if-missing", commands[1])
+	require.Equal(t, "alias 20.1.2 default", commands[2])
+
+	// "activate" fnm shell integration
+	t.Setenv("FNM_MULTISHELL_PATH", tmpDir)
+	// Remove `outPath` before the next test
+	require.NoError(t, os.Remove(outPath))
+	stdout = &bytes.Buffer{}
+	err = installNodeVersion(tmpDir, stdout)
+	require.NoError(t, err)
+	b, err = os.ReadFile(outPath)
+	fmt.Printf("outPath: %s\n", string(b))
+	require.NoError(t, err)
+	commands = strings.Split(strings.TrimSpace(string(b)), "\n")
+	require.Equal(t, "use 20.1.2 --install-if-missing", commands[0])
 	require.Equal(t, "alias 20.1.2 default", commands[1])
 }

--- a/sdk/python/toolchain/toolchain_test.go
+++ b/sdk/python/toolchain/toolchain_test.go
@@ -197,7 +197,7 @@ func TestListPackages(t *testing.T) {
 			// packages, so we have to exclude pip here.
 			var expectedPackages []string
 			for _, pkg := range append([]string{"pulumi_random"}, test.expectedPackages...) {
-				if pkg != "pip" || opts.Toolchain == Poetry {
+				if pkg != "pip" {
 					expectedPackages = append(expectedPackages, pkg)
 				}
 			}
@@ -229,7 +229,7 @@ func TestListPackages(t *testing.T) {
 			// packages, so we have to exclude pip here.
 			var expectedPackages []string
 			for _, pkg := range append([]string{"pulumi_random"}, test.expectedPackages...) {
-				if pkg != "pip" || opts.Toolchain == Poetry {
+				if pkg != "pip" {
 					expectedPackages = append(expectedPackages, pkg)
 				}
 			}
@@ -397,7 +397,7 @@ func writePyprojectForUv(t *testing.T, root string) {
 [project]
 name = "list-packages-test"
 version = "0.0.1"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = []
 `)
 	err = f.Close()
@@ -424,7 +424,7 @@ package-mode = false
 packages = [{include = "test_pulumi_venv"}]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 `)
 	err = f.Close()
 	require.NoError(t, err)


### PR DESCRIPTION
When running `pulumi install --use-language-version-tools`, and `fnm` is installed on the system, we will automatically install the Node.js version specified in `.nvmrc` or `.node-version`.

When the file does not specify the full version, for example `22`, we would always install the latest release of Node.js 22, even if another point release of Node.js 22 is already present on the system. This is unnecessary, and we should use the available version.

This mostly affects Pulumi Deployments, where this installation flag is used by default. Whenever we release a new version of Pulumi, we also release new versions of the docker containers. These containers include the latest version of Node.js (22, and other versions) at the time of release, so the pre-installed version is usually very recent. However if a new Node.js version is released after our release, deployments that specify a Node.js version will always install that, until we update the containers with the next Pulumi release.

By using `fnm use ${VERSION} --install-if-missing` instead, we prefer pre-installed versions, and only install new Node.js versions, if the request version can not be satisfied by any of the pre-installed versions.

https://github.com/pulumi/pulumi/pull/18041 was a previous attempt to fix this, but it did not properly handle the fnm shell integration and had to be reverted.

Ref https://github.com/pulumi/customer-support/issues/1863