### PR TITLE
Stream standard output and error when installing dependencies

### DIFF
--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	pkgCmdUtil "github.com/pulumi/pulumi/pkg/v3/util/cmdutil"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -104,10 +105,11 @@ func NewInstallCmd() *cobra.Command {
 			}
 
 			if !noDependencies {
-				if err = lang.InstallDependencies(plugin.InstallDependenciesRequest{
+				err = pkgCmdUtil.InstallDependencies(lang, plugin.InstallDependenciesRequest{
 					Info:                    programInfo,
 					UseLanguageVersionTools: useLanguageVersionTools,
-				}); err != nil {
+				})
+				if err != nil {
 					return fmt.Errorf("installing dependencies: %w", err)
 				}
 			}

--- a/pkg/cmd/pulumi/newcmd/install.go
+++ b/pkg/cmd/pulumi/newcmd/install.go
@@ -17,6 +17,7 @@ package newcmd
 import (
 	"fmt"
 
+	"github.com/pulumi/pulumi/pkg/v3/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -31,8 +32,9 @@ func InstallDependencies(ctx *plugin.Context, runtime *workspace.ProjectRuntimeI
 		return fmt.Errorf("failed to load language plugin %s: %w", runtime.Name(), err)
 	}
 
-	if err = lang.InstallDependencies(plugin.InstallDependenciesRequest{Info: programInfo}); err != nil {
-		//revive:disable:error-strings // This error message is user facing.
+	err = cmdutil.InstallDependencies(lang, plugin.InstallDependenciesRequest{Info: programInfo})
+	if err != nil {
+		//revive:disable-next-line:error-strings // This error message is user facing.
 		return fmt.Errorf("installing dependencies failed: %w\nRun `pulumi install` to complete the installation.", err)
 	}
 

--- a/pkg/cmd/pulumi/policy/io.go
+++ b/pkg/cmd/pulumi/policy/io.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	pkgCmdUtil "github.com/pulumi/pulumi/pkg/v3/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -76,7 +77,8 @@ func InstallPolicyPackDependencies(ctx context.Context, root string, proj *works
 		return fmt.Errorf("failed to load language plugin %s: %w", proj.Runtime.Name(), err)
 	}
 
-	if err = lang.InstallDependencies(plugin.InstallDependenciesRequest{Info: programInfo}); err != nil {
+	err = pkgCmdUtil.InstallDependencies(lang, plugin.InstallDependenciesRequest{Info: programInfo})
+	if err != nil {
 		return fmt.Errorf("installing dependencies failed: %w", err)
 	}
 

--- a/pkg/resource/deploy/deploytest/languageruntime_test.go
+++ b/pkg/resource/deploy/deploytest/languageruntime_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ func TestLanguageRuntime(t *testing.T) {
 		t.Run("InstallDependencies", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{closed: true}
-			err := p.InstallDependencies(plugin.InstallDependenciesRequest{})
+			_, _, _, err := p.InstallDependencies(plugin.InstallDependenciesRequest{})
 			assert.ErrorIs(t, err, ErrLanguageRuntimeIsClosed)
 		})
 		t.Run("RuntimeOptionsPrompts", func(t *testing.T) {
@@ -99,7 +99,8 @@ func TestLanguageRuntime(t *testing.T) {
 		t.Run("InstallDependencies", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{}
-			assert.NoError(t, p.InstallDependencies(plugin.InstallDependenciesRequest{}))
+			_, _, _, err := p.InstallDependencies(plugin.InstallDependenciesRequest{})
+			assert.NoError(t, err)
 		})
 		t.Run("RuntimeOptionsPrompts", func(t *testing.T) {
 			t.Parallel()

--- a/pkg/resource/deploy/source_query_test.go
+++ b/pkg/resource/deploy/source_query_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -760,7 +760,7 @@ type mockLanguageRuntime struct {
 
 	GetPluginInfoF func() (workspace.PluginInfo, error)
 
-	InstallDependenciesF func(options plugin.InstallDependenciesRequest) error
+	InstallDependenciesF func(options plugin.InstallDependenciesRequest) (io.Reader, io.Reader, <-chan error, error)
 
 	RuntimeOptionsPromptsF func(info plugin.ProgramInfo) ([]plugin.RuntimeOptionPrompt, error)
 
@@ -826,7 +826,9 @@ func (rt *mockLanguageRuntime) GetPluginInfo() (workspace.PluginInfo, error) {
 	panic("unimplemented")
 }
 
-func (rt *mockLanguageRuntime) InstallDependencies(request plugin.InstallDependenciesRequest) error {
+func (rt *mockLanguageRuntime) InstallDependencies(
+	request plugin.InstallDependenciesRequest,
+) (io.Reader, io.Reader, <-chan error, error) {
 	if rt.InstallDependenciesF != nil {
 		return rt.InstallDependenciesF(request)
 	}

--- a/pkg/util/cmdutil/install_dependencies.go
+++ b/pkg/util/cmdutil/install_dependencies.go
@@ -1,0 +1,78 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdutil
+
+import (
+	"errors"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+)
+
+// InstallDependencies installs dependencies for the given language runtime, blocking until the installation is
+// complete. Standard output and error are streamed to os.Stdout and os.Stderr, respectively, and any errors encountered
+// during the installation or streaming of its output are returned.
+func InstallDependencies(lang plugin.LanguageRuntime, req plugin.InstallDependenciesRequest) error {
+	stdout, stderr, done, err := lang.InstallDependencies(req)
+	if err != nil {
+		return err
+	}
+
+	// We'll use a WaitGroup to wait for the stdout (1) and stderr (2) readers to be fully drained, as well as for the
+	// done channel to close (3), before we return.
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	errorChan := make(chan error, 3)
+
+	go func() {
+		defer wg.Done()
+		if _, err := io.Copy(os.Stdout, stdout); err != nil {
+			errorChan <- err
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		if _, err := io.Copy(os.Stderr, stderr); err != nil {
+			errorChan <- err
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		if err := <-done; err != nil {
+			errorChan <- err
+		}
+	}()
+
+	var errs []error
+	wg.Wait()
+	close(errorChan)
+	for err := range errorChan {
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	err = errors.Join(errs...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/sdk/go/common/resource/plugin/langruntime.go
+++ b/sdk/go/common/resource/plugin/langruntime.go
@@ -130,7 +130,10 @@ type LanguageRuntime interface {
 	GetPluginInfo() (workspace.PluginInfo, error)
 
 	// InstallDependencies will install dependencies for the project, e.g. by running `npm install` for nodejs projects.
-	InstallDependencies(request InstallDependenciesRequest) error
+	// It returns io.Readers for stdout and stderr as well as a channel that will be closed when the operation is
+	// complete, producing an error if one occurred. Callers *must* drain the stdout and stderr readers if they await the
+	// done channel to avoid deadlocks.
+	InstallDependencies(request InstallDependenciesRequest) (io.Reader, io.Reader, <-chan error, error)
 
 	// RuntimeOptions returns additional options that can be set for the runtime.
 	RuntimeOptionsPrompts(info ProgramInfo) ([]RuntimeOptionPrompt, error)

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1017,7 +1017,7 @@ func (host *nodeLanguageHost) InstallDependencies(
 		// in here works well enough for conformance testing.
 		tscCmd := exec.Command("npx", "tsc")
 		tscCmd.Dir = req.Info.ProgramDirectory
-		if err := runWithOutput(tscCmd, os.Stdout, os.Stderr); err != nil {
+		if err := runWithOutput(tscCmd, stdout, stderr); err != nil {
 			return fmt.Errorf("failed to run tsc: %w", err)
 		}
 	}


### PR DESCRIPTION
The `InstallDependencies` method of the language host gRPC interface supports streaming back data for the standard output and error of the processes being executed by the language host (e.g. `npm install` for NodeJS). Presently however, we do not expose these streams in the higher-level `LanguageHost` Go interface. This commit changes that, having `LanguageHost`'s `InstallDependencies` method return a pair of `io.Reader`s for standard output and error respectively, as well as a channel that will be closed when the operation completes. This transforms `InstallDependencies` to an asynchronous call and so call sites are modified appropriately to drain the readers and block on the `done` channel's closure. With this change, we can modify the language conformance test server to capture standard output and error when dependency installation goes wrong, making it easier to debug conformance tests in the process.

Fixes #13941