### PR TITLE
Add --all to state delete

### DIFF
--- a/changelog/pending/20250208--cli-state--add-all-to-state-delete.yaml
+++ b/changelog/pending/20250208--cli-state--add-all-to-state-delete.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/state
+  description: Add `--all` to `state delete`

--- a/pkg/cmd/pulumi/state/state_delete.go
+++ b/pkg/cmd/pulumi/state/state_delete.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -37,6 +38,7 @@ type stateDeleteCmd struct {
 	stack            string
 	yes              bool
 	targetDependents bool
+	all              bool
 }
 
 func (cmd *stateDeleteCmd) Run(
@@ -44,35 +46,57 @@ func (cmd *stateDeleteCmd) Run(
 ) error {
 	cmd.yes = cmd.yes || env.SkipConfirmations.Value()
 	var urn resource.URN
-	if len(args) == 0 {
-		if !cmdutil.Interactive() {
-			return missingNonInteractiveArg("resource URN")
-		}
-
-		var err error
-		urn, err = getURNFromState(ctx, ws, backend.DefaultLoginManager, cmd.stack, nil,
-			"Select the resource to delete")
-		if err != nil {
-			return fmt.Errorf("failed to select resource: %w", err)
+	if cmd.all {
+		if len(args) != 0 {
+			return errors.New("cannot specify a resource URN when deleting all resources")
 		}
 	} else {
-		urn = resource.URN(args[0])
+		if len(args) == 0 {
+			if !cmdutil.Interactive() {
+				return missingNonInteractiveArg("resource URN")
+			}
+
+			var err error
+			urn, err = getURNFromState(ctx, ws, backend.DefaultLoginManager, cmd.stack, nil,
+				"Select the resource to delete")
+			if err != nil {
+				return fmt.Errorf("failed to select resource: %w", err)
+			}
+		} else {
+			urn = resource.URN(args[0])
+		}
 	}
 	// Show the confirmation prompt if the user didn't pass the --yes parameter to skip it.
 	showPrompt := !cmd.yes
 
-	err := runStateEdit(
-		ctx, ws, lm, cmd.stack, showPrompt, urn, func(snap *deploy.Snapshot, res *resource.State) error {
-			var handleProtected func(*resource.State) error
-			if cmd.force {
-				handleProtected = func(res *resource.State) error {
-					cmdutil.Diag().Warningf(diag.Message(res.URN,
-						"deleting protected resource %s due to presence of --force"), res.URN)
-					return edit.UnprotectResource(nil, res)
+	var handleProtected func(*resource.State) error
+	if cmd.force {
+		handleProtected = func(res *resource.State) error {
+			cmdutil.Diag().Warningf(diag.Message(res.URN,
+				"deleting protected resource %s due to presence of --force"), res.URN)
+			return edit.UnprotectResource(nil, res)
+		}
+	}
+
+	// If we're deleting everything then run a total state edit, else run on just the resource given.
+	var err error
+	if cmd.all {
+		err = runTotalStateEdit(ctx, ws, lm, cmd.stack, showPrompt, func(opts display.Options, snap *deploy.Snapshot) error {
+			// Iterate the resources backwards (so we delete dependents first) and delete them.
+			for i := len(snap.Resources) - 1; i >= 0; i-- {
+				res := snap.Resources[i]
+				if err := edit.DeleteResource(snap, res, handleProtected, cmd.targetDependents); err != nil {
+					return err
 				}
 			}
-			return edit.DeleteResource(snap, res, handleProtected, cmd.targetDependents)
+			return nil
 		})
+	} else {
+		err = runStateEdit(
+			ctx, ws, lm, cmd.stack, showPrompt, urn, func(snap *deploy.Snapshot, res *resource.State) error {
+				return edit.DeleteResource(snap, res, handleProtected, cmd.targetDependents)
+			})
+	}
 	if err != nil {
 		switch e := err.(type) {
 		case edit.ResourceHasDependenciesError:
@@ -92,7 +116,11 @@ func (cmd *stateDeleteCmd) Run(
 			return err
 		}
 	}
-	fmt.Println("Resource deleted")
+	if cmd.all {
+		fmt.Println("Resources deleted")
+	} else {
+		fmt.Println("Resource deleted")
+	}
 	return nil
 }
 
@@ -127,6 +155,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 		"The name of the stack to operate on. Defaults to the current stack")
 	cmd.Flags().BoolVar(&sdcmd.force, "force", false, "Force deletion of protected resources")
 	cmd.Flags().BoolVarP(&sdcmd.yes, "yes", "y", false, "Skip confirmation prompts")
+	cmd.Flags().BoolVar(&sdcmd.all, "all", false, "Delete all resources in the stack")
 	cmd.Flags().BoolVar(&sdcmd.targetDependents, "target-dependents", false, "Delete the URN and all its dependents")
 	return cmd
 }


### PR DESCRIPTION
Adds a `--all` flag to `pulumi state delete`. This simply iterates backwards to remove each resource from state, still respecting `protect` flags.

Fixes https://github.com/pulumi/pulumi/issues/2437