### PR TITLE
Always print summaries in preview

### DIFF
--- a/changelog/pending/20250206--cli-display--preview-now-always-prints-resource-summaries-even-after-errors.yaml
+++ b/changelog/pending/20250206--cli-display--preview-now-always-prints-resource-summaries-even-after-errors.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/display
+  description: Preview now always prints resource summaries, even after errors

--- a/changelog/pending/20250206--cli-display--preview-now-always-prints-resource-summaries-even-after-errors.yaml
+++ b/changelog/pending/20250206--cli-display--preview-now-always-prints-resource-summaries-even-after-errors.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: cli/display
-  description: Preview now always prints resource summaries, even after errors
+  description: Always print resource summaries in preview, even after errors

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -111,8 +111,7 @@ func RenderDiffEvent(event engine.Event, seen map[resource.URN]engine.StepEventM
 	case engine.PreludeEvent:
 		return renderPreludeEvent(event.Payload().(engine.PreludeEventPayload), opts)
 	case engine.SummaryEvent:
-		const wroteDiagnosticHeader = false
-		return renderSummaryEvent(event.Payload().(engine.SummaryEventPayload), wroteDiagnosticHeader, true, opts)
+		return renderSummaryEvent(event.Payload().(engine.SummaryEventPayload), true, opts)
 	case engine.StdoutColorEvent:
 		return renderStdoutColorEvent(event.Payload().(engine.StdoutEventPayload), opts)
 
@@ -220,14 +219,8 @@ func renderStdoutColorEvent(payload engine.StdoutEventPayload, opts Options) str
 	return opts.Color.Colorize(payload.Message)
 }
 
-func renderSummaryEvent(event engine.SummaryEventPayload, hasError bool, diffStyleSummary bool, opts Options) string {
+func renderSummaryEvent(event engine.SummaryEventPayload, diffStyleSummary bool, opts Options) string {
 	changes := event.ResourceChanges
-
-	// If this is a failed preview, do not render anything. It could be surprising/misleading as it doesn't
-	// describe the totality of the proposed changes (for instance, could be missing resources if it errored early).
-	if event.IsPreview && hasError {
-		return ""
-	}
 
 	out := &bytes.Buffer{}
 	fprintIgnoreError(out, opts.Color.Colorize(

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -579,7 +579,7 @@ func (display *ProgressDisplay) processEndSteps() {
 	wroteMandatoryPolicyViolations := display.printPolicies()
 
 	// Render the actual diagnostics streams (warnings, errors, etc).
-	hasError := display.printDiagnostics()
+	display.printDiagnostics()
 
 	// Print output variables; this comes last, prior to the summary, since these are the final
 	// outputs after having run all of the above.
@@ -588,7 +588,7 @@ func (display *ProgressDisplay) processEndSteps() {
 	// Print a summary of resource operations unless there were mandatory policy violations.
 	// In that case, we want to abruptly terminate the display so as not to confuse.
 	if !wroteMandatoryPolicyViolations {
-		display.printSummary(hasError)
+		display.printSummary()
 	}
 }
 
@@ -646,9 +646,7 @@ func (display *ProgressDisplay) printResourceDiffs() {
 
 // printDiagnostics prints a new "Diagnostics:" section with all of the diagnostics grouped by
 // resource. If no diagnostics were emitted, prints nothing. Returns whether an error was encountered.
-func (display *ProgressDisplay) printDiagnostics() bool {
-	hasError := false
-
+func (display *ProgressDisplay) printDiagnostics() {
 	// Since we display diagnostic information eagerly, we need to keep track of the first
 	// time we wrote some output so we don't inadvertently print the header twice.
 	wroteDiagnosticHeader := false
@@ -678,11 +676,6 @@ func (display *ProgressDisplay) printDiagnostics() bool {
 			for _, v := range payloads {
 				if v.Ephemeral {
 					continue
-				}
-
-				if v.Severity == diag.Error {
-					// An error occurred and the display should consider this a failure.
-					hasError = true
 				}
 
 				msg := display.renderProgressDiagEvent(v, true /*includePrefix:*/)
@@ -728,8 +721,6 @@ func (display *ProgressDisplay) printDiagnostics() bool {
 			colors.Underline + colors.Blue + display.permalink + "?explainFailure" + colors.Reset)
 		display.println("")
 	}
-
-	return hasError
 }
 
 type policyPackSummary struct {
@@ -922,13 +913,13 @@ func (display *ProgressDisplay) printOutputs() {
 }
 
 // printSummary prints the Stack's SummaryEvent in a new section if applicable.
-func (display *ProgressDisplay) printSummary(hasError bool) {
+func (display *ProgressDisplay) printSummary() {
 	// If we never saw the SummaryEvent payload, we have nothing to do.
 	if display.summaryEventPayload == nil {
 		return
 	}
 
-	msg := renderSummaryEvent(*display.summaryEventPayload, hasError, false, display.opts)
+	msg := renderSummaryEvent(*display.summaryEventPayload, false, display.opts)
 	display.println(msg)
 }
 

--- a/pkg/backend/display/progress_test.go
+++ b/pkg/backend/display/progress_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -302,46 +301,6 @@ func TestStatusDisplayFlags(t *testing.T) {
 				assert.NotContains(t, doneStatus, "[retain]", "%s should NOT contain [retain] (done)", step.Op)
 				assert.NotContains(t, inProgressStatus, "[retain]", "%s should NOT contain [retain] (in-progress)", step.Op)
 			}
-		})
-	}
-}
-
-func TestPrintDiagnosticsIsTolerantOfDiagnostics(t *testing.T) {
-	t.Parallel()
-	makeDisplayWithDiagnostic := func(sev diag.Severity) *ProgressDisplay {
-		return &ProgressDisplay{
-			eventUrnToResourceRow: map[resource.URN]ResourceRow{
-				"urn:pulumi:test::test::pulumi:pulumi:Stack::test": &resourceRowData{
-					diagInfo: &DiagInfo{
-						StreamIDToDiagPayloads: map[int32][]engine.DiagEventPayload{
-							0: {
-								{
-									Severity: sev,
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-	}
-
-	tests := []struct {
-		name string
-		give diag.Severity
-		want bool
-	}{
-		{"info", diag.Info, false},
-		{"warning", diag.Warning, false},
-		{"error", diag.Error, true},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			d := makeDisplayWithDiagnostic(tt.give)
-			got := d.printDiagnostics()
-			assert.Equal(t, tt.want, got, "printDiagnostics(%v) = %v, want %v", tt.give, got, tt.want)
 		})
 	}
 }


### PR DESCRIPTION
This changes the CLI to always print the resource summary at the end of previews. Like `up` in the case of errors this might not match what the program _wants_ to do. But errors in preview are unusual, the main one being due to trying to delete protected resources.

Users have requested that they still want to see the summary if the only error is protect deletes (see
https://github.com/pulumi/pulumi/issues/18103).

Fixes https://github.com/pulumi/pulumi/issues/18103.