### PR TITLE
Add some skeletal documentation on the built-in provider

### DIFF
--- a/docs/architecture/providers/README.md
+++ b/docs/architecture/providers/README.md
@@ -69,6 +69,7 @@ their implementation:
 :maxdepth: 1
 :titlesonly:
 
+/docs/architecture/providers/built-in
 /docs/architecture/providers/default
 /docs/architecture/providers/components
 /docs/architecture/providers/dynamic

--- a/docs/architecture/providers/built-in.md
+++ b/docs/architecture/providers/built-in.md
@@ -1,0 +1,12 @@
+(built-in-provider)=
+# The built-in provider
+
+The built-in provider is a special provider that is always available to Pulumi
+programs (see [](gh-file:pulumi#pkg/resource/deploy/builtins.go) for its
+definition and [](gh-file:pulumi#pkg/resource/deploy/deployment.go#L489) for its
+injection into deployments as part of the provider registry). It is used to
+manage resources and functionality that are core to the Pulumi programming
+model, such as [stack
+references](https://www.pulumi.com/tutorials/building-with-pulumi/stack-references/)
+and rehydrating [resource references](res-refs). It exposes the `pulumi` package
+and provider instances thus belong to the package `pulumi:providers:pulumi`.

--- a/docs/architecture/types/README.md
+++ b/docs/architecture/types/README.md
@@ -471,16 +471,19 @@ to lose information:
 A `ResourceReference` represents a reference to a [resource](resource). Resource
 references most commonly appear in the context of [component
 providers](component-providers), where it is often useful for a component to be
-able to return references to its child components in its outputs. Moreover, it
-is useful to be able to rehydrate these references into bonafide strongly-typed
-resources upon deserialization. To this end, a resource reference contains both
-a [URN](urns) and, in the case that the resource is not a
-[component](component-resources), an [ID](resource-ids) and the version of the
-[provider](providers) that manages the resource. While in principle a URN is
-sufficient for the purposes of uniquely identifying a resource, including the ID
-and provider version means that the engine does not have to query state to enact
-several common operations, such as passing an ID to a downstream SDK or provider
-that does not understand full resource references. The provider version in
-particular allows deserialization to ensure that the correct version of the
-relevant SDK is used to rehydrate the referenced resource; this is necessary as
-resource shapes may change between SDK versions.
+able to accept references to other resources, or to return references to its
+child components in its outputs. In order to support the rehydration of these
+references into bonafide strongly-typed resources upon deserialization, a
+resource reference contains both a [URN](urns) and, in the case that the
+resource is not a [component](component-resources), an [ID](resource-ids) and
+the version of the [provider](providers) that manages the resource. While in
+principle a URN is sufficient for the purposes of uniquely identifying a
+resource, including the ID and provider version means that the engine does not
+have to query state to enact several common operations, such as passing an ID to
+a downstream SDK or provider that does not understand full resource references.
+The provider version in particular allows deserialization to ensure that the
+correct version of the relevant SDK is used to rehydrate the referenced
+resource; this is necessary as resource shapes may change between SDK versions.
+
+Resource references are hydrated using the [built-in
+provider](built-in-provider)'s `getResource` invoke.


### PR DESCRIPTION
As part of the recently added conformance tests for testing components, we now have better coverage (and a better understanding of) resource references and their hydration, which is handled by the built-in provider. This small change makes a start at writing some of this down, adding a section for the built-in provider and adjusting the documentation we have on resource references to reference it.