### PR TITLE
add more info when command installation fails

### DIFF
--- a/changelog/pending/20250211--auto-go--include-stderr-when-installpulumicommand-fails.yaml
+++ b/changelog/pending/20250211--auto-go--include-stderr-when-installpulumicommand-fails.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Include stderr when InstallPulumiCommand fails

--- a/sdk/go/auto/cmd.go
+++ b/sdk/go/auto/cmd.go
@@ -17,6 +17,7 @@ package auto
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -231,6 +232,10 @@ func installWindows(ctx context.Context, version semver.Version, root string) er
 	cmd := exec.CommandContext(ctx, command, args...)
 	out, err := cmd.Output()
 	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return fmt.Errorf("installation failed with %w\nSTDOUT: %s\nSTDERR: %s", err, out, string(exitErr.Stderr))
+		}
 		return fmt.Errorf("installation failed with %w: %s", err, out)
 	}
 	return nil
@@ -250,6 +255,10 @@ func installPosix(ctx context.Context, version semver.Version, root string) erro
 	cmd := exec.CommandContext(ctx, scriptPath, args...)
 	out, err := cmd.Output()
 	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return fmt.Errorf("installation failed with %w\nSTDOUT: %s\nSTDERR: %s", err, out, string(exitErr.Stderr))
+		}
 		return fmt.Errorf("installation failed with %w: %s", err, out)
 	}
 	return nil


### PR DESCRIPTION
When the command installation fails, we currently include the error and stdout. `exec.ExitError` also contains the stderr of the command, which is often more relevant when there is a failure, but hides it away unless it's specifically used.

Add it to the error we return from `InstallPulumiCommand`.  This will hopefully help debugging CI failures we've been dealing with today, but also more generally should help users debug why the command fails if it does.