### PR TITLE
Fixes: #17704 - feat(sdk/nodejs): infer a more direct type when `Unwrap`ping tuples

### DIFF
--- a/changelog/pending/20250220--sdk-nodejs--improve-type-inference-for-output-and-unwrap-when-used-on-tuples.yaml
+++ b/changelog/pending/20250220--sdk-nodejs--improve-type-inference-for-output-and-unwrap-when-used-on-tuples.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Improve type inference for `output` and `Unwrap` when used on tuples

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -984,22 +984,25 @@ type primitive = Function | string | number | boolean | undefined | null;
  */
 export type UnwrapSimple<T> =
     // 1. Any of the primitive types just unwrap to themselves.
-    // 2. An array of some types unwraps to an array of that type itself unwrapped. Note, due to a
+    // 2. A tuple of different types unwraps to a tuple of the unwrapped types.
+    // 3. An array of some types unwraps to an array of that type itself unwrapped. Note, due to a
     //    TS limitation we cannot express that as Array<Unwrap<U>> due to how it handles recursive
     //    types. We work around that by introducing an structurally equivalent interface that then
     //    helps make typescript defer type-evaluation instead of doing it eagerly.
-    // 3. An object unwraps to an object with properties of the same name, but where the property
+    // 4. An object unwraps to an object with properties of the same name, but where the property
     //    types have been unwrapped.
-    // 4. return 'never' at the end so that if we've missed something we'll discover it.
+    // 5. return 'never' at the end so that if we've missed something we'll discover it.
     T extends primitive
         ? T
         : T extends Resource
           ? T
-          : T extends Array<infer U>
-            ? UnwrappedArray<U>
-            : T extends object
-              ? UnwrappedObject<T>
-              : never;
+          : T extends [any, ...any[]]
+            ? UnwrappedObject<T> // We treat tuples like objects
+            : T extends Array<infer U>
+              ? UnwrappedArray<U>
+              : T extends object
+                ? UnwrappedObject<T>
+                : never;
 
 export type UnwrappedArray<T> = Array<Unwrap<T>>;
 

--- a/sdk/nodejs/tests/output.spec.ts
+++ b/sdk/nodejs/tests/output.spec.ts
@@ -1311,34 +1311,37 @@ describe("output", () => {
     });
 
     describe("output types", () => {
-      it("creates the right type for arrays", async () => {
-        const input: Array<Output<string>> = [output("hello"), output("world")]
-        const result: Array<string> = await all(input).promise()
-        assert.deepStrictEqual(result, ["hello", "world"]);
-      });
+        it("creates the right type for arrays", async () => {
+            const input: Array<Output<string>> = [output("hello"), output("world")];
+            const result: Array<string> = await all(input).promise();
+            assert.deepStrictEqual(result, ["hello", "world"]);
+        });
 
-      it("creates the right type for tuples", async () => {
-        const input: [Output<string>, Output<number>] = [output("hello"), output(123)]
-        const result: [string, number] = await all(input).promise()
-        assert.deepStrictEqual(result, ["hello", 123]);
-      });
+        it("creates the right type for tuples", async () => {
+            const input: [Output<string>, Output<number>] = [output("hello"), output(123)];
+            const result: [string, number] = await all(input).promise();
+            assert.deepStrictEqual(result, ["hello", 123]);
+        });
 
-      it("creates the right type for many tuples", async () => {
-        // https://github.com/pulumi/pulumi/issues/17704#issuecomment-2460209864
-        const input: Output<[string, number]>[] = [ output(["hello", 123]), output([ "world", 456 ]) ];
-        const result: Array<[string, number]> = await all(input).promise();
-        assert.deepStrictEqual(result, [["hello", 123], ["world", 456]]);
-      });
+        it("creates the right type for many tuples", async () => {
+            // https://github.com/pulumi/pulumi/issues/17704#issuecomment-2460209864
+            const input: Output<[string, number]>[] = [output(["hello", 123]), output(["world", 456])];
+            const result: Array<[string, number]> = await all(input).promise();
+            assert.deepStrictEqual(result, [
+                ["hello", 123],
+                ["world", 456],
+            ]);
+        });
 
-      it("creates the right type for objects", async () => {
-        const input = {
-          name: output("Tom"),
-          likes_dogs: output(true),
-        }
+        it("creates the right type for objects", async () => {
+            const input = {
+                name: output("Tom"),
+                likes_dogs: output(true),
+            };
 
-        const result: { name: string, likes_dogs: boolean } = await output(input).promise()
-        assert.deepStrictEqual(result, { name: "Tom", likes_dogs: true })
-      });
+            const result: { name: string; likes_dogs: boolean } = await output(input).promise();
+            assert.deepStrictEqual(result, { name: "Tom", likes_dogs: true });
+        });
     });
 
     describe("secret operations", () => {

--- a/sdk/nodejs/tests/output.spec.ts
+++ b/sdk/nodejs/tests/output.spec.ts
@@ -1310,6 +1310,37 @@ describe("output", () => {
         });
     });
 
+    describe("output types", () => {
+      it("creates the right type for arrays", async () => {
+        const input: Array<Output<string>> = [output("hello"), output("world")]
+        const result: Array<string> = await all(input).promise()
+        assert.deepStrictEqual(result, ["hello", "world"]);
+      });
+
+      it("creates the right type for tuples", async () => {
+        const input: [Output<string>, Output<number>] = [output("hello"), output(123)]
+        const result: [string, number] = await all(input).promise()
+        assert.deepStrictEqual(result, ["hello", 123]);
+      });
+
+      it("creates the right type for many tuples", async () => {
+        // https://github.com/pulumi/pulumi/issues/17704#issuecomment-2460209864
+        const input: Output<[string, number]>[] = [ output(["hello", 123]), output([ "world", 456 ]) ];
+        const result: Array<[string, number]> = await all(input).promise();
+        assert.deepStrictEqual(result, [["hello", 123], ["world", 456]]);
+      });
+
+      it("creates the right type for objects", async () => {
+        const input = {
+          name: output("Tom"),
+          likes_dogs: output(true),
+        }
+
+        const result: { name: string, likes_dogs: boolean } = await output(input).promise()
+        assert.deepStrictEqual(result, { name: "Tom", likes_dogs: true })
+      });
+    });
+
     describe("secret operations", () => {
         it("ensure secret", async () => {
             const sec = secret("foo");


### PR DESCRIPTION
Currently, if we try to call `all` on a structure involving tuples, they are treated as `Array<X | Y>` instead of `[X, Y]`, which means that `[X, Y]` will unwrap to `UnwrappedArray<X | Y>`, rather than the much more precise `[Unwrap<X>, Unwrap<Y>]`.

This PR implements @justinvp's [suggested fix](https://github.com/pulumi/pulumi/issues/17704#issuecomment-2467426573), and adds a couple tests to ensure that the type inference does indeed behave correctly.

With this change, I managed to compile the [expected behaviour example](https://github.com/pulumi/pulumi/issues/17704#issuecomment-2460209864) successfully, which I then condensed into the labelled test.

Fixes #17704