### PR TITLE
package: also suggest disambiguating for local directories

### DIFF
--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -782,8 +782,8 @@ func ProviderFromSource(pctx *plugin.Context, packageSource string) (plugin.Prov
 		// We assume this was a plugin and not a path, so load the plugin.
 		provider, err := host.Provider(descriptor)
 		if err != nil {
-			// There is an executable with the same name, so suggest that
-			if info, statErr := os.Stat(descriptor.Name); statErr == nil && isExecutable(info) {
+			// There is an executable or directory with the same name, so suggest that
+			if info, statErr := os.Stat(descriptor.Name); statErr == nil && (isExecutable(info) || info.IsDir()) {
 				return nil, fmt.Errorf("could not find installed plugin %s, did you mean ./%[1]s: %w", descriptor.Name, err)
 			}
 


### PR DESCRIPTION
In the `pulumi package *` command family, we try to load the provider based on some properties, and if it fails and a corresponding executable exists, we suggest disambiguating it using "./".

Nowadays we can also have source based plugins, so we should give the user the same disambiguation option if the name matches a local directory instead of an executable.  Do that here.

Small fix I noticed while reading code for https://github.com/pulumi/pulumi/pull/18709.