### PR TITLE
Fix TestDestroyUpgradeWarningParameterized on Windows

### DIFF
--- a/changelog/pending/20250225--sdk-nodejs--fix-searching-for-pulumi-packages-past-junction-points-on-windows.yaml
+++ b/changelog/pending/20250225--sdk-nodejs--fix-searching-for-pulumi-packages-past-junction-points-on-windows.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix searching for pulumi packages past junction points on Windows

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -863,9 +863,6 @@ func TestDestroyUpgradeWarning(t *testing.T) {
 //
 //nolint:paralleltest // pulumi new is not parallel safe
 func TestDestroyUpgradeWarningParameterized(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Very flakey on Windows https://github.com/pulumi/pulumi/issues/18414")
-	}
 	e := ptesting.NewEnvironment(t)
 	defer deleteIfNotFailed(e)
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/18414

Turns out the nodejs runtime wasn't picking up our parameterized package in GetRequiredPackages at all because it was behind a junction point that Go wasn't seeing as a directory.

I'm not sure how this ever passed but I think it might have been due to this change (https://go-review.googlesource.com/c/go/+/565136) in Go 1.23.