### PR TITLE
Elide SourcePosition changes

### DIFF
--- a/changelog/pending/20250212--engine--changes-to-source-position-metadata-will-be-batched-in-the-snapshot-system.yaml
+++ b/changelog/pending/20250212--engine--changes-to-source-position-metadata-will-be-batched-in-the-snapshot-system.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Changes to source position metadata will be batched in the snapshot system

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -257,12 +257,6 @@ func (ssm *sameSnapshotMutation) mustWrite(step *deploy.SameStep) bool {
 		return true
 	}
 
-	// If the source position of this resource has changed, we must write the checkpoint.
-	if old.SourcePosition != new.SourcePosition {
-		logging.V(9).Infof("SnapshotManager: mustWrite() true because of SourcePosition")
-		return true
-	}
-
 	// If the inputs or outputs of this resource have changed, we must write the checkpoint. Note that it is possible
 	// for the inputs of a "same" resource to have changed even if the contents of the input bags are different if the
 	// resource's provider deems the physical change to be semantically irrelevant.
@@ -294,7 +288,9 @@ func (ssm *sameSnapshotMutation) mustWrite(step *deploy.SameStep) bool {
 	}
 
 	// Init errors are strictly advisory, so we do not consider them when deciding whether or not to write the
-	// checkpoint.
+	// checkpoint. Likewise source positions are purely metadata and do not affect the system correctness, so
+	// for performance we elide those as well. This prevents _every_ resource needing a snapshot write when
+	// making large source code changes.
 
 	logging.V(9).Infof("SnapshotManager: mustWrite() false")
 	return false


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/18478

This changes SourcePosition to not be considered an change that requires an immediate snapshot write. This lets us elide the actual snapshot write for each source position change until either a "must write" change happens, or the end of the deployment.

Nothing in the system uses source position for correctness, so if pulumi does crash and fails to ever write the updated source position change it won't break anything in the system on the next run. It will just be display metadata will be out of date for users looking in the console. But on the next successful update they'll all get updated and attempted to write again.

For large projects with hundreds of resources this change could save many writes that would normally get triggered by small code changes e.g. just shifting things by code line or folder.