### PR TITLE
Update corepack for tests

### DIFF
--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -54,6 +54,7 @@
         "@types/uuid": "^9.0.7",
         "@typescript-eslint/eslint-plugin": "^4.29.0",
         "@typescript-eslint/parser": "^4.29.0",
+        "corepack": "^0.31.0",
         "eslint": "^7.32.0",
         "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-import": "^2.23.4",

--- a/sdk/nodejs/tests/runtime/install-package-tests.ts
+++ b/sdk/nodejs/tests/runtime/install-package-tests.ts
@@ -185,8 +185,8 @@ async function runTest(
     let logs = "";
 
     // Install the package manager to test.
-    logs += await exec(`corepack`, ["enable"], { cwd: tmpDir.name });
-    logs += await exec(`corepack`, ["use", `${packageManager}@${packageManagerVersion}`], { cwd: tmpDir.name });
+    logs += await exec(`yarn`, ["run", "corepack", "enable"], { cwd: tmpDir.name });
+    logs += await exec(`yarn`, ["run", "corepack", "use", `${packageManager}@${packageManagerVersion}`], { cwd: tmpDir.name });
 
     const env = {
         PULUMI_CONFIG_PASSPHRASE: "test",

--- a/sdk/nodejs/yarn.lock
+++ b/sdk/nodejs/yarn.lock
@@ -1511,6 +1511,11 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+corepack@^0.31.0:
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/corepack/-/corepack-0.31.0.tgz#442423d2603403cbf2aa6fde3354e460cb792a25"
+  integrity sha512-PFXOWB1S3gzr8Afuwq1sslrxDzLKsef6bu8NXKPxCBJAy54FXm86NutB/kjiPhwjSwV3hMzKSnLFzxTBlWNUqA==
+
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"


### PR DESCRIPTION
Corepack ships with some signatures builtin, which have now expired. This first caused issues for pnpm https://github.com/pulumi/pulumi/pull/18339 and now npm.

Nodejs ships with corepack, but it looks like the included version has not been updated to fix this issue https://github.com/nodejs/corepack/releases/tag/v0.31.0
