### PR TITLE
[Experimental] Add infrastructure to bootstrap providers from component resources

### DIFF
--- a/changelog/pending/20250131--sdk-python--add-infrastructure-to-bootstrap-providers-from-component-resources.yaml
+++ b/changelog/pending/20250131--sdk-python--add-infrastructure-to-bootstrap-providers-from-component-resources.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: "[Experimental] Add infrastructure to bootstrap providers from component resources"

--- a/sdk/python/lib/pulumi/provider/experimental/__init__.py
+++ b/sdk/python/lib/pulumi/provider/experimental/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .host import component_provider_host
+from .metadata import Metadata
+
+__all__ = ["component_provider_host", "Metadata"]

--- a/sdk/python/lib/pulumi/provider/experimental/analyzer.py
+++ b/sdk/python/lib/pulumi/provider/experimental/analyzer.py
@@ -1,0 +1,103 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from ...resource import ComponentResource
+from .component import ComponentDefinition, PropertyDefinition
+from .metadata import Metadata
+
+_NoneType = type(None)  # Available as typing.NoneType in >= 3.10
+
+
+class Analyzer:
+    def __init__(self, metadata: Metadata):
+        self.metadata = metadata
+
+    def analyze(self, path: Path) -> dict[str, ComponentDefinition]:
+        """
+        Analyze walks the directory at `path` and searches for
+        ComponentResources in Python files.
+        """
+        components: dict[str, ComponentDefinition] = {}
+        for file_path in self.iter(path):
+            components.update(self.analyze_file(file_path))
+        return components
+
+    def iter(self, path: Path):
+        for file_path in path.glob("**/*.py"):
+            if is_in_venv(file_path):
+                continue
+            yield file_path
+
+    def analyze_file(self, file_path: Path) -> dict[str, ComponentDefinition]:
+        components: dict[str, ComponentDefinition] = {}
+        module_type = self.load_module(file_path)
+        for name in dir(module_type):
+            obj = getattr(module_type, name)
+            if inspect.isclass(obj) and ComponentResource in obj.__bases__:
+                components[name] = self.analyze_component(obj)
+        return components
+
+    def find_component(self, path: Path, name: str) -> type[ComponentResource]:
+        """
+        Find a component by name in the directory at `self.path`.
+
+        :param name: The name of the component to find.
+        """
+        for file_path in self.iter(path):
+            mod = self.load_module(file_path)
+            comp = getattr(mod, name, None)
+            if comp:
+                return comp
+        raise Exception(f"Could not find component {name}")
+
+    def load_module(self, file_path: Path) -> ModuleType:
+        name = file_path.name.replace(".py", "")
+        spec = importlib.util.spec_from_file_location("component_file", file_path)
+        if not spec:
+            raise Exception(f"Could not load module spec at {file_path}")
+        module_type = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module_type
+        if not spec.loader:
+            raise Exception(f"Could not load module at {file_path}")
+        spec.loader.exec_module(module_type)
+        return module_type
+
+    def analyze_component(
+        self, component: type[ComponentResource]
+    ) -> ComponentDefinition:
+        args = component.__init__.__annotations__.get("args", None)
+        if not args:
+            raise Exception(
+                f"Could not find `args` keyword argument in {component}'s __init__ method"
+            )
+        return ComponentDefinition(
+            description=component.__doc__.strip() if component.__doc__ else None,
+            inputs=self.analyze_types(args),
+            outputs=self.analyze_types(component),
+        )
+
+    def analyze_types(self, typ: type) -> dict[str, PropertyDefinition]:
+        return {}
+
+
+def is_in_venv(path: Path):
+    venv = Path(sys.prefix).resolve()
+    path = path.resolve()
+    return venv in path.parents

--- a/sdk/python/lib/pulumi/provider/experimental/component.py
+++ b/sdk/python/lib/pulumi/provider/experimental/component.py
@@ -1,0 +1,48 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class PropertyType(Enum):
+    STRING = "string"
+    INTEGER = "integer"
+    NUMBER = "number"
+    BOOLEAN = "boolean"
+    OBJECT = "object"
+
+
+@dataclass
+class PropertyDefinition:
+    optional: bool = False
+    type: Optional[PropertyType] = None
+    ref: Optional[str] = None
+    description: Optional[str] = None
+
+
+@dataclass
+class TypeDefinition:
+    name: str
+    type: str
+    properties: dict[str, PropertyDefinition]
+    description: Optional[str] = None
+
+
+@dataclass
+class ComponentDefinition:
+    inputs: dict[str, PropertyDefinition]
+    outputs: dict[str, PropertyDefinition]
+    description: Optional[str] = None

--- a/sdk/python/lib/pulumi/provider/experimental/host.py
+++ b/sdk/python/lib/pulumi/provider/experimental/host.py
@@ -1,0 +1,53 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from ...provider import main
+from .metadata import Metadata
+from .provider import ComponentProvider
+
+is_hosting = False
+
+
+def component_provider_host(metadata: Optional[Metadata] = None):
+    """
+    component_provider_host starts the provider host for the plugin at path
+    sys.argv[0]. This will discover all `pulumi.ComponentResource` sublcasses in
+    the Python source code and infer their schema from their type annotations.
+
+    :param metadata: The metadata for the provider. If not provided, the name
+    defaults to the plugin's directory name, and version defaults to "0.0.1".
+    """
+    global is_hosting  # noqa
+    if is_hosting:
+        # Bail out if we're already hosting. This prevents recursion when the
+        # analyzer loads this file. It's usually good style to not run code at
+        # import time, and use `if __name__ == "__main__"`, but let's make sure
+        # we guard against this.
+        return
+    is_hosting = True
+
+    # When the languge runtime runs the plugin, the first argument is the path
+    # to the plugin's installation directory. This is followed by the engine
+    # address and other optional arguments flags, like `--logtostderr`.
+    path = Path(sys.argv[0])
+    args = sys.argv[1:]
+
+    if metadata is None:
+        metadata = Metadata(path.absolute().name, "0.0.1")
+
+    main(ComponentProvider(metadata, path), args)

--- a/sdk/python/lib/pulumi/provider/experimental/metadata.py
+++ b/sdk/python/lib/pulumi/provider/experimental/metadata.py
@@ -1,0 +1,30 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Metadata:
+    """
+    Metadata about the provider, such as the name and version.
+    """
+
+    name: str
+    """The name of the provider"""
+    version: str
+    """The version of the provider"""
+    display_name: Optional[str] = None
+    """The display name of the provider"""

--- a/sdk/python/lib/pulumi/provider/experimental/provider.py
+++ b/sdk/python/lib/pulumi/provider/experimental/provider.py
@@ -1,0 +1,57 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from ...output import Inputs
+from ...resource import ResourceOptions
+from ..provider import ConstructResult, Provider
+from .analyzer import Analyzer
+from .metadata import Metadata
+from .schema import generate_schema
+
+
+class ComponentProvider(Provider):
+    """
+    ComponentProvider is a Pulumi provider that finds components from Python
+    source code and infers a schema.
+    """
+
+    path: Path
+    """The path to the Python source code."""
+    metadata: Metadata
+    """The metadata for the provider, such as the name and version."""
+
+    def __init__(self, metadata: Metadata, path: Path) -> None:
+        self.path = path
+        self.metadata = metadata
+        self.analyzer = Analyzer(self.metadata)
+        self.components = self.analyzer.analyze(self.path)
+        schema = generate_schema(metadata, self.components)
+        super().__init__(metadata.version, json.dumps(schema.to_json()))
+
+    def construct(
+        self,
+        name: str,
+        resource_type: str,
+        inputs: Inputs,
+        options: Optional[ResourceOptions] = None,
+    ) -> ConstructResult:
+        component_name = resource_type.split(":")[-1]
+        comp = self.analyzer.find_component(self.path, component_name)
+        # ComponentResource's init signature is different from the derived class signature.
+        comp_instance = comp(name, {}, options)  # type: ignore
+        return ConstructResult(comp_instance.urn, {})

--- a/sdk/python/lib/pulumi/provider/experimental/schema.py
+++ b/sdk/python/lib/pulumi/provider/experimental/schema.py
@@ -1,0 +1,166 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Optional
+
+from .component import ComponentDefinition, PropertyDefinition
+from .metadata import Metadata
+
+
+class BuiltinType(Enum):
+    STRING = "string"
+    INTEGER = "integer"
+    NUMBER = "number"
+    BOOLEAN = "boolean"
+    OBJECT = "object"
+
+
+@dataclass
+class ObjectType:
+    type: BuiltinType
+    properties: dict[str, "Property"]
+    required: list[str]
+    description: Optional[str] = None
+
+
+@dataclass
+class ItemType:
+    type: BuiltinType
+
+    def to_json(self) -> dict[str, str]:
+        return {"type": str(self.type)}
+
+
+@dataclass
+class Property:
+    description: Optional[str]
+    type: Optional[BuiltinType]
+    will_replace_on_changes: Optional[bool]
+    items: Optional[ItemType]
+    ref: Optional[str]
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "description": self.description,
+            "type": self.type.value if self.type else None,
+            "willReplaceOnChanges": self.will_replace_on_changes,
+            "items": self.items,
+            "$ref": self.ref,
+        }
+
+    @staticmethod
+    def from_definition(property: PropertyDefinition) -> "Property":
+        return Property(
+            description=property.description,
+            type=BuiltinType(property.type.value) if property.type else None,
+            will_replace_on_changes=False,
+            items=None,
+            ref=property.ref,
+        )
+
+
+@dataclass
+class Resource:
+    is_component: bool
+    input_properties: dict[str, Property]
+    required_inputs: list[str]
+    type_: BuiltinType
+    properties: dict[str, Property]
+    required: list[str]
+    description: Optional[str] = None
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "isComponent": self.is_component,
+            "description": self.description,
+            "type": self.type_.value,
+            "inputProperties": {
+                k: v.to_json() for k, v in self.input_properties.items()
+            },
+            "requiredInputs": self.required_inputs,
+            "properties": {k: v.to_json() for k, v in self.properties.items()},
+            "required": self.required,
+        }
+
+    @staticmethod
+    def from_definition(component: ComponentDefinition) -> "Resource":
+        return Resource(
+            is_component=True,
+            type_=BuiltinType.OBJECT,
+            input_properties={
+                k: Property.from_definition(property)
+                for k, property in component.inputs.items()
+            },
+            required_inputs=[
+                k for k, prop in component.inputs.items() if not prop.optional
+            ],
+            properties={
+                k: Property.from_definition(property)
+                for k, property in component.outputs.items()
+            },
+            required=[k for k, prop in component.outputs.items() if not prop.optional],
+        )
+
+
+@dataclass
+class PackageSpec:
+    name: str
+    displayName: str
+    version: str
+    resources: dict[str, Resource]
+    language: dict[str, dict[str, Any]]
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "displayName": self.displayName,
+            "version": self.version,
+            "resources": {k: v.to_json() for k, v in self.resources.items()},
+            "language": self.language,
+        }
+
+
+def generate_schema(
+    metadata: Metadata, components: dict[str, ComponentDefinition]
+) -> PackageSpec:
+    pkg = PackageSpec(
+        name=metadata.name,
+        version=metadata.version,
+        displayName=metadata.display_name or metadata.name,
+        resources={},
+        language={
+            "nodejs": {
+                "respectSchemaVersion": True,
+            },
+            "python": {
+                "respectSchemaVersion": True,
+            },
+            "csharp": {
+                "respectSchemaVersion": True,
+            },
+            "java": {
+                "respectSchemaVersion": True,
+            },
+            "go": {
+                "respectSchemaVersion": True,
+            },
+        },
+    )
+    for component_name, component in components.items():
+        name = f"{metadata.name}:index:{component_name}"
+        pkg.resources[name] = Resource.from_definition(component)
+
+    return pkg

--- a/sdk/python/lib/test/provider/experimental/test_provider.py
+++ b/sdk/python/lib/test/provider/experimental/test_provider.py
@@ -1,0 +1,29 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pulumi.provider.experimental.provider import ComponentProvider
+
+
+def test_validate_resource_type_invalid():
+    for rt in ["not-valid", "not:valid", "pkg:not-valid-module:type", "pkg:index:"]:
+        try:
+            ComponentProvider.validate_resource_type("pkg", rt)
+            assert False, f"expected {rt} to be invalid"
+        except ValueError:
+            pass
+
+
+def test_validate_resource_type_valid():
+    for rt in ["pkg:index:type", "pkg::type", "pkg:index:Type123"]:
+        ComponentProvider.validate_resource_type("pkg", rt)

--- a/tests/integration/component_provider/python/component-provider-host/Pulumi.yaml
+++ b/tests/integration/component_provider/python/component-provider-host/Pulumi.yaml
@@ -1,0 +1,12 @@
+name: python-component-provider
+description: Using a component provider written in Python
+runtime: yaml
+plugins:
+  providers:
+    - name: provider
+      path: ./provider
+resources:
+  comp:
+    type: provider:index:MyComponent
+outputs:
+  urn: ${comp.urn}

--- a/tests/integration/component_provider/python/component-provider-host/provider/PulumiPlugin.yaml
+++ b/tests/integration/component_provider/python/component-provider-host/provider/PulumiPlugin.yaml
@@ -1,0 +1,5 @@
+runtime:
+  name: python
+  options:
+    toolchain: pip
+    virtualenv: venv

--- a/tests/integration/component_provider/python/component-provider-host/provider/__main__.py
+++ b/tests/integration/component_provider/python/component-provider-host/provider/__main__.py
@@ -1,0 +1,21 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pulumi.provider.experimental import Metadata, component_provider_host
+
+if __name__ == "__main__":
+    component_provider_host(
+        Metadata(name="provider", version="1.2.3", display_name="My Component Provider")
+    )

--- a/tests/integration/component_provider/python/component-provider-host/provider/component.py
+++ b/tests/integration/component_provider/python/component-provider-host/provider/component.py
@@ -1,0 +1,22 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+import pulumi
+
+
+class MyComponent(pulumi.ComponentResource):
+    def __init__(self, name: str, args: dict[str, Any], opts: pulumi.ResourceOptions):
+        super().__init__("component:index:MyComponent", name, {}, opts)


### PR DESCRIPTION
Add a `component_provider_host` function that allows creating providers in Python that host ComponentResources. The ComponentResources are automatically detected from the plugin’s source code, and their schema is infered based on the Python type annotations.

This first PR in the series lays out the ground work and wires everything up. The detected ComponentResources can be constructed, but no properties are infered yet.

Fixes https://github.com/pulumi/pulumi/issues/18372
