### PR TITLE
Add --show-secrets flag for up command

### DIFF
--- a/changelog/pending/20250212--cli-display--add-show-secrets-args-to-pulumi-up-and-pulumi-preview-showing-secrets-in-the-cli-output-fixing-9830.yaml
+++ b/changelog/pending/20250212--cli-display--add-show-secrets-args-to-pulumi-up-and-pulumi-preview-showing-secrets-in-the-cli-output-fixing-9830.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/display
+  description: "Add --show-secrets args to pulumi up and pulumi preview, showing secrets in the CLI output. Fixing #9830"

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -170,7 +170,7 @@ func renderDiffPolicyRemediationEvent(payload engine.PolicyRemediationEventPaylo
 	if detailed {
 		var b bytes.Buffer
 		PrintObjectDiff(&b, *diff, nil,
-			false /*planning*/, 2, true /*summary*/, true /*truncateOutput*/, false /*debug*/)
+			false /*planning*/, 2, true /*summary*/, true /*truncateOutput*/, false /*debug*/, opts.ShowSecrets)
 		remediationLine = fmt.Sprintf("%s\n%s", remediationLine, b.String())
 	} else {
 		var b bytes.Buffer
@@ -388,15 +388,15 @@ func renderDiff(
 		if metadata.DetailedDiff != nil {
 			var buf bytes.Buffer
 			if diff := engine.TranslateDetailedDiff(&metadata, refresh); diff != nil {
-				PrintObjectDiff(&buf, *diff, nil /*include*/, planning, indent+1, opts.SummaryDiff, opts.TruncateOutput, debug)
+				PrintObjectDiff(&buf, *diff, nil /*include*/, planning, indent+1, opts.SummaryDiff, opts.TruncateOutput, debug, opts.ShowSecrets)
 			} else {
 				PrintObject(
-					&buf, metadata.Old.Inputs, planning, indent+1, deploy.OpSame, true /*prefix*/, opts.TruncateOutput, debug)
+					&buf, metadata.Old.Inputs, planning, indent+1, deploy.OpSame, true /*prefix*/, opts.TruncateOutput, debug, opts.ShowSecrets)
 			}
 			details = buf.String()
 		} else {
 			details = getResourcePropertiesDetails(
-				metadata, indent, planning, opts.SummaryDiff, opts.TruncateOutput, debug)
+				metadata, indent, planning, opts.SummaryDiff, opts.TruncateOutput, debug, opts.ShowSecrets)
 		}
 	}
 	fprintIgnoreError(out, opts.Color.Colorize(summary))

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -388,10 +388,12 @@ func renderDiff(
 		if metadata.DetailedDiff != nil {
 			var buf bytes.Buffer
 			if diff := engine.TranslateDetailedDiff(&metadata, refresh); diff != nil {
-				PrintObjectDiff(&buf, *diff, nil /*include*/, planning, indent+1, opts.SummaryDiff, opts.TruncateOutput, debug, opts.ShowSecrets)
+				PrintObjectDiff(&buf, *diff, nil /*include*/, planning, indent+1,
+					opts.SummaryDiff, opts.TruncateOutput, debug, opts.ShowSecrets)
 			} else {
 				PrintObject(
-					&buf, metadata.Old.Inputs, planning, indent+1, deploy.OpSame, true /*prefix*/, opts.TruncateOutput, debug, opts.ShowSecrets)
+					&buf, metadata.Old.Inputs, planning, indent+1, deploy.OpSame, true, /*prefix*/
+					opts.TruncateOutput, debug, opts.ShowSecrets)
 			}
 			details = buf.String()
 		} else {

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -466,7 +466,7 @@ func renderDiffResourceOutputsEvent(
 			// things that are the same.
 			text := getResourceOutputsPropertiesString(
 				payload.Metadata, indent+1, payload.Planning,
-				payload.Debug, refresh, opts.ShowSameResources)
+				payload.Debug, refresh, opts.ShowSameResources, opts.ShowSecrets)
 			if text != "" {
 				header := fmt.Sprintf("%v%v--outputs:--%v\n",
 					deploy.Color(payload.Metadata.Op), getIndentationString(indent+1, payload.Metadata.Op, false), colors.Reset)

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -178,7 +178,8 @@ func getResourcePropertiesSummary(step engine.StepEventMetadata, indent int) str
 }
 
 func getResourcePropertiesDetails(
-	step engine.StepEventMetadata, indent int, planning bool, summary bool, truncateOutput bool, debug bool, showSecrets bool,
+	step engine.StepEventMetadata, indent int, planning bool, summary bool, truncateOutput bool,
+	debug bool, showSecrets bool,
 ) string {
 	var b bytes.Buffer
 
@@ -200,9 +201,11 @@ func getResourcePropertiesDetails(
 			PrintObject(&b, old.Inputs, planning, indent, step.Op, false, truncateOutput, debug, showSecrets)
 		}
 	} else if len(new.Outputs) > 0 && step.Op != deploy.OpImport && step.Op != deploy.OpImportReplacement {
-		printOldNewDiffs(&b, old.Outputs, new.Outputs, nil, planning, indent, step.Op, summary, truncateOutput, debug, showSecrets)
+		printOldNewDiffs(&b, old.Outputs, new.Outputs, nil, planning, indent, step.Op,
+			summary, truncateOutput, debug, showSecrets)
 	} else {
-		printOldNewDiffs(&b, old.Inputs, new.Inputs, step.Diffs, planning, indent, step.Op, summary, truncateOutput, debug, showSecrets)
+		printOldNewDiffs(&b, old.Inputs, new.Inputs, step.Diffs, planning, indent, step.Op,
+			summary, truncateOutput, debug, showSecrets)
 	}
 
 	return b.String()

--- a/pkg/backend/display/object_diff_test.go
+++ b/pkg/backend/display/object_diff_test.go
@@ -108,9 +108,10 @@ func Test_PrintObject(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name     string
-		object   resource.PropertyMap
-		expected string
+		name       string
+		object     resource.PropertyMap
+		expected   string
+		showSecret bool
 	}{
 		{
 			"numbers",
@@ -125,96 +126,39 @@ func Test_PrintObject(t *testing.T) {
 <{%reset%}><{%reset%}>large_float: <{%reset%}><{%reset%}>1.2345671234567e+06<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>large_int  : <{%reset%}><{%reset%}>1234567<{%reset%}><{%reset%}>
 <{%reset%}>`,
+			false,
 		},
-	}
-
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
-			t.Parallel()
-
-			var buf bytes.Buffer
-			PrintObject(&buf, c.object, false, 0, deploy.OpSame, false, false, false, false)
-			assert.Equal(t, c.expected, buf.String())
-		})
-	}
-}
-
-func Test_PrintObjectNoShowSecret(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name     string
-		object   resource.PropertyMap
-		expected string
-	}{
 		{
-			"numbers",
+			"secret_noshow",
 			resource.NewPropertyMapFromMap(map[string]interface{}{
-				"int":         1,
-				"float":       2.3,
-				"large_int":   1234567,
-				"large_float": 1234567.1234567,
-				"secret":      resource.NewSecretProperty(&resource.Secret{Element: resource.NewStringProperty("secrets")}),
+				"secret": resource.NewSecretProperty(&resource.Secret{Element: resource.NewStringProperty("secrets")}),
 				"nested_secret": resource.NewPropertyMapFromMap(map[string]interface{}{
 					"super_secret": resource.NewSecretProperty(&resource.Secret{Element: resource.NewStringProperty("super_secret")}),
 				}),
 			}),
-			`<{%reset%}>float        : <{%reset%}><{%reset%}>2.3<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}>int          : <{%reset%}><{%reset%}>1<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}>large_float  : <{%reset%}><{%reset%}>1.2345671234567e+06<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}>large_int    : <{%reset%}><{%reset%}>1234567<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}>nested_secret: <{%reset%}><{%reset%}>{
+			`<{%reset%}>nested_secret: <{%reset%}><{%reset%}>{
 <{%reset%}><{%reset%}>    super_secret: <{%reset%}><{%reset%}>[secret]<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>}<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>secret       : <{%reset%}><{%reset%}>[secret]<{%reset%}><{%reset%}>
 <{%reset%}>`,
+			false,
 		},
-	}
-
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
-			t.Parallel()
-
-			var buf bytes.Buffer
-			PrintObject(&buf, c.object, false, 0, deploy.OpSame, false, false, false, false)
-			assert.Equal(t, c.expected, buf.String())
-		})
-	}
-}
-
-func Test_PrintObjectShowSecret(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name     string
-		object   resource.PropertyMap
-		expected string
-	}{
 		{
-			"numbers",
+			"secrets_show",
 			resource.NewPropertyMapFromMap(map[string]interface{}{
-				"int":         1,
-				"float":       2.3,
-				"large_int":   1234567,
-				"large_float": 1234567.1234567,
-				"secret":      resource.NewSecretProperty(&resource.Secret{Element: resource.NewStringProperty("my_secret")}),
+				"secret": resource.NewSecretProperty(&resource.Secret{Element: resource.NewStringProperty("my_secret")}),
 				"nested_secret": resource.NewPropertyMapFromMap(map[string]interface{}{
 					"super_secret": resource.NewSecretProperty(&resource.Secret{Element: resource.NewStringProperty("my_super_secret")}),
 				}),
 			}),
-			`<{%reset%}>float        : <{%reset%}><{%reset%}>2.3<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}>int          : <{%reset%}><{%reset%}>1<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}>large_float  : <{%reset%}><{%reset%}>1.2345671234567e+06<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}>large_int    : <{%reset%}><{%reset%}>1234567<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}>nested_secret: <{%reset%}><{%reset%}>{
+			`<{%reset%}>nested_secret: <{%reset%}><{%reset%}>{
 <{%reset%}><{%reset%}>    super_secret: <{%reset%}><{%reset%}>"my_super_secret"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>}<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>secret       : <{%reset%}><{%reset%}>"my_secret"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>
 <{%reset%}>`,
+			true,
 		},
 	}
 
@@ -224,7 +168,7 @@ func Test_PrintObjectShowSecret(t *testing.T) {
 			t.Parallel()
 
 			var buf bytes.Buffer
-			PrintObject(&buf, c.object, false, 0, deploy.OpSame, false, false, false, true)
+			PrintObject(&buf, c.object, false, 0, deploy.OpSame, false, false, false, c.showSecret)
 			assert.Equal(t, c.expected, buf.String())
 		})
 	}

--- a/pkg/backend/display/object_diff_test.go
+++ b/pkg/backend/display/object_diff_test.go
@@ -134,7 +134,97 @@ func Test_PrintObject(t *testing.T) {
 			t.Parallel()
 
 			var buf bytes.Buffer
-			PrintObject(&buf, c.object, false, 0, deploy.OpSame, false, false, false)
+			PrintObject(&buf, c.object, false, 0, deploy.OpSame, false, false, false, false)
+			assert.Equal(t, c.expected, buf.String())
+		})
+	}
+}
+
+func Test_PrintObjectNoShowSecret(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		object   resource.PropertyMap
+		expected string
+	}{
+		{
+			"numbers",
+			resource.NewPropertyMapFromMap(map[string]interface{}{
+				"int":         1,
+				"float":       2.3,
+				"large_int":   1234567,
+				"large_float": 1234567.1234567,
+				"secret":      resource.NewSecretProperty(&resource.Secret{Element: resource.NewStringProperty("secrets")}),
+				"nested_secret": resource.NewPropertyMapFromMap(map[string]interface{}{
+					"super_secret": resource.NewSecretProperty(&resource.Secret{Element: resource.NewStringProperty("super_secret")}),
+				}),
+			}),
+			`<{%reset%}>float        : <{%reset%}><{%reset%}>2.3<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>int          : <{%reset%}><{%reset%}>1<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>large_float  : <{%reset%}><{%reset%}>1.2345671234567e+06<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>large_int    : <{%reset%}><{%reset%}>1234567<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>nested_secret: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>    super_secret: <{%reset%}><{%reset%}>[secret]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>}<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>secret       : <{%reset%}><{%reset%}>[secret]<{%reset%}><{%reset%}>
+<{%reset%}>`,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			PrintObject(&buf, c.object, false, 0, deploy.OpSame, false, false, false, false)
+			assert.Equal(t, c.expected, buf.String())
+		})
+	}
+}
+
+func Test_PrintObjectShowSecret(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		object   resource.PropertyMap
+		expected string
+	}{
+		{
+			"numbers",
+			resource.NewPropertyMapFromMap(map[string]interface{}{
+				"int":         1,
+				"float":       2.3,
+				"large_int":   1234567,
+				"large_float": 1234567.1234567,
+				"secret":      resource.NewSecretProperty(&resource.Secret{Element: resource.NewStringProperty("my_secret")}),
+				"nested_secret": resource.NewPropertyMapFromMap(map[string]interface{}{
+					"super_secret": resource.NewSecretProperty(&resource.Secret{Element: resource.NewStringProperty("my_super_secret")}),
+				}),
+			}),
+			`<{%reset%}>float        : <{%reset%}><{%reset%}>2.3<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>int          : <{%reset%}><{%reset%}>1<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>large_float  : <{%reset%}><{%reset%}>1.2345671234567e+06<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>large_int    : <{%reset%}><{%reset%}>1234567<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>nested_secret: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>    super_secret: <{%reset%}><{%reset%}>"my_super_secret"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>}<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>secret       : <{%reset%}><{%reset%}>"my_secret"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>
+<{%reset%}>`,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			PrintObject(&buf, c.object, false, 0, deploy.OpSame, false, false, false, true)
 			assert.Equal(t, c.expected, buf.String())
 		})
 	}

--- a/pkg/backend/display/object_diff_test.go
+++ b/pkg/backend/display/object_diff_test.go
@@ -133,7 +133,9 @@ func Test_PrintObject(t *testing.T) {
 			resource.NewPropertyMapFromMap(map[string]interface{}{
 				"secret": resource.NewSecretProperty(&resource.Secret{Element: resource.NewStringProperty("secrets")}),
 				"nested_secret": resource.NewPropertyMapFromMap(map[string]interface{}{
-					"super_secret": resource.NewSecretProperty(&resource.Secret{Element: resource.NewStringProperty("super_secret")}),
+					"super_secret": resource.NewSecretProperty(&resource.Secret{
+						Element: resource.NewStringProperty("super_secret"),
+					}),
 				}),
 			}),
 			`<{%reset%}>nested_secret: <{%reset%}><{%reset%}>{
@@ -148,7 +150,9 @@ func Test_PrintObject(t *testing.T) {
 			resource.NewPropertyMapFromMap(map[string]interface{}{
 				"secret": resource.NewSecretProperty(&resource.Secret{Element: resource.NewStringProperty("my_secret")}),
 				"nested_secret": resource.NewPropertyMapFromMap(map[string]interface{}{
-					"super_secret": resource.NewSecretProperty(&resource.Secret{Element: resource.NewStringProperty("my_super_secret")}),
+					"super_secret": resource.NewSecretProperty(&resource.Secret{
+						Element: resource.NewStringProperty("my_super_secret"),
+					}),
 				}),
 			}),
 			`<{%reset%}>nested_secret: <{%reset%}><{%reset%}>{

--- a/pkg/backend/display/options.go
+++ b/pkg/backend/display/options.go
@@ -59,7 +59,7 @@ type Options struct {
 	SuppressTimings        bool                // true to suppress displaying timings of resource actions
 	SuppressProgress       bool                // true to suppress displaying progress spinner.
 	ShowLinkToCopilot      bool                // true to display a 'explainFailure' link to Copilot.
-
+	ShowSecrets            bool                // true to display secrets in the output.
 	// Low level options
 	term                terminal.Terminal
 	DeterministicOutput bool // true to disable timing-based rendering

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -905,7 +905,7 @@ func (display *ProgressDisplay) printOutputs() {
 
 	props := getResourceOutputsPropertiesString(
 		stackStep, 1, display.isPreview, display.opts.Debug,
-		false /* refresh */, display.opts.ShowSameResources)
+		false /* refresh */, display.opts.ShowSameResources, display.opts.ShowSecrets)
 	if props != "" {
 		display.println(colors.SpecHeadline + "Outputs:" + colors.Reset)
 		display.println(props)

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1062,7 +1062,6 @@ func (b *diyBackend) apply(
 ) (*deploy.Plan, sdkDisplay.ResourceChanges, error) {
 	resetKeepRunning := nosleep.KeepRunning()
 	defer resetKeepRunning()
-
 	stackRef := stack.Ref()
 	diyStackRef, err := b.getReference(stackRef)
 	if err != nil {

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -320,6 +320,7 @@ func NewPreviewCmd() *cobra.Command {
 				ShowReplacementSteps:   showReplacementSteps,
 				ShowSameResources:      showSames,
 				ShowReads:              showReads,
+				ShowSecrets:            showSecrets,
 				SuppressOutputs:        suppressOutputs,
 				SuppressProgress:       suppressProgress,
 				IsInteractive:          cmdutil.Interactive(),
@@ -453,6 +454,7 @@ func NewPreviewCmd() *cobra.Command {
 					LocalPolicyPacks:          engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
 					Parallel:                  parallel,
 					Debug:                     debug,
+					ShowSecrets:               showSecrets,
 					Refresh:                   refreshOption,
 					ReplaceTargets:            deploy.NewUrnTargets(replaceURNs),
 					UseLegacyDiff:             env.EnableLegacyDiff.Value(),
@@ -479,11 +481,6 @@ func NewPreviewCmd() *cobra.Command {
 			if importFilePath != "" {
 				events = make(chan engine.Event)
 				importFilePromise = buildImportFile(events)
-			}
-
-			if planFilePath == "" && showSecrets {
-				cmdutil.Diag().Warningf(diag.RawMessage("", /*urn*/
-					"--show-secrets only applies when --save-plan is set"))
 			}
 
 			plan, changes, res := s.Preview(ctx, backend.UpdateOperation{
@@ -573,13 +570,11 @@ func NewPreviewCmd() *cobra.Command {
 		"[EXPERIMENTAL] Save the operations proposed by the preview to a plan file at the given path")
 	cmd.Flags().BoolVarP(
 		&showSecrets, "show-secrets", "", false,
-		"[EXPERIMENTAL] Emit secrets in plaintext in the plan file. Defaults to `false`")
+		"Show secrets in plaintext in the CLI output, if used with --save-plan the secrets will be shown in the plan file. Defaults to `false`")
 
 	if !env.Experimental.Value() {
 		contract.AssertNoErrorf(cmd.PersistentFlags().MarkHidden("save-plan"),
 			`Could not mark "save-plan" as hidden`)
-		contract.AssertNoErrorf(cmd.Flags().MarkHidden("show-secrets"),
-			`Could not mark "show-secrets" as hidden`)
 	}
 	cmd.PersistentFlags().StringVar(
 		&importFilePath, "import-file", "",

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -570,7 +570,7 @@ func NewPreviewCmd() *cobra.Command {
 		"[EXPERIMENTAL] Save the operations proposed by the preview to a plan file at the given path")
 	cmd.Flags().BoolVarP(
 		&showSecrets, "show-secrets", "", false,
-		"Show secrets in plaintext in the CLI output, if used with --save-plan the secrets will be shown in the plan file. Defaults to `false`")
+		"Show secrets in plaintext in the CLI output, if used with --save-plan the secrets will also be shown in the plan file. Defaults to `false`")
 
 	if !env.Experimental.Value() {
 		contract.AssertNoErrorf(cmd.PersistentFlags().MarkHidden("save-plan"),

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -570,7 +570,8 @@ func NewPreviewCmd() *cobra.Command {
 		"[EXPERIMENTAL] Save the operations proposed by the preview to a plan file at the given path")
 	cmd.Flags().BoolVarP(
 		&showSecrets, "show-secrets", "", false,
-		"Show secrets in plaintext in the CLI output, if used with --save-plan the secrets will also be shown in the plan file. Defaults to `false`")
+		"Show secrets in plaintext in the CLI output,"+
+			" if used with --save-plan the secrets will also be shown in the plan file. Defaults to `false`")
 
 	if !env.Experimental.Value() {
 		contract.AssertNoErrorf(cmd.PersistentFlags().MarkHidden("save-plan"),

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -83,6 +83,7 @@ func NewUpCmd() *cobra.Command {
 	var showPolicyRemediations bool
 	var showReplacementSteps bool
 	var showSames bool
+	var showSecrets bool
 	var showReads bool
 	var skipPreview bool
 	var showFullOutput bool
@@ -192,6 +193,7 @@ func NewUpCmd() *cobra.Command {
 			DisableProviderPreview:    env.DisableProviderPreview.Value(),
 			DisableResourceReferences: env.DisableResourceReferences.Value(),
 			DisableOutputValues:       env.DisableOutputValues.Value(),
+			ShowSecrets:               showSecrets,
 			Targets:                   deploy.NewUrnTargets(targetURNs),
 			TargetDependents:          targetDependents,
 			// Trigger a plan to be generated during the preview phase which can be constrained to during the
@@ -427,13 +429,12 @@ func NewUpCmd() *cobra.Command {
 		if err != nil {
 			return err
 		}
-
 		opts.Engine = engine.UpdateOptions{
 			LocalPolicyPacks: engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
 			Parallel:         parallel,
 			Debug:            debug,
 			Refresh:          refreshOption,
-
+			ShowSecrets:      showSecrets,
 			// If we're in experimental mode then we trigger a plan to be generated during the preview phase
 			// which will be constrained to during the update phase.
 			GeneratePlan: env.Experimental.Value(),
@@ -537,6 +538,7 @@ func NewUpCmd() *cobra.Command {
 				EventLogPath:           eventLogPath,
 				Debug:                  debug,
 				JSONDisplay:            jsonDisplay,
+				ShowSecrets:            showSecrets,
 			}
 
 			// we only suppress permalinks if the user passes true. the default is an empty string
@@ -687,6 +689,9 @@ func NewUpCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&showSames, "show-sames", false,
 		"Show resources that don't need be updated because they haven't changed, alongside those that do")
+	cmd.PersistentFlags().BoolVar(
+		&showSecrets, "show-secrets", false,
+		"Show secret outputs in the CLI output")
 	cmd.PersistentFlags().BoolVar(
 		&showReads, "show-reads", false,
 		"Show resources that are being read in, alongside those being managed directly in the stack")

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -587,7 +587,12 @@ func (acts *updateActions) OnResourceStepPre(step deploy.Step) (interface{}, err
 	acts.MapLock.Lock()
 	acts.Seen[step.URN()] = step
 	acts.MapLock.Unlock()
-	acts.Opts.Events.resourcePreEvent(step, false /*planning*/, acts.Opts.Debug, isInternalStep(step), acts.Opts.ShowSecrets)
+	acts.Opts.Events.resourcePreEvent(step,
+		false, /*planning*/
+		acts.Opts.Debug,
+		isInternalStep(step),
+		acts.Opts.ShowSecrets,
+	)
 
 	// Inform the snapshot service that we are about to perform a step.
 	return acts.Context.SnapshotManager.BeginMutation(step)
@@ -647,7 +652,14 @@ func (acts *updateActions) OnResourceStepPost(
 		// the Pulumi program, as component resources only report outputs via calls to RegisterResourceOutputs.
 		// Deletions emit the resourceOutputEvent so the display knows when to stop the time elapsed counter.
 		if step.Res().Custom || acts.Opts.Refresh && step.Op() == deploy.OpRefresh || step.Op() == deploy.OpDelete {
-			acts.Opts.Events.resourceOutputsEvent(op, step, false /*planning*/, acts.Opts.Debug, isInternalStep, acts.Opts.ShowSecrets)
+			acts.Opts.Events.resourceOutputsEvent(
+				op,
+				step,
+				false, /*planning*/
+				acts.Opts.Debug,
+				isInternalStep,
+				acts.Opts.ShowSecrets,
+			)
 		}
 	}
 
@@ -688,7 +700,14 @@ func (acts *updateActions) OnResourceOutputs(step deploy.Step) error {
 	assertSeen(acts.Seen, step)
 	acts.MapLock.Unlock()
 
-	acts.Opts.Events.resourceOutputsEvent(step.Op(), step, false /*planning*/, acts.Opts.Debug, isInternalStep(step), acts.Opts.ShowSecrets)
+	acts.Opts.Events.resourceOutputsEvent(
+		step.Op(),
+		step,
+		false, /*planning*/
+		acts.Opts.Debug,
+		isInternalStep(step),
+		acts.Opts.ShowSecrets,
+	)
 
 	// There's a chance there are new outputs that weren't written out last time.
 	// We need to perform another snapshot write to ensure they get written out.
@@ -750,7 +769,12 @@ func (acts *previewActions) OnResourceStepPre(step deploy.Step) (interface{}, er
 	acts.Seen[step.URN()] = step
 	acts.MapLock.Unlock()
 
-	acts.Opts.Events.resourcePreEvent(step, true /*planning*/, acts.Opts.Debug, isInternalStep(step), acts.Opts.ShowSecrets)
+	acts.Opts.Events.resourcePreEvent(
+		step, true, /*planning*/
+		acts.Opts.Debug,
+		isInternalStep(step),
+		acts.Opts.ShowSecrets,
+	)
 
 	return nil, nil
 }
@@ -791,7 +815,14 @@ func (acts *previewActions) OnResourceStepPost(ctx interface{},
 			acts.MapLock.Unlock()
 		}
 
-		acts.Opts.Events.resourceOutputsEvent(op, step, true /*planning*/, acts.Opts.Debug, isInternalStep, acts.Opts.ShowSecrets)
+		acts.Opts.Events.resourceOutputsEvent(
+			op,
+			step,
+			true, /*planning*/
+			acts.Opts.Debug,
+			isInternalStep,
+			acts.Opts.ShowSecrets,
+		)
 	}
 
 	return nil
@@ -803,7 +834,14 @@ func (acts *previewActions) OnResourceOutputs(step deploy.Step) error {
 	acts.MapLock.Unlock()
 
 	// Print the resource outputs separately.
-	acts.Opts.Events.resourceOutputsEvent(step.Op(), step, true /*planning*/, acts.Opts.Debug, isInternalStep(step), acts.Opts.ShowSecrets)
+	acts.Opts.Events.resourceOutputsEvent(
+		step.Op(),
+		step,
+		true, /*planning*/
+		acts.Opts.Debug,
+		isInternalStep(step),
+		acts.Opts.ShowSecrets,
+	)
 
 	return nil
 }

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -181,6 +181,9 @@ type UpdateOptions struct {
 
 	// The execution kind of the operation.
 	ExecKind string
+
+	// ShowSecrets is true if the engine should display secrets in the CLI.
+	ShowSecrets bool
 }
 
 // HasChanges returns true if there are any non-same changes in the resulting summary.
@@ -202,7 +205,6 @@ func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (
 ) {
 	contract.Requiref(u != nil, "update", "cannot be nil")
 	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
-
 	defer func() { ctx.Events <- NewCancelEvent() }()
 
 	info, err := newDeploymentContext(u, "update", ctx.ParentSpan)
@@ -585,8 +587,7 @@ func (acts *updateActions) OnResourceStepPre(step deploy.Step) (interface{}, err
 	acts.MapLock.Lock()
 	acts.Seen[step.URN()] = step
 	acts.MapLock.Unlock()
-
-	acts.Opts.Events.resourcePreEvent(step, false /*planning*/, acts.Opts.Debug, isInternalStep(step))
+	acts.Opts.Events.resourcePreEvent(step, false /*planning*/, acts.Opts.Debug, isInternalStep(step), acts.Opts.ShowSecrets)
 
 	// Inform the snapshot service that we are about to perform a step.
 	return acts.Context.SnapshotManager.BeginMutation(step)
@@ -621,7 +622,7 @@ func (acts *updateActions) OnResourceStepPost(
 
 		// Issue a true, bonafide error.
 		acts.Opts.Diag.Errorf(diag.GetResourceOperationFailedError(errorURN), err)
-		acts.Opts.Events.resourceOperationFailedEvent(step, status, acts.Steps, acts.Opts.Debug)
+		acts.Opts.Events.resourceOperationFailedEvent(step, status, acts.Steps, acts.Opts.Debug, acts.Opts.ShowSecrets)
 	} else {
 		op, record := step.Op(), step.Logical()
 		if acts.Opts.isRefresh && op == deploy.OpRefresh {
@@ -646,7 +647,7 @@ func (acts *updateActions) OnResourceStepPost(
 		// the Pulumi program, as component resources only report outputs via calls to RegisterResourceOutputs.
 		// Deletions emit the resourceOutputEvent so the display knows when to stop the time elapsed counter.
 		if step.Res().Custom || acts.Opts.Refresh && step.Op() == deploy.OpRefresh || step.Op() == deploy.OpDelete {
-			acts.Opts.Events.resourceOutputsEvent(op, step, false /*planning*/, acts.Opts.Debug, isInternalStep)
+			acts.Opts.Events.resourceOutputsEvent(op, step, false /*planning*/, acts.Opts.Debug, isInternalStep, acts.Opts.ShowSecrets)
 		}
 	}
 
@@ -687,7 +688,7 @@ func (acts *updateActions) OnResourceOutputs(step deploy.Step) error {
 	assertSeen(acts.Seen, step)
 	acts.MapLock.Unlock()
 
-	acts.Opts.Events.resourceOutputsEvent(step.Op(), step, false /*planning*/, acts.Opts.Debug, isInternalStep(step))
+	acts.Opts.Events.resourceOutputsEvent(step.Op(), step, false /*planning*/, acts.Opts.Debug, isInternalStep(step), acts.Opts.ShowSecrets)
 
 	// There's a chance there are new outputs that weren't written out last time.
 	// We need to perform another snapshot write to ensure they get written out.
@@ -749,7 +750,7 @@ func (acts *previewActions) OnResourceStepPre(step deploy.Step) (interface{}, er
 	acts.Seen[step.URN()] = step
 	acts.MapLock.Unlock()
 
-	acts.Opts.Events.resourcePreEvent(step, true /*planning*/, acts.Opts.Debug, isInternalStep(step))
+	acts.Opts.Events.resourcePreEvent(step, true /*planning*/, acts.Opts.Debug, isInternalStep(step), acts.Opts.ShowSecrets)
 
 	return nil, nil
 }
@@ -790,7 +791,7 @@ func (acts *previewActions) OnResourceStepPost(ctx interface{},
 			acts.MapLock.Unlock()
 		}
 
-		acts.Opts.Events.resourceOutputsEvent(op, step, true /*planning*/, acts.Opts.Debug, isInternalStep)
+		acts.Opts.Events.resourceOutputsEvent(op, step, true /*planning*/, acts.Opts.Debug, isInternalStep, acts.Opts.ShowSecrets)
 	}
 
 	return nil
@@ -802,7 +803,7 @@ func (acts *previewActions) OnResourceOutputs(step deploy.Step) error {
 	acts.MapLock.Unlock()
 
 	// Print the resource outputs separately.
-	acts.Opts.Events.resourceOutputsEvent(step.Op(), step, true /*planning*/, acts.Opts.Debug, isInternalStep(step))
+	acts.Opts.Events.resourceOutputsEvent(step.Op(), step, true /*planning*/, acts.Opts.Debug, isInternalStep(step), acts.Opts.ShowSecrets)
 
 	return nil
 }


### PR DESCRIPTION
This PR tries to solve https://github.com/pulumi/pulumi/issues/9830
I expected the change to be simpler but since `filterPropertyValues` override any secret with the `[secret]` ([here](https://github.com/pulumi/pulumi/blob/master/pkg/engine/events.go#L685)) value I needed to change that first.

I will add some new tests, update the `preview` command as well, and add a changelog. But first I'd like some feedback to make sure that I started in the correct direction and that I did not miss something.