### PR TITLE
try to fix flake in TestGeneratedPackage

### DIFF
--- a/pkg/codegen/dotnet/gen_test.go
+++ b/pkg/codegen/dotnet/gen_test.go
@@ -54,15 +54,19 @@ func typeCheckGeneratedPackage(t *testing.T, pwd string) {
 		require.NoError(t, err)
 	}
 
-	// dotnet build requires exclusive access to shared nuget package:
-	// https://github.com/pulumi/pulumi/runs/5436354735?check_suite_focus=true#step:36:277
+	// dotnet build requires exclusive access to shared nuget package
+	// See: https://github.com/pulumi/pulumi/issues/18738
 	buildMutex.Lock()
 	defer buildMutex.Unlock()
 	test.RunCommand(t, "dotnet build", pwd, "dotnet", "build")
 }
 
 func testGeneratedPackage(t *testing.T, pwd string) {
-	test.RunCommand(t, "dotnet build", pwd, "dotnet", "test")
+	// dotnet test requires exclusive access to shared nuget package
+	// See: https://github.com/pulumi/pulumi/issues/18738
+	buildMutex.Lock()
+	defer buildMutex.Unlock()
+	test.RunCommand(t, "dotnet test", pwd, "dotnet", "test")
 }
 
 func TestGenerateType(t *testing.T) {


### PR DESCRIPTION
We already have a mutex around dotnet build, and dotnet test seems to require the same.  Also remove a dead link from the comment and link to an issue instead, which should not be deleted (GitHub action logs get deleted after some relatively short period of time).

Fixes https://github.com/pulumi/pulumi/issues/18738
Fixes https://github.com/pulumi/pulumi/issues/16528
(hopefully)