### PR TITLE
document PULUMI_INTEGRATION_REBUILD_BINARIES

### DIFF
--- a/docs/architecture/testing/integration.md
+++ b/docs/architecture/testing/integration.md
@@ -7,15 +7,11 @@ Integration tests use the built binaries for the CLI and language runtimes. We h
 * [Environment](gh-file:pulumi#sdk/go/common/testing/environment.go#L42): this is lower level than `ProgramTest`. It takes care of creating a temporary directory to run commands in via `Environment.RunCommand`. Use `Environment.ImportDirectory` to import a test scenario into the environment.
 
 ### How and when to use
+
 :::{attention}
-Before running integration tests, make sure to rebuild the binaries your test will use.
-```bash
-# from the repostiory root, build and install `pulumi`
-make build install
-# from sdk/{python,nodejs,go}, build and install the required language runtimes
-cd sdk/python
-make build install
-```
+
+By default the integration tests use the binaries for the CLI and the language runtime plugins from `$PATH`.  You can set `PULUMI_INTEGRATION_REBUILD_BINARIES=true` in your environment to automatically re-build the binaries locally to your repository and have the integration tests use them automatically.
+
 :::
 
 To run a single integration test, run the following command from the repository root.

--- a/docs/architecture/testing/integration.md
+++ b/docs/architecture/testing/integration.md
@@ -12,6 +12,14 @@ Integration tests use the built binaries for the CLI and language runtimes. We h
 
 By default the integration tests use the binaries for the CLI and the language runtime plugins from `$PATH`.  You can set `PULUMI_INTEGRATION_REBUILD_BINARIES=true` in your environment to automatically re-build the binaries locally to your repository and have the integration tests use them automatically.
 
+Alternatively you can build the binaries yourself and make sure they aren in the `$PATH` as follows:
+```bash
+# from the repostiory root, build and install `pulumi`
+make build install
+# from sdk/{python,nodejs,go}, build and install the required language runtimes
+cd sdk/python
+make build install
+```
 :::
 
 To run a single integration test, run the following command from the repository root.


### PR DESCRIPTION
We have this new environment variable to automate rebuilding binaries. Document it as the default way for building integration tests, as it should be more convenient for users running the tests.