### PR TITLE
Use old inputs for Same steps

### DIFF
--- a/changelog/pending/20250204--engine--the-engine-will-correctly-use-old-state-for-provider-config-with-no-reported-differences.yaml
+++ b/changelog/pending/20250204--engine--the-engine-will-correctly-use-old-state-for-provider-config-with-no-reported-differences.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: The engine will correctly use old state for provider config with no reported differences

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -1860,4 +1860,5 @@ func TestProviderSameStep(t *testing.T) {
 	// in the presence of changed values but same_diff results.
 	prov := snap.Resources[0]
 	assert.Equal(t, "200", prov.Inputs["value"].StringValue())
+	assert.Equal(t, "100", prov.Outputs["value"].StringValue())
 }

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -1803,3 +1803,61 @@ func TestRefreshLegacyState(t *testing.T) {
 	assert.Equal(t, "1.3.0", prov.Inputs["version"].StringValue())
 	assert.Equal(t, "http://example.com", prov.Inputs["pluginDownloadURL"].StringValue())
 }
+
+// TestProviderSameStep tests that if we same step a provider it uses the old inputs from state, not the
+// inputs from the program.
+// https://github.com/pulumi/pulumi/pull/18411
+func TestProviderSameStep(t *testing.T) {
+	t.Parallel()
+
+	providerConfigValue := resource.NewStringProperty("100")
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkg", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				DiffConfigF: func(_ context.Context, req plugin.DiffConfigRequest) (plugin.DiffConfigResponse, error) {
+					assert.Equal(t, "100", req.OldInputs["value"].StringValue())
+					assert.Equal(t, "200", req.NewInputs["value"].StringValue())
+					return plugin.DiffConfigResponse{Changes: plugin.DiffNone}, nil
+				},
+				ConfigureF: func(_ context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
+					assert.Equal(t, "100", req.Inputs["value"].StringValue())
+					return plugin.ConfigureResponse{}, nil
+				},
+			}, nil
+		}),
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		_, err := monitor.RegisterResource("pulumi:providers:pkg", "provA", true, deploytest.ResourceOptions{
+			Inputs: resource.PropertyMap{
+				"value": providerConfigValue,
+			},
+		})
+		assert.NoError(t, err)
+
+		return nil
+	})
+
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
+	}
+
+	project := p.GetProject()
+
+	// Run the first update to create the base state
+	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	assert.NoError(t, err)
+
+	// Run another update where we send a new value for the provider config, but diff reports no diff so we
+	// should same step
+	providerConfigValue = resource.NewStringProperty("200")
+	snap, err = lt.TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil)
+	assert.NoError(t, err)
+
+	// But we should still save the new inputs, this is odd but consistent with same steps for other resources
+	// in the presence of changed values but same_diff results.
+	prov := snap.Resources[0]
+	assert.Equal(t, "200", prov.Inputs["value"].StringValue())
+}

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -155,7 +155,9 @@ func (s *SameStep) Apply() (resource.Status, StepCompleteFunc, error) {
 	// We can only do this if the provider is actually a same, not a skipped create.
 	if providers.IsProviderType(s.new.Type) && !s.skippedCreate {
 		if s.Deployment() != nil {
-			// we use the _old_ state here because we want to ensure that the provider is registered under the
+			// We need to use the new state here (so that URN and ID are correct), but we want to use the old
+			// inputs. This ensures that providers that report changed inputs as NO_DIFF consistently see the
+			// old inputs, not the new ones.
 			st := s.new.Copy()
 			st.Inputs = s.old.Inputs
 			err := s.Deployment().SameProvider(st)

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -155,7 +155,10 @@ func (s *SameStep) Apply() (resource.Status, StepCompleteFunc, error) {
 	// We can only do this if the provider is actually a same, not a skipped create.
 	if providers.IsProviderType(s.new.Type) && !s.skippedCreate {
 		if s.Deployment() != nil {
-			err := s.Deployment().SameProvider(s.new)
+			// we use the _old_ state here because we want to ensure that the provider is registered under the
+			st := s.new.Copy()
+			st.Inputs = s.old.Inputs
+			err := s.Deployment().SameProvider(st)
 			if err != nil {
 				return resource.StatusOK, nil,
 					fmt.Errorf("bad provider state for resource %v: %w", s.URN(), err)


### PR DESCRIPTION
Prompted by https://github.com/pulumi/pulumi-docker/issues/1339

As part of investigating this issue it transpired that the engine currently uses the new inputs for provider configuration, even if the provider says there's no difference between the old inputs and the new inputs. 

This leads to inconsistencies when a provider reports no diff, but the values have actually changed. Worse this leads to inconsistencies of if the new or old inputs are used based on the order of operations.

In a normal update the new inputs from the program (or config) would be used to configure the provider, but in a refresh update (e.g. `up --refresh`) the engine would first configure the provider based on the old inputs saved in state. As diff then reported "no diff" the engine would never re-initialize and configure with the new inputs. So depending on if you added `--refresh` or not you either got new or old configuration for the provider.

This makes it consistent that we _always_ use the old inputs in state if the provider reports that there is no configuration diff change.

N.B. We still _save_ the new inputs into state, and so on the next run _they_ will be the old inputs. This matches what we do for same steps for other resources. It feels like there might be an inconsistency lurking here as well, but that needs more thinking and discussion before actioning.
