### PR TITLE
[Experimental/Components]: Infer doc comments

### DIFF
--- a/sdk/nodejs/provider/experimental/analyzer.ts
+++ b/sdk/nodejs/provider/experimental/analyzer.ts
@@ -447,9 +447,3 @@ function symbolTableToSymbols(table: typescript.SymbolTable): typescript.Symbol[
     });
     return symbols;
 }
-
-function debug(label: string, msg: any) {
-    const fs = require("fs");
-    const util = require("util");
-    fs.writeFileSync("/tmp/debug.log", label + ": " + util.inspect(msg) + "\n", { flag: "a" });
-}

--- a/sdk/nodejs/provider/experimental/analyzer.ts
+++ b/sdk/nodejs/provider/experimental/analyzer.ts
@@ -36,6 +36,7 @@ export type PropertyDefinition = ({ type: PropertyType } | { $ref: string }) & {
 
 export type ComponentDefinition = {
     name: string;
+    description?: string;
     inputs: Record<string, PropertyDefinition>;
     outputs: Record<string, PropertyDefinition>;
 };
@@ -49,6 +50,10 @@ export type AnalyzeResult = {
     components: Record<string, ComponentDefinition>;
     typeDefinitions: Record<string, TypeDefinition>;
 };
+
+interface docNode extends typescript.Node {
+    jsDoc?: typescript.JSDoc[];
+}
 
 export class Analyzer {
     private path: string;
@@ -157,11 +162,18 @@ export class Analyzer {
             outputs = this.analyzeSymbols(symbolTableToSymbols(classSymbol.members), node);
         }
 
-        return {
+        const definition: ComponentDefinition = {
             name: componentName!,
-            inputs,
-            outputs,
+            inputs: inputs,
+            outputs: outputs,
         };
+
+        const dNode = node as docNode;
+        if (dNode.jsDoc && dNode.jsDoc.length > 0) {
+            definition.description = dNode.jsDoc.map((doc: typescript.JSDoc) => doc.comment).join("\n");
+        }
+
+        return definition;
     }
 
     private isPulumiComponent(node: typescript.ClassDeclaration): boolean {
@@ -434,4 +446,10 @@ function symbolTableToSymbols(table: typescript.SymbolTable): typescript.Symbol[
         symbols.push(symbol);
     });
     return symbols;
+}
+
+function debug(label: string, msg: any) {
+    const fs = require("fs");
+    const util = require("util");
+    fs.writeFileSync("/tmp/debug.log", label + ": " + util.inspect(msg) + "\n", { flag: "a" });
 }

--- a/sdk/nodejs/provider/experimental/schema.ts
+++ b/sdk/nodejs/provider/experimental/schema.ts
@@ -113,6 +113,7 @@ export function generateSchema(
             requiredInputs: required(component.inputs),
             properties: component.outputs,
             required: required(component.outputs),
+            description: component.description,
         };
     }
 

--- a/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
@@ -213,4 +213,18 @@ describe("Analyzer", function () {
             },
         });
     });
+
+    it("infers component description", async function () {
+        const dir = path.join(__dirname, "testdata", "component-description");
+        const analyzer = new Analyzer(dir, "provider");
+        const { components } = analyzer.analyze();
+        assert.deepStrictEqual(components, {
+            MyComponent: {
+                name: "MyComponent",
+                description: "This is a description of MyComponent\nIt can span multiple lines",
+                inputs: {},
+                outputs: {},
+            },
+        });
+    });
 });

--- a/sdk/nodejs/tests/provider/experimental/testdata/component-description/index.ts
+++ b/sdk/nodejs/tests/provider/experimental/testdata/component-description/index.ts
@@ -1,0 +1,16 @@
+// Copyright 2025-2025, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+// biome-ignore lint: MyComponentArgs needs to be an interface but biome doesn't like that
+export interface MyComponentArgs {}
+
+/**
+ * This is a description of MyComponent
+ * It can span multiple lines
+ */
+export class MyComponent extends pulumi.ComponentResource {
+    constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("provider:index:MyComponent", name, args, opts);
+    }
+}


### PR DESCRIPTION
This is a little awkward because the jsDoc property is private in the compiler API, but I couldn't find a better way to access it.  It should be okay as a best effort to add doc descriptions.

Part of https://github.com/pulumi/pulumi/issues/18365
Ref https://github.com/pulumi/pulumi/issues/15939