### PR TITLE
Fix concurrent map write panics in caching mapper

### DIFF
--- a/changelog/pending/20250227--programgen--fix-concurrent-map-write-panics-in-the-caching-mapper.yaml
+++ b/changelog/pending/20250227--programgen--fix-concurrent-map-write-panics-in-the-caching-mapper.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Fix concurrent map write panics in the caching mapper


### PR DESCRIPTION
The caching mapper is susceptible to concurrent map write panics when doing bulk conversions. This change avoids the panic by adding some locking around the map.

Fixes #18744