### PR TITLE
[Experimental/Component]: support optional types in unions

### DIFF
--- a/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
@@ -62,9 +62,11 @@ describe("Analyzer", function () {
                 name: "MyComponent",
                 inputs: {
                     optionalNumber: { type: "number", optional: true, plain: true },
+                    optionalNumberType: { type: "number", optional: true, plain: true },
                 },
                 outputs: {
                     optionalOutputNumber: { type: "number", optional: true },
+                    optionalOutputType: { type: "number", optional: true },
                 },
             },
         });
@@ -209,6 +211,7 @@ describe("Analyzer", function () {
                     outMapOfStrings: { type: "object", additionalProperties: { type: "string" } },
                     outMapOfNumbers: { type: "object", additionalProperties: { type: "number" } },
                     outMapOfBooleans: { type: "object", additionalProperties: { type: "boolean" } },
+                    outMapOptionalStrings: { type: "object", additionalProperties: { type: "string", optional: true } },
                 },
             },
         });

--- a/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
@@ -211,7 +211,7 @@ describe("Analyzer", function () {
                     outMapOfStrings: { type: "object", additionalProperties: { type: "string" } },
                     outMapOfNumbers: { type: "object", additionalProperties: { type: "number" } },
                     outMapOfBooleans: { type: "object", additionalProperties: { type: "boolean" } },
-                    outMapOptionalStrings: { type: "object", additionalProperties: { type: "string", optional: true } },
+                    outMapOptionalStrings: { type: "object", additionalProperties: { type: "string" }, optional: true },
                 },
             },
         });

--- a/sdk/nodejs/tests/provider/experimental/testdata/map-types/index.ts
+++ b/sdk/nodejs/tests/provider/experimental/testdata/map-types/index.ts
@@ -18,6 +18,7 @@ export class MyComponent extends pulumi.ComponentResource {
     outMapOfStrings: pulumi.Output<{ [key: string]: string }>;
     outMapOfNumbers: pulumi.Output<{ [key: string]: number }>;
     outMapOfBooleans: pulumi.Output<{ [key: string]: boolean }>;
+    outMapOptionalStrings: pulumi.Output<{ [key: string]: string } | undefined>;
 
     constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
         super("provider:index:MyComponent", name, args, opts);

--- a/sdk/nodejs/tests/provider/experimental/testdata/optional-types/index.ts
+++ b/sdk/nodejs/tests/provider/experimental/testdata/optional-types/index.ts
@@ -4,10 +4,12 @@ import * as pulumi from "@pulumi/pulumi";
 
 export interface MyComponentArgs {
     optionalNumber?: number;
+    optionalNumberType: number | undefined;
 }
 
 export class MyComponent extends pulumi.ComponentResource {
     optionalOutputNumber?: pulumi.Output<number>;
+    optionalOutputType?: pulumi.Output<number | undefined>;
 
     constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
         super("provider:index:MyComponent", name, args, opts);


### PR DESCRIPTION
We currently support optional types in typescript by adding `?` to the symbol name.  Also allow optional types by adding `| undefined` instead.

Part of https://github.com/pulumi/pulumi/issues/18365
Ref https://github.com/pulumi/pulumi/issues/15939