### PR TITLE
use namespace instead of publisher for Go package generation

### DIFF
--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -3765,9 +3765,9 @@ func extractModulePath(extPkg schema.PackageReference) string {
 
 	// Default to example.com/pulumi-pkg if we have no other information.
 	root := "example.com/pulumi-" + name
-	// But if we have a publisher use that instead, assuming it's from github
-	if extPkg.Publisher() != "" {
-		root = fmt.Sprintf("github.com/%s/pulumi-%s", extPkg.Publisher(), name)
+	// But if we have a namespace use that instead, assuming it's from github
+	if extPkg.Namespace() != "" {
+		root = fmt.Sprintf("github.com/%s/pulumi-%s", extPkg.Namespace(), name)
 	}
 	// And if we have a repository, use that instead of the publisher
 	if extPkg.Repository() != "" {


### PR DESCRIPTION
If we don't have a better way to generate the module path for Go in codegen, we currently use the Publisher field to do so.  However the Publisher field in the schema is free-form text, and doesn't necessarily fit into a package name.  Use the namespace that was set up for this purpose instead.

Note that this is technically a breaking change, however it's expected that this is not used very much.  This is because most providers would also set the Repository field, which overrides the Publisher/Namespace.

Part of https://github.com/pulumi/pulumi/issues/18369