### PR TITLE
Add BulkEncrypt method for snapshot serialization

### DIFF
--- a/changelog/pending/20250212--engine--add-bulkencrypt-for-snapshot-serialization.yaml
+++ b/changelog/pending/20250212--engine--add-bulkencrypt-for-snapshot-serialization.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Add BulkEncrypt for snapshot serialization

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -492,7 +492,7 @@ func (pc *Client) BulkEncrypt(ctx context.Context, stack StackIdentifier,
 ) ([][]byte, error) {
 	req := apitype.BulkEncryptRequest{Plaintexts: plaintexts}
 	var resp apitype.BulkEncryptResponse
-	if err := pc.restCallWithOptions(ctx, "POST", getStackPath(stack, "bulk-encrypt"), nil, &req, &resp,
+	if err := pc.restCallWithOptions(ctx, "POST", getStackPath(stack, "batch-encrypt"), nil, &req, &resp,
 		httpCallOptions{GzipCompress: true, RetryPolicy: retryAllMethods}); err != nil {
 		return nil, err
 	}

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -138,6 +138,14 @@ func (csm *cachingSecretsManager) EncryptValue(ctx context.Context, plaintext st
 	return csm.encrypter.Value().EncryptValue(ctx, plaintext)
 }
 
+func (csm *cachingSecretsManager) SupportsBulkEncryption(ctx context.Context) bool {
+	return csm.manager.Encrypter().SupportsBulkEncryption(ctx)
+}
+
+func (csm *cachingSecretsManager) BulkEncrypt(ctx context.Context, plaintexts []string) ([]string, error) {
+	return csm.manager.Encrypter().BulkEncrypt(ctx, plaintexts)
+}
+
 func (csm *cachingSecretsManager) DecryptValue(ctx context.Context, ciphertext string) (string, error) {
 	return csm.decrypter.Value().DecryptValue(ctx, ciphertext)
 }

--- a/pkg/resource/stack/secrets_test.go
+++ b/pkg/resource/stack/secrets_test.go
@@ -89,10 +89,11 @@ func deserializeProperty(v interface{}, dec config.Decrypter) (resource.Property
 	if err != nil {
 		return resource.PropertyValue{}, err
 	}
-	if err := json.Unmarshal(b, &v); err != nil {
+	var v2 interface{}
+	if err := json.Unmarshal(b, &v2); err != nil {
 		return resource.PropertyValue{}, err
 	}
-	return DeserializePropertyValue(v, dec)
+	return DeserializePropertyValue(v2, dec)
 }
 
 func TestCachingCrypter(t *testing.T) {

--- a/pkg/resource/stack/secrets_test.go
+++ b/pkg/resource/stack/secrets_test.go
@@ -33,8 +33,9 @@ import (
 )
 
 type testSecretsManager struct {
-	encryptCalls int
-	decryptCalls int
+	encryptCalls         int
+	decryptCalls         int
+	enableBulkEncryption bool
 }
 
 func (t *testSecretsManager) Type() string { return "test" }
@@ -54,6 +55,16 @@ func (t *testSecretsManager) EncryptValue(
 ) (string, error) {
 	t.encryptCalls++
 	return fmt.Sprintf("%v:%v", t.encryptCalls, plaintext), nil
+}
+
+func (t *testSecretsManager) SupportsBulkEncryption(ctx context.Context) bool {
+	return t.enableBulkEncryption
+}
+
+func (t *testSecretsManager) BulkEncrypt(
+	ctx context.Context, secrets []string,
+) ([]string, error) {
+	return config.DefaultBulkEncrypt(ctx, t, secrets)
 }
 
 func (t *testSecretsManager) DecryptValue(

--- a/pkg/secrets/mock.go
+++ b/pkg/secrets/mock.go
@@ -65,7 +65,8 @@ func (msm *MockSecretsManager) Decrypter() config.Decrypter {
 }
 
 type MockEncrypter struct {
-	EncryptValueF func() string
+	EncryptValueF    func() string
+	AllowBulkEncrypt bool
 }
 
 func (me *MockEncrypter) EncryptValue(ctx context.Context, plaintext string) (string, error) {
@@ -74,6 +75,14 @@ func (me *MockEncrypter) EncryptValue(ctx context.Context, plaintext string) (st
 	}
 
 	return "", errors.New("mock value not provided")
+}
+
+func (me *MockEncrypter) SupportsBulkEncryption(ctx context.Context) bool {
+	return me.AllowBulkEncrypt
+}
+
+func (me *MockEncrypter) BulkEncrypt(ctx context.Context, secrets []string) ([]string, error) {
+	return config.DefaultBulkEncrypt(ctx, me, secrets)
 }
 
 type MockDecrypter struct {

--- a/pkg/secrets/mock.go
+++ b/pkg/secrets/mock.go
@@ -65,8 +65,8 @@ func (msm *MockSecretsManager) Decrypter() config.Decrypter {
 }
 
 type MockEncrypter struct {
-	EncryptValueF    func() string
-	AllowBulkEncrypt bool
+	EncryptValueF func() string
+	BulkEncryptF  func() []string
 }
 
 func (me *MockEncrypter) EncryptValue(ctx context.Context, plaintext string) (string, error) {
@@ -78,11 +78,14 @@ func (me *MockEncrypter) EncryptValue(ctx context.Context, plaintext string) (st
 }
 
 func (me *MockEncrypter) SupportsBulkEncryption(ctx context.Context) bool {
-	return me.AllowBulkEncrypt
+	return me.BulkEncryptF != nil
 }
 
 func (me *MockEncrypter) BulkEncrypt(ctx context.Context, secrets []string) ([]string, error) {
-	return config.DefaultBulkEncrypt(ctx, me, secrets)
+	if me.BulkEncryptF == nil {
+		return nil, errors.New("mock value not provided")
+	}
+	return me.BulkEncryptF(), nil
 }
 
 type MockDecrypter struct {

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -422,6 +422,15 @@ func (ec *errorCrypter) EncryptValue(ctx context.Context, _ string) (string, err
 		"correct passphrase or set PULUMI_CONFIG_PASSPHRASE_FILE to a file containing the passphrase")
 }
 
+func (*errorCrypter) SupportsBulkEncryption(ctx context.Context) bool {
+	return false
+}
+
+func (ec *errorCrypter) BulkEncrypt(ctx context.Context, _ []string) ([]string, error) {
+	return nil, errors.New("failed to encrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the " +
+		"correct passphrase or set PULUMI_CONFIG_PASSPHRASE_FILE to a file containing the passphrase")
+}
+
 func (ec *errorCrypter) DecryptValue(ctx context.Context, _ string) (string, error) {
 	return "", errors.New("failed to decrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the " +
 		"correct passphrase or set PULUMI_CONFIG_PASSPHRASE_FILE to a file containing the passphrase")

--- a/sdk/go/common/resource/config/crypt.go
+++ b/sdk/go/common/resource/config/crypt.go
@@ -51,25 +51,6 @@ type Decrypter interface {
 	BulkDecrypt(ctx context.Context, ciphertexts []string) ([]string, error)
 }
 
-// DefaultBulkDecrypt decrypts a list of ciphertexts. Each ciphertext is decrypted sequentially. The returned
-// list of ciphertexts is in the same order as the input list. This should only be used by implementers of Decrypter
-// to implement their BulkDecrypt method in cases where they can't do more efficient than just individual operations.
-func DefaultBulkEncrypt(ctx context.Context, encrypter Encrypter, secrets []string) ([]string, error) {
-	if len(secrets) == 0 {
-		return nil, nil
-	}
-
-	encrypted := make([]string, len(secrets))
-	for i, secret := range secrets {
-		enc, err := encrypter.EncryptValue(ctx, secret)
-		if err != nil {
-			return nil, err
-		}
-		encrypted[i] = enc
-	}
-	return encrypted, nil
-}
-
 // Crypter can both encrypt and decrypt values.
 type Crypter interface {
 	Encrypter

--- a/tests/performance/performance_test.go
+++ b/tests/performance/performance_test.go
@@ -91,3 +91,23 @@ func TestPerfParentChainUpdate(t *testing.T) {
 		},
 	})
 }
+
+//nolint:paralleltest // Do not run in parallel to avoid resource contention
+func TestPerfSecretsBatchUpdate(t *testing.T) {
+	benchmarkEnforcer := &integration.AssertPerfBenchmark{
+		T:                  t,
+		MaxPreviewDuration: 5 * time.Second,
+		MaxUpdateDuration:  5 * time.Second,
+	}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		NoParallel: true,
+		Dir:        filepath.Join("python", "secrets"),
+		Dependencies: []string{
+			filepath.Join("..", "..", "sdk", "python"),
+		},
+		Quick:          false,
+		RequireService: true,
+		ReportStats:    benchmarkEnforcer,
+	})
+}

--- a/tests/performance/python/secrets/Pulumi.yaml
+++ b/tests/performance/python/secrets/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: perf-parents
+runtime: python

--- a/tests/performance/python/secrets/__main__.py
+++ b/tests/performance/python/secrets/__main__.py
@@ -1,0 +1,6 @@
+# Copyright 2024, Pulumi Corporation.
+
+from pulumi import Output, export
+
+for i in range(1, 100):
+    export(f"echo-{i}", Output.secret(Output.from_input(i)))


### PR DESCRIPTION
Making a round-trip to the service for each secret as it's found during serialization is slow. Therefore, we want to find all the secrets we're going to serialize, fetch them in a single bulk request to the service.

Fixes https://github.com/pulumi/home/issues/3896
Fixes https://github.com/pulumi/home/issues/3898
Fixes https://github.com/pulumi/pulumi/issues/15538
Fixes https://github.com/pulumi/pulumi/issues/15293
Fixes https://github.com/pulumi/pulumi/issues/17660

## Design notes

Initially this was going to be designed similarly to the bulk decrypt approach - doing two passes through the object structure at the point of of serialization - once to collect all the secrets, then a second after resolving the secrets via a bulk request.

However, this approach would either require writing completely new methods for locating and serializing the secrets within the deployment snapshot or would call the existing serialize method while passing in a fake encrypter which just captures the values, then throwing away the incomplete serialized object.

Instead, we do a single pass through the serialization, but the bulk encrypter captures pointers to every secret. Once the serialized snapshot has been built, the captured secrets are encrypted in a bulk request then written back to the captured pointers, updating the serialized snapshot. Some serialize methods are called directly, sometimes passing a `cachingSecretsManager` instance. Using this delayed secrets processing requires the caller to call a `completeBulkOperation` method. To ensure the bulk 

Instead, we've come to a design where, if we wrap the serialization process in something like a transaction, where encryption tasks are enqueued, then encrypted in bulk and written back to the target secret at the point of completion. This avoids accidental delaying of encryption by a caller 

### Follow up

We should re-use the same pattern for the bulk decryption too - capturing a pointer to the target secret and delaying the population of the actual value. We can then also combe the cache from the bulk decryption request into the same class as is used for this new bulk encryption flow as both approaches are then based around secret pointers.

### Benchmark

Scenario: export 100 secret outputs from a python program.
Environment: Test run on laptop in UK against [personal review stack](https://api-danielrbradley.review-stacks.pulumi-dev.io/).

| Test         | initial_preview | initial_update | preview_empty | update_empty |
|--------------|-----------------|----------------|---------------|--------------|
| Without bulk | 2.10s           | 19.94s         | 2.44s         | 20.02s       |
| With bulk    | 2.18s           | 2.86s          | 2.32s         | 3.08s        |

Note: the benchmark threashold (5s) will fail until bulk is deployed to the service staging environment.