### PR TITLE
Support uint64 values in config

### DIFF
--- a/changelog/pending/20250212--cli-config--fix-reading-yaml-config-with-uint64-sized-numbers.yaml
+++ b/changelog/pending/20250212--cli-config--fix-reading-yaml-config-with-uint64-sized-numbers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/config
+  description: Fix reading YAML config with uint64 sized numbers

--- a/sdk/go/common/resource/config/map.go
+++ b/sdk/go/common/resource/config/map.go
@@ -341,8 +341,11 @@ func adjustObjectValue(v Value) (object, error) {
 	}
 
 	// If it's convertible to an int, return the int.
-	if i, err := strconv.Atoi(v.value); err == nil {
-		return newObject(int64(i)), nil
+	if i, err := strconv.ParseInt(v.value, 10, 64); err == nil {
+		return newObject(i), nil
+	}
+	if i, err := strconv.ParseUint(v.value, 10, 64); err == nil {
+		return newObject(i), nil
 	}
 
 	// Otherwise, just return the string value.

--- a/sdk/go/common/resource/config/map_test.go
+++ b/sdk/go/common/resource/config/map_test.go
@@ -1465,6 +1465,14 @@ func TestPropertyMap(t *testing.T) {
 		},
 		{
 			Config: Map{
+				MustMakeKey("my", "testKey"): NewValue("18446744073709551615"),
+			},
+			Expected: resource.PropertyMap{
+				"my:testKey": resource.NewNumberProperty(1.8446744073709552e+19),
+			},
+		},
+		{
+			Config: Map{
 				MustMakeKey("my", "testKey"): NewValue("true"),
 			},
 			Expected: resource.PropertyMap{

--- a/sdk/go/common/resource/config/object.go
+++ b/sdk/go/common/resource/config/object.go
@@ -37,7 +37,7 @@ type object struct {
 
 // objectType describes the types of values that may be stored in the value field of an object
 type objectType interface {
-	bool | int64 | float64 | string | []object | map[string]object
+	bool | int64 | uint64 | float64 | string | []object | map[string]object
 }
 
 // newObject creates a new object with the given representation.
@@ -84,6 +84,8 @@ func (c object) decrypt(ctx context.Context, path resource.PropertyPath, decrypt
 	case bool:
 		return NewPlaintext(v), nil
 	case int64:
+		return NewPlaintext(v), nil
+	case uint64:
 		return NewPlaintext(v), nil
 	case float64:
 		return NewPlaintext(v), nil
@@ -385,7 +387,7 @@ func (c object) marshalObjectValue(root bool) any {
 // indicate whether the receiver is secure and whether it is an object.
 func (c object) MarshalString() (text string, secure, object bool, err error) {
 	switch v := c.value.(type) {
-	case bool, int64, float64:
+	case bool, int64, uint64, float64:
 		bytes, err := c.MarshalJSON()
 		return string(bytes), false, false, err
 	case string:
@@ -456,6 +458,8 @@ func unmarshalObject(v any) (object, error) {
 		return object{}, fmt.Errorf("unrepresentable number %v: %w", v, err)
 	case int:
 		return newObject(int64(v)), nil
+	case uint64:
+		return newObject(v), nil
 	case int64:
 		return newObject(v), nil
 	case float64:

--- a/sdk/go/common/resource/config/plaintext.go
+++ b/sdk/go/common/resource/config/plaintext.go
@@ -25,7 +25,7 @@ import (
 
 // PlaintextType describes the allowed types for a Plaintext.
 type PlaintextType interface {
-	bool | int64 | float64 | string | []Plaintext | map[string]Plaintext
+	bool | int64 | uint64 | float64 | string | []Plaintext | map[string]Plaintext
 }
 
 // Plaintext is a single plaintext config value.
@@ -112,6 +112,8 @@ func (c Plaintext) PropertyValue() resource.PropertyValue {
 		prop = resource.NewBoolProperty(v)
 	case int64:
 		prop = resource.NewNumberProperty(float64(v))
+	case uint64:
+		prop = resource.NewNumberProperty(float64(v))
 	case float64:
 		prop = resource.NewNumberProperty(v)
 	case string:
@@ -157,6 +159,8 @@ func (c Plaintext) encrypt(ctx context.Context, path resource.PropertyPath, encr
 	case bool:
 		return newObject(v), nil
 	case int64:
+		return newObject(v), nil
+	case uint64:
 		return newObject(v), nil
 	case float64:
 		return newObject(v), nil

--- a/sdk/go/common/resource/config/plaintext_test.go
+++ b/sdk/go/common/resource/config/plaintext_test.go
@@ -17,6 +17,7 @@ package config
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -52,6 +53,7 @@ func TestPlaintextSecure(t *testing.T) {
 		"hello": NewPlaintext([]Plaintext{
 			NewPlaintext(true),
 			NewPlaintext(int64(42)),
+			NewPlaintext(uint64(math.MaxUint64)),
 			NewPlaintext(float64(3.14159)),
 			NewPlaintext("world"),
 			NewSecurePlaintext("moon"),
@@ -63,6 +65,7 @@ func TestPlaintextSecure(t *testing.T) {
 		"hello": NewPlaintext([]Plaintext{
 			NewPlaintext(true),
 			NewPlaintext(int64(42)),
+			NewPlaintext(uint64(math.MaxUint64)),
 			NewPlaintext(float64(3.14159)),
 			NewPlaintext("world"),
 		}),
@@ -77,6 +80,7 @@ func TestPlaintextEncrypt(t *testing.T) {
 		"hello": NewPlaintext([]Plaintext{
 			NewPlaintext(true),
 			NewPlaintext(int64(42)),
+			NewPlaintext(uint64(math.MaxUint64)),
 			NewPlaintext(float64(3.14159)),
 			NewPlaintext("world"),
 			NewSecurePlaintext("moon"),
@@ -89,6 +93,7 @@ func TestPlaintextEncrypt(t *testing.T) {
 		"hello": newObject([]object{
 			newObject(true),
 			newObject(int64(42)),
+			newObject(uint64(math.MaxUint64)),
 			newObject(float64(3.14159)),
 			newObject("world"),
 			newSecureObject("moon"),
@@ -104,6 +109,7 @@ func TestPlaintextRoundtrip(t *testing.T) {
 		"hello": NewPlaintext([]Plaintext{
 			NewPlaintext(true),
 			NewPlaintext(int64(42)),
+			NewPlaintext(uint64(math.MaxUint64)),
 			NewPlaintext(float64(3.14159)),
 			NewPlaintext("world"),
 			NewSecurePlaintext("moon"),
@@ -114,7 +120,20 @@ func TestPlaintextRoundtrip(t *testing.T) {
 
 	actual, err := value.Decrypt(context.Background(), NopDecrypter)
 	require.NoError(t, err)
-	assert.Equal(t, plain, actual)
+
+	rt := NewPlaintext(map[string]Plaintext{
+		"hello": NewPlaintext([]Plaintext{
+			NewPlaintext(true),
+			NewPlaintext(int64(42)),
+			// uint64 can't roundtrip through JSON
+			NewPlaintext(float64(math.MaxUint64)),
+			NewPlaintext(float64(3.14159)),
+			NewPlaintext("world"),
+			NewSecurePlaintext("moon"),
+		}),
+	})
+
+	assert.Equal(t, rt, actual)
 }
 
 func TestMarshalPlaintext(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/18581

This adds uint64 support to the `config.object` and `config.Plaintext` types. Pretty much a copy of int64 handling, but it means we can roundtrip uint64 without loss of precision. More importantly it means we no longer panic on reading a config file with big numbers like 18446744073709551615 in it.