### PR TITLE
Report all errors back from git clone

### DIFF
--- a/changelog/pending/20250224--cli-new--report-all-errors-from-git-clone-for-multiple-refs.yaml
+++ b/changelog/pending/20250224--cli-new--report-all-errors-from-git-clone-for-multiple-refs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Report all errors from git clone for multiple refs.


### PR DESCRIPTION
Currently when we try a git clone for a given url without a reference we try both master and main. If the clone for master _and_ main both fail we only report back the error that happened for main.

This changes it so we report both errors. I also added some more log lines.