### PR TITLE
[WIP] Always set virtualenv option in GenerateProject

### DIFF
--- a/changelog/pending/20250122--programgen-python--always-set-virtualenv-option-in-generateproject.yaml
+++ b/changelog/pending/20250122--programgen-python--always-set-virtualenv-option-in-generateproject.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/python
+  description: Always set virtualenv option in GenerateProject

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -325,17 +325,11 @@ func GenerateProject(
 		}
 	}
 
-	var options map[string]interface{}
-	if _, ok := localDependencies["pulumi"]; ok {
-		options = map[string]interface{}{
-			"virtualenv": "venv",
-		}
+	options := map[string]interface{}{
+		"virtualenv": "venv",
 	}
 
 	if typechecker != "" {
-		if options == nil {
-			options = map[string]interface{}{}
-		}
 		options["typechecker"] = typechecker
 	}
 


### PR DESCRIPTION
We should always set the virtualenv option to avoid creating projects that use the global Python installation.

Using the global/ambient Python installation is discouraged, and will not work on some installations https://peps.python.org/pep-0668/
