### PR TITLE
correctly run versionless plugins in subdirs

### DIFF
--- a/changelog/pending/20250218--cli-package--correctly-deal-with-subdirs-in-package-add-when-no-version-number-is-specified.yaml
+++ b/changelog/pending/20250218--cli-package--correctly-deal-with-subdirs-in-package-add-when-no-version-number-is-specified.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/package
+  description: Correctly deal with subdirs in package add when no version number is specified

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -2293,6 +2293,11 @@ func getPluginInfoAndPath(
 		match = LegacySelectCompatiblePlugin(plugins, kind, name, version)
 	}
 
+	// If the plugin is located in a subdir, we need to fix up the path to include the subdir.
+	if subdir != "" && match != nil {
+		match.Path = filepath.Join(match.Path, subdir)
+	}
+
 	if match != nil {
 		matchPath := getPluginPath(match)
 		logging.V(6).Infof("GetPluginPath(%s, %s, %v): found in cache at %s", kind, name, version, matchPath)
@@ -2331,10 +2336,6 @@ func SelectPrereleasePlugin(
 ) *PluginInfo {
 	for _, cur := range plugins {
 		if cur.Kind == kind && cur.Name == name && cur.Version != nil && cur.Version.EQ(*version) {
-			// If the plugin is located in a subdir, we need to fix up the path to include the subdir.
-			if subdir != "" {
-				cur.Path = filepath.Join(cur.Path, subdir)
-			}
 			return &cur
 		}
 	}

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1035,6 +1035,16 @@ func NewPluginSpec(
 			// Prefix the url with `git://`, so we can later recognize this as a git URL.
 			pluginDownloadURL = "git://" + u.String()
 			isGitPlugin = true
+			// If there is no version specified, we version the plugin ourselves. This way the user gets
+			// a consistent experience once the plugin is installed, and won't have any problems when the repo
+			// is updated.
+			if versionStr == "" {
+				var err error
+				version, err = gitutil.GetLatestTagOrHash(context.Background(), url)
+				if err != nil {
+					return PluginSpec{}, err
+				}
+			}
 		}
 	}
 

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1037,7 +1037,8 @@ func NewPluginSpec(
 			isGitPlugin = true
 			// If there is no version specified, we version the plugin ourselves. This way the user gets
 			// a consistent experience once the plugin is installed, and won't have any problems when the repo
-			// is updated.
+			// is updated.  The version will then be added to the plugins SDK, and will be reused when the NewPluginSpec
+			// is used, so the user gets a consistent experience.
 			if versionStr == "" {
 				var err error
 				version, err = gitutil.GetLatestTagOrHash(context.Background(), url)

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1793,19 +1793,6 @@ func TestNewPluginSpec(t *testing.T) {
 			Error:  errors.New("VERSION must be valid semver: Invalid character(s) found in patch number \"0.0\""),
 		},
 		{
-			name:   "git plugin",
-			source: "github.com/pulumi/pulumi-example",
-			kind:   apitype.ResourcePlugin,
-			ExpectedPluginSpec: PluginSpec{
-				Name:              "github.com_pulumi_pulumi-example.git",
-				Kind:              apitype.ResourcePlugin,
-				Version:           nil,
-				PluginDownloadURL: "git://github.com/pulumi/pulumi-example",
-				PluginDir:         "",
-				Checksums:         nil,
-			},
-		},
-		{
 			name:   "git plugin with version",
 			source: "github.com/pulumi/pulumi-example@v1.0.0",
 			kind:   apitype.ResourcePlugin,
@@ -1836,19 +1823,6 @@ func TestNewPluginSpec(t *testing.T) {
 			source: "github.com/pulumi/pulumi-example@abcdxyz",
 			kind:   apitype.ResourcePlugin,
 			Error:  errors.New("VERSION must be valid semver or git commit hash: abcdxyz"),
-		},
-		{
-			name:   "https prefixed git plugin",
-			source: "https://github.com/pulumi/pulumi-example",
-			kind:   apitype.ResourcePlugin,
-			ExpectedPluginSpec: PluginSpec{
-				Name:              "github.com_pulumi_pulumi-example.git",
-				Kind:              apitype.ResourcePlugin,
-				Version:           nil,
-				PluginDownloadURL: "git://github.com/pulumi/pulumi-example",
-				PluginDir:         "",
-				Checksums:         nil,
-			},
 		},
 		{
 			name:   "https prefixed git plugin with version",
@@ -1884,12 +1858,13 @@ func TestNewPluginSpec(t *testing.T) {
 		},
 		{
 			name:   "https:// prefixed with no . in URL",
-			source: "https://localhost/test/repo",
+			source: "https://localhost/test/repo@v1.0.0",
 			kind:   apitype.ResourcePlugin,
 			ExpectedPluginSpec: PluginSpec{
 				Name:              "localhost_test_repo.git",
 				Kind:              apitype.ResourcePlugin,
 				PluginDownloadURL: "git://localhost/test/repo",
+				Version:           &v1,
 			},
 		},
 		{


### PR DESCRIPTION
When we have plugins that are located in a subdir of a repository, we need to fix up the path to include that subdir, as we install the whole repository into `~/.pulumi/plugins`, and then use the plugin from a subdir.

Currently we only do that for "prerelease plugins", which means plugins whose version is referenced by a commit hash.  This is however not correct, as plugins from Git plugins don't necessarily have a version number, or they can be referenced by a regular semver version.

Fix up the path unconditionally if we have a subdir instead.

Fixes https://github.com/pulumi/pulumi/issues/18557