### PR TITLE
package add: avoid panic when Pulumi.yaml is invalid

### DIFF
--- a/changelog/pending/20250211--cli-package--avoid-panicing-when-the-project-file-is-invalid.yaml
+++ b/changelog/pending/20250211--cli-package--avoid-panicing-when-the-project-file-is-invalid.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/package
+  description: Avoid panic'ing when the project file is invalid

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -15,7 +15,6 @@
 package packagecmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,7 +24,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -67,7 +65,7 @@ extension, Pulumi package schema is read from it directly:
 		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ws := pkgWorkspace.Instance
 			proj, root, err := ws.ReadProject()
-			if err != nil && errors.Is(err, workspace.ErrProjectNotFound) {
+			if err != nil {
 				return err
 			}
 


### PR DESCRIPTION
In `pulumi package add`, we first read the project, and then use that information.  There is some error checking there, however we only error out if the project is not found, and not for other errors reading the project.

Continuing when there is an error reading the project just leads to potential panics down the line.  E.g. if the project isn't read successfully, we panic in the next lines trying to get the name of the project.

Just error out consistently if there is an error reading the project instead, so the user gets a better hint of what is wrong and why the command is not working rather than a panic.

Fixes https://github.com/pulumi/pulumi/issues/18531

/cc @lunaris, I see you introduced this check when introducing the `package add` command, though neither the PR nor any of the reviews called this out in https://github.com/pulumi/pulumi/pull/16923.  Do you by any chance remember why this extra condition was here, or if it was just an oversight?