### PR TITLE
Always close `workspace.TemplatesRepository`

### DIFF
--- a/pkg/cmd/pulumi/newcmd/new.go
+++ b/pkg/cmd/pulumi/newcmd/new.go
@@ -559,6 +559,7 @@ func NewNewCmd() *cobra.Command {
 			logging.Warningf("could not retrieve templates: %v", err)
 			return []workspace.Template{}, err
 		}
+		defer func() { contract.IgnoreError(repo.Delete()) }()
 
 		// Get the list of templates.
 		return repo.Templates()


### PR DESCRIPTION
This PR just adds a missing call to `repo.Delete()` in `newcmd/new.go`.