### PR TITLE
Fix passing of Name and Type to some provider methods

### DIFF
--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -402,6 +402,8 @@ func TestCRUD(t *testing.T) {
 		// Create
 		create, err := r.Create(context.Background(), plugin.CreateRequest{
 			URN:        urn,
+			Name:       urn.Name(),
+			Type:       urn.Type(),
 			Properties: check.Properties,
 			Timeout:    timeout,
 		})

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -240,6 +240,8 @@ func newQueryResourceMonitor(
 			}
 			resp, err := reg.Create(context.TODO(), plugin.CreateRequest{
 				URN:        urn,
+				Name:       urn.Name(),
+				Type:       urn.Type(),
 				Properties: checkResponse.Properties,
 				Timeout:    9999,
 			})

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -296,6 +296,8 @@ func (s *CreateStep) Apply() (resource.Status, StepCompleteFunc, error) {
 
 		resp, err := prov.Create(context.TODO(), plugin.CreateRequest{
 			URN:        s.URN(),
+			Name:       s.new.URN.Name(),
+			Type:       s.new.URN.Type(),
 			Properties: s.new.Inputs,
 			Timeout:    s.new.CustomTimeouts.Create,
 			Preview:    s.deployment.opts.DryRun,
@@ -869,6 +871,8 @@ func (s *ReadStep) Apply() (resource.Status, StepCompleteFunc, error) {
 		// send of inputs as both "inputs" and "state". Something to break to tidy up in V4.
 		result, err := prov.Read(context.TODO(), plugin.ReadRequest{
 			URN:    urn,
+			Name:   urn.Name(),
+			Type:   urn.Type(),
 			ID:     id,
 			Inputs: s.new.Inputs,
 			State:  s.new.Inputs,
@@ -1024,6 +1028,8 @@ func (s *RefreshStep) Apply() (resource.Status, StepCompleteFunc, error) {
 	var initErrors []string
 	refreshed, err := prov.Read(context.TODO(), plugin.ReadRequest{
 		URN:    s.old.URN,
+		Name:   s.old.URN.Name(),
+		Type:   s.old.URN.Type(),
 		ID:     resourceID,
 		Inputs: s.old.Inputs,
 		State:  s.old.Outputs,
@@ -1278,8 +1284,10 @@ func (s *ImportStep) Apply() (resource.Status, StepCompleteFunc, error) {
 			return resource.StatusOK, nil, err
 		}
 		read, err := prov.Read(context.TODO(), plugin.ReadRequest{
-			URN: s.new.URN,
-			ID:  s.new.ID,
+			URN:  s.new.URN,
+			Name: s.new.URN.Name(),
+			Type: s.new.URN.Type(),
+			ID:   s.new.ID,
 		})
 		rst = read.Status
 

--- a/pkg/resource/deploy/step_test.go
+++ b/pkg/resource/deploy/step_test.go
@@ -167,6 +167,7 @@ func TestCreateStep(t *testing.T) {
 				var createCalled bool
 				s := &CreateStep{
 					new: &resource.State{
+						URN:    "urn:pulumi:stack::project::some-type::some-urn",
 						Custom: true,
 					},
 					deployment: &Deployment{
@@ -190,6 +191,7 @@ func TestCreateStep(t *testing.T) {
 				t.Parallel()
 				s := &CreateStep{
 					new: &resource.State{
+						URN:    "urn:pulumi:stack::project::some-type::some-urn",
 						Custom: true,
 					},
 					deployment: &Deployment{
@@ -218,6 +220,7 @@ func TestCreateStep(t *testing.T) {
 				t.Parallel()
 				s := &CreateStep{
 					new: &resource.State{
+						URN:    "urn:pulumi:stack::project::some-type::some-urn",
 						Custom: true,
 					},
 					deployment: &Deployment{
@@ -512,7 +515,7 @@ func TestReadStep(t *testing.T) {
 			s := &ReadStep{
 				old: &resource.State{},
 				new: &resource.State{
-					URN:    "some-urn",
+					URN:    "urn:pulumi:stack::project::some-type::some-urn",
 					ID:     "some-id",
 					Custom: true,
 					// Use denydefaultprovider ID to ensure failure.
@@ -538,7 +541,7 @@ func TestReadStep(t *testing.T) {
 			s := &ReadStep{
 				old: &resource.State{},
 				new: &resource.State{
-					URN:    "some-urn",
+					URN:    "urn:pulumi:stack::project::some-type::some-urn",
 					ID:     "some-id",
 					Custom: true,
 					// Use denydefaultprovider ID to ensure failure.
@@ -803,7 +806,7 @@ func TestRefreshStepPatterns(t *testing.T) {
 	for _, tc := range tests {
 		s := &RefreshStep{
 			old: &resource.State{
-				URN:      "some-urn",
+				URN:      "urn:pulumi:stack::project::some-type::some-urn",
 				ID:       "some-id",
 				Type:     "some-type",
 				Custom:   true,
@@ -866,7 +869,7 @@ func TestRefreshStep(t *testing.T) {
 			expectedErr := errors.New("expected error")
 			s := &RefreshStep{
 				old: &resource.State{
-					URN:    "some-urn",
+					URN:    "urn:pulumi:stack::project::some-type::some-urn",
 					ID:     "some-id",
 					Custom: true,
 					// Use denydefaultprovider ID to ensure failure.
@@ -891,7 +894,7 @@ func TestRefreshStep(t *testing.T) {
 			t.Parallel()
 			s := &RefreshStep{
 				old: &resource.State{
-					URN:    "some-urn",
+					URN:    "urn:pulumi:stack::project::some-type::some-urn",
 					ID:     "some-id",
 					Type:   "some-type",
 					Custom: true,


### PR DESCRIPTION
We never saw these in practice because the gRPC layer always fills them in, but if running engine tests without grpc we'd be missing this data on the requests.

Noticed this while working on some tests for the new refresh logic and tried to use `Name` and it was empty.