### PR TITLE
fix test backend usage in automation test

### DIFF
--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -851,9 +851,8 @@ describe("LocalWorkspace", () => {
             fullyQualifiedStackName(getTestOrg(), projectName, `int_test${getTestSuffix()}`),
         );
         const stacks = await Promise.all(
-            stackNames.map(
-                async (stackName) => LocalWorkspace.createStack({ stackName, projectName, program }),
-                withTestBackend({}, "inline_node"),
+            stackNames.map(async (stackName) =>
+                LocalWorkspace.createStack({ stackName, projectName, program }, withTestBackend({}, "inline_node")),
             ),
         );
         await stacks.map((stack) => stack.workspace.removeStack(stack.name));


### PR DESCRIPTION
For automation tests we want to use the local backend if PULUMI_ACCESS_TOKEN is not set.  We attempted to do this in this test, however we didn't pass it to `LocalWorkspace.createStack`, but rather to the `map` function and failed to realize that.

Pass the test backend to the right function to make this work without having to set a pulumi access token in the environment.