### PR TITLE
Detect when we are in the merge queue and override the branch name

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -395,6 +395,7 @@ jobs:
           directory: junit/
           files: "*,!.gitkeep"
           fail_ci_if_error: false
+          override_branch: ${{ startsWith(github.head_ref, 'gh-readonly-queue/master') && 'master' || github.head_ref }}
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Summarize Test Time by Package


### PR DESCRIPTION
When running in the merge queue, the branch is something like
`gh-readonly-queue/master/pr-18479-698d5ab6caba2dc23d64be1c1df00f57c9a6b8cb`.
Detect this and override the branch to be `master`.
