### PR TITLE
Repalce ProviderParameterization with workspace.Parameterization

### DIFF
--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -309,7 +309,7 @@ func gatherPackagesFromSnapshot(plugctx *plugin.Context, target *deploy.Target) 
 		var packageParameterization *workspace.Parameterization
 		if parameterization != nil {
 			packageParameterization = &workspace.Parameterization{
-				Name:    string(parameterization.Name),
+				Name:    parameterization.Name,
 				Version: parameterization.Version,
 				Value:   parameterization.Value,
 			}

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -120,7 +120,7 @@ func GenerateHCL2Definition(
 	}
 	if parameters != nil {
 		parameterization = &schema.ParameterizationDescriptor{
-			Name:    string(parameters.Name),
+			Name:    parameters.Name,
 			Version: parameters.Version,
 			Value:   parameters.Value,
 		}

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 type Parameterization struct {
@@ -44,7 +45,7 @@ type Parameterization struct {
 // ToProviderParameterization converts a workspace parameterization to a provider parameterization.
 func (p *Parameterization) ToProviderParameterization(
 	typ tokens.Type, version *semver.Version,
-) (tokens.Package, *semver.Version, *providers.ProviderParameterization, error) {
+) (tokens.Package, *semver.Version, *workspace.Parameterization, error) {
 	if p == nil {
 		return typ.Package(), version, nil, nil
 	}
@@ -53,7 +54,11 @@ func (p *Parameterization) ToProviderParameterization(
 		return "", nil, nil, errors.New("version must be provided")
 	}
 
-	return p.PluginName, &p.PluginVersion, providers.NewProviderParameterization(typ.Package(), *version, p.Value), nil
+	return p.PluginName, &p.PluginVersion, &workspace.Parameterization{
+		Name:    string(typ.Package()),
+		Version: *version,
+		Value:   p.Value,
+	}, nil
 }
 
 // An Import specifies a resource to import.

--- a/pkg/resource/deploy/providers/provider.go
+++ b/pkg/resource/deploy/providers/provider.go
@@ -22,26 +22,8 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
-
-type ProviderParameterization struct {
-	// The name of the parametrized package.
-	Name tokens.Package
-	// The version of the parametrized package.
-	Version semver.Version
-	// The value of the parameter.
-	Value []byte
-}
-
-// NewProviderParameterization constructs a new provider parameterization.
-func NewProviderParameterization(name tokens.Package, version semver.Version, value []byte,
-) *ProviderParameterization {
-	return &ProviderParameterization{
-		Name:    name,
-		Version: version,
-		Value:   value,
-	}
-}
 
 // A ProviderRequest is a tuple of an optional semantic version, download server url, parameter, and a package name.
 // Whenever the engine receives a registration for a resource that doesn't explicitly specify a provider, the engine
@@ -62,7 +44,7 @@ type ProviderRequest struct {
 	name              tokens.Package
 	pluginDownloadURL string
 	pluginChecksums   map[string][]byte
-	parameterization  *ProviderParameterization
+	parameterization  *workspace.Parameterization
 }
 
 // NewProviderRequest constructs a new provider request from an optional version, optional
@@ -70,7 +52,7 @@ type ProviderRequest struct {
 func NewProviderRequest(
 	name tokens.Package, version *semver.Version,
 	pluginDownloadURL string, checksums map[string][]byte,
-	parameterization *ProviderParameterization,
+	parameterization *workspace.Parameterization,
 ) ProviderRequest {
 	return ProviderRequest{
 		version:           version,
@@ -83,7 +65,7 @@ func NewProviderRequest(
 
 // Parameterization returns the parameterization of this provider request. May be nil if no parameterization was
 // provided.
-func (p ProviderRequest) Parameterization() *ProviderParameterization {
+func (p ProviderRequest) Parameterization() *workspace.Parameterization {
 	return p.parameterization
 }
 
@@ -100,7 +82,7 @@ func (p ProviderRequest) Version() *semver.Version {
 // Package returns this provider request's package.
 func (p ProviderRequest) Package() tokens.Package {
 	if p.parameterization != nil {
-		return p.parameterization.Name
+		return tokens.Package(p.parameterization.Name)
 	}
 	return p.name
 }


### PR DESCRIPTION
Happened to be looking in this area of the codebase and noticed that these were pretty much the same (bar some string / `tokens.Package` differences, but `tokens.Package` is just a string).

So this cleans up to just replace `ProviderParameterization` with `workspace.Parameterization` everywhere.