### PR TITLE
Fix parsing of config keys with paths and colons in path segments

### DIFF
--- a/changelog/pending/20250129--cli-config--fix-parsing-of-config-keys-with-paths-and-colons-in-path-segments.yaml
+++ b/changelog/pending/20250129--cli-config--fix-parsing-of-config-keys-with-paths-and-colons-in-path-segments.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/config
+  description: Fix parsing of config keys with paths and colons in path segments

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2024, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -290,7 +290,7 @@ func newConfigGetCmd(stack *string) *cobra.Command {
 				return err
 			}
 
-			key, err := ParseConfigKey(args[0])
+			key, err := ParseConfigKey(args[0], path)
 			if err != nil {
 				return fmt.Errorf("invalid configuration key: %w", err)
 			}
@@ -349,7 +349,7 @@ func newConfigRmCmd(stack *string) *cobra.Command {
 				return err
 			}
 
-			key, err := ParseConfigKey(args[0])
+			key, err := ParseConfigKey(args[0], path)
 			if err != nil {
 				return fmt.Errorf("invalid configuration key: %w", err)
 			}
@@ -417,7 +417,7 @@ func newConfigRmAllCmd(stack *string) *cobra.Command {
 			}
 
 			for _, arg := range args {
-				key, err := ParseConfigKey(arg)
+				key, err := ParseConfigKey(arg, path)
 				if err != nil {
 					return fmt.Errorf("invalid configuration key: %w", err)
 				}
@@ -636,7 +636,7 @@ func (c *configSetCmd) Run(ctx context.Context, args []string, project *workspac
 	if loadProjectStack == nil {
 		loadProjectStack = cmdStack.LoadProjectStack
 	}
-	key, err := ParseConfigKey(args[0])
+	key, err := ParseConfigKey(args[0], c.Path)
 	if err != nil {
 		return fmt.Errorf("invalid configuration key: %w", err)
 	}
@@ -772,7 +772,7 @@ func newConfigSetAllCmd(stack *string) *cobra.Command {
 			}
 
 			for _, ptArg := range plaintextArgs {
-				key, value, err := parseKeyValuePair(ptArg)
+				key, value, err := parseKeyValuePair(ptArg, path)
 				if err != nil {
 					return err
 				}
@@ -787,7 +787,7 @@ func newConfigSetAllCmd(stack *string) *cobra.Command {
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 
 			for _, sArg := range secretArgs {
-				key, value, err := parseKeyValuePair(sArg)
+				key, value, err := parseKeyValuePair(sArg, path)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/pulumi/newcmd/config.go
+++ b/pkg/cmd/pulumi/newcmd/config.go
@@ -1,4 +1,4 @@
-// Copyright 2024, Pulumi Corporation.
+// Copyright 2024-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -146,7 +146,7 @@ func isPreconfiguredEmptyStack(
 
 	// Can stackConfig satisfy the config requirements of templateConfig?
 	for templateKey, templateVal := range templateConfig {
-		parsedTemplateKey, parseErr := cmdConfig.ParseConfigKey(templateKey)
+		parsedTemplateKey, parseErr := cmdConfig.ParseConfigKey(templateKey, false)
 		if parseErr != nil {
 			contract.IgnoreError(parseErr)
 			return false
@@ -187,7 +187,7 @@ func promptForConfig(
 	// the project name will be prepended.
 	parsedTemplateConfig := make(map[config.Key]workspace.ProjectTemplateConfigValue)
 	for k, v := range templateConfig {
-		parsedKey, parseErr := cmdConfig.ParseConfigKey(k)
+		parsedKey, parseErr := cmdConfig.ParseConfigKey(k, false)
 		if parseErr != nil {
 			return nil, parseErr
 		}
@@ -310,7 +310,7 @@ func ParseConfig(configArray []string, path bool) (config.Map, error) {
 	for _, c := range configArray {
 		kvp := strings.SplitN(c, "=", 2)
 
-		key, err := cmdConfig.ParseConfigKey(kvp[0])
+		key, err := cmdConfig.ParseConfigKey(kvp[0], path)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Currently, the following command fails:

```
$ pulumi config set pulumi:autonaming.providers.aws.resources.aws:s3/bucket:Bucket.mode verbatim --path=true
error: invalid configuration key: could not parse pulumi:autonaming.providers.aws.resources.aws:s3/bucket:Bucket.mode as a configuration key (configuration keys should be of the form `<namespace>:<name>`)
```

because we expect 0 to 2 `:` symbols in the configuration key string.

This expectation is too strict for the `path: true` case, because colons may appear in non-top path segments, as in the above example. The command above should produce

```
config:
  pulumi:autonaming:
    providers:
      aws:
        resources:
          aws:s3/bucket:Bucket:
            mode: verbatim
```

This PR modifies `ParseConfigKey` behavior to allow that. `ParseConfigKey` now accepts whether the given key is supposed to be a path. If it's not a path, the behavior is the same as before. If it is a path, we attempt to parse the key as path, and then only apply the namespace calculation to the top-level segment (e.g. auto-prefix it with the project name if needed). We then use that calculated namespace to construct the full Key.

One pesky detail is that the old command allowed some keys that are not valid paths, e.g. `pulumi config set aws:boo. value1 --path=true` succeeded before but would fail if we require it to be a valid path. To keep backwards compat, I chose to fallback to non-path parsing if path parsing fails. It's ugly but avoids breaking existing users...

After the change, `pulumi config set pulumi:autonaming.providers.aws.resources.aws:s3/bucket:Bucket.mode verbatim --path=true` works as expected.

I'd love to get a careful review on what else I may be breaking or other test cases that I'm missing.

Resolve https://github.com/pulumi/pulumi/issues/18342 
