### PR TITLE
Default to UnknownID in providers.NewReference

### DIFF
--- a/pkg/engine/lifecycletest/continue_on_error_test.go
+++ b/pkg/engine/lifecycletest/continue_on_error_test.go
@@ -886,13 +886,8 @@ func TestContinueOnErrorWithChangingProviderOnCreate(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		resp, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true)
 		assert.NoError(t, err)
-		provID := resp.ID
 
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-
-		provRef, err := providers.NewReference(resp.URN, provID)
+		provRef, err := providers.NewReference(resp.URN, resp.ID)
 		assert.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
@@ -934,13 +929,8 @@ func TestContinueOnErrorWithChangingProviderOnCreate(t *testing.T) {
 			Version: "2.0.0",
 		})
 		assert.NoError(t, err)
-		provID := resp.ID
 
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-
-		provRef, err := providers.NewReference(resp.URN, provID)
+		provRef, err := providers.NewReference(resp.URN, resp.ID)
 		assert.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{

--- a/pkg/engine/lifecycletest/delete_before_replace_test.go
+++ b/pkg/engine/lifecycletest/delete_before_replace_test.go
@@ -318,17 +318,12 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 	inputsB := resource.NewPropertyMapFromMap(map[string]interface{}{"A": "foo"})
 
 	var provURN, urnA, urnB resource.URN
-	var provID resource.ID
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		var resp *deploytest.RegisterResourceResponse
 		resp, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true)
 		assert.NoError(t, err)
-		provURN, provID = resp.URN, resp.ID
+		provURN = resp.URN
 
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-		provRef, err := providers.NewReference(provURN, provID)
+		provRef, err := providers.NewReference(provURN, resp.ID)
 		assert.NoError(t, err)
 		provA := provRef.String()
 

--- a/pkg/engine/lifecycletest/parameterized_test.go
+++ b/pkg/engine/lifecycletest/parameterized_test.go
@@ -321,12 +321,8 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 			PackageRef: extRef,
 		})
 		assert.NoError(t, err)
-		provID := prov.ID
 
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-		provRef, err := providers.NewReference(prov.URN, provID)
+		provRef, err := providers.NewReference(prov.URN, prov.ID)
 		assert.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgExt:m:typA", "resD", true, deploytest.ResourceOptions{
@@ -590,12 +586,8 @@ func TestReplacementParameterizedProviderImport(t *testing.T) {
 			PackageRef: extRef,
 		})
 		assert.NoError(t, err)
-		provID := prov.ID
 
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-		provRef, err := providers.NewReference(prov.URN, provID)
+		provRef, err := providers.NewReference(prov.URN, prov.ID)
 		assert.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgExt:m:typA", "resC", true, deploytest.ResourceOptions{

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -80,13 +80,8 @@ func TestSingleResourceExplicitProviderLifecycle(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		resp, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true)
 		assert.NoError(t, err)
-		provID := resp.ID
 
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-
-		provRef, err := providers.NewReference(resp.URN, provID)
+		provRef, err := providers.NewReference(resp.URN, resp.ID)
 		assert.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
@@ -320,13 +315,8 @@ func TestSingleResourceExplicitProviderReplace(t *testing.T) {
 		resp, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true,
 			deploytest.ResourceOptions{Inputs: providerInputs})
 		assert.NoError(t, err)
-		provID := resp.ID
 
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-
-		provRef, err := providers.NewReference(resp.URN, provID)
+		provRef, err := providers.NewReference(resp.URN, resp.ID)
 		assert.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
@@ -469,12 +459,7 @@ func TestSingleResourceExplicitProviderAliasUpdateDelete(t *testing.T) {
 			})
 		assert.NoError(t, err)
 
-		provID := resp.ID
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-
-		provRef, err := providers.NewReference(resp.URN, provID)
+		provRef, err := providers.NewReference(resp.URN, resp.ID)
 		assert.NoError(t, err)
 
 		if registerResource {
@@ -565,12 +550,7 @@ func TestSingleResourceExplicitProviderAliasReplace(t *testing.T) {
 			})
 		assert.NoError(t, err)
 
-		provID := resp.ID
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-
-		provRef, err := providers.NewReference(resp.URN, provID)
+		provRef, err := providers.NewReference(resp.URN, resp.ID)
 		assert.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
@@ -709,12 +689,7 @@ func TestSingleResourceExplicitProviderDeleteBeforeReplace(t *testing.T) {
 			deploytest.ResourceOptions{Inputs: providerInputs})
 		assert.NoError(t, err)
 
-		provID := resp.ID
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-
-		provRef, err := providers.NewReference(resp.URN, provID)
+		provRef, err := providers.NewReference(resp.URN, resp.ID)
 		assert.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
@@ -1045,12 +1020,7 @@ func TestProviderVersionDefault(t *testing.T) {
 		resp, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true)
 		assert.NoError(t, err)
 
-		provID := resp.ID
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-
-		provRef, err := providers.NewReference(resp.URN, provID)
+		provRef, err := providers.NewReference(resp.URN, resp.ID)
 		assert.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
@@ -1093,12 +1063,7 @@ func TestProviderVersionOption(t *testing.T) {
 			})
 		assert.NoError(t, err)
 
-		provID := resp.ID
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-
-		provRef, err := providers.NewReference(resp.URN, provID)
+		provRef, err := providers.NewReference(resp.URN, resp.ID)
 		assert.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
@@ -1143,12 +1108,7 @@ func TestProviderVersionInput(t *testing.T) {
 			})
 		assert.NoError(t, err)
 
-		provID := resp.ID
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-
-		provRef, err := providers.NewReference(resp.URN, provID)
+		provRef, err := providers.NewReference(resp.URN, resp.ID)
 		assert.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
@@ -1194,12 +1154,7 @@ func TestProviderVersionInputAndOption(t *testing.T) {
 			})
 		assert.NoError(t, err)
 
-		provID := resp.ID
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-
-		provRef, err := providers.NewReference(resp.URN, provID)
+		provRef, err := providers.NewReference(resp.URN, resp.ID)
 		assert.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
@@ -1238,12 +1193,7 @@ func TestPluginDownloadURLPassthrough(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		provID := resp.ID
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-
-		provRef, err := providers.NewReference(resp.URN, provID)
+		provRef, err := providers.NewReference(resp.URN, resp.ID)
 		assert.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
@@ -1679,12 +1629,7 @@ func TestComponentProvidersInheritance(t *testing.T) {
 		resp, err := monitor.RegisterResource("pulumi:providers:pkg", "provA", true)
 		assert.NoError(t, err)
 
-		provID := resp.ID
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-
-		provRef, err := providers.NewReference(resp.URN, provID)
+		provRef, err := providers.NewReference(resp.URN, resp.ID)
 		assert.NoError(t, err)
 
 		respA, err := monitor.RegisterResource("my_component", "resA", false, deploytest.ResourceOptions{
@@ -1860,12 +1805,7 @@ func TestInternalFiltered(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		provID := resp.ID
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-
-		provRef, err := providers.NewReference(resp.URN, provID)
+		provRef, err := providers.NewReference(resp.URN, resp.ID)
 		assert.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -2344,12 +2344,7 @@ func TestProviderPreviewUnknowns(t *testing.T) {
 			})
 		require.NoError(t, err)
 
-		provID := resp.ID
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-
-		provRef, err := providers.NewReference(resp.URN, provID)
+		provRef, err := providers.NewReference(resp.URN, resp.ID)
 		assert.NoError(t, err)
 
 		ins := resource.NewPropertyMapFromMap(map[string]interface{}{

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -901,12 +901,7 @@ func TestCreateDuringTargetedUpdate_UntargetedProviderReferencedByTarget(t *test
 		resp, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true)
 		assert.NoError(t, err)
 
-		provID := resp.ID
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-
-		provRef, err := providers.NewReference(resp.URN, provID)
+		provRef, err := providers.NewReference(resp.URN, resp.ID)
 		assert.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
@@ -1747,12 +1742,7 @@ func TestTargetDependentsExplicitProvider(t *testing.T) {
 			providers.MakeProviderType("pkgA"), "provider", true, deploytest.ResourceOptions{})
 		assert.NoError(t, err)
 
-		provID := resp.ID
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-
-		provRef, err := providers.NewReference(resp.URN, provID)
+		provRef, err := providers.NewReference(resp.URN, resp.ID)
 		assert.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
@@ -1839,12 +1829,7 @@ func TestTargetDependentsSiblingResources(t *testing.T) {
 			providers.MakeProviderType("pkgA"), "provider", true, deploytest.ResourceOptions{})
 		assert.NoError(t, err)
 
-		provID := resp.ID
-		if provID == "" {
-			provID = providers.UnknownID
-		}
-
-		provRef, err := providers.NewReference(resp.URN, provID)
+		provRef, err := providers.NewReference(resp.URN, resp.ID)
 		assert.NoError(t, err)
 
 		resp, err = monitor.RegisterResource("pkgA:m:typA", "explicitX", true, deploytest.ResourceOptions{
@@ -3797,12 +3782,7 @@ func TestUntargetedProviderChange(t *testing.T) {
 			resp, err := monitor.RegisterResource("pulumi:providers:pkgB", "explicit", true)
 			assert.NoError(t, err)
 
-			provID := resp.ID
-
-			if provID == "" {
-				provID = providers.UnknownID
-			}
-			provider, err = providers.NewReference(resp.URN, provID)
+			provider, err = providers.NewReference(resp.URN, resp.ID)
 			assert.NoError(t, err)
 		}
 

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -162,7 +162,6 @@ func (noopOutputsEvent) Done()                         {}
 type importer struct {
 	deployment *Deployment
 	executor   *stepExecutor
-	preview    bool
 }
 
 func (i *importer) executeSerial(ctx context.Context, steps ...Step) bool {
@@ -342,12 +341,8 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 	// Update the URN to reference map.
 	for _, s := range steps {
 		res := s.Res()
-		id := res.ID
-		if i.preview {
-			id = providers.UnknownID
-		}
-		ref, err := providers.NewReference(res.URN, id)
-		contract.AssertNoErrorf(err, "could not create provider reference with URN %q and ID %q", res.URN, id)
+		ref, err := providers.NewReference(res.URN, res.ID)
+		contract.AssertNoErrorf(err, "could not create provider reference with URN %q and ID %q", res.URN, res.ID)
 		urnToReference[res.URN] = ref.String()
 	}
 

--- a/pkg/resource/deploy/providers/reference.go
+++ b/pkg/resource/deploy/providers/reference.go
@@ -131,6 +131,9 @@ func NewReference(urn resource.URN, id resource.ID) (Reference, error) {
 	if err := validateURN(urn); err != nil {
 		return Reference{}, err
 	}
+	if id == "" {
+		id = UnknownID
+	}
 	return Reference{urn: urn, id: id}, nil
 }
 


### PR DESCRIPTION
We were a little inconsistent in the tests if we bothered to check if ID was empty and setting it to UnknownID or if we just passed the ID directly. There was also a lot of duplicate code doing that empty check. This moves the empty check to "providers.NewReference" so we can just always pass ID directly.