### PR TITLE
Add the `stack rename` command to the Go Automation API.

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -20,5 +20,6 @@ node = "20"
 "npm:yarn" = "latest"
 python = '3.11'
 uv = "latest"
+"go:github.com/mitranim/gow" = "latest"
 
 [plugins]

--- a/changelog/pending/20250226--auto-go--add-the-ability-to-rename-the-given-stack-to-the-go-automation-api.yaml
+++ b/changelog/pending/20250226--auto-go--add-the-ability-to-rename-the-given-stack-to-the-go-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Add the ability to rename the given stack to the Go Automation API

--- a/sdk/go/auto/optrename/optrename.go
+++ b/sdk/go/auto/optrename/optrename.go
@@ -16,11 +16,7 @@
 // github.com/sdk/v2/go/x/auto Stack.Rename(...optrename.Option)
 package optrename
 
-import (
-	"io"
-
-	"github.com/pulumi/pulumi/sdk/v3/go/auto/events"
-)
+import "io"
 
 // The new name of the stack.
 func StackName(message string) Option {
@@ -33,13 +29,6 @@ func StackName(message string) Option {
 func ErrorProgressStreams(writers ...io.Writer) Option {
 	return optionFunc(func(opts *Options) {
 		opts.ErrorProgressStreams = writers
-	})
-}
-
-// EventStreams allows specifying one or more channels to receive the Pulumi event stream
-func EventStreams(channels ...chan<- events.EngineEvent) Option {
-	return optionFunc(func(opts *Options) {
-		opts.EventStreams = channels
 	})
 }
 
@@ -65,8 +54,6 @@ type Options struct {
 	ProgressStreams []io.Writer
 	// ErrorProgressStreams allows specifying one or more io.Writers to redirect incremental refresh stderr
 	ErrorProgressStreams []io.Writer
-	// EventStreams allows specifying one or more channels to receive the Pulumi event stream
-	EventStreams []chan<- events.EngineEvent
 	// Show config secrets when they appear.
 	ShowSecrets *bool
 }

--- a/sdk/go/auto/optrename/optrename.go
+++ b/sdk/go/auto/optrename/optrename.go
@@ -1,0 +1,79 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package optrename contains functional options to be used with stack rename operations
+// github.com/sdk/v2/go/x/auto Stack.Rename(...optrename.Option)
+package optrename
+
+import (
+	"io"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/events"
+)
+
+// The new name of the stack.
+func StackName(message string) Option {
+	return optionFunc(func(opts *Options) {
+		opts.StackName = message
+	})
+}
+
+// ErrorProgressStreams allows specifying one or more io.Writers to redirect incremental rename stderr
+func ErrorProgressStreams(writers ...io.Writer) Option {
+	return optionFunc(func(opts *Options) {
+		opts.ErrorProgressStreams = writers
+	})
+}
+
+// EventStreams allows specifying one or more channels to receive the Pulumi event stream
+func EventStreams(channels ...chan<- events.EngineEvent) Option {
+	return optionFunc(func(opts *Options) {
+		opts.EventStreams = channels
+	})
+}
+
+// ShowSecrets configures whether to show config secrets when they appear in the config.
+func ShowSecrets(show bool) Option {
+	return optionFunc(func(opts *Options) {
+		opts.ShowSecrets = &show
+	})
+}
+
+// Option is a parameter to be applied to a Stack.Rename() operation
+type Option interface {
+	ApplyOption(*Options)
+}
+
+// ---------------------------------- implementation details ----------------------------------
+
+// Options is an implementation detail
+type Options struct {
+	// The new name for the stack.
+	StackName string
+	// ProgressStreams allows specifying one or more io.Writers to redirect incremental refresh stdout
+	ProgressStreams []io.Writer
+	// ErrorProgressStreams allows specifying one or more io.Writers to redirect incremental refresh stderr
+	ErrorProgressStreams []io.Writer
+	// EventStreams allows specifying one or more channels to receive the Pulumi event stream
+	EventStreams []chan<- events.EngineEvent
+	// Show config secrets when they appear.
+	ShowSecrets *bool
+}
+
+type optionFunc func(*Options)
+
+// ApplyOption is an implementation detail
+func (o optionFunc) ApplyOption(opts *Options) {
+	o(opts)
+}

--- a/sdk/go/auto/optrename/optrename.go
+++ b/sdk/go/auto/optrename/optrename.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -907,8 +907,8 @@ func (s *Stack) Rename(ctx context.Context, opts ...optrename.Option) (RenameRes
 }
 
 func renameOptsToCmd(renameOpts *optrename.Options, s *Stack) []string {
-	args := slice.Prealloc[string](2)
-	return append(args, "rename", renameOpts.StackName)
+	args := slice.Prealloc[string](3)
+	return append(args, "stack", "rename", renameOpts.StackName)
 }
 
 // Destroy deletes all resources in a stack, leaving all history and configuration intact.

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -868,16 +868,6 @@ func (s *Stack) Rename(ctx context.Context, opts ...optrename.Option) (RenameRes
 
 	args := renameOptsToCmd(renameOpts, s)
 
-	if len(renameOpts.EventStreams) > 0 {
-		eventChannels := renameOpts.EventStreams
-		t, err := tailLogs("rename", eventChannels)
-		if err != nil {
-			return res, fmt.Errorf("failed to tail logs: %w", err)
-		}
-		defer t.Close()
-		args = append(args, "--event-log", t.Filename)
-	}
-
 	stdout, stderr, code, err := s.runPulumiCmdSync(
 		ctx,
 		renameOpts.ProgressStreams,      /* additionalOutputs */

--- a/sdk/go/auto/stack_test.go
+++ b/sdk/go/auto/stack_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optimport"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optrefresh"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optrename"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optremove"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optup"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
@@ -319,6 +320,27 @@ func TestRefreshOptsClearPendingCreates(t *testing.T) {
 	)
 
 	assert.Contains(t, args, "--clear-pending-creates")
+}
+
+func TestRename(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	sName := ptesting.RandomStackName()
+	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
+	pDir := filepath.Join(".", "test", "testproj")
+
+	stack, err := NewStackLocalSource(ctx, stackName, pDir)
+	require.NoError(t, err)
+
+	args := renameOptsToCmd(
+		&optrename.Options{
+			StackName: "test-rename",
+		},
+		&stack,
+	)
+
+	assert.Equal(t, args, []string { "stack", "rename", "test-rename" })
 }
 
 func TestPreviewImportResources(t *testing.T) {

--- a/sdk/go/auto/stack_test.go
+++ b/sdk/go/auto/stack_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optimport"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optrefresh"
-	"github.com/pulumi/pulumi/sdk/v3/go/auto/optrename"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optremove"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optrename"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optup"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
@@ -340,7 +340,7 @@ func TestRename(t *testing.T) {
 		&stack,
 	)
 
-	assert.Equal(t, args, []string { "stack", "rename", "test-rename" })
+	assert.Equal(t, args, []string{"stack", "rename", "test-rename"})
 }
 
 func TestPreviewImportResources(t *testing.T) {


### PR DESCRIPTION
To match both TypeScript and Python, this PR adds the `stack rename` command to the Automation API for Go.

* #15357
* #18696
* #18712

Fixes #15357.