### PR TITLE
add num accounts to policy group summary

### DIFF
--- a/sdk/go/common/apitype/policy.go
+++ b/sdk/go/common/apitype/policy.go
@@ -214,6 +214,7 @@ type PolicyGroupSummary struct {
 	Name                  string `json:"name"`
 	IsOrgDefault          bool   `json:"isOrgDefault"`
 	NumStacks             int    `json:"numStacks"`
+	NumAccounts           int    `json:"numAccounts,omitempty"`
 	NumEnabledPolicyPacks int    `json:"numEnabledPolicyPacks"`
 }
 


### PR DESCRIPTION
Policy Groups can now contain accounts as well as stacks.  We need this field to be returned from the pulumi cloud API