### PR TITLE
Attempt to resolve the PULUMI_NODEJS_TSCONFIG_PATH, if defined.

### DIFF
--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -251,7 +251,7 @@ export async function run(
     // if there's a tsconfig.json file here. Otherwise, just tell ts-node to not load project options at all.
     // This helps with cases like pulumi/pulumi#1772.
     const defaultTsConfigPath = "tsconfig.json";
-    const tsConfigPath: string = process.env["PULUMI_NODEJS_TSCONFIG_PATH"] ?? defaultTsConfigPath;
+    const tsConfigPath: string = process.env["PULUMI_NODEJS_TSCONFIG_PATH"] ? path.resolve(process.env["PULUMI_NODEJS_TSCONFIG_PATH"]) : defaultTsConfigPath;
     const skipProject = !fs.existsSync(tsConfigPath);
 
     span.setAttribute("typescript-enabled", typeScript);


### PR DESCRIPTION
This spares us from having to define absolute paths in the environment variables, which can lead to non-portable scripts -- for example, when deploying from local vs. CI/CD.
