### PR TITLE
Don't create two plugin hosts in ProviderFromSource

### DIFF
--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -853,12 +853,7 @@ func ProviderFromSource(packageSource string) (plugin.Provider, error) {
 		}
 	}
 
-	host, err := plugin.NewDefaultHost(pCtx, nil, false, nil, nil, nil, "")
-	if err != nil {
-		return nil, err
-	}
-
-	p, err := plugin.NewProviderFromPath(host, pCtx, packageSource)
+	p, err := plugin.NewProviderFromPath(pCtx.Host, pCtx, packageSource)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Small little fix, we don't need to create a plugin host at this point in the code because we already have a full plugin context from above.