### PR TITLE
Add `--preview-only` to the `refresh` command in the Python Automation API

### DIFF
--- a/changelog/pending/20250221--auto-python--add-preview-only-to-the-refresh-command-in-the-python-automation-api.yaml
+++ b/changelog/pending/20250221--auto-python--add-preview-only-to-the-refresh-command-in-the-python-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/python
+  description: Add `--preview-only` to the `refresh` command in the Python Automation API

--- a/sdk/python/lib/pulumi/automation/_cmd.py
+++ b/sdk/python/lib/pulumi/automation/_cmd.py
@@ -17,6 +17,7 @@ import os
 import subprocess
 import tempfile
 import urllib.request
+import sys
 from typing import Any, Callable, Dict, List, Mapping, Optional
 
 from semver import VersionInfo
@@ -206,6 +207,7 @@ class PulumiCommand:
             env = _fixup_path(env, os.path.dirname(self.command))
         cmd = [self.command]
         cmd.extend(args)
+        sys.stderr.write(str(args))
 
         stdout_chunks: List[str] = []
 

--- a/sdk/python/lib/pulumi/automation/_cmd.py
+++ b/sdk/python/lib/pulumi/automation/_cmd.py
@@ -17,7 +17,6 @@ import os
 import subprocess
 import tempfile
 import urllib.request
-import sys
 from typing import Any, Callable, Dict, List, Mapping, Optional
 
 from semver import VersionInfo
@@ -207,7 +206,6 @@ class PulumiCommand:
             env = _fixup_path(env, os.path.dirname(self.command))
         cmd = [self.command]
         cmd.extend(args)
-        sys.stderr.write(str(args))
 
         stdout_chunks: List[str] = []
 

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -513,6 +513,7 @@ class Stack:
         self,
         parallel: Optional[int] = None,
         message: Optional[str] = None,
+        preview_only: Optional[bool] = None,
         target: Optional[List[str]] = None,
         expect_no_changes: Optional[bool] = None,
         clear_pending_creates: Optional[bool] = None,
@@ -535,6 +536,7 @@ class Stack:
         :param parallel: Parallel is the number of resource operations to run in parallel at once.
                          (1 for no parallelism). Defaults to unbounded (2147483647).
         :param message: Message (optional) to associate with the refresh operation.
+        :param preview_only: Only show a preview of the refresh, but don't perform the refresh itself.
         :param target: Specify an exclusive list of resource URNs to refresh.
         :param expect_no_changes: Return an error if any changes occur during this update.
         :param clear_pending_creates: Clear all pending creates, dropping them from the state.
@@ -552,7 +554,7 @@ class Stack:
         :returns: RefreshResult
         """
         extra_args = _parse_extra_args(**locals())
-        args = ["refresh", "--yes", "--skip-preview"]
+        args = ["refresh", "--yes"]
         args.extend(extra_args)
 
         args.extend(self._remote_args())
@@ -1004,6 +1006,7 @@ def _parse_extra_args(**kwargs) -> List[str]:
     extra_args: List[str] = []
 
     message: Optional[str] = kwargs.get("message")
+    preview_only: Optional[bool] = kwargs.get("preview_only")
     expect_no_changes: Optional[bool] = kwargs.get("expect_no_changes")
     clear_pending_creates: Optional[bool] = kwargs.get("clear_pending_creates")
     diff: Optional[bool] = kwargs.get("diff")
@@ -1026,6 +1029,10 @@ def _parse_extra_args(**kwargs) -> List[str]:
     attach_debugger: Optional[bool] = kwargs.get("attach_debugger")
     refresh: Optional[bool] = kwargs.get("refresh")
 
+    if preview_only:
+        extra_args.extend("--preview-only")
+    else:
+        extra_args.extend("--skip-preview")
     if message:
         extra_args.extend(["--message", message])
     if expect_no_changes:

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -1030,9 +1030,9 @@ def _parse_extra_args(**kwargs) -> List[str]:
     refresh: Optional[bool] = kwargs.get("refresh")
 
     if preview_only:
-        extra_args.extend("--preview-only")
+        extra_args.append("--preview-only")
     else:
-        extra_args.extend("--skip-preview")
+        extra_args.append("--skip-preview")
     if message:
         extra_args.extend(["--message", message])
     if expect_no_changes:

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -319,7 +319,7 @@ class Stack:
         """
         program = program or self.workspace.program
         extra_args = _parse_extra_args(**locals())
-        args = ["up", "--yes"]
+        args = ["up", "--yes", "--skip-preview"]
         args.extend(extra_args)
 
         if plan is not None:
@@ -555,8 +555,13 @@ class Stack:
         """
         extra_args = _parse_extra_args(**locals())
         args = ["refresh", "--yes"]
-        args.extend(extra_args)
 
+        if preview_only:
+            args.append("--preview-only")
+        else:
+            args.append("--skip-preview")
+
+        args.extend(extra_args)
         args.extend(self._remote_args())
 
         kind = ExecKind.INLINE.value if self.workspace.program else ExecKind.LOCAL.value
@@ -633,7 +638,7 @@ class Stack:
         :returns: DestroyResult
         """
         extra_args = _parse_extra_args(**locals())
-        args = ["destroy", "--yes"]
+        args = ["destroy", "--yes", "--skip-preview"]
         args.extend(extra_args)
 
         args.extend(self._remote_args())
@@ -702,7 +707,7 @@ class Stack:
         :param on_output: A function to process the stdout stream.
         :param show_secrets: Include config secrets in the ImportResult summary.
         """
-        args = ["import", "--yes"]
+        args = ["import", "--yes", "--skip-preview"]
         if message is not None:
             args.extend(["--message", message])
 
@@ -1006,7 +1011,6 @@ def _parse_extra_args(**kwargs) -> List[str]:
     extra_args: List[str] = []
 
     message: Optional[str] = kwargs.get("message")
-    preview_only: Optional[bool] = kwargs.get("preview_only")
     expect_no_changes: Optional[bool] = kwargs.get("expect_no_changes")
     clear_pending_creates: Optional[bool] = kwargs.get("clear_pending_creates")
     diff: Optional[bool] = kwargs.get("diff")
@@ -1029,10 +1033,6 @@ def _parse_extra_args(**kwargs) -> List[str]:
     attach_debugger: Optional[bool] = kwargs.get("attach_debugger")
     refresh: Optional[bool] = kwargs.get("refresh")
 
-    if preview_only:
-        extra_args.append("--preview-only")
-    else:
-        extra_args.append("--skip-preview")
     if message:
         extra_args.extend(["--message", message])
     if expect_no_changes:

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -319,7 +319,7 @@ class Stack:
         """
         program = program or self.workspace.program
         extra_args = _parse_extra_args(**locals())
-        args = ["up", "--yes", "--skip-preview"]
+        args = ["up", "--yes"]
         args.extend(extra_args)
 
         if plan is not None:
@@ -633,7 +633,7 @@ class Stack:
         :returns: DestroyResult
         """
         extra_args = _parse_extra_args(**locals())
-        args = ["destroy", "--yes", "--skip-preview"]
+        args = ["destroy", "--yes"]
         args.extend(extra_args)
 
         args.extend(self._remote_args())
@@ -702,7 +702,7 @@ class Stack:
         :param on_output: A function to process the stdout stream.
         :param show_secrets: Include config secrets in the ImportResult summary.
         """
-        args = ["import", "--yes", "--skip-preview"]
+        args = ["import", "--yes"]
         if message is not None:
             args.extend(["--message", message])
 


### PR DESCRIPTION
Like #18662, this adds support for the `--preview-only` flag in the `refresh` command when using the Python Automation API. It implements the same `--yes` behaviour as the NodeJS version: whether we skip preview or only show the preview, we always set `--yes` to avoid problems with later prompts in future.

Fixes #17598 