### PR TITLE
introduce helper function for exiterr, and use it in language tests

### DIFF
--- a/sdk/go/common/util/errutil/format_exiterr.go
+++ b/sdk/go/common/util/errutil/format_exiterr.go
@@ -1,0 +1,34 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errutil
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// ErrorWithStderr returns an error that includes the stderr output if the error is an ExitError.
+func ErrorWithStderr(err error, message string) error {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		stderr := strings.TrimSpace(string(exitErr.Stderr))
+		if len(stderr) > 0 {
+			return fmt.Errorf("%s: %w: %s", message, exitErr, exitErr.Stderr)
+		}
+	}
+	return fmt.Errorf("%s: %w", message, err)
+}

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -50,6 +50,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tail"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/errutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/executable"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -1014,7 +1015,7 @@ func (host *goLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest) 
 
 	program, err := compileProgram(req.Info.ProgramDirectory, opts.buildTarget, req.GetAttachDebugger())
 	if err != nil {
-		return nil, fmt.Errorf("error in compiling Go: %w", err)
+		return nil, errutil.ErrorWithStderr(err, "error in compiling Go")
 	}
 	if opts.buildTarget == "" {
 		// If there is no specified buildTarget, delete the temporary program after running it.
@@ -1209,7 +1210,7 @@ func (host *goLanguageHost) RunPlugin(
 
 	program, err := compileProgram(req.Info.ProgramDirectory, "", false)
 	if err != nil {
-		return fmt.Errorf("error in compiling Go: %w", err)
+		return errutil.ErrorWithStderr(err, "error in compiling Go")
 	}
 	defer os.Remove(program)
 

--- a/sdk/python/toolchain/toolchain.go
+++ b/sdk/python/toolchain/toolchain.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/errutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
@@ -213,11 +214,7 @@ func installPython(ctx context.Context, cwd string, showOutput bool, infoWriter,
 	}
 	err = cmd.Run()
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			return fmt.Errorf("error while running pyenv install: %s", string(exitErr.Stderr))
-		}
-		return fmt.Errorf("error while running pyenv install: %s", err)
+		return errutil.ErrorWithStderr(err, "error while running pyenv install")
 	}
 	return nil
 }
@@ -234,16 +231,4 @@ func searchup(currentDir, fileToFind string) (string, error) {
 		return "", os.ErrNotExist
 	}
 	return searchup(parentDir, fileToFind)
-}
-
-// errorWithStderr returns an error that includes the stderr output if the error is an ExitError.
-func errorWithStderr(err error, message string) error {
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		stderr := strings.TrimSpace(string(exitErr.Stderr))
-		if len(stderr) > 0 {
-			return fmt.Errorf("%s: %w: %s", message, exitErr, exitErr.Stderr)
-		}
-	}
-	return fmt.Errorf("%s: %w", message, err)
 }

--- a/sdk/python/toolchain/toolchain_test.go
+++ b/sdk/python/toolchain/toolchain_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/errutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -478,12 +479,13 @@ func TestErrorWithStderr(t *testing.T) {
 	t.Parallel()
 
 	err := errors.New("error")
-	require.Equal(t, "the error message: error", errorWithStderr(err, "the error message").Error())
+	require.Equal(t, "the error message: error", errutil.ErrorWithStderr(err, "the error message").Error())
 
 	exitErr := &exec.ExitError{ProcessState: &os.ProcessState{}, Stderr: []byte("command said something")}
 	require.Equal(t, "the error message: exit status 0: command said something",
-		errorWithStderr(exitErr, "the error message").Error())
+		errutil.ErrorWithStderr(exitErr, "the error message").Error())
 
 	exitErrNoStderr := &exec.ExitError{ProcessState: &os.ProcessState{}}
-	require.Equal(t, "the error message: exit status 0", errorWithStderr(exitErrNoStderr, "the error message").Error())
+	require.Equal(t, "the error message: exit status 0",
+		errutil.ErrorWithStderr(exitErrNoStderr, "the error message").Error())
 }

--- a/sdk/python/toolchain/uv.go
+++ b/sdk/python/toolchain/uv.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/errutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
@@ -142,14 +143,14 @@ func (u *uv) InstallDependencies(ctx context.Context, cwd string, useLanguageVer
 			initCmd := u.uvCommand(ctx, pyprojectTomlDir, showOutput, infoWriter, errorWriter,
 				"init", "--no-readme", "--no-package", "--no-pin-python")
 			if err := initCmd.Run(); err != nil {
-				return errorWithStderr(err, "error initializing python project")
+				return errutil.ErrorWithStderr(err, "error initializing python project")
 			}
 
 			if hasRequirementsTxt {
 				requirementsTxt := filepath.Join(requirementsTxtDir, "requirements.txt")
 				addCmd := u.uvCommand(ctx, cwd, showOutput, infoWriter, errorWriter, "add", "-r", requirementsTxt)
 				if err := addCmd.Run(); err != nil {
-					return errorWithStderr(err, "error installing dependecies from requirements.txt")
+					return errutil.ErrorWithStderr(err, "error installing dependecies from requirements.txt")
 				}
 				// Remove the requirements.txt file, after calling `uv add`, the
 				// dependencies are tracked in pyproject.toml.
@@ -173,7 +174,7 @@ func (u *uv) InstallDependencies(ctx context.Context, cwd string, useLanguageVer
 	// install the dependencies.
 	syncCmd := u.uvCommand(ctx, cwd, showOutput, infoWriter, errorWriter, "sync")
 	if err := syncCmd.Run(); err != nil {
-		return errorWithStderr(err, "error installing dependencies")
+		return errutil.ErrorWithStderr(err, "error installing dependencies")
 	}
 	return nil
 }
@@ -184,7 +185,7 @@ func (u *uv) EnsureVenv(ctx context.Context, cwd string, useLanguageVersionTools
 	venvCmd := u.uvCommand(ctx, cwd, showOutput, infoWriter, errorWriter, "venv", "--quiet",
 		"--allow-existing", u.virtualenvPath)
 	if err := venvCmd.Run(); err != nil {
-		return errorWithStderr(err, "error creating virtual environment")
+		return errutil.ErrorWithStderr(err, "error creating virtual environment")
 	}
 
 	return nil
@@ -229,13 +230,13 @@ func (u *uv) ListPackages(ctx context.Context, transitive bool) ([]PythonPackage
 			cmd.Dir = u.root
 			pipCmd = cmd
 		} else {
-			return nil, errorWithStderr(err, "checking for pip")
+			return nil, errutil.ErrorWithStderr(err, "checking for pip")
 		}
 	}
 
 	output, err := pipCmd.Output()
 	if err != nil {
-		return nil, errorWithStderr(err, "listing packages")
+		return nil, errutil.ErrorWithStderr(err, "listing packages")
 	}
 
 	var packages []PythonPackage


### PR DESCRIPTION
In Go, `exec.ExitErr` contains the whole Stderr of a command.  However it's `Error()` function unfortunately only returns the exit status, which in most cases is not enough to debug the problem.  In most cases we want to format these errors including the stderr to make the problems more debuggable.

Factor out the helper function we already have for the python toolchain, and make it available to other places as well.  Start using it in the Go conformance tests, where I ran into this today.  We should spread the usage of this to wherever we deal with ExitErrors, but let's start here for now.