### PR TITLE
Fix setting indexed top-level config keys with path=true

### DIFF
--- a/changelog/pending/20250204--cli-config--fix-setting-indexed-top-level-config-keys.yaml
+++ b/changelog/pending/20250204--cli-config--fix-setting-indexed-top-level-config-keys.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/config
+  description: Fix setting indexed top-level config keys

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -290,7 +290,7 @@ func newConfigGetCmd(stack *string) *cobra.Command {
 				return err
 			}
 
-			key, err := ParseConfigKey(args[0], path)
+			key, err := ParseConfigKey(ws, args[0], path)
 			if err != nil {
 				return fmt.Errorf("invalid configuration key: %w", err)
 			}
@@ -349,7 +349,7 @@ func newConfigRmCmd(stack *string) *cobra.Command {
 				return err
 			}
 
-			key, err := ParseConfigKey(args[0], path)
+			key, err := ParseConfigKey(ws, args[0], path)
 			if err != nil {
 				return fmt.Errorf("invalid configuration key: %w", err)
 			}
@@ -417,7 +417,7 @@ func newConfigRmAllCmd(stack *string) *cobra.Command {
 			}
 
 			for _, arg := range args {
-				key, err := ParseConfigKey(arg, path)
+				key, err := ParseConfigKey(ws, arg, path)
 				if err != nil {
 					return fmt.Errorf("invalid configuration key: %w", err)
 				}
@@ -636,7 +636,7 @@ func (c *configSetCmd) Run(ctx context.Context, args []string, project *workspac
 	if loadProjectStack == nil {
 		loadProjectStack = cmdStack.LoadProjectStack
 	}
-	key, err := ParseConfigKey(args[0], c.Path)
+	key, err := ParseConfigKey(pkgWorkspace.Instance, args[0], c.Path)
 	if err != nil {
 		return fmt.Errorf("invalid configuration key: %w", err)
 	}

--- a/pkg/cmd/pulumi/config/io_test.go
+++ b/pkg/cmd/pulumi/config/io_test.go
@@ -543,7 +543,7 @@ func TestParseConfigKey(t *testing.T) {
 			name:    "path segments with colons",
 			input:   "mynamespace:mykey.segment1:suffix",
 			path:    true,
-			wantKey: config.MustMakeKey("mynamespace", "mykey[\"segment1:suffix\"]"),
+			wantKey: config.MustMakeKey("mynamespace", "mykey.segment1:suffix"),
 		},
 		{
 			name:    "non-path segments with colons fail to parse",
@@ -558,16 +558,46 @@ func TestParseConfigKey(t *testing.T) {
 			wantErr: "configuration keys should be of the form `<namespace>:<name>`",
 		},
 		{
+			name:    "invalid path with colon before bracket",
+			input:   "mynamespace:my:key[\"segment\"]",
+			path:    true,
+			wantErr: "configuration keys should be of the form `<namespace>:<name>`",
+		},
+		{
 			name:    "key paths",
 			input:   "mynamespace:mykey[\"segment1:suffix\"]",
 			path:    true,
 			wantKey: config.MustMakeKey("mynamespace", "mykey[\"segment1:suffix\"]"),
 		},
 		{
+			name:    "bracket as top-level path segment",
+			input:   "mynamespace:[\"foo\"]",
+			path:    true,
+			wantKey: config.MustMakeKey("mynamespace", "[\"foo\"]"),
+		},
+		{
 			name:    "invalid path",
 			input:   "mynamespace:.segment1",
 			path:    true,
 			wantKey: config.MustMakeKey("mynamespace", ".segment1"),
+		},
+		{
+			name:    "path with multiple brackets",
+			input:   "mynamespace:mykey[\"segment1\"][\"segment2\"]",
+			path:    true,
+			wantKey: config.MustMakeKey("mynamespace", "mykey[\"segment1\"][\"segment2\"]"),
+		},
+		{
+			name:    "empty segment in path",
+			input:   "mynamespace:mykey..segment",
+			path:    true,
+			wantKey: config.MustMakeKey("mynamespace", "mykey..segment"),
+		},
+		{
+			name:    "old-style key as non-path",
+			input:   "aws:config:region.value",
+			path:    false,
+			wantKey: config.MustMakeKey("aws", "region.value"),
 		},
 	}
 

--- a/pkg/cmd/pulumi/newcmd/config.go
+++ b/pkg/cmd/pulumi/newcmd/config.go
@@ -146,7 +146,7 @@ func isPreconfiguredEmptyStack(
 
 	// Can stackConfig satisfy the config requirements of templateConfig?
 	for templateKey, templateVal := range templateConfig {
-		parsedTemplateKey, parseErr := cmdConfig.ParseConfigKey(templateKey, false)
+		parsedTemplateKey, parseErr := cmdConfig.ParseConfigKey(pkgWorkspace.Instance, templateKey, false)
 		if parseErr != nil {
 			contract.IgnoreError(parseErr)
 			return false
@@ -187,7 +187,7 @@ func promptForConfig(
 	// the project name will be prepended.
 	parsedTemplateConfig := make(map[config.Key]workspace.ProjectTemplateConfigValue)
 	for k, v := range templateConfig {
-		parsedKey, parseErr := cmdConfig.ParseConfigKey(k, false)
+		parsedKey, parseErr := cmdConfig.ParseConfigKey(pkgWorkspace.Instance, k, false)
 		if parseErr != nil {
 			return nil, parseErr
 		}
@@ -310,7 +310,7 @@ func ParseConfig(configArray []string, path bool) (config.Map, error) {
 	for _, c := range configArray {
 		kvp := strings.SplitN(c, "=", 2)
 
-		key, err := cmdConfig.ParseConfigKey(kvp[0], path)
+		key, err := cmdConfig.ParseConfigKey(pkgWorkspace.Instance, kvp[0], path)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
https://github.com/pulumi/pulumi/pull/18378 has unfortunately led to a regression in previously working `pulumi config` commands that utilize both an explicit namespace and a top-level "indexer" syntax for config keys, for example

```
pulumi config set-all --path --plaintext 'example:["foo"]=bar'
```

This PR revamps the implementation of #18378. Since `resource.ParsePropertyPathStrict` is not namespace-aware and can return erroneous empty keys, I've substituted it with a manual piece of path parcing. It breaks down the path by two possible delimeters `.` and `[` and parses the first (top) segment with its namespace, then uses that namespace to construct the entire key.

A few tes cases added to cover potential use cases.

Fix https://github.com/pulumi/pulumi/issues/18443