### PR TITLE
Refactor capabilities

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -185,6 +185,7 @@ type Backend interface {
 		ctx context.Context, orgName string, query string,
 	) (*apitype.ResourceSearchResponse, error)
 	PromptAI(ctx context.Context, requestBody AIPromptRequestBody) (*http.Response, error)
+	// Capabilities returns the capabilities of the backend indicating what features are available.
 	Capabilities(ctx context.Context) apitype.Capabilities
 }
 

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -2157,14 +2157,12 @@ func decodeCapabilities(wireLevel []apitype.APICapabilityConfig) (capabilities, 
 	for _, entry := range wireLevel {
 		switch entry.Capability {
 		case apitype.DeltaCheckpointUploads:
-			var upcfg apitype.DeltaCheckpointUploadsConfigV1
+			var upcfg apitype.DeltaCheckpointUploadsConfigV2
 			if err := json.Unmarshal(entry.Configuration, &upcfg); err != nil {
 				msg := "decoding DeltaCheckpointUploadsConfig returned %w"
 				return capabilities{}, fmt.Errorf(msg, err)
 			}
-			parsed.deltaCheckpointUpdates = &apitype.DeltaCheckpointUploadsConfigV2{
-				CheckpointCutoffSizeBytes: upcfg.CheckpointCutoffSizeBytes,
-			}
+			parsed.deltaCheckpointUpdates = &upcfg
 		case apitype.DeltaCheckpointUploadsV2:
 			if entry.Version == 2 {
 				var upcfg apitype.DeltaCheckpointUploadsConfigV2

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -45,7 +45,7 @@ func TestEnabledFullyQualifiedStackNames(t *testing.T) {
 	_, err := NewLoginManager().Login(ctx, PulumiCloudURL, false, "", "", nil, true, display.Options{})
 	require.NoError(t, err)
 
-	b, err := New(diagtest.LogSink(t), PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
+	b, err := New(ctx, diagtest.LogSink(t), PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
 	require.NoError(t, err)
 
 	stackName := ptesting.RandomStackName()
@@ -80,7 +80,7 @@ func TestDisabledFullyQualifiedStackNames(t *testing.T) {
 	_, err := NewLoginManager().Login(ctx, PulumiCloudURL, false, "", "", nil, true, display.Options{})
 	require.NoError(t, err)
 
-	b, err := New(diagtest.LogSink(t), PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
+	b, err := New(ctx, diagtest.LogSink(t), PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
 	require.NoError(t, err)
 
 	stackName := ptesting.RandomStackName()
@@ -236,7 +236,7 @@ func TestDisableIntegrityChecking(t *testing.T) {
 	_, err := NewLoginManager().Login(ctx, PulumiCloudURL, false, "", "", nil, true, display.Options{})
 	require.NoError(t, err)
 
-	b, err := New(diagtest.LogSink(t), PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
+	b, err := New(ctx, diagtest.LogSink(t), PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
 	require.NoError(t, err)
 
 	stackName := ptesting.RandomStackName()

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -246,7 +246,7 @@ func TestGetCapabilities(t *testing.T) {
 	})
 	t.Run("updated-service-with-delta-checkpoint-capability", func(t *testing.T) {
 		t.Parallel()
-		cfg := apitype.DeltaCheckpointUploadsConfigV1{
+		cfg := apitype.DeltaCheckpointUploadsConfigV2{
 			CheckpointCutoffSizeBytes: 1024 * 1024 * 4,
 		}
 		cfgJSON, err := json.Marshal(cfg)

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -274,6 +274,11 @@ func TestGetCapabilities(t *testing.T) {
 		assert.Equal(t, `{"checkpointCutoffSizeBytes":4194304}`,
 			string(resp.Capabilities[0].Configuration))
 		assert.Equal(t, resp.Capabilities[1].Capability, apitype.BulkEncrypt)
+
+		parsed, err := resp.Parse()
+		require.NoError(t, err)
+		assert.Equal(t, parsed.DeltaCheckpointUpdates, &cfg)
+		assert.True(t, parsed.BulkEncryption)
 	})
 }
 

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -256,6 +256,8 @@ func TestGetCapabilities(t *testing.T) {
 				Version:       3,
 				Capability:    apitype.DeltaCheckpointUploads,
 				Configuration: json.RawMessage(cfgJSON),
+			}, {
+				Capability: apitype.BulkEncrypt,
 			}},
 		}
 		respJSON, err := json.Marshal(actualResp)
@@ -267,10 +269,11 @@ func TestGetCapabilities(t *testing.T) {
 		resp, err := c.GetCapabilities(context.Background())
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
-		assert.Len(t, resp.Capabilities, 1)
+		assert.Len(t, resp.Capabilities, 2)
 		assert.Equal(t, apitype.DeltaCheckpointUploads, resp.Capabilities[0].Capability)
 		assert.Equal(t, `{"checkpointCutoffSizeBytes":4194304}`,
 			string(resp.Capabilities[0].Configuration))
+		assert.Equal(t, resp.Capabilities[1].Capability, apitype.BulkEncrypt)
 	})
 }
 

--- a/pkg/backend/httpstate/mock.go
+++ b/pkg/backend/httpstate/mock.go
@@ -86,4 +86,8 @@ func (b *MockHTTPBackend) Search(
 	return b.FSearch(ctx, orgName, queryParams)
 }
 
+func (b *MockHTTPBackend) Capabilities(context.Context) Capabilities {
+	return Capabilities{}
+}
+
 var _ Backend = (*MockHTTPBackend)(nil)

--- a/pkg/backend/httpstate/mock.go
+++ b/pkg/backend/httpstate/mock.go
@@ -86,8 +86,8 @@ func (b *MockHTTPBackend) Search(
 	return b.FSearch(ctx, orgName, queryParams)
 }
 
-func (b *MockHTTPBackend) Capabilities(context.Context) Capabilities {
-	return Capabilities{}
+func (b *MockHTTPBackend) Capabilities(context.Context) apitype.Capabilities {
+	return apitype.Capabilities{}
 }
 
 var _ Backend = (*MockHTTPBackend)(nil)

--- a/pkg/backend/httpstate/snapshot.go
+++ b/pkg/backend/httpstate/snapshot.go
@@ -110,8 +110,8 @@ func (b *cloudBackend) newSnapshotPersister(ctx context.Context, update client.U
 		backend:     b,
 	}
 
-	caps := b.capabilities(ctx)
-	deltaCaps := caps.deltaCheckpointUpdates
+	caps := b.Capabilities(ctx)
+	deltaCaps := caps.DeltaCheckpointUpdates
 	if deltaCaps != nil {
 		p.deploymentDiffState = newDeploymentDiffState(deltaCaps.CheckpointCutoffSizeBytes)
 	}

--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -185,7 +185,7 @@ func TestCloudSnapshotPersisterUseOfDiffProtocol(t *testing.T) {
 
 	initPersister := func() *cloudSnapshotPersister {
 		server := newMockServer()
-		backendGeneric, err := New(nil, server.URL, nil, false)
+		backendGeneric, err := New(ctx, nil, server.URL, nil, false)
 		assert.NoError(t, err)
 		backend := backendGeneric.(*cloudBackend)
 		persister := backend.newSnapshotPersister(ctx, client.UpdateIdentifier{

--- a/pkg/cmd/pulumi/backend/login_manager.go
+++ b/pkg/cmd/pulumi/backend/login_manager.go
@@ -68,7 +68,7 @@ func (f *lm) Current(
 	if err != nil {
 		return nil, err
 	}
-	return httpstate.New(sink, url, project, insecure)
+	return httpstate.New(ctx, sink, url, project, insecure)
 }
 
 func (f *lm) Login(
@@ -93,7 +93,7 @@ func (f *lm) Login(
 	if err != nil {
 		return nil, err
 	}
-	return httpstate.New(sink, url, project, insecure)
+	return httpstate.New(ctx, sink, url, project, insecure)
 }
 
 type MockLoginManager struct {

--- a/pkg/cmd/pulumi/org/org_search_test.go
+++ b/pkg/cmd/pulumi/org/org_search_test.go
@@ -169,6 +169,6 @@ func (f *stubHTTPBackend) CurrentUser() (string, []string, *workspace.TokenInfor
 	return f.CurrentUserF()
 }
 
-func (*stubHTTPBackend) Capabilities(context.Context) httpstate.Capabilities {
-	return httpstate.Capabilities{}
+func (*stubHTTPBackend) Capabilities(context.Context) apitype.Capabilities {
+	return apitype.Capabilities{}
 }

--- a/pkg/cmd/pulumi/org/org_search_test.go
+++ b/pkg/cmd/pulumi/org/org_search_test.go
@@ -168,3 +168,7 @@ func (f *stubHTTPBackend) NaturalLanguageSearch(
 func (f *stubHTTPBackend) CurrentUser() (string, []string, *workspace.TokenInformation, error) {
 	return f.CurrentUserF()
 }
+
+func (*stubHTTPBackend) Capabilities(context.Context) httpstate.Capabilities {
+	return httpstate.Capabilities{}
+}

--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -14,7 +14,9 @@
 
 package apitype
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 // An APICapability is the name of a capability or feature that a service backend
 // may or may not support.
@@ -31,11 +33,6 @@ const (
 	// Indicates that the service backend supports stack bulk encryption.
 	BulkEncrypt APICapability = "bulk-encrypt"
 )
-
-// Deprecated. Use DeltaCheckpointUploadsConfigV2.
-type DeltaCheckpointUploadsConfigV1 struct {
-	CheckpointCutoffSizeBytes int `json:"checkpointCutoffSizeBytes"`
-}
 
 type DeltaCheckpointUploadsConfigV2 struct {
 	// CheckpointCutoffSizeBytes defines the size of a checkpoint file, in bytes,

--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -55,7 +55,8 @@ type CapabilitiesResponse struct {
 	Capabilities []APICapabilityConfig `json:"capabilities"`
 }
 
-// Represents feature-detected capabilities of the service the backend is connected to.
+// Represents the set of features a backend is capable of supporting.
+// This is a user-friendly representation of the CapabilitiesResponse.
 type Capabilities struct {
 	// If non-nil, indicates that delta checkpoint updates are supported.
 	DeltaCheckpointUpdates *DeltaCheckpointUploadsConfigV2
@@ -64,6 +65,7 @@ type Capabilities struct {
 	BulkEncryption bool
 }
 
+// Parse decodes the CapabilitiesResponse into a Capabilities struct for ease of use.
 func (r CapabilitiesResponse) Parse() (Capabilities, error) {
 	var parsed Capabilities
 	for _, entry := range r.Capabilities {
@@ -71,16 +73,14 @@ func (r CapabilitiesResponse) Parse() (Capabilities, error) {
 		case DeltaCheckpointUploads:
 			var upcfg DeltaCheckpointUploadsConfigV2
 			if err := json.Unmarshal(entry.Configuration, &upcfg); err != nil {
-				msg := "decoding DeltaCheckpointUploadsConfig returned %w"
-				return Capabilities{}, fmt.Errorf(msg, err)
+				return Capabilities{}, fmt.Errorf("decoding DeltaCheckpointUploadsConfig returned %w", err)
 			}
 			parsed.DeltaCheckpointUpdates = &upcfg
 		case DeltaCheckpointUploadsV2:
 			if entry.Version == 2 {
 				var upcfg DeltaCheckpointUploadsConfigV2
 				if err := json.Unmarshal(entry.Configuration, &upcfg); err != nil {
-					msg := "decoding DeltaCheckpointUploadsConfigV2 returned %w"
-					return Capabilities{}, fmt.Errorf(msg, err)
+					return Capabilities{}, fmt.Errorf("decoding DeltaCheckpointUploadsConfigV2 returned %w", err)
 				}
 				parsed.DeltaCheckpointUpdates = &upcfg
 			}

--- a/sdk/go/common/apitype/service_test.go
+++ b/sdk/go/common/apitype/service_test.go
@@ -1,0 +1,115 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCapabilities(t *testing.T) {
+	t.Parallel()
+	t.Run("parse empty", func(t *testing.T) {
+		t.Parallel()
+		actual, err := CapabilitiesResponse{}.Parse()
+		assert.NoError(t, err)
+		assert.Equal(t, Capabilities{}, actual)
+	})
+	t.Run("parse delta v1", func(t *testing.T) {
+		t.Parallel()
+		response := CapabilitiesResponse{
+			Capabilities: []APICapabilityConfig{
+				{
+					Capability:    DeltaCheckpointUploads,
+					Configuration: json.RawMessage(`{}`),
+				},
+			},
+		}
+		actual, err := response.Parse()
+		assert.NoError(t, err)
+		assert.Equal(t, Capabilities{
+			DeltaCheckpointUpdates: &DeltaCheckpointUploadsConfigV2{},
+		}, actual)
+	})
+	t.Run("parse delta v1 with config", func(t *testing.T) {
+		t.Parallel()
+		response := CapabilitiesResponse{
+			Capabilities: []APICapabilityConfig{
+				{
+					Capability:    DeltaCheckpointUploads,
+					Configuration: json.RawMessage(`{"checkpointCutoffSizeBytes": 1024}`),
+				},
+			},
+		}
+		actual, err := response.Parse()
+		assert.NoError(t, err)
+		assert.Equal(t, Capabilities{
+			DeltaCheckpointUpdates: &DeltaCheckpointUploadsConfigV2{
+				CheckpointCutoffSizeBytes: 1024,
+			},
+		}, actual)
+	})
+	t.Run("parse delta v2", func(t *testing.T) {
+		t.Parallel()
+		response := CapabilitiesResponse{
+			Capabilities: []APICapabilityConfig{
+				{
+					Capability:    DeltaCheckpointUploadsV2,
+					Version:       2,
+					Configuration: json.RawMessage("{}"),
+				},
+			},
+		}
+		actual, err := response.Parse()
+		assert.NoError(t, err)
+		assert.Equal(t, Capabilities{
+			DeltaCheckpointUpdates: &DeltaCheckpointUploadsConfigV2{},
+		}, actual)
+	})
+	t.Run("parse delta v2 with config", func(t *testing.T) {
+		t.Parallel()
+		response := CapabilitiesResponse{
+			Capabilities: []APICapabilityConfig{
+				{
+					Capability:    DeltaCheckpointUploadsV2,
+					Version:       2,
+					Configuration: json.RawMessage(`{"checkpointCutoffSizeBytes": 1024}`),
+				},
+			},
+		}
+		actual, err := response.Parse()
+		assert.NoError(t, err)
+		assert.Equal(t, Capabilities{
+			DeltaCheckpointUpdates: &DeltaCheckpointUploadsConfigV2{
+				CheckpointCutoffSizeBytes: 1024,
+			},
+		}, actual)
+	})
+	t.Run("parse bulk encrypt", func(t *testing.T) {
+		t.Parallel()
+		response := CapabilitiesResponse{
+			Capabilities: []APICapabilityConfig{
+				{Capability: BulkEncrypt},
+			},
+		}
+		actual, err := response.Parse()
+		assert.NoError(t, err)
+		assert.Equal(t, Capabilities{
+			BulkEncryption: true,
+		}, actual)
+	})
+}


### PR DESCRIPTION
Simplify & expose capabilities for a backend for wider use outside the backend class itself.
- Refactor the existing "capabilities" to be exposed as part of the Backend interface and not only as part of the backend internals.
- Use a `Promise` to encapsulate the pre-fetch and caching h/t @Frassle 

Stacked on top of:
- https://github.com/pulumi/pulumi/pull/18588
