### PR TITLE
Don't overwrite schema versions if they exist

### DIFF
--- a/changelog/pending/20250221--engine--dont-overwrite-schema-versions-if-they-exist.yaml
+++ b/changelog/pending/20250221--engine--dont-overwrite-schema-versions-if-they-exist.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Don't overwrite schema versions if they exist


### PR DESCRIPTION
When loading a schema from a provider, we previously added logic that would overwrite the version in the returned schema with the plugin version if the schema had an older version. It's not clear why we did this, and is a bit odd when the plugin name and the package name match, but in the case of parameterized providers where plugin and package are different, it's outright wrong. This change thus adapts this behaviour to match its original intention -- adding a version only when one is missing (and moreover, only when parameterization is not involved).

Part of #18187