### PR TITLE
Flesh out documentation for language runtime gRPCs

### DIFF
--- a/docs/architecture/plugins.md
+++ b/docs/architecture/plugins.md
@@ -11,9 +11,9 @@ following kinds of plugins:
   [providers](providers) for more) expose a [standardized gRPC
   interface](pulumirpc.ResourceProvider) for managing resources (such as those
   in an AWS or GCP cloud).
-* *Language plugins* host programs written in a particular language, allowing
-  the engine to invoke Pulumi programs without having to understand the
-  specifics of their implementation.
+* [*Language plugins*](languages) host programs written in a particular
+  language, allowing the engine to invoke Pulumi programs without having to
+  understand the specifics of their implementation.
 * *Analyzer plugins* are used to analyze Pulumi programs for potential issues
   before they are executed. Analyzers underpin [CrossGuard, Pulumi's Policy as
   Code](https://www.pulumi.com/docs/using-pulumi/crossguard/) product.

--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -16,7 +16,7 @@
 1027667133 3164 proto/pulumi/converter.proto
 1998652962 3845 proto/pulumi/engine.proto
 1921230328 1269 proto/pulumi/errors.proto
-2888070731 13849 proto/pulumi/language.proto
+881720039 27131 proto/pulumi/language.proto
 1674803920 2966 proto/pulumi/plugin.proto
 1142872678 57051 proto/pulumi/provider.proto
 940215571 17847 proto/pulumi/resource.proto

--- a/proto/pulumi/language.proto
+++ b/proto/pulumi/language.proto
@@ -23,290 +23,564 @@ package pulumirpc;
 
 option go_package = "github.com/pulumi/pulumi/sdk/v3/proto/go;pulumirpc";
 
-// LanguageRuntime is the interface that the planning monitor uses to drive execution of an interpreter responsible
-// for confguring and creating resource objects.
+// The LanguageRuntime service defines a standard interface for [language hosts/runtimes](languages). At a high level, a
+// language runtime provides the ability to execute programs, install and query dependencies, and generate code for a
+// specific language.
 service LanguageRuntime {
-    // `Handshake` is the first call made by the engine to a language host. It is used to pass the 
-    // engine's address to the language host so that it may establish its own connections back,
-    // and to establish protocol configuration that will be used to communicate between the two parties. 
+    // `Handshake` is the first call made by the engine to a language host. It is used to pass the engine's address to
+    // the language host so that it may establish its own connections back, and to establish protocol configuration that
+    // will be used to communicate between the two parties.
     rpc Handshake(LanguageHandshakeRequest) returns (LanguageHandshakeResponse) {}
 
-    // GetRequiredPlugins computes the complete set of anticipated plugins required by a program.
+    // `GetRequiredPlugins` computes the complete set of anticipated [plugins](plugins) required by a Pulumi program.
+    // Among other things, it is intended to be used to pre-install plugins before running a program with
+    // [](pulumirpc.LanguageRuntime.Run), to avoid the need to install them on-demand in response to [resource
+    // registrations](resource-registration) sent back from the running program to the engine.
+    //
+    // :::{important}
+    // The use of `GetRequiredPlugins` is deprecated in favour of [](pulumirpc.LanguageRuntime.GetRequiredPackages),
+    // which returns more granular information about which plugins are required by which packages.
+    // :::
     rpc GetRequiredPlugins(GetRequiredPluginsRequest) returns (GetRequiredPluginsResponse) {
         option deprecated = true;
     }
-    // GetRequiredPackages computes the complete set of anticipated packages required by a program.
+
+    // `GetRequiredPackages` computes the complete set of anticipated [packages](pulumirpc.PackageDependency) required
+    // by a program. It is used to pre-install packages before running a program with [](pulumirpc.LanguageRuntime.Run),
+    // to avoid the need to install them on-demand in response to [resource registrations](resource-registration) sent
+    // back from the running program to the engine. Moreover, when importing resources into a stack, it is used to
+    // determine which plugins are required to service the import of a given resource, since given the presence of
+    // [parameterized providers](parameterized-providers), it is not in general true that a package name corresponds 1:1
+    // with a plugin name. It replaces [](pulumirpc.LanguageRuntime.GetRequiredPlugins) in the face of [parameterized
+    // providers](parameterized-providers), which as mentioned above can enable multiple instances of the same plugin to
+    // provide multiple packages.
     rpc GetRequiredPackages(GetRequiredPackagesRequest) returns (GetRequiredPackagesResponse) {}
 
-    // Run executes a program and returns its result.
+    // `Run` executes a Pulumi program, returning information about whether or not the program produced an error.
     rpc Run(RunRequest) returns (RunResponse) {}
-    // GetPluginInfo returns generic information about this plugin, like its version.
+
+    // `GetPluginInfo` returns information about the [plugin](plugins) implementing this language runtime.
     rpc GetPluginInfo(google.protobuf.Empty) returns (PluginInfo) {}
 
-    // InstallDependencies will install dependencies for the project, e.g. by running `npm install` for nodejs projects.
-    rpc InstallDependencies(InstallDependenciesRequest) returns (stream  InstallDependenciesResponse) {}
+    // `InstallDependencies` accepts a request specifying a Pulumi project and program that can be executed with
+    // [](pulumirpc.LanguageRuntime.Run) and installs the dependencies for that program (e.g. by running `npm install`
+    // for NodeJS, or `pip install` for Python). Since dependency installation could take a while, and callers may wish
+    // to report on its progress, this method returns a stream of [](pulumirpc.InstallDependenciesResponse) messages
+    // containing information about standard error and output.
+    rpc InstallDependencies(InstallDependenciesRequest) returns (stream InstallDependenciesResponse) {}
 
-    // RuntimeOptionsPrompts returns a list of additional prompts to ask during `pulumi new`.
+    // `RuntimeOptionsPrompts` accepts a request specifying a Pulumi project and returns a list of additional prompts to
+    // ask during `pulumi new`.
     rpc RuntimeOptionsPrompts(RuntimeOptionsRequest) returns (RuntimeOptionsResponse) {}
 
-    // About returns information about the runtime for this language.
+    // `About` returns information about the language runtime being used.
     rpc About(AboutRequest) returns (AboutResponse) {}
 
-    // GetProgramDependencies returns the set of dependencies required by the program.
+    // `GetProgramDependencies` computes the set of language-level dependencies (e.g. NPM packages for NodeJS, or Maven
+    // libraries for Java) required by a program.
     rpc GetProgramDependencies(GetProgramDependenciesRequest) returns (GetProgramDependenciesResponse) {}
 
-    // RunPlugin executes a plugin program and returns its result asynchronously.
+    // `RunPlugin` is used to execute a program written in this host's language that implements a Pulumi
+    // [plugin](plugins). It it is plugins what [](pulumirpc.LanguageRuntime.Run) is to programs. Since a plugin is not
+    // expected to terminate until instructed/for a long time, this method returns a stream of
+    // [](pulumirpc.RunPluginResponse) messages containing information about standard error and output, as well as the
+    // exit code of the plugin when it does terminate.
     rpc RunPlugin(RunPluginRequest) returns (stream RunPluginResponse) {}
 
-    // GenerateProgram generates a given PCL program into a program for this language.
+    // `GenerateProgram` generates code in this host's language that implements the given [PCL](pcl) program. Unlike
+    // [](pulumirpc.LanguageRuntime.GenerateProject), this method *only* generates program code, and does not e.g.
+    // generate a `package.json` for a NodeJS project that details how to run that code.
+    // [](pulumirpc.LanguageRuntime.GenerateProject), this method underpins ["programgen"](programgen) and the main
+    // functionality powering `pulumi convert`.
     rpc GenerateProgram(GenerateProgramRequest) returns (GenerateProgramResponse) {}
 
-    // GenerateProject generates a given PCL program into a project for this language.
+    // `GenerateProject` generates code in this host's language that implements the given [PCL](pcl) program and wraps
+    // it in some language-specific notion of a "project", where a project is a buildable or runnable artifact. In this
+    // sense, `GenerateProject`'s output is a superset of that of [](pulumirpc.LanguageRuntime.GenerateProgram). For
+    // instance, when generating a NodeJS project, this method might generate a corresponding `package.json` file, as
+    // well as the relevant NodeJS program code. Along with [](pulumirpc.LanguageRuntime.GenerateProgram), this method
+    // underpins ["programgen"](programgen) and the main functionality powering `pulumi convert`.
     rpc GenerateProject(GenerateProjectRequest) returns (GenerateProjectResponse) {}
 
-    // GeneratePackage generates a given pulumi package into a package for this language.
+    // `GeneratePackage` generates code in this host's language that implements an [SDK](sdkgen) ("sdkgen") for the
+    // given Pulumi package, as specified by a [schema](schema).
     rpc GeneratePackage(GeneratePackageRequest) returns (GeneratePackageResponse) {}
 
-    // Pack packs a package into a language specific artifact.
+    // `Pack` accepts a request specifying a generated SDK package and packs it into a language-specific artifact. For
+    // instance, in the case of Java, it might produce a JAR file from a list of `.java` sources; in the case of NodeJS,
+    // a `.tgz` file might be produced from a list of `.js` sources; and so on. Presently, `Pack` is primarily used in
+    // [language conformance tests](language-conformance-tests), though it is intended to be used more widely in future
+    // to standardise e.g. provider publishing workflows.
     rpc Pack(PackRequest) returns (PackResponse) {}
 }
 
-// ProgramInfo are the common set of options that a language runtime needs to execute or query a program. This
-// is filled in by the engine based on where the `Pulumi.yaml` file was, the `runtime.options` property, and
-// the `main` property.
+// A `ProgramInfo` struct specifies a Pulumi program, and is built typically based on the location of a `Pulumi.yaml`
+// file and the `runtime`, `main` and other properties within that file.
 message ProgramInfo {
-    // the root of the project, where the `Pulumi.yaml` file is located.
+    // The root of the project containing the program, where the `Pulumi.yaml` file is located. This should be an
+    // absolute path on the filesystem that is accessible to the language host.
     string root_directory = 1;
-    // the absolute path to the directory of the program to execute. Generally, but not required to be,
-    // underneath the root directory.
+
+    // The directory containing the program to execute (e.g. the location of the `index.ts` for a TypeScript NodeJS
+    // program). This should be an absolute path on the filesystem that is accessible to the language host. If
+    // `ProgramInfo` is being built from a `Pulumi.yaml`, this will typically be the directory portion of the `main`
+    // property in that file.
     string program_directory = 2;
-    // the entry point of the program, normally '.' meaning to just use the program directory, but can also be
-    // a filename inside the program directory. How that filename is interpreted, if at all, is language
-    // specific.
+
+    // The entry point of the program to execute. This should be a relative path from the `program_directory`, and is
+    // often just `.` to indicate the program directory itself, but it can also be a filename inside the directory.. If
+    // `ProgramInfo` is being built from a `Pulumi.yaml`, this will typically be the filename specified `main` property
+    // in that file if it is present, or the aforementioned `.` if not.
     string entry_point = 3;
-    // JSON style options from the `Pulumi.yaml` runtime options section.
+
+    // A struct capturing any language-specific options. If `ProgramInfo` is being built from a `Pulumi.yaml`, this will
+    // contain the `runtime.options` property from that file.
     google.protobuf.Struct options = 4;
 }
 
+// `AboutRequest` is the type of requests sent as part of an [](pulumirpc.LanguageRuntime.About) call.
 message AboutRequest {
-    ProgramInfo info = 1; // the program info to use.
+    // The program to use.
+    ProgramInfo info = 1;
 }
 
-// AboutResponse returns runtime information about the language.
+// `AboutResponse` is the type of responses sent by an [](pulumirpc.LanguageRuntime.About) call. It contains information
+// about the language runtime being used.
 message AboutResponse {
-    string executable = 1; // the primary executable for the runtime of this language.
-    string version = 2; // the version of the runtime for this language.
-    map<string, string> metadata = 3; // other information about this language.
+    // The primary executable for the runtime of this language. This should be an absolute path. E.g. for NodeJS on a
+    // POSIX system, this might be something like `/usr/bin/node`.
+    string executable = 1;
+
+    // The version of the runtime underpinning the language host. E.g. for a NodeJS host, this might be the version of
+    // `node` being used.
+    string version = 2;
+
+    // Other host-specific metadata about the runtime underpinning the language host.
+    map<string, string> metadata = 3;
 }
 
+// `GetProgramDependenciesRequest` is the type of requests sent as part of a
+// [](pulumirpc.LanguageRuntime.GetProgramDependencies) call.
 message GetProgramDependenciesRequest {
-    string project = 1 [deprecated = true]; // the project name, the engine always sets this to "deprecated" now.
-    string pwd = 2 [deprecated = true];     // the program's working directory. Deprecated, use info.program_directory instead.
-    string program = 3 [deprecated = true]; // the path to the program. Deprecated, use info.entry_point instead.
-    bool transitiveDependencies = 4; // if transitive dependencies should be included in the result.
-    ProgramInfo info = 5; // the program info to use to calculate dependencies.
+    // The project name.
+    //
+    // :::{important}
+    // This is deprecated in favour of passing a [program info](pulumirpc.ProgramInfo) struct as the `info` field. Newer
+    // versions of the engine will always set this field to the string `"deprecated"`.
+    // :::
+    string project = 1 [deprecated = true];
+
+    // The program's working directory.
+    //
+    // :::{important}
+    // This is deprecated in favour of passing a [program info](pulumirpc.ProgramInfo) struct as the `info` field, with
+    // the `program_directory` field set to this value.
+    // :::
+    string pwd = 2 [deprecated = true];
+
+    // The path to the program.
+    //
+    // :::{important}
+    // This is deprecated in favour of passing a [program info](pulumirpc.ProgramInfo) struct as the `info` field, with
+    // the `entry_point` field set to this value.
+    // :::
+    string program = 3 [deprecated = true];
+
+    // True if transitive dependencies should be included in the response.
+    bool transitiveDependencies = 4;
+
+    // The program to use.
+    ProgramInfo info = 5;
 }
 
+// `DependencyInfo` is a struct that captures information about a language-specific dependency required by a program
+// (e.g. an NPM package for NodeJS, or a Maven library for Java). It is returned as part of a
+// [](pulumirpc.LanguageRuntime.GetProgramDependenciesResponse).
 message DependencyInfo {
-    string name = 1; // The name of the dependency.
-    string version = 2; // The version of the dependency.
+    // The name of the dependency.
+    string name = 1;
+
+    // The version of the dependency.
+    string version = 2;
 }
 
+// `GetProgramDependenciesResponse` is the type of responses sent by a
+// [](pulumirpc.LanguageRuntime.GetProgramDependencies) call. It contains information about the dependencies of a
+// program.
 message GetProgramDependenciesResponse {
-    repeated DependencyInfo dependencies = 1; // the dependencies of this program
+    // The dependencies of the program specified by the request.
+    repeated DependencyInfo dependencies = 1;
 }
 
+// `GetRequiredPluginsRequest` is the type of requests sent as part of a
+// [](pulumirpc.LanguageRuntime.GetRequiredPlugins) call.
 message GetRequiredPluginsRequest {
-    string project = 1 [deprecated = true]; // the project name, the engine always sets this to "deprecated" now.
-    string pwd = 2 [deprecated = true];     // the program's working directory. Deprecated, use info.program_directory instead.
-    string program = 3 [deprecated = true]; // the path to the program. Deprecated, use info.entry_point instead.
-    ProgramInfo info = 4; // the program info to use to calculate plugins.
+    // The project name.
+    //
+    // :::{important}
+    // This is deprecated in favour of passing a [program info](pulumirpc.ProgramInfo) struct as the `info` field. Newer
+    // versions of the engine will always set this field to the string `"deprecated"`.
+    // :::
+    string project = 1 [deprecated = true];
+
+    // The program's working directory.
+    //
+    // :::{important}
+    // This is deprecated in favour of passing a [program info](pulumirpc.ProgramInfo) struct as the `info` field, with
+    // the `program_directory` field set to this value.
+    // :::
+    string pwd = 2 [deprecated = true];
+
+    // The path to the program.
+    //
+    // :::{important}
+    // This is deprecated in favour of passing a [program info](pulumirpc.ProgramInfo) struct as the `info` field, with
+    // the `entry_point` field set to this value.
+    // :::
+    string program = 3 [deprecated = true];
+
+    // The program to use.
+    ProgramInfo info = 4;
 }
 
+// `GetRequiredPluginsResponse` is the type of responses sent by a [](pulumirpc.LanguageRuntime.GetRequiredPlugins)
+// call. It contains information about the plugins required by a program.
 message GetRequiredPluginsResponse {
-    repeated PluginDependency plugins = 1; // a list of plugins required by this program.
+    // The plugins required by the program specified by the request.
+    repeated PluginDependency plugins = 1;
 }
 
+// `GetRequiredPackagesRequest` is the type of requests sent as part of a
+// [](pulumirpc.LanguageRuntime.GetRequiredPackages) call.
 message GetRequiredPackagesRequest {
-    ProgramInfo info = 1; // the program info to use to calculate packages.
+    // The program to use.
+    ProgramInfo info = 1;
 }
 
+// `GetRequiredPackagesResponse` is the type of responses sent by a [](pulumirpc.LanguageRuntime.GetRequiredPackages)
+// call. It contains information about the packages required by a program.
 message GetRequiredPackagesResponse {
-    repeated PackageDependency packages = 1; // a list of packages required by this program.
+    // The packages required by the program specified by the request.
+    repeated PackageDependency packages = 1;
 }
 
-// RunRequest asks the interpreter to execute a program.
+// `RunRequest` is the type of requests sent as part of a [](pulumirpc.LanguageRuntime.Run) call.
 message RunRequest {
-    string project = 1;             // the project name.
-    string stack = 2;               // the name of the stack being deployed into.
-    string pwd = 3;                 // the program's working directory.
-    string program = 4 [deprecated = true];             // the path to the program to execute. Deprecated, use info.entry_point instead.
-    repeated string args = 5;       // any arguments to pass to the program.
-    map<string, string> config = 6; // the configuration variables to apply before running.
-    bool dryRun = 7;                // true if we're only doing a dryrun (preview).
-    int32 parallel = 8;             // the degree of parallelism for resource operations (<=1 for serial).
-    string monitor_address = 9;     // the address for communicating back to the resource monitor.
-    bool queryMode = 10;            // true if we're only doing a query.
-    repeated string configSecretKeys = 11; // the configuration keys that have secret values.
-    string organization = 12;       // the organization of the stack being deployed into.
-    google.protobuf.Struct configPropertyMap = 13; // the configuration variables to apply before running.
-    ProgramInfo info = 14; // the program info to use to execute the program.
+    // The project name.
+    string project = 1;
+
+    // The name of the stack being deployed into.
+    string stack = 2;
+
+    // The program's working directory.
+    string pwd = 3;
+
+    // The path to the program.
+    //
+    // :::{important}
+    // This is deprecated in favour of passing a [program info](pulumirpc.ProgramInfo) struct as the `info` field, with
+    // the `entry_point` field set to this value.
+    // :::
+    string program = 4 [deprecated = true];
+
+    // Any arguments to pass to the program.
+    repeated string args = 5;
+
+    // Configuration variables to apply before running the program.
+    map<string, string> config = 6;
+
+    // True if we are only doing a dry run (preview).
+    bool dryRun = 7;
+
+    // The degree of parallelism that should be used for resource operations. A value less than or equal to 1 indicates
+    // serial execution.
+    int32 parallel = 8;
+
+    // The address of the [](pulumirpc.ResourceMonitor) that the program should connect to send [resource
+    // registrations](resource-registration) and other calls to.
+    string monitor_address = 9;
+
+    // True if and only if we are only performing a query.
+    bool queryMode = 10;
+
+    // A list of configuration keys whose values should be treated as secrets.
+    repeated string configSecretKeys = 11;
+
+    // The organization of the stack being deployed into.
+    string organization = 12;
+
+    // Configuration variables to apply before running the program.
+    google.protobuf.Struct configPropertyMap = 13;
+
+    // The program to use.
+    ProgramInfo info = 14;
+
     // The target of a codegen.LoaderServer to use for loading schemas.
     string loader_target = 15;
-    bool attach_debugger = 16;       // true if the language host is supposed to start the program under a debugger.
+
+    // True if and only if the host should start the program under a debugger.
+    bool attach_debugger = 16;
 }
 
-// RunResponse is the response back from the interpreter/source back to the monitor.
+// `RunResponse` is the type of responses sent by a [](pulumirpc.LanguageRuntime.Run) call.
 message RunResponse {
-    // An unhandled error if any occurred.
+    // Information about any unhandled error that occurred during the run.
     string error = 1;
 
-    // An error happened.  And it was reported to the user.  Work should stop immediately
-    // with nothing further to print to the user.  This corresponds to a "result.Bail()"
-    // value in the 'go' layer.
+    // True if an error happened, but it was reported to the user. Work should halt immediately, reporting nothing
+    // further to the user (since this reporting has already happened). This corresponds to a `result.Bail()` value
+    // being raised in the Go application layer.
     bool bail = 2;
 }
 
+// `InstallDependenciesRequest` is the type of requests sent as part of an
+// [](pulumirpc.LanguageRuntime.InstallDependencies) call.
 message InstallDependenciesRequest {
-    string directory = 1 [deprecated = true]; // the program's working directory. Deprecated, use info.program_directory instead.
-    bool is_terminal = 2; // if we are running in a terminal and should use ANSI codes
-    ProgramInfo info = 3; // the program info to use to execute the plugin.
-    bool use_language_version_tools = 4; // if we should use language version tools like pyenv or
-                                         // nvm to setup the language version.
+    // The program's working directory.
+    //
+    // :::{important}
+    // This is deprecated in favour of passing a [program info](pulumirpc.ProgramInfo) struct as the `info` field, with
+    // the `program_directory` field set to this value.
+    // :::
+    string directory = 1 [deprecated = true];
+
+    // True if we are running in a terminal and may use [ANSI escape
+    // codes](https://en.wikipedia.org/wiki/ANSI_escape_code) in our output.
+    bool is_terminal = 2;
+
+    // The program to use.
+    ProgramInfo info = 3;
+
+    // True if the host should use language-specific version managers, such as `pyenv` or `nvm`, to set up the version
+    // of the language toolchain used.
+    bool use_language_version_tools = 4;
 }
 
+// `InstallDependenciesResponse` is the type of responses streamed by an
+// [](pulumirpc.LanguageRuntime.InstallDependencies) call.
 message InstallDependenciesResponse {
-    bytes stdout = 1; // a line of stdout text.
-    bytes stderr = 2; // a line of stderr text.
+    // A line of standard output.
+    bytes stdout = 1;
+
+    // A line of standard error.
+    bytes stderr = 2;
 }
 
+// `RuntimeOptionsRequest` is the type of requests sent as part of a [](pulumirpc.LanguageRuntime.RuntimeOptionsPrompts)
+// call.
 message RuntimeOptionsRequest {
-    ProgramInfo info = 1; // The current program info used to evaluate which prompts should be asked.
+    // The program to use.
+    ProgramInfo info = 1;
 }
 
+// `RuntimeOptionPrompt` is a struct that captures information about a runtime option that should be prompted for during
+// `pulumi new`.
 message RuntimeOptionPrompt {
+    // `RuntimeOptionType` is an enum that captures the type of a runtime option.
     enum RuntimeOptionType {
+        // A string value.
         STRING = 0;
+
+        // A 32-bit integer value.
         INT32 = 1;
     }
 
+    // `RuntimeOptionValue` is a struct that captures the value of a runtime option.
     message RuntimeOptionValue {
+        // The type of the runtime option.
         RuntimeOptionType promptType = 1;
+
+        // The string value of the runtime option, if and only if the type is `STRING`.
         string stringValue = 2;
+
+        // The 32-bit integer value of the runtime option, if and only if the type is `INT32`.
         int32 int32Value = 3;
+
+        // The display name of the runtime option, to be used in prompts.
         string displayName = 4;
     }
 
+    // A unique key that identifies the runtime option.
     string key = 1;
+
+    // A human-readable description of the runtime option.
     string description = 2;
+
+    // The type of the runtime option.
     RuntimeOptionType promptType = 3;
+
+    // A set of choices for the runtime option that may be displayed as part of the prompting process.
     repeated RuntimeOptionValue choices = 4;
+
+    // The default value of the runtime option.
     RuntimeOptionValue default = 5;
 }
 
+// `RuntimeOptionsResponse` is the type of responses sent by a [](pulumirpc.LanguageRuntime.RuntimeOptionsPrompts) call.
+// It contains information about additional prompts to ask during `pulumi new`.
 message RuntimeOptionsResponse {
-    repeated RuntimeOptionPrompt prompts = 1; // additional prompts to ask the user
+    // Prompts to ask the user.
+    repeated RuntimeOptionPrompt prompts = 1;
 }
 
+// `RunPluginRequest` is the type of requests sent as part of a [](pulumirpc.LanguageRuntime.RunPlugin) call.
 message RunPluginRequest{
-    string pwd = 1; // the program's working directory.
-    string program = 2 [deprecated = true]; // the path to the program to execute. Deprecated, use info.entry_point instead.
-    repeated string args = 3; // any arguments to pass to the program.
-    repeated string env = 4; // any environment variables to set as part of the program.
-    ProgramInfo info = 5; // the program info to use to execute the plugin.
+    // The plugin program's working directory.
+    string pwd = 1;
+
+    // The path to the plugin program.
+    //
+    // :::{important}
+    // This is deprecated in favour of passing a [program info](pulumirpc.ProgramInfo) struct as the `info` field, with
+    // the `entry_point` field set to this value.
+    // :::
+    string program = 2 [deprecated = true];
+
+    // Any arguments to pass to the plugin program.
+    repeated string args = 3;
+
+    // Any environment variables to set prior to executing the plugin program.
+    repeated string env = 4;
+
+    // The [plugin program](pulumirpc.ProgramInfo) to use.
+    ProgramInfo info = 5;
 }
 
+// `RunPluginResponse` is the type of responses streamed by a [](pulumirpc.LanguageRuntime.RunPlugin) call.
 message RunPluginResponse {
     oneof output {
-        bytes stdout = 1; // a line of stdout text.
-        bytes stderr = 2; // a line of stderr text.
-        int32 exitcode = 3; // the exit code of the provider.
+        // A line of standard output.
+        bytes stdout = 1;
+
+        // A line of standard error.
+        bytes stderr = 2;
+
+        // An exit code that the plugin program has terminated with. This should be the last message sent by the host.
+        int32 exitcode = 3;
     }
 }
 
+// `GenerateProgramRequest` is the type of requests sent as part of a [](pulumirpc.LanguageRuntime.GenerateProgram)
+// call.
 message GenerateProgramRequest {
-    // the PCL source of the project.
+    // The source of the project, represented as a map of file names to [PCL](pcl) source code.
     map<string, string> source = 1;
+
     // The target of a codegen.LoaderServer to use for loading schemas.
     string loader_target = 2;
-    // if PCL binding should be strict or not.
+
+    // True if [PCL binding](pcl-binding) should be strict.
     bool strict = 3;
 }
 
+// `GenerateProgramResponse` is the type of responses sent by a [](pulumirpc.LanguageRuntime.GenerateProgram) call.
 message GenerateProgramResponse {
-    // any diagnostics from code generation.
+    // Any diagnostics raised by code generation.
     repeated pulumirpc.codegen.Diagnostic diagnostics = 1;
-    // the generated program source code.
+
+    // The generated program source code, represented as a map of file names to byte contents.
     map<string, bytes> source = 2;
 }
 
+// `GenerateProjectRequest` is the type of requests sent as part of a [](pulumirpc.LanguageRuntime.GenerateProject) call.
 message GenerateProjectRequest {
-    // the directory to generate the project from.
+    // The directory containing [PCL](pcl) source code, from which the project should be generated.
     string source_directory = 1;
-    // the directory to generate the project in.
+
+    // The directory in which generated project files should be written. This should be an absolute path on the
+    // filesystem that is accessible to the language host.
     string target_directory = 2;
-    // the JSON-encoded pulumi project file.
+
+    // A string containing JSON to be used as the Pulumi project file (that is, as the contents of `Pulumi.yaml`).
     string project = 3;
-    // if PCL binding should be strict or not.
+
+    // True if [PCL binding](pcl-binding) should be strict.
     bool strict = 4;
+
     // The target of a codegen.LoaderServer to use for loading schemas.
     string loader_target = 5;
-    // local dependencies to use instead of using the package system. This is a map of package name to a local
-    // path of a language specific artifact to use for the SDK for that package.
+
+    // Local dependencies that the generated project should reference explicitly, instead of e.g. using the language's
+    // package system. This is a map of package names to local paths of language-specific artifacts that should be used.
+    // For instance, in the case of a NodeJS project, this might be a map of NPM package names to local paths to be
+    // used, such as `{ "@pulumi/aws": "/some/path/to/aws.tgz" }` if a local tarball is to be used instead of the
+    // published `@pulumi/aws` package.
     map<string, string> local_dependencies = 6;
 }
 
+// `GenerateProjectResponse` is the type of responses sent by a [](pulumirpc.LanguageRuntime.GenerateProject) call.
 message GenerateProjectResponse {
-    // any diagnostics from code generation.
+    // Any diagnostics raised by code generation.
     repeated pulumirpc.codegen.Diagnostic diagnostics = 1;
 }
 
+// `GeneratePackageRequest` is the type of requests sent as part of a [](pulumirpc.LanguageRuntime.GeneratePackage) call.
 message GeneratePackageRequest {
-    // the directory to generate the package in.
+    // The directory to generate the package in. This should be an absolute path on the filesystem that is accessible to
+    // the language host.
     string directory = 1;
-    // the JSON-encoded schema.
+
+    // A JSON-encoded string containing the schema from which the SDK package should be generated.
     string schema = 2;
-    // extra files to copy to the package output.
+
+    // Extra files that should be copied as-is to the generated output.
     map<string, bytes> extra_files = 3;
+
     // The target of a codegen.LoaderServer to use for loading schemas.
     string loader_target = 4;
-    // local dependencies to use instead of using the package system. This is a map of package name to a local
-    // path of a language specific artifact to use for the SDK for that package.
+
+    // Local dependencies that the generated package should reference explicitly, instead of e.g. using the language's
+    // package system. This is a map of package names to local paths of language-specific artifacts that should be used.
+    // For instance, in the case of a NodeJS package, this might be a map of NPM package names to local paths to be
+    // used, such as `{ "@pulumi/aws": "/some/path/to/aws.tgz" }` if a local tarball is to be used instead of the
+    // published `@pulumi/aws` package.
     map<string, string> local_dependencies = 5;
-    // if true generates an SDK appropriate for local usage, this may differ from a standard publishable SDK depending
-    // on the language.
+
+    // If true, generates an SDK appropriate for local usage. This may differ from a standard publishable SDK depending
+    // on the language (e.g. for a NodeJS package that is intended to be imported locally, the language host may choose
+    // not to generate a `package.json`).
     bool local = 6;
 }
 
+// `GeneratePackageResponse` is the type of responses sent by a [](pulumirpc.LanguageRuntime.GeneratePackage) call.
 message GeneratePackageResponse {
-    // any diagnostics from code generation.
+    // Any diagnostics raised by code generation.
     repeated pulumirpc.codegen.Diagnostic diagnostics = 1;
 }
 
+// `PackRequest` is the type of requests sent as part of a [](pulumirpc.LanguageRuntime.Pack) call.
 message PackRequest {
-    // the directory of a package to pack.
+    // The directory containing the package to pack. This should be an absolute path on the filesystem that is accessible
+    // to the language host.
     string package_directory = 1;
-    // the directory to write the packed artifact to.
+
+    // The directory to write the packed artifact to. This should be an absolute path on the filesystem that is
+    // accessible to the language host.
     string destination_directory = 2;
 }
 
+// `PackResponse` is the type of responses sent by a [](pulumirpc.LanguageRuntime.Pack) call.
 message PackResponse {
-    // the full path of the packed artifact.
+    // The path to the packed artifact. This should be an absolute path on the filesystem that is accessible to the
+    // language host.
     string artifact_path = 1;
 }
 
+// `LanguageHandshakeRequest` is the type of requests sent as part of a [](pulumirpc.LanguageRuntime.Handshake) call.
 message LanguageHandshakeRequest {
-    // The grpc address for the engine.
+    // The gRPC address of the engine calling the language host.
     string engine_address = 1;
 
-    // The optional root directory, where the `PulumiPlugin.yaml` file or language binary is located.
-    // This can't be sent when the engine is attaching to a language via a port number.
+    // The optional root directory, where the `PulumiPlugin.yaml` file or language binary is located. This can't be sent
+    // when the engine is attaching to a language via a port number.
     optional string root_directory = 2;
-    // The optional absolute path to the directory of the language program to execute. Generally, but not
-    // required to be, underneath the root directory. This can't be sent when the engine is attaching to a
-    // language via a port number.
+
+    // The optional absolute path to the directory of the language program to execute. Generally, but not required to
+    // be, underneath the root directory. This can't be sent when the engine is attaching to a language via a port
+    // number.
     optional string program_directory = 3;
 }
 
+// `LanguageHandshakeResponse` is the type of responses sent by a [](pulumirpc.LanguageRuntime.Handshake) call.
 message LanguageHandshakeResponse {
 }

--- a/sdk/nodejs/proto/language_grpc_pb.js
+++ b/sdk/nodejs/proto/language_grpc_pb.js
@@ -332,12 +332,13 @@ function deserialize_pulumirpc_RuntimeOptionsResponse(buffer_arg) {
 }
 
 
-// LanguageRuntime is the interface that the planning monitor uses to drive execution of an interpreter responsible
-// for confguring and creating resource objects.
+// The LanguageRuntime service defines a standard interface for [language hosts/runtimes](languages). At a high level, a
+// language runtime provides the ability to execute programs, install and query dependencies, and generate code for a
+// specific language.
 var LanguageRuntimeService = exports.LanguageRuntimeService = {
-  // `Handshake` is the first call made by the engine to a language host. It is used to pass the 
-// engine's address to the language host so that it may establish its own connections back,
-// and to establish protocol configuration that will be used to communicate between the two parties. 
+  // `Handshake` is the first call made by the engine to a language host. It is used to pass the engine's address to
+// the language host so that it may establish its own connections back, and to establish protocol configuration that
+// will be used to communicate between the two parties.
 handshake: {
     path: '/pulumirpc.LanguageRuntime/Handshake',
     requestStream: false,
@@ -349,7 +350,15 @@ handshake: {
     responseSerialize: serialize_pulumirpc_LanguageHandshakeResponse,
     responseDeserialize: deserialize_pulumirpc_LanguageHandshakeResponse,
   },
-  // GetRequiredPlugins computes the complete set of anticipated plugins required by a program.
+  // `GetRequiredPlugins` computes the complete set of anticipated [plugins](plugins) required by a Pulumi program.
+// Among other things, it is intended to be used to pre-install plugins before running a program with
+// [](pulumirpc.LanguageRuntime.Run), to avoid the need to install them on-demand in response to [resource
+// registrations](resource-registration) sent back from the running program to the engine.
+//
+// :::{important}
+// The use of `GetRequiredPlugins` is deprecated in favour of [](pulumirpc.LanguageRuntime.GetRequiredPackages),
+// which returns more granular information about which plugins are required by which packages.
+// :::
 getRequiredPlugins: {
     path: '/pulumirpc.LanguageRuntime/GetRequiredPlugins',
     requestStream: false,
@@ -361,7 +370,15 @@ getRequiredPlugins: {
     responseSerialize: serialize_pulumirpc_GetRequiredPluginsResponse,
     responseDeserialize: deserialize_pulumirpc_GetRequiredPluginsResponse,
   },
-  // GetRequiredPackages computes the complete set of anticipated packages required by a program.
+  // `GetRequiredPackages` computes the complete set of anticipated [packages](pulumirpc.PackageDependency) required
+// by a program. It is used to pre-install packages before running a program with [](pulumirpc.LanguageRuntime.Run),
+// to avoid the need to install them on-demand in response to [resource registrations](resource-registration) sent
+// back from the running program to the engine. Moreover, when importing resources into a stack, it is used to
+// determine which plugins are required to service the import of a given resource, since given the presence of
+// [parameterized providers](parameterized-providers), it is not in general true that a package name corresponds 1:1
+// with a plugin name. It replaces [](pulumirpc.LanguageRuntime.GetRequiredPlugins) in the face of [parameterized
+// providers](parameterized-providers), which as mentioned above can enable multiple instances of the same plugin to
+// provide multiple packages.
 getRequiredPackages: {
     path: '/pulumirpc.LanguageRuntime/GetRequiredPackages',
     requestStream: false,
@@ -373,7 +390,7 @@ getRequiredPackages: {
     responseSerialize: serialize_pulumirpc_GetRequiredPackagesResponse,
     responseDeserialize: deserialize_pulumirpc_GetRequiredPackagesResponse,
   },
-  // Run executes a program and returns its result.
+  // `Run` executes a Pulumi program, returning information about whether or not the program produced an error.
 run: {
     path: '/pulumirpc.LanguageRuntime/Run',
     requestStream: false,
@@ -385,7 +402,7 @@ run: {
     responseSerialize: serialize_pulumirpc_RunResponse,
     responseDeserialize: deserialize_pulumirpc_RunResponse,
   },
-  // GetPluginInfo returns generic information about this plugin, like its version.
+  // `GetPluginInfo` returns information about the [plugin](plugins) implementing this language runtime.
 getPluginInfo: {
     path: '/pulumirpc.LanguageRuntime/GetPluginInfo',
     requestStream: false,
@@ -397,7 +414,11 @@ getPluginInfo: {
     responseSerialize: serialize_pulumirpc_PluginInfo,
     responseDeserialize: deserialize_pulumirpc_PluginInfo,
   },
-  // InstallDependencies will install dependencies for the project, e.g. by running `npm install` for nodejs projects.
+  // `InstallDependencies` accepts a request specifying a Pulumi project and program that can be executed with
+// [](pulumirpc.LanguageRuntime.Run) and installs the dependencies for that program (e.g. by running `npm install`
+// for NodeJS, or `pip install` for Python). Since dependency installation could take a while, and callers may wish
+// to report on its progress, this method returns a stream of [](pulumirpc.InstallDependenciesResponse) messages
+// containing information about standard error and output.
 installDependencies: {
     path: '/pulumirpc.LanguageRuntime/InstallDependencies',
     requestStream: false,
@@ -409,7 +430,8 @@ installDependencies: {
     responseSerialize: serialize_pulumirpc_InstallDependenciesResponse,
     responseDeserialize: deserialize_pulumirpc_InstallDependenciesResponse,
   },
-  // RuntimeOptionsPrompts returns a list of additional prompts to ask during `pulumi new`.
+  // `RuntimeOptionsPrompts` accepts a request specifying a Pulumi project and returns a list of additional prompts to
+// ask during `pulumi new`.
 runtimeOptionsPrompts: {
     path: '/pulumirpc.LanguageRuntime/RuntimeOptionsPrompts',
     requestStream: false,
@@ -421,7 +443,7 @@ runtimeOptionsPrompts: {
     responseSerialize: serialize_pulumirpc_RuntimeOptionsResponse,
     responseDeserialize: deserialize_pulumirpc_RuntimeOptionsResponse,
   },
-  // About returns information about the runtime for this language.
+  // `About` returns information about the language runtime being used.
 about: {
     path: '/pulumirpc.LanguageRuntime/About',
     requestStream: false,
@@ -433,7 +455,8 @@ about: {
     responseSerialize: serialize_pulumirpc_AboutResponse,
     responseDeserialize: deserialize_pulumirpc_AboutResponse,
   },
-  // GetProgramDependencies returns the set of dependencies required by the program.
+  // `GetProgramDependencies` computes the set of language-level dependencies (e.g. NPM packages for NodeJS, or Maven
+// libraries for Java) required by a program.
 getProgramDependencies: {
     path: '/pulumirpc.LanguageRuntime/GetProgramDependencies',
     requestStream: false,
@@ -445,7 +468,11 @@ getProgramDependencies: {
     responseSerialize: serialize_pulumirpc_GetProgramDependenciesResponse,
     responseDeserialize: deserialize_pulumirpc_GetProgramDependenciesResponse,
   },
-  // RunPlugin executes a plugin program and returns its result asynchronously.
+  // `RunPlugin` is used to execute a program written in this host's language that implements a Pulumi
+// [plugin](plugins). It it is plugins what [](pulumirpc.LanguageRuntime.Run) is to programs. Since a plugin is not
+// expected to terminate until instructed/for a long time, this method returns a stream of
+// [](pulumirpc.RunPluginResponse) messages containing information about standard error and output, as well as the
+// exit code of the plugin when it does terminate.
 runPlugin: {
     path: '/pulumirpc.LanguageRuntime/RunPlugin',
     requestStream: false,
@@ -457,7 +484,11 @@ runPlugin: {
     responseSerialize: serialize_pulumirpc_RunPluginResponse,
     responseDeserialize: deserialize_pulumirpc_RunPluginResponse,
   },
-  // GenerateProgram generates a given PCL program into a program for this language.
+  // `GenerateProgram` generates code in this host's language that implements the given [PCL](pcl) program. Unlike
+// [](pulumirpc.LanguageRuntime.GenerateProject), this method *only* generates program code, and does not e.g.
+// generate a `package.json` for a NodeJS project that details how to run that code.
+// [](pulumirpc.LanguageRuntime.GenerateProject), this method underpins ["programgen"](programgen) and the main
+// functionality powering `pulumi convert`.
 generateProgram: {
     path: '/pulumirpc.LanguageRuntime/GenerateProgram',
     requestStream: false,
@@ -469,7 +500,12 @@ generateProgram: {
     responseSerialize: serialize_pulumirpc_GenerateProgramResponse,
     responseDeserialize: deserialize_pulumirpc_GenerateProgramResponse,
   },
-  // GenerateProject generates a given PCL program into a project for this language.
+  // `GenerateProject` generates code in this host's language that implements the given [PCL](pcl) program and wraps
+// it in some language-specific notion of a "project", where a project is a buildable or runnable artifact. In this
+// sense, `GenerateProject`'s output is a superset of that of [](pulumirpc.LanguageRuntime.GenerateProgram). For
+// instance, when generating a NodeJS project, this method might generate a corresponding `package.json` file, as
+// well as the relevant NodeJS program code. Along with [](pulumirpc.LanguageRuntime.GenerateProgram), this method
+// underpins ["programgen"](programgen) and the main functionality powering `pulumi convert`.
 generateProject: {
     path: '/pulumirpc.LanguageRuntime/GenerateProject',
     requestStream: false,
@@ -481,7 +517,8 @@ generateProject: {
     responseSerialize: serialize_pulumirpc_GenerateProjectResponse,
     responseDeserialize: deserialize_pulumirpc_GenerateProjectResponse,
   },
-  // GeneratePackage generates a given pulumi package into a package for this language.
+  // `GeneratePackage` generates code in this host's language that implements an [SDK](sdkgen) ("sdkgen") for the
+// given Pulumi package, as specified by a [schema](schema).
 generatePackage: {
     path: '/pulumirpc.LanguageRuntime/GeneratePackage',
     requestStream: false,
@@ -493,7 +530,11 @@ generatePackage: {
     responseSerialize: serialize_pulumirpc_GeneratePackageResponse,
     responseDeserialize: deserialize_pulumirpc_GeneratePackageResponse,
   },
-  // Pack packs a package into a language specific artifact.
+  // `Pack` accepts a request specifying a generated SDK package and packs it into a language-specific artifact. For
+// instance, in the case of Java, it might produce a JAR file from a list of `.java` sources; in the case of NodeJS,
+// a `.tgz` file might be produced from a list of `.js` sources; and so on. Presently, `Pack` is primarily used in
+// [language conformance tests](language-conformance-tests), though it is intended to be used more widely in future
+// to standardise e.g. provider publishing workflows.
 pack: {
     path: '/pulumirpc.LanguageRuntime/Pack',
     requestStream: false,

--- a/sdk/proto/go/language_grpc.pb.go
+++ b/sdk/proto/go/language_grpc.pb.go
@@ -23,36 +23,76 @@ const _ = grpc.SupportPackageIsVersion7
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type LanguageRuntimeClient interface {
-	// `Handshake` is the first call made by the engine to a language host. It is used to pass the
-	// engine's address to the language host so that it may establish its own connections back,
-	// and to establish protocol configuration that will be used to communicate between the two parties.
+	// `Handshake` is the first call made by the engine to a language host. It is used to pass the engine's address to
+	// the language host so that it may establish its own connections back, and to establish protocol configuration that
+	// will be used to communicate between the two parties.
 	Handshake(ctx context.Context, in *LanguageHandshakeRequest, opts ...grpc.CallOption) (*LanguageHandshakeResponse, error)
 	// Deprecated: Do not use.
-	// GetRequiredPlugins computes the complete set of anticipated plugins required by a program.
+	// `GetRequiredPlugins` computes the complete set of anticipated [plugins](plugins) required by a Pulumi program.
+	// Among other things, it is intended to be used to pre-install plugins before running a program with
+	// [](pulumirpc.LanguageRuntime.Run), to avoid the need to install them on-demand in response to [resource
+	// registrations](resource-registration) sent back from the running program to the engine.
+	//
+	// :::{important}
+	// The use of `GetRequiredPlugins` is deprecated in favour of [](pulumirpc.LanguageRuntime.GetRequiredPackages),
+	// which returns more granular information about which plugins are required by which packages.
+	// :::
 	GetRequiredPlugins(ctx context.Context, in *GetRequiredPluginsRequest, opts ...grpc.CallOption) (*GetRequiredPluginsResponse, error)
-	// GetRequiredPackages computes the complete set of anticipated packages required by a program.
+	// `GetRequiredPackages` computes the complete set of anticipated [packages](pulumirpc.PackageDependency) required
+	// by a program. It is used to pre-install packages before running a program with [](pulumirpc.LanguageRuntime.Run),
+	// to avoid the need to install them on-demand in response to [resource registrations](resource-registration) sent
+	// back from the running program to the engine. Moreover, when importing resources into a stack, it is used to
+	// determine which plugins are required to service the import of a given resource, since given the presence of
+	// [parameterized providers](parameterized-providers), it is not in general true that a package name corresponds 1:1
+	// with a plugin name. It replaces [](pulumirpc.LanguageRuntime.GetRequiredPlugins) in the face of [parameterized
+	// providers](parameterized-providers), which as mentioned above can enable multiple instances of the same plugin to
+	// provide multiple packages.
 	GetRequiredPackages(ctx context.Context, in *GetRequiredPackagesRequest, opts ...grpc.CallOption) (*GetRequiredPackagesResponse, error)
-	// Run executes a program and returns its result.
+	// `Run` executes a Pulumi program, returning information about whether or not the program produced an error.
 	Run(ctx context.Context, in *RunRequest, opts ...grpc.CallOption) (*RunResponse, error)
-	// GetPluginInfo returns generic information about this plugin, like its version.
+	// `GetPluginInfo` returns information about the [plugin](plugins) implementing this language runtime.
 	GetPluginInfo(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*PluginInfo, error)
-	// InstallDependencies will install dependencies for the project, e.g. by running `npm install` for nodejs projects.
+	// `InstallDependencies` accepts a request specifying a Pulumi project and program that can be executed with
+	// [](pulumirpc.LanguageRuntime.Run) and installs the dependencies for that program (e.g. by running `npm install`
+	// for NodeJS, or `pip install` for Python). Since dependency installation could take a while, and callers may wish
+	// to report on its progress, this method returns a stream of [](pulumirpc.InstallDependenciesResponse) messages
+	// containing information about standard error and output.
 	InstallDependencies(ctx context.Context, in *InstallDependenciesRequest, opts ...grpc.CallOption) (LanguageRuntime_InstallDependenciesClient, error)
-	// RuntimeOptionsPrompts returns a list of additional prompts to ask during `pulumi new`.
+	// `RuntimeOptionsPrompts` accepts a request specifying a Pulumi project and returns a list of additional prompts to
+	// ask during `pulumi new`.
 	RuntimeOptionsPrompts(ctx context.Context, in *RuntimeOptionsRequest, opts ...grpc.CallOption) (*RuntimeOptionsResponse, error)
-	// About returns information about the runtime for this language.
+	// `About` returns information about the language runtime being used.
 	About(ctx context.Context, in *AboutRequest, opts ...grpc.CallOption) (*AboutResponse, error)
-	// GetProgramDependencies returns the set of dependencies required by the program.
+	// `GetProgramDependencies` computes the set of language-level dependencies (e.g. NPM packages for NodeJS, or Maven
+	// libraries for Java) required by a program.
 	GetProgramDependencies(ctx context.Context, in *GetProgramDependenciesRequest, opts ...grpc.CallOption) (*GetProgramDependenciesResponse, error)
-	// RunPlugin executes a plugin program and returns its result asynchronously.
+	// `RunPlugin` is used to execute a program written in this host's language that implements a Pulumi
+	// [plugin](plugins). It it is plugins what [](pulumirpc.LanguageRuntime.Run) is to programs. Since a plugin is not
+	// expected to terminate until instructed/for a long time, this method returns a stream of
+	// [](pulumirpc.RunPluginResponse) messages containing information about standard error and output, as well as the
+	// exit code of the plugin when it does terminate.
 	RunPlugin(ctx context.Context, in *RunPluginRequest, opts ...grpc.CallOption) (LanguageRuntime_RunPluginClient, error)
-	// GenerateProgram generates a given PCL program into a program for this language.
+	// `GenerateProgram` generates code in this host's language that implements the given [PCL](pcl) program. Unlike
+	// [](pulumirpc.LanguageRuntime.GenerateProject), this method *only* generates program code, and does not e.g.
+	// generate a `package.json` for a NodeJS project that details how to run that code.
+	// [](pulumirpc.LanguageRuntime.GenerateProject), this method underpins ["programgen"](programgen) and the main
+	// functionality powering `pulumi convert`.
 	GenerateProgram(ctx context.Context, in *GenerateProgramRequest, opts ...grpc.CallOption) (*GenerateProgramResponse, error)
-	// GenerateProject generates a given PCL program into a project for this language.
+	// `GenerateProject` generates code in this host's language that implements the given [PCL](pcl) program and wraps
+	// it in some language-specific notion of a "project", where a project is a buildable or runnable artifact. In this
+	// sense, `GenerateProject`'s output is a superset of that of [](pulumirpc.LanguageRuntime.GenerateProgram). For
+	// instance, when generating a NodeJS project, this method might generate a corresponding `package.json` file, as
+	// well as the relevant NodeJS program code. Along with [](pulumirpc.LanguageRuntime.GenerateProgram), this method
+	// underpins ["programgen"](programgen) and the main functionality powering `pulumi convert`.
 	GenerateProject(ctx context.Context, in *GenerateProjectRequest, opts ...grpc.CallOption) (*GenerateProjectResponse, error)
-	// GeneratePackage generates a given pulumi package into a package for this language.
+	// `GeneratePackage` generates code in this host's language that implements an [SDK](sdkgen) ("sdkgen") for the
+	// given Pulumi package, as specified by a [schema](schema).
 	GeneratePackage(ctx context.Context, in *GeneratePackageRequest, opts ...grpc.CallOption) (*GeneratePackageResponse, error)
-	// Pack packs a package into a language specific artifact.
+	// `Pack` accepts a request specifying a generated SDK package and packs it into a language-specific artifact. For
+	// instance, in the case of Java, it might produce a JAR file from a list of `.java` sources; in the case of NodeJS,
+	// a `.tgz` file might be produced from a list of `.js` sources; and so on. Presently, `Pack` is primarily used in
+	// [language conformance tests](language-conformance-tests), though it is intended to be used more widely in future
+	// to standardise e.g. provider publishing workflows.
 	Pack(ctx context.Context, in *PackRequest, opts ...grpc.CallOption) (*PackResponse, error)
 }
 
@@ -241,36 +281,76 @@ func (c *languageRuntimeClient) Pack(ctx context.Context, in *PackRequest, opts 
 // All implementations must embed UnimplementedLanguageRuntimeServer
 // for forward compatibility
 type LanguageRuntimeServer interface {
-	// `Handshake` is the first call made by the engine to a language host. It is used to pass the
-	// engine's address to the language host so that it may establish its own connections back,
-	// and to establish protocol configuration that will be used to communicate between the two parties.
+	// `Handshake` is the first call made by the engine to a language host. It is used to pass the engine's address to
+	// the language host so that it may establish its own connections back, and to establish protocol configuration that
+	// will be used to communicate between the two parties.
 	Handshake(context.Context, *LanguageHandshakeRequest) (*LanguageHandshakeResponse, error)
 	// Deprecated: Do not use.
-	// GetRequiredPlugins computes the complete set of anticipated plugins required by a program.
+	// `GetRequiredPlugins` computes the complete set of anticipated [plugins](plugins) required by a Pulumi program.
+	// Among other things, it is intended to be used to pre-install plugins before running a program with
+	// [](pulumirpc.LanguageRuntime.Run), to avoid the need to install them on-demand in response to [resource
+	// registrations](resource-registration) sent back from the running program to the engine.
+	//
+	// :::{important}
+	// The use of `GetRequiredPlugins` is deprecated in favour of [](pulumirpc.LanguageRuntime.GetRequiredPackages),
+	// which returns more granular information about which plugins are required by which packages.
+	// :::
 	GetRequiredPlugins(context.Context, *GetRequiredPluginsRequest) (*GetRequiredPluginsResponse, error)
-	// GetRequiredPackages computes the complete set of anticipated packages required by a program.
+	// `GetRequiredPackages` computes the complete set of anticipated [packages](pulumirpc.PackageDependency) required
+	// by a program. It is used to pre-install packages before running a program with [](pulumirpc.LanguageRuntime.Run),
+	// to avoid the need to install them on-demand in response to [resource registrations](resource-registration) sent
+	// back from the running program to the engine. Moreover, when importing resources into a stack, it is used to
+	// determine which plugins are required to service the import of a given resource, since given the presence of
+	// [parameterized providers](parameterized-providers), it is not in general true that a package name corresponds 1:1
+	// with a plugin name. It replaces [](pulumirpc.LanguageRuntime.GetRequiredPlugins) in the face of [parameterized
+	// providers](parameterized-providers), which as mentioned above can enable multiple instances of the same plugin to
+	// provide multiple packages.
 	GetRequiredPackages(context.Context, *GetRequiredPackagesRequest) (*GetRequiredPackagesResponse, error)
-	// Run executes a program and returns its result.
+	// `Run` executes a Pulumi program, returning information about whether or not the program produced an error.
 	Run(context.Context, *RunRequest) (*RunResponse, error)
-	// GetPluginInfo returns generic information about this plugin, like its version.
+	// `GetPluginInfo` returns information about the [plugin](plugins) implementing this language runtime.
 	GetPluginInfo(context.Context, *emptypb.Empty) (*PluginInfo, error)
-	// InstallDependencies will install dependencies for the project, e.g. by running `npm install` for nodejs projects.
+	// `InstallDependencies` accepts a request specifying a Pulumi project and program that can be executed with
+	// [](pulumirpc.LanguageRuntime.Run) and installs the dependencies for that program (e.g. by running `npm install`
+	// for NodeJS, or `pip install` for Python). Since dependency installation could take a while, and callers may wish
+	// to report on its progress, this method returns a stream of [](pulumirpc.InstallDependenciesResponse) messages
+	// containing information about standard error and output.
 	InstallDependencies(*InstallDependenciesRequest, LanguageRuntime_InstallDependenciesServer) error
-	// RuntimeOptionsPrompts returns a list of additional prompts to ask during `pulumi new`.
+	// `RuntimeOptionsPrompts` accepts a request specifying a Pulumi project and returns a list of additional prompts to
+	// ask during `pulumi new`.
 	RuntimeOptionsPrompts(context.Context, *RuntimeOptionsRequest) (*RuntimeOptionsResponse, error)
-	// About returns information about the runtime for this language.
+	// `About` returns information about the language runtime being used.
 	About(context.Context, *AboutRequest) (*AboutResponse, error)
-	// GetProgramDependencies returns the set of dependencies required by the program.
+	// `GetProgramDependencies` computes the set of language-level dependencies (e.g. NPM packages for NodeJS, or Maven
+	// libraries for Java) required by a program.
 	GetProgramDependencies(context.Context, *GetProgramDependenciesRequest) (*GetProgramDependenciesResponse, error)
-	// RunPlugin executes a plugin program and returns its result asynchronously.
+	// `RunPlugin` is used to execute a program written in this host's language that implements a Pulumi
+	// [plugin](plugins). It it is plugins what [](pulumirpc.LanguageRuntime.Run) is to programs. Since a plugin is not
+	// expected to terminate until instructed/for a long time, this method returns a stream of
+	// [](pulumirpc.RunPluginResponse) messages containing information about standard error and output, as well as the
+	// exit code of the plugin when it does terminate.
 	RunPlugin(*RunPluginRequest, LanguageRuntime_RunPluginServer) error
-	// GenerateProgram generates a given PCL program into a program for this language.
+	// `GenerateProgram` generates code in this host's language that implements the given [PCL](pcl) program. Unlike
+	// [](pulumirpc.LanguageRuntime.GenerateProject), this method *only* generates program code, and does not e.g.
+	// generate a `package.json` for a NodeJS project that details how to run that code.
+	// [](pulumirpc.LanguageRuntime.GenerateProject), this method underpins ["programgen"](programgen) and the main
+	// functionality powering `pulumi convert`.
 	GenerateProgram(context.Context, *GenerateProgramRequest) (*GenerateProgramResponse, error)
-	// GenerateProject generates a given PCL program into a project for this language.
+	// `GenerateProject` generates code in this host's language that implements the given [PCL](pcl) program and wraps
+	// it in some language-specific notion of a "project", where a project is a buildable or runnable artifact. In this
+	// sense, `GenerateProject`'s output is a superset of that of [](pulumirpc.LanguageRuntime.GenerateProgram). For
+	// instance, when generating a NodeJS project, this method might generate a corresponding `package.json` file, as
+	// well as the relevant NodeJS program code. Along with [](pulumirpc.LanguageRuntime.GenerateProgram), this method
+	// underpins ["programgen"](programgen) and the main functionality powering `pulumi convert`.
 	GenerateProject(context.Context, *GenerateProjectRequest) (*GenerateProjectResponse, error)
-	// GeneratePackage generates a given pulumi package into a package for this language.
+	// `GeneratePackage` generates code in this host's language that implements an [SDK](sdkgen) ("sdkgen") for the
+	// given Pulumi package, as specified by a [schema](schema).
 	GeneratePackage(context.Context, *GeneratePackageRequest) (*GeneratePackageResponse, error)
-	// Pack packs a package into a language specific artifact.
+	// `Pack` accepts a request specifying a generated SDK package and packs it into a language-specific artifact. For
+	// instance, in the case of Java, it might produce a JAR file from a list of `.java` sources; in the case of NodeJS,
+	// a `.tgz` file might be produced from a list of `.js` sources; and so on. Presently, `Pack` is primarily used in
+	// [language conformance tests](language-conformance-tests), though it is intended to be used more widely in future
+	// to standardise e.g. provider publishing workflows.
 	Pack(context.Context, *PackRequest) (*PackResponse, error)
 	mustEmbedUnimplementedLanguageRuntimeServer()
 }

--- a/sdk/python/lib/pulumi/runtime/proto/language_pb2_grpc.py
+++ b/sdk/python/lib/pulumi/runtime/proto/language_pb2_grpc.py
@@ -8,8 +8,9 @@ from . import plugin_pb2 as pulumi_dot_plugin__pb2
 
 
 class LanguageRuntimeStub(object):
-    """LanguageRuntime is the interface that the planning monitor uses to drive execution of an interpreter responsible
-    for confguring and creating resource objects.
+    """The LanguageRuntime service defines a standard interface for [language hosts/runtimes](languages). At a high level, a
+    language runtime provides the ability to execute programs, install and query dependencies, and generate code for a
+    specific language.
     """
 
     def __init__(self, channel):
@@ -91,105 +92,146 @@ class LanguageRuntimeStub(object):
 
 
 class LanguageRuntimeServicer(object):
-    """LanguageRuntime is the interface that the planning monitor uses to drive execution of an interpreter responsible
-    for confguring and creating resource objects.
+    """The LanguageRuntime service defines a standard interface for [language hosts/runtimes](languages). At a high level, a
+    language runtime provides the ability to execute programs, install and query dependencies, and generate code for a
+    specific language.
     """
 
     def Handshake(self, request, context):
-        """`Handshake` is the first call made by the engine to a language host. It is used to pass the 
-        engine's address to the language host so that it may establish its own connections back,
-        and to establish protocol configuration that will be used to communicate between the two parties. 
+        """`Handshake` is the first call made by the engine to a language host. It is used to pass the engine's address to
+        the language host so that it may establish its own connections back, and to establish protocol configuration that
+        will be used to communicate between the two parties.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def GetRequiredPlugins(self, request, context):
-        """GetRequiredPlugins computes the complete set of anticipated plugins required by a program.
+        """`GetRequiredPlugins` computes the complete set of anticipated [plugins](plugins) required by a Pulumi program.
+        Among other things, it is intended to be used to pre-install plugins before running a program with
+        [](pulumirpc.LanguageRuntime.Run), to avoid the need to install them on-demand in response to [resource
+        registrations](resource-registration) sent back from the running program to the engine.
+
+        :::{important}
+        The use of `GetRequiredPlugins` is deprecated in favour of [](pulumirpc.LanguageRuntime.GetRequiredPackages),
+        which returns more granular information about which plugins are required by which packages.
+        :::
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def GetRequiredPackages(self, request, context):
-        """GetRequiredPackages computes the complete set of anticipated packages required by a program.
+        """`GetRequiredPackages` computes the complete set of anticipated [packages](pulumirpc.PackageDependency) required
+        by a program. It is used to pre-install packages before running a program with [](pulumirpc.LanguageRuntime.Run),
+        to avoid the need to install them on-demand in response to [resource registrations](resource-registration) sent
+        back from the running program to the engine. Moreover, when importing resources into a stack, it is used to
+        determine which plugins are required to service the import of a given resource, since given the presence of
+        [parameterized providers](parameterized-providers), it is not in general true that a package name corresponds 1:1
+        with a plugin name. It replaces [](pulumirpc.LanguageRuntime.GetRequiredPlugins) in the face of [parameterized
+        providers](parameterized-providers), which as mentioned above can enable multiple instances of the same plugin to
+        provide multiple packages.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def Run(self, request, context):
-        """Run executes a program and returns its result.
+        """`Run` executes a Pulumi program, returning information about whether or not the program produced an error.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def GetPluginInfo(self, request, context):
-        """GetPluginInfo returns generic information about this plugin, like its version.
+        """`GetPluginInfo` returns information about the [plugin](plugins) implementing this language runtime.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def InstallDependencies(self, request, context):
-        """InstallDependencies will install dependencies for the project, e.g. by running `npm install` for nodejs projects.
+        """`InstallDependencies` accepts a request specifying a Pulumi project and program that can be executed with
+        [](pulumirpc.LanguageRuntime.Run) and installs the dependencies for that program (e.g. by running `npm install`
+        for NodeJS, or `pip install` for Python). Since dependency installation could take a while, and callers may wish
+        to report on its progress, this method returns a stream of [](pulumirpc.InstallDependenciesResponse) messages
+        containing information about standard error and output.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def RuntimeOptionsPrompts(self, request, context):
-        """RuntimeOptionsPrompts returns a list of additional prompts to ask during `pulumi new`.
+        """`RuntimeOptionsPrompts` accepts a request specifying a Pulumi project and returns a list of additional prompts to
+        ask during `pulumi new`.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def About(self, request, context):
-        """About returns information about the runtime for this language.
+        """`About` returns information about the language runtime being used.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def GetProgramDependencies(self, request, context):
-        """GetProgramDependencies returns the set of dependencies required by the program.
+        """`GetProgramDependencies` computes the set of language-level dependencies (e.g. NPM packages for NodeJS, or Maven
+        libraries for Java) required by a program.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def RunPlugin(self, request, context):
-        """RunPlugin executes a plugin program and returns its result asynchronously.
+        """`RunPlugin` is used to execute a program written in this host's language that implements a Pulumi
+        [plugin](plugins). It it is plugins what [](pulumirpc.LanguageRuntime.Run) is to programs. Since a plugin is not
+        expected to terminate until instructed/for a long time, this method returns a stream of
+        [](pulumirpc.RunPluginResponse) messages containing information about standard error and output, as well as the
+        exit code of the plugin when it does terminate.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def GenerateProgram(self, request, context):
-        """GenerateProgram generates a given PCL program into a program for this language.
+        """`GenerateProgram` generates code in this host's language that implements the given [PCL](pcl) program. Unlike
+        [](pulumirpc.LanguageRuntime.GenerateProject), this method *only* generates program code, and does not e.g.
+        generate a `package.json` for a NodeJS project that details how to run that code.
+        [](pulumirpc.LanguageRuntime.GenerateProject), this method underpins ["programgen"](programgen) and the main
+        functionality powering `pulumi convert`.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def GenerateProject(self, request, context):
-        """GenerateProject generates a given PCL program into a project for this language.
+        """`GenerateProject` generates code in this host's language that implements the given [PCL](pcl) program and wraps
+        it in some language-specific notion of a "project", where a project is a buildable or runnable artifact. In this
+        sense, `GenerateProject`'s output is a superset of that of [](pulumirpc.LanguageRuntime.GenerateProgram). For
+        instance, when generating a NodeJS project, this method might generate a corresponding `package.json` file, as
+        well as the relevant NodeJS program code. Along with [](pulumirpc.LanguageRuntime.GenerateProgram), this method
+        underpins ["programgen"](programgen) and the main functionality powering `pulumi convert`.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def GeneratePackage(self, request, context):
-        """GeneratePackage generates a given pulumi package into a package for this language.
+        """`GeneratePackage` generates code in this host's language that implements an [SDK](sdkgen) ("sdkgen") for the
+        given Pulumi package, as specified by a [schema](schema).
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def Pack(self, request, context):
-        """Pack packs a package into a language specific artifact.
+        """`Pack` accepts a request specifying a generated SDK package and packs it into a language-specific artifact. For
+        instance, in the case of Java, it might produce a JAR file from a list of `.java` sources; in the case of NodeJS,
+        a `.tgz` file might be produced from a list of `.js` sources; and so on. Presently, `Pack` is primarily used in
+        [language conformance tests](language-conformance-tests), though it is intended to be used more widely in future
+        to standardise e.g. provider publishing workflows.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -276,8 +318,9 @@ def add_LanguageRuntimeServicer_to_server(servicer, server):
 
  # This class is part of an EXPERIMENTAL API.
 class LanguageRuntime(object):
-    """LanguageRuntime is the interface that the planning monitor uses to drive execution of an interpreter responsible
-    for confguring and creating resource objects.
+    """The LanguageRuntime service defines a standard interface for [language hosts/runtimes](languages). At a high level, a
+    language runtime provides the ability to execute programs, install and query dependencies, and generate code for a
+    specific language.
     """
 
     @staticmethod

--- a/sdk/python/lib/pulumi/runtime/proto/language_pb2_grpc.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/language_pb2_grpc.pyi
@@ -25,8 +25,9 @@ import pulumi.language_pb2
 import pulumi.plugin_pb2
 
 class LanguageRuntimeStub:
-    """LanguageRuntime is the interface that the planning monitor uses to drive execution of an interpreter responsible
-    for confguring and creating resource objects.
+    """The LanguageRuntime service defines a standard interface for [language hosts/runtimes](languages). At a high level, a
+    language runtime provides the ability to execute programs, install and query dependencies, and generate code for a
+    specific language.
     """
 
     def __init__(self, channel: grpc.Channel) -> None: ...
@@ -34,79 +35,130 @@ class LanguageRuntimeStub:
         pulumi.language_pb2.LanguageHandshakeRequest,
         pulumi.language_pb2.LanguageHandshakeResponse,
     ]
-    """`Handshake` is the first call made by the engine to a language host. It is used to pass the 
-    engine's address to the language host so that it may establish its own connections back,
-    and to establish protocol configuration that will be used to communicate between the two parties.
+    """`Handshake` is the first call made by the engine to a language host. It is used to pass the engine's address to
+    the language host so that it may establish its own connections back, and to establish protocol configuration that
+    will be used to communicate between the two parties.
     """
     GetRequiredPlugins: grpc.UnaryUnaryMultiCallable[
         pulumi.language_pb2.GetRequiredPluginsRequest,
         pulumi.language_pb2.GetRequiredPluginsResponse,
     ]
-    """GetRequiredPlugins computes the complete set of anticipated plugins required by a program."""
+    """`GetRequiredPlugins` computes the complete set of anticipated [plugins](plugins) required by a Pulumi program.
+    Among other things, it is intended to be used to pre-install plugins before running a program with
+    [](pulumirpc.LanguageRuntime.Run), to avoid the need to install them on-demand in response to [resource
+    registrations](resource-registration) sent back from the running program to the engine.
+
+    :::{important}
+    The use of `GetRequiredPlugins` is deprecated in favour of [](pulumirpc.LanguageRuntime.GetRequiredPackages),
+    which returns more granular information about which plugins are required by which packages.
+    :::
+    """
     GetRequiredPackages: grpc.UnaryUnaryMultiCallable[
         pulumi.language_pb2.GetRequiredPackagesRequest,
         pulumi.language_pb2.GetRequiredPackagesResponse,
     ]
-    """GetRequiredPackages computes the complete set of anticipated packages required by a program."""
+    """`GetRequiredPackages` computes the complete set of anticipated [packages](pulumirpc.PackageDependency) required
+    by a program. It is used to pre-install packages before running a program with [](pulumirpc.LanguageRuntime.Run),
+    to avoid the need to install them on-demand in response to [resource registrations](resource-registration) sent
+    back from the running program to the engine. Moreover, when importing resources into a stack, it is used to
+    determine which plugins are required to service the import of a given resource, since given the presence of
+    [parameterized providers](parameterized-providers), it is not in general true that a package name corresponds 1:1
+    with a plugin name. It replaces [](pulumirpc.LanguageRuntime.GetRequiredPlugins) in the face of [parameterized
+    providers](parameterized-providers), which as mentioned above can enable multiple instances of the same plugin to
+    provide multiple packages.
+    """
     Run: grpc.UnaryUnaryMultiCallable[
         pulumi.language_pb2.RunRequest,
         pulumi.language_pb2.RunResponse,
     ]
-    """Run executes a program and returns its result."""
+    """`Run` executes a Pulumi program, returning information about whether or not the program produced an error."""
     GetPluginInfo: grpc.UnaryUnaryMultiCallable[
         google.protobuf.empty_pb2.Empty,
         pulumi.plugin_pb2.PluginInfo,
     ]
-    """GetPluginInfo returns generic information about this plugin, like its version."""
+    """`GetPluginInfo` returns information about the [plugin](plugins) implementing this language runtime."""
     InstallDependencies: grpc.UnaryStreamMultiCallable[
         pulumi.language_pb2.InstallDependenciesRequest,
         pulumi.language_pb2.InstallDependenciesResponse,
     ]
-    """InstallDependencies will install dependencies for the project, e.g. by running `npm install` for nodejs projects."""
+    """`InstallDependencies` accepts a request specifying a Pulumi project and program that can be executed with
+    [](pulumirpc.LanguageRuntime.Run) and installs the dependencies for that program (e.g. by running `npm install`
+    for NodeJS, or `pip install` for Python). Since dependency installation could take a while, and callers may wish
+    to report on its progress, this method returns a stream of [](pulumirpc.InstallDependenciesResponse) messages
+    containing information about standard error and output.
+    """
     RuntimeOptionsPrompts: grpc.UnaryUnaryMultiCallable[
         pulumi.language_pb2.RuntimeOptionsRequest,
         pulumi.language_pb2.RuntimeOptionsResponse,
     ]
-    """RuntimeOptionsPrompts returns a list of additional prompts to ask during `pulumi new`."""
+    """`RuntimeOptionsPrompts` accepts a request specifying a Pulumi project and returns a list of additional prompts to
+    ask during `pulumi new`.
+    """
     About: grpc.UnaryUnaryMultiCallable[
         pulumi.language_pb2.AboutRequest,
         pulumi.language_pb2.AboutResponse,
     ]
-    """About returns information about the runtime for this language."""
+    """`About` returns information about the language runtime being used."""
     GetProgramDependencies: grpc.UnaryUnaryMultiCallable[
         pulumi.language_pb2.GetProgramDependenciesRequest,
         pulumi.language_pb2.GetProgramDependenciesResponse,
     ]
-    """GetProgramDependencies returns the set of dependencies required by the program."""
+    """`GetProgramDependencies` computes the set of language-level dependencies (e.g. NPM packages for NodeJS, or Maven
+    libraries for Java) required by a program.
+    """
     RunPlugin: grpc.UnaryStreamMultiCallable[
         pulumi.language_pb2.RunPluginRequest,
         pulumi.language_pb2.RunPluginResponse,
     ]
-    """RunPlugin executes a plugin program and returns its result asynchronously."""
+    """`RunPlugin` is used to execute a program written in this host's language that implements a Pulumi
+    [plugin](plugins). It it is plugins what [](pulumirpc.LanguageRuntime.Run) is to programs. Since a plugin is not
+    expected to terminate until instructed/for a long time, this method returns a stream of
+    [](pulumirpc.RunPluginResponse) messages containing information about standard error and output, as well as the
+    exit code of the plugin when it does terminate.
+    """
     GenerateProgram: grpc.UnaryUnaryMultiCallable[
         pulumi.language_pb2.GenerateProgramRequest,
         pulumi.language_pb2.GenerateProgramResponse,
     ]
-    """GenerateProgram generates a given PCL program into a program for this language."""
+    """`GenerateProgram` generates code in this host's language that implements the given [PCL](pcl) program. Unlike
+    [](pulumirpc.LanguageRuntime.GenerateProject), this method *only* generates program code, and does not e.g.
+    generate a `package.json` for a NodeJS project that details how to run that code.
+    [](pulumirpc.LanguageRuntime.GenerateProject), this method underpins ["programgen"](programgen) and the main
+    functionality powering `pulumi convert`.
+    """
     GenerateProject: grpc.UnaryUnaryMultiCallable[
         pulumi.language_pb2.GenerateProjectRequest,
         pulumi.language_pb2.GenerateProjectResponse,
     ]
-    """GenerateProject generates a given PCL program into a project for this language."""
+    """`GenerateProject` generates code in this host's language that implements the given [PCL](pcl) program and wraps
+    it in some language-specific notion of a "project", where a project is a buildable or runnable artifact. In this
+    sense, `GenerateProject`'s output is a superset of that of [](pulumirpc.LanguageRuntime.GenerateProgram). For
+    instance, when generating a NodeJS project, this method might generate a corresponding `package.json` file, as
+    well as the relevant NodeJS program code. Along with [](pulumirpc.LanguageRuntime.GenerateProgram), this method
+    underpins ["programgen"](programgen) and the main functionality powering `pulumi convert`.
+    """
     GeneratePackage: grpc.UnaryUnaryMultiCallable[
         pulumi.language_pb2.GeneratePackageRequest,
         pulumi.language_pb2.GeneratePackageResponse,
     ]
-    """GeneratePackage generates a given pulumi package into a package for this language."""
+    """`GeneratePackage` generates code in this host's language that implements an [SDK](sdkgen) ("sdkgen") for the
+    given Pulumi package, as specified by a [schema](schema).
+    """
     Pack: grpc.UnaryUnaryMultiCallable[
         pulumi.language_pb2.PackRequest,
         pulumi.language_pb2.PackResponse,
     ]
-    """Pack packs a package into a language specific artifact."""
+    """`Pack` accepts a request specifying a generated SDK package and packs it into a language-specific artifact. For
+    instance, in the case of Java, it might produce a JAR file from a list of `.java` sources; in the case of NodeJS,
+    a `.tgz` file might be produced from a list of `.js` sources; and so on. Presently, `Pack` is primarily used in
+    [language conformance tests](language-conformance-tests), though it is intended to be used more widely in future
+    to standardise e.g. provider publishing workflows.
+    """
 
 class LanguageRuntimeServicer(metaclass=abc.ABCMeta):
-    """LanguageRuntime is the interface that the planning monitor uses to drive execution of an interpreter responsible
-    for confguring and creating resource objects.
+    """The LanguageRuntime service defines a standard interface for [language hosts/runtimes](languages). At a high level, a
+    language runtime provides the ability to execute programs, install and query dependencies, and generate code for a
+    specific language.
     """
 
     
@@ -115,9 +167,9 @@ class LanguageRuntimeServicer(metaclass=abc.ABCMeta):
         request: pulumi.language_pb2.LanguageHandshakeRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.language_pb2.LanguageHandshakeResponse:
-        """`Handshake` is the first call made by the engine to a language host. It is used to pass the 
-        engine's address to the language host so that it may establish its own connections back,
-        and to establish protocol configuration that will be used to communicate between the two parties.
+        """`Handshake` is the first call made by the engine to a language host. It is used to pass the engine's address to
+        the language host so that it may establish its own connections back, and to establish protocol configuration that
+        will be used to communicate between the two parties.
         """
     
     def GetRequiredPlugins(
@@ -125,90 +177,140 @@ class LanguageRuntimeServicer(metaclass=abc.ABCMeta):
         request: pulumi.language_pb2.GetRequiredPluginsRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.language_pb2.GetRequiredPluginsResponse:
-        """GetRequiredPlugins computes the complete set of anticipated plugins required by a program."""
+        """`GetRequiredPlugins` computes the complete set of anticipated [plugins](plugins) required by a Pulumi program.
+        Among other things, it is intended to be used to pre-install plugins before running a program with
+        [](pulumirpc.LanguageRuntime.Run), to avoid the need to install them on-demand in response to [resource
+        registrations](resource-registration) sent back from the running program to the engine.
+
+        :::{important}
+        The use of `GetRequiredPlugins` is deprecated in favour of [](pulumirpc.LanguageRuntime.GetRequiredPackages),
+        which returns more granular information about which plugins are required by which packages.
+        :::
+        """
     
     def GetRequiredPackages(
         self,
         request: pulumi.language_pb2.GetRequiredPackagesRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.language_pb2.GetRequiredPackagesResponse:
-        """GetRequiredPackages computes the complete set of anticipated packages required by a program."""
+        """`GetRequiredPackages` computes the complete set of anticipated [packages](pulumirpc.PackageDependency) required
+        by a program. It is used to pre-install packages before running a program with [](pulumirpc.LanguageRuntime.Run),
+        to avoid the need to install them on-demand in response to [resource registrations](resource-registration) sent
+        back from the running program to the engine. Moreover, when importing resources into a stack, it is used to
+        determine which plugins are required to service the import of a given resource, since given the presence of
+        [parameterized providers](parameterized-providers), it is not in general true that a package name corresponds 1:1
+        with a plugin name. It replaces [](pulumirpc.LanguageRuntime.GetRequiredPlugins) in the face of [parameterized
+        providers](parameterized-providers), which as mentioned above can enable multiple instances of the same plugin to
+        provide multiple packages.
+        """
     
     def Run(
         self,
         request: pulumi.language_pb2.RunRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.language_pb2.RunResponse:
-        """Run executes a program and returns its result."""
+        """`Run` executes a Pulumi program, returning information about whether or not the program produced an error."""
     
     def GetPluginInfo(
         self,
         request: google.protobuf.empty_pb2.Empty,
         context: grpc.ServicerContext,
     ) -> pulumi.plugin_pb2.PluginInfo:
-        """GetPluginInfo returns generic information about this plugin, like its version."""
+        """`GetPluginInfo` returns information about the [plugin](plugins) implementing this language runtime."""
     
     def InstallDependencies(
         self,
         request: pulumi.language_pb2.InstallDependenciesRequest,
         context: grpc.ServicerContext,
     ) -> collections.abc.Iterator[pulumi.language_pb2.InstallDependenciesResponse]:
-        """InstallDependencies will install dependencies for the project, e.g. by running `npm install` for nodejs projects."""
+        """`InstallDependencies` accepts a request specifying a Pulumi project and program that can be executed with
+        [](pulumirpc.LanguageRuntime.Run) and installs the dependencies for that program (e.g. by running `npm install`
+        for NodeJS, or `pip install` for Python). Since dependency installation could take a while, and callers may wish
+        to report on its progress, this method returns a stream of [](pulumirpc.InstallDependenciesResponse) messages
+        containing information about standard error and output.
+        """
     
     def RuntimeOptionsPrompts(
         self,
         request: pulumi.language_pb2.RuntimeOptionsRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.language_pb2.RuntimeOptionsResponse:
-        """RuntimeOptionsPrompts returns a list of additional prompts to ask during `pulumi new`."""
+        """`RuntimeOptionsPrompts` accepts a request specifying a Pulumi project and returns a list of additional prompts to
+        ask during `pulumi new`.
+        """
     
     def About(
         self,
         request: pulumi.language_pb2.AboutRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.language_pb2.AboutResponse:
-        """About returns information about the runtime for this language."""
+        """`About` returns information about the language runtime being used."""
     
     def GetProgramDependencies(
         self,
         request: pulumi.language_pb2.GetProgramDependenciesRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.language_pb2.GetProgramDependenciesResponse:
-        """GetProgramDependencies returns the set of dependencies required by the program."""
+        """`GetProgramDependencies` computes the set of language-level dependencies (e.g. NPM packages for NodeJS, or Maven
+        libraries for Java) required by a program.
+        """
     
     def RunPlugin(
         self,
         request: pulumi.language_pb2.RunPluginRequest,
         context: grpc.ServicerContext,
     ) -> collections.abc.Iterator[pulumi.language_pb2.RunPluginResponse]:
-        """RunPlugin executes a plugin program and returns its result asynchronously."""
+        """`RunPlugin` is used to execute a program written in this host's language that implements a Pulumi
+        [plugin](plugins). It it is plugins what [](pulumirpc.LanguageRuntime.Run) is to programs. Since a plugin is not
+        expected to terminate until instructed/for a long time, this method returns a stream of
+        [](pulumirpc.RunPluginResponse) messages containing information about standard error and output, as well as the
+        exit code of the plugin when it does terminate.
+        """
     
     def GenerateProgram(
         self,
         request: pulumi.language_pb2.GenerateProgramRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.language_pb2.GenerateProgramResponse:
-        """GenerateProgram generates a given PCL program into a program for this language."""
+        """`GenerateProgram` generates code in this host's language that implements the given [PCL](pcl) program. Unlike
+        [](pulumirpc.LanguageRuntime.GenerateProject), this method *only* generates program code, and does not e.g.
+        generate a `package.json` for a NodeJS project that details how to run that code.
+        [](pulumirpc.LanguageRuntime.GenerateProject), this method underpins ["programgen"](programgen) and the main
+        functionality powering `pulumi convert`.
+        """
     
     def GenerateProject(
         self,
         request: pulumi.language_pb2.GenerateProjectRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.language_pb2.GenerateProjectResponse:
-        """GenerateProject generates a given PCL program into a project for this language."""
+        """`GenerateProject` generates code in this host's language that implements the given [PCL](pcl) program and wraps
+        it in some language-specific notion of a "project", where a project is a buildable or runnable artifact. In this
+        sense, `GenerateProject`'s output is a superset of that of [](pulumirpc.LanguageRuntime.GenerateProgram). For
+        instance, when generating a NodeJS project, this method might generate a corresponding `package.json` file, as
+        well as the relevant NodeJS program code. Along with [](pulumirpc.LanguageRuntime.GenerateProgram), this method
+        underpins ["programgen"](programgen) and the main functionality powering `pulumi convert`.
+        """
     
     def GeneratePackage(
         self,
         request: pulumi.language_pb2.GeneratePackageRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.language_pb2.GeneratePackageResponse:
-        """GeneratePackage generates a given pulumi package into a package for this language."""
+        """`GeneratePackage` generates code in this host's language that implements an [SDK](sdkgen) ("sdkgen") for the
+        given Pulumi package, as specified by a [schema](schema).
+        """
     
     def Pack(
         self,
         request: pulumi.language_pb2.PackRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.language_pb2.PackResponse:
-        """Pack packs a package into a language specific artifact."""
+        """`Pack` accepts a request specifying a generated SDK package and packs it into a language-specific artifact. For
+        instance, in the case of Java, it might produce a JAR file from a list of `.java` sources; in the case of NodeJS,
+        a `.tgz` file might be produced from a list of `.js` sources; and so on. Presently, `Pack` is primarily used in
+        [language conformance tests](language-conformance-tests), though it is intended to be used more widely in future
+        to standardise e.g. provider publishing workflows.
+        """
 
 def add_LanguageRuntimeServicer_to_server(servicer: LanguageRuntimeServicer, server: typing.Union[grpc.Server, grpc.aio.Server]) -> None: ...


### PR DESCRIPTION
This commit fleshes out documentation for the `LanguageRuntime` gRPC service which underpins Pulumi's language runtimes. The documentation is pretty complete already for the most part -- this commit just adds some cross-references to various bits and pieces, some concrete examples here and there, and fills in the gaps.