### PR TITLE
Filter __internal keys when calling provider diff

### DIFF
--- a/changelog/pending/20250204--engine--filter-__internal-keys-when-calling-providers-diffconfig.yaml
+++ b/changelog/pending/20250204--engine--filter-__internal-keys-when-calling-providers-diffconfig.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Filter __internal keys when calling providers DiffConfig

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -1803,3 +1803,95 @@ func TestRefreshLegacyState(t *testing.T) {
 	assert.Equal(t, "1.3.0", prov.Inputs["version"].StringValue())
 	assert.Equal(t, "http://example.com", prov.Inputs["pluginDownloadURL"].StringValue())
 }
+
+// This tests that we don't send __internal through to the provider instance itself
+func TestInternalFiltered(t *testing.T) {
+	t.Parallel()
+
+	internalKey := resource.PropertyKey("__internal")
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				DiffConfigF: func(_ context.Context, req plugin.DiffConfigRequest) (plugin.DiffConfigResponse, error) {
+					assert.NotContains(t, req.NewInputs, internalKey)
+					assert.NotContains(t, req.OldInputs, internalKey)
+					assert.NotContains(t, req.OldOutputs, internalKey)
+					return plugin.DiffResult{}, nil
+				},
+				CheckConfigF: func(_ context.Context, req plugin.CheckConfigRequest) (plugin.CheckConfigResponse, error) {
+					assert.NotContains(t, req.News, internalKey)
+					assert.NotContains(t, req.Olds, internalKey)
+					return plugin.CheckConfigResponse{}, nil
+				},
+				ConfigureF: func(_ context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
+					assert.NotContains(t, req.Inputs, internalKey)
+					return plugin.ConfigureResponse{}, nil
+				},
+			}, nil
+		}),
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.1.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				DiffConfigF: func(_ context.Context, req plugin.DiffConfigRequest) (plugin.DiffConfigResponse, error) {
+					assert.NotContains(t, req.NewInputs, internalKey)
+					assert.NotContains(t, req.OldInputs, internalKey)
+					assert.NotContains(t, req.OldOutputs, internalKey)
+					return plugin.DiffResult{}, nil
+				},
+				CheckConfigF: func(_ context.Context, req plugin.CheckConfigRequest) (plugin.CheckConfigResponse, error) {
+					assert.NotContains(t, req.News, internalKey)
+					assert.NotContains(t, req.Olds, internalKey)
+					return plugin.CheckConfigResponse{}, nil
+				},
+				ConfigureF: func(_ context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
+					assert.NotContains(t, req.Inputs, internalKey)
+					return plugin.ConfigureResponse{}, nil
+				},
+			}, nil
+		}),
+	}
+
+	pkgAType := providers.MakeProviderType("pkgA")
+	providerVersion := "1.0.0"
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		resp, err := monitor.RegisterResource(pkgAType, "provA", true, deploytest.ResourceOptions{
+			Version: providerVersion,
+		})
+		assert.NoError(t, err)
+
+		provID := resp.ID
+		if provID == "" {
+			provID = providers.UnknownID
+		}
+
+		provRef, err := providers.NewReference(resp.URN, provID)
+		assert.NoError(t, err)
+
+		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
+			Provider: provRef.String(),
+		})
+		assert.NoError(t, err)
+
+		_, err = monitor.RegisterResource("pkgA:m:typA", "resB", true, deploytest.ResourceOptions{
+			Version: providerVersion,
+		})
+		assert.NoError(t, err)
+
+		return nil
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
+	}
+
+	project := p.GetProject()
+	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	assert.NoError(t, err)
+
+	// Change the version to trigger diffs and check we still don't get __internal keys
+	providerVersion = "1.1.0"
+	_, err = lt.TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil)
+	assert.NoError(t, err)
+}

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1776,9 +1776,9 @@ func (sg *stepGenerator) providerChanged(urn resource.URN, old, new *resource.St
 
 	diff, err := newProv.DiffConfig(context.TODO(), plugin.DiffConfigRequest{
 		URN:           newRef.URN(),
-		OldInputs:     oldRes.Inputs,
+		OldInputs:     providers.FilterProviderConfig(oldRes.Inputs),
 		OldOutputs:    oldRes.Outputs,
-		NewInputs:     newRes.Inputs,
+		NewInputs:     providers.FilterProviderConfig(newRes.Inputs),
 		AllowUnknowns: true,
 	})
 	if err != nil {


### PR DESCRIPTION
Noticed this while looking into https://github.com/pulumi/pulumi/issues/18449. 

Whenever we call provider methods to do with config (e.g. DiffConfig) we should filter out the "__internal" key that the engine adds to state for tracking engine internal data. We were doing this correctly everywhere except in one place in the step generator when calculating diffs due to provider changes. 

This fixes that place up and also adds a test to check we don't regress this.