### PR TITLE
Go: fix packages/Go SDK generation when name contains "-"

### DIFF
--- a/changelog/pending/20250205--cli-package--fix-package-add-and-code-generation-when-package-name-contains-dashes.yaml
+++ b/changelog/pending/20250205--cli-package--fix-package-add-and-code-generation-when-package-name-contains-dashes.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/package
+  description: Fix package add and code generation when package name contains dashes in Go

--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -394,7 +394,9 @@ func linkGoPackage(root string, pkg *schema.Package, out string) error {
 		return err
 	}
 	if pkg.Parameterization == nil {
-		relOut = filepath.Join(relOut, pkg.Name)
+		// Go SDK Gen replaces all "-" in the name.  See pkg/codegen/gen.go:goPackage
+		name := strings.ReplaceAll(pkg.Name, "-", "")
+		relOut = filepath.Join(relOut, name)
 	}
 	if runtime.GOOS == "windows" {
 		relOut = ".\\" + relOut

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -4647,7 +4647,7 @@ func packageName(pkg *schema.Package) string {
 		info = goInfo
 	}
 	if info.RootPackageName != "" {
-		return strings.ReplaceAll(info.RootPackageName, "-", "")
+		return goPackage(info.RootPackageName)
 	}
 	root, err := packageRoot(pkg.Reference())
 	contract.AssertNoErrorf(err, "We generated the ref from a pkg, so we know its a valid ref")

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -4647,7 +4647,7 @@ func packageName(pkg *schema.Package) string {
 		info = goInfo
 	}
 	if info.RootPackageName != "" {
-		return info.RootPackageName
+		return strings.ReplaceAll(info.RootPackageName, "-", "")
 	}
 	root, err := packageRoot(pkg.Reference())
 	contract.AssertNoErrorf(err, "We generated the ref from a pkg, so we know its a valid ref")

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -1264,14 +1264,15 @@ func TestPackageAddGoParameterized(t *testing.T) {
 	require.NoError(t, err)
 
 	_, _ = e.RunCommand("pulumi", "plugin", "install", "resource", "terraform-provider")
-	_, _ = e.RunCommand("pulumi", "package", "add", "terraform-provider", "hashicorp/random")
+	_, _ = e.RunCommand("pulumi", "package", "add", "terraform-provider", "NetApp/netapp-cloudmanager", "25.1.0")
 
-	assert.True(t, e.PathExists("sdks/random/go.mod"))
-	packageModBytes, err := os.ReadFile(filepath.Join(e.CWD, "sdks/random/go.mod"))
+	assert.True(t, e.PathExists("sdks/netapp-cloudmanager/go.mod"))
+	packageModBytes, err := os.ReadFile(filepath.Join(e.CWD, "sdks/netapp-cloudmanager/go.mod"))
 	assert.NoError(t, err)
 	packageMod, err := modfile.Parse("package.mod", packageModBytes, nil)
 	assert.NoError(t, err)
-	assert.Equal(t, "github.com/pulumi/pulumi-terraform-provider/sdks/go/random/v3", packageMod.Module.Mod.Path)
+	assert.Equal(t, "github.com/pulumi/pulumi-terraform-provider/sdks/go/netapp-cloudmanager/v25",
+		packageMod.Module.Mod.Path)
 
 	modBytes, err := os.ReadFile(filepath.Join(e.CWD, "go.mod"))
 	assert.NoError(t, err)
@@ -1279,13 +1280,17 @@ func TestPackageAddGoParameterized(t *testing.T) {
 	assert.NoError(t, err)
 
 	containsRename := false
+	containedRenames := make([]string, len(gomod.Replace))
 	for _, r := range gomod.Replace {
-		if r.New.Path == "./sdks/random" && r.Old.Path == "github.com/pulumi/pulumi-terraform-provider/sdks/go/random/v3" {
+		if r.New.Path == "./sdks/netapp-cloudmanager" &&
+			r.Old.Path == "github.com/pulumi/pulumi-terraform-provider/sdks/go/netapp-cloudmanager/v25" {
 			containsRename = true
 		}
+		containedRenames = append(containedRenames, r.Old.Path+" => "+r.New.Path)
 	}
 
-	assert.True(t, containsRename)
+	assert.True(t, containsRename,
+		fmt.Sprintf("expected go.mod to contain a replace for the package.  Contains: %v", containedRenames))
 }
 
 //nolint:paralleltest // mutates environment


### PR DESCRIPTION
When trying to `pulumi package add` that contains a `-` in its name, we currently fail twofold:

1) The package is generated into a folder
  `sdks/<name>/<name-with-dashes-removed>` by the combination of go
  codegen and `package add`.  However we currently try to look in
  `sdks/<name>/<name>`, which fails if `name` contains any dashes.

2) If the package added is coming as parameterized package from
   terraform-provider, it includes a `-` in the RootPackageName, which
   in turn breaks code generation, as Go doesn't allow dashes in
   package names.  Arguably this is a bug in the terraform-provider,
   but given its buggy, and it's not super clear why, let's fix it
   here as well.

Fixes https://github.com/pulumi/pulumi/issues/18455