### PR TITLE
Fetch Org-wide Project Templates from `app.pulumi.com`

### DIFF
--- a/changelog/pending/20250224--cli-new--allow-pulumi-new-to-use-templates-defined-in-the-pulumi-cloud.yaml
+++ b/changelog/pending/20250224--cli-new--allow-pulumi-new-to-use-templates-defined-in-the-pulumi-cloud.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/new
+  description: Allow `pulumi new` to use templates defined in the Pulumi Cloud

--- a/pkg/cmd/pulumi/newcmd/new_ai_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_ai_test.go
@@ -31,6 +31,7 @@ func TestErrorsOnNonHTTPBackend(t *testing.T) {
 			return name == projectName, nil
 		},
 		SupportsTemplatesF: func() bool { return false },
+		NameF:              func() string { return "mock" },
 	})
 
 	testNewArgs := newArgs{

--- a/pkg/cmd/pulumi/newcmd/new_ai_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_ai_test.go
@@ -30,6 +30,7 @@ func TestErrorsOnNonHTTPBackend(t *testing.T) {
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return name == projectName, nil
 		},
+		SupportsTemplatesF: func() bool { return false },
 	})
 
 	testNewArgs := newArgs{

--- a/pkg/cmd/pulumi/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_test.go
@@ -757,7 +757,7 @@ func TestPulumiNewSetsTemplateTag(t *testing.T) {
 						return template, nil
 					}
 				}
-				return cmdTemplates.Template{}, errors.New("template not found")
+				return nil, errors.New("template not found")
 			}
 
 			runtimeOptionsMock := func(ctx *plugin.Context, info *workspace.ProjectRuntimeInfo,

--- a/pkg/cmd/pulumi/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_test.go
@@ -255,6 +255,7 @@ func TestCreatingProjectWithExistingPromptedNameFails(t *testing.T) {
 			return name == projectName, nil
 		},
 		SupportsTemplatesF: func() bool { return false },
+		NameF:              func() string { return "mock" },
 	})
 
 	args := newArgs{
@@ -280,6 +281,7 @@ func TestGeneratingProjectWithExistingArgsSpecifiedNameSucceeds(t *testing.T) {
 			return true, nil
 		},
 		SupportsTemplatesF: func() bool { return false },
+		NameF:              func() string { return "mock" },
 	})
 
 	// Generate-only command is not creating any stacks, so don't bother with with the name uniqueness check.
@@ -312,6 +314,7 @@ func TestGeneratingProjectWithExistingPromptedNameSucceeds(t *testing.T) {
 			return true, nil
 		},
 		SupportsTemplatesF: func() bool { return false },
+		NameF:              func() string { return "mock" },
 	})
 
 	// Generate-only command is not creating any stacks, so don't bother with with the name uniqueness check.
@@ -409,6 +412,7 @@ func TestGeneratingProjectWithInvalidPromptedNameFails(t *testing.T) {
 			return true, nil
 		},
 		SupportsTemplatesF: func() bool { return false },
+		NameF:              func() string { return "mock" },
 	})
 
 	// Generate-only command is not creating any stacks, so don't bother with with the name uniqueness check.
@@ -939,6 +943,7 @@ Available Templates:
 func TestPulumiNewWithoutTemplateSupport(t *testing.T) {
 	mockBackendInstance(t, &backend.MockBackend{
 		SupportsTemplatesF: func() bool { return false },
+		NameF:              func() string { return "mock" },
 	})
 
 	newCmd := NewNewCmd()

--- a/pkg/cmd/pulumi/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_test.go
@@ -15,6 +15,7 @@
 package newcmd
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -28,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdTemplates "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/templates"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -252,6 +254,7 @@ func TestCreatingProjectWithExistingPromptedNameFails(t *testing.T) {
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return name == projectName, nil
 		},
+		SupportsTemplatesF: func() bool { return false },
 	})
 
 	args := newArgs{
@@ -276,6 +279,7 @@ func TestGeneratingProjectWithExistingArgsSpecifiedNameSucceeds(t *testing.T) {
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return true, nil
 		},
+		SupportsTemplatesF: func() bool { return false },
 	})
 
 	// Generate-only command is not creating any stacks, so don't bother with with the name uniqueness check.
@@ -307,6 +311,7 @@ func TestGeneratingProjectWithExistingPromptedNameSucceeds(t *testing.T) {
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return true, nil
 		},
+		SupportsTemplatesF: func() bool { return false },
 	})
 
 	// Generate-only command is not creating any stacks, so don't bother with with the name uniqueness check.
@@ -403,6 +408,7 @@ func TestGeneratingProjectWithInvalidPromptedNameFails(t *testing.T) {
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return true, nil
 		},
+		SupportsTemplatesF: func() bool { return false },
 	})
 
 	// Generate-only command is not creating any stacks, so don't bother with with the name uniqueness check.
@@ -744,14 +750,14 @@ func TestPulumiNewSetsTemplateTag(t *testing.T) {
 			chdir(t, tempdir)
 			uniqueProjectName := filepath.Base(tempdir) + "test"
 
-			chooseTemplateMock := func(templates []workspace.Template, opts display.Options,
-			) (workspace.Template, error) {
+			chooseTemplateMock := func(templates []cmdTemplates.Template, opts display.Options,
+			) (cmdTemplates.Template, error) {
 				for _, template := range templates {
-					if template.Name == tt.prompted {
+					if template.Name() == tt.prompted {
 						return template, nil
 					}
 				}
-				return workspace.Template{}, errors.New("template not found")
+				return cmdTemplates.Template{}, errors.New("template not found")
 			}
 
 			runtimeOptionsMock := func(ctx *plugin.Context, info *workspace.ProjectRuntimeInfo,
@@ -817,4 +823,229 @@ func TestPulumiPromptRuntimeOptions(t *testing.T) {
 	proj := loadProject(t, tempdir)
 	require.Equal(t, 1, len(proj.Runtime.Options()))
 	require.Equal(t, "someValue", proj.Runtime.Options()["someOption"])
+}
+
+//nolint:paralleltest // Sets a global mock backend
+func TestPulumiNewWithOrgTemplates(t *testing.T) {
+	mockBackendInstance(t, &backend.MockBackend{
+		SupportsTemplatesF: func() bool { return true },
+		CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
+			return "fred", []string{"org1", "personal"}, nil, nil
+		},
+		ListTemplatesF: func(_ context.Context, orgName string) (apitype.ListOrgTemplatesResponse, error) {
+			switch orgName {
+			case "org1":
+				return apitype.ListOrgTemplatesResponse{
+					OrgHasTemplates: true,
+					Templates: map[string][]*apitype.PulumiTemplateRemote{
+						"github.com/example/foo": {
+							{
+								SourceName:  "Foo",
+								Name:        "template-1",
+								TemplateURL: "github.com/example/foo/template-1",
+								ProjectTemplate: apitype.ProjectTemplate{
+									DisplayName: "Display 1",
+									Description: "Describe 1",
+								},
+							},
+							{
+								SourceName:  "Foo",
+								Name:        "template-2",
+								TemplateURL: "github.com/example/foo/template-2",
+								ProjectTemplate: apitype.ProjectTemplate{
+									DisplayName: "Display 2",
+									Description: "Describe 2",
+								},
+							},
+						},
+					},
+				}, nil
+			case "personal":
+				return apitype.ListOrgTemplatesResponse{OrgHasTemplates: false}, nil
+			default:
+				return apitype.ListOrgTemplatesResponse{}, fmt.Errorf("unknown org %q", orgName)
+			}
+		},
+	})
+
+	newCmd := NewNewCmd()
+	var stdout, stderr bytes.Buffer
+	newCmd.SetOut(&stdout)
+	newCmd.SetErr(&stderr)
+	newCmd.SetArgs([]string{"--list-templates"})
+	err := newCmd.Execute()
+	require.NoError(t, err)
+
+	// Check that the normal prefix is still there
+	assert.Contains(t, stdout.String(), `
+Available Templates:
+`)
+	// Check that our org based templates are there
+	assert.Contains(t, stdout.String(), `
+  template-1                         Describe 1
+  template-2                         Describe 2
+`)
+
+	// Check that normal templates are there
+	assertTemplateContains(t, stdout.String(), `
+  aws-csharp                         A minimal AWS C# Pulumi program
+  aws-fsharp                         A minimal AWS F# Pulumi program
+  aws-go                             A minimal AWS Go Pulumi program
+  aws-java                           A minimal AWS Java Pulumi program
+  aws-javascript                     A minimal AWS JavaScript Pulumi program
+  aws-python                         A minimal AWS Python Pulumi program
+  aws-scala                          A minimal AWS Scala Pulumi program
+  aws-typescript                     A minimal AWS TypeScript Pulumi program
+  aws-visualbasic                    A minimal AWS VB.NET Pulumi program
+  aws-yaml                           A minimal AWS Pulumi YAML program
+`)
+	assert.Equal(t, "", stderr.String())
+}
+
+// TestPulumiNewWithoutPulumiAccessToken checks that we won't error if we run `pulumi new
+// --list-templates` without PULUMI_ACCESS_TOKEN set.
+//
+//nolint:paralleltest // Changes environmental variables
+func TestPulumiNewWithoutPulumiAccessToken(t *testing.T) {
+	t.Setenv("PULUMI_ACCESS_TOKEN", "")
+
+	newCmd := NewNewCmd()
+	var stdout, stderr bytes.Buffer
+	newCmd.SetOut(&stdout)
+	newCmd.SetErr(&stderr)
+	newCmd.SetArgs([]string{"--list-templates"})
+	err := newCmd.Execute()
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout.String(), `
+Available Templates:
+`)
+	assertTemplateContains(t, stdout.String(), `
+  aws-csharp                              A minimal AWS C# Pulumi program
+  aws-fsharp                              A minimal AWS F# Pulumi program
+  aws-go                                  A minimal AWS Go Pulumi program
+  aws-java                                A minimal AWS Java Pulumi program
+  aws-javascript                          A minimal AWS JavaScript Pulumi program
+  aws-python                              A minimal AWS Python Pulumi program
+  aws-scala                               A minimal AWS Scala Pulumi program
+  aws-typescript                          A minimal AWS TypeScript Pulumi program
+  aws-visualbasic                         A minimal AWS VB.NET Pulumi program
+  aws-yaml                                A minimal AWS Pulumi YAML program
+`)
+	assert.Equal(t, "", stderr.String())
+}
+
+//nolint:paralleltest // Sets a global mock backend
+func TestPulumiNewWithoutTemplateSupport(t *testing.T) {
+	mockBackendInstance(t, &backend.MockBackend{
+		SupportsTemplatesF: func() bool { return false },
+	})
+
+	newCmd := NewNewCmd()
+	var stdout, stderr bytes.Buffer
+	newCmd.SetOut(&stdout)
+	newCmd.SetErr(&stderr)
+	newCmd.SetArgs([]string{"--list-templates"})
+	err := newCmd.Execute()
+	require.NoError(t, err)
+
+	// Check that normal templates are there
+	assert.Contains(t, stdout.String(), `
+Available Templates:
+  aiven-go                           A minimal Aiven Go Pulumi program
+`)
+	assert.Equal(t, "", stderr.String())
+}
+
+//nolint:paralleltest // Sets a global mock backend, changes the directory
+func TestPulumiNewOrgTemplate(t *testing.T) {
+	tempdir := tempProjectDir(t)
+	chdir(t, tempdir)
+	mockBackendInstance(t, &backend.MockBackend{
+		SupportsTemplatesF: func() bool { return true },
+		CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
+			return "fred", []string{"org1"}, nil, nil
+		},
+		ListTemplatesF: func(_ context.Context, orgName string) (apitype.ListOrgTemplatesResponse, error) {
+			switch orgName {
+			case "org1":
+				return apitype.ListOrgTemplatesResponse{
+					OrgHasTemplates: true,
+					Templates: map[string][]*apitype.PulumiTemplateRemote{
+						"github.com/example/foo": {
+							{
+								SourceName:  "Foo",
+								Name:        "template-1",
+								TemplateURL: "https://github.com/example/foo/template-1",
+								ProjectTemplate: apitype.ProjectTemplate{
+									DisplayName: "Display 1",
+									Description: "Describe 1",
+								},
+							},
+						},
+					},
+				}, nil
+			default:
+				return apitype.ListOrgTemplatesResponse{}, fmt.Errorf("unknown org %q", orgName)
+			}
+		},
+		DownloadTemplateF: func(_ context.Context, orgName, templateSource string) (backend.TarReaderCloser, error) {
+			if orgName != "org1" {
+				return nil, fmt.Errorf("unknown org %q", orgName)
+			}
+			if templateSource != "https://github.com/example/foo/template-1" {
+				return nil, fmt.Errorf("unknown template source %q", templateSource)
+			}
+
+			return backend.MockTarReader{
+				"Pulumi.yaml": {Content: `name: ${PROJECT}
+description: ${DESCRIPTION}
+runtime: yaml
+template:
+  description: Describe 1
+
+resources:
+  # Create an AWS resource (S3 Bucket)
+  my-bucket:
+    type: aws:s3:BucketV2
+`},
+			}, nil
+		},
+	})
+
+	newCmd := NewNewCmd()
+	var stdout, stderr bytes.Buffer
+	newCmd.SetOut(&stdout)
+	newCmd.SetErr(&stderr)
+	newCmd.SetArgs([]string{"template-1", "--generate-only", "--yes"})
+	err := newCmd.Execute()
+	require.NoError(t, err)
+
+	proj := loadProject(t, tempdir)
+	require.Equal(t, "yaml", proj.Runtime.Name())
+}
+
+// Assert that actual contains the template rows show in expected.
+//
+// This parsing based comparison is necessary since raw string comparison is unstable
+// under insertion due to white-space changes.
+func assertTemplateContains(t *testing.T, actual, expected string) {
+	parse := func(stdout string) []struct{ name, description string } {
+		stdout = strings.TrimPrefix(stdout, `Available Templates:
+`)
+		lines := strings.Split(strings.TrimSpace(stdout), "\n")
+		out := make([]struct{ name, description string }, len(lines))
+		for i, l := range lines {
+			parts := strings.Fields(l)
+			out[i].name = parts[0]
+			out[i].description = strings.Join(parts[1:], " ")
+		}
+		return out
+	}
+
+	expectedP := parse(expected)
+	actualP := parse(actual)
+	for _, e := range expectedP {
+		assert.Contains(t, actualP, e)
+	}
 }

--- a/pkg/cmd/pulumi/newcmd/template.go
+++ b/pkg/cmd/pulumi/newcmd/template.go
@@ -39,7 +39,7 @@ const (
 func ChooseTemplate(templates []cmdTemplates.Template, opts display.Options) (cmdTemplates.Template, error) {
 	const chooseTemplateErr = "no template selected; please use `pulumi new` to choose one"
 	if !opts.IsInteractive {
-		return cmdTemplates.Template{}, errors.New(chooseTemplateErr)
+		return nil, errors.New(chooseTemplateErr)
 	}
 
 	// Customize the prompt a little bit (and disable color since it doesn't match our scheme).
@@ -57,7 +57,7 @@ func ChooseTemplate(templates []cmdTemplates.Template, opts display.Options) (cm
 		Options:  options,
 		PageSize: pageSize,
 	}, &option, ui.SurveyIcons(opts.Color)); err != nil {
-		return cmdTemplates.Template{}, errors.New(chooseTemplateErr)
+		return nil, errors.New(chooseTemplateErr)
 	}
 
 	return optionToTemplateMap[option], nil

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -267,7 +267,7 @@ func NewUpCmd() *cobra.Command {
 	) error {
 		// Retrieve the template repo.
 		templateSource := cmdTemplates.New(ctx,
-			templateNameOrURL, cmdTemplates.ScopeDefault,
+			templateNameOrURL, cmdTemplates.ScopeAll,
 			workspace.TemplateKindPulumiProject, cmdutil.Interactive())
 		defer func() {
 			contract.IgnoreError(templateSource.Close())

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -34,6 +34,7 @@ import (
 	newcmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/newcmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/plan"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	cmdTemplates "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/templates"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/autonaming"
@@ -265,16 +266,15 @@ func NewUpCmd() *cobra.Command {
 		cmd *cobra.Command,
 	) error {
 		// Retrieve the template repo.
-		repo, err := workspace.RetrieveTemplates(ctx, templateNameOrURL, false, workspace.TemplateKindPulumiProject)
-		if err != nil {
-			return err
-		}
+		templateSource := cmdTemplates.New(ctx,
+			templateNameOrURL, cmdTemplates.ScopeDefault,
+			workspace.TemplateKindPulumiProject, cmdutil.Interactive())
 		defer func() {
-			contract.IgnoreError(repo.Delete())
+			contract.IgnoreError(templateSource.Close())
 		}()
 
 		// List the templates from the repo.
-		templates, err := repo.Templates()
+		templates, err := templateSource.Templates()
 		if err != nil {
 			return err
 		}
@@ -283,9 +283,17 @@ func NewUpCmd() *cobra.Command {
 		if len(templates) == 0 {
 			return errors.New("no template found")
 		} else if len(templates) == 1 {
-			template = templates[0]
+			template, err = templates[0].Download(ctx)
+			if err != nil {
+				return err
+			}
 		} else {
-			if template, err = newcmd.ChooseTemplate(templates, opts.Display); err != nil {
+			t, err := newcmd.ChooseTemplate(templates, opts.Display)
+			if err != nil {
+				return err
+			}
+			template, err = t.Download(ctx)
+			if err != nil {
 				return err
 			}
 		}

--- a/pkg/cmd/pulumi/templates/org.go
+++ b/pkg/cmd/pulumi/templates/org.go
@@ -88,10 +88,13 @@ func (s *Source) getOrgTemplates(
 			logging.Warningf("Failed to get templates from %q: %s", org, err.Error())
 			return
 		} else if orgTemplates.HasAccessError {
-			logging.Warningf("Failed to get templates from %q: Access Denied", org)
+			logging.Warningf("Failed to get templates from %q: Access Denied\n"+
+				"Please check that %s can access all template sources", org, b.Name())
 			return
 		} else if orgTemplates.HasUpstreamError {
-			logging.Warningf("Failed to get templates from %q: Upstream Error", org)
+			// This is a catch-all error indicating only that *something* went
+			// wrong with fetching templates for an org.
+			logging.Warningf("Failed to get templates from %q: %s could not download the template", org, b.Name())
 			return
 		}
 

--- a/pkg/cmd/pulumi/templates/org.go
+++ b/pkg/cmd/pulumi/templates/org.go
@@ -159,8 +159,13 @@ func (s *Source) getOrgTemplates(
 	}
 }
 
-func writeTar(_ context.Context, reader *tar.Reader, dst string) error {
+func writeTar(ctx context.Context, reader *tar.Reader, dst string) error {
 	for {
+		// If the context has been canceled or has timed out, return.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		header, err := reader.Next()
 		if errors.Is(err, io.EOF) {
 			return nil

--- a/pkg/cmd/pulumi/templates/org.go
+++ b/pkg/cmd/pulumi/templates/org.go
@@ -1,0 +1,221 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templates
+
+import (
+	"archive/tar"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func (s *Source) getOrgTemplates(
+	ctx context.Context, templateName string,
+	interactive bool, wg *sync.WaitGroup,
+) {
+	ws := pkgWorkspace.Instance
+	project, _, err := ws.ReadProject()
+	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+		s.addError(err)
+		return
+	}
+
+	b, err := cmdBackend.CurrentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, display.Options{
+		Color:         cmdutil.GetGlobalColorization(),
+		IsInteractive: interactive,
+	})
+	if err != nil {
+		if !errors.Is(err, backend.MissingEnvVarForNonInteractiveError{}) {
+			s.addError(err)
+		}
+		return
+	}
+	if !b.SupportsTemplates() {
+		return
+	}
+
+	logging.Infof("Listing Org Templates from the cloud")
+	user, orgs, _, err := b.CurrentUser()
+	if err != nil {
+		s.addError(err)
+		return
+	} else if user == "" {
+		return // No current user - so don't proceed.
+	}
+
+	alreadySeenSourceURLs := map[string]struct{}{}
+
+	handleOrg := func(org string) {
+		defer wg.Done()
+		logging.Infof("Checking for templates from %q", org)
+		orgTemplates, err := b.ListTemplates(ctx, org)
+		if apiError := new(apitype.ErrorResponse); errors.As(err, &apiError) {
+			// This is what happens when we try to access org templates for an org that hasn't enabled org templates.
+			if apiError.Code == 402 {
+				logging.Infof("%q does not have access to org templates (code=%d)", org, apiError.Code)
+				return
+			}
+		} else if err != nil {
+			s.addError(err)
+			logging.Warningf("Failed to get templates from %q: %s", org, err.Error())
+			return
+		} else if orgTemplates.HasAccessError {
+			logging.Warningf("Failed to get templates from %q: Access Denied", org)
+			return
+		} else if orgTemplates.HasUpstreamError {
+			logging.Warningf("Failed to get templates from %q: Upstream Error", org)
+			return
+		}
+
+		for source, sourceTemplates := range orgTemplates.Templates {
+			logging.Infof("sourcing templates from %q", source)
+			for _, template := range sourceTemplates {
+				// These template are maintained using https://github.com/pulumi/templates, and are
+				// ingested without going through the Pulumi Cloud.
+				//
+				//
+				if strings.HasPrefix(template.TemplateURL, "https://github.com/pulumi/templates") {
+					continue
+				}
+
+				// Check if we already have this template from another source.
+				if _, ok := alreadySeenSourceURLs[template.TemplateURL]; ok {
+					// Skip a template that we have already seen.
+					continue
+				}
+				alreadySeenSourceURLs[template.TemplateURL] = struct{}{}
+
+				// If we are searching for a template of a specific name,
+				// only match templates of that name.
+				if templateName != "" && templateName != template.Name {
+					logging.V(10).Infof("skipping template %q", template.Name)
+					continue
+				}
+
+				logging.V(10).Infof("adding template %q", template.Name)
+				s.addTemplate(Template{
+					name:               template.Name,
+					description:        "", // No description present.
+					projectDescription: template.Description,
+					source:             s,
+					download: func(ctx context.Context) (workspace.Template, error) {
+						templateDir, err := os.MkdirTemp("", "pulumi-template-")
+						if err != nil {
+							return workspace.Template{}, err
+						}
+						// Having created a template directory, we now add it to the list of directories to close.
+						s.addCloser(func() error { return os.RemoveAll(templateDir) })
+
+						tarReader, err := b.DownloadTemplate(ctx, org, template.TemplateURL)
+						if err != nil {
+							return workspace.Template{}, err
+						}
+						if err := errors.Join(
+							writeTar(ctx, tarReader.Tar(), templateDir),
+							tarReader.Close(),
+						); err != nil {
+							return workspace.Template{}, err
+						}
+						logging.Infof("downloaded %q into %q", template.Name, templateDir)
+
+						return workspace.LoadTemplate(templateDir)
+					},
+				})
+			}
+		}
+	}
+
+	for _, org := range orgs {
+		wg.Add(1)
+		go handleOrg(org)
+	}
+}
+
+func writeTar(_ context.Context, reader *tar.Reader, dst string) error {
+	for {
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		} else if err != nil {
+			return err
+		}
+
+		logging.V(8).Infof("Decompressing %q", header.Name)
+
+		path := filepath.Clean(header.Name)
+		if !filepath.IsLocal(path) {
+			return fmt.Errorf("refusing to write non-local path %q", path)
+		}
+
+		target := filepath.Join(dst, path)
+
+		// Ensure that we can write the directory
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if header.Mode > math.MaxUint32 {
+				return fmt.Errorf("invalid file mode for %q: %02x", header.Name, header.Mode)
+			}
+
+			fileMode := os.FileMode(header.Mode) //nolint:gosec // We checked the overflow
+			err := os.Mkdir(target, fileMode)
+			if err != nil && !errors.Is(err, fs.ErrExist) {
+				return err
+			}
+
+		case tar.TypeReg:
+			if header.Mode > math.MaxUint32 {
+				return fmt.Errorf("invalid file mode for %q: %02x", header.Name, header.Mode)
+			}
+
+			fileMode := os.FileMode(header.Mode) //nolint:gosec // We checked the overflow
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, fileMode)
+			if err != nil {
+				return err
+			}
+
+			// Write the tar file into f
+			if _, err := io.Copy(f, reader); err != nil {
+				return errors.Join(err, f.Close())
+			}
+
+			// Close f. We don't use defer because we want to close each file
+			// after we open it, not leave it all until the download function
+			// exits.
+			if err := f.Close(); err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/pkg/cmd/pulumi/templates/org.go
+++ b/pkg/cmd/pulumi/templates/org.go
@@ -56,9 +56,11 @@ func (s *Source) getOrgTemplates(
 		if !errors.Is(err, backend.MissingEnvVarForNonInteractiveError{}) {
 			s.addError(err)
 		}
+		logging.Infof("could not get a backend for org templates")
 		return
 	}
 	if !b.SupportsTemplates() {
+		logging.Infof("%s does not support Org Templates", b.Name())
 		return
 	}
 

--- a/pkg/cmd/pulumi/templates/templates.go
+++ b/pkg/cmd/pulumi/templates/templates.go
@@ -1,0 +1,227 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package templates adds an abstraction for project templates that may be local or
+// remote.
+//
+// All templates are convertible into [workspace.Template].
+package templates
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// Source provides access to a set of project templates, any set of which may be present on
+// disk.
+//
+// Source is responsible for cleaning up old templates, and should always be [Close]d when
+// created.
+type Source struct {
+	templates    []Template
+	errorOnEmpty []error
+	errors       []error
+	closers      []func() error
+	closed       bool
+
+	// m should be held whenever Source is mutated.
+	m  sync.Mutex
+	wg sync.WaitGroup
+}
+
+// Templates lists the templates available to the [Source].
+func (s *Source) Templates() ([]Template, error) {
+	s.wg.Wait() // Wait to ensure that all templates have been fetched before returning the template list.
+
+	s.lockOpen("read templates")
+	defer s.m.Unlock()
+	if err := errors.Join(s.errors...); err != nil {
+		return nil, err
+	}
+	if len(s.templates) == 0 {
+		return nil, errors.Join(s.errorOnEmpty...)
+	}
+	return s.templates, nil
+}
+
+func (s *Source) addTemplate(t Template) {
+	s.lockOpen("add template")
+	s.templates = append(s.templates, t)
+	s.m.Unlock()
+}
+
+func (s *Source) addCloser(f func() error) {
+	s.lockOpen("add closer")
+	s.closers = append(s.closers, f)
+	s.m.Unlock()
+}
+
+func (s *Source) addError(err error) {
+	s.lockOpen("add error")
+	s.errors = append(s.errors, err)
+	s.m.Unlock()
+}
+
+func (s *Source) addErrorOnEmpty(err error) {
+	s.lockOpen("add error on empty")
+	s.errorOnEmpty = append(s.errorOnEmpty, err)
+	s.m.Unlock()
+}
+
+func (s *Source) lockOpen(action string) {
+	s.m.Lock()
+	if s.closed {
+		panic("Attempted to act on closed source: " + action)
+	}
+}
+
+// Close cleans up the [Source] and any associated templates.
+//
+// Close should always be called when [Source] is dropped.
+func (s *Source) Close() error {
+	s.wg.Wait() // Wait to ensure that all templates have been fetched so all closers are visible.
+
+	s.lockOpen("close")
+	defer s.m.Unlock()
+	s.closed = true
+	errs := make([]error, len(s.closers))
+	for i, f := range s.closers {
+		errs[i] = f()
+	}
+	return errors.Join(errs...)
+}
+
+type Template struct {
+	name               string
+	description        string
+	projectDescription string
+
+	error error
+
+	download func(ctx context.Context) (workspace.Template, error)
+
+	source *Source
+}
+
+func (t Template) Name() string               { return t.name }
+func (t Template) Description() string        { return t.description }
+func (t Template) ProjectDescription() string { return t.projectDescription }
+func (t Template) Error() error               { return t.error }
+
+func (t Template) Download(ctx context.Context) (workspace.Template, error) {
+	if t.source == nil {
+		panic("Cannot download a template without a host")
+	}
+	if t.source.closed {
+		panic("Cannot download a template from an already closed host")
+	}
+
+	return t.download(ctx)
+}
+
+type Scope struct{ kind string }
+
+var (
+	ScopeDefault     = Scope{}
+	scopeDefault     = ScopeAll
+	ScopeTraditional = Scope{"traditional"}
+	ScopeLocal       = Scope{"none"}
+	ScopeAll         = Scope{"all"}
+)
+
+// Create a new [Template] [Source] associated with a given [Scope].
+func New(
+	ctx context.Context, templateNamePathOrURL string, scope Scope,
+	templateKind workspace.TemplateKind, interactive bool,
+) *Source {
+	// apply the default scope, if necessary
+	if scope == ScopeDefault {
+		scope = scopeDefault
+	}
+
+	var source Source
+	ctx, cancel := context.WithCancel(ctx)
+	source.closers = append(source.closers, func() error { cancel(); return nil })
+
+	queryKind := getTemplateQuery(templateNamePathOrURL)
+
+	if scope == ScopeAll || scope == ScopeTraditional || scope == ScopeLocal {
+		source.wg.Add(1)
+		go func() {
+			source.getWorkspaceTemplates(ctx, templateNamePathOrURL, scope, templateKind, &source.wg)
+			source.wg.Done()
+		}()
+	}
+
+	if scope == ScopeAll && templateKind == workspace.TemplateKindPulumiProject && queryKind == queryName {
+		source.wg.Add(1)
+		go func() {
+			source.getOrgTemplates(ctx, templateNamePathOrURL, interactive, &source.wg)
+			source.wg.Done()
+		}()
+	}
+
+	return &source
+}
+
+type queryKind string
+
+const (
+	queryName queryKind = "query-name"
+	queryURL  queryKind = "query-url"
+	queryPath queryKind = "query-path"
+)
+
+func getTemplateQuery(query string) queryKind {
+	if workspace.IsTemplateURL(query) {
+		return queryURL
+	}
+	if isTemplatePath(query) {
+		return queryPath
+	}
+	return queryName
+}
+
+func isTemplatePath(query string) bool {
+	_, err := os.Stat(query)
+	if errors.Is(err, fs.ErrNotExist) {
+		if looksLikePath(query) {
+			const msg = "%q looks like a file path, but no file exists. Assuming to be a template name"
+			logging.Warningf(msg, query)
+		}
+		return false
+	} else if err != nil {
+		logging.Warningf("unable to stat %q: %s", query, err.Error())
+		return false
+	}
+
+	// query does point to a local file.
+
+	if !looksLikePath(query) {
+		const msg = `Assuming %[1]q is a file path, use "./%[1]s" to be unambiguous`
+		logging.Warningf(msg, query)
+	}
+	return err == nil
+}
+
+func looksLikePath(query string) bool {
+	return strings.HasPrefix(query, "./") || strings.HasPrefix(query, "/")
+}

--- a/pkg/cmd/pulumi/templates/templates.go
+++ b/pkg/cmd/pulumi/templates/templates.go
@@ -137,33 +137,28 @@ func (t Template) Download(ctx context.Context) (workspace.Template, error) {
 	return t.download(ctx)
 }
 
-type Scope struct{ kind string }
+// SearchScope dictates where [New] will search for templates.
+type SearchScope struct{ kind string }
 
 var (
-	ScopeDefault     = Scope{}
-	scopeDefault     = ScopeAll
-	ScopeTraditional = Scope{"traditional"}
-	ScopeLocal       = Scope{"none"}
-	ScopeAll         = Scope{"all"}
+	// ScopeAll searches for templates in all available locations.
+	ScopeAll = SearchScope{}
+	// ScopeLocal searches for templates only locally (on disk).
+	ScopeLocal = SearchScope{"local"}
 )
 
-// Create a new [Template] [Source] associated with a given [Scope].
+// Create a new [Template] [Source] associated with a given [SearchScope].
 func New(
-	ctx context.Context, templateNamePathOrURL string, scope Scope,
+	ctx context.Context, templateNamePathOrURL string, scope SearchScope,
 	templateKind workspace.TemplateKind, interactive bool,
 ) *Source {
-	// apply the default scope, if necessary
-	if scope == ScopeDefault {
-		scope = scopeDefault
-	}
-
 	var source Source
 	ctx, cancel := context.WithCancel(ctx)
 	source.closers = append(source.closers, func() error { cancel(); return nil })
 
 	queryKind := getTemplateQuery(templateNamePathOrURL)
 
-	if scope == ScopeAll || scope == ScopeTraditional || scope == ScopeLocal {
+	if scope == ScopeAll || scope == ScopeLocal {
 		source.wg.Add(1)
 		go func() {
 			source.getWorkspaceTemplates(ctx, templateNamePathOrURL, scope, templateKind, &source.wg)

--- a/pkg/cmd/pulumi/templates/templates.go
+++ b/pkg/cmd/pulumi/templates/templates.go
@@ -160,8 +160,6 @@ func New(
 	ctx, cancel := context.WithCancel(ctx)
 	source.closers = append(source.closers, func() error { cancel(); return nil })
 
-	queryKind := getTemplateQuery(templateNamePathOrURL)
-
 	if scope == ScopeAll || scope == ScopeLocal {
 		source.wg.Add(1)
 		go func() {
@@ -170,7 +168,7 @@ func New(
 		}()
 	}
 
-	if scope == ScopeAll && templateKind == workspace.TemplateKindPulumiProject && queryKind == queryName {
+	if scope == ScopeAll && templateKind == workspace.TemplateKindPulumiProject && isTemplateName(templateNamePathOrURL) {
 		source.wg.Add(1)
 		go func() {
 			source.getOrgTemplates(ctx, templateNamePathOrURL, interactive, &source.wg)
@@ -181,22 +179,9 @@ func New(
 	return &source
 }
 
-type queryKind string
-
-const (
-	queryName queryKind = "query-name"
-	queryURL  queryKind = "query-url"
-	queryPath queryKind = "query-path"
-)
-
-func getTemplateQuery(query string) queryKind {
-	if workspace.IsTemplateURL(query) {
-		return queryURL
-	}
-	if isTemplatePath(query) {
-		return queryPath
-	}
-	return queryName
+func isTemplateName(templateNamePathOrURL string) bool {
+	return !workspace.IsTemplateURL(templateNamePathOrURL) &&
+		!isTemplatePath(templateNamePathOrURL)
 }
 
 func isTemplatePath(query string) bool {

--- a/pkg/cmd/pulumi/templates/templates_test.go
+++ b/pkg/cmd/pulumi/templates/templates_test.go
@@ -1,0 +1,291 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templates
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:paralleltest // replaces global backend instance
+func TestFilterOnName(t *testing.T) {
+	ctx := testContext(t)
+
+	template1 := &apitype.PulumiTemplateRemote{
+		ProjectTemplate: apitype.ProjectTemplate{},
+		Name:            "name1",
+		SourceName:      "source1",
+		TemplateURL:     "example.com/source1/name1",
+	}
+
+	setBackend(t, &backend.MockBackend{
+		SupportsTemplatesF: func() bool { return true },
+		CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
+			return "doe", []string{"org1"}, &workspace.TokenInformation{}, nil
+		},
+		ListTemplatesF: func(_ context.Context, orgName string) (apitype.ListOrgTemplatesResponse, error) {
+			assert.Equal(t, "org1", orgName)
+
+			return apitype.ListOrgTemplatesResponse{
+				Templates: map[string][]*apitype.PulumiTemplateRemote{
+					"source1": {template1},
+					"source2": {
+						{
+							ProjectTemplate: apitype.ProjectTemplate{},
+							Name:            "name2",
+							SourceName:      "source2",
+							TemplateURL:     "example.com/source2/name1",
+						},
+					},
+				},
+				OrgHasTemplates: true,
+			}, nil
+		},
+	})
+
+	source := newImpl(ctx, "name1",
+		ScopeAll, workspace.TemplateKindPulumiProject,
+		false, templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+	)
+
+	template, err := source.Templates()
+	require.NoError(t, err)
+	assert.Equal(t,
+		[]Template{orgTemplate{t: template1, org: "org1", source: source, backend: cmdBackend.BackendInstance}},
+		template)
+}
+
+//nolint:paralleltest // replaces global backend instance
+func TestMultipleTemplateSources(t *testing.T) {
+	ctx := testContext(t)
+
+	template1 := &apitype.PulumiTemplateRemote{
+		ProjectTemplate: apitype.ProjectTemplate{},
+		Name:            "name1",
+		SourceName:      "source1",
+		TemplateURL:     "example.com/source1/name1",
+	}
+
+	template2 := &apitype.PulumiTemplateRemote{
+		ProjectTemplate: apitype.ProjectTemplate{},
+		Name:            "name2",
+		SourceName:      "source2",
+		TemplateURL:     "example.com/source2/name1",
+	}
+
+	setBackend(t, &backend.MockBackend{
+		SupportsTemplatesF: func() bool { return true },
+		CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
+			return "doe", []string{"org1"}, &workspace.TokenInformation{}, nil
+		},
+		ListTemplatesF: func(_ context.Context, orgName string) (apitype.ListOrgTemplatesResponse, error) {
+			assert.Equal(t, "org1", orgName)
+
+			return apitype.ListOrgTemplatesResponse{
+				Templates: map[string][]*apitype.PulumiTemplateRemote{
+					"source1": {template1},
+					"source2": {template2},
+				},
+				OrgHasTemplates: true,
+			}, nil
+		},
+	})
+
+	repoTemplateDir := t.TempDir()
+	subdir := filepath.Join(repoTemplateDir, "sub")
+	require.NoError(t, os.Mkdir(subdir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(subdir, "Pulumi.yaml"), []byte(`name: template3
+runtime: dotnet
+description: An ASP.NET application running a simple container in a EKS Cluster
+`), 0o600))
+	repoTemplates := templateRepository(workspace.TemplateRepository{
+		Root:         repoTemplateDir,
+		SubDirectory: subdir,
+	}, nil)
+
+	source := newImpl(ctx, "",
+		ScopeAll, workspace.TemplateKindPulumiProject,
+		false, repoTemplates,
+	)
+
+	template, err := source.Templates()
+	require.NoError(t, err)
+	assert.ElementsMatch(t,
+		[]Template{
+			workspaceTemplate{t: workspace.Template{
+				Dir:                subdir,
+				Name:               "sub",
+				ProjectName:        "template3",
+				ProjectDescription: "An ASP.NET application running a simple container in a EKS Cluster",
+			}},
+			orgTemplate{t: template1, org: "org1", source: source, backend: cmdBackend.BackendInstance},
+			orgTemplate{t: template2, org: "org1", source: source, backend: cmdBackend.BackendInstance},
+		},
+		template)
+}
+
+//nolint:paralleltest // replaces global backend instance
+func TestSurfaceListTemplateErrors(t *testing.T) {
+	ctx := testContext(t)
+
+	somethingWentWrong := errors.New("something went wrong")
+
+	setBackend(t, &backend.MockBackend{
+		SupportsTemplatesF: func() bool { return true },
+		CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
+			return "doe", []string{"org1"}, &workspace.TokenInformation{}, nil
+		},
+		ListTemplatesF: func(_ context.Context, orgName string) (apitype.ListOrgTemplatesResponse, error) {
+			assert.Equal(t, "org1", orgName)
+			return apitype.ListOrgTemplatesResponse{}, somethingWentWrong
+		},
+	})
+
+	source := newImpl(ctx, "name1",
+		ScopeAll, workspace.TemplateKindPulumiProject,
+		false, templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+	)
+
+	_, err := source.Templates()
+	assert.ErrorIs(t, err, somethingWentWrong)
+}
+
+//nolint:paralleltest // replaces global backend instance
+func TestSurfaceOnEmptyError(t *testing.T) {
+	ctx := testContext(t)
+
+	setBackend(t, &backend.MockBackend{
+		SupportsTemplatesF: func() bool { return true },
+		CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
+			return "doe", []string{"org1"}, &workspace.TokenInformation{}, nil
+		},
+		ListTemplatesF: func(_ context.Context, orgName string) (apitype.ListOrgTemplatesResponse, error) {
+			assert.Equal(t, "org1", orgName)
+			return apitype.ListOrgTemplatesResponse{}, nil
+		},
+	})
+
+	source := newImpl(ctx, "name1",
+		ScopeAll, workspace.TemplateKindPulumiProject,
+		false, templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+	)
+
+	_, err := source.Templates()
+	var expected workspace.TemplateNotFoundError
+	assert.ErrorAsf(t, err, &expected, "what's in %#v", source.errorOnEmpty)
+}
+
+//nolint:paralleltest // replaces global backend instance
+func TestOrgTemplateDownload(t *testing.T) {
+	ctx := testContext(t)
+
+	template1 := &apitype.PulumiTemplateRemote{
+		ProjectTemplate: apitype.ProjectTemplate{},
+		Name:            "name1",
+		SourceName:      "source1",
+		TemplateURL:     "example.com/source1/name1",
+	}
+
+	pulumiYAML := `name: template1
+runtime: dotnet
+description: An ASP.NET application running a simple container in a EKS Cluster
+`
+	anotherFile := `This is another file`
+
+	setBackend(t, &backend.MockBackend{
+		SupportsTemplatesF: func() bool { return true },
+		CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
+			return "doe", []string{"org1"}, &workspace.TokenInformation{}, nil
+		},
+		ListTemplatesF: func(_ context.Context, orgName string) (apitype.ListOrgTemplatesResponse, error) {
+			assert.Equal(t, "org1", orgName)
+
+			return apitype.ListOrgTemplatesResponse{
+				Templates: map[string][]*apitype.PulumiTemplateRemote{
+					"source1": {template1},
+				},
+				OrgHasTemplates: true,
+			}, nil
+		},
+		DownloadTemplateF: func(_ context.Context, orgName, templateSource string) (backend.TarReaderCloser, error) {
+			assert.Equal(t, "org1", orgName)
+			assert.Equal(t, template1.TemplateURL, templateSource)
+
+			return backend.MockTarReader{
+				"Pulumi.yaml": backend.MockTarFile{Content: pulumiYAML},
+				"other.txt":   backend.MockTarFile{Content: anotherFile},
+			}, nil
+		},
+	})
+
+	source := newImpl(ctx, "name1",
+		ScopeAll, workspace.TemplateKindPulumiProject,
+		false, templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+	)
+
+	template, err := source.Templates()
+	require.NoError(t, err)
+	assert.Equal(t,
+		[]Template{orgTemplate{t: template1, org: "org1", source: source, backend: cmdBackend.BackendInstance}},
+		template)
+	t.Cleanup(func() {
+		assert.NoError(t, source.Close())
+	})
+
+	wTemplate, err := template[0].Download(ctx)
+	require.NoError(t, err)
+
+	{ // Pulumi.yaml
+		file, err := os.ReadFile(filepath.Join(wTemplate.Dir, "Pulumi.yaml"))
+		require.NoError(t, err)
+		assert.Equal(t, pulumiYAML, string(file))
+	}
+	{ // other.txt
+		file, err := os.ReadFile(filepath.Join(wTemplate.Dir, "other.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, anotherFile, string(file))
+	}
+}
+
+func templateRepository(repo workspace.TemplateRepository, err error) getWorkspaceTemplateFunc {
+	return func(ctx context.Context, templateNamePathOrURL string, offline bool,
+		templateKind workspace.TemplateKind,
+	) (workspace.TemplateRepository, error) {
+		return repo, err
+	}
+}
+
+func setBackend(t *testing.T, backend backend.Backend) {
+	oldBackend := cmdBackend.BackendInstance
+	cmdBackend.BackendInstance = backend
+	t.Cleanup(func() { cmdBackend.BackendInstance = oldBackend })
+}
+
+func testContext(t *testing.T) context.Context {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	return ctx
+}

--- a/pkg/cmd/pulumi/templates/workspace.go
+++ b/pkg/cmd/pulumi/templates/workspace.go
@@ -60,11 +60,6 @@ func (s *Source) getWorkspaceTemplates(
 }
 
 // Retrieve a Private template from the given Pulumi Cloud URL **including an auth token for Pulumi Cloud**.
-//
-// workspace.GetAccount ensures the user has a valid session with the Pulumi Cloud backend.
-//   - If the user is not logged in, the login flow will be initiated.
-//   - If the user is not logged in and pulumi does not recognize the backend as a known workspace then
-//     the user will see an authentication error.
 func retrievePrivatePulumiCloudTemplate(templateURL string) (workspace.TemplateRepository, error) {
 	u, err := url.Parse(templateURL)
 	if err != nil {

--- a/pkg/cmd/pulumi/templates/workspace.go
+++ b/pkg/cmd/pulumi/templates/workspace.go
@@ -1,0 +1,118 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templates
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func (s *Source) getWorkspaceTemplates(
+	ctx context.Context, templateNamePathOrURL string, scope Scope, templateKind workspace.TemplateKind,
+	_ *sync.WaitGroup,
+) {
+	repo, err := workspace.RetrieveTemplates(ctx, templateNamePathOrURL, scope == ScopeLocal, templateKind)
+	if err != nil {
+		if notFound := new(workspace.TemplateNotFoundError); errors.As(err, notFound) {
+			s.addErrorOnEmpty(notFound)
+			return
+		}
+		// Bail on all errors unless its a 401 from a Pulumi Cloud backend...
+		if !errors.Is(err, workspace.ErrPulumiCloudUnauthorized) {
+			s.addError(err)
+			return
+		}
+
+		// ...If the request has 401'd AND we've identified the backend as being a Pulumi Cloud instance, we can
+		// attempt to retrieve the template using the user's Pulumi Cloud credentials.
+		repo, err = retrievePrivatePulumiCloudTemplate(templateNamePathOrURL)
+		if err != nil {
+			s.addError(err)
+			return
+		}
+	}
+	s.addCloser(repo.Delete)
+	workspaceTemplates, err := repo.Templates()
+	if err != nil {
+		s.addError(err)
+		return
+	}
+
+	s.addDownloadedTemplates(workspaceTemplates)
+}
+
+// Retrieve a Private template from the given Pulumi Cloud URL **including an auth token for Pulumi Cloud**.
+//
+// workspace.GetAccount ensures the user has a valid session with the Pulumi Cloud backend.
+//   - If the user is not logged in, the login flow will be initiated.
+//   - If the user is not logged in and pulumi does not recognize the backend as a known workspace then
+//     the user will see an authentication error.
+func retrievePrivatePulumiCloudTemplate(templateURL string) (workspace.TemplateRepository, error) {
+	u, err := url.Parse(templateURL)
+	if err != nil {
+		return workspace.TemplateRepository{}, fmt.Errorf("parsing template URL: %w", err)
+	}
+	// Docs convention is to store the cloud URL with the protocol.
+	// e.g. `pulumi login https://api.pulumi.com` or `pulumi login https://api.acme.org`
+	templatePulumiCloudHost := "https://" + u.Host
+
+	account, err := workspace.GetAccount(templatePulumiCloudHost)
+	if err != nil {
+		return workspace.TemplateRepository{}, fmt.Errorf(
+			"looking up pulumi cloud backend %s: %w",
+			templatePulumiCloudHost,
+			err,
+		)
+	}
+
+	if account.AccessToken == "" {
+		return workspace.TemplateRepository{}, fmt.Errorf("no access token found for %s", templatePulumiCloudHost)
+	}
+
+	templateRepository, err := workspace.RetrieveZIPTemplates(templateURL, func(req *http.Request) {
+		req.Header.Set("Authorization", "token "+account.AccessToken)
+	})
+
+	if errors.Is(err, workspace.ErrPulumiCloudUnauthorized) {
+		return workspace.TemplateRepository{}, fmt.Errorf(
+			"unauthorized to access template at %s. You may not have access to this template or token may have expired",
+			templatePulumiCloudHost,
+		)
+	}
+
+	// Caller can handle other errors
+	return templateRepository, err
+}
+
+func (s *Source) addDownloadedTemplates(src []workspace.Template) {
+	for _, t := range src {
+		s.addTemplate(Template{
+			name:               t.Name,
+			description:        t.Description,
+			projectDescription: t.ProjectDescription,
+			source:             s,
+			error:              t.Error,
+			download: func(context.Context) (workspace.Template, error) {
+				return t, nil
+			},
+		})
+	}
+}

--- a/pkg/cmd/pulumi/templates/workspace.go
+++ b/pkg/cmd/pulumi/templates/workspace.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (s *Source) getWorkspaceTemplates(
-	ctx context.Context, templateNamePathOrURL string, scope Scope, templateKind workspace.TemplateKind,
+	ctx context.Context, templateNamePathOrURL string, scope SearchScope, templateKind workspace.TemplateKind,
 	_ *sync.WaitGroup,
 ) {
 	repo, err := workspace.RetrieveTemplates(ctx, templateNamePathOrURL, scope == ScopeLocal, templateKind)


### PR DESCRIPTION
This PR allows `pulumi new` to fetch org-wide templates from `app.pulumi.com` when they
are enabled. Part of https://github.com/pulumi/pulumi-service/issues/25732.

Conceptually, there are 2 parts to this PR:

- Wraps `workspace.RetrieveTemplates` in a new API specific for `cmd`:

    ```go
    // Create a new [Template] [Source] associated with a given [Scope].
    func New(
    	ctx context.Context, templateNamePathOrURL string, scope Scope,
    	templateKind workspace.TemplateKind, interactive bool,
    ) *Source { ... }
    ```

    This is necessary because `workspace.RetrieveTemplates` is in `sdk`: `"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"`. The new template download functionality needs to depend on various backend features such as `cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"`, which are obviously in `pkg`.

    The new `cmdTemplate.Template` abstraction allows for templates that are not present in the file system, such as those sourced by `(*Client) ListOrgTemplates`.

- Adjusts the template chooser and the rest of `cmd` to use the new `cmdTemplates.{Source,Template}` wrapper instead of `workspace.Template`. This is the mechanism that realizes the next two changes.