### PR TITLE
[sdk/nodejs] Append coverage data

### DIFF
--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -65,14 +65,14 @@ install_plugin:: build
 install:: install_package install_plugin
 
 unit_tests:: $(TEST_ALL_DEPS)
-	yarn run nyc -s mocha --timeout 120000 \
+	yarn run nyc --no-clean -s mocha --timeout 120000 \
 		--exclude 'bin/tests/automation/**/*.spec.js' \
 		--exclude 'bin/tests/runtime/closure-integration-tests.js' \
 		'bin/tests/**/*.spec.js'
-	yarn run nyc -s mocha 'bin/tests_with_mocks/**/*.spec.js'
+	yarn run nyc --no-clean -s mocha 'bin/tests_with_mocks/**/*.spec.js'
 
 test_auto:: $(TEST_ALL_DEPS)
-	yarn run nyc -s mocha --timeout 300000 'bin/tests/automation/**/*.spec.js'
+	yarn run nyc --no-clean -s mocha --timeout 300000 'bin/tests/automation/**/*.spec.js'
 
 test_integration:: $(TEST_ALL_DEPS)
 	node 'bin/tests/runtime/closure-integration-tests.js'


### PR DESCRIPTION
From local testing, when running `make unit_tests` in `sdk/nodejs`, and then subsequently running `yarn run nyc report`, I only see coverage associated with the `tests_with_mocks`. The coverage data for the previous `nyc` command, which contains the majority of unit tests, appears to be missing from the coverage report.

This change adds `--no-clean`, so that the coverage data is appended and not cleared out between runs.

Similar to the problem we fixed for the Python SDK: https://github.com/pulumi/pulumi/pull/18475