### PR TITLE
add additional debugging output to TestConvertTerraformProviderPython

### DIFF
--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1556,13 +1556,15 @@ func TestConvertTerraformProviderPython(t *testing.T) {
 	err = json.Unmarshal([]byte(out), &a)
 	assert.NoError(t, err)
 	found := false
+	depList := []string{}
 	for _, dep := range a.Dependencies {
 		if dep.Name == "pulumi_supabase" {
 			found = true
 			break
 		}
+		depList = append(depList, dep.Name)
 	}
-	require.True(t, found, "pulumi_subabase should be installed")
+	require.True(t, found, fmt.Sprintf("pulumi_supabase not found in dependencies.  Full list: %v", depList))
 }
 
 func TestConfigGetterOverloads(t *testing.T) {


### PR DESCRIPTION
I've seen this test flake/fail a few times, but unfortunately there's not much to go on for debugging it.  Add the full list of dependencies to the output to see if that helps a bit to shed light on what's happening.