### PR TITLE
fix flaky TestRunCanceled

### DIFF
--- a/sdk/go/auto/cmd_test.go
+++ b/sdk/go/auto/cmd_test.go
@@ -309,11 +309,11 @@ func TestRunCanceled(t *testing.T) {
 	stdout, _, code, err := cmd.Run(ctx, e.CWD, nil, nil, nil, env, "preview", "-s", stackName)
 	if runtime.GOOS == "windows" {
 		require.ErrorContains(t, err, "exit status 0xffffffff")
-		require.Contains(t, stdout, "error: preview canceled")
+		require.Contains(t, stdout, ".*error: preview canceled.*|.*signal: interrupt", stdout)
 		require.Equal(t, 4294967295, code)
 	} else {
 		require.ErrorContains(t, err, "exit status 255")
-		require.Contains(t, stdout, "error: preview canceled")
+		require.Regexp(t, ".*error: preview canceled.*|.*signal: interrupt", stdout)
 		require.Equal(t, 255, code)
 	}
 

--- a/sdk/go/auto/cmd_test.go
+++ b/sdk/go/auto/cmd_test.go
@@ -307,13 +307,12 @@ func TestRunCanceled(t *testing.T) {
 		"PULUMI_CONFIG_PASSPHRASE=correct horse battery staple",
 	}
 	stdout, _, code, err := cmd.Run(ctx, e.CWD, nil, nil, nil, env, "preview", "-s", stackName)
+	require.Regexp(t, ".*error: preview canceled.*|.*signal: interrupt", stdout)
 	if runtime.GOOS == "windows" {
 		require.ErrorContains(t, err, "exit status 0xffffffff")
-		require.Contains(t, stdout, ".*error: preview canceled.*|.*signal: interrupt", stdout)
 		require.Equal(t, 4294967295, code)
 	} else {
 		require.ErrorContains(t, err, "exit status 255")
-		require.Regexp(t, ".*error: preview canceled.*|.*signal: interrupt", stdout)
 		require.Equal(t, 255, code)
 	}
 


### PR DESCRIPTION
This test currently flakes sometimes because the stdiout is "signal: interrupt" instead of "error: preview canceled".  This can happen depending on when exactly the preview is canceled.

It would be nicer if the error always said "preview canceled", but the important thing is that we interrupt the preview successfully, and it's probably not worth our time right now to figure out exactly where this is flaky and why we're not getting the nice output in some rare cases.

It is however important that the test is not flaky, so let's just fix the test to also accept "signal: interrupt" as potential output when the preview is canceled.

Fixes https://github.com/pulumi/pulumi/issues/18389