### PR TITLE
Add `make test_watch`, a test-watching command for Python

### DIFF
--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -65,6 +65,16 @@ test_auto:: $(TEST_ALL_DEPS)
 
 test_all:: test_fast test_auto test_go
 
+PULUMI_TEST_ORG ?= $(shell pulumi whoami --json | jq ".organizations[0]")
+
+# Watches all the python files and runs the tests every time they change.
+# Can optionally be given a substring search of tests to match. For example, to
+# iterate on one test specifically, one could use the following command:
+#
+# $ make test_watch TEST_GREP="lists tag values"
+test_watch::
+	. .venv/*/activate && PULUMI_TEST_ORG=$(PULUMI_TEST_ORG) ptw --runner "pytest lib/test -k $(TEST_GREP)"
+
 dist:: GOBIN=$(or $(shell go env GOBIN),$(shell go env GOPATH)/bin)
 dist::
 	GOBIN=${GOBIN} go install -C cmd/pulumi-language-python \

--- a/sdk/python/lib/test/automation/test_isolation.py
+++ b/sdk/python/lib/test/automation/test_isolation.py
@@ -27,6 +27,7 @@ import pytest
 
 import pulumi
 from pulumi import automation
+from .test_utils import get_test_org
 
 
 class BadResource(pulumi.CustomResource):
@@ -50,7 +51,9 @@ def ignore(*args, **kw):
 
 
 def check_isolation(minimal=False):
-    stack_name = f"isolation-test-{uuid.uuid4()}"
+    stack_name = automation.fully_qualified_stack_name(
+        get_test_org(), "isolation-test", f"isolation-test-{uuid.uuid4()}"
+    )
 
     stack = automation.create_stack(
         stack_name=stack_name, project_name="isolation-test", program=program
@@ -81,8 +84,8 @@ async def async_stack_destroy(stack):
 
 @pytest.mark.asyncio
 async def test_parallel_updates():
-    first_stack_name = f"stack-{uuid.uuid4()}"
-    second_stack_name = f"stack-{uuid.uuid4()}"
+    first_stack_name = automation.fully_qualified_stack_name(get_test_org(), "test-parallel", f"stack-{uuid.uuid4()}")
+    second_stack_name = automation.fully_qualified_stack_name(get_test_org(), "test-parallel", f"stack-{uuid.uuid4()}")
     stacks = [
         automation.create_stack(
             stack_name, project_name="test-parallel", program=program

--- a/sdk/python/lib/test/automation/test_isolation.py
+++ b/sdk/python/lib/test/automation/test_isolation.py
@@ -84,8 +84,12 @@ async def async_stack_destroy(stack):
 
 @pytest.mark.asyncio
 async def test_parallel_updates():
-    first_stack_name = automation.fully_qualified_stack_name(get_test_org(), "test-parallel", f"stack-{uuid.uuid4()}")
-    second_stack_name = automation.fully_qualified_stack_name(get_test_org(), "test-parallel", f"stack-{uuid.uuid4()}")
+    first_stack_name = automation.fully_qualified_stack_name(
+        get_test_org(), "test-parallel", f"stack-{uuid.uuid4()}"
+    )
+    second_stack_name = automation.fully_qualified_stack_name(
+        get_test_org(), "test-parallel", f"stack-{uuid.uuid4()}"
+    )
     stacks = [
         automation.create_stack(
             stack_name, project_name="test-parallel", program=program

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -135,8 +135,12 @@ class TestLocalWorkspace(unittest.TestCase):
     def test_stack_functions(self):
         project_settings = ProjectSettings(name="python_test", runtime="python")
         ws = LocalWorkspace(project_settings=project_settings)
-        stack_1_name = automation.fully_qualified_stack_name(get_test_org(), project_name, f"python_int_test_first_{get_test_suffix()}")
-        stack_2_name = automation.fully_qualified_stack_name(get_test_org(), project_name, f"python_int_test_first_{get_test_suffix()}")
+        stack_1_name = automation.fully_qualified_stack_name(
+            get_test_org(), project_name, f"python_int_test_first_{get_test_suffix()}"
+        )
+        stack_2_name = automation.fully_qualified_stack_name(
+            get_test_org(), project_name, f"python_int_test_first_{get_test_suffix()}"
+        )
 
         # Create a stack
         ws.create_stack(stack_1_name)

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -135,10 +135,10 @@ class TestLocalWorkspace(unittest.TestCase):
     def test_stack_functions(self):
         project_settings = ProjectSettings(name="python_test", runtime="python")
         ws = LocalWorkspace(project_settings=project_settings)
-        stack_1_name = automation.fully_qualified_stack_name(
+        stack_1_name = fully_qualified_stack_name(
             get_test_org(), project_name, f"python_int_test_first_{get_test_suffix()}"
         )
-        stack_2_name = automation.fully_qualified_stack_name(
+        stack_2_name = fully_qualified_stack_name(
             get_test_org(), project_name, f"python_int_test_first_{get_test_suffix()}"
         )
 

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -136,10 +136,10 @@ class TestLocalWorkspace(unittest.TestCase):
         project_settings = ProjectSettings(name="python_test", runtime="python")
         ws = LocalWorkspace(project_settings=project_settings)
         stack_1_name = fully_qualified_stack_name(
-            get_test_org(), "python_test", f"python_int_test_first_{get_test_suffix()}"
+            get_test_org(), "python_test", f"first_{get_test_suffix()}"
         )
         stack_2_name = fully_qualified_stack_name(
-            get_test_org(), "python_test", f"python_int_test_second_{get_test_suffix()}"
+            get_test_org(), "python_test", f"second_{get_test_suffix()}"
         )
 
         # Create a stack

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -120,23 +120,23 @@ class TestLocalWorkspace(unittest.TestCase):
 
     def test_plugin_functions(self):
         ws = LocalWorkspace()
-        # Install aws 3.0.0 plugin
-        ws.install_plugin("aws", "v3.0.0")
+        # Install aws 6.1.0 plugin
+        ws.install_plugin("aws", "v6.1.0")
         # Check the plugin is present
         plugin_list = ws.list_plugins()
-        self.assertTrue(found_plugin(plugin_list, "aws", "3.0.0"))
+        self.assertTrue(found_plugin(plugin_list, "aws", "6.1.0"))
 
         # Remove the plugin
-        ws.remove_plugin("aws", "3.0.0")
+        ws.remove_plugin("aws", "6.1.0")
         # Check that the plugin has been removed
         plugin_list = ws.list_plugins()
-        self.assertFalse(found_plugin(plugin_list, "aws", "3.0.0"))
+        self.assertFalse(found_plugin(plugin_list, "aws", "6.1.0"))
 
     def test_stack_functions(self):
         project_settings = ProjectSettings(name="python_test", runtime="python")
         ws = LocalWorkspace(project_settings=project_settings)
-        stack_1_name = f"python_int_test_first_{get_test_suffix()}"
-        stack_2_name = f"python_int_test_second_{get_test_suffix()}"
+        stack_1_name = automation.fully_qualified_stack_name(get_test_org(), project_name, f"python_int_test_first_{get_test_suffix()}")
+        stack_2_name = automation.fully_qualified_stack_name(get_test_org(), project_name, f"python_int_test_first_{get_test_suffix()}")
 
         # Create a stack
         ws.create_stack(stack_1_name)

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -135,12 +135,8 @@ class TestLocalWorkspace(unittest.TestCase):
     def test_stack_functions(self):
         project_settings = ProjectSettings(name="python_test", runtime="python")
         ws = LocalWorkspace(project_settings=project_settings)
-        stack_1_name = fully_qualified_stack_name(
-            get_test_org(), "python_test", f"first_{get_test_suffix()}"
-        )
-        stack_2_name = fully_qualified_stack_name(
-            get_test_org(), "python_test", f"second_{get_test_suffix()}"
-        )
+        stack_1_name = get_test_org() + "/" + f"first_{get_test_suffix()}"
+        stack_2_name = get_test_org() + "/" + f"second_{get_test_suffix()}"
 
         # Create a stack
         ws.create_stack(stack_1_name)

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -139,7 +139,7 @@ class TestLocalWorkspace(unittest.TestCase):
             get_test_org(), "python_test", f"python_int_test_first_{get_test_suffix()}"
         )
         stack_2_name = fully_qualified_stack_name(
-            get_test_org(), "python_test", f"python_int_test_first_{get_test_suffix()}"
+            get_test_org(), "python_test", f"python_int_test_second_{get_test_suffix()}"
         )
 
         # Create a stack

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -136,10 +136,10 @@ class TestLocalWorkspace(unittest.TestCase):
         project_settings = ProjectSettings(name="python_test", runtime="python")
         ws = LocalWorkspace(project_settings=project_settings)
         stack_1_name = fully_qualified_stack_name(
-            get_test_org(), project_name, f"python_int_test_first_{get_test_suffix()}"
+            get_test_org(), "python_test", f"python_int_test_first_{get_test_suffix()}"
         )
         stack_2_name = fully_qualified_stack_name(
-            get_test_org(), project_name, f"python_int_test_first_{get_test_suffix()}"
+            get_test_org(), "python_test", f"python_int_test_first_{get_test_suffix()}"
         )
 
         # Create a stack

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     'pyyaml~=6.0',
     'debugpy~=1.8.7',
     'pip>=24.3.1,<26',
+    "pytest-watch>=4.2.0",
 ]
 
 [dependency-groups]

--- a/sdk/python/pytest.ini
+++ b/sdk/python/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --junitxml ../../junit/python-test-auto.xml

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 
 [[package]]
@@ -302,6 +303,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/70/43/86fe3f9e130c4137b
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/d1/e73b6ad76f0b1fb7f23c35c6d95dbc506a9c8804f43dda8cb5b0fa6331fd/dill-0.3.9-py3-none-any.whl", hash = "sha256:468dff3b89520b474c0397703366b7b95eebe6303f108adf9b19da1f702be87a", size = 119418 },
 ]
+
+[[package]]
+name = "docopt"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901 }
 
 [[package]]
 name = "docutils"
@@ -645,6 +652,7 @@ dependencies = [
     { name = "grpcio" },
     { name = "pip" },
     { name = "protobuf" },
+    { name = "pytest-watch" },
     { name = "pyyaml" },
     { name = "semver" },
     { name = "six" },
@@ -674,6 +682,7 @@ requires-dist = [
     { name = "grpcio", specifier = "~=1.66.2" },
     { name = "pip", specifier = ">=24.3.1,<26" },
     { name = "protobuf", specifier = "~=4.21" },
+    { name = "pytest-watch", specifier = ">=4.2.0" },
     { name = "pyyaml", specifier = "~=6.0" },
     { name = "semver", specifier = "~=2.13" },
     { name = "six", specifier = "~=1.12" },
@@ -775,6 +784,18 @@ sdist = { url = "https://files.pythonhosted.org/packages/93/0d/04719abc7a4bdb3a7
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/27/14af9ef8321f5edc7527e47def2a21d8118c6f329a9342cc61387a0c0599/pytest_timeout-2.3.1-py3-none-any.whl", hash = "sha256:68188cb703edfc6a18fad98dc25a3c61e9f24d644b0b70f33af545219fc7813e", size = 14148 },
 ]
+
+[[package]]
+name = "pytest-watch"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "docopt" },
+    { name = "pytest" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/47/ab65fc1d682befc318c439940f81a0de1026048479f732e84fe714cd69c0/pytest-watch-4.2.0.tar.gz", hash = "sha256:06136f03d5b361718b8d0d234042f7b2f203910d8568f63df2f866b547b3d4b9", size = 16340 }
 
 [[package]]
 name = "pywin32-ctypes"
@@ -1061,6 +1082,43 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369 },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/56/90994d789c61df619bfc5ce2ecdabd5eeff564e1eb47512bd01b5e019569/watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26", size = 96390 },
+    { url = "https://files.pythonhosted.org/packages/55/46/9a67ee697342ddf3c6daa97e3a587a56d6c4052f881ed926a849fcf7371c/watchdog-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112", size = 88389 },
+    { url = "https://files.pythonhosted.org/packages/44/65/91b0985747c52064d8701e1075eb96f8c40a79df889e59a399453adfb882/watchdog-6.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c897ac1b55c5a1461e16dae288d22bb2e412ba9807df8397a635d88f671d36c3", size = 89020 },
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393 },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392 },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019 },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471 },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449 },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054 },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480 },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451 },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057 },
+    { url = "https://files.pythonhosted.org/packages/05/52/7223011bb760fce8ddc53416beb65b83a3ea6d7d13738dde75eeb2c89679/watchdog-6.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e6f0e77c9417e7cd62af82529b10563db3423625c5fce018430b249bf977f9e8", size = 96390 },
+    { url = "https://files.pythonhosted.org/packages/9c/62/d2b21bc4e706d3a9d467561f487c2938cbd881c69f3808c43ac1ec242391/watchdog-6.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:90c8e78f3b94014f7aaae121e6b909674df5b46ec24d6bebc45c44c56729af2a", size = 88386 },
+    { url = "https://files.pythonhosted.org/packages/ea/22/1c90b20eda9f4132e4603a26296108728a8bfe9584b006bd05dd94548853/watchdog-6.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e7631a77ffb1f7d2eefa4445ebbee491c720a5661ddf6df3498ebecae5ed375c", size = 89017 },
+    { url = "https://files.pythonhosted.org/packages/30/ad/d17b5d42e28a8b91f8ed01cb949da092827afb9995d4559fd448d0472763/watchdog-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881", size = 87902 },
+    { url = "https://files.pythonhosted.org/packages/5c/ca/c3649991d140ff6ab67bfc85ab42b165ead119c9e12211e08089d763ece5/watchdog-6.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11", size = 88380 },
+    { url = "https://files.pythonhosted.org/packages/5b/79/69f2b0e8d3f2afd462029031baafb1b75d11bb62703f0e1022b2e54d49ee/watchdog-6.0.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7a0e56874cfbc4b9b05c60c8a1926fedf56324bb08cfbc188969777940aef3aa", size = 87903 },
+    { url = "https://files.pythonhosted.org/packages/e2/2b/dc048dd71c2e5f0f7ebc04dd7912981ec45793a03c0dc462438e0591ba5d/watchdog-6.0.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:e6439e374fc012255b4ec786ae3c4bc838cd7309a540e5fe0952d03687d8804e", size = 88381 },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079 },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076 },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077 },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077 },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065 },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070 },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067 },
 ]
 
 [[package]]


### PR DESCRIPTION
Very similar PR to #18750: this allows us to run specific pytests every time a code or test file is updated. This also gets the tests to pass on my machine.