### PR TITLE
Set branch name for test reports on merge

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -389,12 +389,25 @@ jobs:
           path: |
             coverage/*
             !coverage/.gitkeep
+      - name: Debug branch name
+        env:
+          REF: ${{ github.ref }}
+          REF_NAME: ${{ github.ref_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          BRANCH_NAME: ${{ github.event_name == 'merge_group' && 'master' || github.head_ref }}
+        run: |
+          echo REF="${REF}"
+          echo REF_NAME="${REF_NAME}"
+          echo HEAD_REF="${HEAD_REF}"
+          echo EVENT_NAME="${EVENT_NAME}"
+          echo BRANCH_NAME="${BRANCH_NAME}"
       - name: Upload codecov test results
         uses: codecov/test-results-action@v1
         with:
           directory: junit/
           fail_ci_if_error: false
-          override_branch: ${{ startsWith(github.head_ref, 'gh-readonly-queue/master') && 'master' || github.head_ref }}
+          override_branch: ${{ github.event_name == 'merge_group' && 'master' || github.head_ref }}
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Summarize Test Time by Package


### PR DESCRIPTION
I attempted to fix this in https://github.com/pulumi/pulumi/pull/18488, but that didn't work.