### PR TITLE
[Experimental/components] Skip tests and .files while analyzing Python components

### DIFF
--- a/sdk/python/lib/test/provider/experimental/test_analyzer.py
+++ b/sdk/python/lib/test/provider/experimental/test_analyzer.py
@@ -949,6 +949,28 @@ def test_analyze_component_mutually_recursive_complex_types_file():
     }
 
 
+def test_analyze_component_excluded_files():
+    analyzer = Analyzer(metadata)
+
+    (components, type_definitions) = analyzer.analyze(
+        Path(Path(__file__).parent, "testdata", "excluded-files")
+    )
+    assert components == {
+        "Component": ComponentDefinition(
+            name="Component",
+            module="component.py",
+            inputs={
+                "foo": PropertyDefinition(
+                    type=PropertyType.STRING,
+                )
+            },
+            inputs_mapping={"foo": "foo"},
+            outputs={},
+            outputs_mapping={},
+        )
+    }
+
+
 def test_unwrap_output():
     str_output = pulumi.Output[str]
     unwrapped = unwrap_output(str_output)

--- a/sdk/python/lib/test/provider/experimental/testdata/excluded-files/.projectrc.py
+++ b/sdk/python/lib/test/provider/experimental/testdata/excluded-files/.projectrc.py
@@ -1,0 +1,14 @@
+from typing import TypedDict
+
+import pulumi
+
+
+class SkipMeArgs(TypedDict):
+    foo: pulumi.Input[str]
+
+
+class SkipMeComponent(pulumi.ComponentResource):
+    def __init__(self, args: SkipMeArgs): ...
+
+
+# We expect analyzer to skip the tests folder and not analyze this file.

--- a/sdk/python/lib/test/provider/experimental/testdata/excluded-files/component.py
+++ b/sdk/python/lib/test/provider/experimental/testdata/excluded-files/component.py
@@ -1,0 +1,11 @@
+from typing import TypedDict
+
+import pulumi
+
+
+class Args(TypedDict):
+    foo: pulumi.Input[str]
+
+
+class Component(pulumi.ComponentResource):
+    def __init__(self, args: Args): ...

--- a/sdk/python/lib/test/provider/experimental/testdata/excluded-files/tests/test_skipme.py
+++ b/sdk/python/lib/test/provider/experimental/testdata/excluded-files/tests/test_skipme.py
@@ -1,0 +1,14 @@
+from typing import TypedDict
+
+import pulumi
+
+
+class SkipMeArgs(TypedDict):
+    foo: pulumi.Input[str]
+
+
+class SkipMeComponent(pulumi.ComponentResource):
+    def __init__(self, args: SkipMeArgs): ...
+
+
+# We expect analyzer to skip the tests folder and not analyze this file.


### PR DESCRIPTION
This PR changes our Python component analyzer to skip certain files and directories, in particular `tests` and and file starting with a dot. I think it's a reasonable default not to expect our users to define any components in those files.

Resolves https://github.com/pulumi/pulumi/issues/18646. While we could add a configuration nob for this and make users define the exclusion as the issue suggest, I believe we want to minimize the number of needed configuration values to achieve our goal of meeting users where they are.