### PR TITLE
Define template groups

### DIFF
--- a/pkg/cmd/pulumi/newcmd/new.go
+++ b/pkg/cmd/pulumi/newcmd/new.go
@@ -628,7 +628,9 @@ func NewNewCmd() *cobra.Command {
 					logging.Warningf("could not list templates: %v", err)
 					return err
 				}
-				available, _ := templatesToOptionArrayAndMap(templates)
+				available, _ := templatesToOptionArrayAndMap(templates, func(t workspace.Template) template {
+					return template(t)
+				})
 				fmt.Println("")
 				fmt.Println("Available Templates:")
 				for _, t := range available {

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -82,6 +82,9 @@ type ProjectTemplate struct {
 	Quickstart string `json:"quickstart,omitempty" yaml:"quickstart,omitempty"`
 	// Config is an optional template config.
 	Config map[string]ProjectTemplateConfigValue `json:"config,omitempty" yaml:"config,omitempty"`
+
+	GroupMember *ProjectTemplateGroupMember `json:"groupMember,omitempty" yaml:"groupMember,omitempty"`
+
 	// Important indicates the template is important.
 	//
 	// Deprecated: We don't use this field any more.
@@ -98,6 +101,12 @@ type ProjectTemplateConfigValue struct {
 	Default string `json:"default,omitempty" yaml:"default,omitempty"`
 	// Secret may be set to true to indicate that the config value should be encrypted.
 	Secret bool `json:"secret,omitempty" yaml:"secret,omitempty"`
+}
+
+type ProjectTemplateGroupMember struct {
+	GroupName        string `json:"groupName,omitempty" yaml:"groupName,omitempty"`
+	InGroupName      string `json:"inGroupName,omitempty" yaml:"inGroupName,omitempty"`
+	GroupDescription string `json:"groupDescription,omitempty" yaml:"groupDescription,omitempty"`
 }
 
 // ProjectBackend is the configuration for where the backend state is stored. If unset, will use the

--- a/sdk/go/common/workspace/project.json
+++ b/sdk/go/common/workspace/project.json
@@ -156,6 +156,13 @@
                         "null"
                     ]
                 },
+                "groupMember":{
+                    "description": "The group if the template is a member of the group.",
+                    "type":[
+                        "object",
+                        "null"
+                    ]
+                },
                 "description":{
                     "description":"Description of the template.",
                     "type":[

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -203,9 +203,28 @@ type Template struct {
 	Quickstart  string                                // Optional text to be displayed after template creation.
 	Config      map[string]ProjectTemplateConfigValue // Optional template config.
 	Error       error                                 // Non-nil if the template is broken.
+	Group       *TemplateGroupMembership              // The group the template belongs to, if any.
 
 	ProjectName        string // Name of the project.
 	ProjectDescription string // Optional description of the project.
+}
+
+type TemplateGroupMembership struct {
+	// The name of the group the template belongs to.
+	//
+	// This name must match other members of the template group (by definition).
+	GroupName string
+
+	// The description of the entire group. GroupDescription may be set on any number of group
+	// members, but it must match for all non-empty members.
+	GroupDescription string
+
+	// The name of the template in the context of a group.
+	//
+	// For example, consider the template group "aivien" with members "aiven-python",
+	// "aiven-typescript", "aiven-python". The InGroupName of "aiven-python" might be "python",
+	// since "python" uniquely identifies the project in the context of the "aiven" group.
+	InGroupName string
 }
 
 // Errored returns if the template has an error
@@ -475,6 +494,14 @@ func LoadTemplate(path string) (Template, error) {
 		template.Description = proj.Template.Description
 		template.Quickstart = proj.Template.Quickstart
 		template.Config = proj.Template.Config
+
+		if group := proj.Template.GroupMember; group != nil {
+			template.Group = &TemplateGroupMembership{
+				GroupName:        group.GroupName,
+				InGroupName:      group.InGroupName,
+				GroupDescription: group.GroupDescription,
+			}
+		}
 	}
 	if proj.Description != nil {
 		template.ProjectDescription = *proj.Description


### PR DESCRIPTION
Allow templates to define groups for display purposes. This improves the `pulumi new` experience by reducing the number of effective templates by 4.

Each template that wants to participate in a group would add a `groupMember` section:

```patch
 name: ${PROJECT}
 description: ${DESCRIPTION}
 runtime: go
 template:
   description: A minimal Aiven Go Pulumi program
+  groupMember:
+    groupName: aiven
+    inGroupName: go
+    groupDescription: A minimal Aiven Pulumi program
   config:
     aiven:apiToken:
       description: The token that allows you access to your Aiven account
       secret: true
```

Then the user would have `"aiven"` displayed during template selection, and if they selected `"aiven"` then they would see the individual templates.

## DO NOT MERGE

This is a **not** a backwards compatible change. Unfortunately, [JSON schema validation](https://github.com/pulumi/pulumi/blob/285ce466123a7551d24c9762c88966e682fb2804/sdk/go/common/workspace/project.go#L398-L402) means that adding **any** field to a project is breaking, so additive changes are not possible!

This was originally intended to be a mergable (backwards compatible) change, but I learned during implementation that this would prevent old version of `pulumi` from consuming updated templates.

Related to https://github.com/pulumi/pulumi/issues/7823 (since reducing the template count would reduce flickering).