### PR TITLE
Support parameterizing providers when calling `get-mapping`

### DIFF
--- a/changelog/pending/20250221--cli-package--support-parameterizing-providers-when-calling-get-mapping.yaml
+++ b/changelog/pending/20250221--cli-package--support-parameterizing-providers-when-calling-get-mapping.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/package
+  description: Support parameterizing providers when calling `get-mapping`


### PR DESCRIPTION
This change makes a small extension to `pulumi package get-mapping` so that, like its sibling `get-schema` command, it can accept and apply a parameterization before requesting a mapping from a provider.