### PR TITLE
Don't attach "gitHub:repo" and "gitHub:owner" as implicit config

### DIFF
--- a/changelog/pending/20250207--backend-service--dont-send-github-owner-and-github-repo-tags-to-the-service.yaml
+++ b/changelog/pending/20250207--backend-service--dont-send-github-owner-and-github-repo-tags-to-the-service.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: backend/service
+  description: Don't send "gitHub:owner" and "gitHub:repo" tags to the service.

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -250,13 +250,6 @@ func addGitMetadataToStackTags(tags map[apitype.StackTagName]string, projPath st
 	} else {
 		return fmt.Errorf("detecting VCS info for stack tags for remote %v: %w", remoteURL, err)
 	}
-	// Set the old stack tags keys as GitHub so that the UI will continue to work,
-	// regardless of whether the remote URL is a GitHub URL or not.
-	// TODO remove these when the UI no longer needs them.
-	if tags[apitype.VCSOwnerNameTag] != "" {
-		tags[apitype.GitHubOwnerNameTag] = tags[apitype.VCSOwnerNameTag]
-		tags[apitype.GitHubRepositoryNameTag] = tags[apitype.VCSRepositoryNameTag]
-	}
 
 	return nil
 }

--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -412,13 +412,6 @@ const (
 	ProjectDescriptionTag StackTagName = "pulumi:description"
 	// ProjectTemplateTag is a tag that represents the template that was used to create a project.
 	ProjectTemplateTag StackTagName = "pulumi:template"
-	// GitHubOwnerNameTag is a tag that represents the name of the owner on GitHub that this stack
-	// may be associated with (inferred by the CLI based on git remote info).
-	// TODO [pulumi/pulumi-service#2306] Once the UI is updated, we would no longer need the GitHub specific keys.
-	GitHubOwnerNameTag StackTagName = "gitHub:owner"
-	// GitHubRepositoryNameTag is a tag that represents the name of a repository on GitHub that this stack
-	// may be associated with (inferred by the CLI based on git remote info).
-	GitHubRepositoryNameTag StackTagName = "gitHub:repo"
 	// VCSOwnerNameTag is a tag that represents the name of the owner on the cloud VCS that this stack
 	// may be associated with (inferred by the CLI based on git remote info).
 	VCSOwnerNameTag StackTagName = "vcs:owner"


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/18330

Consumers of these tags have had 6 years to migrate to the new `"vcs:owner"`, `"vcs:repo"` and `"vcs:kind"` tags.