### PR TITLE
[Experimental/Components] Hook up inputs & outputs in the provider

### DIFF
--- a/changelog/pending/20250214--sdk-nodejs--experimental-components-hook-up-inputs-and-outputs-in-the-provider.yaml
+++ b/changelog/pending/20250214--sdk-nodejs--experimental-components-hook-up-inputs-and-outputs-in-the-provider.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: "[Experimental/Components] Hook up inputs & outputs in the provider"

--- a/tests/integration/component_provider/nodejs/component-provider-host/provider/component.ts
+++ b/tests/integration/component_provider/nodejs/component-provider-host/provider/component.ts
@@ -11,8 +11,17 @@ export interface MyComponentArgs {
 export class MyComponent extends pulumi.ComponentResource {
     aNumberOutput: pulumi.Output<number>;
     anOptionalStringOutput?: pulumi.Output<string>;
+    aBooleanOutput: pulumi.Output<boolean>;
 
     constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
         super("nodejs-component-provider:index:MyComponent", name, args, opts);
+        this.aNumberOutput = pulumi.output(args.aNumber * 2);
+        this.anOptionalStringOutput = pulumi.output("Hello, " + (args.anOptionalString ?? "World") + "!");
+        this.aBooleanOutput = pulumi.output(args.aBooleanInput).apply(b => !b);
+        this.registerOutputs({
+            aNumberOutput: this.aNumberOutput,
+            anOptionalStringOutput: this.anOptionalStringOutput,
+            aBooleanOutput: this.aBooleanOutput,
+        });
     }
 }

--- a/tests/integration/component_provider/nodejs/component-provider-host/python/__main__.py
+++ b/tests/integration/component_provider/nodejs/component-provider-host/python/__main__.py
@@ -4,8 +4,11 @@ import pulumi_nodejs_component_provider as provider
 comp = provider.MyComponent(
     "comp",
     a_number=123,
-    an_optional_string="hello",
+    an_optional_string="Bonnie",
     a_boolean_input=pulumi.Output.from_input(True),
 )
 
 pulumi.export("urn", comp.urn)
+pulumi.export("aNumberOutput", comp.a_number_output)
+pulumi.export("anOptionalStringOutput", comp.an_optional_string_output)
+pulumi.export("aBooleanOutput", comp.a_boolean_output)

--- a/tests/integration/component_provider/nodejs/component-provider-host/yaml/Pulumi.yaml
+++ b/tests/integration/component_provider/nodejs/component-provider-host/yaml/Pulumi.yaml
@@ -10,7 +10,10 @@ resources:
     type: nodejs-component-provider:index:MyComponent
     properties:
       aNumber: 123
-      anOptionalString: "hello"
+      anOptionalString: "Bonnie"
       aBooleanInput: true
 outputs:
   urn: ${comp.urn}
+  aNumberOutput: ${comp.aNumberOutput}
+  anOptionalStringOutput: ${comp.anOptionalStringOutput}
+  aBooleanOutput: ${comp.aBooleanOutput}

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2487,9 +2487,12 @@ func TestNodejsComponentProviderGetSchema(t *testing.T) {
 			},
 			"anOptionalStringOutput": {
 				"type": "string"
+			},
+			"aBooleanOutput": {
+				"type": "boolean"
 			}
 		},
-		"required": ["aNumberOutput"]
+		"required": ["aBooleanOutput", "aNumberOutput"]
 	}
 	`
 	expected := make(map[string]interface{})
@@ -2528,6 +2531,9 @@ func TestNodejsComponentProviderRun(t *testing.T) {
 					require.NoError(t, err)
 					require.Equal(t, tokens.Type("nodejs-component-provider:index:MyComponent"), urn.Type())
 					require.Equal(t, "comp", urn.Name())
+					require.Equal(t, float64(246), stack.Outputs["aNumberOutput"].(float64))
+					require.Equal(t, "Hello, Bonnie!", stack.Outputs["anOptionalStringOutput"].(string))
+					require.Equal(t, false, stack.Outputs["aBooleanOutput"].(bool))
 				},
 			})
 		})


### PR DESCRIPTION
This passes outputs back from the provider's Construct call, making the
components work end-to-end.

Fixes https://github.com/pulumi/pulumi/issues/18367
Ref https://github.com/pulumi/pulumi/issues/15939