### PR TITLE
stack/policy rm: require yes flag in non-interactive mode

### DIFF
--- a/changelog/pending/20250225--cli--make-policy-rm-and-stack-rm-non-interactive-when-requested.yaml
+++ b/changelog/pending/20250225--cli--make-policy-rm-and-stack-rm-non-interactive-when-requested.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Make policy rm and stack rm non-interactive when requested

--- a/pkg/cmd/pulumi/policy/policy_rm.go
+++ b/pkg/cmd/pulumi/policy/policy_rm.go
@@ -15,6 +15,7 @@
 package policy
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -55,6 +56,10 @@ func newPolicyRmCmd() *cobra.Command {
 
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
+			}
+
+			if !cmdutil.Interactive() && !yes {
+				return errors.New("non-interactive mode requires --yes flag")
 			}
 
 			prompt := fmt.Sprintf("This will permanently remove the '%s' policy!", args[0])

--- a/pkg/cmd/pulumi/stack/stack_rm.go
+++ b/pkg/cmd/pulumi/stack/stack_rm.go
@@ -80,6 +80,10 @@ func newStackRmCmd() *cobra.Command {
 				return err
 			}
 
+			if !cmdutil.Interactive() && !yes {
+				return errors.New("non-interactive mode requires --yes flag")
+			}
+
 			// Ensure the user really wants to do this.
 			prompt := fmt.Sprintf("This will permanently remove the '%s' stack!", s.Ref())
 			if !yes && !ui.ConfirmPrompt(prompt, s.Ref().String(), opts) {


### PR DESCRIPTION
When `--non-interactive` is specified on the command line, pulumi promises to disable interactive mode for all commands, which means it should never prompt.  This however currently does not work for `policy rm` and `stack rm`, both of which still prompt even when `--non-interactive` is specified.

Instead of that, error out when `--non-interactive` is specified, but `--yes` isn't.

Prompted by https://github.com/pulumi/pulumi/issues/4717#issuecomment-2680086602.