### PR TITLE
Allow resource annotations to be publicly queried, for real

### DIFF
--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -390,7 +390,7 @@ func (b *binder) bindResourceTypes(node *Resource) hcl.Diagnostics {
 // corresponding Resource node. We define a wrapper type that does not implement any interfaces so as to reduce the
 // chance of the annotation being plucked out by an interface-type query by accident.
 type ResourceAnnotation struct {
-	node *Resource
+	Node *Resource
 }
 
 type resourceScopes struct {

--- a/pkg/codegen/pcl/call.go
+++ b/pkg/codegen/pcl/call.go
@@ -58,7 +58,7 @@ func (b *binder) bindCallSignature(args []model.Expression) (model.StaticFunctio
 	var selfRes *Resource
 	if objectType, ok := self.Type().(*model.ObjectType); ok {
 		if annotation, ok := model.GetObjectTypeAnnotation[*ResourceAnnotation](objectType); ok {
-			selfRes = annotation.node
+			selfRes = annotation.Node
 		}
 	}
 


### PR DESCRIPTION
This is a follow-up to #18276, in which we made the `ResourceAnnotation` type public, but forgot to also make its `node` field public at the same time. Doing this should actually make the type usefully accessible to other packages, so that we can proceed with e.g. implementing `Call` in Java as intended.