### PR TITLE
Add `stack rename` to the Python Automation API

### DIFF
--- a/changelog/pending/20250225--auto-python--add-the-ability-to-rename-the-given-stack-to-the-python-automation-api.yaml
+++ b/changelog/pending/20250225--auto-python--add-the-ability-to-rename-the-given-stack-to-the-python-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/python
+  description: Add the ability to rename the given stack to the Python Automation API

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -613,7 +613,7 @@ class Stack:
         :returns: RenameResult
         """
         extra_args = _parse_extra_args(**locals())
-        args = ["stack", "rename"]
+        args = ["stack", "rename", stack_name]
         args.extend(extra_args)
 
         args.extend(self._remote_args())

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -604,14 +604,13 @@ class Stack:
         show_secrets: bool = True,
     ) -> RenameResult:
         """
-        Compares the current stack’s resource state with the state known to exist in the actual
-        cloud provider. Any such changes are adopted into the current stack.
+        Renames the current stack.
 
         :param stack_name: The new name for the stack.
         :param on_output: A function to process the stdout stream.
         :param on_event: A function to process structured events from the Pulumi event stream.
         :param show_secrets: Include config secrets in the RefreshResult summary.
-        :returns: RefreshResult
+        :returns: RenameResult
         """
         extra_args = _parse_extra_args(**locals())
         args = ["stack", "rename"]
@@ -630,7 +629,7 @@ class Stack:
             log_watcher_thread.start()
 
         try:
-            refresh_result = self._run_pulumi_cmd_sync(args, on_output)
+            rename_result = self._run_pulumi_cmd_sync(args, on_output)
         finally:
             _cleanup(temp_dir, log_watcher_thread)
 
@@ -639,7 +638,7 @@ class Stack:
         summary = self.info(show_secrets and not self._remote)
         assert summary is not None
         return RenameResult(
-            stdout=refresh_result.stdout, stderr=refresh_result.stderr, summary=summary
+            stdout=rename_result.stdout, stderr=rename_result.stderr, summary=summary
         )
 
     def destroy(

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -619,9 +619,6 @@ class Stack:
 
         args.extend(self._remote_args())
 
-        kind = ExecKind.INLINE.value if self.workspace.program else ExecKind.LOCAL.value
-        args.extend(["--exec-kind", kind])
-
         log_watcher_thread = None
         temp_dir = None
         if on_event:
@@ -697,6 +694,9 @@ class Stack:
         args.extend(extra_args)
 
         args.extend(self._remote_args())
+
+        kind = ExecKind.INLINE.value if self.workspace.program else ExecKind.LOCAL.value
+        args.extend(["--exec-kind", kind])
 
         log_watcher_thread = None
         temp_dir = None

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -698,9 +698,6 @@ class Stack:
 
         args.extend(self._remote_args())
 
-        kind = ExecKind.INLINE.value if self.workspace.program else ExecKind.LOCAL.value
-        args.extend(["--exec-kind", kind])
-
         log_watcher_thread = None
         temp_dir = None
         if on_event:

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -178,10 +178,12 @@ class RefreshResult(BaseResult):
         super().__init__(stdout, stderr)
         self.summary = summary
 
+
 class RenameResult(BaseResult):
     def __init__(self, stdout: str, stderr: str, summary: UpdateSummary):
         super().__init__(stdout, stderr)
         self.summary = summary
+
 
 class DestroyResult(BaseResult):
     def __init__(self, stdout: str, stderr: str, summary: UpdateSummary):
@@ -600,7 +602,7 @@ class Stack:
         on_output: Optional[OnOutput] = None,
         on_event: Optional[OnEvent] = None,
         show_secrets: bool = True,
-    ) -> RefreshResult:
+    ) -> RenameResult:
         """
         Compares the current stack’s resource state with the state known to exist in the actual
         cloud provider. Any such changes are adopted into the current stack.

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -214,8 +214,8 @@ class TestLocalWorkspace(unittest.TestCase):
         ws = LocalWorkspace(project_settings=project_settings)
         stack_name = stack_namer(project_name)
 
-        Stack.create(stack_name, ws)
-        ws.stack().rename(stack_name + "_renamed", ws)
+        stack = Stack.create(stack_name, ws)
+        stack.rename(stack_name + "_renamed", ws)
         ws.remove_stack(stack_name + "_renamed")
 
     def test_config_env_functions(self):

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -215,7 +215,7 @@ class TestLocalWorkspace(unittest.TestCase):
         stack_name = stack_namer(project_name)
 
         Stack.create(stack_name, ws)
-        Stack.rename(stack_name + "_renamed", ws)
+        ws.stack().rename(stack_name + "_renamed", ws)
         ws.remove_stack(stack_name + "_renamed")
 
     def test_config_env_functions(self):

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -216,6 +216,8 @@ class TestLocalWorkspace(unittest.TestCase):
 
         stack = Stack.create(stack_name, ws)
         stack.rename(stack_name + "_renamed")
+
+        # This will throw if the renamed stack doesn't exist.
         ws.remove_stack(stack_name + "_renamed")
 
     def test_config_env_functions(self):

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -206,6 +206,18 @@ class TestLocalWorkspace(unittest.TestCase):
         self.assertEqual(Stack.create_or_select(stack_name, ws).name, stack_name)
         ws.remove_stack(stack_name)
 
+    # If we rename a stack, we should be able to delete the stack by using the
+    # new name.
+    def test_stack_rename(self):
+        project_name = "python_rename_test"
+        project_settings = ProjectSettings(name=project_name, runtime="python")
+        ws = LocalWorkspace(project_settings=project_settings)
+        stack_name = stack_namer(project_name)
+
+        Stack.create(stack_name, ws)
+        Stack.rename(stack_name + '_renamed', ws)
+        ws.remove_stack(stack_name + '_renamed')
+
     def test_config_env_functions(self):
         if get_test_org() != "moolumi":
             self.skipTest(

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -215,7 +215,7 @@ class TestLocalWorkspace(unittest.TestCase):
         stack_name = stack_namer(project_name)
 
         stack = Stack.create(stack_name, ws)
-        stack.rename(stack_name + "_renamed", ws)
+        stack.rename(stack_name + "_renamed")
         ws.remove_stack(stack_name + "_renamed")
 
     def test_config_env_functions(self):

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -215,8 +215,8 @@ class TestLocalWorkspace(unittest.TestCase):
         stack_name = stack_namer(project_name)
 
         Stack.create(stack_name, ws)
-        Stack.rename(stack_name + '_renamed', ws)
-        ws.remove_stack(stack_name + '_renamed')
+        Stack.rename(stack_name + "_renamed", ws)
+        ws.remove_stack(stack_name + "_renamed")
 
     def test_config_env_functions(self):
         if get_test_org() != "moolumi":


### PR DESCRIPTION
As with the NodeJS Automation API, this PR adds the ability to rename the current stack using the automation API. It also adds a test that follows the same approach as with NodeJS.

* #18696
* #15357 