### PR TITLE
support `PULUMI_STACK` environment variable for selecting your stack

### DIFF
--- a/changelog/pending/20250226--cli-config-state--support-a-pulumi_stack-environment-variable-for-selecting-your-stack.yaml
+++ b/changelog/pending/20250226--cli-config-state--support-a-pulumi_stack-environment-variable-for-selecting-your-stack.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/config,state
+  description: Support a PULUMI_STACK environment variable for selecting your stack

--- a/pkg/backend/state/stacks.go
+++ b/pkg/backend/state/stacks.go
@@ -40,7 +40,7 @@ func CurrentStack(ctx context.Context, backend backend.Backend) (backend.Stack, 
 }
 
 func getCurrentStackName() (string, error) {
-	// PULUMI_STACK environment variable overrides any stack name in the pulumi settings
+	// PULUMI_STACK environment variable overrides any stack name in the workspace settings
 	if stackName, ok := os.LookupEnv("PULUMI_STACK"); ok {
 		return stackName, nil
 	}

--- a/pkg/backend/state/stacks.go
+++ b/pkg/backend/state/stacks.go
@@ -23,13 +23,10 @@ import (
 
 // CurrentStack reads the current stack and returns an instance connected to its backend provider.
 func CurrentStack(ctx context.Context, backend backend.Backend) (backend.Stack, error) {
-	w, err := workspace.New()
+	stackName, err := getCurrentStackName()
 	if err != nil {
 		return nil, err
-	}
-
-	stackName := w.Settings().Stack
-	if stackName == "" {
+	} else if stackName == "" {
 		return nil, nil
 	}
 
@@ -39,6 +36,15 @@ func CurrentStack(ctx context.Context, backend backend.Backend) (backend.Stack, 
 	}
 
 	return backend.GetStack(ctx, ref)
+}
+
+func getCurrentStackName() (string, error) {
+	w, err := workspace.New()
+	if err != nil {
+		return "", err
+	}
+
+	return w.Settings().Stack, nil
 }
 
 // SetCurrentStack changes the current stack to the given stack name.

--- a/pkg/backend/state/stacks.go
+++ b/pkg/backend/state/stacks.go
@@ -16,6 +16,7 @@ package state
 
 import (
 	"context"
+	"os"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -39,6 +40,11 @@ func CurrentStack(ctx context.Context, backend backend.Backend) (backend.Stack, 
 }
 
 func getCurrentStackName() (string, error) {
+	// PULUMI_STACK environment variable overrides any stack name in the pulumi settings
+	if stackName, ok := os.LookupEnv("PULUMI_STACK"); ok {
+		return stackName, nil
+	}
+
 	w, err := workspace.New()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Description

closes https://github.com/pulumi/pulumi/issues/13550

My team regularly utilizes [direnv](https://direnv.net/) to select between deployment environments using directories.

We would love to use this same approach to select our pulumi stack. We aren't willing to wrap `pulumi` to accomplish this, but it seems like adding an environment variable override is easy enough to upstream. 😀

## Commits

1) As a NOP change, I created a `getCurrentStackName()` function that returns a **string**. This just sets up my second commit for an easier change.
2) If `PULUMI_STACK` is defined, return it as the string value

## Testing

### 1) Built a pulumi bin (creates `~/.pulumi-dev/bin/pulumi`):
```
make build install
```

### 2) Tried it out

#### ✅ without the env var, it makes me select my stack manually

```bash
$ ~/.pulumi-dev/bin/pulumi up
Please choose a stack, or create a new one:  [Use arrows to move, type to filter]
  bedrock
> cluster
  network
  <create a new stack>
```

#### ✅ with the env var, my stack is already selected

```bash
$ export PULUMI_STACK=cluster
$ ~/.pulumi-dev/bin/pulumi up
Previewing update (cluster):
...
```

#### ✅ with the env var pointing to a non-existent stack, it falls back to select

(I checked and this is the same behavior as if I manually put `tomato` in my workspace settings)

```bash
$ export PULUMI_STACK=tomato
$ ~/.pulumi-dev/bin/pulumi up
Please choose a stack, or create a new one:  [Use arrows to move, type to filter]
  bedrock
> cluster
  network
```

#### ✅ with an invalid env var, a reasonable error is shown

```bash
$ PULUMI_STACK="not,a;good%string" ~/.pulumi-dev/bin/pulumi up
error: a stack name may only contain alphanumeric, hyphens, underscores, or periods: invalid character ',' at position 3
```

#### ✅ the env var overrides the workspace settings, but not the `--stack` arg

```bash
# selecting bedrock
$ ~/.pulumi-dev/bin/pulumi stack select
Please choose a stack, or create a new one: bedrock

# uses "bedrock" by default
$ ~/.pulumi-dev/bin/pulumi up
Previewing update (bedrock):
...

# env variable overrides to "cluster"
$ PULUMI_STACK=cluster ~/.pulumi-dev/bin/pulumi up
Previewing update (cluster):
...

# however, passing --stack wins over the environment variable (which is what I would expect)
$ PULUMI_STACK=cluster ~/.pulumi-dev/bin/pulumi up --stack network
Previewing update (network):
...
```