### PR TITLE
Fill in some more Name and Type fields on requests

### DIFF
--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -484,6 +484,8 @@ func (s *DeleteStep) Apply() (resource.Status, StepCompleteFunc, error) {
 
 		if rst, err := prov.Delete(context.TODO(), plugin.DeleteRequest{
 			URN:     s.URN(),
+			Name:    s.URN().Name(),
+			Type:    s.URN().Type(),
 			ID:      s.old.ID,
 			Inputs:  s.old.Inputs,
 			Outputs: s.old.Outputs,
@@ -647,6 +649,8 @@ func (s *UpdateStep) Apply() (resource.Status, StepCompleteFunc, error) {
 		// Update to the combination of the old "all" state, but overwritten with new inputs.
 		resp, upderr := prov.Update(context.TODO(), plugin.UpdateRequest{
 			URN:           s.URN(),
+			Name:          s.URN().Name(),
+			Type:          s.URN().Type(),
 			ID:            s.old.ID,
 			OldInputs:     s.old.Inputs,
 			OldOutputs:    s.old.Outputs,
@@ -1370,6 +1374,8 @@ func (s *ImportStep) Apply() (resource.Status, StepCompleteFunc, error) {
 		// definitely a provider bug.
 		resp, err := prov.Check(context.TODO(), plugin.CheckRequest{
 			URN:           s.new.URN,
+			Name:          s.URN().Name(),
+			Type:          s.URN().Type(),
 			Olds:          s.old.Inputs,
 			News:          s.new.Inputs,
 			AllowUnknowns: s.deployment.opts.DryRun,
@@ -1416,6 +1422,8 @@ func (s *ImportStep) Apply() (resource.Status, StepCompleteFunc, error) {
 	// Check the inputs using the provider inputs for defaults.
 	resp, err := prov.Check(context.TODO(), plugin.CheckRequest{
 		URN:           s.new.URN,
+		Name:          s.new.URN.Name(),
+		Type:          s.new.URN.Type(),
 		Olds:          s.old.Inputs,
 		News:          s.new.Inputs,
 		AllowUnknowns: s.deployment.opts.DryRun,

--- a/pkg/resource/deploy/step_test.go
+++ b/pkg/resource/deploy/step_test.go
@@ -415,6 +415,7 @@ func TestUpdateStep(t *testing.T) {
 			s := &UpdateStep{
 				old: &resource.State{},
 				new: &resource.State{
+					URN:    "urn:pulumi:stack::project::some-type::some-urn",
 					Custom: true,
 					// Use denydefaultprovider ID to ensure failure.
 					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
@@ -439,6 +440,7 @@ func TestUpdateStep(t *testing.T) {
 			s := &UpdateStep{
 				old: &resource.State{},
 				new: &resource.State{
+					URN:    "urn:pulumi:stack::project::some-type::some-urn",
 					Custom: true,
 					// Use denydefaultprovider ID to ensure failure.
 					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",


### PR DESCRIPTION
Same as https://github.com/pulumi/pulumi/pull/18611, we were missing a few more places where we should have been sending Name and Type. Again the grpc layer normally filled these in so this was only noticeable from tests.