### PR TITLE
Fix panic in help new

### DIFF
--- a/changelog/pending/20250220--cli--fix-a-panic-in-help-new-when-local-templates-werent-present.yaml
+++ b/changelog/pending/20250220--cli--fix-a-panic-in-help-new-when-local-templates-werent-present.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix a panic in `help new` when local templates weren't present

--- a/pkg/cmd/pulumi/main_test.go
+++ b/pkg/cmd/pulumi/main_test.go
@@ -1,0 +1,38 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// regresion test for https://github.com/pulumi/pulumi/issues/18659
+//
+//nolint:paralleltest // sets PULUMI_HOME and os.Args
+func TestNewHelp(t *testing.T) {
+	tempdir := t.TempDir()
+	t.Setenv("PULUMI_HOME", tempdir)
+
+	args := os.Args
+	os.Args = []string{"pulumi", "help", "new"}
+	defer func() { os.Args = args }()
+
+	cmd := NewPulumiCmd()
+	err := cmd.Execute()
+	require.NoError(t, err)
+}

--- a/pkg/cmd/pulumi/newcmd/new.go
+++ b/pkg/cmd/pulumi/newcmd/new.go
@@ -649,7 +649,10 @@ func NewNewCmd() *cobra.Command {
 		// Show default help.
 		defaultHelp(cmd, args)
 
-		templates, err := getTemplates(cmd.Context())
+		// You'd think you could use cmd.Context() here but cobra doesn't set context on the cmd even though
+		// the parent help command has it. If https://github.com/spf13/cobra/issues/2240 gets fixed we can
+		// change back to cmd.Context() here.
+		templates, err := getTemplates(context.Background())
 		if err != nil {
 			logging.Warningf("could not list templates: %v", err)
 			return


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/18659

Comment in code pretty much covers it, but repeating here:

You'd think you could use cmd.Context() in the help function but cobra doesn't set context on the cmd even though the parent help command has it. I've raised https://github.com/spf13/cobra/issues/2240 to see about fixing it.