### PR TITLE
provide friendlier exception when dict has no type arguments

### DIFF
--- a/sdk/python/lib/pulumi/provider/experimental/analyzer.py
+++ b/sdk/python/lib/pulumi/provider/experimental/analyzer.py
@@ -91,6 +91,15 @@ class InvalidMapKeyError(Exception):
         )
 
 
+class InvalidMapTypeError(Exception):
+    def __init__(self, arg: type, typ: type, property_name: str):
+        self.property = property_name
+        self.typ = typ
+        super().__init__(
+            f"map types must specify two type arguments, got '{arg.__name__}' for '{typ.__name__}.{property_name}'"
+        )
+
+
 class InvalidListTypeError(Exception):
     def __init__(self, arg: type, typ: type, property_name: str):
         self.property = property_name
@@ -369,6 +378,8 @@ class Analyzer:
             )
         elif is_dict(arg):
             args = get_args(arg)
+            if len(args) != 2:
+                raise InvalidMapTypeError(arg, typ, name)
             if args[0] is not str:
                 raise InvalidMapKeyError(args[0], typ, name)
             return PropertyDefinition(

--- a/sdk/python/lib/test/provider/experimental/test_analyzer.py
+++ b/sdk/python/lib/test/provider/experimental/test_analyzer.py
@@ -25,6 +25,7 @@ from pulumi.provider.experimental.analyzer import (
     DuplicateTypeError,
     InvalidListTypeError,
     InvalidMapKeyError,
+    InvalidMapTypeError,
     TypeNotFoundError,
     is_dict,
     is_list,
@@ -431,6 +432,23 @@ def test_analyze_dict_non_str_key():
         analyzer.analyze_component(Component, Path("test_analyzer"))
     except InvalidMapKeyError as e:
         assert str(e) == "map keys must be strings, got 'int' for 'Args.bad_dict'"
+
+
+def test_analyze_dice_no_types():
+    class Args(TypedDict):
+        bad_dict: pulumi.Input[dict]
+
+    class Component(pulumi.ComponentResource):
+        def __init__(self, args: Args): ...
+
+    analyzer = Analyzer(metadata)
+    try:
+        analyzer.analyze_component(Component, Path("test_analyzer"))
+    except InvalidMapTypeError as e:
+        assert (
+            str(e)
+            == "map types must specify two type arguments, got 'dict' for 'Args.bad_dict'"
+        )
 
 
 def test_analyze_dict_simple():


### PR DESCRIPTION
In python it's possible to write something like `pulumi.Input[dict]`, where `dict` has no type arguments.  This currently causes us to throw a confusing exception.  Detect that case, and provide a better error message to the user.