### PR TITLE
Append coverage data

### DIFF
--- a/sdk/python/scripts/test_auto.sh
+++ b/sdk/python/scripts/test_auto.sh
@@ -4,7 +4,7 @@ PULUMI_TEST_COVERAGE_PATH=$PULUMI_TEST_COVERAGE_PATH
 
 set -euo pipefail
 
-coverage run -m pytest lib/test/automation
+coverage run --append -m pytest lib/test/automation
 
 if [[ "$PULUMI_TEST_COVERAGE_PATH" ]]; then
     if [ -e .coverage ]; then

--- a/sdk/python/scripts/test_fast.sh
+++ b/sdk/python/scripts/test_fast.sh
@@ -7,17 +7,17 @@ set -euo pipefail
 # TODO the ignored test seems to fail in pytest but not unittest. Need
 # to trackdown why.
 
-coverage run -m pytest lib/test \
+coverage run --append -m pytest lib/test \
              --ignore lib/test/automation \
              --ignore lib/test/langhost/resource_thens/test_resource_thens.py
 
-coverage run -m unittest \
+coverage run --append -m unittest \
              lib/test/langhost/resource_thens/test_resource_thens.py
 
 # Using python -m also adds lib/test_with_mocks to sys.path which
 # avoids package resolution issues.
 
-(cd lib/test_with_mocks && coverage run -m pytest)
+(cd lib/test_with_mocks && coverage run --append -m pytest)
 
 if [[ "$PULUMI_TEST_COVERAGE_PATH" ]]; then
     if [ -e .coverage ]; then


### PR DESCRIPTION
Without `--append` we overwrite the coverage data. For `test-fast` that means we only get the coverage from `lib/test_with_mocks` 🤦 