### PR TITLE
Skip install-package-tests

### DIFF
--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -76,7 +76,8 @@ test_auto:: $(TEST_ALL_DEPS)
 
 test_integration:: $(TEST_ALL_DEPS)
 	node 'bin/tests/runtime/closure-integration-tests.js'
-	node 'bin/tests/runtime/install-package-tests.js'
+# TODO[https://github.com/pulumi/pulumi/issues/18392]: Re-enable this test.
+#	node 'bin/tests/runtime/install-package-tests.js'
 
 TSC_SUPPORTED_VERSIONS = ~3.8.3 ^3 ^4
 

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -67,6 +67,7 @@ unit_tests:: $(TEST_ALL_DEPS)
 	yarn run nyc -s mocha --timeout 120000 \
 		--exclude 'bin/tests/automation/**/*.spec.js' \
 		--exclude 'bin/tests/runtime/closure-integration-tests.js' \
+		--exclude 'bin/tests/runtime/install-package-tests.js' \
 		'bin/tests/**/*.spec.js'
 	yarn run nyc -s mocha 'bin/tests_with_mocks/**/*.spec.js'
 


### PR DESCRIPTION
The current version of corepack that ships with nodejs has an issue installing the latest version of npm and pnpm.

Re-enabling is tracked by #18392
