### PR TITLE
Add bulk encrypt service types

### DIFF
--- a/changelog/pending/20250213--backend-service--add-bulk-encrypte-service-types.yaml
+++ b/changelog/pending/20250213--backend-service--add-bulk-encrypte-service-types.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: backend/service
+  description: Add bulk encrypte service types

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -2108,6 +2108,9 @@ func (c httpstateBackendClient) GetStackResourceOutputs(
 type capabilities struct {
 	// If non-nil, indicates that delta checkpoint updates are supported.
 	deltaCheckpointUpdates *apitype.DeltaCheckpointUploadsConfigV2
+
+	// Indicates whether the service supports bulk encryption.
+	bulkEncryption bool
 }
 
 // Builds a lazy wrapper around doDetectCapabilities.
@@ -2171,6 +2174,8 @@ func decodeCapabilities(wireLevel []apitype.APICapabilityConfig) (capabilities, 
 				}
 				parsed.deltaCheckpointUpdates = &upcfg
 			}
+		case apitype.BulkEncrypt:
+			parsed.bulkEncryption = true
 		default:
 			continue
 		}

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -486,6 +486,20 @@ func (pc *Client) EncryptValue(ctx context.Context, stack StackIdentifier, plain
 	return resp.Ciphertext, nil
 }
 
+// BulkEncrypt encrypts multiple plaintext values in the context of the indicated stack.
+func (pc *Client) BulkEncrypt(ctx context.Context, stack StackIdentifier,
+	plaintexts [][]byte,
+) ([][]byte, error) {
+	req := apitype.BulkEncryptRequest{Plaintexts: plaintexts}
+	var resp apitype.BulkEncryptResponse
+	if err := pc.restCallWithOptions(ctx, "POST", getStackPath(stack, "bulk-encrypt"), nil, &req, &resp,
+		httpCallOptions{GzipCompress: true, RetryPolicy: retryAllMethods}); err != nil {
+		return nil, err
+	}
+
+	return resp.Ciphertexts, nil
+}
+
 // DecryptValue decrypts a ciphertext value in the context of the indicated stack.
 func (pc *Client) DecryptValue(ctx context.Context, stack StackIdentifier, ciphertext []byte) ([]byte, error) {
 	req := apitype.DecryptValueRequest{Ciphertext: ciphertext}

--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -27,6 +27,9 @@ const (
 	// DeltaCheckpointUploads is the feature that enables the CLI to upload checkpoints
 	// via the PatchUpdateCheckpointDeltaRequest API to save on network bytes.
 	DeltaCheckpointUploadsV2 APICapability = "delta-checkpoint-uploads-v2"
+
+	// Indicates that the service backend supports stack bulk encryption.
+	BulkEncrypt APICapability = "bulk-encrypt"
 )
 
 // Deprecated. Use DeltaCheckpointUploadsConfigV2.

--- a/sdk/go/common/apitype/stacks.go
+++ b/sdk/go/common/apitype/stacks.go
@@ -78,6 +78,18 @@ type EncryptValueResponse struct {
 	Ciphertext []byte `json:"ciphertext"`
 }
 
+// BulkEncryptRequest defines the request body for encrypting multiple values.
+type BulkEncryptRequest struct {
+	// The values to encrypt.
+	Plaintexts [][]byte `json:"plaintexts"`
+}
+
+// BulkEncryptResponse defines the response body for multiple encrypted values.
+type BulkEncryptResponse struct {
+	// The encrypted values, in order of the plaintexts from the request.
+	Ciphertexts [][]byte `json:"ciphertexts"`
+}
+
 // DecryptValueRequest defines the request body for decrypting a value.
 type DecryptValueRequest struct {
 	// The value to decrypt.


### PR DESCRIPTION
Extracted from https://github.com/pulumi/pulumi/pull/18576 in order to create the service types to be consumed by the service so we can implement and test the service in parallel with https://github.com/pulumi/pulumi/pull/18576.

1. ~Refactor the existing "capabilities" to be exposed as part of the `Backend` interface and not only as part of the backend internals.~
2. Create the service types (request, response & capability) and implement within the client.