### PR TITLE
Permit output arguments in plain invokes for backwards compatibility

### DIFF
--- a/changelog/pending/20250121--sdk-nodejs-python--permit-output-arguments-in-plain-invokes-for-backwards-compatibility.yaml
+++ b/changelog/pending/20250121--sdk-nodejs-python--permit-output-arguments-in-plain-invokes-for-backwards-compatibility.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs,python
+  description: Permit output arguments in plain invokes for backwards compatibility

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -108,7 +108,7 @@ export function invokeOutput<T>(
     packageRef?: Promise<string | undefined>,
 ): Output<T> {
     const [output, resolve] = createOutput<T>(`invoke(${tok})`);
-    invokeAsync(tok, props, opts, packageRef)
+    invokeAsync(tok, props, opts, packageRef, true /* checkDependencies */)
         .then((response) => {
             const { result, isKnown, containsSecrets, dependencies } = response;
             resolve(<T>result, isKnown, containsSecrets, dependencies, undefined);
@@ -159,7 +159,7 @@ export function invokeSingleOutput<T>(
     packageRef?: Promise<string | undefined>,
 ): Output<T> {
     const [output, resolve] = createOutput<T>(`invokeSingleOutput(${tok})`);
-    invokeAsync(tok, props, opts, packageRef)
+    invokeAsync(tok, props, opts, packageRef, true /* checkDependencies */)
         .then((response) => {
             const { result, isKnown, containsSecrets, dependencies } = response;
             const value = extractSingleValue(result);
@@ -224,6 +224,7 @@ async function invokeAsync(
     props: Inputs,
     opts: InvokeOutputOptions,
     packageRef?: Promise<string | undefined>,
+    checkDependencies?: boolean,
 ): Promise<{
     result: Inputs | undefined;
     isKnown: boolean;
@@ -252,30 +253,38 @@ async function invokeAsync(
                 dependencies: [],
             };
         }
-        // If we depend on any CustomResources, we need to ensure that their
-        // ID is known before proceeding. If it is not known, we will return
-        // an unknown result.
-        const resourcesToWaitFor = new Set<Resource>(dependsOnDeps);
-        // Add the dependencies from the inputs to the set of resources to wait for.
-        for (const resourceDeps of deps.values()) {
-            for (const value of resourceDeps.values()) {
-                resourcesToWaitFor.add(value);
+
+        // Only check the resource dependencies for output form invokes. For
+        // plain invokes, we do not want to check the dependencies. Technically,
+        // these should only receive plain arguments, but this is not strictly
+        // enforced, and in practice people pass in outputs. This happens to
+        // work because we serialize the arguments.
+        if (checkDependencies) {
+            // If we depend on any CustomResources, we need to ensure that their
+            // ID is known before proceeding. If it is not known, we will return
+            // an unknown result.
+            const resourcesToWaitFor = new Set<Resource>(dependsOnDeps);
+            // Add the dependencies from the inputs to the set of resources to wait for.
+            for (const resourceDeps of deps.values()) {
+                for (const value of resourceDeps.values()) {
+                    resourcesToWaitFor.add(value);
+                }
             }
-        }
-        // The expanded set of dependencies, including children of components.
-        const expandedDeps = await getAllTransitivelyReferencedResources(resourcesToWaitFor, new Set());
-        // Ensure that all resource IDs are known before proceeding.
-        for (const dep of expandedDeps.values()) {
-            // DependencyResources inherit from CustomResource, but they don't set the id. Skip them.
-            if (CustomResource.isInstance(dep) && dep.id) {
-                const known = await dep.id.isKnown;
-                if (!known) {
-                    return {
-                        result: {},
-                        isKnown: false,
-                        containsSecrets: false,
-                        dependencies: [],
-                    };
+            // The expanded set of dependencies, including children of components.
+            const expandedDeps = await getAllTransitivelyReferencedResources(resourcesToWaitFor, new Set());
+            // Ensure that all resource IDs are known before proceeding.
+            for (const dep of expandedDeps.values()) {
+                // DependencyResources inherit from CustomResource, but they don't set the id. Skip them.
+                if (CustomResource.isInstance(dep) && dep.id) {
+                    const known = await dep.id.isKnown;
+                    if (!known) {
+                        return {
+                            result: {},
+                            isKnown: false,
+                            containsSecrets: false,
+                            dependencies: [],
+                        };
+                    }
                 }
             }
         }

--- a/sdk/nodejs/tests/runtime/langhost/cases/079.invoke_plain_takes_output/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/079.invoke_plain_takes_output/index.js
@@ -1,0 +1,28 @@
+// Plain invoke calls serialize_properties on the arguments, so even though it
+// is supposed to only take plain values, it still happens to work with Outputs.
+// In practice, people rely on this behavior, so we test it here to ensure we
+// don't break this behavior.
+
+const assert = require("assert");
+const pulumi = require("../../../../../");
+
+const dependency = { resolved: false };
+
+class MyResource extends pulumi.CustomResource {
+    constructor(name, opts) {
+        super("test:index:MyResource", name, {}, opts);
+    }
+}
+
+const dep = new MyResource("dep");
+
+const arg = new pulumi.Output(
+    new Set([dep]), // dependencies, unknown during preview
+    Promise.resolve("banana"),
+    Promise.resolve(true), // isKnown
+    Promise.resolve(false), // isSecret
+);
+
+pulumi.runtime.invoke("test:index:echo", { arg }).then((result) => {
+    assert.deepStrictEqual({ arg: "banana" }, result);
+});

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -1687,6 +1687,25 @@ describe("rpc", () => {
                 return { failures: undefined, ret: args };
             },
         },
+        invoke_plain_takes_output: {
+            pwd: path.join(base, "079.invoke_plain_takes_output"),
+            expectResourceCount: 1,
+            registerResource: (
+                ctx: any,
+                dryrun: boolean,
+                t: string,
+                name: string,
+                res: any,
+                dependencies?: string[],
+                ...args: any
+            ) => {
+                const id = dryrun ? undefined : name + "_id";
+                return { urn: makeUrn(t, name), id, props: undefined };
+            },
+            invoke: (ctx: any, dryrun: boolean, tok: string, args: any, version: string, provider: string) => {
+                return { failures: undefined, ret: args };
+            },
+        },
     };
 
     for (const casename of Object.keys(cases)) {

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -153,7 +153,7 @@ def invoke_output(
     async def do_invoke_output() -> None:
         try:
             invoke_result = await _invoke(
-                tok, props, opts, typ, package_ref=package_ref
+                tok, props, opts, typ, package_ref=package_ref, check_dependencies=True
             )
 
             resolve_value.set_result(
@@ -196,6 +196,7 @@ def _invoke(
     opts: Optional[Union[InvokeOptions, InvokeOutputOptions]],
     typ: Optional[type],
     package_ref: Optional[Awaitable[Optional[str]]],
+    check_dependencies: Optional[bool] = False,
 ) -> Awaitable[InvokeResult]:
     log.debug(f"Invoking function: tok={tok}")
     if opts is None:
@@ -243,28 +244,35 @@ def _invoke(
         )
 
         # The direct dependencies of the invoke.
-        depends_on_dependencies: Set["Resource"] = await _resolve_depends_on(
-            opts._depends_on_list() if isinstance(opts, InvokeOutputOptions) else []
-        )
-        # If we depend on any CustomResources, we need to ensure that their
-        # ID is known before proceeding. If it is not known, we will return
-        # an unknown result.
-        resources_to_wait_for: Set["Resource"] = set(depends_on_dependencies)
-        # Add the dependencies from the inputs to the set of resources to wait for.
-        for deps in property_dependencies.values():
-            resources_to_wait_for = resources_to_wait_for.union(deps)
-        # The expanded set of dependencies, including children of components.
-        expanded_deps = await rpc._expand_dependencies(resources_to_wait_for, None)
-        # Ensure that all resource IDs are known before proceeding.
-        for res in expanded_deps.values():
-            # DependencyResources inherit from CustomResource, but they don't
-            # set the id. Skip them.
-            if isinstance(res, CustomResource) and res.__dict__.get("id", None):
-                if not await res.id.is_known():
-                    return (
-                        InvokeResult(None, is_secret=False, is_known=False),
-                        None,
-                    )
+        depends_on_dependencies: Set["Resource"] = set()
+        # Only check the resource dependencies for output form invokes. For
+        # plain invokes, we do not want to check the dependencies. Technically,
+        # these should only receive plain arguments, but this is not strictly
+        # enforced, and in practice people pass in outputs. This happens to work
+        # because we serialize the arguments.
+        if check_dependencies:
+            depends_on_dependencies = await _resolve_depends_on(
+                opts._depends_on_list() if isinstance(opts, InvokeOutputOptions) else []
+            )
+            # If we depend on any CustomResources, we need to ensure that their
+            # ID is known before proceeding. If it is not known, we will return
+            # an unknown result.
+            resources_to_wait_for: Set["Resource"] = set(depends_on_dependencies)
+            # Add the dependencies from the inputs to the set of resources to wait for.
+            for deps in property_dependencies.values():
+                resources_to_wait_for = resources_to_wait_for.union(deps)
+            # The expanded set of dependencies, including children of components.
+            expanded_deps = await rpc._expand_dependencies(resources_to_wait_for, None)
+            # Ensure that all resource IDs are known before proceeding.
+            for res in expanded_deps.values():
+                # DependencyResources inherit from CustomResource, but they don't
+                # set the id. Skip them.
+                if isinstance(res, CustomResource) and res.__dict__.get("id", None):
+                    if not await res.id.is_known():
+                        return (
+                            InvokeResult(None, is_secret=False, is_known=False),
+                            None,
+                        )
 
         version = opts.version or "" if opts is not None else ""
         plugin_download_url = opts.plugin_download_url or "" if opts is not None else ""


### PR DESCRIPTION
Plain invokes happen to serialize arguments, which allows passing in output types. With https://github.com/pulumi/pulumi/pull/18204 we started checking if the resource dependencies of the arguments (and from `dependsOn`) are known, and returned unknown if not. However this broke backwards compatibility for plain invokes in the TypeScript and Python SDKs. 

This PR ensures that we only check the dependencies if we are using output form invokes. In Python and TypesScript, arguments of output type decay to  promises/tasks, without dependency information, when passed to plain invokes.

