### PR TITLE
Bump minimum pulumi version for Parameterized Go codegen to v3.147.0

### DIFF
--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -5084,7 +5084,7 @@ func GeneratePackage(tool string,
 		pulumiPackagePath := "github.com/pulumi/pulumi/sdk/v3"
 		pulumiVersion := "v3.30.0"
 		if pkg.Parameterization != nil {
-			pulumiVersion = "v3.133.0"
+			pulumiVersion = "v3.147.0"
 		}
 		err = gomod.AddRequire(pulumiPackagePath, pulumiVersion)
 		contract.AssertNoErrorf(err, "could not add require statement to go.mod")

--- a/sdk/go/pulumi-language-go/testdata/sdks/goodbye-2.0.0/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/sdks/goodbye-2.0.0/go.mod
@@ -2,6 +2,6 @@ module example.com/pulumi-goodbye/sdk/go/v2
 
 go 1.20
 
-require github.com/pulumi/pulumi/sdk/v3 v3.133.0
+require github.com/pulumi/pulumi/sdk/v3 v3.147.0
 
 replace github.com/pulumi/pulumi/sdk/v3 => /ROOT/artifacts/github.com_pulumi_pulumi_sdk_v3

--- a/sdk/go/pulumi-language-go/testdata/sdks/subpackage-2.0.0/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/sdks/subpackage-2.0.0/go.mod
@@ -2,6 +2,6 @@ module example.com/pulumi-subpackage/sdk/go/v2
 
 go 1.20
 
-require github.com/pulumi/pulumi/sdk/v3 v3.133.0
+require github.com/pulumi/pulumi/sdk/v3 v3.147.0
 
 replace github.com/pulumi/pulumi/sdk/v3 => /ROOT/artifacts/github.com_pulumi_pulumi_sdk_v3


### PR DESCRIPTION
This incorporates a breaking change that was added in v3.147.0.

Fixes https://github.com/pulumi/pulumi/issues/18384.
