### PR TITLE
Preview-only refresh in NodeJS

### DIFF
--- a/changelog/pending/20250220--auto-nodejs--add-the-preview-only-flag-to-the-refresh-command-in-the-nodejs-automation-api.yaml
+++ b/changelog/pending/20250220--auto-nodejs--add-the-preview-only-flag-to-the-refresh-command-in-the-nodejs-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/nodejs
+  description: Add the `--preview-only` flag to the `refresh` command in the NodeJS Automation API

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -440,8 +440,9 @@ Event: ${line}\n${e.toString()}`);
      *  Options to customize the behavior of the refresh.
      */
     async refresh(opts?: RefreshOptions): Promise<RefreshResult> {
-        const args = ["refresh", "--yes", "--skip-preview"];
+        const args = ["refresh", "--yes"];
 
+        args.push(opts?.previewOnly ? "--preview-only" : "--skip-preview");
         args.push(...this.remoteArgs());
 
         if (opts) {
@@ -1449,6 +1450,11 @@ export interface RefreshOptions extends GlobalOpts {
      * Optional message to associate with the operation.
      */
     message?: string;
+
+    /**
+     * Only show a preview of the refresh, but don't perform the refresh itself.
+     */
+    previewOnly?: boolean;
 
     /**
      * Return an error if any changes occur during this operation.


### PR DESCRIPTION
The `previewOnly` parameter now allows users to set the `--preview-only` flag in the NodeJS Automation API. This overrides [`--skip-preview` in the same way as Go](https://github.com/mcblair/pulumi/blob/edcecda3473ffe1733dd7e8e854addeadb893e04/sdk/go/auto/stack.go#L727-L729)*. As with #18653, it's difficult to test that flags are set at the moment, but I have manually tested that the flag shows up correctly:

```javascript
[
  'refresh',
  '--preview-only',
  '--exec-agent',
  'pulumi/pulumi/test',
  '--exec-kind',
  'auto.inline',
  '--stack',
  'organization/inline_node/int_test42ed92ec-177e-4156-8af2-223e0ebc91b7'
]
```

_* Note that, unlike Go, it doesn't unset the `--yes` flag when `--preview-only` is set. Given that Go doesn't seem to handle any prompts that may follow, it seems like this could be a thing we want to change in the Go code?_