### PR TITLE
add more randomness to random stack names

### DIFF
--- a/sdk/go/common/testing/util.go
+++ b/sdk/go/common/testing/util.go
@@ -22,7 +22,7 @@ import (
 )
 
 func RandomStackName() string {
-	b := make([]byte, 4)
+	b := make([]byte, 8)
 	_, err := rand.Read(b)
 	contract.AssertNoErrorf(err, "failed to generate random stack name")
 	return "test" + hex.EncodeToString(b)


### PR DESCRIPTION
I recently run into a flake where a random stack name had a name clash (https://github.com/pulumi/pulumi/actions/runs/13434278928/job/37533061535?pr=18631).

Double the number of random bytes to hopefully avoid this in the future.