### PR TITLE
Revert provider sdks to target net6

### DIFF
--- a/changelog/pending/20250226--sdkgen-dotnet--revert-provider-sdks-to-target-net6.yaml
+++ b/changelog/pending/20250226--sdkgen-dotnet--revert-provider-sdks-to-target-net6.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/dotnet
+  description: Revert provider SDKs to target net6

--- a/pkg/codegen/dotnet/templates.go
+++ b/pkg/codegen/dotnet/templates.go
@@ -163,7 +163,7 @@ const csharpProjectFileTemplateText = `<Project Sdk="Microsoft.NET.Sdk">
     <Version>{{.Version}}</Version>
     {{- end }}
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/assets-and-archives/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/assets-and-archives/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/azure-native-nested-types/dotnet/Pulumi.AzureNative.csproj
+++ b/tests/testdata/codegen/azure-native-nested-types/dotnet/Pulumi.AzureNative.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/pulumi/pulumi-azure-native</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/config-variables/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/config-variables/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/cyclic-types/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/cyclic-types/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/dash-named-schema/dotnet/Pulumi.FooBar.csproj
+++ b/tests/testdata/codegen/dash-named-schema/dotnet/Pulumi.FooBar.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/dashed-import-schema/dotnet/Pulumi.Plant.csproj
+++ b/tests/testdata/codegen/dashed-import-schema/dotnet/Pulumi.Plant.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/different-enum/dotnet/Pulumi.Plant.csproj
+++ b/tests/testdata/codegen/different-enum/dotnet/Pulumi.Plant.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/enum-reference/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/enum-reference/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/external-resource-schema/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/external-resource-schema/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/functions-secrets/dotnet/Pulumi.Mypkg.csproj
+++ b/tests/testdata/codegen/functions-secrets/dotnet/Pulumi.Mypkg.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/hyphen-url/dotnet/Pulumi.Registrygeoreplication.csproj
+++ b/tests/testdata/codegen/hyphen-url/dotnet/Pulumi.Registrygeoreplication.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/kubernetes20/dotnet/Pulumi.Kubernetes.csproj
+++ b/tests/testdata/codegen/kubernetes20/dotnet/Pulumi.Kubernetes.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/pulumi/pulumi-kubernetes</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/legacy-names/dotnet/Pulumi.Legacy_names.csproj
+++ b/tests/testdata/codegen/legacy-names/dotnet/Pulumi.Legacy_names.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/naming-collisions/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/naming-collisions/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/nested-module-thirdparty/dotnet/Pulumi.FooBar.csproj
+++ b/tests/testdata/codegen/nested-module-thirdparty/dotnet/Pulumi.FooBar.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/nested-module/dotnet/Pulumi.Foo.csproj
+++ b/tests/testdata/codegen/nested-module/dotnet/Pulumi.Foo.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/other-owned/dotnet/Other.Example.csproj
+++ b/tests/testdata/codegen/other-owned/dotnet/Other.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/output-funcs-edgeorder/dotnet/Pulumi.Myedgeorder.csproj
+++ b/tests/testdata/codegen/output-funcs-edgeorder/dotnet/Pulumi.Myedgeorder.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/output-funcs-tfbridge20/dotnet/Pulumi.Mypkg.csproj
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/dotnet/Pulumi.Mypkg.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/output-funcs/dotnet/Pulumi.Mypkg.csproj
+++ b/tests/testdata/codegen/output-funcs/dotnet/Pulumi.Mypkg.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/plain-and-default/dotnet/Pulumi.FooBar.csproj
+++ b/tests/testdata/codegen/plain-and-default/dotnet/Pulumi.FooBar.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/plain-object-defaults/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/plain-object-defaults/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/plain-object-disable-defaults/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/plain-object-disable-defaults/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/plain-schema-gh6957/dotnet/Pulumi.Xyz.csproj
+++ b/tests/testdata/codegen/plain-schema-gh6957/dotnet/Pulumi.Xyz.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/provider-config-schema/dotnet/Configstation.Pulumi.Configstation.csproj
+++ b/tests/testdata/codegen/provider-config-schema/dotnet/Configstation.Pulumi.Configstation.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/provider-type-schema/dotnet/Pulumi.ProviderType.csproj
+++ b/tests/testdata/codegen/provider-type-schema/dotnet/Pulumi.ProviderType.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/regress-8403/dotnet/Pulumi.Mongodbatlas.csproj
+++ b/tests/testdata/codegen/regress-8403/dotnet/Pulumi.Mongodbatlas.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/regress-node-8110/dotnet/Pulumi.My8110.csproj
+++ b/tests/testdata/codegen/regress-node-8110/dotnet/Pulumi.My8110.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/replace-on-change/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/replace-on-change/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/resource-args-python/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/resource-args-python/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/resource-property-overlap/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/resource-property-overlap/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/secrets/dotnet/Pulumi.Mypkg.csproj
+++ b/tests/testdata/codegen/secrets/dotnet/Pulumi.Mypkg.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/simple-enum-schema/dotnet/Pulumi.Plant.csproj
+++ b/tests/testdata/codegen/simple-enum-schema/dotnet/Pulumi.Plant.csproj
@@ -11,7 +11,7 @@
     <PackageIcon>logo.png</PackageIcon>
     <Version>0.0.1</Version>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/simple-methods-schema/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-methods-schema/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/simple-plain-schema/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-plain-schema/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/simple-resource-schema/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-resource-schema/dotnet/Pulumi.Example.csproj
@@ -11,7 +11,7 @@
     <PackageIcon>logo.png</PackageIcon>
     <Version>1.2.3</Version>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/simple-resource-with-aliases/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-resource-with-aliases/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/simple-yaml-schema/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/simple-yaml-schema/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/simplified-invokes/dotnet/Pulumi.Std.csproj
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/Pulumi.Std.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/pulumi/pulumi-std</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/transpiled_examples/cue-random-pp/dotnet/dotnet.csproj
+++ b/tests/testdata/codegen/transpiled_examples/cue-random-pp/dotnet/dotnet.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.73.0" />
+    <PackageReference Include="Pulumi" Version="3.74.0" />
     <PackageReference Include="Pulumi.Random" Version="4.11.2" />
   </ItemGroup>
 

--- a/tests/testdata/codegen/transpiled_examples/getting-started-pp/dotnet/dotnet.csproj
+++ b/tests/testdata/codegen/transpiled_examples/getting-started-pp/dotnet/dotnet.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.73.0" />
+    <PackageReference Include="Pulumi" Version="3.74.0" />
     <PackageReference Include="Pulumi.Aws" Version="4.26.0" />
   </ItemGroup>
 

--- a/tests/testdata/codegen/transpiled_examples/kubernetes-pp/dotnet/dotnet.csproj
+++ b/tests/testdata/codegen/transpiled_examples/kubernetes-pp/dotnet/dotnet.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.73.0" />
+    <PackageReference Include="Pulumi" Version="3.74.0" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.7.2" />
   </ItemGroup>
 

--- a/tests/testdata/codegen/transpiled_examples/random-pp/dotnet/dotnet.csproj
+++ b/tests/testdata/codegen/transpiled_examples/random-pp/dotnet/dotnet.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.73.0" />
+    <PackageReference Include="Pulumi" Version="3.74.0" />
     <PackageReference Include="Pulumi.Random" Version="4.11.2" />
   </ItemGroup>
 

--- a/tests/testdata/codegen/unions-inline/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/unions-inline/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/unions-inside-arrays/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/unions-inside-arrays/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/urn-id-properties/dotnet/Pulumi.Urnid.csproj
+++ b/tests/testdata/codegen/urn-id-properties/dotnet/Pulumi.Urnid.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/using-shared-types-in-config/dotnet/Pulumi.Credentials.csproj
+++ b/tests/testdata/codegen/using-shared-types-in-config/dotnet/Pulumi.Credentials.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
There's no need for provider SDKs to target net8 yet (we're not using any net8 features). It just causes unnecessary downstream pain as everything has to update to net8 at once. 