### PR TITLE
[sdk/python] Fix `get_organization` returning `None`

### DIFF
--- a/changelog/pending/20250228--sdk-python--fix-get_organization-returning-none-from-older-sdks.yaml
+++ b/changelog/pending/20250228--sdk-python--fix-get_organization-returning-none-from-older-sdks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix `get_organization` returning `None` from older SDKs 

--- a/sdk/python/cmd/pulumi-language-python-exec
+++ b/sdk/python/cmd/pulumi-language-python-exec
@@ -4,6 +4,7 @@
 import argparse
 import asyncio
 from typing import Optional
+import inspect
 import logging
 import os
 import sys
@@ -92,27 +93,30 @@ if __name__ == "__main__":
             pulumi.runtime.set_config(k, v)
 
     # Configure the runtime so that the user program hooks up to Pulumi as appropriate.
-    # New versions of pulumi python support setting organization, old versions do not
+    # Note that older versions of the `pulumi` python SDK do not support newer
+    # parameters like `organization` and `root_directory`. We automatically fall back
+    # to excluding unsupported parameters, if needed.
+    settings_kwargs = {
+        "monitor": args.monitor,
+        "engine": args.engine,
+        "project": args.project,
+        "stack": args.stack,
+        "parallel": int(args.parallel),
+        "dry_run": args.dry_run == "true",
+        "organization": args.organization,
+        "root_directory": args.root_directory,
+    }
     try:
-        settings = pulumi.runtime.Settings(
-            monitor=args.monitor,
-            engine=args.engine,
-            project=args.project,
-            root_directory=args.root_directory,
-            stack=args.stack,
-            parallel=int(args.parallel),
-            dry_run=args.dry_run == "true",
-            organization=args.organization,
-        )
+        # Try to create the `Settings` object with all possible parameters.
+        settings = pulumi.runtime.Settings(**settings_kwargs)
     except TypeError:
-        settings = pulumi.runtime.Settings(
-            monitor=args.monitor,
-            engine=args.engine,
-            project=args.project,
-            stack=args.stack,
-            parallel=int(args.parallel),
-            dry_run=args.dry_run == "true"
-        )
+        # The `Settings` class didn't support some of the parameters we passed in.
+        # Fall back to a slower path that inspects the valid parameters from the
+        # signature, filters out unsupported parameters, and tries to create the
+        # `Settings` object again with only supported parameters.
+        settings_params = inspect.signature(pulumi.runtime.Settings.__init__).parameters
+        filtered_kwargs = {k: v for k, v in settings_kwargs.items() if k in settings_params}
+        settings = pulumi.runtime.Settings(**filtered_kwargs)
 
     pulumi.runtime.configure(settings)
 

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -2121,3 +2121,17 @@ func installPythonProviderDependencies(t *testing.T, dir string) {
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "output: %s", out)
 }
+
+// Regression test for https://github.com/pulumi/pulumi/issues/18768
+//
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestOrganization(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          filepath.Join("python", "organization"),
+		Dependencies: []string{
+			// We explicitly do not depend on the local Python SDK here.
+			// Instead, the version specified in requirements.txt is used.
+		},
+		Quick: true,
+	})
+}

--- a/tests/integration/python/organization/.gitignore
+++ b/tests/integration/python/organization/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+/.pulumi/
+/dist/
+/*.egg-info
+venv/

--- a/tests/integration/python/organization/Pulumi.yaml
+++ b/tests/integration/python/organization/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-python-organization
+description: A simple Python Pulumi program that expects the organization to be set
+runtime: python

--- a/tests/integration/python/organization/__main__.py
+++ b/tests/integration/python/organization/__main__.py
@@ -1,0 +1,3 @@
+import pulumi
+
+assert pulumi.get_organization() is not None, "Organization expected but not found"

--- a/tests/integration/python/organization/requirements.txt
+++ b/tests/integration/python/organization/requirements.txt
@@ -1,0 +1,4 @@
+# We explicitly use this version of the SDK, whose `pulumi.runtime.Settings.__init__` does
+# not have a `root_directory` parameter, which causes the `organization` not to be set.
+# See https://github.com/pulumi/pulumi/issues/18768.
+pulumi==3.152.0


### PR DESCRIPTION
When versions v3.152.0 and earlier of the `pulumi` python SDK are used with v3.153.0 of the CLI, the `pulumi.get_organization()` function returns `None` rather than the expected organization. This is a regression that was introduced by #18595.

This is what's happening: `pulumi-language-python-exec` ships with the CLI. In v3.153.0, it tries to create an instance of `pulumi.runtime.Settings`, passing a new parameter: `root_directory`. However, older versions of the `pulumi` python SDK do not support this parameter. An error is raised, which is caught and we fall back to default values, which doesn't have the `organization`, so it ends up being `None`.

This change fixes the problem in `pulumi-language-python-exec`. We first try to create `Settings` with all possible parameters. If it runs into an error, it falls back to a slower path that inspects the signature of `Settings.__init__` to determine the supported parameters, and then tries to create `Settings` again with only the parameters it supports.

Fixes #18768