### PR TITLE
Implement `stack rename` for the NodeJS automation API

### DIFF
--- a/changelog/pending/20250224--auto-nodejs--add-stack-rename-to-the-nodejs-automation-api.yaml
+++ b/changelog/pending/20250224--auto-nodejs--add-stack-rename-to-the-nodejs-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/nodejs
+  description: Add `stack rename` to the NodeJS Automation API

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -1628,11 +1628,6 @@ export interface RenameOptions extends GlobalOpts {
     onOutput?: (out: string) => void;
 
     /**
-     * A callback to be executed when the operation yields an event.
-     */
-    onEvent?: (event: EngineEvent) => void;
-
-    /**
      * Include secrets in the UpSummary.
      */
     showSecrets?: boolean;

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -596,11 +596,10 @@ Event: ${line}\n${e.toString()}`);
 
         applyGlobalOpts(options, args);
 
-        let renameResult: CommandResult;
-        renameResult = await this.runPulumiCmd(args, options?.onOutput, options?.signal);
+        const renameResult = await this.runPulumiCmd(args, options?.onOutput, options?.signal);
 
         if (this.isRemote && options?.showSecrets) {
-          throw new Error("can't enable `showSecrets` for remote workspaces");
+            throw new Error("can't enable `showSecrets` for remote workspaces");
         }
 
         const summary = await this.info(!this.isRemote && options?.showSecrets);

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -793,11 +793,10 @@ describe("LocalWorkspace", () => {
         assert.strictEqual(renameRes.summary.kind, "rename");
         assert.strictEqual(renameRes.summary.result, "succeeded");
 
+        // The stack selection should be a no-op as it's the already-selected
+        // stack.
         await stack.up({ userAgent });
-
-        // This stack shouldn't exist anymore.
-        await assert.rejects(stack.workspace.selectStack(stackName));
-        await stack.workspace.selectStack(stackName);
+        await stack.workspace.selectStack(renamed);
 
         // pulumi destroy
         await stack.workspace.selectStack(renamed);

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -781,7 +781,7 @@ describe("LocalWorkspace", () => {
             return {};
         };
 
-        const suffix =  `int_test${getTestSuffix()}`;
+        const suffix = `int_test${getTestSuffix()}`;
 
         const stackName = fullyQualifiedStackName(getTestOrg(), "inline_node", suffix);
         const shortName = getTestOrg() + "/" + suffix;
@@ -797,17 +797,15 @@ describe("LocalWorkspace", () => {
         await stack.up({ userAgent });
         stack.workspace.selectStack(stackName);
 
-        let output = "";
+        let returned = "";
         const renameRes = await stack.rename({
-          stackName: stackRenamed,
-          onOutput: e => output += e,
+            stackName: stackRenamed,
+            onOutput: (e) => (returned += e),
         });
 
-        const after =
-          (await stack.workspace.listStacks())
-            .find(x => x.name.startsWith(shortName));
+        const after = (await stack.workspace.listStacks()).find((x) => x.name.startsWith(shortName));
 
-        assert.strictEqual(output, `Renamed ${shortName} to ${shortRenamed}\n`);
+        assert.strictEqual(returned, `Renamed ${shortName} to ${shortRenamed}\n`);
         assert.strictEqual(after?.name, shortRenamed);
 
         assert.strictEqual(renameRes.summary.kind, "rename");

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -801,10 +801,10 @@ describe("LocalWorkspace", () => {
           (await stack.workspace.listStacks())
             .find(x => x.name.startsWith(shortName));
 
-        let output = ""
+        let output = "";
         const renameRes = await stack.rename({
           stackName: stackRenamed,
-          onOutput: e => output += e
+          onOutput: e => output += e,
         });
 
         const after =
@@ -812,7 +812,7 @@ describe("LocalWorkspace", () => {
             .find(x => x.name.startsWith(shortName));
 
         assert.strictEqual(output, `Renamed ${shortName} to ${shortRenamed}\n`);
-        assert.strictEqual(after.name, shortRenamed)
+        assert.strictEqual(after.name, shortRenamed);
 
         assert.strictEqual(renameRes.summary.kind, "rename");
         assert.strictEqual(renameRes.summary.result, "succeeded");

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -770,7 +770,7 @@ describe("LocalWorkspace", () => {
 
         await stack.destroy();
     });
-    it("renames a stack", async () => {
+    it(`renames a stack`, async () => {
         const program = async () => {
             class MyResource extends ComponentResource {
                 constructor(name: string, opts?: ComponentResourceOptions) {
@@ -787,19 +787,20 @@ describe("LocalWorkspace", () => {
             withTestBackend({}, "inline_node"),
         );
 
-        await stack.up({ userAgent });
         const renamed = stackName + '_renamed'
-
         const renameRes = await stack.rename({ stackName: renamed });
-        assert.strictEqual(renameRes.stdout, "");
+
         assert.strictEqual(renameRes.summary.kind, "rename");
         assert.strictEqual(renameRes.summary.result, "succeeded");
 
+        await stack.up({ userAgent });
+
         // This stack shouldn't exist anymore.
         await assert.rejects(stack.workspace.selectStack(stackName));
-        await stack.workspace.selectStack(renamed);
+        await stack.workspace.selectStack(stackName);
 
         // pulumi destroy
+        await stack.workspace.selectStack(renamed);
         const destroyRes = await stack.destroy({ userAgent });
         assert.strictEqual(destroyRes.summary.kind, "destroy");
         assert.strictEqual(destroyRes.summary.result, "succeeded");

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -791,6 +791,7 @@ describe("LocalWorkspace", () => {
         const renamed = stackName + '_renamed'
 
         const renameRes = await stack.rename({ stackName: renamed });
+        assert.strictEqual(renameRes.stdout, "");
         assert.strictEqual(renameRes.summary.kind, "rename");
         assert.strictEqual(renameRes.summary.result, "succeeded");
 

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -797,10 +797,6 @@ describe("LocalWorkspace", () => {
         await stack.up({ userAgent });
         stack.workspace.selectStack(stackName);
 
-        const before =
-          (await stack.workspace.listStacks())
-            .find(x => x.name.startsWith(shortName));
-
         let output = "";
         const renameRes = await stack.rename({
           stackName: stackRenamed,
@@ -812,7 +808,7 @@ describe("LocalWorkspace", () => {
             .find(x => x.name.startsWith(shortName));
 
         assert.strictEqual(output, `Renamed ${shortName} to ${shortRenamed}\n`);
-        assert.strictEqual(after.name, shortRenamed);
+        assert.strictEqual(after?.name, shortRenamed);
 
         assert.strictEqual(renameRes.summary.kind, "rename");
         assert.strictEqual(renameRes.summary.result, "succeeded");

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -787,7 +787,7 @@ describe("LocalWorkspace", () => {
             withTestBackend({}, "inline_node"),
         );
 
-        const renamed = stackName + '_renamed'
+        const renamed = stackName + "_renamed";
         const renameRes = await stack.rename({ stackName: renamed });
 
         assert.strictEqual(renameRes.summary.kind, "rename");
@@ -802,7 +802,6 @@ describe("LocalWorkspace", () => {
         const destroyRes = await stack.destroy({ userAgent });
         assert.strictEqual(destroyRes.summary.kind, "destroy");
         assert.strictEqual(destroyRes.summary.result, "succeeded");
-
     });
     it(`refreshes with refresh option`, async () => {
         // We create a simple program, and scan the output for an indication

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -807,14 +807,12 @@ describe("LocalWorkspace", () => {
           onOutput: e => output += e
         });
 
-        await stack.workspace.refreshConfig(stackRenamed)
-
         const after =
           (await stack.workspace.listStacks())
             .find(x => x.name.startsWith(shortName));
 
         assert.strictEqual(output, `Renamed ${shortName} to ${shortRenamed}\n`);
-        assert.equal(after.name, shortRenamed)
+        assert.strictEqual(after.name, shortRenamed)
 
         assert.strictEqual(renameRes.summary.kind, "rename");
         assert.strictEqual(renameRes.summary.result, "succeeded");

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -799,7 +799,6 @@ describe("LocalWorkspace", () => {
         await stack.workspace.selectStack(renamed);
 
         // pulumi destroy
-        await stack.workspace.selectStack(renamed);
         const destroyRes = await stack.destroy({ userAgent });
         assert.strictEqual(destroyRes.summary.kind, "destroy");
         assert.strictEqual(destroyRes.summary.result, "succeeded");

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -800,7 +800,9 @@ describe("LocalWorkspace", () => {
         let returned = "";
         const renameRes = await stack.rename({
             stackName: stackRenamed,
-            onOutput: (e) => (returned += e),
+            onOutput: (e) => {
+                returned += e;
+            },
         });
 
         const after = (await stack.workspace.listStacks()).find((x) => x.name.startsWith(shortName));


### PR DESCRIPTION
The first of a series of PRs to add the ability to rename stacks to the automation API. I tried to follow the same pattern as the other commands in the API, but I'd appreciate someone with more experience here taking a look to make sure I've not missed something important! 

* https://github.com/pulumi/pulumi/issues/15357