### PR TITLE
skip flaky TestUpdatePlans test on windows

### DIFF
--- a/sdk/go/auto/stack_test.go
+++ b/sdk/go/auto/stack_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -68,6 +69,11 @@ func TestGetPermalink(t *testing.T) {
 
 func TestUpdatePlans(t *testing.T) {
 	t.Parallel()
+
+	// TODO[pulumi/pulumi#18459]: This test should be reenabled on windows once we fix the flakyness
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows due to flakiness")
+	}
 
 	ctx := context.Background()
 	sName := ptesting.RandomStackName()


### PR DESCRIPTION
This test has been really flaky in the last days (all the flakes I remember were on Windows).  Disable it for now, and track re-enabling it in https://github.com/pulumi/pulumi/issues/18459.