### PR TITLE
Fix mapping in the presence of hardcoded entries

### DIFF
--- a/changelog/pending/20250221--cli--fix-mapping-in-the-presence-of-hardcoded-entries.yaml
+++ b/changelog/pending/20250221--cli--fix-mapping-in-the-presence-of-hardcoded-entries.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix mapping in the presence of hardcoded entries


### PR DESCRIPTION
In adding parameterization support to the `Mapper` interface (#18671), we broke the ability to use hardcoded mappings as an alternative to plugin mappings. This change restores that and adds a test so that we hopefully won't miss it again.