### PR TITLE
Fix plugin "exited prematurely" false positives

### DIFF
--- a/changelog/pending/20250304--cli-plugin--fix-plugin-exited-prematurely-false-positives.yaml
+++ b/changelog/pending/20250304--cli-plugin--fix-plugin-exited-prematurely-false-positives.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/plugin
+  description: Fix plugin "exited prematurely" false positives


### PR DESCRIPTION
When closing a plugin, the plugin's connection state is used to determine whether the plugin had crashed, where a connection state other than `Ready` is presumed crashed. This can lead to false positives, as it's possible for the connection state to change from `Ready` to `Idle` after an idle timeout (e.g. 5 minutes) for plugins that have not crashed.

This leads to incorrect messages reported to users, such as:

```
   Detected that /Users/user/.pulumi/plugins/resource-random-v4.18.0/pulumi-resource-random exited prematurely.
             This is *always* a bug in the provider. Please report the issue to the provider author as appropriate.
```

This change avoids the false positives by making a request to a health check service on the plugin as a way of determining if the plugin is still alive. Most plugins don't and won't implement this service, but that's OK because we treat an unimplemented status as OK. If we get any other error (unavailable, deadline_exceeded, etc.) the plugin is presumed crashed.

Fixes #18238