### PR TITLE
[Experimental/Components]: make provider version optional

### DIFF
--- a/sdk/python/lib/pulumi/provider/experimental/metadata.py
+++ b/sdk/python/lib/pulumi/provider/experimental/metadata.py
@@ -24,7 +24,7 @@ class Metadata:
 
     name: str
     """The name of the provider"""
-    version: str
+    version: Optional[str] = None
     """The version of the provider"""
     display_name: Optional[str] = None
     """The display name of the provider"""

--- a/sdk/python/lib/pulumi/provider/experimental/schema.py
+++ b/sdk/python/lib/pulumi/provider/experimental/schema.py
@@ -163,7 +163,7 @@ class PackageSpec:
 
     name: str
     displayName: str
-    version: str
+    version: Optional[str]
     resources: dict[str, Resource]
     types: dict[str, ComplexType]
     language: dict[str, dict[str, Any]]

--- a/sdk/python/lib/pulumi/provider/provider.py
+++ b/sdk/python/lib/pulumi/provider/provider.py
@@ -88,10 +88,10 @@ class Provider:
 
     """
 
-    version: str
+    version: Optional[str]
     schema: Optional[str]
 
-    def __init__(self, version: str, schema: Optional[str] = None) -> None:
+    def __init__(self, version: Optional[str], schema: Optional[str] = None) -> None:
         """
         :param str version: The version of the provider. Must be valid semver.
         :param Optional[str] schema: The JSON-encoded schema for this provider's package.

--- a/sdk/python/lib/pulumi/provider/server.py
+++ b/sdk/python/lib/pulumi/provider/server.py
@@ -410,6 +410,8 @@ class ProviderServicer(ResourceProviderServicer):
         )
 
     async def GetPluginInfo(self, request, context) -> proto.PluginInfo:
+        if self.provider.version is None:
+            raise Exception("provider version not set")
         return proto.PluginInfo(version=self.provider.version)
 
     async def GetSchema(

--- a/sdk/python/lib/pulumi/provider/server.py
+++ b/sdk/python/lib/pulumi/provider/server.py
@@ -411,7 +411,7 @@ class ProviderServicer(ResourceProviderServicer):
 
     async def GetPluginInfo(self, request, context) -> proto.PluginInfo:
         if self.provider.version is None:
-            raise Exception("provider version not set")
+            return proto.PluginInfo(version="")
         return proto.PluginInfo(version=self.provider.version)
 
     async def GetSchema(


### PR DESCRIPTION
We don't want to force, in fact we want to discourage, authors from specifying the version of the plugin, particularly in Git plugins. Make it optional in the Metadata class, so it no longer needs to be passed in.

Note that this means `GetPluginInfo` will not return a version in some cases.  We could probably try to grab that version from the Git repo for each language, but doing that is a bit awkward.  Note that in many cases we don't use the version form `GetPluginInfo` anyway, e.g. in `pulumi plugin ls` we seem to use the version from the directory in `~/.pulumi/plugins`.  