### PR TITLE
[Experimental/Components] Check for required inputs

### DIFF
--- a/changelog/pending/20250207--sdk-python--experimental-components-check-for-required-inputs.yaml
+++ b/changelog/pending/20250207--sdk-python--experimental-components-check-for-required-inputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: "[Experimental/Components] Check for required inputs"

--- a/sdk/python/lib/pulumi/provider/experimental/provider.py
+++ b/sdk/python/lib/pulumi/provider/experimental/provider.py
@@ -88,10 +88,9 @@ class ComponentProvider(Provider):
             input_val = inputs.get(schema_name, None)
             if input_val is None:
                 if not prop.optional:
-                    property_path = f"{component_def.name}.{schema_name}"
                     raise InputPropertyError(
-                        property_path,
-                        f"Missing required input '{property_path}'",
+                        schema_name,
+                        f"Missing required input '{schema_name}' on '{component_def.name}'",
                     )
                 continue
             py_name = component_def.inputs_mapping[schema_name]
@@ -128,12 +127,10 @@ class ComponentProvider(Provider):
             input_val = inputs.get(schema_name, None)
             if input_val is None:
                 if not prop.optional:
-                    property_path = (
-                        f"{component_def.name}.{property_name}.{schema_name}"
-                    )
+                    property_path = f"{property_name}.{schema_name}"
                     raise InputPropertyError(
                         property_path,
-                        f"Missing required input '{property_path}'",
+                        f"Missing required input '{property_path}' on '{component_def.name}'",
                     )
                 continue
             py_name = type_def.properties_mapping[schema_name]

--- a/sdk/python/lib/pulumi/provider/experimental/provider.py
+++ b/sdk/python/lib/pulumi/provider/experimental/provider.py
@@ -16,6 +16,7 @@ import json
 from pathlib import Path
 from typing import Any, Optional, Union
 
+from ...errors import InputPropertyError
 from ...output import Input, Inputs, Output
 from ...resource import ComponentResource, ResourceOptions
 from ..provider import ConstructResult, Provider
@@ -23,9 +24,6 @@ from .analyzer import Analyzer
 from .component import ComponentDefinition, PropertyDefinition, TypeDefinition
 from .metadata import Metadata
 from .schema import generate_schema
-
-
-class MissingPropertyError(Exception): ...
 
 
 class ComponentProvider(Provider):
@@ -90,8 +88,10 @@ class ComponentProvider(Provider):
             input_val = inputs.get(schema_name, None)
             if input_val is None:
                 if not prop.optional:
-                    raise MissingPropertyError(
-                        f"Missing required input '{component_def.name}.{schema_name}'"
+                    property_path = f"{component_def.name}.{schema_name}"
+                    raise InputPropertyError(
+                        property_path,
+                        f"Missing required input '{property_path}'",
                     )
                 continue
             py_name = component_def.inputs_mapping[schema_name]
@@ -128,8 +128,12 @@ class ComponentProvider(Provider):
             input_val = inputs.get(schema_name, None)
             if input_val is None:
                 if not prop.optional:
-                    raise MissingPropertyError(
-                        f"Missing required input '{type_def.name}.{schema_name}' for input '{component_def.name}.{property_name}'"
+                    property_path = (
+                        f"{component_def.name}.{property_name}.{schema_name}"
+                    )
+                    raise InputPropertyError(
+                        property_path,
+                        f"Missing required input '{property_path}'",
                     )
                 continue
             py_name = type_def.properties_mapping[schema_name]

--- a/sdk/python/lib/test/provider/experimental/test_provider.py
+++ b/sdk/python/lib/test/provider/experimental/test_provider.py
@@ -13,11 +13,9 @@
 # limitations under the License.
 
 from pathlib import Path
+from pulumi.errors import InputPropertyError
 from pulumi.provider.experimental.metadata import Metadata
-from pulumi.provider.experimental.provider import (
-    ComponentProvider,
-    MissingPropertyError,
-)
+from pulumi.provider.experimental.provider import ComponentProvider
 
 
 def test_validate_resource_type_invalid():
@@ -44,23 +42,17 @@ def test_map_inputs():
     try:
         provider.map_inputs({}, component_def)
         assert False, "expected an error"
-    except MissingPropertyError as e:
-        assert str(e) == "Missing required input 'MyComponent.a'"
+    except InputPropertyError as e:
+        assert e.reason == "Missing required input 'MyComponent.a'"
 
     try:
         provider.map_inputs({"a": {}}, component_def)
         assert False, "expected an error"
-    except MissingPropertyError as e:
-        assert (
-            str(e)
-            == "Missing required input 'RequiredType.b' for input 'MyComponent.a'"
-        )
+    except InputPropertyError as e:
+        assert e.reason == "Missing required input 'MyComponent.a.b'"
 
     try:
         provider.map_inputs({"a": {"b": {}}}, component_def)
         assert False, "expected an error"
-    except MissingPropertyError as e:
-        assert (
-            str(e)
-            == "Missing required input 'RequiredTypeNested.c' for input 'MyComponent.a.b'"
-        )
+    except InputPropertyError as e:
+        assert e.reason == "Missing required input 'MyComponent.a.b.c'"

--- a/sdk/python/lib/test/provider/experimental/test_provider.py
+++ b/sdk/python/lib/test/provider/experimental/test_provider.py
@@ -43,16 +43,16 @@ def test_map_inputs():
         provider.map_inputs({}, component_def)
         assert False, "expected an error"
     except InputPropertyError as e:
-        assert e.reason == "Missing required input 'MyComponent.a'"
+        assert e.reason == "Missing required input 'a' on 'MyComponent'"
 
     try:
         provider.map_inputs({"a": {}}, component_def)
         assert False, "expected an error"
     except InputPropertyError as e:
-        assert e.reason == "Missing required input 'MyComponent.a.b'"
+        assert e.reason == "Missing required input 'a.b' on 'MyComponent'"
 
     try:
         provider.map_inputs({"a": {"b": {}}}, component_def)
         assert False, "expected an error"
     except InputPropertyError as e:
-        assert e.reason == "Missing required input 'MyComponent.a.b.c'"
+        assert e.reason == "Missing required input 'a.b.c' on 'MyComponent'"

--- a/sdk/python/lib/test/provider/experimental/testdata/missing-input/component.py
+++ b/sdk/python/lib/test/provider/experimental/testdata/missing-input/component.py
@@ -1,0 +1,36 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import TypedDict
+
+import pulumi
+
+
+class RequiredTypeNested(TypedDict):
+    c: pulumi.Input[str]
+
+
+class RequiredType(TypedDict):
+    b: pulumi.Input[RequiredTypeNested]
+
+
+class Args(TypedDict):
+    a: pulumi.Input[RequiredType]
+
+
+class MyComponent(pulumi.ComponentResource):
+    def __init__(self, name: str, args: Args, opts: pulumi.ResourceOptions):
+        super().__init__("component:index:MyComponent", name, {}, opts)
+        self.register_outputs({})


### PR DESCRIPTION
While SDKS or the runtime (in the case of YAML) do some validation of the inputs, the provider should still check the inputs itself and raise an error if anything is missing.

Fixes https://github.com/pulumi/pulumi/issues/18458
Ref https://github.com/pulumi/pulumi/issues/18458