### PR TITLE
[Experimental/Components] Instantiate components

### DIFF
--- a/changelog/pending/20250213--sdk-nodejs--experimental-components-instantiation-components.yaml
+++ b/changelog/pending/20250213--sdk-nodejs--experimental-components-instantiation-components.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: "[Experimental/Components] Instantiate components"

--- a/sdk/nodejs/tests/provider/experimental/provider.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/provider.spec.ts
@@ -1,0 +1,35 @@
+// Copyright 2025-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "assert";
+import { ComponentProvider } from "../../../provider/experimental/provider";
+
+describe("validateResourceType", function () {
+    it("throws", function () {
+        for (const resourceType of ["not-valid", "not:valid", "pkg:not-valid-module:type:", "pkg:index"]) {
+            try {
+                ComponentProvider.validateResourceType("a", resourceType);
+                assert.fail("expected error");
+            } catch (err) {
+                // pass
+            }
+        }
+    });
+
+    it("accepts", function () {
+        for (const resourceType of ["pkg:index:type", "pkg::type", "pkg:index:Type123"]) {
+            ComponentProvider.validateResourceType("pkg", resourceType);
+        }
+    });
+});

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -113,6 +113,7 @@
         "tests/automation/localWorkspace.spec.ts",
         "tests/automation/remoteWorkspace.spec.ts",
         "tests/automation/util.ts",
+        "tests/provider/experimental/provider.spec.ts",
         "tests_with_mocks/mocks.spec.ts",
         "npm/testdata/nested/project/index.ts",
         "types/arborist.d.ts"

--- a/tests/integration/component_provider/.gitignore
+++ b/tests/integration/component_provider/.gitignore
@@ -1,2 +1,3 @@
 # The YAML runtime creates this when running the tests
+schema-nodejs-component-provider.json
 schema-provider.json

--- a/tests/integration/component_provider/nodejs/component-provider-host/python/Pulumi.yaml
+++ b/tests/integration/component_provider/nodejs/component-provider-host/python/Pulumi.yaml
@@ -1,0 +1,11 @@
+name: python-component-provider-python
+description: Using a component provider written in Python from Python
+runtime:
+  name: python
+  options:
+    toolchain: pip
+    virtualenv: venv
+plugins:
+  providers:
+    - name: nodejs-component-provider
+      path: ../provider

--- a/tests/integration/component_provider/nodejs/component-provider-host/python/__main__.py
+++ b/tests/integration/component_provider/nodejs/component-provider-host/python/__main__.py
@@ -1,0 +1,6 @@
+import pulumi
+import pulumi_nodejs_component_provider as provider
+
+comp = provider.MyComponent("comp")
+
+pulumi.export("urn", comp.urn)

--- a/tests/integration/component_provider/nodejs/component-provider-host/yaml/Pulumi.yaml
+++ b/tests/integration/component_provider/nodejs/component-provider-host/yaml/Pulumi.yaml
@@ -1,0 +1,13 @@
+name: nodejs-component-provider-yaml
+description: Using a component provider written in Node.js from YAML
+runtime: yaml
+plugins:
+  providers:
+    - name: nodejs-component-provider
+      path: ../provider
+resources:
+  comp:
+    type: nodejs-component-provider:index:MyComponent
+    properties: {}
+outputs:
+  urn: ${comp.urn}

--- a/tests/integration/component_provider/python/recursive-types/.gitignore
+++ b/tests/integration/component_provider/python/recursive-types/.gitignore
@@ -1,2 +1,0 @@
-# The YAML runtime creates this when running the tests
-schema-provider.json


### PR DESCRIPTION
Make it possible to instantiate a component and return its URN. We don’t have schema inference yet, besides the component name, so inputs and outputs are ignored.

Part of https://github.com/pulumi/pulumi/issues/18367
Ref https://github.com/pulumi/pulumi/issues/15939