### PR TITLE
Skip TestDestroyUpgradeWarningParameterized on Windows

### DIFF
--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -840,6 +840,9 @@ func TestDestroyUpgradeWarning(t *testing.T) {
 //
 //nolint:paralleltest // pulumi new is not parallel safe
 func TestDestroyUpgradeWarningParameterized(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Very flakey on Windows https://github.com/pulumi/pulumi/issues/18414")
+	}
 	e := ptesting.NewEnvironment(t)
 	defer deleteIfNotFailed(e)
 


### PR DESCRIPTION
Re-enabling is tracked in https://github.com/pulumi/pulumi/issues/18414