### PR TITLE
Do not cache schema if we never read it back

### DIFF
--- a/changelog/pending/20250217--pkg--do-not-cache-schema-if-we-never-read-it-back.yaml
+++ b/changelog/pending/20250217--pkg--do-not-cache-schema-if-we-never-read-it-back.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pkg
+  description: Do not cache schema if we never read it back

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -386,7 +386,9 @@ func (l *pluginLoader) loadSchemaBytes(
 		version = pluginInfo.Version
 	}
 
-	if pluginInfo.SchemaPath != "" && version != nil && descriptor.Parameterization == nil {
+	canCache := pluginInfo.SchemaPath != "" && version != nil && descriptor.Parameterization == nil
+
+	if canCache {
 		schemaBytes, ok := l.loadCachedSchemaBytes(descriptor.Name, pluginInfo.SchemaPath, pluginInfo.SchemaTime)
 		if ok {
 			return schemaBytes, nil, nil
@@ -398,7 +400,7 @@ func (l *pluginLoader) loadSchemaBytes(
 		return nil, nil, fmt.Errorf("Error loading schema from plugin: %w", err)
 	}
 
-	if pluginInfo.SchemaPath != "" {
+	if canCache {
 		err = atomic.WriteFile(pluginInfo.SchemaPath, bytes.NewReader(schemaBytes))
 		if err != nil {
 			return nil, nil, fmt.Errorf("Error writing schema from plugin to cache: %w", err)


### PR DESCRIPTION
This change makes is so that Pulumi (and plugins like pulumi-yaml) will not write schema cache if we do not read it back. In particular, this affects plugins from PATH that is usually read-only and version is nil, and hence writing the schema cache would fail.

Related discussion: https://github.com/pulumi/pulumi/pull/10971#discussion_r990558593