### PR TITLE
allow integration tests to automatically rebuild binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,9 @@ build:: build_proto build_display_wasm .make/ensure/go
 build_display_wasm:: .make/ensure/go
 	cd pkg && GOOS=js GOARCH=wasm go build -o ../bin/pulumi-display.wasm -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ./backend/display/wasm
 
+build_local:: build_proto .make/ensure/go
+	export GOBIN=$(shell realpath ./bin) && make dist
+
 install:: .make/ensure/phony .make/ensure/go
 	cd pkg && GOBIN=$(PULUMI_BIN) go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${PROJECT}
 

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -66,11 +66,12 @@ test_auto:: $(TEST_ALL_DEPS)
 test_all:: test_fast test_auto test_go
 
 dist::
+	export GOBIN=$(or $(shell go env GOBIN),$(shell go env GOPATH)/bin)
 	go install -C cmd/pulumi-language-python \
 		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
-	cp ./cmd/pulumi-language-python-exec "$$(go env GOPATH)"/bin/
-	cp ./dist/pulumi-resource-pulumi-python "$$(go env GOPATH)"/bin/
-	cp ./dist/pulumi-analyzer-policy-python "$$(go env GOPATH)"/bin/
+	cp ./cmd/pulumi-language-python-exec "$GOBIN"
+	cp ./dist/pulumi-resource-pulumi-python "$GOBIN"
+	cp ./dist/pulumi-analyzer-policy-python "$GOBIN"
 
 brew:: BREW_VERSION := $(shell ../../scripts/get-version HEAD)
 brew::

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2024, Pulumi Corporation.
+// Copyright 2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tests
+package ints
 
 import (
 	"fmt"
@@ -20,19 +20,9 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
-
-	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 )
 
 func TestMain(m *testing.M) {
-	// Disable stack backups for tests to avoid filling up ~/.pulumi/backups with unnecessary
-	// backups of test stacks.
-	disableCheckpointBackups := env.DIYBackendDisableCheckpointBackups.Var().Name()
-	if err := os.Setenv(disableCheckpointBackups, "1"); err != nil {
-		fmt.Printf("error setting env var '%s': %v\n", disableCheckpointBackups, err)
-		os.Exit(1)
-	}
-
 	if os.Getenv("PULUMI_INTEGRATION_REBUILD_BINARIES") == "true" {
 		// Find the root of the repository
 		stdout, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()


### PR DESCRIPTION
One of the most common pitfalls for me is forgetting to rebuild the binaries before running the integration tests.  There's currently no automated way to do it, and since the integration tests just pick up the binaries from $PATH they just use whatever is currently installed on the system.

This PR introduces a new environment variable that can be set, that makes the integration tests automatically build the binary into a `bin` folder in the local repository.  This folder is then added to the path, so `pulumi` and the language hosts from that path are being used instead of the system version.

Naturally this adds a little bit of time to integration tests, but only if the envrionment variable is set. Locally to me this seems like a good tradeoff, since integration tests are most of the time slower than rebuilding the binary anyway, and most of the time the binaries need to be rebuilt to run the integration tests. 