### PR TITLE
Improve the warning when using plugins from PATH

### DIFF
--- a/changelog/pending/20250206--cli-plugin--improve-the-warning-when-using-plugins-from-path.yaml
+++ b/changelog/pending/20250206--cli-plugin--improve-the-warning-when-using-plugins-from-path.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/plugin
+  description: Improve the warning when using plugins from PATH

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -2243,7 +2243,7 @@ func getPluginInfoAndPath(
 				if fullAmbientPath != bundledPath {
 					var expected string
 					if bundledPath != "" {
-						expected = " expected %s" + bundledPath
+						expected = " expected " + bundledPath
 					}
 					d.Warningf(diag.Message("", "using %s from $PATH at %s%s"), filename, ambientPath, expected)
 				}

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -2241,7 +2241,11 @@ func getPluginInfoAndPath(
 			// hits any errors then we just skip this warning, better to not warn than to error in a new way.
 			if err == nil {
 				if fullAmbientPath != bundledPath {
-					d.Warningf(diag.Message("", "using %s from $PATH at %s"), filename, ambientPath)
+					var expected string
+					if bundledPath != "" {
+						expected = " expected %s" + bundledPath
+					}
+					d.Warningf(diag.Message("", "using %s from $PATH at %s%s"), filename, ambientPath, expected)
 				}
 			}
 		}

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1547,6 +1547,47 @@ func TestAmbientPluginsWarn(t *testing.T) {
 }
 
 //nolint:paralleltest // modifies environment variables
+func TestAmbientBundledPluginsWarn(t *testing.T) {
+	// Get the path of this executable
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	// Create a fake side-by-side plugin next to this executable, it must match one of our bundled names
+	bundledPath := filepath.Join(filepath.Dir(exe), "pulumi-language-nodejs")
+	err = os.WriteFile(bundledPath, []byte{}, 0o700) //nolint: gosec // we intended to write an executable file here
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := os.Remove(bundledPath)
+		require.NoError(t, err)
+	})
+
+	// Create a copy of the fake plugin in the path
+	pathDir := t.TempDir()
+	t.Setenv("PATH", pathDir)
+	ambientPath := filepath.Join(pathDir, "pulumi-language-nodejs")
+	err = os.WriteFile(ambientPath, []byte{}, 0o700) //nolint: gosec
+	require.NoError(t, err)
+
+	var stderr bytes.Buffer
+	d := diag.DefaultSink(
+		iotest.LogWriter(t), // stdout
+		&stderr,
+		diag.FormatOptions{Color: "never"},
+	)
+
+	// Lookup the plugin with ambient search turned on
+	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
+	path, err := GetPluginPath(d, apitype.LanguagePlugin, "nodejs", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, ambientPath, path)
+
+	// Check we get a warning about loading this plugin
+	expectedMessage := fmt.Sprintf("warning: using pulumi-language-nodejs from $PATH at %s expected %s\n",
+		ambientPath, filepath.Join(filepath.Dir(exe), "pulumi-language-nodejs"))
+	assert.Equal(t, expectedMessage, stderr.String())
+}
+
+//nolint:paralleltest // modifies environment variables
 func TestBundledPluginsDoNotWarn(t *testing.T) {
 	// Get the path of this executable
 	exe, err := os.Executable()


### PR DESCRIPTION
For bundled plugins this will now also print what the expected path was in the warning.

Old:
```
warning: using pulumi-language-nodejs from $PATH at /tmp/TestAmbientBundledPluginsWarn10582890/001/pulumi-language-nodejs
```

New:
```
warning: using pulumi-language-nodejs from $PATH at /tmp/TestAmbientBundledPluginsWarn10582890/001/pulumi-language-nodejs expected /tmp/go-build809231495/b001/pulumi-language-nodejs
```

This only applies to bundled plugins (like the language plugins), other plugins like resource providers don't have a single expected location, instead we would have looked them up in the ~/.pulumi/plugins folder.