### PR TITLE
(hopefully) fix flaky TestRunCanceled

### DIFF
--- a/sdk/go/auto/cmd_test.go
+++ b/sdk/go/auto/cmd_test.go
@@ -306,8 +306,7 @@ func TestRunCanceled(t *testing.T) {
 		"PULUMI_BACKEND_URL=" + e.LocalURL(),
 		"PULUMI_CONFIG_PASSPHRASE=correct horse battery staple",
 	}
-	stdout, _, code, err := cmd.Run(ctx, e.CWD, nil, nil, nil, env, "preview", "-s", stackName)
-	require.Regexp(t, ".*error: preview canceled.*|.*signal: interrupt", stdout)
+	_, _, code, err := cmd.Run(ctx, e.CWD, nil, nil, nil, env, "preview", "-s", stackName)
 	if runtime.GOOS == "windows" {
 		require.ErrorContains(t, err, "exit status 0xffffffff")
 		require.Equal(t, 4294967295, code)


### PR DESCRIPTION
There's many possiblilities of what the output is when pulumi up is canceled, depending on the exact moment the cancelation signal gets through to the process.  Trying to match against all of them seems like a bit of a fools errand, so let's only match against the exit code, which should still give us enough information to check whether the run was canceled successfully or not.

Fixes https://github.com/pulumi/pulumi/issues/18573