### PR TITLE
[Experimental/Components] Infer plain types

### DIFF
--- a/changelog/pending/20250207--sdk-python--experimental-components-infer-plain-types.yaml
+++ b/changelog/pending/20250207--sdk-python--experimental-components-infer-plain-types.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: "[Experimental/Components] Infer plain types"

--- a/sdk/python/lib/pulumi/provider/experimental/analyzer.py
+++ b/sdk/python/lib/pulumi/provider/experimental/analyzer.py
@@ -375,7 +375,7 @@ class Analyzer:
             else:
                 if type_def.module and type_def.module != arg.__module__:
                     raise DuplicateTypeError(arg.__module__, type_def)
-            (properties, properties_mapping) = self.analyze_type(arg, plain)
+            (properties, properties_mapping) = self.analyze_type(arg, can_be_plain=True)
             type_def.properties = properties
             type_def.properties_mapping = properties_mapping
             if type_def.name in self.unresolved_forward_refs:

--- a/sdk/python/lib/pulumi/provider/experimental/analyzer.py
+++ b/sdk/python/lib/pulumi/provider/experimental/analyzer.py
@@ -138,7 +138,7 @@ class Analyzer:
         # Python handle this for us.
         for name, type_def in [*self.unresolved_forward_refs.items()]:
             a = self.find_type(module_path, type_def.name)
-            (properties, properties_mapping) = self.analyze_type(a)
+            (properties, properties_mapping) = self.analyze_type(a, can_be_plain=False)
             type_def.properties = properties
             type_def.properties_mapping = properties_mapping
             del self.unresolved_forward_refs[name]
@@ -212,8 +212,8 @@ class Analyzer:
                 f"ComponentResource '{component.__name__}' requires an argument named 'args' with a type annotation in its __init__ method"
             )
 
-        (inputs, inputs_mapping) = self.analyze_type(args)
-        (outputs, outputs_mapping) = self.analyze_type(component)
+        (inputs, inputs_mapping) = self.analyze_type(args, can_be_plain=True)
+        (outputs, outputs_mapping) = self.analyze_type(component, can_be_plain=False)
         return ComponentDefinition(
             name=component.__name__,
             description=component.__doc__.strip() if component.__doc__ else None,
@@ -225,7 +225,7 @@ class Analyzer:
         )
 
     def analyze_type(
-        self, typ: type
+        self, typ: type, can_be_plain: bool
     ) -> tuple[dict[str, PropertyDefinition], dict[str, str]]:
         """
         analyze_type returns a dictionary of the properties of a type based on
@@ -254,7 +254,8 @@ class Analyzer:
         ann = self.get_annotations(typ)
         mapping: dict[str, str] = {camel_case(k): k for k in ann.keys()}
         return {
-            camel_case(k): self.analyze_property(v, typ, k) for k, v in ann.items()
+            camel_case(k): self.analyze_property(v, typ, k, can_be_plain)
+            for k, v in ann.items()
         }, mapping
 
     def analyze_property(
@@ -262,6 +263,7 @@ class Analyzer:
         arg: type,
         typ: type,
         name: str,
+        plain: bool,
         optional: Optional[bool] = None,
     ) -> PropertyDefinition:
         """
@@ -274,26 +276,34 @@ class Analyzer:
         """
         optional = optional if optional is not None else is_optional(arg)
         if is_plain(arg):
-            # TODO: handle plain types
             return PropertyDefinition(
                 type=py_type_to_property_type(arg),
                 optional=optional,
+                # We are currently looking at a plain type, but it might be
+                # wrapped in a pulumi.Input or pulumi.Output, in which case this
+                # isn't plain.
+                plain=plain,
             )
         elif is_input(arg):
             return self.analyze_property(
-                unwrap_input(arg), typ, name, optional=optional
+                unwrap_input(arg), typ, name, plain=False, optional=optional
             )
         elif is_output(arg):
             return self.analyze_property(
-                unwrap_output(arg), typ, name, optional=optional
+                unwrap_output(arg), typ, name, plain=False, optional=optional
             )
         elif is_optional(arg):
-            return self.analyze_property(unwrap_optional(arg), typ, name, optional=True)
+            return self.analyze_property(
+                unwrap_optional(arg), typ, name, plain=True, optional=True
+            )
         elif is_list(arg):
             args = get_args(arg)
-            items = self.analyze_property(args[0], typ, name)
+            items = self.analyze_property(args[0], typ, name, plain=True)
             return PropertyDefinition(
-                type=PropertyType.ARRAY, optional=optional, items=items
+                type=PropertyType.ARRAY,
+                optional=optional,
+                plain=plain,
+                items=items,
             )
         elif is_dict(arg):
             args = get_args(arg)
@@ -302,7 +312,13 @@ class Analyzer:
             return PropertyDefinition(
                 type=PropertyType.OBJECT,
                 optional=optional,
-                additional_properties=self.analyze_property(args[1], typ, name),
+                plain=plain,
+                additional_properties=self.analyze_property(
+                    args[1],
+                    typ,
+                    name,
+                    plain=True,
+                ),
             )
         elif is_forward_ref(arg):
             name = cast(ForwardRef, arg).__forward_arg__
@@ -317,6 +333,7 @@ class Analyzer:
                 return PropertyDefinition(
                     ref=ref,
                     optional=optional,
+                    plain=plain,
                 )
             else:
                 # Forward ref to a type we haven't seen yet. We create an empty
@@ -337,6 +354,7 @@ class Analyzer:
                 return PropertyDefinition(
                     ref=ref,
                     optional=optional,
+                    plain=plain,
                 )
         elif not is_builtin(arg):
             # We have a custom type, analyze it recursively. Immediately add the
@@ -357,7 +375,7 @@ class Analyzer:
             else:
                 if type_def.module and type_def.module != arg.__module__:
                     raise DuplicateTypeError(arg.__module__, type_def)
-            (properties, properties_mapping) = self.analyze_type(arg)
+            (properties, properties_mapping) = self.analyze_type(arg, plain)
             type_def.properties = properties
             type_def.properties_mapping = properties_mapping
             if type_def.name in self.unresolved_forward_refs:
@@ -366,6 +384,7 @@ class Analyzer:
             return PropertyDefinition(
                 ref=ref,
                 optional=optional,
+                plain=plain,
             )
         else:
             raise ValueError(f"unsupported type {arg}")

--- a/sdk/python/lib/pulumi/provider/experimental/component.py
+++ b/sdk/python/lib/pulumi/provider/experimental/component.py
@@ -34,6 +34,7 @@ class PropertyDefinition:
     description: Optional[str] = None
     items: Optional["PropertyDefinition"] = None
     additional_properties: Optional["PropertyDefinition"] = None
+    plain: bool = False
 
 
 @dataclass

--- a/sdk/python/lib/test/provider/experimental/test_analyzer.py
+++ b/sdk/python/lib/test/provider/experimental/test_analyzer.py
@@ -110,17 +110,35 @@ def test_analyze_component_empty():
 
 
 def test_analyze_component_plain_types():
+    class ComplexType(TypedDict):
+        name: Optional[pulumi.Input[list[str]]]
+
     class Args(TypedDict):
-        input_int: int
-        input_str: str
-        input_float: float
-        input_bool: bool
+        a_int: int
+        a_str: str
+        a_float: float
+        a_bool: bool
+        a_optional: Optional[str]
+        a_list: list[str]
+        a_input_list: pulumi.Input[list[str]]
+        a_list_input: list[pulumi.Input[str]]
+        a_input_list_input: pulumi.Input[list[pulumi.Input[str]]]
+        a_dict: dict[str, int]
+        a_dict_input: dict[str, pulumi.Input[int]]
+        a_input_dict: pulumi.Input[dict[str, int]]
+        a_input_dict_input: pulumi.Input[dict[str, pulumi.Input[int]]]
+        a_complex_type: ComplexType
+        a_input_complex_type: pulumi.Input[ComplexType]
 
     class Component(pulumi.ComponentResource):
-        output_int: pulumi.Output[int]
-        output_str: pulumi.Output[str]
-        output_float: pulumi.Output[float]
-        output_bool: pulumi.Output[bool]
+        a_int: int
+        a_str: str
+        a_float: float
+        a_bool: bool
+        a_optional: Optional[str]
+        a_output_list: pulumi.Output[list[str]]
+        a_output_complex: pulumi.Output[ComplexType]
+        a_optional_output_complex: Optional[pulumi.Output[ComplexType]]
 
         def __init__(self, args: Args): ...
 
@@ -130,28 +148,116 @@ def test_analyze_component_plain_types():
         name="Component",
         module="test_analyzer",
         inputs={
-            "inputInt": PropertyDefinition(type=PropertyType.INTEGER),
-            "inputStr": PropertyDefinition(type=PropertyType.STRING),
-            "inputFloat": PropertyDefinition(type=PropertyType.NUMBER),
-            "inputBool": PropertyDefinition(type=PropertyType.BOOLEAN),
+            "aInt": PropertyDefinition(type=PropertyType.INTEGER, plain=True),
+            "aStr": PropertyDefinition(type=PropertyType.STRING, plain=True),
+            "aFloat": PropertyDefinition(type=PropertyType.NUMBER, plain=True),
+            "aBool": PropertyDefinition(type=PropertyType.BOOLEAN, plain=True),
+            "aOptional": PropertyDefinition(
+                type=PropertyType.STRING, optional=True, plain=True
+            ),
+            "aList": PropertyDefinition(
+                type=PropertyType.ARRAY,
+                items=PropertyDefinition(type=PropertyType.STRING, plain=True),
+                plain=True,
+            ),
+            "aInputList": PropertyDefinition(
+                type=PropertyType.ARRAY,
+                items=PropertyDefinition(type=PropertyType.STRING, plain=True),
+                plain=False,
+            ),
+            "aListInput": PropertyDefinition(
+                type=PropertyType.ARRAY,
+                items=PropertyDefinition(type=PropertyType.STRING, plain=False),
+                plain=True,
+            ),
+            "aInputListInput": PropertyDefinition(
+                type=PropertyType.ARRAY,
+                items=PropertyDefinition(type=PropertyType.STRING, plain=False),
+                plain=False,
+            ),
+            "aDict": PropertyDefinition(
+                type=PropertyType.OBJECT,
+                additional_properties=PropertyDefinition(
+                    type=PropertyType.INTEGER, plain=True
+                ),
+                plain=True,
+            ),
+            "aDictInput": PropertyDefinition(
+                type=PropertyType.OBJECT,
+                additional_properties=PropertyDefinition(
+                    type=PropertyType.INTEGER, plain=False
+                ),
+                plain=True,
+            ),
+            "aInputDict": PropertyDefinition(
+                type=PropertyType.OBJECT,
+                additional_properties=PropertyDefinition(
+                    type=PropertyType.INTEGER, plain=True
+                ),
+                plain=False,
+            ),
+            "aInputDictInput": PropertyDefinition(
+                type=PropertyType.OBJECT,
+                additional_properties=PropertyDefinition(
+                    type=PropertyType.INTEGER, plain=False
+                ),
+                plain=False,
+            ),
+            "aComplexType": PropertyDefinition(
+                ref="#/types/my-component:index:ComplexType",
+                plain=True,
+            ),
+            "aInputComplexType": PropertyDefinition(
+                ref="#/types/my-component:index:ComplexType",
+                plain=False,
+            ),
         },
         inputs_mapping={
-            "inputInt": "input_int",
-            "inputStr": "input_str",
-            "inputFloat": "input_float",
-            "inputBool": "input_bool",
+            "aInt": "a_int",
+            "aStr": "a_str",
+            "aFloat": "a_float",
+            "aBool": "a_bool",
+            "aOptional": "a_optional",
+            "aList": "a_list",
+            "aInputList": "a_input_list",
+            "aInputListInput": "a_input_list_input",
+            "aListInput": "a_list_input",
+            "aDict": "a_dict",
+            "aDictInput": "a_dict_input",
+            "aInputDict": "a_input_dict",
+            "aInputDictInput": "a_input_dict_input",
+            "aComplexType": "a_complex_type",
+            "aInputComplexType": "a_input_complex_type",
         },
         outputs={
-            "outputInt": PropertyDefinition(type=PropertyType.INTEGER),
-            "outputStr": PropertyDefinition(type=PropertyType.STRING),
-            "outputFloat": PropertyDefinition(type=PropertyType.NUMBER),
-            "outputBool": PropertyDefinition(type=PropertyType.BOOLEAN),
+            "aInt": PropertyDefinition(type=PropertyType.INTEGER, plain=False),
+            "aStr": PropertyDefinition(type=PropertyType.STRING, plain=False),
+            "aFloat": PropertyDefinition(type=PropertyType.NUMBER, plain=False),
+            "aBool": PropertyDefinition(type=PropertyType.BOOLEAN, plain=False),
+            "aOptional": PropertyDefinition(
+                type=PropertyType.STRING, plain=True, optional=True
+            ),
+            "aOutputList": PropertyDefinition(
+                type=PropertyType.ARRAY,
+                items=PropertyDefinition(type=PropertyType.STRING, plain=True),
+                plain=False,
+            ),
+            "aOutputComplex": PropertyDefinition(
+                ref="#/types/my-component:index:ComplexType", plain=False
+            ),
+            "aOptionalOutputComplex": PropertyDefinition(
+                ref="#/types/my-component:index:ComplexType", plain=False, optional=True
+            ),
         },
         outputs_mapping={
-            "outputInt": "output_int",
-            "outputStr": "output_str",
-            "outputFloat": "output_float",
-            "outputBool": "output_bool",
+            "aInt": "a_int",
+            "aStr": "a_str",
+            "aFloat": "a_float",
+            "aBool": "a_bool",
+            "aOptional": "a_optional",
+            "aOutputList": "a_output_list",
+            "aOutputComplex": "a_output_complex",
+            "aOptionalOutputComplex": "a_optional_output_complex",
         },
     )
 
@@ -173,14 +279,16 @@ def test_analyze_list_simple():
         inputs={
             "listInput": PropertyDefinition(
                 type=PropertyType.ARRAY,
-                items=PropertyDefinition(type=PropertyType.STRING),
+                items=PropertyDefinition(type=PropertyType.STRING, plain=True),
             )
         },
         inputs_mapping={"listInput": "list_input"},
         outputs={
             "listOutput": PropertyDefinition(
                 type=PropertyType.ARRAY,
-                items=PropertyDefinition(type=PropertyType.STRING, optional=True),
+                items=PropertyDefinition(
+                    type=PropertyType.STRING, optional=True, plain=True
+                ),
                 optional=True,
             )
         },
@@ -208,14 +316,18 @@ def test_analyze_list_complex():
         inputs={
             "listInput": PropertyDefinition(
                 type=PropertyType.ARRAY,
-                items=PropertyDefinition(ref="#/types/my-component:index:ComplexType"),
+                items=PropertyDefinition(
+                    ref="#/types/my-component:index:ComplexType", plain=True
+                ),
             )
         },
         inputs_mapping={"listInput": "list_input"},
         outputs={
             "listOutput": PropertyDefinition(
                 type=PropertyType.ARRAY,
-                items=PropertyDefinition(ref="#/types/my-component:index:ComplexType"),
+                items=PropertyDefinition(
+                    ref="#/types/my-component:index:ComplexType", plain=True
+                ),
             )
         },
         outputs_mapping={"listOutput": "list_output"},
@@ -228,7 +340,7 @@ def test_analyze_list_complex():
             properties={
                 "name": PropertyDefinition(
                     type=PropertyType.ARRAY,
-                    items=PropertyDefinition(type=PropertyType.STRING),
+                    items=PropertyDefinition(type=PropertyType.STRING, plain=True),
                     optional=True,
                 ),
             },
@@ -270,7 +382,9 @@ def test_analyze_dict_simple():
         inputs={
             "dictInput": PropertyDefinition(
                 type=PropertyType.OBJECT,
-                additional_properties=PropertyDefinition(type=PropertyType.INTEGER),
+                additional_properties=PropertyDefinition(
+                    type=PropertyType.INTEGER, plain=True
+                ),
             )
         },
         inputs_mapping={"dictInput": "dict_input"},
@@ -278,7 +392,7 @@ def test_analyze_dict_simple():
             "dictOutput": PropertyDefinition(
                 type=PropertyType.OBJECT,
                 additional_properties=PropertyDefinition(
-                    type=PropertyType.INTEGER, optional=True
+                    type=PropertyType.INTEGER, optional=True, plain=True
                 ),
                 optional=True,
             )
@@ -308,7 +422,7 @@ def test_analyze_dict_complex():
             "dictInput": PropertyDefinition(
                 type=PropertyType.OBJECT,
                 additional_properties=PropertyDefinition(
-                    ref="#/types/my-component:index:ComplexType"
+                    ref="#/types/my-component:index:ComplexType", plain=True
                 ),
             )
         },
@@ -317,7 +431,9 @@ def test_analyze_dict_complex():
             "dictOutput": PropertyDefinition(
                 type=PropertyType.OBJECT,
                 additional_properties=PropertyDefinition(
-                    ref="#/types/my-component:index:ComplexType", optional=True
+                    ref="#/types/my-component:index:ComplexType",
+                    optional=True,
+                    plain=True,
                 ),
                 optional=True,
             )
@@ -332,7 +448,10 @@ def test_analyze_dict_complex():
             properties={
                 "name": PropertyDefinition(
                     type=PropertyType.OBJECT,
-                    additional_properties=PropertyDefinition(type=PropertyType.INTEGER),
+                    additional_properties=PropertyDefinition(
+                        type=PropertyType.INTEGER,
+                        plain=True,
+                    ),
                     optional=True,
                 ),
             },

--- a/sdk/python/lib/test/provider/experimental/test_analyzer.py
+++ b/sdk/python/lib/test/provider/experimental/test_analyzer.py
@@ -111,7 +111,8 @@ def test_analyze_component_empty():
 
 def test_analyze_component_plain_types():
     class ComplexType(TypedDict):
-        name: Optional[pulumi.Input[list[str]]]
+        a_input_list_str: Optional[pulumi.Input[list[str]]]
+        a_str: str
 
     class Args(TypedDict):
         a_int: int
@@ -260,6 +261,22 @@ def test_analyze_component_plain_types():
             "aOptionalOutputComplex": "a_optional_output_complex",
         },
     )
+    assert analyzer.type_definitions == {
+        "ComplexType": TypeDefinition(
+            name="ComplexType",
+            module="test_analyzer",
+            type="object",
+            properties={
+                "aInputListStr": PropertyDefinition(
+                    type=PropertyType.ARRAY,
+                    items=PropertyDefinition(type=PropertyType.STRING, plain=True),
+                    optional=True,
+                ),
+                "aStr": PropertyDefinition(type=PropertyType.STRING, plain=True),
+            },
+            properties_mapping={"aInputListStr": "a_input_list_str", "aStr": "a_str"},
+        )
+    }
 
 
 def test_analyze_list_simple():

--- a/tests/integration/component_provider/python/component-provider-host/Pulumi.yaml
+++ b/tests/integration/component_provider/python/component-provider-host/Pulumi.yaml
@@ -20,9 +20,9 @@ resources:
         b: 2
         c: 3
       complexInput:
-        complexStr: world
-        nested:
-          nestedStr: this is nested
+        strInput: world
+        nestedInput:
+          strPlain: this is nested
 outputs:
   urn: ${comp.urn}
   strOutput: ${comp.strOutput}

--- a/tests/integration/component_provider/python/component-provider-host/provider/component.py
+++ b/tests/integration/component_provider/python/component-provider-host/provider/component.py
@@ -19,12 +19,12 @@ import pulumi
 
 
 class Nested(TypedDict):
-    nested_str: str
+    str_plain: str
 
 
 class Complex(TypedDict):
-    complex_str: pulumi.Input[str]
-    nested: pulumi.Input[Nested]
+    str_input: pulumi.Input[str]
+    nested_input: pulumi.Input[Nested]
 
 
 class Args(TypedDict):
@@ -52,10 +52,10 @@ class MyComponent(pulumi.ComponentResource):
         ).apply(lambda x: x * 2 if x else 7)
         self.complex_output = pulumi.Output.from_input(
             {
-                "complex_str": "complex_str_value",
-                "nested": pulumi.Output.from_input(
+                "str_input": "complex_str_input_value",
+                "nested_input": pulumi.Output.from_input(
                     {
-                        "nested_str": "nested_str_value",
+                        "str_plain": "nested_str_plain_value",
                     }
                 ),
             }

--- a/tests/integration/component_provider/python/component-provider-host/provider/component.py
+++ b/tests/integration/component_provider/python/component-provider-host/provider/component.py
@@ -37,8 +37,8 @@ class Args(TypedDict):
 
 class MyComponent(pulumi.ComponentResource):
     str_output: pulumi.Output[str]
-    optional_int_output: pulumi.Output[Optional[int]]
-    complex_output: pulumi.Output[Optional[Complex]]
+    optional_int_output: Optional[pulumi.Output[int]]
+    complex_output: Optional[pulumi.Output[Complex]]
     list_output: pulumi.Output[list[str]]
     dict_output: pulumi.Output[dict[str, int]]
 
@@ -49,7 +49,7 @@ class MyComponent(pulumi.ComponentResource):
         )
         self.optional_int_output = pulumi.Output.from_input(
             args.get("optional_int_input", None)
-        ).apply(lambda x: x * 2 if x else None)
+        ).apply(lambda x: x * 2 if x else 7)
         self.complex_output = pulumi.Output.from_input(
             {
                 "complex_str": "complex_str_value",

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1843,9 +1843,9 @@ func TestPythonComponentProviderRun(t *testing.T) {
 			require.Equal(t, "HELLO", stack.Outputs["strOutput"].(string))
 			require.Equal(t, float64(84), stack.Outputs["optionalIntOutput"].(float64))
 			complexOutput := stack.Outputs["complexOutput"].(map[string]interface{})
-			require.Equal(t, "complex_str_value", complexOutput["complexStr"].(string))
-			nested := complexOutput["nested"].(map[string]interface{})
-			require.Equal(t, "nested_str_value", nested["nestedStr"].(string))
+			require.Equal(t, "complex_str_input_value", complexOutput["strInput"].(string))
+			nested := complexOutput["nestedInput"].(map[string]interface{})
+			require.Equal(t, "nested_str_plain_value", nested["strPlain"].(string))
 			require.Equal(t, []interface{}{"A", "B", "C"}, stack.Outputs["listOutput"].([]interface{}))
 			require.Equal(t, map[string]interface{}{
 				"a": float64(2),
@@ -1935,24 +1935,24 @@ func TestPythonComponentProviderGetSchema(t *testing.T) {
 	expectedTypesJSON := `{
 		"provider:index:Complex": {
 			"properties": {
-				"complexStr": {
-					"type": "string", "plain": true
+				"strInput": {
+					"type": "string"
 				},
-				"nested": {
+				"nestedInput": {
 					"$ref": "#/types/provider:index:Nested"
 				}
 			},
 			"type": "object",
-			"required": ["complexStr", "nested"]
+			"required": ["nestedInput", "strInput"]
 		},
 		"provider:index:Nested": {
 			"properties": {
-				"nestedStr": {
+				"strPlain": {
 					"type": "string", "plain": true
 				}
 			},
 			"type": "object",
-			"required": ["nestedStr"]
+			"required": ["strPlain"]
 		}
 	}`
 	expectedTypes := make(map[string]interface{})

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1901,17 +1901,19 @@ func TestPythonComponentProviderGetSchema(t *testing.T) {
 		"inputProperties": {
 			"strInput": { "type": "string" },
 			"optionalIntInput": { "type": "integer" },
-			"complexInput": { "$ref": "#/types/provider:index:Complex" },
+			"complexInput": { "$ref": "#/types/provider:index:Complex"},
 			"listInput": {
 				"type": "array",
 				"items": {
-					"type": "string"
+					"type": "string",
+					"plain": true
 				}
 			},
 			"dictInput": {
 				"type": "object",
 				"additionalProperties": {
-					"type": "integer"
+					"type": "integer",
+					"plain": true
 				}
 			}
 		},
@@ -1922,6 +1924,11 @@ func TestPythonComponentProviderGetSchema(t *testing.T) {
 	resources := schema["resources"].(map[string]interface{})
 	component := resources["provider:index:MyComponent"].(map[string]interface{})
 	require.NoError(t, json.Unmarshal([]byte(expectedJSON), &expected))
+	// TODO https://github.com/pulumi/pulumi/issues/18481
+	// properties.dictOutput.additionalProperties.plain and
+	// properties.listOutput.items.plain should be true, but they are not. The
+	// actual JSON the provider returns has these fields set to true, however
+	// somehwere in `package get-schema`, this information is lost.
 	require.Equal(t, expected, component)
 
 	// Check the complex types
@@ -1929,7 +1936,7 @@ func TestPythonComponentProviderGetSchema(t *testing.T) {
 		"provider:index:Complex": {
 			"properties": {
 				"complexStr": {
-					"type": "string"
+					"type": "string", "plain": true
 				},
 				"nested": {
 					"$ref": "#/types/provider:index:Nested"
@@ -1941,7 +1948,7 @@ func TestPythonComponentProviderGetSchema(t *testing.T) {
 		"provider:index:Nested": {
 			"properties": {
 				"nestedStr": {
-					"type": "string"
+					"type": "string", "plain": true
 				}
 			},
 			"type": "object",


### PR DESCRIPTION
When inferring types, we should set the plain attribute on the types, depending on whether types can be outputs or not.

Fixes https://github.com/pulumi/pulumi/issues/18482
Ref https://github.com/pulumi/pulumi/issues/15939