### PR TITLE
Fix panic for corrupted secret values

### DIFF
--- a/changelog/pending/20250208--engine--fix-a-potential-panic-for-corrupted-secret-values.yaml
+++ b/changelog/pending/20250208--engine--fix-a-potential-panic-for-corrupted-secret-values.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix a potential panic for corrupted secret values


### PR DESCRIPTION
If a secret value (of the form "v1:\<nonce\>:\<ciphertext\>") was corrupted with an improperly sized nonce field the system would panic when calling `aesgcm.Open`. This adds a check to instead error in this case, rather than panicking.

This likely has little impact on usage apart from getting a nice error rather than a panic in this case. Generally if secret decryption fails for any reason the CLI is incapable of doing anything else anyway.

Fixes https://github.com/pulumi/home/issues/3889