### PR TITLE
add test infrastructure for `pulumi config set`

### DIFF
--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -625,6 +625,10 @@ func (c *configSetCmd) Run(ctx context.Context, args []string, project *workspac
 	if stdin == nil {
 		stdin = os.Stdin
 	}
+	loadProjectStack := c.LoadProjectStack
+	if loadProjectStack == nil {
+		loadProjectStack = cmdStack.LoadProjectStack
+	}
 	key, err := ParseConfigKey(args[0])
 	if err != nil {
 		return fmt.Errorf("invalid configuration key: %w", err)
@@ -655,7 +659,7 @@ func (c *configSetCmd) Run(ctx context.Context, args []string, project *workspac
 		}
 	}
 
-	ps, err := c.LoadProjectStack(project, s)
+	ps, err := loadProjectStack(project, s)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/config/config_test.go
+++ b/pkg/cmd/pulumi/config/config_test.go
@@ -1,0 +1,93 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:paralleltest // changes global ConfigFile variable
+func TestConfigSet(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name     string
+		args     []string
+		expected string
+		path     bool
+	}{
+		{
+			name:     "toplevel int",
+			args:     []string{"testProject:test", "123"},
+			expected: "config:\n  testProject:test: \"123\"\n",
+			path:     false,
+		},
+		{
+			name:     "path'd int",
+			args:     []string{"testProject:test[0]", "123"},
+			expected: "config:\n  testProject:test:\n    - 123\n",
+			path:     true,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run("", func(t *testing.T) {
+			project := workspace.Project{
+				Name: "testProject",
+			}
+
+			s := backend.MockStack{
+				RefF: func() backend.StackReference {
+					return &backend.MockStackReference{
+						NameV: tokens.MustParseStackName("testStack"),
+					}
+				},
+			}
+
+			configSetCmd := &configSetCmd{
+				Path: c.path,
+				LoadProjectStack: func(project *workspace.Project, _ backend.Stack) (*workspace.ProjectStack, error) {
+					return workspace.LoadProjectStackBytes(project, []byte{}, "Pulumi.stack.yaml", encoding.YAML)
+				},
+			}
+
+			tmpdir := t.TempDir()
+			stack.ConfigFile = filepath.Join(tmpdir, "Pulumi.stack.yaml")
+			defer func() {
+				stack.ConfigFile = ""
+			}()
+
+			err := configSetCmd.Run(ctx, c.args, &project, &s)
+			require.NoError(t, err)
+
+			// verify the config was set
+			data, err := os.ReadFile(stack.ConfigFile)
+			require.NoError(t, err)
+
+			require.Equal(t, c.expected, string(data))
+		})
+	}
+}


### PR DESCRIPTION
Add test infrastructure to test the `pulumi config set` command, and add a simple test for it.  This test isn't meant to comprehensively test everything in the command, but rather as a start to be able to add more tests more easily as we go and add more features.

I wanted to add tests for https://github.com/pulumi/pulumi/pull/18287, but without the test infrastructure in place it's rather painful.  This is a step towards that, so #18287 can be tested properly.