### PR TITLE
Use the corepack executable from dev dependencies

### DIFF
--- a/changelog/pending/20250130--sdk-nodejs--use-the-corepack-executable-from-dev-dependencies.yaml
+++ b/changelog/pending/20250130--sdk-nodejs--use-the-corepack-executable-from-dev-dependencies.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Use the corepack executable from dev dependencies

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -76,6 +76,7 @@
             "optional": true
         }
     },
+    "packageManager": "yarn@1.22.22",
     "pulumi": {
         "comment": "Do not remove. Marks this as as a deployment-time-only package"
     },

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -54,6 +54,7 @@
         "@types/uuid": "^9.0.7",
         "@typescript-eslint/eslint-plugin": "^4.29.0",
         "@typescript-eslint/parser": "^4.29.0",
+        "corepack": "^0.31.0",
         "eslint": "^7.32.0",
         "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-import": "^2.23.4",

--- a/sdk/nodejs/tests/runtime/install-package-tests.ts
+++ b/sdk/nodejs/tests/runtime/install-package-tests.ts
@@ -117,10 +117,7 @@ async function main() {
             // },
             {
                 name: "pnpm",
-                // TODO: This should use the latest version.
-                // https://github.com/pulumi/pulumi/issues/18338
-                // version: "*", // Latest version.
-                version: "10.0.0",
+                version: "*", // Latest version.
             },
         ];
 
@@ -184,9 +181,15 @@ async function runTest(
 
     let logs = "";
 
+    // Get the corepack executable from the yarn bin directory, which allows us
+    // to use the version of corepack that's installed as part of our dev
+    // dependencies. This avoids having to install corepack globally or in CI.
+    const { stdout: bin } = await execa("yarn", ["bin"], {});
+    const corepack = path.join(bin.trim(), "corepack");
+
     // Install the package manager to test.
-    logs += await exec(`corepack`, ["enable"], { cwd: tmpDir.name });
-    logs += await exec(`corepack`, ["use", `${packageManager}@${packageManagerVersion}`], { cwd: tmpDir.name });
+    logs += await exec(corepack, ["enable"], { cwd: tmpDir.name });
+    logs += await exec(corepack, ["use", `${packageManager}@${packageManagerVersion}`], { cwd: tmpDir.name });
 
     const env = {
         PULUMI_CONFIG_PASSPHRASE: "test",

--- a/sdk/nodejs/yarn.lock
+++ b/sdk/nodejs/yarn.lock
@@ -1511,6 +1511,11 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+corepack@^0.31.0:
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/corepack/-/corepack-0.31.0.tgz#442423d2603403cbf2aa6fde3354e460cb792a25"
+  integrity sha512-PFXOWB1S3gzr8Afuwq1sslrxDzLKsef6bu8NXKPxCBJAy54FXm86NutB/kjiPhwjSwV3hMzKSnLFzxTBlWNUqA==
+
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"


### PR DESCRIPTION
The corepack version that ships with current nodejs releases uses old keys to verify signatures, causing the installation of the latest pnpm and npm versions, which use a newer key, to fail. Instead of relying on an implicit corepack version, include a version with recent signatures (>=0.31.0) in our dev dependencies, and use that in our tests.

Fixes https://github.com/pulumi/pulumi/issues/18338
