### PR TITLE
add some documentation for appending .git to the URL to disambiguate

### DIFF
--- a/changelog/pending/20250129--cli-new--improve-docs-for-disambiguating-repositories-on-hosts-where-the-url-is-ambiguous.yaml
+++ b/changelog/pending/20250129--cli-new--improve-docs-for-disambiguating-repositories-on-hosts-where-the-url-is-ambiguous.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/new
+  description: Improve docs for disambiguating repositories on hosts where the URL is ambiguous

--- a/pkg/cmd/pulumi/newcmd/new.go
+++ b/pkg/cmd/pulumi/newcmd/new.go
@@ -595,6 +595,10 @@ func NewNewCmd() *cobra.Command {
 			"* `pulumi new https://bitbucket.org/<user>/<repo>`\n" +
 			"* `pulumi new https://github.com/<user>/<repo>`\n" +
 			"\n" +
+			"  Note: If the URL doesn't follow the usual scheme of the given host (e.g. for GitLab subprojects)\n" +
+			"        you can append `.git` to the repository to disambiguate and point to the correct repository.\n" +
+			"        For example `https://gitlab.com/<project>/<subproject>/<repository>.git`.\n" +
+			"\n" +
 			"To create the project from a branch of a specific source control location, pass the url to the branch, e.g.\n" +
 			"* `pulumi new https://gitlab.com/<user>/<repo>/tree/<branch>`\n" +
 			"* `pulumi new https://bitbucket.org/<user>/<repo>/tree/<branch>`\n" +


### PR DESCRIPTION
We support this disambiguation mechanism, but it's not widely known, and I don't think it's documented anywhere.  Add it to the documentation for `pulumi new` to publicise this feature a bit more widely.

Fixes https://github.com/pulumi/pulumi/issues/17582 (I don't think we can do much better here, but happy to leave the issue open if others disagree)