### PR TITLE
Automation API for Go now permits setting --diff flag on refresh

### DIFF
--- a/changelog/pending/20250304--auto-go--automation-api-for-go-now-permits-setting-diff-flag-on-refresh.yaml
+++ b/changelog/pending/20250304--auto-go--automation-api-for-go-now-permits-setting-diff-flag-on-refresh.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Automation API for Go now permits setting --diff flag on refresh

--- a/sdk/go/auto/optrefresh/optrefresh.go
+++ b/sdk/go/auto/optrefresh/optrefresh.go
@@ -122,6 +122,13 @@ func SuppressOutputs() Option {
 	})
 }
 
+// Display operation as a rich diff showing the overall change.
+func Diff() Option {
+	return optionFunc(func(o *Options) {
+		o.Diff = true
+	})
+}
+
 // ConfigFile specifies a file to use for configuration values rather than detecting the file name
 func ConfigFile(path string) Option {
 	return optionFunc(func(opts *Options) {
@@ -169,6 +176,8 @@ type Options struct {
 	SuppressOutputs bool
 	// Run using the configuration values in the specified file rather than detecting the file name
 	ConfigFile string
+	// When set, display operation as a rich diff showing the overall change
+	Diff bool
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -772,6 +772,9 @@ func refreshOptsToCmd(o *optrefresh.Options, s *Stack, isPreview bool) []string 
 	if o.ConfigFile != "" {
 		args = append(args, "--config-file="+o.ConfigFile)
 	}
+	if o.Diff {
+		args = append(args, "--diff")
+	}
 
 	// Apply the remote args, if needed.
 	args = append(args, s.remoteArgs()...)

--- a/sdk/go/auto/stack_test.go
+++ b/sdk/go/auto/stack_test.go
@@ -299,6 +299,22 @@ func TestRefreshOptsConfigFile(t *testing.T) {
 	assert.Contains(t, args, "--config-file="+configFilePath)
 }
 
+func TestRefreshOptsDiff(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	pDir := filepath.Join(".", "test", "testproj")
+
+	stack, err := NewStackLocalSource(ctx, ptesting.RandomStackName(), pDir)
+	require.NoError(t, err)
+
+	argsUp := refreshOptsToCmd(&optrefresh.Options{Diff: true}, &stack, true)
+	assert.Contains(t, argsUp, "--diff", argsUp)
+
+	argsPreview := refreshOptsToCmd(&optrefresh.Options{Diff: true}, &stack, false)
+	assert.Contains(t, argsPreview, "--diff", argsUp)
+}
+
 func TestRefreshOptsClearPendingCreates(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Automation API for Go now permits setting --diff flag on refresh