### PR TITLE
[Experimental] Handle inputs and outputs

### DIFF
--- a/changelog/pending/20250131--sdk-python--experimental-camelcase-property-names.yaml
+++ b/changelog/pending/20250131--sdk-python--experimental-camelcase-property-names.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: "[Experimental/Components] Handle inputs and outputs"

--- a/sdk/python/lib/pulumi/provider/experimental/component.py
+++ b/sdk/python/lib/pulumi/provider/experimental/component.py
@@ -38,6 +38,8 @@ class TypeDefinition:
     name: str
     type: str
     properties: dict[str, PropertyDefinition]
+    properties_mapping: dict[str, str]
+    """Mapping from the schema name to the Python name."""
     description: Optional[str] = None
 
 
@@ -45,4 +47,8 @@ class TypeDefinition:
 class ComponentDefinition:
     inputs: dict[str, PropertyDefinition]
     outputs: dict[str, PropertyDefinition]
+    inputs_mapping: dict[str, str]
+    """Mapping from the schema name to the Python name."""
+    outputs_mapping: dict[str, str]
+    """Mapping from the schema name to the Python name."""
     description: Optional[str] = None

--- a/sdk/python/lib/pulumi/provider/experimental/util.py
+++ b/sdk/python/lib/pulumi/provider/experimental/util.py
@@ -1,0 +1,24 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def camel_case(name: str) -> str:
+    arr = name.split("_")
+    return arr[0] + "".join([_upper_first(w) for w in arr[1:]])
+
+
+def _upper_first(name: str) -> str:
+    if len(name) == 0:
+        return ""
+    return name[0].upper() + name[1:]

--- a/sdk/python/lib/test/provider/experimental/test_analyzer.py
+++ b/sdk/python/lib/test/provider/experimental/test_analyzer.py
@@ -48,13 +48,23 @@ def test_analyze_component():
         description="Component doc string",
         inputs={
             "algorithm": PropertyDefinition(type=PropertyType.STRING),
-            "ecdsa_curve": PropertyDefinition(type=PropertyType.STRING, optional=True),
+            "ecdsaCurve": PropertyDefinition(type=PropertyType.STRING, optional=True),
             "bits": PropertyDefinition(type=PropertyType.INTEGER, optional=True),
+        },
+        inputs_mapping={
+            "algorithm": "algorithm",
+            "ecdsaCurve": "ecdsa_curve",
+            "bits": "bits",
         },
         outputs={
             "pem": PropertyDefinition(type=PropertyType.STRING),
-            "private_key": PropertyDefinition(type=PropertyType.STRING),
-            "ca_cert": PropertyDefinition(type=PropertyType.STRING),
+            "privateKey": PropertyDefinition(type=PropertyType.STRING),
+            "caCert": PropertyDefinition(type=PropertyType.STRING),
+        },
+        outputs_mapping={
+            "pem": "pem",
+            "privateKey": "private_key",
+            "caCert": "ca_cert",
         },
     )
 
@@ -81,7 +91,9 @@ def test_analyze_component_empty():
     component = analyzer.analyze_component(Empty)
     assert component == ComponentDefinition(
         inputs={},
+        inputs_mapping={},
         outputs={},
+        outputs_mapping={},
     )
 
 
@@ -104,16 +116,28 @@ def test_analyze_component_plain_types():
     component = analyzer.analyze_component(Empty)
     assert component == ComponentDefinition(
         inputs={
-            "input_int": PropertyDefinition(type=PropertyType.INTEGER),
-            "input_str": PropertyDefinition(type=PropertyType.STRING),
-            "input_float": PropertyDefinition(type=PropertyType.NUMBER),
-            "input_bool": PropertyDefinition(type=PropertyType.BOOLEAN),
+            "inputInt": PropertyDefinition(type=PropertyType.INTEGER),
+            "inputStr": PropertyDefinition(type=PropertyType.STRING),
+            "inputFloat": PropertyDefinition(type=PropertyType.NUMBER),
+            "inputBool": PropertyDefinition(type=PropertyType.BOOLEAN),
+        },
+        inputs_mapping={
+            "inputInt": "input_int",
+            "inputStr": "input_str",
+            "inputFloat": "input_float",
+            "inputBool": "input_bool",
         },
         outputs={
-            "output_int": PropertyDefinition(type=PropertyType.INTEGER),
-            "output_str": PropertyDefinition(type=PropertyType.STRING),
-            "output_float": PropertyDefinition(type=PropertyType.NUMBER),
-            "output_bool": PropertyDefinition(type=PropertyType.BOOLEAN),
+            "outputInt": PropertyDefinition(type=PropertyType.INTEGER),
+            "outputStr": PropertyDefinition(type=PropertyType.STRING),
+            "outputFloat": PropertyDefinition(type=PropertyType.NUMBER),
+            "outputBool": PropertyDefinition(type=PropertyType.BOOLEAN),
+        },
+        outputs_mapping={
+            "outputInt": "output_int",
+            "outputStr": "output_str",
+            "outputFloat": "output_float",
+            "outputBool": "output_bool",
         },
     )
 
@@ -135,15 +159,17 @@ def test_analyze_component_complex_type():
     component = analyzer.analyze_component(Component)
     assert component == ComponentDefinition(
         inputs={
-            "some_complex_type": PropertyDefinition(
+            "someComplexType": PropertyDefinition(
                 ref="#/types/my-component:index:ComplexType"
             ),
         },
+        inputs_mapping={"someComplexType": "some_complex_type"},
         outputs={
-            "complex_output": PropertyDefinition(
+            "complexOutput": PropertyDefinition(
                 ref="#/types/my-component:index:ComplexType"
             )
         },
+        outputs_mapping={"complexOutput": "complex_output"},
     )
     assert analyzer.type_definitions == {
         "ComplexType": TypeDefinition(
@@ -151,9 +177,13 @@ def test_analyze_component_complex_type():
             type="object",
             properties={
                 "value": PropertyDefinition(type=PropertyType.STRING),
-                "optional_value": PropertyDefinition(
+                "optionalValue": PropertyDefinition(
                     type=PropertyType.INTEGER, optional=True
                 ),
+            },
+            properties_mapping={
+                "value": "value",
+                "optionalValue": "optional_value",
             },
         )
     }

--- a/sdk/python/lib/test/provider/experimental/test_util.py
+++ b/sdk/python/lib/test/provider/experimental/test_util.py
@@ -1,0 +1,13 @@
+from pulumi.provider.experimental.util import camel_case
+
+
+def test_camel_case():
+    assert camel_case("foo_bar") == "fooBar"
+    assert camel_case("foo_bar_baz") == "fooBarBaz"
+    assert camel_case("Foo_Bar_Baz") == "FooBarBaz"
+    assert camel_case("URL") == "URL"
+    assert camel_case("url") == "url"
+    assert camel_case("Foo_URL") == "FooURL"
+    assert camel_case("FooURL") == "FooURL"
+    assert camel_case("foo_") == "foo"
+    assert camel_case("foo_bar_") == "fooBar"

--- a/tests/integration/component_provider/python/component-provider-host/Pulumi.yaml
+++ b/tests/integration/component_provider/python/component-provider-host/Pulumi.yaml
@@ -8,5 +8,10 @@ plugins:
 resources:
   comp:
     type: provider:index:MyComponent
+    properties:
+      strInput: hello
+      optionalIntInput: 42
 outputs:
   urn: ${comp.urn}
+  strOutput: ${comp.strOutput}
+  optionalIntOutput: ${comp.optionalIntOutput}

--- a/tests/integration/component_provider/python/component-provider-host/provider/component.py
+++ b/tests/integration/component_provider/python/component-provider-host/provider/component.py
@@ -12,11 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
+
+from typing import Optional, TypedDict
 
 import pulumi
 
 
+class Args(TypedDict):
+    str_input: pulumi.Input[str]
+    optional_int_input: Optional[pulumi.Input[int]]
+
+
 class MyComponent(pulumi.ComponentResource):
-    def __init__(self, name: str, args: dict[str, Any], opts: pulumi.ResourceOptions):
+    str_output: pulumi.Output[str]
+    optional_int_output: pulumi.Output[Optional[int]]
+
+    def __init__(self, name: str, args: Args, opts: pulumi.ResourceOptions):
         super().__init__("component:index:MyComponent", name, {}, opts)
+        self.str_output = pulumi.Output.from_input(args.get("str_input")).apply(
+            lambda x: x.upper()
+        )
+        self.optional_int_output = pulumi.Output.from_input(
+            args.get("optional_int_input", None)
+        ).apply(lambda x: x * 2 if x else None)
+        self.register_outputs(
+            {
+                "str_output": self.str_output,
+                "optional_int_output": self.optional_int_output,
+            }
+        )


### PR DESCRIPTION
Names need to be camel cased in the schema. Going from snake_case to camelCase is fine, however for the opposite direction we need to keep track of the original names. For example `URL` might have been `u_r_l` or `URL` originally.

With the mapping in place, we can send inputs into the component, and retrive the outputs.

Ref https://github.com/pulumi/pulumi/issues/18366