### PR TITLE
Experimental/Components]: Handle assets and archives

### DIFF
--- a/sdk/nodejs/provider/experimental/analyzer.ts
+++ b/sdk/nodejs/provider/experimental/analyzer.ts
@@ -240,6 +240,26 @@ export class Analyzer {
             // be plain anymore, since it's wrapped in an output.
             const innerType = this.unwrapTypeReference(type);
             return this.analyzeType(innerType, location, optional, false /* plain */);
+        } else if (isAsset(type)) {
+            const $ref = "pulumi.json#/Asset";
+            const prop: PropertyDefinition = { $ref };
+            if (optional) {
+                prop.optional = true;
+            }
+            if (plain) {
+                prop.plain = true;
+            }
+            return prop;
+        } else if (isArchive(type)) {
+            const $ref = "pulumi.json#/Archive";
+            const prop: PropertyDefinition = { $ref };
+            if (optional) {
+                prop.optional = true;
+            }
+            if (plain) {
+                prop.plain = true;
+            }
+            return prop;
         } else if (type.isClassOrInterface()) {
             // This is a complex type, create a typedef and then reference it in
             // the PropertyDefinition.
@@ -375,6 +395,23 @@ function isOutput(type: typescript.Type): boolean {
     const sourceFile = symbol?.declarations?.[0].getSourceFile();
     const matchesSourceFile =
         sourceFile?.fileName.endsWith("output.ts") || sourceFile?.fileName.endsWith("output.d.ts");
+    return !!matchesName && !!matchesSourceFile;
+}
+
+function isAsset(type: typescript.Type): boolean {
+    const symbol = type.getSymbol();
+    const matchesName = symbol?.escapedName === "Asset";
+    const sourceFile = symbol?.declarations?.[0].getSourceFile();
+    const matchesSourceFile = sourceFile?.fileName.endsWith("asset.ts") || sourceFile?.fileName.endsWith("asset.d.ts");
+    return !!matchesName && !!matchesSourceFile;
+}
+
+function isArchive(type: typescript.Type): boolean {
+    const symbol = type.getSymbol();
+    const matchesName = symbol?.escapedName === "Archive";
+    const sourceFile = symbol?.declarations?.[0].getSourceFile();
+    const matchesSourceFile =
+        sourceFile?.fileName.endsWith("archive.ts") || sourceFile?.fileName.endsWith("archive.d.ts");
     return !!matchesName && !!matchesSourceFile;
 }
 

--- a/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
@@ -213,4 +213,25 @@ describe("Analyzer", function () {
             },
         });
     });
+
+    it("infers asset/archive types", async function () {
+        const dir = path.join(__dirname, "testdata", "asset-archive-types");
+        const analyzer = new Analyzer(dir, "provider");
+        const { components } = analyzer.analyze();
+        assert.deepStrictEqual(components, {
+            MyComponent: {
+                name: "MyComponent",
+                inputs: {
+                    anAsset: { $ref: "pulumi.json#/Asset", plain: true },
+                    anArchive: { $ref: "pulumi.json#/Archive", plain: true },
+                    inputAsset: { $ref: "pulumi.json#/Asset" },
+                    inputArchive: { $ref: "pulumi.json#/Archive" },
+                },
+                outputs: {
+                    outAsset: { $ref: "pulumi.json#/Asset" },
+                    outArchive: { $ref: "pulumi.json#/Archive" },
+                },
+            },
+        });
+    });
 });

--- a/sdk/nodejs/tests/provider/experimental/testdata/asset-archive-types/index.ts
+++ b/sdk/nodejs/tests/provider/experimental/testdata/asset-archive-types/index.ts
@@ -1,0 +1,19 @@
+// Copyright 2025-2025, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+export interface MyComponentArgs {
+    anAsset: pulumi.asset.Asset;
+    anArchive: pulumi.asset.Archive;
+    inputAsset: pulumi.Input<pulumi.asset.Asset>;
+    inputArchive: pulumi.Input<pulumi.asset.Archive>;
+}
+
+export class MyComponent extends pulumi.ComponentResource {
+    outAsset: pulumi.Output<pulumi.asset.Asset>;
+    outArchive: pulumi.Output<pulumi.asset.Archive>;
+
+    constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("provider:index:MyComponent", name, args, opts);
+    }
+}


### PR DESCRIPTION
Handle assets and archives in the components analyzer.

Part of https://github.com/pulumi/pulumi/issues/18365
Ref https://github.com/pulumi/pulumi/issues/15939

Stacked on top of https://github.com/pulumi/pulumi/pull/18631