### PR TITLE
Improve local Go SDK help text

### DIFF
--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -451,6 +451,7 @@ func linkGoPackage(root string, pkg *schema.Package, out string) error {
 	}
 
 	fmt.Printf("Go mod file updated to use local sdk for %s\n", pkg.Name)
+	fmt.Printf("To use this package, import %s\n", goInfo.ImportBasePath)
 
 	return nil
 }


### PR DESCRIPTION
When using a local Go SDK, it is not clear from either the help text or the module replacement what the `import` path specification should be.

This pull request surfaces the Go importBasePath to the user.

Fixes #18385.


