### PR TITLE
Support `--clear-pending-creates` for `refresh` command in NodeJS Automation API.

### DIFF
--- a/changelog/pending/20250220--auto-nodejs--support-clear-pending-creates-in-the-nodejs-automation-api.yaml
+++ b/changelog/pending/20250220--auto-nodejs--support-clear-pending-creates-in-the-nodejs-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/nodejs
+  description: Support `--clear-pending-creates` in the NodeJS automation API

--- a/changelog/pending/20250220--auto-nodejs--support-clear-pending-creates-in-the-nodejs-automation-api.yaml
+++ b/changelog/pending/20250220--auto-nodejs--support-clear-pending-creates-in-the-nodejs-automation-api.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: auto/nodejs
-  description: Support `--clear-pending-creates` in the NodeJS automation API
+  description: Support `--clear-pending-creates` for the `refresh` command in the NodeJS automation API

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -177,9 +177,6 @@ Event: ${line}\n${e.toString()}`);
             if (opts.expectNoChanges) {
                 args.push("--expect-no-changes");
             }
-            if (opts.clearPendingCreates) {
-                args.push("--clear-pending-creates");
-            }
             if (opts.refresh) {
                 args.push("--refresh");
             }
@@ -319,9 +316,6 @@ Event: ${line}\n${e.toString()}`);
             if (opts.expectNoChanges) {
                 args.push("--expect-no-changes");
             }
-            if (opts.clearPendingCreates) {
-                args.push("--clear-pending-creates");
-            }
             if (opts.refresh) {
                 args.push("--refresh");
             }
@@ -456,6 +450,9 @@ Event: ${line}\n${e.toString()}`);
             }
             if (opts.expectNoChanges) {
                 args.push("--expect-no-changes");
+            }
+            if (opts.clearPendingCreates) {
+                args.push("--clear-pending-creates");
             }
             if (opts.target) {
                 for (const tURN of opts.target) {
@@ -1272,11 +1269,6 @@ export interface UpOptions extends GlobalOpts {
     expectNoChanges?: boolean;
 
     /**
-     * Clear all pending creates, dropping them from the state
-     */
-    clearPendingCreates?: boolean;
-
-    /**
      * Refresh the state of the stack's resources before this update.
      */
     refresh?: boolean;
@@ -1377,11 +1369,6 @@ export interface PreviewOptions extends GlobalOpts {
     expectNoChanges?: boolean;
 
     /**
-     * Clear all pending creates, dropping them from the state
-     */
-    clearPendingCreates?: boolean;
-
-    /**
      * Refresh the state of the stack's resources against the cloud provider before running preview.
      */
     refresh?: boolean;
@@ -1470,6 +1457,11 @@ export interface RefreshOptions extends GlobalOpts {
      * Return an error if any changes occur during this operation.
      */
     expectNoChanges?: boolean;
+
+    /**
+     * Clear all pending creates, dropping them from the state
+     */
+    clearPendingCreates?: boolean;
 
     /**
      * Specify a set of resource URNs to operate on. Other resources will not be updated.

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -177,6 +177,9 @@ Event: ${line}\n${e.toString()}`);
             if (opts.expectNoChanges) {
                 args.push("--expect-no-changes");
             }
+            if (opts.clearPendingCreates) {
+                args.push("--clear-pending-creates");
+            }
             if (opts.refresh) {
                 args.push("--refresh");
             }
@@ -315,6 +318,9 @@ Event: ${line}\n${e.toString()}`);
             }
             if (opts.expectNoChanges) {
                 args.push("--expect-no-changes");
+            }
+            if (opts.clearPendingCreates) {
+                args.push("--clear-pending-creates");
             }
             if (opts.refresh) {
                 args.push("--refresh");
@@ -1266,6 +1272,11 @@ export interface UpOptions extends GlobalOpts {
     expectNoChanges?: boolean;
 
     /**
+     * Clear all pending creates, dropping them from the state
+     */
+    clearPendingCreates?: boolean;
+
+    /**
      * Refresh the state of the stack's resources before this update.
      */
     refresh?: boolean;
@@ -1364,6 +1375,11 @@ export interface PreviewOptions extends GlobalOpts {
      * Return an error if any changes occur during this operation.
      */
     expectNoChanges?: boolean;
+
+    /**
+     * Clear all pending creates, dropping them from the state
+     */
+    clearPendingCreates?: boolean;
 
     /**
      * Refresh the state of the stack's resources against the cloud provider before running preview.


### PR DESCRIPTION
The `--clear-pending-creates` flag already exists for [the Go API](https://github.com/pulumi/pulumi/pull/18101/files), but didn't previously exist for NodeJS. This PR adds the flag as an option to `RefreshOptions` to mimic the behaviour of Go's code.

I couldn't find any tests for checking that options are added correctly in NodeJS, but I manually tested it by logging the command from one of the tests that I had modified, and things look to be working correctly:

```javascript
[
  'refresh',
  '--yes',
  '--skip-preview',
  '--clear-pending-creates',
  '--exec-agent',
  'pulumi/pulumi/test',
  '--exec-kind',
  'auto.inline',
  '--stack',
  'organization/inline_node/int_test9848130f-6e00-4aa2-ad97-277bd5a916e7'
]
```