### PR TITLE
Do not `os.Exit` from `RunCmdFunc`

### DIFF
--- a/pkg/cmd/pulumi/about/about.go
+++ b/pkg/cmd/pulumi/about/about.go
@@ -67,7 +67,7 @@ func NewAboutCmd() *cobra.Command {
 			" - the current stack\n" +
 			" - the current backend\n",
 		Args: cmdutil.MaximumNArgs(0),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			summary := getSummaryAbout(ctx, pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, transitiveDependencies, stack)
 			if jsonOut {

--- a/pkg/cmd/pulumi/about/about_env.go
+++ b/pkg/cmd/pulumi/about/about_env.go
@@ -41,7 +41,7 @@ func newAboutEnvCmd() *cobra.Command {
 		// unhide once most existing variables are using the new env var framework and
 		// show up here.
 		Hidden: !env.Experimental.Value(),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			table := cmdutil.Table{
 				Headers: []string{"Variable", "Description", "Value"},
 			}

--- a/pkg/cmd/pulumi/ai/ai.go
+++ b/pkg/cmd/pulumi/ai/ai.go
@@ -59,7 +59,7 @@ func NewAICommand() *cobra.Command {
 		Long:   "Contains the current set of supported CLI functionality for the Pulumi AI service.",
 		Hidden: !env.Experimental.Value(),
 		Args:   cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			if len(args) == 0 {
 				return cmd.Help()

--- a/pkg/cmd/pulumi/ai/ai_web.go
+++ b/pkg/cmd/pulumi/ai/ai_web.go
@@ -146,7 +146,7 @@ If you do not want to submit the prompt to Pulumi AI, you can opt-out of this
 by passing the --no-auto-submit flag.
 `,
 		Args: cmdutil.MaximumNArgs(1),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			return aiwebcmd.Run(ctx, args)
 		},

--- a/pkg/cmd/pulumi/auth/login.go
+++ b/pkg/cmd/pulumi/auth/login.go
@@ -95,7 +95,7 @@ func NewLoginCmd() *cobra.Command {
 			"\n" +
 			"    $ pulumi login azblob://my-pulumi-state-bucket\n",
 		Args: cmdutil.MaximumNArgs(1),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			displayOptions := display.Options{
 				Color: cmdutil.GetGlobalColorization(),

--- a/pkg/cmd/pulumi/auth/logout.go
+++ b/pkg/cmd/pulumi/auth/logout.go
@@ -47,7 +47,7 @@ func NewLogoutCmd() *cobra.Command {
 			"If you would like to log out of all backends simultaneously, you can pass `--all`,\n\n" +
 			"    $ pulumi logout --all",
 		Args: cmdutil.MaximumNArgs(1),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			// If a <cloud> was specified as an argument, use it.
 			if len(args) > 0 {
 				if cloudURL != "" || all {

--- a/pkg/cmd/pulumi/cancel/cancel.go
+++ b/pkg/cmd/pulumi/cancel/cancel.go
@@ -47,7 +47,7 @@ func NewCancelCmd() *cobra.Command {
 			"\n" +
 			"After this command completes successfully, the stack will be ready for further\n" +
 			"updates.",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			// Use the stack provided or, if missing, default to the current one.
 			if len(args) > 0 {

--- a/pkg/cmd/pulumi/cmd/cmd.go
+++ b/pkg/cmd/pulumi/cmd/cmd.go
@@ -40,8 +40,8 @@ import (
 // helpful messages in the case of decryption or snapshot integrity errors.
 func RunCmdFunc(
 	run func(cmd *cobra.Command, args []string) error,
-) func(cmd *cobra.Command, args []string) {
-	return cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+) func(cmd *cobra.Command, args []string) error {
+	return cmdutil.RunFuncE(func(cmd *cobra.Command, args []string) error {
 		err := run(cmd, args)
 		return processCmdErrors(err)
 	})

--- a/pkg/cmd/pulumi/completion/gen.go
+++ b/pkg/cmd/pulumi/completion/gen.go
@@ -33,7 +33,7 @@ func NewGenCompletionCmd(root *cobra.Command) *cobra.Command {
 		Aliases: []string{"completion"},
 		Args:    cmdutil.ExactArgs(1),
 		Short:   "Generate completion scripts for the Pulumi CLI",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			switch {
 			case args[0] == "bash":
 				return root.GenBashCompletion(os.Stdout)

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -61,7 +61,7 @@ func NewConfigCmd() *cobra.Command {
 			"`pulumi config set`. To remove an existing value run `pulumi config rm`. To get the value of\n" +
 			"for a specific configuration key, use `pulumi config get <key-name>`.",
 		Args: cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			opts := display.Options{
@@ -155,7 +155,7 @@ func newConfigCopyCmd(stack *string) *cobra.Command {
 		Long: "Copies the config from the current stack to the destination stack. If `key` is omitted,\n" +
 			"then all of the config from the current stack will be copied to the destination stack.",
 		Args: cmdutil.MaximumNArgs(1),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			opts := display.Options{
@@ -271,7 +271,7 @@ func newConfigGetCmd(stack *string) *cobra.Command {
 			"  - `pulumi config get --path 'names[0]'` will get the value of the first item, " +
 			"if the value of `names` is a list.",
 		Args: cmdutil.SpecificArgs([]string{"key"}),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			opts := display.Options{
@@ -325,7 +325,7 @@ func newConfigRmCmd(stack *string) *cobra.Command {
 			"  - `pulumi config rm --path 'names[0]'` will remove the first item, " +
 			"if the value of `names` is a list.",
 		Args: cmdutil.SpecificArgs([]string{"key"}),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			opts := display.Options{
@@ -387,7 +387,7 @@ func newConfigRmAllCmd(stack *string) *cobra.Command {
 			"  - `pulumi config rm-all outer.inner 'foo[0]' key1` will remove the literal" +
 			"    `outer.inner`, `foo[0]` and `key1` keys",
 		Args: cmdutil.MinimumNArgs(1),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			opts := display.Options{
@@ -444,7 +444,7 @@ func newConfigRefreshCmd(stk *string) *cobra.Command {
 		Use:   "refresh",
 		Short: "Update the local configuration based on the most recent deployment of the stack",
 		Args:  cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			opts := display.Options{
@@ -582,7 +582,7 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 			"integers are treated as numbers. All other values are treated as strings.  Top level entries\n" +
 			"are always treated as strings.",
 		Args: cmdutil.RangeArgs(1, 2),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			opts := display.Options{
@@ -741,7 +741,7 @@ func newConfigSetAllCmd(stack *string) *cobra.Command {
 			"  - `pulumi config set-all --path --plaintext '[\"parent.name\"].[\"nested.name\"]'=value` will set the \n" +
 			"    value of `parent.name` to a map `nested.name: value`.",
 		Args: cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			opts := display.Options{

--- a/pkg/cmd/pulumi/config/config_env_add.go
+++ b/pkg/cmd/pulumi/config/config_env_add.go
@@ -33,7 +33,7 @@ func newConfigEnvAddCmd(parent *configEnvCmd) *cobra.Command {
 			"per the ESC merge rules. The list of stacks behaves as if it were the import list in an anonymous\n" +
 			"environment.",
 		Args: cmdutil.MinimumNArgs(1),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			parent.initArgs()
 			return impl.run(cmd.Context(), args)
 		}),

--- a/pkg/cmd/pulumi/config/config_env_init.go
+++ b/pkg/cmd/pulumi/config/config_env_init.go
@@ -54,7 +54,7 @@ func newConfigEnvInitCmd(parent *configEnvCmd) *cobra.Command {
 			"then replaces the stack's configuration values with a reference to that environment.\n" +
 			"The environment will be created in the same organization as the stack.",
 		Args: cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			parent.initArgs()
 			return impl.run(cmd.Context(), args)
 		}),

--- a/pkg/cmd/pulumi/config/config_env_ls.go
+++ b/pkg/cmd/pulumi/config/config_env_ls.go
@@ -32,7 +32,7 @@ func newConfigEnvLsCmd(parent *configEnvCmd) *cobra.Command {
 		Short: "Lists imported environments.",
 		Long:  "Lists the environments imported into a stack's configuration.",
 		Args:  cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			parent.initArgs()
 			return impl.run(cmd.Context(), args)
 		}),

--- a/pkg/cmd/pulumi/config/config_env_rm.go
+++ b/pkg/cmd/pulumi/config/config_env_rm.go
@@ -31,7 +31,7 @@ func newConfigEnvRmCmd(parent *configEnvCmd) *cobra.Command {
 		Short: "Remove environment from a stack",
 		Long:  "Removes an environment from a stack's import list.",
 		Args:  cmdutil.ExactArgs(1),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			parent.initArgs()
 			return impl.run(cmd.Context(), args)
 		}),

--- a/pkg/cmd/pulumi/console/console.go
+++ b/pkg/cmd/pulumi/console/console.go
@@ -38,7 +38,7 @@ func NewConsoleCmd() *cobra.Command {
 		Use:   "console",
 		Short: "Opens the current stack in the Pulumi Console",
 		Args:  cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -77,7 +77,7 @@ func NewConvertCmd() *cobra.Command {
 			"Example command usage:" +
 			"\n" +
 			"    pulumi convert --from yaml --language java --out . \n",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {
 				return fmt.Errorf("get current working directory: %w", err)

--- a/pkg/cmd/pulumi/deployment/deployment.go
+++ b/pkg/cmd/pulumi/deployment/deployment.go
@@ -31,7 +31,7 @@ func NewDeploymentCmd() *cobra.Command {
 			"\n" +
 			"Use this command to trigger deployment jobs and manage deployment settings.",
 		Args: cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		}),
 	}

--- a/pkg/cmd/pulumi/deployment/deployment_run.go
+++ b/pkg/cmd/pulumi/deployment/deployment_run.go
@@ -44,7 +44,7 @@ func newDeploymentRunCmd() *cobra.Command {
 			"This command queues a new deployment job for any supported operation of type \n" +
 			"update, preview, destroy, refresh, detect-drift or remediate-drift.",
 		Args: cmdutil.RangeArgs(1, 2),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 

--- a/pkg/cmd/pulumi/deployment/deployment_settings_config.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_config.go
@@ -67,7 +67,7 @@ func newDeploymentSettingsCmd() *cobra.Command {
 			"Use this command to manage a stack's deployment settings like\n" +
 			"generating the deployment file, updating secrets or pushing the\n" +
 			"updated settings to Pulumi Cloud.",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		}),
 	}
@@ -180,7 +180,7 @@ func newDeploymentSettingsInitCmd() *cobra.Command {
 		Args:       cmdutil.ExactArgs(0),
 		Short:      "Initialize the stack's deployment.yaml file",
 		Long:       "",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			d, err := initializeDeploymentSettingsCmd(cmd.Context(), pkgWorkspace.Instance, stack)
 			if err != nil {
 				return err
@@ -293,7 +293,7 @@ func newDeploymentSettingsConfigureCmd() *cobra.Command {
 		Args:  cmdutil.ExactArgs(0),
 		Short: "Updates stack's deployment settings secrets",
 		Long:  "",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			if !cmdutil.Interactive() {
 				return errors.New("configure command is only supported in interactive mode")
 			}

--- a/pkg/cmd/pulumi/deployment/deployment_settings_ops.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_ops.go
@@ -43,7 +43,7 @@ func newDeploymentSettingsPullCmd() *cobra.Command {
 		Args:  cmdutil.ExactArgs(0),
 		Short: "Pull the stack's deployment settings from Pulumi Cloud into the deployment.yaml file",
 		Long:  "",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			d, err := initializeDeploymentSettingsCmd(cmd.Context(), pkgWorkspace.Instance, stack)
 			if err != nil {
 				return err
@@ -85,7 +85,7 @@ func newDeploymentSettingsUpdateCmd() *cobra.Command {
 		Args:       cmdutil.ExactArgs(0),
 		Short:      "Update stack deployment settings from deployment.yaml",
 		Long:       "",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
 			if err := verifyInteractiveMode(yes); err != nil {
@@ -139,7 +139,7 @@ func newDeploymentSettingsDestroyCmd() *cobra.Command {
 		Args:       cmdutil.ExactArgs(0),
 		Short:      "Delete all the stack's deployment settings",
 		Long:       "",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
 			if err := verifyInteractiveMode(yes); err != nil {
@@ -188,7 +188,7 @@ func newDeploymentSettingsEnvCmd() *cobra.Command {
 		Args:  cmdutil.RangeArgs(1, 2),
 		Short: "Update stack's deployment settings secrets",
 		Long:  "",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			d, err := initializeDeploymentSettingsCmd(cmd.Context(), pkgWorkspace.Instance, stack)
 			if err != nil {

--- a/pkg/cmd/pulumi/events/replay.go
+++ b/pkg/cmd/pulumi/events/replay.go
@@ -61,7 +61,7 @@ func NewReplayEventsCmd() *cobra.Command {
 			"using either the progress view or the diff view.\n",
 		Args:   cmdutil.ExactArgs(2),
 		Hidden: !env.DebugCommands.Value(),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			var action apitype.UpdateKind
 			switch args[0] {
 			case "update":

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -47,7 +47,7 @@ func NewInstallCmd() *cobra.Command {
 		Long: "Install packages and plugins for the current program or policy pack.\n" +
 			"\n" +
 			"This command is used to manually install packages and plugins required by your program or policy pack.",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
 			installPolicyPackDeps, err := shouldInstallPolicyPackDependencies()

--- a/pkg/cmd/pulumi/logs/logs.go
+++ b/pkg/cmd/pulumi/logs/logs.go
@@ -54,7 +54,7 @@ func NewLogsCmd() *cobra.Command {
 			"provider. For example, for AWS resources, the `pulumi logs` command will query\n" +
 			"CloudWatch Logs for log data relevant to resources in a stack.\n",
 		Args: cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cobraCmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cobraCmd *cobra.Command, args []string) error {
 			ctx := cobraCmd.Context()
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 			ws := pkgWorkspace.Instance

--- a/pkg/cmd/pulumi/main.go
+++ b/pkg/cmd/pulumi/main.go
@@ -53,7 +53,7 @@ func main() {
 	defer panicHandler(finished)
 
 	if err := NewPulumiCmd().Execute(); err != nil {
-		os.Exit(1)
+		os.Exit(-1)
 	}
 	*finished = true
 }

--- a/pkg/cmd/pulumi/markdown/gen.go
+++ b/pkg/cmd/pulumi/markdown/gen.go
@@ -43,7 +43,7 @@ func NewGenMarkdownCmd(root *cobra.Command) *cobra.Command {
 		Args:   cmdutil.ExactArgs(1),
 		Short:  "Generate Pulumi CLI documentation as Markdown (one file per command)",
 		Hidden: true,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			var files []string
 
 			// filePrepender is used to add front matter to each file, and to keep track of all

--- a/pkg/cmd/pulumi/newcmd/new.go
+++ b/pkg/cmd/pulumi/newcmd/new.go
@@ -617,7 +617,7 @@ func NewNewCmd() *cobra.Command {
 			"* `pulumi new --ai \"<prompt>\" --language <language>`\n" +
 			"Any missing but required information will be prompted for.\n",
 		Args: cmdutil.MaximumNArgs(1),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, cliArgs []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := cmd.Context()
 			if len(cliArgs) > 0 {
 				args.templateNameOrURL = cliArgs[0]

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -100,7 +100,7 @@ func NewDestroyCmd() *cobra.Command {
 			"\n" +
 			"Warning: this command is generally irreversible and should be used with great care.",
 		Args: cmdArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
 			// Destroy is always permitted to fall back to looking for secrets providers in state, since we explicitly

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -663,7 +663,7 @@ func NewImportCmd() *cobra.Command {
 			"for all resources that need creating from the preview. This will fill in all the name,\n" +
 			"type, parent and provider information for you and just require you to fill in resource\n" +
 			"IDs and any properties.\n",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -304,7 +304,7 @@ func NewPreviewCmd() *cobra.Command {
 			"The program to run is loaded from the project in the current directory. Use the `-C` or\n" +
 			"`--cwd` flag to use a different directory.",
 		Args: cmdArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 			ws := pkgWorkspace.Instance

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -96,7 +96,7 @@ func NewRefreshCmd() *cobra.Command {
 			"The program to run is loaded from the project in the current directory. Use the `-C` or\n" +
 			"`--cwd` flag to use a different directory.",
 		Args: cmdArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 			ws := pkgWorkspace.Instance

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -471,7 +471,7 @@ func NewUpCmd() *cobra.Command {
 			"The program to run is loaded from the project in the current directory by default. Use the `-C` or\n" +
 			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.MaximumNArgs(1),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 			ws := pkgWorkspace.Instance

--- a/pkg/cmd/pulumi/operations/watch.go
+++ b/pkg/cmd/pulumi/operations/watch.go
@@ -71,7 +71,7 @@ func NewWatchCmd() *cobra.Command {
 			"The program to watch is loaded from the project in the current directory by default. Use the `-C` or\n" +
 			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.MaximumNArgs(1),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 			ws := pkgWorkspace.Instance

--- a/pkg/cmd/pulumi/org/org.go
+++ b/pkg/cmd/pulumi/org/org.go
@@ -38,7 +38,7 @@ func NewOrgCmd() *cobra.Command {
 			"Use this command to manage organization configuration, " +
 			"e.g. setting the default organization for a backend",
 		Args: cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			// Try to read the current project
 			ws := pkgWorkspace.Instance
 			project, _, err := ws.ReadProject()
@@ -89,7 +89,7 @@ func newOrgSetDefaultCmd() *cobra.Command {
 			"Currently, only the managed and self-hosted backends support organizations. " +
 			"If you try and set a default organization for a backend that does not \n" +
 			"support create organizations, then an error will be returned by the CLI",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			displayOpts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
@@ -135,7 +135,7 @@ func newOrgGetDefaultCmd() *cobra.Command {
 			"the current backend.\n" +
 			"\n" +
 			"Currently, only the managed and self-hosted backends support organizations.",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			displayOpts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),

--- a/pkg/cmd/pulumi/org/org_search.go
+++ b/pkg/cmd/pulumi/org/org_search.go
@@ -196,7 +196,7 @@ func newSearchCmd() *cobra.Command {
 		Short: "Search for resources in Pulumi Cloud",
 		Long:  "Search for resources in Pulumi Cloud.",
 		Args:  cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			if len(scmd.queryParams) == 0 {
 				return cmd.Help()

--- a/pkg/cmd/pulumi/org/org_search_ai.go
+++ b/pkg/cmd/pulumi/org/org_search_ai.go
@@ -124,7 +124,7 @@ func newSearchAICmd() *cobra.Command {
 		Short: "Search for resources in Pulumi Cloud using Pulumi AI",
 		Long:  "Search for resources in Pulumi Cloud using Pulumi AI",
 		Args:  cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			return scmd.Run(ctx, args)
 		},

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -62,7 +62,7 @@ When <schema> is a path to a local file with a '.json', '.yml' or '.yaml'
 extension, Pulumi package schema is read from it directly:
 
   pulumi package add ./my/schema.json`,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ws := pkgWorkspace.Instance
 			proj, root, err := ws.ReadProject()
 			if err != nil {

--- a/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
@@ -39,7 +39,7 @@ is the name of the source provider (e.g. "terraform", if a mapping was being req
 from Terraform to Pulumi). If you need to pass parameters, you must provide a provider
 key. In the event that you wish to pass none, you must therefore explicitly pass an
 empty string.`,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			key := args[0]
 			source := args[1]
 			var provider string

--- a/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
@@ -36,7 +36,7 @@ func newExtractSchemaCommand() *cobra.Command {
 <schema_source> can be a package name or the path to a plugin binary or folder.
 If a folder either the plugin binary must match the folder name (e.g. 'aws' and 'pulumi-resource-aws')` +
 			` or it must have a PulumiPlugin.yaml file specifying the runtime to use.`,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			source := args[0]
 
 			wd, err := os.Getwd()

--- a/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
@@ -45,7 +45,7 @@ func newGenSdkCommand() *cobra.Command {
 <schema_source> can be a package name or the path to a plugin binary or folder.
 If a folder either the plugin binary must match the folder name (e.g. 'aws' and 'pulumi-resource-aws')` +
 			` or it must have a PulumiPlugin.yaml file specifying the runtime to use.`,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			source := args[0]
 
 			wd, err := os.Getwd()

--- a/pkg/cmd/pulumi/packagecmd/package_pack_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_pack_sdk.go
@@ -35,7 +35,7 @@ func newPackagePackCmd() *cobra.Command {
 		Args:   cobra.ExactArgs(2),
 		Short:  "Pack a package SDK to a language specific artifact.",
 		Hidden: !env.Dev.Value(),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			return packCmd.Run(ctx, args)
 		}),

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -37,7 +37,7 @@ func newPackagePublishCmd() *cobra.Command {
 		Args:   cobra.RangeArgs(0, 1),
 		Short:  "Publish a package SDK to supported package registries.",
 		Hidden: !env.Dev.Value(),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			return publCmd.Run(ctx, args)
 		}),

--- a/pkg/cmd/pulumi/plugin/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install.go
@@ -56,7 +56,7 @@ func newPluginInstallCmd() *cobra.Command {
 			"If VERSION is specified, it cannot be a range; it must be a specific number.\n" +
 			"If VERSION is unspecified, Pulumi will attempt to look up the latest version of\n" +
 			"the plugin, though the result is not guaranteed.",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			return picmd.Run(ctx, args)
 		}),

--- a/pkg/cmd/pulumi/plugin/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin/plugin_ls.go
@@ -35,7 +35,7 @@ func newPluginLsCmd() *cobra.Command {
 		Use:   "ls",
 		Short: "List plugins",
 		Args:  cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			// Produce a list of plugins, sorted by name and version.
 			var plugins []workspace.PluginInfo
 			var err error

--- a/pkg/cmd/pulumi/plugin/plugin_rm.go
+++ b/pkg/cmd/pulumi/plugin/plugin_rm.go
@@ -52,7 +52,7 @@ func newPluginRmCmd() *cobra.Command {
 			"This removal cannot be undone.  If a deleted plugin is subsequently required\n" +
 			"in order to execute a Pulumi program, it must be re-downloaded and installed\n" +
 			"using the plugin install command.",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			yes = yes || env.SkipConfirmations.Value()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),

--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -137,7 +137,7 @@ func newPluginRunCmd() *cobra.Command {
 			"\n" +
 			"Directly executes a plugin binary, if VERSION is not specified " +
 			"the latest installed plugin will be used.",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			return c.run(cmd.Context(), args)
 		}),
 	}

--- a/pkg/cmd/pulumi/policy/policy_disable.go
+++ b/pkg/cmd/pulumi/policy/policy_disable.go
@@ -35,7 +35,7 @@ func newPolicyDisableCmd() *cobra.Command {
 		Args:  cmdutil.ExactArgs(1),
 		Short: "Disable a Policy Pack for a Pulumi organization",
 		Long:  "Disable a Policy Pack for a Pulumi organization",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, cliArgs []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := cmd.Context()
 			// Obtain current PolicyPack, tied to the Pulumi Cloud backend.
 			var err error

--- a/pkg/cmd/pulumi/policy/policy_enable.go
+++ b/pkg/cmd/pulumi/policy/policy_enable.go
@@ -42,7 +42,7 @@ func newPolicyEnableCmd() *cobra.Command {
 		Short: "Enable a Policy Pack for a Pulumi organization",
 		Long: "Enable a Policy Pack for a Pulumi organization. " +
 			"Can specify latest to enable the latest version of the Policy Pack or a specific version number.",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, cliArgs []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := cmd.Context()
 			// Obtain current PolicyPack, tied to the Pulumi Cloud backend.
 			policyPack, err := requirePolicyPack(ctx, cliArgs[0], cmdBackend.DefaultLoginManager)

--- a/pkg/cmd/pulumi/policy/policy_group_ls.go
+++ b/pkg/cmd/pulumi/policy/policy_group_ls.go
@@ -50,7 +50,7 @@ func newPolicyGroupLsCmd() *cobra.Command {
 		Args:  cmdutil.MaximumNArgs(1),
 		Short: "List all Policy Groups for a Pulumi organization",
 		Long:  "List all Policy Groups for a Pulumi organization",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, cliArgs []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := cmd.Context()
 
 			// Try to read the current project

--- a/pkg/cmd/pulumi/policy/policy_ls.go
+++ b/pkg/cmd/pulumi/policy/policy_ls.go
@@ -40,7 +40,7 @@ func newPolicyLsCmd() *cobra.Command {
 		Args:  cmdutil.MaximumNArgs(1),
 		Short: "List all Policy Packs for a Pulumi organization",
 		Long:  "List all Policy Packs for a Pulumi organization",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, cliArgs []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := cmd.Context()
 
 			// Try to read the current project

--- a/pkg/cmd/pulumi/policy/policy_new.go
+++ b/pkg/cmd/pulumi/policy/policy_new.go
@@ -59,7 +59,7 @@ func newPolicyNewCmd() *cobra.Command {
 			"Once you're done authoring the Policy Pack, you will need to publish the pack to your organization.\n" +
 			"Only organization administrators can publish a Policy Pack.",
 		Args: cmdutil.MaximumNArgs(1),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, cliArgs []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := cmd.Context()
 			if len(cliArgs) > 0 {
 				args.templateNameOrURL = cliArgs[0]

--- a/pkg/cmd/pulumi/policy/policy_publish.go
+++ b/pkg/cmd/pulumi/policy/policy_publish.go
@@ -43,7 +43,7 @@ func newPolicyPublishCmd() *cobra.Command {
 		Long: "Publish a Policy Pack to the Pulumi Cloud\n" +
 			"\n" +
 			"If an organization name is not specified, the default org (if set) or the current user account is used.",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			return policyPublishCmd.Run(cmd.Context(), cmdBackend.DefaultLoginManager, args)
 		}),
 	}

--- a/pkg/cmd/pulumi/policy/policy_rm.go
+++ b/pkg/cmd/pulumi/policy/policy_rm.go
@@ -40,7 +40,7 @@ func newPolicyRmCmd() *cobra.Command {
 		Short: "Removes a Policy Pack from a Pulumi organization",
 		Long: "Removes a Policy Pack from a Pulumi organization. " +
 			"The Policy Pack must be disabled from all Policy Groups before it can be removed.",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			yes = yes || env.SkipConfirmations.Value()
 			// Obtain current PolicyPack, tied to the Pulumi Cloud backend.

--- a/pkg/cmd/pulumi/policy/policy_validate.go
+++ b/pkg/cmd/pulumi/policy/policy_validate.go
@@ -33,7 +33,7 @@ func newPolicyValidateCmd() *cobra.Command {
 		Args:  cmdutil.ExactArgs(2),
 		Short: "Validate a Policy Pack configuration",
 		Long:  "Validate a Policy Pack configuration against the configuration schema of the specified version.",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, cliArgs []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := cmd.Context()
 			// Obtain current PolicyPack, tied to the Pulumi Cloud backend.
 			policyPack, err := requirePolicyPack(ctx, cliArgs[0], cmdBackend.DefaultLoginManager)

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -204,7 +204,7 @@ func NewPulumiCmd() *cobra.Command {
 			"    - pulumi destroy  : Tear down your stack's resources entirely\n" +
 			"\n" +
 			"For more information, please visit the project page: https://www.pulumi.com/docs/",
-		PersistentPreRun: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			// We run this method for its side-effects. On windows, this will enable the windows terminal
 			// to understand ANSI escape codes.
 			_, _, _ = term.StdStreams()

--- a/pkg/cmd/pulumi/query/query.go
+++ b/pkg/cmd/pulumi/query/query.go
@@ -51,7 +51,7 @@ func NewQueryCmd() *cobra.Command {
 			"`--cwd` flag to use a different directory.",
 		Args:   cmdutil.NoArgs,
 		Hidden: !env.Experimental.Value() && !env.DebugCommands.Value(),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			interactive := cmdutil.Interactive()
 

--- a/pkg/cmd/pulumi/schema/schema_check.go
+++ b/pkg/cmd/pulumi/schema/schema_check.go
@@ -43,7 +43,7 @@ func newSchemaCheckCommand() *cobra.Command {
 			"Ensure that a Pulumi package schema meets the requirements imposed by the\n" +
 			"schema spec as well as additional requirements imposed by the supported\n" +
 			"target languages.",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			file := args[0]
 
 			// Read from stdin or a specified file

--- a/pkg/cmd/pulumi/stack/stack.go
+++ b/pkg/cmd/pulumi/stack/stack.go
@@ -61,7 +61,7 @@ func NewStackCmd() *cobra.Command {
 			"Each stack has a configuration and update history associated with it, stored in\n" +
 			"the workspace, in addition to a full checkpoint of the last known good update.\n",
 		Args: cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, _ []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			opts := display.Options{

--- a/pkg/cmd/pulumi/stack/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack/stack_change_secrets_provider.go
@@ -68,7 +68,7 @@ func newStackChangeSecretsProviderCmd() *cobra.Command {
 			"* `pulumi stack change-secrets-provider " +
 			"\"gcpkms://projects/<p>/locations/<l>/keyRings/<r>/cryptoKeys/<k>\"`\n" +
 			"* `pulumi stack change-secrets-provider \"hashivault://mykey\"`",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			return scspcmd.Run(ctx, args)
 		}),

--- a/pkg/cmd/pulumi/stack/stack_export.go
+++ b/pkg/cmd/pulumi/stack/stack_export.go
@@ -47,7 +47,7 @@ func newStackExportCmd() *cobra.Command {
 			"`pulumi stack import`. This process may be used to correct inconsistencies\n" +
 			"in a stack's state due to failed deployments, manual changes to cloud\n" +
 			"resources, etc.",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			opts := display.Options{

--- a/pkg/cmd/pulumi/stack/stack_graph.go
+++ b/pkg/cmd/pulumi/stack/stack_graph.go
@@ -67,7 +67,7 @@ func newStackGraphCmd() *cobra.Command {
 			"This command can be used to view the dependency graph that a Pulumi program\n" +
 			"emitted when it was run. This graph is output in the DOT format. This command operates\n" +
 			"on your stack's most recent deployment.",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			opts := display.Options{

--- a/pkg/cmd/pulumi/stack/stack_history.go
+++ b/pkg/cmd/pulumi/stack/stack_history.go
@@ -54,7 +54,7 @@ func newStackHistoryCmd() *cobra.Command {
 		Long: `Display history for a stack
 
 This command displays data about previous updates for a stack.`,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ssml := NewStackSecretsManagerLoaderFromEnv()
 			ws := pkgWorkspace.Instance

--- a/pkg/cmd/pulumi/stack/stack_import.go
+++ b/pkg/cmd/pulumi/stack/stack_import.go
@@ -44,7 +44,7 @@ func newStackImportCmd() *cobra.Command {
 			"hand-edited to correct inconsistencies due to failed updates, manual changes\n" +
 			"to cloud resources, etc. can be reimported to the stack using this command.\n" +
 			"The updated deployment will be read from standard in.",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			opts := display.Options{

--- a/pkg/cmd/pulumi/stack/stack_init.go
+++ b/pkg/cmd/pulumi/stack/stack_init.go
@@ -72,7 +72,7 @@ func newStackInitCmd() *cobra.Command {
 			"`--copy-config-from` flag:\n" +
 			"\n" +
 			"* `pulumi stack init --copy-config-from dev`",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			return sicmd.Run(ctx, args)
 		}),

--- a/pkg/cmd/pulumi/stack/stack_ls.go
+++ b/pkg/cmd/pulumi/stack/stack_ls.go
@@ -61,7 +61,7 @@ func newStackLsCmd() *cobra.Command {
 			"the tag name as well as the tag value, separated by an equals sign. For example\n" +
 			"'environment=production' or just 'gcp:project'.",
 		Args: cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, _ []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			cmdArgs := stackLSArgs{
 				jsonOut:    jsonOut,

--- a/pkg/cmd/pulumi/stack/stack_output.go
+++ b/pkg/cmd/pulumi/stack/stack_output.go
@@ -50,7 +50,7 @@ func newStackOutputCmd() *cobra.Command {
 			"\n" +
 			"By default, this command lists all output properties exported from a stack.\n" +
 			"If a specific property-name is supplied, just that property's value is shown.",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			return socmd.Run(cmd.Context(), args)
 		}),
 	}

--- a/pkg/cmd/pulumi/stack/stack_rename.go
+++ b/pkg/cmd/pulumi/stack/stack_rename.go
@@ -47,7 +47,7 @@ func newStackRenameCmd() *cobra.Command {
 			"You can also rename the stack's project by passing a fully-qualified stack name as well. For example:\n" +
 			"'robot-co/new-project-name/production'. However in order to update the stack again, you would also need\n" +
 			"to update the name field of Pulumi.yaml, so the project names match.",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			opts := display.Options{

--- a/pkg/cmd/pulumi/stack/stack_rm.go
+++ b/pkg/cmd/pulumi/stack/stack_rm.go
@@ -52,7 +52,7 @@ func newStackRmCmd() *cobra.Command {
 			"`destroy` command for removing a resources, as this is a distinct operation.\n" +
 			"\n" +
 			"After this command completes, the stack will no longer be available for updates.",
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			yes = yes || env.SkipConfirmations.Value()

--- a/pkg/cmd/pulumi/stack/stack_select.go
+++ b/pkg/cmd/pulumi/stack/stack_select.go
@@ -46,7 +46,7 @@ func newStackSelectCmd() *cobra.Command {
 			"If no <stack> argument is supplied, you will be prompted to select one interactively.\n" +
 			"If provided stack name is not found you may pass the --create flag to create and select it",
 		Args: cmdutil.MaximumNArgs(1),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			opts := display.Options{

--- a/pkg/cmd/pulumi/stack/stack_tag.go
+++ b/pkg/cmd/pulumi/stack/stack_tag.go
@@ -62,7 +62,7 @@ func newStackTagGetCmd(stack *string) *cobra.Command {
 		Use:   "get <name>",
 		Short: "Get a single stack tag value",
 		Args:  cmdutil.SpecificArgs([]string{"name"}),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			name := args[0]
@@ -104,7 +104,7 @@ func newStackTagLsCmd(stack *string) *cobra.Command {
 		Use:   "ls",
 		Short: "List all stack tags",
 		Args:  cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			opts := display.Options{
@@ -168,7 +168,7 @@ func newStackTagRmCmd(stack *string) *cobra.Command {
 		Use:   "rm <name>",
 		Short: "Remove a stack tag",
 		Args:  cmdutil.SpecificArgs([]string{"name"}),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			name := args[0]
@@ -206,7 +206,7 @@ func newStackTagSetCmd(stack *string) *cobra.Command {
 		Use:   "set <name> <value>",
 		Short: "Set a stack tag",
 		Args:  cmdutil.SpecificArgs([]string{"name", "value"}),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			name := args[0]

--- a/pkg/cmd/pulumi/stack/stack_unselect.go
+++ b/pkg/cmd/pulumi/stack/stack_unselect.go
@@ -34,7 +34,7 @@ func newStackUnselectCmd() *cobra.Command {
 			"This way, next time pulumi needs to execute an operation, the user is prompted with one of the stacks to select\n" +
 			"from.\n",
 		Args: cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			currentWorkspace, err := workspace.New()
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/state/state_delete.go
+++ b/pkg/cmd/pulumi/state/state_delete.go
@@ -144,7 +144,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 `,
 		Example: "pulumi state delete 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:kubernetes::eks-provider'",
 		Args:    cmdutil.MaximumNArgs(1),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			return sdcmd.Run(ctx, args, ws, lm)
 		}),

--- a/pkg/cmd/pulumi/state/state_edit.go
+++ b/pkg/cmd/pulumi/state/state_edit.go
@@ -58,7 +58,7 @@ This command can be used to surgically edit a stack's state in the editor
 specified by the EDITOR environment variable and will provide the user with
 a preview showing a diff of the altered state.`,
 		Args: cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			if !cmdutil.Interactive() {
 				return errors.New("pulumi state edit must be run in interactive mode")
 			}

--- a/pkg/cmd/pulumi/state/state_move.go
+++ b/pkg/cmd/pulumi/state/state_move.go
@@ -70,7 +70,7 @@ This command can be used to move resources from one stack to another. This can b
 splitting a stack into multiple stacks or when merging multiple stacks into one.
 `,
 		Args: cmdutil.MinimumNArgs(1),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 

--- a/pkg/cmd/pulumi/state/state_rename.go
+++ b/pkg/cmd/pulumi/state/state_rename.go
@@ -178,7 +178,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 `,
 		Example: "pulumi state rename 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:kubernetes::eks-provider' new-name-here",
 		Args:    cmdutil.MaximumNArgs(2),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			yes = yes || env.SkipConfirmations.Value()

--- a/pkg/cmd/pulumi/state/state_repair.go
+++ b/pkg/cmd/pulumi/state/state_repair.go
@@ -94,7 +94,7 @@ valid, and remains invalid after repair has been attempted, this command will
 not write any changes.
 `,
 		Args: cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			cmd.Flags().Visit(func(f *pflag.Flag) {
 				stateRepair.FlagsString += fmt.Sprintf(" --%s=%q", f.Name, f.Value)
 			})

--- a/pkg/cmd/pulumi/state/state_unprotect.go
+++ b/pkg/cmd/pulumi/state/state_unprotect.go
@@ -47,7 +47,7 @@ This command clears the 'protect' bit on one or more resources, allowing those r
 
 To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 		Args: cmdutil.MaximumNArgs(1),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 			yes = yes || env.SkipConfirmations.Value()

--- a/pkg/cmd/pulumi/state/state_upgrade.go
+++ b/pkg/cmd/pulumi/state/state_upgrade.go
@@ -47,7 +47,7 @@ func newStateUpgradeCommand() *cobra.Command {
 This only has an effect on DIY backends.
 `,
 		Args: cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			if err := sucmd.Run(cmd.Context()); err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/trace/convert.go
+++ b/pkg/cmd/pulumi/trace/convert.go
@@ -716,7 +716,7 @@ func NewConvertTraceCmd() *cobra.Command {
 			"inspected using `go tool pprof`.",
 		Args:   cmdutil.ExactArgs(1),
 		Hidden: !env.DebugCommands.Value(),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			store := appdash.NewMemoryStore()
 			if err := readTrace(args[0], store); err != nil {
 				return err

--- a/pkg/cmd/pulumi/trace/view.go
+++ b/pkg/cmd/pulumi/trace/view.go
@@ -43,7 +43,7 @@ func NewViewTraceCmd() *cobra.Command {
 			"port 8008; the --port flag can be used to change this if necessary.",
 		Args:   cmdutil.ExactArgs(1),
 		Hidden: !env.DebugCommands.Value(),
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			url, err := url.Parse(fmt.Sprintf("http://localhost:%d", port))
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/version/version.go
+++ b/pkg/cmd/pulumi/version/version.go
@@ -28,7 +28,7 @@ func NewVersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Print Pulumi's version number",
 		Args:  cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			fmt.Printf("%v\n", version.Version)
 			return nil
 		}),

--- a/pkg/cmd/pulumi/whoami/whoami.go
+++ b/pkg/cmd/pulumi/whoami/whoami.go
@@ -42,7 +42,7 @@ func NewWhoAmICmd() *cobra.Command {
 			"\n" +
 			"Displays the username of the currently logged in user.",
 		Args: cmdutil.NoArgs,
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
 			return whocmd.Run(cmd.Context())
 		}),
 	}

--- a/sdk/go/common/util/cmdutil/exit.go
+++ b/sdk/go/common/util/cmdutil/exit.go
@@ -17,7 +17,6 @@ package cmdutil
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
@@ -61,67 +60,61 @@ func DetailedError(err error) string {
 	return msg
 }
 
-// runPostCommandHooks runs any post-hooks present on the given cobra.Command. This logic is copied directly from
-// cobra itself; see https://github.com/spf13/cobra/blob/4dab30cb33e6633c33c787106bafbfbfdde7842d/command.go#L768-L785
-// for the original.
-func runPostCommandHooks(c *cobra.Command, args []string) error {
-	if c.PostRunE != nil {
-		if err := c.PostRunE(c, args); err != nil {
-			return err
-		}
-	} else if c.PostRun != nil {
-		c.PostRun(c, args)
-	}
-	for p := c; p != nil; p = p.Parent() {
-		if p.PersistentPostRunE != nil {
-			if err := p.PersistentPostRunE(c, args); err != nil {
-				return err
-			}
-			break
-		} else if p.PersistentPostRun != nil {
-			p.PersistentPostRun(c, args)
-			break
-		}
-	}
-	return nil
-}
-
-// RunFunc wraps an error-returning run func with standard Pulumi error handling.  All Pulumi
-// commands should wrap themselves in this or [RunResultFunc] to ensure consistent and appropriate
-// error behavior.  In particular, we want to avoid any calls to os.Exit in the middle of a
-// callstack which might prohibit reaping of child processes, resources, etc.  And we wish to avoid
-// the default Cobra unhandled error behavior, because it is formatted incorrectly and needlessly
-// prints usage.
+// RunFunc is like [RunFuncE], but it calls [os.Exit] when an error is encountered.
 //
-// If run returns a BailError, we will not print an error message, but will still be a non-zero exit code.
+// Deprecated: Please switch to RunFuncE instead:
+//
+//	-Run: cmd.RunFunc(func(cmd *cobra.Command, args []string) error {
+//	+RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+//
+// RunFuncE allows better testing because it doesn't call [os.Exit] on an error.
 func RunFunc(run func(cmd *cobra.Command, args []string) error) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
-		if err := run(cmd, args); err != nil {
-			// Sadly, the fact that we hard-exit below means that it's up to us to replicate the Cobra post-run
-			// behavior here.
-			if postRunErr := runPostCommandHooks(cmd, args); postRunErr != nil {
-				err = result.MergeBails(err, postRunErr)
-			}
-
-			// If we were asked to bail, that means we already printed out a message.  We just need
-			// to quit at this point (with an error code so no one thinks we succeeded).  Bailing
-			// always indicates a failure, just one we don't need to print a message for.
-			if result.IsBail(err) {
-				os.Exit(-1)
-				return
-			}
-
-			// If there is a stack trace, and logging is enabled, append it.  Otherwise, debug logging it.
-			var msg string
-			if logging.LogToStderr {
-				msg = DetailedError(err)
-			} else {
-				msg = errorMessage(err)
-				logging.V(3).Info(DetailedError(err))
-			}
-
-			ExitError(msg)
+		f := RunFuncE(run)
+		if f(cmd, args) != nil {
+			// RunFuncE has already displayed any error message that needs to
+			// be displayed, so we just exit.
+			os.Exit(-1)
 		}
+	}
+}
+
+// RunFuncE wraps an error-returning run func with standard Pulumi error handling.  All
+// Pulumi commands should wrap themselves in this to ensure consistent and appropriate
+// error behavior.  In particular, we want to avoid any calls to os.Exit in the middle of
+// a callstack which might prohibit reaping of child processes, resources, etc.  And we
+// wish to avoid the default Cobra unhandled error behavior, because it is formatted
+// incorrectly and needlessly prints usage.
+//
+// If run returns a BailError, we will not print an error message.
+func RunFuncE(run func(cmd *cobra.Command, args []string) error) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+
+		err := run(cmd, args)
+		if err == nil {
+			return nil
+		}
+
+		// If we were asked to bail, that means we already printed out a message.  We just need
+		// to quit at this point (with an error code so no one thinks we succeeded).  Bailing
+		// always indicates a failure, just one we don't need to print a message for.
+		if result.IsBail(err) {
+			// We return the error so a non-zero exit code is printed.
+			return err
+		}
+
+		var msg string
+		if logging.LogToStderr {
+			msg = DetailedError(err)
+		} else {
+			msg = errorMessage(err)
+			logging.V(3).Info(DetailedError(err))
+		}
+
+		Diag().Errorf(diag.Message("", "%s"), msg)
+		return err
 	}
 }
 
@@ -132,15 +125,8 @@ func Exit(err error) {
 
 // ExitError issues an error and exits with a standard error exit code.
 func ExitError(msg string) {
-	// Escape percent sign before passing the message as a format string (e.g., msg could contain %PATH% on Windows).
-	format := strings.ReplaceAll(msg, "%", "%%")
-	exitErrorCodef(-1, format)
-}
-
-// exitErrorCodef formats the message with arguments, issues an error and exists with the given error exit code.
-func exitErrorCodef(code int, format string, args ...interface{}) {
-	Diag().Errorf(diag.Message("", format), args...)
-	os.Exit(code)
+	Diag().Errorf(diag.Message("", "%s"), msg)
+	os.Exit(-1)
 }
 
 // errorMessage returns a message, possibly cleaning up the text if appropriate.


### PR DESCRIPTION
This PR changes how Pulumi's `cobra` commands error, bringing it more inline with how cobra prefers errors to be handled.

This allows directly testing full cobra commands:

```go
func TestMyNewStuff(t *testing.T) {
	t.Cleanup(captureStdout())
	
	cmd := NewNewCmd()
	cmd.SetArgs("--list-templates")
	err := cmd.Execute()
	assert.NoError(t, err)

	assert.Contains(t, os.Stdout, "my-magic-template")
}
```

All *interesting* edits are made in the first commit: a49bc00acc81011075dc6a77d09e59e1b1356afe. The second commit (f54d8db30e5f3ba3790c55ed8a87c91703eabf82) consists exclusively of changing call sites of `cmd.RunCmdFunc` to accommodate the change in function signature:

```patch
-		Run: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: cmd.RunCmdFunc(func(cmd *cobra.Command, args []string) error {
```

This change was motivated by #18627, since `pulumi new --list-templates` doesn't support unit tests as currently written.

### How this works

Cobra has added two flags to [`cobra.Command`](https://pkg.go.dev/github.com/spf13/cobra#Command) that make this possible: `SilenceErrors` and `SilenceUsage`. By setting both, we get a command that doesn't print anything when something goes wrong, which is what we want. We can print our own error messages, formatted as we want them. This PR implements `RunFuncE` to run it's inner func and print out any appropriate error message *and* return a bailed error. `main` then checks for an error, exiting non-zero if it finds one. Because only `main` calls `os.Exit`, we can test entire functions as unit tests.

### Observable changes

There are two observable changes, both minor:

- We return a different non-zero exit code (255 instead of 1) when we fail to run a command (for example: `pulumi not-a-command`).
- We don't suggest upgrading `pulumi` to the latest version if a command fails.

If either of these changes are problematic, we can restore the old behavior with a little additional complexity.

#### Different error codes

Previously, `pulumi` would return either `255` (-1) (when exiting from `cmd.RunCmdFunc`) or `1` (when exiting from `main.go`).

```console
$ pulumi aoeiu 
Error: unknown command "aoeiu" for "pulumi"
Run 'pulumi --help' for usage.
$ echo $?
1
```

```console
$ pulumi up
error: no Pulumi.yaml project file found (searching upwards from /Users/ianwahbe/go/src/github.com/pulumi/pulumi). If you have not created a project yet, use `pulumi new` to do so: no project file found
$ echo $?
255
```

After this change, `pulumi` only calls `os.Exit` from `main.go`, so it always returns the same exit code: `255`. I chose 255 since it's the most common exit code we return. If we believe that this is a breaking change for users, we can add back the distinction.

#### Upgrading `pulumi` to latest on failure

Cobra doesn't run `(Persistent)?PostRun` commands on a command where the `Run(E?)` command fails. The only usage of `(Persistent)?PostRun` commands in pulumi/pulumi is to display the  `checkVersionMsg`. Before this PR, we were incorrectly simulating `PersistentPostRun` hooks even when an error was returned. Since this PR lets cobra run it's hooks natively, we get the native behavior.