### PR TITLE
Rejig import files to record base plugin names and versions in the paramterisation block

### DIFF
--- a/changelog/pending/20250205--cli-import--fix-the-declaration-of-parameterized-providers-in-import-json-files.yaml
+++ b/changelog/pending/20250205--cli-import--fix-the-declaration-of-parameterized-providers-in-import-json-files.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/import
+  description: Fix the declaration of parameterized providers in import JSON files

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -273,7 +273,11 @@ func newDeployment(
 
 			if imp.Provider == "" && (!imp.Component || imp.Remote) {
 				if imp.Version == nil {
-					imp.Version = defaultProviderInfo[imp.Type.Package()].Version
+					dpi := defaultProviderInfo[imp.Type.Package()]
+					imp.Version = dpi.Version
+					if dpi.Parameterization != nil {
+						imp.Version = &dpi.Parameterization.Version
+					}
 				}
 				if imp.PluginDownloadURL == "" {
 					imp.PluginDownloadURL = defaultProviderInfo[imp.Type.Package()].PluginDownloadURL
@@ -282,7 +286,19 @@ func newDeployment(
 					imp.PluginChecksums = defaultProviderInfo[imp.Type.Package()].Checksums
 				}
 				if imp.Parameterization == nil {
-					imp.Parameterization = defaultProviderInfo[imp.Type.Package()].Parameterization
+					dpi := defaultProviderInfo[imp.Type.Package()]
+
+					if dpi.Parameterization != nil {
+						if dpi.Version == nil {
+							return nil, fmt.Errorf("no version specified for provider %q", dpi.Name)
+						}
+
+						imp.Parameterization = &deploy.Parameterization{
+							PluginName:    tokens.Package(dpi.Name),
+							PluginVersion: *dpi.Version,
+							Value:         dpi.Parameterization.Value,
+						}
+					}
 				}
 			}
 		}

--- a/pkg/resource/deploy/providers/provider.go
+++ b/pkg/resource/deploy/providers/provider.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 type ProviderParameterization struct {
@@ -42,15 +41,6 @@ func NewProviderParameterization(name tokens.Package, version semver.Version, va
 		Version: version,
 		Value:   value,
 	}
-}
-
-// ToProviderParameterization converts a workspace parameterization to a provider parameterization.
-func ToProviderParameterization(parameterization *workspace.Parameterization) *ProviderParameterization {
-	if parameterization == nil {
-		return nil
-	}
-	return NewProviderParameterization(
-		tokens.Package(parameterization.Name), parameterization.Version, parameterization.Value)
 }
 
 // A ProviderRequest is a tuple of an optional semantic version, download server url, parameter, and a package name.

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -890,11 +890,7 @@ func TestDestroyUpgradeWarningParameterized(t *testing.T) {
 		"than the specified program version: 3.6.0 < 3.6.3")
 }
 
-// Quick sanity tests to check that import for a parameterized package works. This uses python as the language choice
-// shouldn't matter for the test. Regression test for https://github.com/pulumi/pulumi/issues/17289.
-//
-//nolint:paralleltest // pulumi new is not parallel safe
-func TestImportParameterizedSmoke(t *testing.T) {
+func testImportParameterizedSmoke(t *testing.T, withUp bool) {
 	e := ptesting.NewEnvironment(t)
 	defer deleteIfNotFailed(e)
 
@@ -923,7 +919,9 @@ func TestImportParameterizedSmoke(t *testing.T) {
 	replaceStringInFile(filepath.Join(projectDir, "__main__.py"), "RandomPet", "Pet")
 	e.RunCommand("pulumi", "install")
 
-	e.RunCommand("pulumi", "up", "--yes")
+	if withUp {
+		e.RunCommand("pulumi", "up", "--yes")
+	}
 
 	// Now try and import a random resource. This should use the project's currently known packages to help choose the
 	// right provider. "random" alone isn't enough to know to use the parameterized provider -- normally, it would use the
@@ -963,4 +961,21 @@ func TestImportParameterizedSmoke(t *testing.T) {
 
 	assert.Equal(t, "p-9hUg", resource["id"])
 	assert.Equal(t, ref, resource["provider"])
+}
+
+// Quick sanity tests to check that import for a parameterized package works. This uses python as the language choice
+// shouldn't matter for the test. Regression test for https://github.com/pulumi/pulumi/issues/17289.
+//
+//nolint:paralleltest // pulumi new is not parallel safe
+func TestImportParameterizedSmoke(t *testing.T) {
+	testImportParameterizedSmoke(t, true)
+}
+
+// Quick sanity tests to check that import for a parameterized package works when there's no existing state. This uses
+// python as the language choice shouldn't matter for the test. Regression test for
+// https://github.com/pulumi/pulumi/issues/18449.
+//
+//nolint:paralleltest // pulumi new is not parallel safe
+func TestImportParameterizedSmokeFreshState(t *testing.T) {
+	testImportParameterizedSmoke(t, false)
 }


### PR DESCRIPTION
An alternative take on https://github.com/pulumi/pulumi/pull/18259

Noted while looking at that PR that we were duplicating information into the import file (the parameterized package name, was already part of the type token, and was being declared in the parameterization block).

Parameterization is awkward because in some places we have the plugin name at the root level (e.g. for package descriptors) and in other places the plugin name is in the parameterisation block (e.g. in schema).

This results in quite a lot of book keeping of when we need to flip from one to the other. Imports are another case of this.
The import file already defines "type" which specifies the package name as part of that. So it needs the base plugin name as extra information in the parameterisation block.
But import also deals with default provider information which is made of package descriptors which have the plugin name at the root level, not the package name.
Thus these required inverting transforms.

Closes #18259