### PR TITLE
Add Mise to `pulumi/pulumi`

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,23 @@
+[env]
+PULUMI_ROOT = "{{env.PWD}}/.root"
+
+_.path = [
+  "{{env.PULUMI_ROOT}}/bin",
+]
+
+[tools]
+github-cli = "latest"
+"go:github.com/go-delve/delve/cmd/dlv" = "latest"
+"go:golang.org/x/tools/gopls" = "latest"
+go = "1.23"
+gofumpt = "latest"
+golangci-lint = "latest"
+jq = "latest"
+node = "20"
+"npm:pnpm" = "latest"
+"npm:typescript" = "latest"
+"npm:typescript-language-server" = "latest"
+"npm:yarn" = "latest"
+python = '3.11'
+
+[plugins]

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,7 @@ complete documentation for maintainers of and contributors to Pulumi.
 :titlesonly:
 
 Home <self>
-/docs/documentation/README
-/docs/debugging/README
+/docs/contributing/README
 /docs/architecture/README
 /docs/references/README
 :::

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -1,0 +1,11 @@
+(contributing)=
+# Contributing
+
+:::{toctree}
+:maxdepth: 2
+:titlesonly:
+
+/docs/contributing/development
+/docs/documentation/README
+/docs/debugging/README
+:::

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -1,0 +1,41 @@
+(dev)=
+# Development
+
+(devenv)=
+## Tools and environment
+
+This repository makes use of a number of tools. At a minimum, you'll want to
+install the following on your machine:
+
+- [Go](https://go.dev/dl/), for building and running the code in this
+  repository, including the Go SDK.
+- [NodeJS](https://nodejs.org/en/download/), for working with the NodeJS SDK.
+- [Python](https://www.python.org/downloads/), for working with the Python SDK.
+- [.NET](https://dotnet.microsoft.com/download), for working with the .Net SDK.
+- [Golangci-lint](https://github.com/golangci/golangci-lint), for linting Go
+  code.
+- [gofumpt](https://github.com/mvdan/gofumpt) for formatting Go code. See
+  [installation](https://github.com/mvdan/gofumpt#installation) for editor setup
+  instructions.
+- [Yarn](https://yarnpkg.com/), for building and working with the NodeJS SDK.
+- [Pulumictl](https://github.com/pulumi/pulumictl)
+- [jq](https://stedolan.github.io/jq/)
+
+For consistency and ease of use, this repository provides a
+[](gh-file:pulumi#.mise.toml) file for configuring [Mise](https://mise.jdx.dev),
+a tool for managing development environments (similar in nature to `direnv` or
+`asdf`). To use it, you only need to install Mise and activate the environment,
+which you can do as follows:
+
+1. [Install
+   Mise](https://mise.jdx.dev/getting-started.html#installing-mise-cli).
+2. Configure your shell to [activate
+   Mise](https://mise.jdx.dev/getting-started.html#activate-mise). This is
+   typically accomplished by adding an appropriate invocation of `mise activate`
+   to your shell's configuration file (e.g. `.bashrc`, `.zshrc`, etc.).
+3. Restart your shell session so that your configuration changes take effect.
+4. `cd` into the root of this repository. You should find that the tools you
+   need are now available in your `PATH`. If not, running `mise install` should
+   sort things out.
+
+Use of Mise is currently experimental and optional.

--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -1,0 +1,66 @@
+# Documentation
+
+Documentation is built with [Sphinx](https://www.sphinx-doc.org) and authored in
+Markdown as much as possible. Markdown support for Sphinx is provided by
+[MyST](https://myst-parser.readthedocs.io), which provides a number of
+extensions to the Markdown dialect you may be used to in order to take advantage
+of various Sphinx features.
+
+## Workflow
+
+### Building
+
+The `docs` directory contains a `Makefile` (<gh-file:pulumi#docs/Makefile>) for
+working with the documentation. Generally you'll just want:
+
+```sh
+make -C docs watch
+```
+
+which will watch for changes and rebuild the documentation as needed, serving
+the results at <http://localhost:8000/docs/README.html>.
+
+### Deployment
+
+This documentation is deployed to [Read the Docs](https://readthedocs.org) as
+part of our CI/CD pipelines. The `build` target in the `Makefile` is used to
+build an HTML version of the documentation that Read the Docs then deploys. See
+the <gh-file:pulumi#.readthedocs.yaml> configuration in the root of the
+repository for more information.
+
+#### Previewing changes
+
+If you want to preview the documentation as it will appear on Read the Docs,
+simply raise a PR with your changes. Read the Docs will build your PR and
+generate a preview site for you to review. The link to the preview site will
+appear in the list of checks on your PR. See [Read the Docs' documentation on
+preview builds](https://docs.readthedocs.io/en/stable/pull-requests.html) for
+more.
+
+#### Local builds
+
+If you want to build the documentation without watching for changes, you can use
+the `build` target yourself locally, too. Set the `READTHEDOCS_OUTPUT`
+environment variable to the location you'd like the documentation to be built to
+and then run the build:
+
+```sh
+export READTHEDOCS_OUTPUT=/path/to/output
+make -C docs build
+```
+
+`build` will compile documentation to a static HTML website in the
+`/path/to/output/html` directory; you can open the `index.html` file in your
+browser to view the built files from there:
+
+```sh
+open /path/to/output/html/index.html
+```
+
+:::{toctree}
+:maxdepth: 1
+:titlesonly:
+
+/docs/documentation/writing
+/docs/documentation/diagrams
+:::

--- a/docs/documentation/diagrams.md
+++ b/docs/documentation/diagrams.md
@@ -1,0 +1,204 @@
+# Diagrams
+
+MyST supports [Mermaid](https://mermaid.js.org) diagrams. Mermaid is a
+diagramming and charting tool that renders Markdown-inspired text definitions to
+create and modify diagrams dynamically. Use the ```` ```mermaid ```` language
+type to create a diagram. This page gives some examples (taken from the official
+site at the time of writing) but as always you can find more comprehensive
+information in the official documentation.
+
+## Flow charts
+
+````markdown
+```mermaid
+graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;
+```
+````
+
+```mermaid
+graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;
+```
+
+## Sequence diagrams
+
+````markdown
+```mermaid
+sequenceDiagram
+    participant Alice
+    participant Bob
+    Alice->>John: Hello John, how are you?
+    loop HealthCheck
+        John->>John: Fight against hypochondria
+    end
+    Note right of John: Rational thoughts <br/>prevail!
+    John-->>Alice: Great!
+    John->>Bob: How about you?
+    Bob-->>John: Jolly good!
+```
+````
+
+```mermaid
+sequenceDiagram
+    participant Alice
+    participant Bob
+    Alice->>John: Hello John, how are you?
+    loop HealthCheck
+        John->>John: Fight against hypochondria
+    end
+    Note right of John: Rational thoughts <br/>prevail!
+    John-->>Alice: Great!
+    John->>Bob: How about you?
+    Bob-->>John: Jolly good!
+```
+
+## Gantt charts
+
+````markdown
+```mermaid
+gantt
+dateFormat YYYY-MM-DD
+title      Adding GANTT charts to Mermaid
+excludes   weekdays 2014-01-10
+
+section A section
+Completed task            :done,    des1, 2014-01-06,2014-01-08
+Active task               :active,  des2, 2014-01-09, 3d
+Future task               :         des3, after des2, 5d
+Future task2               :         des4, after des3, 5d
+```
+````
+
+```mermaid
+gantt
+dateFormat YYYY-MM-DD
+title      Adding GANTT charts to Mermaid
+excludes   weekdays 2014-01-10
+
+section A section
+Completed task            :done,    des1, 2014-01-06,2014-01-08
+Active task               :active,  des2, 2014-01-09, 3d
+Future task               :         des3, after des2, 5d
+Future task2               :         des4, after des3, 5d
+```
+
+## Class diagrams
+
+````markdown
+```mermaid
+classDiagram
+Class01 <|-- AveryLongClass : Cool
+Class03 *-- Class04
+Class05 o-- Class06
+Class07 .. Class08
+Class09 --> C2 : Where am i?
+Class09 --* C3
+Class09 --|> Class07
+Class07 : equals()
+Class07 : Object[] elementData
+Class01 : size()
+Class01 : int chimp
+Class01 : int gorilla
+Class08 <--> C2: Cool label
+```
+````
+
+```mermaid
+classDiagram
+Class01 <|-- AveryLongClass : Cool
+Class03 *-- Class04
+Class05 o-- Class06
+Class07 .. Class08
+Class09 --> C2 : Where am i?
+Class09 --* C3
+Class09 --|> Class07
+Class07 : equals()
+Class07 : Object[] elementData
+Class01 : size()
+Class01 : int chimp
+Class01 : int gorilla
+Class08 <--> C2: Cool label
+```
+
+## Commit graphs and trees (Git graphs)
+
+````markdown
+```mermaid
+    gitGraph
+       commit
+       commit
+       branch develop
+       commit
+       commit
+       commit
+       checkout main
+       commit
+       commit
+```
+````
+
+```mermaid
+    gitGraph
+       commit
+       commit
+       branch develop
+       commit
+       commit
+       commit
+       checkout main
+       commit
+       commit
+```
+
+## Entity-relationship (ER) diagrams
+
+````markdown
+```mermaid
+erDiagram
+    CUSTOMER ||--o{ ORDER : places
+    ORDER ||--|{ LINE-ITEM : contains
+    CUSTOMER }|..|{ DELIVERY-ADDRESS : uses
+```
+````
+
+```mermaid
+erDiagram
+    CUSTOMER ||--o{ ORDER : places
+    ORDER ||--|{ LINE-ITEM : contains
+    CUSTOMER }|..|{ DELIVERY-ADDRESS : uses
+```
+
+## User journey diagrams
+
+````markdown
+```mermaid
+journey
+    title My working day
+    section Go to work
+      Make tea: 5: Me
+      Go upstairs: 3: Me
+      Do work: 1: Me, Cat
+    section Go home
+      Go downstairs: 5: Me
+      Sit down: 5: Me
+```
+````
+
+```mermaid
+journey
+    title My working day
+    section Go to work
+      Make tea: 5: Me
+      Go upstairs: 3: Me
+      Do work: 1: Me, Cat
+    section Go home
+      Go downstairs: 5: Me
+      Sit down: 5: Me
+```

--- a/docs/documentation/writing.md
+++ b/docs/documentation/writing.md
@@ -1,0 +1,166 @@
+# Writing documentation
+
+## Contributing
+
+The sources of all the pages on this website are maintained in the
+[docs](https://github.com/pulumi/pulumi/tree/master/docs) folder of the
+[pulumi](https://github.com/pulumi/pulumi) GitHub repository. Pulumi welcomes contributions to the developer
+documentation via Pull Requests.
+
+## Conventions
+
+* Write documentation in Markdown (`.md` files) where possible. While Sphinx
+  supports reStructuredText (rST, `.rst` files), Markdown is generally more
+  ubiquitous, and easier to read and write for contributors. Most advanced
+  reStructuredText features are made available by the
+  [MyST parser](https://myst-parser.readthedocs.io) we use, so you should be
+  able to do everything you need to do in Markdown. If you can't, consider
+  opening an issue so that we can make it possible!
+
+* The entry point for documentation on a component, service, library, etc.
+  should be named `README.md`.
+
+* Use headers correctly. All documents *must* have a top-level ("h1") header --
+  this is `#` in Markdown. There *must* not be more than one top-level header in
+  a given file.
+
+* If you are documenting a single thing (a component, service, library etc.) you
+  should in almost all cases use the name of that thing (or an appropriate
+  human-readable counterpart) as the top-level header (e.g.
+  `# Code generation` in `pkg/codegen/README.md`).
+
+* If you are documenting a group of things (e.g. a package or bounded context
+  consisting of multiple libraries, services, maybe some words on how
+  development works, etc.) you should aggregate the documentation for those
+  things using an appropriate table of contents. Use the `toctree` directive
+  (available using triple-colon fences in MyST) to achieve this. You can make
+  use of globs to make this more "free" if you want:
+
+  ```markdown
+  :::{toctree}
+  :glob:
+  :maxdepth: 1
+  :titlesonly:
+
+  /path/to/package/**/README
+  :::
+  ```
+
+## MyST-compatible Markdown style guide/cheatsheet
+
+The following is a quick reference for writing MyST-compatible Markdown. For
+more comprehensive documentation, see the [MyST
+documentation](https://myst-parser.readthedocs.io).
+
+:::{note}
+The `# H1: Document title` in the example snippet below is actually written as
+an H2 (`##`) in the source document so as not to violate the principle of only
+having one top-level header per document (and in turn not break any tables of
+contents).
+:::
+
+````markdown
+# H1: Document title
+
+H1s are denoted with `#`; H2s with `##`; H3s with `###`; and so on. Leave a
+blank line before any heading. A document should have exactly one H1.
+
+Lines should be no longer than 120 characters. Except where noted, favour
+`lower-kebab-case` for identifiers/reference names etc.
+
+## H2: Getting into it
+
+Many "reStructuredText-only" features are made available in MyST Markdown using
+triple-colon fences. For example, admonitions (hints, notes, etc.) look as
+follows:
+
+:::{note}
+An example one-line note.
+:::
+
+Code blocks work as they do in normal Markdown, using backticks for inline code
+and triple backticks for blocks. Specifying a supported language will enable
+syntax highlighting:
+
+```bash
+# Execute a bash script.
+$ /some/interesting/bash/script.sh
+```
+
+Use *single asterisks for emphasis* (italics), **double asterisks for heavy
+emphasis** (boldface) and `backticks for monospace`. Links can be
+take a number of forms -- [here's an external HTTP example](https://example.com)
+and [here's a link to a part of the document](#sec-some-part-of-the-document).
+External links will open in a new tab by default.[^side-note-1]
+
+[^side-note-1]: Check out this neat side note too!
+
+(sec-some-part-of-the-document)=
+
+### H3: Cross-referencing
+
+You can define a label for a block as above using the `(label)=` syntax and
+refer to it using an `#id` as shown above. As above, follow a convention of
+prefixing sections with `sec-` and adhere to kebab-case.
+
+### H3: Custom link types
+
+MyST supports custom URL schemes and we (ab)use these for convenient linking to
+GitHub issues and files:
+
+* <gh-issue:pulumi#1234> will link to issue 1234 in the `pulumi` repository.
+* <gh-file:pulumi#README.md> will link to the `README.md` file in the `pulumi`
+  repository.
+````
+
+## H1: Document title
+
+H1s are denoted with `#`; H2s with `##`; H3s with `###`; and so on. Leave a
+blank line before any heading. A document should have exactly one H1.
+
+Lines should be no longer than 120 characters. Except where noted, favour
+`lower-kebab-case` for identifiers/reference names etc.
+
+## H2: Getting into it
+
+Many "reStructuredText-only" features are made available in MyST Markdown using
+triple-colon fences. For example, admonitions (hints, notes, etc.) look as
+follows:
+
+:::{note}
+An example one-line note.
+:::
+
+Code blocks work as they do in normal Markdown, using backticks for inline code
+and triple backticks for blocks. Specifying a supported language will enable
+syntax highlighting:
+
+```bash
+# Execute a bash script.
+$ /some/interesting/bash/script.sh
+```
+
+Use *single asterisks for emphasis* (italics), **double asterisks for heavy
+emphasis** (boldface) and `backticks for monospace`. Links can
+take a number of forms -- [here's an external HTTP example](https://example.com)
+and [here's a link to a part of the document](#sec-some-part-of-the-document).
+External links will open in a new tab by default.[^side-note-1]
+
+[^side-note-1]: Check out this neat side note too!
+
+(sec-some-part-of-the-document)=
+
+### H3: Cross-referencing
+
+You can define a label for a block as above using the `(label)=` syntax and
+refer to it using an `#id` as shown above. As above, follow a convention of
+prefixing sections with `sec-` and adhere to kebab-case.
+
+### H3: Custom link types
+
+MyST supports custom URL schemes and we (ab)use these for convenient linking to
+GitHub issues and files:
+
+* <gh-issue:pulumi#1234> will link to issue 1234 in the `pulumi` repository.
+* <gh-file:pulumi#README.md> will link to the `README.md` file in the `pulumi`
+  repository.


### PR DESCRIPTION
This commit adds [Mise](https://mise.jdx.dev) to the repository as a means to standardise on the development tooling used for working with `pulumi/pulumi`. It also stubs out some introductory documentation on it and cleans up/gathers some of the existing pages we have on contributing to the repository. As we flesh this out, we should hope to clean out the cruft from/restructure `CONTRIBUTING.md` to make it more accessible/point to these pages instead.