### PR TITLE
Apply autonaming strategy only to custom resources, not components

### DIFF
--- a/changelog/pending/20250210--engine--apply-autonaming-strategy-only-to-custom-resources-not-components.yaml
+++ b/changelog/pending/20250210--engine--apply-autonaming-strategy-only-to-custom-resources-not-components.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Apply autonaming strategy only to custom resources, not components

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -624,7 +624,7 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, err
 			"generated fewer (%d) than expected (%d) random bytes", n, len(randomSeed))
 	}
 	var autonaming *plugin.AutonamingOptions
-	if sg.deployment.opts.Autonamer != nil {
+	if sg.deployment.opts.Autonamer != nil && goal.Custom {
 		var dbr bool
 		autonaming, dbr = sg.deployment.opts.Autonamer.AutonamingForResource(urn, randomSeed)
 		// If autonaming settings had no randomness in the name, we must delete before creating a replacement.

--- a/tests/integration/autonaming/index.ts
+++ b/tests/integration/autonaming/index.ts
@@ -9,5 +9,14 @@ class Named extends pulumi.CustomResource {
     }
 }
 
+class MyComponent extends pulumi.ComponentResource {
+    constructor(name: string) {
+        // We have a type of shape provider:resourcename without a module name intentionally,
+        // to test against regressing https://github.com/pulumi/pulumi/issues/18499.
+        super('testprovider:my-component', name);
+    }
+}
+
 export let autoName = new Named("test1").name;
 export let explicitName = new Named("test2", "explicit-name").name;
+export let componentUrn = new MyComponent("test3").urn;

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2338,6 +2338,8 @@ func TestAutonaming(t *testing.T) {
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					assert.Equal(t, "explicit-name", stackInfo.RootResource.Outputs["explicitName"])
 					assert.Equal(t, tc.autoName, stackInfo.RootResource.Outputs["autoName"])
+					assert.True(t, strings.HasSuffix(stackInfo.RootResource.Outputs["componentUrn"].(string), "::test3"),
+						"Expected componentUrn to end with '::test3', got %v", stackInfo.RootResource.Outputs["componentUrn"])
 				},
 			})
 		})


### PR DESCRIPTION
We currently try calculating auto-naming strategy even for component resources, which doesn't make much sense. It turns out components can have type tokens of arbitrary shape (i.e. not necessarily `package:module:name` but can be anything), which trips our autonaming calculation expectations.

The PR dodges that problem by (correctly) not calculating any autonaming strategy for component resources, only for custom resources.

An integration test creates a component resource with an unusual type token and makes sure the deployment goes well and component URN is what we expect (there is no `name` property).

Resolve https://github.com/pulumi/pulumi/issues/18499