### PR TITLE
Fix python source positions for new SDKs

### DIFF
--- a/changelog/pending/20250212--sdk-python--fix-source-position-information-to-point-to-user-code-not-provider-sdks.yaml
+++ b/changelog/pending/20250212--sdk-python--fix-source-position-information-to-point-to-user-code-not-provider-sdks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix source position information to point to user code, not provider SDKs

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -659,21 +659,42 @@ def _translate_replace_on_changes(
     return replace_on_changes
 
 
-def _get_source_position(skip: int) -> Optional[source_pb2.SourcePosition]:
+def _get_source_position() -> Optional[source_pb2.SourcePosition]:
     """
-    Returns the source position of the Nth stack frame, where N is skip+1.
+    Returns the source position of the first stack frame in user code. This should look up to find what called into the
+    core sdk (i.e. Resource.__init__) and then skip that caller type if it is a Resource or ComponentResource.
 
-    This is used to compute the source position of the user code that instantiated a resource. The number of frames to
-    skip is parameterized in order to account for differing call stacks for different operations.
+    This is used to compute the source position of the user code that instantiated a resource.
     """
+    
+    # This is somewhat brittle in that it expects a call stack of the form:
+    # - register_resource/read_resource
+    # - Resource class constructor
+    # - abstract Resource subclass constructor (CustomResource or ComponentResource)
+    # - concrete Resource subclass constructor (this maybe split into __internal_init__)
+    # - user code
+    #
+    # This stack reflects the expected class hierarchy of "cloud resource / component resource < customresource/componentresource < resource".
 
-    # Capture a stack that includes the Nth stack frame. If the stack is not deep enough, return the empty string.
-    stack = traceback.extract_stack(limit=skip + 2)
-    if len(stack) < skip + 2:
+    # Capture a stack that includes the last 7 frames, this should be enough to cover the above.
+    stack = traceback.extract_stack(limit=7)
+
+    # Look up the stack to find the third __init__ frame (the first is Resource, the second is
+    # CustomResource/ComponentResource, the third should be the concrete resource, including skipping any __internal_init__ function)
+    n = 0 # how many __inits__ we've seen
+    for i in range(len(stack) - 1, -1, -1):
+        f = stack[i]
+        if f.name == "__init__":
+            n = n + 1
+            if n == 3:
+                break
+    
+    # If we didn't find the third init frame before the end then just return None
+    if i < 1:
         return None
 
-    # Extract the Nth stack frame. If that frame is missing file or line information, return the empty string.
-    caller = stack[0]
+    # Extract the Ith stack frame. If that frame is missing file or line information, return the empty string.
+    caller = stack[i-1]
     if caller.filename == "" or caller.lineno is None:
         return None
 
@@ -682,7 +703,7 @@ def _get_source_position(skip: int) -> Optional[source_pb2.SourcePosition]:
     except BaseException:  # noqa: BLE001 catch blind exception
         return None
 
-    # Convert the Nth source position to a source position URI by converting the filename to a URI and appending
+    # Convert the Ith source position to a source position URI by converting the filename to a URI and appending
     # the line and column fragment.
     return source_pb2.SourcePosition(uri=uri, line=caller.lineno)
 
@@ -726,16 +747,7 @@ def read_resource(
     resolvers = rpc.transfer_properties(res, props, custom)
 
     # Get the source position.
-    #
-    # This is somewhat brittle in that it expects a call stack of the form:
-    # - read_resource
-    # - Resource class constructor
-    # - abstract Resource subclass constructor
-    # - concrete Resource subclass constructor
-    # - user code
-    #
-    # This stack reflects the expected class hierarchy of "cloud resource / component resource < customresource/componentresource < resource".
-    source_position = _get_source_position(4)
+    source_position = _get_source_position()
 
     async def do_read():
         try:
@@ -900,16 +912,7 @@ def register_resource(
     resolvers = rpc.transfer_properties(res, props, custom)
 
     # Get the source position.
-    #
-    # This is somewhat brittle in that it expects a call stack of the form:
-    # - register_resource
-    # - Resource class constructor
-    # - abstract Resource subclass constructor
-    # - concrete Resource subclass constructor
-    # - user code
-    #
-    # This stack reflects the expected class hierarchy of "cloud resource / component resource < customresource/componentresource < resource".
-    source_position = _get_source_position(4)
+    source_position = _get_source_position()
 
     async def do_register() -> None:
         try:

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -666,7 +666,7 @@ def _get_source_position() -> Optional[source_pb2.SourcePosition]:
 
     This is used to compute the source position of the user code that instantiated a resource.
     """
-    
+
     # This is somewhat brittle in that it expects a call stack of the form:
     # - register_resource/read_resource
     # - Resource class constructor
@@ -681,20 +681,20 @@ def _get_source_position() -> Optional[source_pb2.SourcePosition]:
 
     # Look up the stack to find the third __init__ frame (the first is Resource, the second is
     # CustomResource/ComponentResource, the third should be the concrete resource, including skipping any __internal_init__ function)
-    n = 0 # how many __inits__ we've seen
+    n = 0  # how many __inits__ we've seen
     for i in range(len(stack) - 1, -1, -1):
         f = stack[i]
         if f.name == "__init__":
             n = n + 1
             if n == 3:
                 break
-    
+
     # If we didn't find the third init frame before the end then just return None
     if i < 1:
         return None
 
     # Extract the Ith stack frame. If that frame is missing file or line information, return the empty string.
-    caller = stack[i-1]
+    caller = stack[i - 1]
     if caller.filename == "" or caller.lineno is None:
         return None
 

--- a/sdk/python/lib/test/langhost/source_position/__main__.py
+++ b/sdk/python/lib/test/langhost/source_position/__main__.py
@@ -16,6 +16,9 @@ from pulumi import ComponentResource, CustomResource
 
 class MyResource(CustomResource):
     def __init__(self, name, opts=None):
+        self.__internal_init__(name, opts)
+
+    def __internal_init__(self, name, opts):
         CustomResource.__init__(
             self, "test:index:MyResource", name, props={}, opts=opts
         )

--- a/sdk/python/lib/test/langhost/source_position/test_source_position.py
+++ b/sdk/python/lib/test/langhost/source_position/test_source_position.py
@@ -43,15 +43,15 @@ class SourcePositionTest(LanghostTest):
         _providers,
         source_position,
     ):
-        assert source_position is not None
-        assert source_position.uri.endswith("__main__.py")
+        self.assertIsNotNone(source_position)
+        self.assertTrue(source_position.uri.endswith("__main__.py"), source_position.uri)
 
         if name == "custom":
-            self.assertEqual(source_position.line, 31)
+            self.assertEqual(source_position.line, 34)
         elif name == "component":
-            self.assertEqual(source_position.line, 32)
+            self.assertEqual(source_position.line, 35)
         else:
-            assert False
+            self.fail("unexpected name: " + name)
 
         return {
             "urn": self.make_urn(ty, name),

--- a/sdk/python/lib/test/langhost/source_position/test_source_position.py
+++ b/sdk/python/lib/test/langhost/source_position/test_source_position.py
@@ -44,7 +44,9 @@ class SourcePositionTest(LanghostTest):
         source_position,
     ):
         self.assertIsNotNone(source_position)
-        self.assertTrue(source_position.uri.endswith("__main__.py"), source_position.uri)
+        self.assertTrue(
+            source_position.uri.endswith("__main__.py"), source_position.uri
+        )
 
         if name == "custom":
             self.assertEqual(source_position.line, 34)


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/18478

At some point python SDKs started using an `__internal_init__` method as part of generated resource constructors. This changed the expected height of user code in the stack traces we grab for setting `sourcePosition` and our tests never picked this up because they used a handwritten SDK that only had an `__init__` method.

This updates the test so that one resource has an `__internal_init__` that is called by `__init__` and then fixes `get_source_position` so it can handle both cases. It does this by looking up the stack for the third `__init__` call and then picking the frame above that. 

Still a bit brittle, but I think it's the best you can do by just looking at function names, and we're probably not going to add anymore classes into the inheritance chain.