### PR TITLE
[auto] Fix `up` with nested secret in config file

### DIFF
--- a/changelog/pending/20250221--auto--fix-up-with-nested-secret-in-config-file.yaml
+++ b/changelog/pending/20250221--auto--fix-up-with-nested-secret-in-config-file.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto
+  description: Fix `up` with nested secret in config file

--- a/pkg/cmd/pulumi/stack/stack_history_test.go
+++ b/pkg/cmd/pulumi/stack/stack_history_test.go
@@ -1,9 +1,22 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package stack
 
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -14,13 +27,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDisplayUpdatesJSONWithFailedDecryptedSecureObject(t *testing.T) {
-	mockDecrypter := &FailingDecrypter{}
+func TestBuildUpdatesJSONWithFailedDecryptedSecureObject(t *testing.T) {
+	t.Parallel()
+
+	mockDecrypter := &failingDecrypter{}
 
 	update := []backend.UpdateInfo{
 		{
 			Version:   1,
-			Kind:      apitype.UpdateKind(apitype.UpdateUpdate),
+			Kind:      apitype.UpdateUpdate,
 			StartTime: time.Now().Unix(),
 			Message:   "Update with config that can't be decrypted",
 			Environment: map[string]string{
@@ -32,21 +47,21 @@ func TestDisplayUpdatesJSONWithFailedDecryptedSecureObject(t *testing.T) {
 			Result:  backend.SucceededResult,
 			EndTime: time.Now().Add(time.Minute).Unix(),
 			ResourceChanges: display.ResourceChanges{
-				display.StepOp(apitype.OpType(apitype.OpCreate)): 1,
+				display.StepOp(apitype.OpCreate): 1,
 			},
 		},
 	}
 
-	err := displayUpdatesJSON(update, mockDecrypter)
+	_, err := buildUpdatesJSON(update, mockDecrypter)
 	assert.NoError(t, err, "Expected config to not error and substitute ERROR_UNABLE_TO_DECRYPT")
 }
 
-type FailingDecrypter struct{}
+type failingDecrypter struct{}
 
-func (m *FailingDecrypter) DecryptValue(ctx context.Context, ciphertext string) (string, error) {
-	return ciphertext, fmt.Errorf("bad value")
+func (m *failingDecrypter) DecryptValue(ctx context.Context, ciphertext string) (string, error) {
+	return ciphertext, errors.New("bad value")
 }
 
-func (m *FailingDecrypter) BulkDecrypt(ctx context.Context, ciphertexts []string) (map[string]string, error) {
-	return map[string]string{}, errors.New("fake failure")
+func (m *failingDecrypter) BulkDecrypt(ctx context.Context, ciphertexts []string) ([]string, error) {
+	return []string{}, errors.New("fake failure")
 }

--- a/pkg/cmd/pulumi/stack/stack_history_test.go
+++ b/pkg/cmd/pulumi/stack/stack_history_test.go
@@ -1,0 +1,52 @@
+package stack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDisplayUpdatesJSONWithFailedDecryptedSecureObject(t *testing.T) {
+	mockDecrypter := &FailingDecrypter{}
+
+	update := []backend.UpdateInfo{
+		{
+			Version:   1,
+			Kind:      apitype.UpdateKind(apitype.UpdateUpdate),
+			StartTime: time.Now().Unix(),
+			Message:   "Update with config that can't be decrypted",
+			Environment: map[string]string{
+				"PULUMI_ENV": "test",
+			},
+			Config: config.Map{
+				config.MustMakeKey("test", "key2"): config.NewSecureObjectValue("object"),
+			},
+			Result:  backend.SucceededResult,
+			EndTime: time.Now().Add(time.Minute).Unix(),
+			ResourceChanges: display.ResourceChanges{
+				display.StepOp(apitype.OpType(apitype.OpCreate)): 1,
+			},
+		},
+	}
+
+	err := displayUpdatesJSON(update, mockDecrypter)
+	assert.NoError(t, err, "Expected config to not error and substitute ERROR_UNABLE_TO_DECRYPT")
+}
+
+type FailingDecrypter struct{}
+
+func (m *FailingDecrypter) DecryptValue(ctx context.Context, ciphertext string) (string, error) {
+	return ciphertext, fmt.Errorf("bad value")
+}
+
+func (m *FailingDecrypter) BulkDecrypt(ctx context.Context, ciphertexts []string) (map[string]string, error) {
+	return map[string]string{}, errors.New("fake failure")
+}


### PR DESCRIPTION
At the end of running an `up` operation from Automation API, the
`pulumi stack history` command is invoked to retrieve an update summary
of the operation.

We want the `stack history --json` command to succeed even if there are
problems decrypting secrets in the config, which can happen when the
`stack history` command doesn't have the encryption salt (because it is
stored in a separate config file). If there is an error decrypting a
config secret, the config's value is replaced with
`ERROR_UNABLE_TO_DECRYPT` rather than having the command fail.

Unfortunately, this does not work when there is a config value with a
nested secret. In that case, an obscure "unexpected end of JSON input"
error is returned and the command fails.

This happens because we attempt to unmarshal the nested value, which is
represented as a JSON string, regardless of whether the decrypt succeeded
or failed. In the failure case, the JSON string is an empty string, so
the unmarshal fails with this error.

This change fixes the problem to only unmarshal the nested value if
there were no errors decrypting secrets and the value is not empty.

Fixes #18329