### PR TITLE
Rename batch crypt types

### DIFF
--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -486,12 +486,12 @@ func (pc *Client) EncryptValue(ctx context.Context, stack StackIdentifier, plain
 	return resp.Ciphertext, nil
 }
 
-// BulkEncrypt encrypts multiple plaintext values in the context of the indicated stack.
-func (pc *Client) BulkEncrypt(ctx context.Context, stack StackIdentifier,
+// BatchEncrypt encrypts multiple plaintext values in the context of the indicated stack.
+func (pc *Client) BatchEncrypt(ctx context.Context, stack StackIdentifier,
 	plaintexts [][]byte,
 ) ([][]byte, error) {
-	req := apitype.BulkEncryptRequest{Plaintexts: plaintexts}
-	var resp apitype.BulkEncryptResponse
+	req := apitype.BatchEncryptRequest{Plaintexts: plaintexts}
+	var resp apitype.BatchEncryptResponse
 	if err := pc.restCallWithOptions(ctx, "POST", getStackPath(stack, "bulk-encrypt"), nil, &req, &resp,
 		httpCallOptions{GzipCompress: true, RetryPolicy: retryAllMethods}); err != nil {
 		return nil, err
@@ -531,12 +531,12 @@ func (pc *Client) LogBulk3rdPartySecretsProviderDecryptionEvent(ctx context.Cont
 		nil, &req, nil)
 }
 
-// BulkDecryptValue decrypts a ciphertext value in the context of the indicated stack.
-func (pc *Client) BulkDecryptValue(ctx context.Context, stack StackIdentifier,
+// BatchDecryptValue decrypts a ciphertext value in the context of the indicated stack.
+func (pc *Client) BatchDecryptValue(ctx context.Context, stack StackIdentifier,
 	ciphertexts [][]byte,
 ) (map[string][]byte, error) {
-	req := apitype.BulkDecryptValueRequest{Ciphertexts: ciphertexts}
-	var resp apitype.BulkDecryptValueResponse
+	req := apitype.BatchDecryptRequest{Ciphertexts: ciphertexts}
+	var resp apitype.BatchDecryptResponse
 	if err := pc.restCallWithOptions(ctx, "POST", getStackPath(stack, "batch-decrypt"), nil, &req, &resp,
 		httpCallOptions{GzipCompress: true, RetryPolicy: retryAllMethods}); err != nil {
 		return nil, err

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -492,7 +492,7 @@ func (pc *Client) BatchEncrypt(ctx context.Context, stack StackIdentifier,
 ) ([][]byte, error) {
 	req := apitype.BatchEncryptRequest{Plaintexts: plaintexts}
 	var resp apitype.BatchEncryptResponse
-	if err := pc.restCallWithOptions(ctx, "POST", getStackPath(stack, "bulk-encrypt"), nil, &req, &resp,
+	if err := pc.restCallWithOptions(ctx, "POST", getStackPath(stack, "batch-encrypt"), nil, &req, &resp,
 		httpCallOptions{GzipCompress: true, RetryPolicy: retryAllMethods}); err != nil {
 		return nil, err
 	}

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -163,7 +163,7 @@ func TestGzip(t *testing.T) {
 	assert.NoError(t, err)
 
 	// POST /events/batch
-	_, err = client.BulkDecryptValue(context.Background(), identifier, nil)
+	_, err = client.BatchDecryptValue(context.Background(), identifier, nil)
 	assert.NoError(t, err)
 }
 
@@ -257,7 +257,7 @@ func TestGetCapabilities(t *testing.T) {
 				Capability:    apitype.DeltaCheckpointUploads,
 				Configuration: json.RawMessage(cfgJSON),
 			}, {
-				Capability: apitype.BulkEncrypt,
+				Capability: apitype.BatchEncrypt,
 			}},
 		}
 		respJSON, err := json.Marshal(actualResp)
@@ -273,12 +273,12 @@ func TestGetCapabilities(t *testing.T) {
 		assert.Equal(t, apitype.DeltaCheckpointUploads, resp.Capabilities[0].Capability)
 		assert.Equal(t, `{"checkpointCutoffSizeBytes":4194304}`,
 			string(resp.Capabilities[0].Configuration))
-		assert.Equal(t, resp.Capabilities[1].Capability, apitype.BulkEncrypt)
+		assert.Equal(t, resp.Capabilities[1].Capability, apitype.BatchEncrypt)
 
 		parsed, err := resp.Parse()
 		require.NoError(t, err)
 		assert.Equal(t, parsed.DeltaCheckpointUpdates, &cfg)
-		assert.True(t, parsed.BulkEncryption)
+		assert.True(t, parsed.BatchEncryption)
 	})
 }
 

--- a/pkg/cmd/pulumi/config/io_test.go
+++ b/pkg/cmd/pulumi/config/io_test.go
@@ -302,7 +302,7 @@ func TestStackEnvConfig(t *testing.T) {
 				DecryptValueF: func() string {
 					return "plaintext"
 				},
-				BulkDecryptF: func() []string {
+				BatchDecryptF: func() []string {
 					return []string{
 						"whatiamdoing",
 					}
@@ -387,7 +387,7 @@ func TestCopyConfig(t *testing.T) {
 				DecryptValueF: func() string {
 					return "plaintext"
 				},
-				BulkDecryptF: func() []string {
+				BatchDecryptF: func() []string {
 					return []string{
 						"whatiamdoing",
 					}

--- a/pkg/cmd/pulumi/stack/stack_history_test.go
+++ b/pkg/cmd/pulumi/stack/stack_history_test.go
@@ -62,6 +62,6 @@ func (m *failingDecrypter) DecryptValue(ctx context.Context, ciphertext string) 
 	return ciphertext, errors.New("bad value")
 }
 
-func (m *failingDecrypter) BulkDecrypt(ctx context.Context, ciphertexts []string) ([]string, error) {
+func (m *failingDecrypter) BatchDecrypt(ctx context.Context, ciphertexts []string) ([]string, error) {
 	return []string{}, errors.New("fake failure")
 }

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -372,7 +372,7 @@ func (b brokenDecrypter) DecryptValue(_ context.Context, _ string) (string, erro
 	return "", errors.New(b.ErrorMessage)
 }
 
-func (b brokenDecrypter) BulkDecrypt(_ context.Context, _ []string) ([]string, error) {
+func (b brokenDecrypter) BatchDecrypt(_ context.Context, _ []string) ([]string, error) {
 	return nil, errors.New(b.ErrorMessage)
 }
 

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -1789,7 +1789,7 @@ func (d *decrypterMock) DecryptValue(ctx context.Context, ciphertext string) (st
 	panic("unimplemented")
 }
 
-func (d *decrypterMock) BulkDecrypt(ctx context.Context, ciphertexts []string) ([]string, error) {
+func (d *decrypterMock) BatchDecrypt(ctx context.Context, ciphertexts []string) ([]string, error) {
 	if d.BulkDecryptF != nil {
 		return d.BulkDecryptF(ctx, ciphertexts)
 	}

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -1776,7 +1776,7 @@ func TestStreamInvokeQuery(t *testing.T) {
 type decrypterMock struct {
 	DecryptValueF func(
 		ctx context.Context, ciphertext string) (string, error)
-	BulkDecryptF func(
+	BatchDecryptF func(
 		ctx context.Context, ciphertexts []string) ([]string, error)
 }
 
@@ -1790,8 +1790,8 @@ func (d *decrypterMock) DecryptValue(ctx context.Context, ciphertext string) (st
 }
 
 func (d *decrypterMock) BatchDecrypt(ctx context.Context, ciphertexts []string) ([]string, error) {
-	if d.BulkDecryptF != nil {
-		return d.BulkDecryptF(ctx, ciphertexts)
+	if d.BatchDecryptF != nil {
+		return d.BatchDecryptF(ctx, ciphertexts)
 	}
 	panic("unimplemented")
 }

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -267,7 +267,7 @@ func DeserializeDeploymentV3(
 		}
 
 		// Decrypt the collected secrets and create a decrypter that will use the result as a cache.
-		decrypted, err := d.BulkDecrypt(ctx, ciphertexts)
+		decrypted, err := d.BatchDecrypt(ctx, ciphertexts)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -142,8 +142,8 @@ func (csm *cachingSecretsManager) DecryptValue(ctx context.Context, ciphertext s
 	return csm.decrypter.Value().DecryptValue(ctx, ciphertext)
 }
 
-func (csm *cachingSecretsManager) BulkDecrypt(ctx context.Context, ciphertexts []string) ([]string, error) {
-	return csm.decrypter.Value().BulkDecrypt(ctx, ciphertexts)
+func (csm *cachingSecretsManager) BatchDecrypt(ctx context.Context, ciphertexts []string) ([]string, error) {
+	return csm.decrypter.Value().BatchDecrypt(ctx, ciphertexts)
 }
 
 // encryptSecret encrypts the plaintext associated with the given secret value.
@@ -208,8 +208,8 @@ func (c *mapDecrypter) DecryptValue(ctx context.Context, ciphertext string) (str
 	return plaintext, nil
 }
 
-func (c *mapDecrypter) BulkDecrypt(ctx context.Context, ciphertexts []string) ([]string, error) {
-	// Loop and find the entries that are already cached, then BulkDecrypt the rest
+func (c *mapDecrypter) BatchDecrypt(ctx context.Context, ciphertexts []string) ([]string, error) {
+	// Loop and find the entries that are already cached, then batch decrypt the rest
 	decryptedResult := make([]string, len(ciphertexts))
 	var toDecrypt []string
 	if c.cache == nil {
@@ -230,8 +230,8 @@ func (c *mapDecrypter) BulkDecrypt(ctx context.Context, ciphertexts []string) ([
 		return decryptedResult, nil
 	}
 
-	// try and bulk decrypt the rest
-	decrypted, err := c.decrypter.BulkDecrypt(ctx, toDecrypt)
+	// try and decrypt the rest in a single batch request
+	decrypted, err := c.decrypter.BatchDecrypt(ctx, toDecrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/secrets/mock.go
+++ b/pkg/secrets/mock.go
@@ -78,7 +78,7 @@ func (me *MockEncrypter) EncryptValue(ctx context.Context, plaintext string) (st
 
 type MockDecrypter struct {
 	DecryptValueF func() string
-	BulkDecryptF  func() []string
+	BatchDecryptF func() []string
 }
 
 func (md *MockDecrypter) DecryptValue(ctx context.Context, ciphertext string) (string, error) {
@@ -89,9 +89,9 @@ func (md *MockDecrypter) DecryptValue(ctx context.Context, ciphertext string) (s
 	return "", errors.New("mock value not provided")
 }
 
-func (md *MockDecrypter) BulkDecrypt(ctx context.Context, ciphertexts []string) ([]string, error) {
-	if md.BulkDecryptF != nil {
-		return md.BulkDecryptF(), nil
+func (md *MockDecrypter) BatchDecrypt(ctx context.Context, ciphertexts []string) ([]string, error) {
+	if md.BatchDecryptF != nil {
+		return md.BatchDecryptF(), nil
 	}
 
 	return nil, errors.New("mock value not provided")

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -427,7 +427,7 @@ func (ec *errorCrypter) DecryptValue(ctx context.Context, _ string) (string, err
 		"correct passphrase or set PULUMI_CONFIG_PASSPHRASE_FILE to a file containing the passphrase")
 }
 
-func (ec *errorCrypter) BulkDecrypt(ctx context.Context, _ []string) ([]string, error) {
+func (ec *errorCrypter) BatchDecrypt(ctx context.Context, _ []string) ([]string, error) {
 	return nil, errors.New("failed to decrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the " +
 		"correct passphrase or set PULUMI_CONFIG_PASSPHRASE_FILE to a file containing the passphrase")
 }

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -66,7 +66,7 @@ func (c *serviceCrypter) DecryptValue(ctx context.Context, cipherstring string) 
 	return string(plaintext), nil
 }
 
-func (c *serviceCrypter) BulkDecrypt(ctx context.Context, secrets []string) ([]string, error) {
+func (c *serviceCrypter) BatchDecrypt(ctx context.Context, secrets []string) ([]string, error) {
 	secretsToDecrypt := slice.Prealloc[[]byte](len(secrets))
 	for _, val := range secrets {
 		ciphertext, err := base64.StdEncoding.DecodeString(val)

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -76,7 +76,7 @@ func (c *serviceCrypter) BatchDecrypt(ctx context.Context, secrets []string) ([]
 		secretsToDecrypt = append(secretsToDecrypt, ciphertext)
 	}
 
-	decryptedList, err := c.client.BulkDecryptValue(ctx, c.stack, secretsToDecrypt)
+	decryptedList, err := c.client.BatchDecryptValue(ctx, c.stack, secretsToDecrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -31,8 +31,9 @@ const (
 	// via the PatchUpdateCheckpointDeltaRequest API to save on network bytes.
 	DeltaCheckpointUploadsV2 APICapability = "delta-checkpoint-uploads-v2"
 
-	// Indicates that the service backend supports stack bulk encryption.
-	BulkEncrypt APICapability = "bulk-encrypt"
+	// Indicates that the service backend supports batch encryption.
+	// These names don't match due to a historical rename for user consistency.
+	BatchEncrypt APICapability = "bulk-encrypt"
 )
 
 type DeltaCheckpointUploadsConfigV2 struct {
@@ -61,8 +62,8 @@ type Capabilities struct {
 	// If non-nil, indicates that delta checkpoint updates are supported.
 	DeltaCheckpointUpdates *DeltaCheckpointUploadsConfigV2
 
-	// Indicates whether the service supports bulk encryption.
-	BulkEncryption bool
+	// Indicates whether the service supports batch encryption.
+	BatchEncryption bool
 }
 
 // Parse decodes the CapabilitiesResponse into a Capabilities struct for ease of use.
@@ -84,8 +85,8 @@ func (r CapabilitiesResponse) Parse() (Capabilities, error) {
 				}
 				parsed.DeltaCheckpointUpdates = &upcfg
 			}
-		case BulkEncrypt:
-			parsed.BulkEncryption = true
+		case BatchEncrypt:
+			parsed.BatchEncryption = true
 		default:
 			continue
 		}

--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -32,8 +32,7 @@ const (
 	DeltaCheckpointUploadsV2 APICapability = "delta-checkpoint-uploads-v2"
 
 	// Indicates that the service backend supports batch encryption.
-	// These names don't match due to a historical rename for user consistency.
-	BatchEncrypt APICapability = "bulk-encrypt"
+	BatchEncrypt APICapability = "batch-encrypt"
 )
 
 type DeltaCheckpointUploadsConfigV2 struct {

--- a/sdk/go/common/apitype/service_test.go
+++ b/sdk/go/common/apitype/service_test.go
@@ -103,13 +103,13 @@ func TestCapabilities(t *testing.T) {
 		t.Parallel()
 		response := CapabilitiesResponse{
 			Capabilities: []APICapabilityConfig{
-				{Capability: BulkEncrypt},
+				{Capability: BatchEncrypt},
 			},
 		}
 		actual, err := response.Parse()
 		assert.NoError(t, err)
 		assert.Equal(t, Capabilities{
-			BulkEncryption: true,
+			BatchEncryption: true,
 		}, actual)
 	})
 }

--- a/sdk/go/common/apitype/stacks.go
+++ b/sdk/go/common/apitype/stacks.go
@@ -78,14 +78,14 @@ type EncryptValueResponse struct {
 	Ciphertext []byte `json:"ciphertext"`
 }
 
-// BulkEncryptRequest defines the request body for encrypting multiple values.
-type BulkEncryptRequest struct {
+// BatchEncryptRequest defines the request body for encrypting multiple values.
+type BatchEncryptRequest struct {
 	// The values to encrypt.
 	Plaintexts [][]byte `json:"plaintexts"`
 }
 
-// BulkEncryptResponse defines the response body for multiple encrypted values.
-type BulkEncryptResponse struct {
+// BatchEncryptResponse defines the response body for multiple encrypted values.
+type BatchEncryptResponse struct {
 	// The encrypted values, in order of the plaintexts from the request.
 	Ciphertexts [][]byte `json:"ciphertexts"`
 }
@@ -108,14 +108,14 @@ type Log3rdPartyDecryptionEvent struct {
 	CommandName string `json:"commandName,omitempty"`
 }
 
-// BulkDecryptValueRequest defines the request body for bulk decrypting secret values.
-type BulkDecryptValueRequest struct {
+// BatchDecryptRequest defines the request body for bulk decrypting secret values.
+type BatchDecryptRequest struct {
 	Ciphertexts [][]byte `json:"ciphertexts"`
 }
 
-// BulkDecryptValueResponse defines the response body for bulk decrypted secret values. The key in
+// BatchDecryptResponse defines the response body for bulk decrypted secret values. The key in
 // the map is the base64 encoding of the ciphertext.
-type BulkDecryptValueResponse struct {
+type BatchDecryptResponse struct {
 	Plaintexts map[string][]byte `json:"plaintexts"`
 }
 

--- a/sdk/go/common/resource/config/value_test.go
+++ b/sdk/go/common/resource/config/value_test.go
@@ -215,10 +215,10 @@ func (d passThroughDecrypter) DecryptValue(
 	return ciphertext, nil
 }
 
-func (d passThroughDecrypter) BulkDecrypt(
+func (d passThroughDecrypter) BatchDecrypt(
 	ctx context.Context, ciphertexts []string,
 ) ([]string, error) {
-	return DefaultBulkDecrypt(ctx, d, ciphertexts)
+	return DefaultBatchDecrypt(ctx, d, ciphertexts)
 }
 
 func TestSecureValues(t *testing.T) {


### PR DESCRIPTION
Make naming of types and methods consistent with the actual service API route (which we can't easily change).

1. Rename BulkDecrypt to BatchDecrypt
2. Rename "bulk" api types to "batch"

This will require some additional fixes on the service side on the next update.