### PR TITLE
Remove unused `pulumi new` template code

### DIFF
--- a/pkg/cmd/pulumi/newcmd/new.go
+++ b/pkg/cmd/pulumi/newcmd/new.go
@@ -628,7 +628,7 @@ func NewNewCmd() *cobra.Command {
 					logging.Warningf("could not list templates: %v", err)
 					return err
 				}
-				available, _ := templatesToOptionArrayAndMap(templates, true)
+				available, _ := templatesToOptionArrayAndMap(templates)
 				fmt.Println("")
 				fmt.Println("Available Templates:")
 				for _, t := range available {

--- a/pkg/cmd/pulumi/newcmd/template.go
+++ b/pkg/cmd/pulumi/newcmd/template.go
@@ -46,7 +46,7 @@ func ChooseTemplate(templates []workspace.Template, opts display.Options) (works
 	// Customize the prompt a little bit (and disable color since it doesn't match our scheme).
 	surveycore.DisableColor = true
 
-	options, optionToTemplateMap := templatesToOptionArrayAndMap(templates, true)
+	options, optionToTemplateMap := templatesToOptionArrayAndMap(templates)
 	nopts := len(options)
 	pageSize := cmd.OptimalPageSize(cmd.OptimalPageSizeOpts{Nopts: nopts})
 	message := fmt.Sprintf("\rPlease choose a template (%d total):\n", nopts)
@@ -66,9 +66,7 @@ func ChooseTemplate(templates []workspace.Template, opts display.Options) (works
 
 // templatesToOptionArrayAndMap returns an array of option strings and a map of option strings to templates.
 // Each option string is made up of the template name and description with some padding in between.
-func templatesToOptionArrayAndMap(templates []workspace.Template,
-	showAll bool,
-) ([]string, map[string]workspace.Template) {
+func templatesToOptionArrayAndMap(templates []workspace.Template) ([]string, map[string]workspace.Template) {
 	// Find the longest name length. Used to add padding between the name and description.
 	maxNameLength := 0
 	for _, template := range templates {
@@ -82,10 +80,6 @@ func templatesToOptionArrayAndMap(templates []workspace.Template,
 	var brokenOptions []string
 	nameToTemplateMap := make(map[string]workspace.Template)
 	for _, template := range templates {
-		// If showAll is false, then only include templates marked Important
-		if !showAll && !template.Important {
-			continue
-		}
 		// If template is broken, indicate it in the project description.
 		if template.Errored() {
 			template.ProjectDescription = BrokenTemplateDescription
@@ -105,12 +99,6 @@ func templatesToOptionArrayAndMap(templates []workspace.Template,
 	// After sorting the options, add the broken templates to the end
 	sort.Strings(options)
 	options = append(options, brokenOptions...)
-
-	if !showAll {
-		// If showAll is false, include an option to show all
-		option := "Show additional templates"
-		options = append(options, option)
-	}
 
 	return options, nameToTemplateMap
 }

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -83,6 +83,8 @@ type ProjectTemplate struct {
 	// Config is an optional template config.
 	Config map[string]ProjectTemplateConfigValue `json:"config,omitempty" yaml:"config,omitempty"`
 	// Important indicates the template is important.
+	//
+	// Deprecated: We don't use this field any more.
 	Important bool `json:"important,omitempty" yaml:"important,omitempty"`
 	// Metadata are key/value pairs used to attach additional metadata to a template.
 	Metadata map[string]string `json:"metadata,omitempty" yaml:"metadata,omitempty"`

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -202,7 +202,6 @@ type Template struct {
 	Description string                                // Description of the template.
 	Quickstart  string                                // Optional text to be displayed after template creation.
 	Config      map[string]ProjectTemplateConfigValue // Optional template config.
-	Important   bool                                  // Indicates whether the template should be listed by default.
 	Error       error                                 // Non-nil if the template is broken.
 
 	ProjectName        string // Name of the project.
@@ -476,7 +475,6 @@ func LoadTemplate(path string) (Template, error) {
 		template.Description = proj.Template.Description
 		template.Quickstart = proj.Template.Quickstart
 		template.Config = proj.Template.Config
-		template.Important = proj.Template.Important
 	}
 	if proj.Description != nil {
 		template.ProjectDescription = *proj.Description


### PR DESCRIPTION
This PR applies two refactors:

- It removes the `Important` field from our template presentation layer, since we don't do anything with it in our code.
- It removes the `showAll` parameter from `templatesToOptionArrayAndMap`, since it is always set to `true`.

Neither change has any effect on the behavior of the built binary.