### PR TITLE
[Experimental/Components]: return an error for resource references

### DIFF
--- a/sdk/nodejs/provider/experimental/analyzer.ts
+++ b/sdk/nodejs/provider/experimental/analyzer.ts
@@ -315,6 +315,8 @@ export class Analyzer {
                 prop.description = docString;
             }
             return prop;
+	} else if (isResourceReference(type, this.checker)) {
+	    throw new Error(`Resource references are not supported yet: found type '${this.checker.typeToString(type)}'`);
         } else if (type.isClassOrInterface()) {
             // This is a complex type, create a typedef and then reference it in
             // the PropertyDefinition.
@@ -582,6 +584,23 @@ function isInput(type: typescript.Type): boolean {
         }
     }
     return hasOutput && hasPromise && hasOther;
+}
+
+function isResourceReference(type: typescript.Type, checker: typescript.TypeChecker): boolean {
+    if (type.isClassOrInterface()) {
+	const baseTypes = checker.getBaseTypes(type as typescript.InterfaceType);
+	for (const baseType of baseTypes) {
+	    const symbol = baseType.getSymbol();
+	    const matchesName = symbol?.escapedName === "CustomResource" || symbol?.escapedName === "ComponentResource" || symbol?.escapedName === "Resource";
+	    const sourceFile = symbol?.declarations?.[0].getSourceFile();
+	    const matchesSourceFile =
+		sourceFile?.fileName.endsWith("resource.ts") || sourceFile?.fileName.endsWith("resource.d.ts");
+	    if (matchesName && matchesSourceFile) {
+		return true;
+	    }
+	}
+    }
+    return false;
 }
 
 function tsTypeToPropertyType(type: typescript.Type): PropertyType {

--- a/sdk/nodejs/provider/experimental/analyzer.ts
+++ b/sdk/nodejs/provider/experimental/analyzer.ts
@@ -315,8 +315,10 @@ export class Analyzer {
                 prop.description = docString;
             }
             return prop;
-	} else if (isResourceReference(type, this.checker)) {
-	    throw new Error(`Resource references are not supported yet: found type '${this.checker.typeToString(type)}'`);
+        } else if (isResourceReference(type, this.checker)) {
+            throw new Error(
+                `Resource references are not supported yet: found type '${this.checker.typeToString(type)}'`,
+            );
         } else if (type.isClassOrInterface()) {
             // This is a complex type, create a typedef and then reference it in
             // the PropertyDefinition.
@@ -588,17 +590,20 @@ function isInput(type: typescript.Type): boolean {
 
 function isResourceReference(type: typescript.Type, checker: typescript.TypeChecker): boolean {
     if (type.isClassOrInterface()) {
-	const baseTypes = checker.getBaseTypes(type as typescript.InterfaceType);
-	for (const baseType of baseTypes) {
-	    const symbol = baseType.getSymbol();
-	    const matchesName = symbol?.escapedName === "CustomResource" || symbol?.escapedName === "ComponentResource" || symbol?.escapedName === "Resource";
-	    const sourceFile = symbol?.declarations?.[0].getSourceFile();
-	    const matchesSourceFile =
-		sourceFile?.fileName.endsWith("resource.ts") || sourceFile?.fileName.endsWith("resource.d.ts");
-	    if (matchesName && matchesSourceFile) {
-		return true;
-	    }
-	}
+        const baseTypes = checker.getBaseTypes(type as typescript.InterfaceType);
+        for (const baseType of baseTypes) {
+            const symbol = baseType.getSymbol();
+            const matchesName =
+                symbol?.escapedName === "CustomResource" ||
+                symbol?.escapedName === "ComponentResource" ||
+                symbol?.escapedName === "Resource";
+            const sourceFile = symbol?.declarations?.[0].getSourceFile();
+            const matchesSourceFile =
+                sourceFile?.fileName.endsWith("resource.ts") || sourceFile?.fileName.endsWith("resource.d.ts");
+            if (matchesName && matchesSourceFile) {
+                return true;
+            }
+        }
     }
     return false;
 }

--- a/sdk/nodejs/provider/experimental/analyzer.ts
+++ b/sdk/nodejs/provider/experimental/analyzer.ts
@@ -589,23 +589,21 @@ function isInput(type: typescript.Type): boolean {
 }
 
 function isResourceReference(type: typescript.Type, checker: typescript.TypeChecker): boolean {
-    if (type.isClassOrInterface()) {
-        const baseTypes = checker.getBaseTypes(type as typescript.InterfaceType);
-        for (const baseType of baseTypes) {
-            const symbol = baseType.getSymbol();
-            const matchesName =
-                symbol?.escapedName === "CustomResource" ||
-                symbol?.escapedName === "ComponentResource" ||
-                symbol?.escapedName === "Resource";
-            const sourceFile = symbol?.declarations?.[0].getSourceFile();
-            const matchesSourceFile =
-                sourceFile?.fileName.endsWith("resource.ts") || sourceFile?.fileName.endsWith("resource.d.ts");
-            if (matchesName && matchesSourceFile) {
-                return true;
-            }
-        }
+    if (!type.isClass()) {
+        return false;
     }
-    return false;
+    return checker.getBaseTypes(type as typescript.InterfaceType).some((baseType) => {
+        const symbol = baseType.getSymbol();
+        const matchesName =
+            symbol?.escapedName === "CustomResource" ||
+            symbol?.escapedName === "ComponentResource" ||
+            symbol?.escapedName === "Resource";
+
+        const sourceFile = symbol?.declarations?.[0].getSourceFile();
+        const matchesSourceFile =
+            sourceFile?.fileName.endsWith("resource.ts") || sourceFile?.fileName.endsWith("resource.d.ts");
+        return (matchesName && matchesSourceFile) || isResourceReference(baseType, checker);
+    });
 }
 
 function tsTypeToPropertyType(type: typescript.Type): PropertyType {

--- a/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
@@ -299,6 +299,15 @@ describe("Analyzer", function () {
         });
     });
 
+    it("errors nicely for resource references", async function() {
+	const dir = path.join(__dirname, "testdata", "resource-reference");
+	const analyzer = new Analyzer(dir, "provider");
+	assert.throws(
+	    () => analyzer.analyze(),
+	    /Resource references are not supported yet: found type 'MyResource'/,
+	);
+    });
+
     it("infers component description", async function () {
         const dir = path.join(__dirname, "testdata", "component-description");
         const analyzer = new Analyzer(dir, "provider");

--- a/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
@@ -299,13 +299,10 @@ describe("Analyzer", function () {
         });
     });
 
-    it("errors nicely for resource references", async function() {
-	const dir = path.join(__dirname, "testdata", "resource-reference");
-	const analyzer = new Analyzer(dir, "provider");
-	assert.throws(
-	    () => analyzer.analyze(),
-	    /Resource references are not supported yet: found type 'MyResource'/,
-	);
+    it("errors nicely for resource references", async function () {
+        const dir = path.join(__dirname, "testdata", "resource-reference");
+        const analyzer = new Analyzer(dir, "provider");
+        assert.throws(() => analyzer.analyze(), /Resource references are not supported yet: found type 'MyResource'/);
     });
 
     it("infers component description", async function () {

--- a/sdk/nodejs/tests/provider/experimental/testdata/resource-reference/index.ts
+++ b/sdk/nodejs/tests/provider/experimental/testdata/resource-reference/index.ts
@@ -1,0 +1,25 @@
+// Copyright 2025-2025, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+export abstract class MyAbstractResource extends pulumi.CustomResource {
+    constructor(name: string, args: {}, opts?: pulumi.CustomResourceOptions) {
+        super("provider:index:MyAbstractResource", name, args, opts);
+    }
+}
+
+export class MyResource extends MyAbstractResource {
+    constructor(name: string, args: {}, opts?: pulumi.CustomResourceOptions) {
+        super("provider:index:MyResource", name, args, opts);
+    }
+}
+
+export interface MyComponentArgs {
+    aResource: MyResource;
+}
+
+export class MyComponent extends pulumi.ComponentResource {
+    constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("provider:index:MyComponent", name, args, opts);
+    }
+}


### PR DESCRIPTION
Currently resource references are wrongly parsed as types, which will then later not work.  Since we're not supporting them for now, give a nice error to the user instead of doing something broken.