### PR TITLE
Make RunPlugin default to using a virtualenv

### DIFF
--- a/changelog/pending/20250128--sdk-python--make-runplugin-to-default-to-using-a-virtualenv.yaml
+++ b/changelog/pending/20250128--sdk-python--make-runplugin-to-default-to-using-a-virtualenv.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Make RunPlugin default to using a virtualenv

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -1332,6 +1332,11 @@ func (host *pythonLanguageHost) RunPlugin(
 	args := []string{req.Info.ProgramDirectory}
 	args = append(args, req.Args...)
 
+	// Default the `virtualenv` option to `venv` if not provided. We don't support running
+	// plugins using the global or ambient Python environment.
+	if opts.Toolchain == toolchain.Pip && opts.Virtualenv == "" {
+		opts.Virtualenv = "venv"
+	}
 	tc, err := toolchain.ResolveToolchain(opts)
 	if err != nil {
 		return err

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -1517,7 +1517,6 @@ func TestRunPlugin(t *testing.T) {
 	pythonSdkPath, err := filepath.Abs(filepath.Join("..", "..", "sdk", "python"))
 	require.NoError(t, err)
 	e.RunCommand(filepath.Join("venv", "bin", "python"), "-m", "pip", "install", "-e", pythonSdkPath)
-	e.Env = append(e.Env, "PATH="+filepath.Join(e.CWD, "venv", "bin")+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	e.CWD = filepath.Join(e.RootPath, "go")
 	sdkPath, err := filepath.Abs("../../sdk/")

--- a/tests/integration/run_plugin/provider-python/__main__.py
+++ b/tests/integration/run_plugin/provider-python/__main__.py
@@ -1,8 +1,11 @@
 # Copyright 2024, Pulumi Corporation.
 
-import pulumi.provider as provider
-import sys
 import os
+import sys
+from pathlib import Path
+
+import pulumi.provider as provider
+
 
 class Provider(provider.Provider):
     VERSION = "0.0.1"
@@ -13,5 +16,12 @@ class Provider(provider.Provider):
     def construct(self, name, resource_type, inputs, options):
         return provider.ConstructResult("", {"ITS_ALIVE": "IT'S ALIVE!"})
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
+    provider_dir = Path(__file__).absolute().parent
+    expected_venv = provider_dir / "venv"
+    venv = os.getenv("VIRTUAL_ENV", "")
+    assert (
+        Path(venv) == expected_venv
+    ), f"Expected VIRTUAL_ENV to be {expected_venv}, got {venv}"
     provider.main(Provider(), sys.argv[1:])


### PR DESCRIPTION
For Python plugins `PluginSpec.InstallDependencies` always installs plugin dependencies into a virtual environment named `venv` in the plugin's directory.

Python's `RunPlugin` reads the options from `PulumiPlugin.yaml` to determine the toolchain to use. If no toolchain options are set, this proceeds to use the dependencies from the global Python installation, which is not what we want to happen. Instead, we should default to `toolchain: pip` (the default already) with `virtualenv: venv`, to match the installation step.

Fixes https://github.com/pulumi/pulumi/issues/18347
