### PR TITLE
Collect junit reports for python tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ coverage.cov
 *.cov
 **/obj/
 coverage/
+junit/
 venv/
 .envrc
 # Ignore VSCode created solution file

--- a/sdk/python/scripts/test_auto.sh
+++ b/sdk/python/scripts/test_auto.sh
@@ -4,7 +4,10 @@ PULUMI_TEST_COVERAGE_PATH=$PULUMI_TEST_COVERAGE_PATH
 
 set -euo pipefail
 
-coverage run --append -m pytest lib/test/automation
+mkdir -p ../../junit
+JUNIT_DIR=$(realpath ../../junit)
+
+coverage run --append -m pytest --junitxml "$JUNIT_DIR/python-test-auto.xml" lib/test/automation
 
 if [[ "$PULUMI_TEST_COVERAGE_PATH" ]]; then
     if [ -e .coverage ]; then

--- a/sdk/python/scripts/test_fast.sh
+++ b/sdk/python/scripts/test_fast.sh
@@ -4,20 +4,16 @@ PULUMI_TEST_COVERAGE_PATH=$PULUMI_TEST_COVERAGE_PATH
 
 set -euo pipefail
 
-# TODO the ignored test seems to fail in pytest but not unittest. Need
-# to trackdown why.
+mkdir -p ../../junit
+JUNIT_DIR=$(realpath ../../junit)
 
-coverage run --append -m pytest lib/test \
-             --ignore lib/test/automation \
-             --ignore lib/test/langhost/resource_thens/test_resource_thens.py
-
-coverage run --append -m unittest \
-             lib/test/langhost/resource_thens/test_resource_thens.py
+coverage run --append -m pytest --junitxml "$JUNIT_DIR/python-test-fast.xml" lib/test \
+             --ignore lib/test/automation
 
 # Using python -m also adds lib/test_with_mocks to sys.path which
 # avoids package resolution issues.
 
-(cd lib/test_with_mocks && coverage run --append -m pytest)
+(cd lib/test_with_mocks && coverage run --append -m pytest --junitxml "$JUNIT_DIR/python-test-fast-with-mocks.xml")
 
 if [[ "$PULUMI_TEST_COVERAGE_PATH" ]]; then
     if [ -e .coverage ]; then


### PR DESCRIPTION
Follow up to https://github.com/pulumi/pulumi/pull/18479 which collects report for Go tests. This now adds Junit reports for Python tests.

Example results https://app.codecov.io/gh/pulumi/pulumi/tests/julienp%2Fgather-junit-info-for-python?term=lib.test.provider.experimental.test_analyzer