### PR TITLE
Fix sending parent in resource transforms

### DIFF
--- a/changelog/pending/20250219--engine--send-parent-urn-to-resource-transforms.yaml
+++ b/changelog/pending/20250219--engine--send-parent-urn-to-resource-transforms.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Send parent URN to resource transforms

--- a/pkg/engine/lifecycletest/transformation_test.go
+++ b/pkg/engine/lifecycletest/transformation_test.go
@@ -394,6 +394,7 @@ func TestRemoteTransformationsConstruct(t *testing.T) {
 				props resource.PropertyMap, opts *pulumirpc.TransformResourceOptions,
 			) (resource.PropertyMap, *pulumirpc.TransformResourceOptions, error) {
 				if typ == "pkgA:m:typA" {
+					assert.Equal(t, "urn:pulumi:test::test::pkgA:m:typC::resC", parent)
 					props["foo"] = pvApply(props["foo"], func(v resource.PropertyValue) resource.PropertyValue {
 						return resource.NewNumberProperty(v.NumberValue() + 1)
 					})
@@ -773,7 +774,6 @@ func TestTransformsProviderOpt(t *testing.T) {
 			TransformFunction(func(name, typ string, custom bool, parent string,
 				props resource.PropertyMap, opts *pulumirpc.TransformResourceOptions,
 			) (resource.PropertyMap, *pulumirpc.TransformResourceOptions, error) {
-				fmt.Println("provider: ", opts.Provider)
 				if opts.Provider == "" {
 					opts.Provider = implicitProvider
 				}

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -1432,6 +1432,7 @@ func (rm *resmon) wrapTransformCallback(cb *pulumirpc.Callback) (TransformFuncti
 		request, err := proto.Marshal(&pulumirpc.TransformRequest{
 			Name:       name,
 			Type:       typ,
+			Parent:     string(parent),
 			Custom:     custom,
 			Properties: mprops,
 			Options:    opts,


### PR DESCRIPTION
Fixes #18643

The engine wasn't filling in the parent URN for resource transform requests. Looks like all the SDKs already have the code to receive this.