### PR TITLE
Don’t set the files option codecov/test-results-action

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -393,7 +393,6 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           directory: junit/
-          files: "*,!.gitkeep"
           fail_ci_if_error: false
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
We can upload all the files in the junit directory. This should help the action succeeding on windows.