### PR TITLE
Simplify deployment deserialization encyption

### DIFF
--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -669,8 +669,7 @@ func (eng *languageTestServer) RunLanguageTest(
 
 	// Just use base64 "secrets" for these tests
 	sm := b64secrets.NewBase64SecretsManager()
-	dec, err := sm.Decrypter()
-	contract.AssertNoErrorf(err, "base64 must be able to create a Decrypter")
+	dec := sm.Decrypter()
 
 	// Create a temp dir for the a diy backend to run in for the test
 	backendDir := filepath.Join(token.TemporaryDirectory, "backends", req.Test)

--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -360,9 +360,9 @@ func ConvertJSONEvent(apiEvent apitype.EngineEvent) (engine.Event, error) {
 		// Deserialize the before and after properties, ignoring serialization
 		// errors as the other event types do (e.g., step events).
 		crypter := config.BlindingCrypter
-		before, err := stack.DeserializeProperties(p.Before, crypter, crypter)
+		before, err := stack.DeserializeProperties(p.Before, crypter)
 		contract.IgnoreError(err)
-		after, err := stack.DeserializeProperties(p.After, crypter, crypter)
+		after, err := stack.DeserializeProperties(p.After, crypter)
 		contract.IgnoreError(err)
 
 		event = engine.NewEvent(engine.PolicyRemediationEventPayload{
@@ -512,10 +512,10 @@ func convertJSONStepEventStateMetadata(md *apitype.StepEventStateMetadata) *engi
 	}
 
 	crypter := config.BlindingCrypter
-	inputs, err := stack.DeserializeProperties(md.Inputs, crypter, crypter)
+	inputs, err := stack.DeserializeProperties(md.Inputs, crypter)
 	contract.IgnoreError(err)
 
-	outputs, err := stack.DeserializeProperties(md.Outputs, crypter, crypter)
+	outputs, err := stack.DeserializeProperties(md.Outputs, crypter)
 	contract.IgnoreError(err)
 
 	return &engine.StepEventStateMetadata{

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -160,7 +160,7 @@ func TestSamesWithEmptyArraysInInputs(t *testing.T) {
 
 	// Model reading from state file
 	state := map[string]interface{}{"defaults": []interface{}{}}
-	inputs, err := stack.DeserializeProperties(state, config.NopDecrypter, config.NopEncrypter)
+	inputs, err := stack.DeserializeProperties(state, config.NopDecrypter)
 	assert.NoError(t, err)
 
 	res := NewResourceWithInputs(aUniqueUrnResourceA, inputs)

--- a/pkg/cmd/pulumi/config/io.go
+++ b/pkg/cmd/pulumi/config/io.go
@@ -156,10 +156,7 @@ func getStackConfigurationFromProjectStack(
 		}, nil
 	}
 
-	crypter, err := sm.Decrypter()
-	if err != nil {
-		return backend.StackConfiguration{}, fmt.Errorf("getting configuration decrypter: %w", err)
-	}
+	crypter := sm.Decrypter()
 
 	return backend.StackConfiguration{
 		EnvironmentImports: workspaceStack.Environment.Imports(),

--- a/pkg/cmd/pulumi/config/io_test.go
+++ b/pkg/cmd/pulumi/config/io_test.go
@@ -293,11 +293,11 @@ func TestStackEnvConfig(t *testing.T) {
 	}
 
 	mockSecretsManager := &secrets.MockSecretsManager{
-		EncrypterF: func() (config.Encrypter, error) {
+		EncrypterF: func() config.Encrypter {
 			encrypter := &secrets.MockEncrypter{EncryptValueF: func() string { return "ciphertext" }}
-			return encrypter, nil
+			return encrypter
 		},
-		DecrypterF: func() (config.Decrypter, error) {
+		DecrypterF: func() config.Decrypter {
 			decrypter := &secrets.MockDecrypter{
 				DecryptValueF: func() string {
 					return "plaintext"
@@ -309,7 +309,7 @@ func TestStackEnvConfig(t *testing.T) {
 				},
 			}
 
-			return decrypter, nil
+			return decrypter
 		},
 	}
 
@@ -378,11 +378,11 @@ func TestCopyConfig(t *testing.T) {
 	}
 
 	mockSecretsManager := &secrets.MockSecretsManager{
-		EncrypterF: func() (config.Encrypter, error) {
+		EncrypterF: func() config.Encrypter {
 			encrypter := &secrets.MockEncrypter{EncryptValueF: func() string { return "ciphertext" }}
-			return encrypter, nil
+			return encrypter
 		},
-		DecrypterF: func() (config.Decrypter, error) {
+		DecrypterF: func() config.Decrypter {
 			decrypter := &secrets.MockDecrypter{
 				DecryptValueF: func() string {
 					return "plaintext"
@@ -394,7 +394,7 @@ func TestCopyConfig(t *testing.T) {
 				},
 			}
 
-			return decrypter, nil
+			return decrypter
 		},
 	}
 

--- a/pkg/cmd/pulumi/logs/logs.go
+++ b/pkg/cmd/pulumi/logs/logs.go
@@ -85,14 +85,8 @@ func NewLogsCmd() *cobra.Command {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}
 
-			decrypter, err := sm.Decrypter()
-			if err != nil {
-				return fmt.Errorf("getting stack decrypter: %w", err)
-			}
-			encrypter, err := sm.Encrypter()
-			if err != nil {
-				return fmt.Errorf("getting stack encrypter: %w", err)
-			}
+			decrypter := sm.Decrypter()
+			encrypter := sm.Encrypter()
 
 			stackName := s.Ref().Name().String()
 			configErr := workspace.ValidateStackConfigAndApplyProjectConfig(

--- a/pkg/cmd/pulumi/newcmd/config.go
+++ b/pkg/cmd/pulumi/newcmd/config.go
@@ -217,14 +217,8 @@ func promptForConfig(
 			return nil, fmt.Errorf("saving stack config: %w", err)
 		}
 	}
-	encrypter, err := sm.Encrypter()
-	if err != nil {
-		return nil, err
-	}
-	decrypter, err := sm.Decrypter()
-	if err != nil {
-		return nil, err
-	}
+	encrypter := sm.Encrypter()
+	decrypter := sm.Decrypter()
 
 	c := make(config.Map)
 

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -231,14 +231,8 @@ func NewDestroyCmd() *cobra.Command {
 				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
 
-			decrypter, err := sm.Decrypter()
-			if err != nil {
-				return fmt.Errorf("getting stack decrypter: %w", err)
-			}
-			encrypter, err := sm.Encrypter()
-			if err != nil {
-				return fmt.Errorf("getting stack encrypter: %w", err)
-			}
+			decrypter := sm.Decrypter()
+			encrypter := sm.Encrypter()
 
 			stackName := s.Ref().Name().String()
 			configError := workspace.ValidateStackConfigAndApplyProjectConfig(

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -935,14 +935,8 @@ func NewImportCmd() *cobra.Command {
 				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
 
-			decrypter, err := sm.Decrypter()
-			if err != nil {
-				return fmt.Errorf("getting stack decrypter: %w", err)
-			}
-			encrypter, err := sm.Encrypter()
-			if err != nil {
-				return fmt.Errorf("getting stack encrypter: %w", err)
-			}
+			decrypter := sm.Decrypter()
+			encrypter := sm.Encrypter()
 
 			stackName := s.Ref().Name().String()
 			configErr := workspace.ValidateStackConfigAndApplyProjectConfig(

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -405,14 +405,8 @@ func NewPreviewCmd() *cobra.Command {
 				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
 
-			decrypter, err := sm.Decrypter()
-			if err != nil {
-				return fmt.Errorf("getting stack decrypter: %w", err)
-			}
-			encrypter, err := sm.Encrypter()
-			if err != nil {
-				return fmt.Errorf("getting stack encrypter: %w", err)
-			}
+			decrypter := sm.Decrypter()
+			encrypter := sm.Encrypter()
 
 			stackName := s.Ref().Name().String()
 			configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
@@ -510,10 +504,7 @@ func NewPreviewCmd() *cobra.Command {
 				return errors.New("error: no changes were expected but changes were proposed")
 			default:
 				if planFilePath != "" {
-					encrypter, err := sm.Encrypter()
-					if err != nil {
-						return err
-					}
+					encrypter := sm.Encrypter()
 					if err = pkgPlan.Write(planFilePath, plan, encrypter, showSecrets); err != nil {
 						return err
 					}

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -204,14 +204,8 @@ func NewRefreshCmd() *cobra.Command {
 				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
 
-			decrypter, err := sm.Decrypter()
-			if err != nil {
-				return fmt.Errorf("getting stack decrypter: %w", err)
-			}
-			encrypter, err := sm.Encrypter()
-			if err != nil {
-				return fmt.Errorf("getting stack encrypter: %w", err)
-			}
+			decrypter := sm.Decrypter()
+			encrypter := sm.Encrypter()
 
 			stackName := s.Ref().Name().String()
 			configErr := workspace.ValidateStackConfigAndApplyProjectConfig(

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -199,8 +199,7 @@ func NewUpCmd() *cobra.Command {
 
 		if planFilePath != "" {
 			dec := sm.Decrypter()
-			enc := sm.Encrypter()
-			p, err := plan.Read(planFilePath, dec, enc)
+			p, err := plan.Read(planFilePath, dec)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -140,14 +140,8 @@ func NewUpCmd() *cobra.Command {
 			return fmt.Errorf("gathering environment metadata: %w", err)
 		}
 
-		decrypter, err := sm.Decrypter()
-		if err != nil {
-			return fmt.Errorf("getting stack decrypter: %w", err)
-		}
-		encrypter, err := sm.Encrypter()
-		if err != nil {
-			return fmt.Errorf("getting stack encrypter: %w", err)
-		}
+		decrypter := sm.Decrypter()
+		encrypter := sm.Encrypter()
 
 		stackName := s.Ref().Name().String()
 		configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
@@ -204,14 +198,8 @@ func NewUpCmd() *cobra.Command {
 		}
 
 		if planFilePath != "" {
-			dec, err := sm.Decrypter()
-			if err != nil {
-				return err
-			}
-			enc, err := sm.Encrypter()
-			if err != nil {
-				return err
-			}
+			dec := sm.Decrypter()
+			enc := sm.Encrypter()
 			p, err := plan.Read(planFilePath, dec, enc)
 			if err != nil {
 				return err
@@ -401,14 +389,8 @@ func NewUpCmd() *cobra.Command {
 			return fmt.Errorf("gathering environment metadata: %w", err)
 		}
 
-		decrypter, err := sm.Decrypter()
-		if err != nil {
-			return fmt.Errorf("getting stack decrypter: %w", err)
-		}
-		encrypter, err := sm.Encrypter()
-		if err != nil {
-			return fmt.Errorf("getting stack encrypter: %w", err)
-		}
+		decrypter := sm.Decrypter()
+		encrypter := sm.Encrypter()
 
 		stackName := s.Ref().String()
 		configErr := workspace.ValidateStackConfigAndApplyProjectConfig(

--- a/pkg/cmd/pulumi/operations/watch.go
+++ b/pkg/cmd/pulumi/operations/watch.go
@@ -131,14 +131,8 @@ func NewWatchCmd() *cobra.Command {
 				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
 
-			decrypter, err := sm.Decrypter()
-			if err != nil {
-				return fmt.Errorf("getting stack decrypter: %w", err)
-			}
-			encrypter, err := sm.Encrypter()
-			if err != nil {
-				return fmt.Errorf("getting stack encrypter: %w", err)
-			}
+			decrypter := sm.Decrypter()
+			encrypter := sm.Encrypter()
 
 			stackName := s.Ref().Name().String()
 			configErr := workspace.ValidateStackConfigAndApplyProjectConfig(

--- a/pkg/cmd/pulumi/plan/plan.go
+++ b/pkg/cmd/pulumi/plan/plan.go
@@ -42,7 +42,7 @@ func Write(path string, plan *deploy.Plan, enc config.Encrypter, showSecrets boo
 	return encoder.Encode(deploymentPlan)
 }
 
-func Read(path string, dec config.Decrypter, enc config.Encrypter) (*deploy.Plan, error) {
+func Read(path string, dec config.Decrypter) (*deploy.Plan, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -53,5 +53,5 @@ func Read(path string, dec config.Decrypter, enc config.Encrypter) (*deploy.Plan
 	if err := json.NewDecoder(f).Decode(&deploymentPlan); err != nil {
 		return nil, err
 	}
-	return stack.DeserializePlan(deploymentPlan, dec, enc)
+	return stack.DeserializePlan(deploymentPlan, dec)
 }

--- a/pkg/cmd/pulumi/stack/secrets.go
+++ b/pkg/cmd/pulumi/stack/secrets.go
@@ -178,10 +178,7 @@ func (l *SecretsManagerLoader) GetDecrypter(
 		return nil, SecretsManagerUnchanged, err
 	}
 
-	dec, err := sm.Decrypter()
-	if err != nil {
-		return nil, state, err
-	}
+	dec := sm.Decrypter()
 	return dec, state, nil
 }
 
@@ -196,10 +193,7 @@ func (l *SecretsManagerLoader) GetEncrypter(
 		return nil, SecretsManagerUnchanged, err
 	}
 
-	enc, err := sm.Encrypter()
-	if err != nil {
-		return nil, state, err
-	}
+	enc := sm.Encrypter()
 	return enc, state, nil
 }
 

--- a/pkg/cmd/pulumi/stack/secrets_test.go
+++ b/pkg/cmd/pulumi/stack/secrets_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 //nolint:paralleltest // Modifies the environment
@@ -59,12 +60,10 @@ func TestStackSecretsManagerLoaderDecrypterFallsBack(t *testing.T) {
 	t.Parallel()
 
 	// Arrange.
-	fellback := false
 	sm := &secrets.MockSecretsManager{
 		TypeF: func() string { return "mock" },
 		DecrypterF: func() config.Decrypter {
-			fellback = true
-			return config.NopDecrypter
+			return &secrets.MockDecrypter{DecryptValueF: func() string { return "defaulted plaintext" }}
 		},
 	}
 	snap := &deploy.Snapshot{SecretsManager: sm}
@@ -79,7 +78,9 @@ func TestStackSecretsManagerLoaderDecrypterFallsBack(t *testing.T) {
 	ssml := SecretsManagerLoader{FallbackToState: true}
 
 	// Act.
-	_, state, err := ssml.GetDecrypter(context.Background(), s, ps)
+	decrypter, state, err := ssml.GetDecrypter(context.Background(), s, ps)
+	require.NoError(t, err)
+	plaintext, err := decrypter.DecryptValue(context.Background(), "test")
 
 	// Assert.
 	//
@@ -91,7 +92,7 @@ func TestStackSecretsManagerLoaderDecrypterFallsBack(t *testing.T) {
 		t, SecretsManagerUnchanged, state,
 		"A mock decrypter should have no effect on the project stack",
 	)
-	assert.True(t, fellback, "Should have fallen back to the mock decrypter")
+	assert.Equal(t, plaintext, "defaulted plaintext", "Should have fallen back to the mock decrypter")
 }
 
 func TestStackSecretsManagerLoaderDecrypterUpdatesConfig(t *testing.T) {
@@ -130,12 +131,10 @@ func TestStackSecretsManagerLoaderDecrypterUsesDefaultSecretsManager(t *testing.
 	t.Parallel()
 
 	// Arrange.
-	defaulted := false
 	sm := &secrets.MockSecretsManager{
 		TypeF: func() string { return "mock" },
 		DecrypterF: func() config.Decrypter {
-			defaulted = true
-			return config.NopDecrypter
+			return &secrets.MockDecrypter{DecryptValueF: func() string { return "defaulted plaintext" }}
 		},
 	}
 
@@ -152,7 +151,9 @@ func TestStackSecretsManagerLoaderDecrypterUsesDefaultSecretsManager(t *testing.
 	ssml := SecretsManagerLoader{FallbackToState: false}
 
 	// Act.
-	_, state, err := ssml.GetDecrypter(context.Background(), s, ps)
+	decrypter, state, err := ssml.GetDecrypter(context.Background(), s, ps)
+	require.NoError(t, err)
+	plaintext, err := decrypter.DecryptValue(context.Background(), "test")
 
 	// Assert.
 	assert.NoError(t, err)
@@ -160,19 +161,17 @@ func TestStackSecretsManagerLoaderDecrypterUsesDefaultSecretsManager(t *testing.
 		t, SecretsManagerUnchanged, state,
 		"No fallback manager should mean no changes to the project stack",
 	)
-	assert.True(t, defaulted, "Should have loaded the default decrypter")
+	assert.Equal(t, plaintext, "defaulted plaintext", "Should have loaded the default decrypter")
 }
 
 func TestStackSecretsManagerLoaderEncrypterFallsBack(t *testing.T) {
 	t.Parallel()
 
 	// Arrange.
-	fellback := false
 	sm := &secrets.MockSecretsManager{
 		TypeF: func() string { return "mock" },
 		EncrypterF: func() config.Encrypter {
-			fellback = true
-			return config.NopEncrypter
+			return &secrets.MockEncrypter{EncryptValueF: func() string { return "defaulted ciphertext" }}
 		},
 	}
 	snap := &deploy.Snapshot{SecretsManager: sm}
@@ -187,7 +186,9 @@ func TestStackSecretsManagerLoaderEncrypterFallsBack(t *testing.T) {
 	ssml := SecretsManagerLoader{FallbackToState: true}
 
 	// Act.
-	_, state, err := ssml.GetEncrypter(context.Background(), s, ps)
+	encrypter, state, err := ssml.GetEncrypter(context.Background(), s, ps)
+	require.NoError(t, err)
+	ciphertext, err := encrypter.EncryptValue(context.Background(), "test")
 
 	// Assert.
 	//
@@ -199,7 +200,7 @@ func TestStackSecretsManagerLoaderEncrypterFallsBack(t *testing.T) {
 		t, SecretsManagerUnchanged, state,
 		"A mock encrypter should have no effect on the project stack",
 	)
-	assert.True(t, fellback, "Should have fallen back to the mock encrypter")
+	assert.Equal(t, ciphertext, "defaulted ciphertext", "Should have fallen back to the mock encrypter")
 }
 
 func TestStackSecretsManagerLoaderEncrypterUpdatesConfig(t *testing.T) {
@@ -238,12 +239,10 @@ func TestStackSecretsManagerLoaderEncrypterUsesDefaultSecretsManager(t *testing.
 	t.Parallel()
 
 	// Arrange.
-	defaulted := false
 	sm := &secrets.MockSecretsManager{
 		TypeF: func() string { return "mock" },
 		EncrypterF: func() config.Encrypter {
-			defaulted = true
-			return config.NopEncrypter
+			return &secrets.MockEncrypter{EncryptValueF: func() string { return "defaulted ciphertext" }}
 		},
 	}
 
@@ -260,7 +259,9 @@ func TestStackSecretsManagerLoaderEncrypterUsesDefaultSecretsManager(t *testing.
 	ssml := SecretsManagerLoader{FallbackToState: false}
 
 	// Act.
-	_, state, err := ssml.GetEncrypter(context.Background(), s, ps)
+	encrypter, state, err := ssml.GetEncrypter(context.Background(), s, ps)
+	require.NoError(t, err)
+	ciphertext, err := encrypter.EncryptValue(context.Background(), "test")
 
 	// Assert.
 	assert.NoError(t, err)
@@ -268,5 +269,5 @@ func TestStackSecretsManagerLoaderEncrypterUsesDefaultSecretsManager(t *testing.
 		t, SecretsManagerUnchanged, state,
 		"No fallback manager should mean no changes to the project stack",
 	)
-	assert.True(t, defaulted, "Should have loaded the default encrypter")
+	assert.Equal(t, ciphertext, "defaulted ciphertext", "Should have used the default encrypter")
 }

--- a/pkg/cmd/pulumi/stack/secrets_test.go
+++ b/pkg/cmd/pulumi/stack/secrets_test.go
@@ -62,9 +62,9 @@ func TestStackSecretsManagerLoaderDecrypterFallsBack(t *testing.T) {
 	fellback := false
 	sm := &secrets.MockSecretsManager{
 		TypeF: func() string { return "mock" },
-		DecrypterF: func() (config.Decrypter, error) {
+		DecrypterF: func() config.Decrypter {
 			fellback = true
-			return config.NopDecrypter, nil
+			return config.NopDecrypter
 		},
 	}
 	snap := &deploy.Snapshot{SecretsManager: sm}
@@ -100,7 +100,7 @@ func TestStackSecretsManagerLoaderDecrypterUpdatesConfig(t *testing.T) {
 	// Arrange.
 	sm := &secrets.MockSecretsManager{
 		TypeF:      func() string { return passphrase.Type },
-		DecrypterF: func() (config.Decrypter, error) { return config.NopDecrypter, nil },
+		DecrypterF: func() config.Decrypter { return config.NopDecrypter },
 		StateF:     func() json.RawMessage { return []byte(`{"salt":"test-salt"}`) },
 	}
 	snap := &deploy.Snapshot{SecretsManager: sm}
@@ -133,9 +133,9 @@ func TestStackSecretsManagerLoaderDecrypterUsesDefaultSecretsManager(t *testing.
 	defaulted := false
 	sm := &secrets.MockSecretsManager{
 		TypeF: func() string { return "mock" },
-		DecrypterF: func() (config.Decrypter, error) {
+		DecrypterF: func() config.Decrypter {
 			defaulted = true
-			return config.NopDecrypter, nil
+			return config.NopDecrypter
 		},
 	}
 
@@ -170,9 +170,9 @@ func TestStackSecretsManagerLoaderEncrypterFallsBack(t *testing.T) {
 	fellback := false
 	sm := &secrets.MockSecretsManager{
 		TypeF: func() string { return "mock" },
-		EncrypterF: func() (config.Encrypter, error) {
+		EncrypterF: func() config.Encrypter {
 			fellback = true
-			return config.NopEncrypter, nil
+			return config.NopEncrypter
 		},
 	}
 	snap := &deploy.Snapshot{SecretsManager: sm}
@@ -208,7 +208,7 @@ func TestStackSecretsManagerLoaderEncrypterUpdatesConfig(t *testing.T) {
 	// Arrange.
 	sm := &secrets.MockSecretsManager{
 		TypeF:      func() string { return passphrase.Type },
-		EncrypterF: func() (config.Encrypter, error) { return config.NopEncrypter, nil },
+		EncrypterF: func() config.Encrypter { return config.NopEncrypter },
 		StateF:     func() json.RawMessage { return []byte(`{"salt":"test-salt"}`) },
 	}
 	snap := &deploy.Snapshot{SecretsManager: sm}
@@ -241,9 +241,9 @@ func TestStackSecretsManagerLoaderEncrypterUsesDefaultSecretsManager(t *testing.
 	defaulted := false
 	sm := &secrets.MockSecretsManager{
 		TypeF: func() string { return "mock" },
-		EncrypterF: func() (config.Encrypter, error) {
+		EncrypterF: func() config.Encrypter {
 			defaulted = true
-			return config.NopEncrypter, nil
+			return config.NopEncrypter
 		},
 	}
 

--- a/pkg/cmd/pulumi/stack/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack/stack_change_secrets_provider.go
@@ -192,10 +192,7 @@ func migrateOldConfigAndCheckpointToNewSecretsProvider(
 	)
 
 	// get the encrypter for the new secrets manager
-	newEncrypter, err := newSecretsManager.Encrypter()
-	if err != nil {
-		return err
-	}
+	newEncrypter := newSecretsManager.Encrypter()
 
 	// Create a copy of the current config map and re-encrypt using the new secrets provider
 	newProjectConfig, err := currentConfig.Config.Copy(decrypter, newEncrypter)

--- a/pkg/cmd/pulumi/stack/stack_change_secrets_provider_test.go
+++ b/pkg/cmd/pulumi/stack/stack_change_secrets_provider_test.go
@@ -250,8 +250,7 @@ runtime: mock
 	require.NoError(t, err)
 
 	// Write a dummy config file with a secret in it
-	b64Encrypter, err := secretsManager.Encrypter()
-	require.NoError(t, err)
+	b64Encrypter := secretsManager.Encrypter()
 	secretBar, err := b64Encrypter.EncryptValue(ctx, "bar")
 	require.NoError(t, err)
 	cfgKey := config.MustMakeKey("testStack", "secret")
@@ -271,8 +270,7 @@ runtime: mock
 
 	// Check that the snapshot now has a passphrase secrets manager
 	assert.Equal(t, "passphrase", snapshot.SecretsManager.Type())
-	passphraseDecrypter, err := snapshot.SecretsManager.Decrypter()
-	require.NoError(t, err)
+	passphraseDecrypter := snapshot.SecretsManager.Decrypter()
 	// Check that the snapshot still records the secret value with the same value
 	foo := snapshot.Resources[0].Outputs["foo"]
 	assert.True(t, foo.IsSecret())

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -256,7 +256,7 @@ func TestGenerateHCL2Definition(t *testing.T) {
 	for _, s := range cases.Resources {
 		s := s
 		t.Run(string(s.URN), func(t *testing.T) {
-			state, err := stack.DeserializeResource(s, config.NopDecrypter, config.NopEncrypter)
+			state, err := stack.DeserializeResource(s, config.NopDecrypter)
 			if !assert.NoError(t, err) {
 				t.Fatal()
 			}
@@ -438,7 +438,7 @@ func TestGenerateHCL2DefinitionsWithDependantResources(t *testing.T) {
 
 	states := make([]*resource.State, 0)
 	for _, r := range resources {
-		state, err := stack.DeserializeResource(r, config.NopDecrypter, config.NopEncrypter)
+		state, err := stack.DeserializeResource(r, config.NopDecrypter)
 		if !assert.NoError(t, err) {
 			t.Fatal()
 		}
@@ -529,7 +529,7 @@ func TestGenerateHCL2DefinitionsWithDependantResourcesUsingNameOrArnProperty(t *
 
 	states := make([]*resource.State, 0)
 	for _, r := range resources {
-		state, err := stack.DeserializeResource(r, config.NopDecrypter, config.NopEncrypter)
+		state, err := stack.DeserializeResource(r, config.NopDecrypter)
 		if !assert.NoError(t, err) {
 			t.Fatal()
 		}
@@ -618,7 +618,7 @@ func TestGenerateHCL2DefinitionsWithAmbiguousReferencesMaintainsLiteralValue(t *
 
 	states := make([]*resource.State, 0)
 	for _, r := range resources {
-		state, err := stack.DeserializeResource(r, config.NopDecrypter, config.NopEncrypter)
+		state, err := stack.DeserializeResource(r, config.NopDecrypter)
 		if !assert.NoError(t, err) {
 			t.Fatal()
 		}
@@ -690,7 +690,7 @@ func TestGenerateHCL2DefinitionsDoesNotMakeSelfReferences(t *testing.T) {
 
 	states := make([]*resource.State, 0)
 	for _, r := range resources {
-		state, err := stack.DeserializeResource(r, config.NopDecrypter, config.NopEncrypter)
+		state, err := stack.DeserializeResource(r, config.NopDecrypter)
 		if !assert.NoError(t, err) {
 			t.Fatal()
 		}

--- a/pkg/importer/language_test.go
+++ b/pkg/importer/language_test.go
@@ -48,7 +48,7 @@ func TestGenerateLanguageDefinition(t *testing.T) {
 		s := s
 		t.Run(string(s.URN), func(t *testing.T) {
 			t.Parallel()
-			state, err := stack.DeserializeResource(s, config.NopDecrypter, config.NopEncrypter)
+			state, err := stack.DeserializeResource(s, config.NopDecrypter)
 			if !assert.NoError(t, err) {
 				t.Fatal()
 			}
@@ -164,7 +164,7 @@ func TestGenerateLanguageDefinitionsRetriesCodegenWhenEncounteringCircularRefere
 
 	states := make([]*resource.State, 0)
 	for _, r := range resources {
-		state, err := stack.DeserializeResource(r, config.NopDecrypter, config.NopEncrypter)
+		state, err := stack.DeserializeResource(r, config.NopDecrypter)
 		if !assert.NoError(t, err) {
 			t.Fatal()
 		}
@@ -240,7 +240,7 @@ func TestGenerateLanguageDefinitionsAllowsGeneratingParentVariables(t *testing.T
 
 	states := make([]*resource.State, 0)
 	for _, r := range resources {
-		state, err := stack.DeserializeResource(r, config.NopDecrypter, config.NopEncrypter)
+		state, err := stack.DeserializeResource(r, config.NopDecrypter)
 		if !assert.NoError(t, err) {
 			t.Fatal()
 		}

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -663,7 +663,7 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter,
 					// new *resource.Secret as the key.
 					if cachingCrypter, ok := dec.(*cachingSecretsManager); ok {
 						if !cipherOk {
-							encryptedText, err := enc.EncryptValue(ctx, plaintext)
+							encryptedText, err := cachingCrypter.EncryptValue(ctx, plaintext)
 							if err != nil {
 								return resource.PropertyValue{}, fmt.Errorf("encrypting secret value: %w", err)
 							}

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -496,7 +496,7 @@ func SerializePropertyValue(ctx context.Context, prop resource.PropertyValue, en
 			// If the encrypter is a cachingCrypter, call through its encryptSecret method, which will look for a matching
 			// *resource.Secret + plaintext in its cache in order to avoid re-encrypting the value.
 			var ciphertext string
-			if cachingCrypter, ok := enc.(*cachingCrypter); ok {
+			if cachingCrypter, ok := enc.(*cachingSecretsManager); ok {
 				ciphertext, err = cachingCrypter.encryptSecret(ctx, prop.SecretValue(), plaintext)
 			} else {
 				ciphertext, err = enc.EncryptValue(ctx, plaintext)
@@ -672,7 +672,7 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter,
 					prop := resource.MakeSecret(ev)
 					// If the decrypter is a cachingCrypter, insert the plain- and ciphertext into the cache with the
 					// new *resource.Secret as the key.
-					if cachingCrypter, ok := dec.(*cachingCrypter); ok {
+					if cachingCrypter, ok := dec.(*cachingSecretsManager); ok {
 						if !cipherOk {
 							encryptedText, err := enc.EncryptValue(ctx, plaintext)
 							if err != nil {

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -110,11 +110,7 @@ func SerializeDeployment(ctx context.Context, snap *deploy.Snapshot, showSecrets
 	sm := snap.SecretsManager
 	var enc config.Encrypter
 	if sm != nil {
-		e, err := sm.Encrypter()
-		if err != nil {
-			return nil, fmt.Errorf("getting encrypter for deployment: %w", err)
-		}
-		enc = e
+		enc = sm.Encrypter()
 	} else {
 		enc = config.NewPanicCrypter()
 	}
@@ -260,10 +256,7 @@ func DeserializeDeploymentV3(
 		dec = config.NewPanicCrypter()
 		enc = config.NewPanicCrypter()
 	} else {
-		d, err := secretsManager.Decrypter()
-		if err != nil {
-			return nil, err
-		}
+		d := secretsManager.Decrypter()
 
 		// Do a first pass through state and collect all of the secrets that need decrypting.
 		// We will collect all secrets and decrypt them all at once, rather than just-in-time.
@@ -287,11 +280,7 @@ func DeserializeDeploymentV3(
 		}
 		dec = newMapDecrypter(d, cache)
 
-		e, err := secretsManager.Encrypter()
-		if err != nil {
-			return nil, err
-		}
-		enc = e
+		enc = secretsManager.Encrypter()
 	}
 
 	// For every serialized resource vertex, create a ResourceDeployment out of it.

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -230,7 +230,7 @@ func TestUnsupportedSecret(t *testing.T) {
 	rawProp := map[string]interface{}{
 		resource.SigKey: resource.SecretSig,
 	}
-	_, err := DeserializePropertyValue(rawProp, config.NewPanicCrypter(), config.NewPanicCrypter())
+	_, err := DeserializePropertyValue(rawProp, config.NewPanicCrypter())
 	assert.Error(t, err)
 }
 
@@ -240,7 +240,7 @@ func TestUnknownSig(t *testing.T) {
 	rawProp := map[string]interface{}{
 		resource.SigKey: "foobar",
 	}
-	_, err := DeserializePropertyValue(rawProp, config.NewPanicCrypter(), config.NewPanicCrypter())
+	_, err := DeserializePropertyValue(rawProp, config.NewPanicCrypter())
 	assert.Error(t, err)
 }
 
@@ -273,7 +273,7 @@ func TestDeserializeResourceReferencePropertyValueID(t *testing.T) {
 		"custom-resource-unknown-id": serialize(resource.MakeCustomResourceReference("urn3", "", "3.4.5")),
 	}
 
-	deserialized, err := DeserializePropertyValue(serialized, config.NewPanicCrypter(), config.NewPanicCrypter())
+	deserialized, err := DeserializePropertyValue(serialized, config.NewPanicCrypter())
 	assert.NoError(t, err)
 
 	assert.Equal(t, resource.NewPropertyValue(map[string]interface{}{
@@ -581,7 +581,7 @@ func TestDeserializePropertyValue(t *testing.T) {
 
 	rapid.Check(t, func(t *rapid.T) {
 		v := ObjectValueGenerator(6).Draw(t, "property value")
-		_, err := DeserializePropertyValue(v, config.NopDecrypter, config.NopEncrypter)
+		_, err := DeserializePropertyValue(v, config.NopDecrypter)
 		assert.NoError(t, err)
 	})
 }
@@ -653,7 +653,7 @@ func TestRoundTripPropertyValue(t *testing.T) {
 		wireObject, err := wireValue(original)
 		require.NoError(t, err)
 
-		deserialized, err := DeserializePropertyValue(wireObject, config.NopDecrypter, config.NopEncrypter)
+		deserialized, err := DeserializePropertyValue(wireObject, config.NopDecrypter)
 		require.NoError(t, err)
 
 		resource_testing.AssertEqualPropertyValues(t, replaceOutputsWithComputed(original), deserialized)

--- a/pkg/resource/stack/plan.go
+++ b/pkg/resource/stack/plan.go
@@ -55,14 +55,13 @@ func SerializePlanDiff(
 func DeserializePlanDiff(
 	diff apitype.PlanDiffV1,
 	dec config.Decrypter,
-	enc config.Encrypter,
 ) (deploy.PlanDiff, error) {
-	adds, err := DeserializeProperties(diff.Adds, dec, enc)
+	adds, err := DeserializeProperties(diff.Adds, dec)
 	if err != nil {
 		return deploy.PlanDiff{}, err
 	}
 
-	updates, err := DeserializeProperties(diff.Updates, dec, enc)
+	updates, err := DeserializeProperties(diff.Updates, dec)
 	if err != nil {
 		return deploy.PlanDiff{}, err
 	}
@@ -155,16 +154,15 @@ func SerializePlan(plan *deploy.Plan, enc config.Encrypter, showSecrets bool) (a
 func DeserializeResourcePlan(
 	plan apitype.ResourcePlanV1,
 	dec config.Decrypter,
-	enc config.Encrypter,
 ) (*deploy.ResourcePlan, error) {
 	var goal *deploy.GoalPlan
 	if plan.Goal != nil {
-		inputDiff, err := DeserializePlanDiff(plan.Goal.InputDiff, dec, enc)
+		inputDiff, err := DeserializePlanDiff(plan.Goal.InputDiff, dec)
 		if err != nil {
 			return nil, err
 		}
 
-		outputDiff, err := DeserializePlanDiff(plan.Goal.OutputDiff, dec, enc)
+		outputDiff, err := DeserializePlanDiff(plan.Goal.OutputDiff, dec)
 		if err != nil {
 			return nil, err
 		}
@@ -191,7 +189,7 @@ func DeserializeResourcePlan(
 
 	var outputs resource.PropertyMap
 	if plan.Outputs != nil {
-		outs, err := DeserializeProperties(plan.Outputs, dec, enc)
+		outs, err := DeserializeProperties(plan.Outputs, dec)
 		if err != nil {
 			return nil, err
 		}
@@ -211,7 +209,7 @@ func DeserializeResourcePlan(
 	}, nil
 }
 
-func DeserializePlan(plan apitype.DeploymentPlanV1, dec config.Decrypter, enc config.Encrypter) (*deploy.Plan, error) {
+func DeserializePlan(plan apitype.DeploymentPlanV1, dec config.Decrypter) (*deploy.Plan, error) {
 	manifest, err := deploy.DeserializeManifest(plan.Manifest)
 	if err != nil {
 		return nil, err
@@ -223,7 +221,7 @@ func DeserializePlan(plan apitype.DeploymentPlanV1, dec config.Decrypter, enc co
 		ResourcePlans: make(map[resource.URN]*deploy.ResourcePlan),
 	}
 	for urn, resourcePlan := range plan.ResourcePlans {
-		deserializedResourcePlan, err := DeserializeResourcePlan(resourcePlan, dec, enc)
+		deserializedResourcePlan, err := DeserializeResourcePlan(resourcePlan, dec)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -105,12 +105,15 @@ type cachingSecretsManager struct {
 // secrets.Manager that will be used to encrypt and decrypt values stored in a serialized deployment can be wrapped
 // in a caching secrets manager in order to avoid re-encrypting secrets each time the deployment is serialized.
 func NewCachingSecretsManager(manager secrets.Manager) secrets.Manager {
-	return &cachingSecretsManager{
-		manager:   manager,
-		encrypter: lazy.New(manager.Encrypter),
-		decrypter: lazy.New(manager.Decrypter),
-		cache:     make(map[*resource.Secret]cacheEntry),
+	sm := &cachingSecretsManager{
+		manager: manager,
+		cache:   make(map[*resource.Secret]cacheEntry),
 	}
+	if manager != nil {
+		sm.encrypter = lazy.New(manager.Encrypter)
+		sm.decrypter = lazy.New(manager.Decrypter)
+	}
+	return sm
 }
 
 func (csm *cachingSecretsManager) Type() string {

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -104,16 +104,8 @@ type cachingSecretsManager struct {
 // secrets.Manager that will be used to encrypt and decrypt values stored in a serialized deployment can be wrapped
 // in a caching secrets manager in order to avoid re-encrypting secrets each time the deployment is serialized.
 func NewCachingSecretsManager(manager secrets.Manager) secrets.Manager {
-	// All secrets managers should have an encrypter and decrypter, but if they don't, we'll use a panic crypter
-	// Only the mock secrets manager might be missing these
-	encrypter, err := manager.Encrypter()
-	if err != nil {
-		encrypter = config.NewPanicCrypter()
-	}
-	decrypter, err := manager.Decrypter()
-	if err != nil {
-		decrypter = config.NewPanicCrypter()
-	}
+	encrypter := manager.Encrypter()
+	decrypter := manager.Decrypter()
 	return &cachingSecretsManager{
 		manager:   manager,
 		encrypter: encrypter,
@@ -130,12 +122,12 @@ func (csm *cachingSecretsManager) State() json.RawMessage {
 	return csm.manager.State()
 }
 
-func (csm *cachingSecretsManager) Encrypter() (config.Encrypter, error) {
-	return csm, nil
+func (csm *cachingSecretsManager) Encrypter() config.Encrypter {
+	return csm
 }
 
-func (csm *cachingSecretsManager) Decrypter() (config.Decrypter, error) {
-	return csm, nil
+func (csm *cachingSecretsManager) Decrypter() config.Decrypter {
+	return csm
 }
 
 func (csm *cachingSecretsManager) EncryptValue(ctx context.Context, plaintext string) (string, error) {

--- a/pkg/resource/stack/secrets_test.go
+++ b/pkg/resource/stack/secrets_test.go
@@ -81,7 +81,7 @@ func deserializeProperty(v interface{}, dec config.Decrypter) (resource.Property
 	if err := json.Unmarshal(b, &v); err != nil {
 		return resource.PropertyValue{}, err
 	}
-	return DeserializePropertyValue(v, dec, config.NewPanicCrypter())
+	return DeserializePropertyValue(v, dec)
 }
 
 func TestCachingCrypter(t *testing.T) {

--- a/pkg/resource/stack/secrets_test.go
+++ b/pkg/resource/stack/secrets_test.go
@@ -41,12 +41,12 @@ func (t *testSecretsManager) Type() string { return "test" }
 
 func (t *testSecretsManager) State() json.RawMessage { return nil }
 
-func (t *testSecretsManager) Encrypter() (config.Encrypter, error) {
-	return t, nil
+func (t *testSecretsManager) Encrypter() config.Encrypter {
+	return t
 }
 
-func (t *testSecretsManager) Decrypter() (config.Decrypter, error) {
-	return t, nil
+func (t *testSecretsManager) Decrypter() config.Decrypter {
+	return t
 }
 
 func (t *testSecretsManager) EncryptValue(
@@ -95,8 +95,7 @@ func TestCachingCrypter(t *testing.T) {
 	foo2 := resource.MakeSecret(resource.NewStringProperty("foo"))
 	bar := resource.MakeSecret(resource.NewStringProperty("bar"))
 
-	enc, err := csm.Encrypter()
-	assert.NoError(t, err)
+	enc := csm.Encrypter()
 
 	// Serialize the first copy of "foo". Encrypt should be called once, as this value has not yet been encrypted.
 	foo1Ser, err := SerializePropertyValue(ctx, foo1, enc, false /* showSecrets */)
@@ -135,8 +134,7 @@ func TestCachingCrypter(t *testing.T) {
 	assert.Equal(t, 3, sm.encryptCalls)
 	assert.Equal(t, barSer, barSer2)
 
-	dec, err := csm.Decrypter()
-	assert.NoError(t, err)
+	dec := csm.Decrypter()
 
 	// Decrypt foo1Ser. Decrypt should be called.
 	foo1Dec, err := deserializeProperty(foo1Ser, dec)
@@ -160,8 +158,7 @@ func TestCachingCrypter(t *testing.T) {
 	// ciphertext into the cache with the associated secret.
 	csm = NewCachingSecretsManager(sm)
 
-	dec, err = csm.Decrypter()
-	assert.NoError(t, err)
+	dec = csm.Decrypter()
 
 	// Decrypt foo1Ser. Decrypt should be called.
 	foo1Dec, err = deserializeProperty(foo1Ser, dec)
@@ -181,8 +178,7 @@ func TestCachingCrypter(t *testing.T) {
 	assert.True(t, bar.DeepEquals(barDec))
 	assert.Equal(t, 6, sm.decryptCalls)
 
-	enc, err = csm.Encrypter()
-	assert.NoError(t, err)
+	enc = csm.Encrypter()
 
 	// Serialize the first copy of "foo" again. Encrypt should not be called, as this value has already been
 	// cached by the earlier calls to Decrypt.
@@ -211,8 +207,7 @@ func TestBulkDecrypt(t *testing.T) {
 
 	ctx := context.Background()
 	sm := &testSecretsManager{}
-	decrypter, err := sm.Decrypter()
-	assert.NoError(t, err)
+	decrypter := sm.Decrypter()
 	csm := newMapDecrypter(decrypter, map[string]string{})
 
 	decrypted, err := csm.BulkDecrypt(ctx, []string{"1:foo", "2:bar", "3:baz"})
@@ -254,17 +249,14 @@ func (t *mapTestSecretsManager) Type() string { return t.sm.Type() }
 
 func (t *mapTestSecretsManager) State() json.RawMessage { return t.sm.State() }
 
-func (t *mapTestSecretsManager) Encrypter() (config.Encrypter, error) {
+func (t *mapTestSecretsManager) Encrypter() config.Encrypter {
 	return t.sm.Encrypter()
 }
 
-func (t *mapTestSecretsManager) Decrypter() (config.Decrypter, error) {
-	d, err := t.sm.Decrypter()
-	if err != nil {
-		return nil, err
-	}
+func (t *mapTestSecretsManager) Decrypter() config.Decrypter {
+	d := t.sm.Decrypter()
 	t.d = &mapTestDecrypter{d: d}
-	return t.d, nil
+	return t.d
 }
 
 type mapTestDecrypter struct {

--- a/pkg/secrets/b64/manager.go
+++ b/pkg/secrets/b64/manager.go
@@ -31,7 +31,7 @@ func NewBase64SecretsManager() secrets.Manager {
 
 type manager struct{}
 
-func (m *manager) Type() string                         { return Type }
-func (m *manager) State() json.RawMessage               { return nil }
-func (m *manager) Encrypter() (config.Encrypter, error) { return config.Base64Crypter, nil }
-func (m *manager) Decrypter() (config.Decrypter, error) { return config.Base64Crypter, nil }
+func (m *manager) Type() string                { return Type }
+func (m *manager) State() json.RawMessage      { return nil }
+func (m *manager) Encrypter() config.Encrypter { return config.Base64Crypter }
+func (m *manager) Decrypter() config.Decrypter { return config.Base64Crypter }

--- a/pkg/secrets/cloud/aws_test.go
+++ b/pkg/secrets/cloud/aws_test.go
@@ -209,11 +209,8 @@ func TestAWSKmsExistingKey(t *testing.T) {
 	manager, err := NewCloudSecretsManager(stackConfig, url, false)
 	require.NoError(t, err)
 
-	enc, err := manager.Encrypter()
-	require.NoError(t, err)
-
-	dec, err := manager.Decrypter()
-	require.NoError(t, err)
+	enc := manager.Encrypter()
+	dec := manager.Decrypter()
 
 	ciphertext, err := enc.EncryptValue(ctx, "plaintext")
 	require.NoError(t, err)
@@ -236,11 +233,8 @@ func TestAWSKmsExistingState(t *testing.T) {
 	manager, err := NewCloudSecretsManagerFromState([]byte(cloudState))
 	require.NoError(t, err)
 
-	enc, err := manager.Encrypter()
-	require.NoError(t, err)
-
-	dec, err := manager.Decrypter()
-	require.NoError(t, err)
+	enc := manager.Encrypter()
+	dec := manager.Decrypter()
 
 	ciphertext, err := enc.EncryptValue(ctx, "plaintext")
 	require.NoError(t, err)

--- a/pkg/secrets/cloud/azure_test.go
+++ b/pkg/secrets/cloud/azure_test.go
@@ -85,11 +85,8 @@ func TestAzureKeyVaultExistingKey(t *testing.T) {
 	manager, err := NewCloudSecretsManager(stackConfig, url, false)
 	require.NoError(t, err)
 
-	enc, err := manager.Encrypter()
-	require.NoError(t, err)
-
-	dec, err := manager.Decrypter()
-	require.NoError(t, err)
+	enc := manager.Encrypter()
+	dec := manager.Decrypter()
 
 	ciphertext, err := enc.EncryptValue(ctx, "plaintext")
 	require.NoError(t, err)
@@ -112,11 +109,8 @@ func TestAzureKeyVaultExistingState(t *testing.T) {
 	manager, err := NewCloudSecretsManagerFromState([]byte(cloudState))
 	require.NoError(t, err)
 
-	enc, err := manager.Encrypter()
-	require.NoError(t, err)
-
-	dec, err := manager.Decrypter()
-	require.NoError(t, err)
+	enc := manager.Encrypter()
+	dec := manager.Decrypter()
 
 	ciphertext, err := enc.EncryptValue(ctx, "plaintext")
 	require.NoError(t, err)
@@ -164,9 +158,7 @@ func TestAzureKeyVaultExistingKeyState(t *testing.T) {
 	manager, err := NewCloudSecretsManager(stackConfig, url, false)
 	require.NoError(t, err)
 
-	enc, err := manager.Encrypter()
-	require.NoError(t, err)
-
+	enc := manager.Encrypter()
 	ciphertext, err := enc.EncryptValue(ctx, "plaintext")
 	require.NoError(t, err)
 
@@ -174,9 +166,7 @@ func TestAzureKeyVaultExistingKeyState(t *testing.T) {
 	newManager, err := NewCloudSecretsManagerFromState(manager.State())
 	require.NoError(t, err)
 
-	dec, err := newManager.Decrypter()
-	require.NoError(t, err)
-
+	dec := newManager.Decrypter()
 	plaintext, err := dec.DecryptValue(ctx, ciphertext)
 	require.NoError(t, err)
 	assert.Equal(t, "plaintext", plaintext)
@@ -199,11 +189,8 @@ func TestAzureKeyVaultAutoFix15329(t *testing.T) {
 	manager, err := NewCloudSecretsManagerFromState([]byte(cloudState))
 	require.NoError(t, err)
 
-	enc, err := manager.Encrypter()
-	require.NoError(t, err)
-
-	dec, err := manager.Decrypter()
-	require.NoError(t, err)
+	enc := manager.Encrypter()
+	dec := manager.Decrypter()
 
 	ciphertext, err := enc.EncryptValue(ctx, "plaintext")
 	require.NoError(t, err)

--- a/pkg/secrets/cloud/gcp_test.go
+++ b/pkg/secrets/cloud/gcp_test.go
@@ -86,11 +86,8 @@ func TestGCPExistingKey(t *testing.T) {
 	manager, err := NewCloudSecretsManager(stackConfig, url, false)
 	require.NoError(t, err)
 
-	enc, err := manager.Encrypter()
-	require.NoError(t, err)
-
-	dec, err := manager.Decrypter()
-	require.NoError(t, err)
+	enc := manager.Encrypter()
+	dec := manager.Decrypter()
 
 	ciphertext, err := enc.EncryptValue(ctx, "plaintext")
 	require.NoError(t, err)
@@ -115,11 +112,8 @@ func TestGCPExistingState(t *testing.T) {
 	manager, err := NewCloudSecretsManagerFromState([]byte(cloudState))
 	require.NoError(t, err)
 
-	enc, err := manager.Encrypter()
-	require.NoError(t, err)
-
-	dec, err := manager.Decrypter()
-	require.NoError(t, err)
+	enc := manager.Encrypter()
+	dec := manager.Decrypter()
 
 	ciphertext, err := enc.EncryptValue(ctx, "plaintext")
 	require.NoError(t, err)

--- a/pkg/secrets/cloud/manager.go
+++ b/pkg/secrets/cloud/manager.go
@@ -130,10 +130,10 @@ type Manager struct {
 	crypter config.Crypter
 }
 
-func (m *Manager) Type() string                         { return Type }
-func (m *Manager) State() json.RawMessage               { return m.state }
-func (m *Manager) Encrypter() (config.Encrypter, error) { return m.crypter, nil }
-func (m *Manager) Decrypter() (config.Decrypter, error) { return m.crypter, nil }
+func (m *Manager) Type() string                { return Type }
+func (m *Manager) State() json.RawMessage      { return m.state }
+func (m *Manager) Encrypter() config.Encrypter { return m.crypter }
+func (m *Manager) Decrypter() config.Decrypter { return m.crypter }
 
 func EditProjectStack(info *workspace.ProjectStack, state json.RawMessage) error {
 	info.EncryptionSalt = ""

--- a/pkg/secrets/cloud/manager_test.go
+++ b/pkg/secrets/cloud/manager_test.go
@@ -51,11 +51,8 @@ func testURL(ctx context.Context, t *testing.T, url string) {
 	}
 	require.NoError(t, err)
 
-	enc, err := manager.Encrypter()
-	require.NoError(t, err)
-
-	dec, err := manager.Decrypter()
-	require.NoError(t, err)
+	enc := manager.Encrypter()
+	dec := manager.Decrypter()
 
 	ciphertext, err := enc.EncryptValue(ctx, "plaintext")
 	require.NoError(t, err)

--- a/pkg/secrets/manager.go
+++ b/pkg/secrets/manager.go
@@ -32,11 +32,11 @@ type Manager interface {
 	// deployment into a snapshot.
 	State() json.RawMessage
 	// Encrypter returns a `config.Encrypter` that can be used to encrypt values when serializing a snapshot into a
-	// deployment, or an error if one can not be constructed.
-	Encrypter() (config.Encrypter, error)
+	// deployment.
+	Encrypter() config.Encrypter
 	// Decrypter returns a `config.Decrypter` that can be used to decrypt values when deserializing a snapshot from a
-	// deployment, or an error if one can not be constructed.
-	Decrypter() (config.Decrypter, error)
+	// deployment.
+	Decrypter() config.Decrypter
 }
 
 // AreCompatible returns true if the two Managers are of the same type and have the same state.

--- a/pkg/secrets/mock.go
+++ b/pkg/secrets/mock.go
@@ -26,8 +26,8 @@ import (
 type MockSecretsManager struct {
 	TypeF      func() string
 	StateF     func() json.RawMessage
-	EncrypterF func() (config.Encrypter, error)
-	DecrypterF func() (config.Decrypter, error)
+	EncrypterF func() config.Encrypter
+	DecrypterF func() config.Decrypter
 }
 
 var _ Manager = &MockSecretsManager{}
@@ -48,7 +48,7 @@ func (msm *MockSecretsManager) State() json.RawMessage {
 	panic("not implemented")
 }
 
-func (msm *MockSecretsManager) Encrypter() (config.Encrypter, error) {
+func (msm *MockSecretsManager) Encrypter() config.Encrypter {
 	if msm.EncrypterF != nil {
 		return msm.EncrypterF()
 	}
@@ -56,7 +56,7 @@ func (msm *MockSecretsManager) Encrypter() (config.Encrypter, error) {
 	panic("not implemented")
 }
 
-func (msm *MockSecretsManager) Decrypter() (config.Decrypter, error) {
+func (msm *MockSecretsManager) Decrypter() config.Decrypter {
 	if msm.DecrypterF != nil {
 		return msm.DecrypterF()
 	}

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -107,14 +107,14 @@ func (sm *localSecretsManager) State() json.RawMessage {
 	return sm.state
 }
 
-func (sm *localSecretsManager) Decrypter() (config.Decrypter, error) {
+func (sm *localSecretsManager) Decrypter() config.Decrypter {
 	contract.Assertf(sm.crypter != nil, "decrypter not initialized")
-	return sm.crypter, nil
+	return sm.crypter
 }
 
-func (sm *localSecretsManager) Encrypter() (config.Encrypter, error) {
+func (sm *localSecretsManager) Encrypter() config.Encrypter {
 	contract.Assertf(sm.crypter != nil, "encrypter not initialized")
-	return sm.crypter, nil
+	return sm.crypter
 }
 
 func EditProjectStack(info *workspace.ProjectStack, state json.RawMessage) error {

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -114,14 +114,14 @@ func (sm *serviceSecretsManager) State() json.RawMessage {
 	return sm.state
 }
 
-func (sm *serviceSecretsManager) Decrypter() (config.Decrypter, error) {
+func (sm *serviceSecretsManager) Decrypter() config.Decrypter {
 	contract.Assertf(sm.crypter != nil, "decrypter not initialized")
-	return sm.crypter, nil
+	return sm.crypter
 }
 
-func (sm *serviceSecretsManager) Encrypter() (config.Encrypter, error) {
+func (sm *serviceSecretsManager) Encrypter() config.Encrypter {
 	contract.Assertf(sm.crypter != nil, "encrypter not initialized")
-	return sm.crypter, nil
+	return sm.crypter
 }
 
 func NewServiceSecretsManager(

--- a/sdk/go/common/lazy/lazy.go
+++ b/sdk/go/common/lazy/lazy.go
@@ -1,0 +1,45 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lazy
+
+import "sync"
+
+// Lazy is a type that represents a value that is computed only once on first access
+// and then cached for subsequent calls. This is thread-safe.
+type Lazy[T any] interface {
+	Value() T
+}
+
+type lazy[T any] struct {
+	once   sync.Once
+	result T
+	f      func() T
+}
+
+// New creates a new Lazy[T] with the given function to compute the value.
+func New[T any](f func() T) Lazy[T] {
+	return &lazy[T]{
+		f:    f,
+		once: sync.Once{},
+	}
+}
+
+// Value returns the computed value, computing it on the first access.
+func (l *lazy[T]) Value() T {
+	l.once.Do(func() {
+		l.result = l.f()
+	})
+	return l.result
+}


### PR DESCRIPTION
1. Remove unused error returns when constructing an `Encrypter` or `Decrypter` from a `SecretManager`.
2. Remove passing an `Encrypter` into the deserialization methods.

## Design rational

1. We were calling encrypt within deserialize whenever the source was plaintext, but would just discard the result if the decrypter wasn't an instance of `cachingCrypter`. Therefore the first optimisation we can make is to only encrypt after we've established that we've got a `cachingCrypter` to write to.
3. When the decrypter is a `cachingCrypter`, it must have been created by the `cachingManager` and so we know that the encrypter also came from the `cachingManager`. However, the `cachingCrypter` was instantiated twice - once with only an encrypter and once with only a decrypter. If we make the encrypter available within the same instance of the `cachingCrypter`, then we can use the encrypter from the instance instead of requiring the encrypter to be passed in as a separate argument.
4. If the `cachingCrypter` class is just implementing the Encrypter and Decrypter interfaces with the values from the `cachingSecretsManager`, we could just implement these interfaces directly on the `cachingSecretsManager` instead to avoid copying references to the cache into the `cachingCrypter`. This makes it much easier to follow how the cache gets reused between the decrypter and encrypter instances as they're now the same object.

Adding the crypter interface onto the `cachingSecretsManager` makes it easiest to fetch the underlying encrypter and decrypter instances within the constructor which opens a couple of questions:

### Is both Encrypter and Decrypter always available?

- Passphrase, service, cloud and base64 secret managers only have a single crypter object returned from both Encrypter and Decrypter methods.
- The cachingSecretsManager just calls through to the provided Encrypter or Decrypter.
- Only the MockSecretsManager could have only one of the encrypter or decrypter set up. However, this panics rather than returns an error.

### In what situations are we returned an error when asking the SecretManager for an Encrypter or Decrypter?
- Never.

Therefore, we can just delete the error returns from all `SecretManager` `Encrypter()` and `Decrypter()` methods.

Finally, having moved the `EncryptValue` call to the `cachingSecretsManager`, we no longer use the encrypter on any code paths for Snapshot deserialization and can remove all unused instances of this argument.

Commits are factored to separate out these logical steps for review.

## Pending questions

> Why do we call encrypt at all during deserialization?

It appears the purpose it to prime the cache so that all existing secrets are contained in the cache after deserialization so we're able to re-serialize it very quickly, if unchanged.

> Do we always need these cached values?

Not always. The cache is only _required_ when round-tripping a deployment, which could in theory be done using a NoopCrypter which never really deserializes the secrets but just sets the plaintexts to the ciphertext then reverses the process during serialization.

Therefore we can't entirely remove the process of injecting the secret values into the cache, but this should allow us to simplify further with the new abstractions being built for bulk serialization in https://github.com/pulumi/pulumi/pull/18576