### PR TITLE
Fix pnpm test

### DIFF
--- a/sdk/nodejs/tests/runtime/install-package-tests.ts
+++ b/sdk/nodejs/tests/runtime/install-package-tests.ts
@@ -117,7 +117,10 @@ async function main() {
             // },
             {
                 name: "pnpm",
-                version: "*", // Latest version.
+                // TODO: This should use the latest version.
+                // https://github.com/pulumi/pulumi/issues/18338
+                // version: "*", // Latest version.
+                version: "10.0.0",
             },
         ];
 


### PR DESCRIPTION
Due to https://github.com/nodejs/corepack/issues/612 we had to pin `pnpm` to 10.0.0 in `sdk/nodejs/tests/runtime/install-package-tests.ts`
