### PR TITLE
Preview conformance tests

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -110,7 +110,7 @@ GO_TEST_SHUFFLE         ?= off  # -shuffle flag, randomizes order of tests withi
 GO_TEST_TAGS            ?= all
 GO_TEST_RACE            ?= true
 
-GO_TEST_FLAGS = -count=1 -cover -tags="${GO_TEST_TAGS}" -timeout 90m \
+GO_TEST_FLAGS = -count=1 -cover -tags="${GO_TEST_TAGS}" -timeout 1h \
 	-parallel=${GO_TEST_PARALLELISM} \
 	-shuffle=${GO_TEST_SHUFFLE} \
 	-p=${GO_TEST_PKG_PARALLELISM} \

--- a/build/common.mk
+++ b/build/common.mk
@@ -110,7 +110,7 @@ GO_TEST_SHUFFLE         ?= off  # -shuffle flag, randomizes order of tests withi
 GO_TEST_TAGS            ?= all
 GO_TEST_RACE            ?= true
 
-GO_TEST_FLAGS = -count=1 -cover -tags="${GO_TEST_TAGS}" -timeout 1h \
+GO_TEST_FLAGS = -count=1 -cover -tags="${GO_TEST_TAGS}" -timeout 90m \
 	-parallel=${GO_TEST_PARALLELISM} \
 	-shuffle=${GO_TEST_SHUFFLE} \
 	-p=${GO_TEST_PKG_PARALLELISM} \

--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -1077,7 +1077,7 @@ func (eng *languageTestServer) RunLanguageTest(
 
 		assertPreview := run.AssertPreview
 		if assertPreview == nil {
-			// if no assertPreview is provided for the test run, we creat a default implementation
+			// if no assertPreview is provided for the test run, we create a default implementation
 			// where we simply assert that the preview changes did not error
 			assertPreview = func(l *tests.L, proj string, err error, p *deploy.Plan, changes display.ResourceChanges) {
 				assert.NoErrorf(l, err, "expected no error in preview")

--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -52,6 +52,7 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	testingrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/testing"
 	"github.com/segmentio/encoding/json"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -1078,9 +1079,8 @@ func (eng *languageTestServer) RunLanguageTest(
 		if assertPreview == nil {
 			// if no assertPreview is provided for the test run, we creat a default implementation
 			// where we simply assert that the preview changes did not error
-			// and that there is a stack resource to be created in the changes
 			assertPreview = func(l *tests.L, proj string, err error, p *deploy.Plan, changes display.ResourceChanges) {
-				tests.AssertStackResource(l, err, changes)
+				assert.NoErrorf(l, err, "expected no error in preview")
 			}
 		}
 

--- a/cmd/pulumi-test-language/l2_destroy_test.go
+++ b/cmd/pulumi-test-language/l2_destroy_test.go
@@ -239,7 +239,9 @@ func (h *L2DestroyLanguageHost) Run(
 		}
 	}
 
-	h.currentRun++
+	if !req.DryRun {
+		h.currentRun++
+	}
 
 	return &pulumirpc.RunResponse{}, nil
 }

--- a/cmd/pulumi-test-language/providers/simple_invoke_provider.go
+++ b/cmd/pulumi-test-language/providers/simple_invoke_provider.go
@@ -211,6 +211,17 @@ func (p *SimpleInvokeProvider) Invoke(
 				Failures: makeCheckFailure("value", "missing value"),
 			}, nil
 		}
+
+		if value.IsComputed() {
+			return plugin.InvokeResponse{
+				Properties: resource.PropertyMap{
+					"result": resource.NewComputedProperty(resource.Computed{
+						Element: resource.NewNullProperty(),
+					}),
+				},
+			}, nil
+		}
+
 		if !value.IsString() {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("value", "is not a string"),
@@ -241,6 +252,20 @@ func (p *SimpleInvokeProvider) Invoke(
 				Failures: makeCheckFailure("value", "missing value"),
 			}, nil
 		}
+
+		if value.IsComputed() {
+			return plugin.InvokeResponse{
+				Properties: resource.PropertyMap{
+					"response": resource.NewComputedProperty(resource.Computed{
+						Element: resource.NewNullProperty(),
+					}),
+					"secret": resource.NewComputedProperty(resource.Computed{
+						Element: resource.NewNullProperty(),
+					}),
+				},
+			}, nil
+		}
+
 		if !value.IsString() {
 			reason := fmt.Sprintf("value is not a string: %v", value)
 			return plugin.InvokeResponse{

--- a/cmd/pulumi-test-language/providers/simple_invoke_provider.go
+++ b/cmd/pulumi-test-language/providers/simple_invoke_provider.go
@@ -214,11 +214,10 @@ func (p *SimpleInvokeProvider) Invoke(
 
 		if value.IsComputed() {
 			return plugin.InvokeResponse{
-				Properties: resource.PropertyMap{
-					"result": resource.NewComputedProperty(resource.Computed{
-						Element: resource.NewNullProperty(),
-					}),
-				},
+				// providers should not get computed values (during preview)
+				// since we bail out early in the core SDKs or generated provider SDKs
+				// when we encounter unknowns
+				Failures: makeCheckFailure("value", "value is unknown when calling myInvoke"),
 			}, nil
 		}
 
@@ -255,14 +254,7 @@ func (p *SimpleInvokeProvider) Invoke(
 
 		if value.IsComputed() {
 			return plugin.InvokeResponse{
-				Properties: resource.PropertyMap{
-					"response": resource.NewComputedProperty(resource.Computed{
-						Element: resource.NewNullProperty(),
-					}),
-					"secret": resource.NewComputedProperty(resource.Computed{
-						Element: resource.NewNullProperty(),
-					}),
-				},
+				Failures: makeCheckFailure("value", "value is unknown when calling secretInvoke"),
 			}, nil
 		}
 

--- a/cmd/pulumi-test-language/providers/simple_provider.go
+++ b/cmd/pulumi-test-language/providers/simple_provider.go
@@ -134,7 +134,7 @@ func (p *SimpleProvider) Check(
 			Failures: makeCheckFailure("value", "missing value"),
 		}, nil
 	}
-	if !value.IsBool() {
+	if !value.IsBool() && !value.IsComputed() {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("value", "value is not a boolean"),
 		}, nil

--- a/cmd/pulumi-test-language/tests/l2_failed_create_continue_on_error.go
+++ b/cmd/pulumi-test-language/tests/l2_failed_create_continue_on_error.go
@@ -34,6 +34,12 @@ func init() {
 				UpdateOptions: engine.UpdateOptions{
 					ContinueOnError: true,
 				},
+				AssertPreview: func(l *L,
+					projectDirectory string, err error,
+					plan *deploy.Plan, changes display.ResourceChanges,
+				) {
+					require.True(l, result.IsBail(err), "expected a bail result on preview")
+				},
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,

--- a/cmd/pulumi-test-language/tests/types.go
+++ b/cmd/pulumi-test-language/tests/types.go
@@ -235,6 +235,8 @@ type TestRun struct {
 	Main string
 	// TODO: This should just return "string", if == "" then ok, else fail
 	Assert func(*L, string, error, *deploy.Snapshot, display.ResourceChanges)
+	// Assert resource changes during preview runs.
+	AssertPreview func(*L, string, error, *deploy.Plan, display.ResourceChanges)
 	// updateOptions can be used to set the update options for the engine.
 	UpdateOptions engine.UpdateOptions
 }


### PR DESCRIPTION
### Description 

This PR adds a preview step to every conformance test with the ability to assert certain aspects of the resource changes and the generated plan via an `AssertPreview` function. When the tests do not specify an `AssertPreview` function, we give a default implementation that simply checks whether the preview is successful. 

The PR makes slight changes to a couple conformance provider implementations such that they don't hard fail when encountering unknown values (during preview)

Fixes #18296