### PR TITLE
Flesh out documentation on converters

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -122,9 +122,10 @@ well as discussing how they are verified and tested.
 
 /docs/architecture/deployment-execution/README
 /docs/architecture/types/README
-/docs/architecture/languages
-/docs/architecture/providers/README
 /docs/architecture/plugins
+/docs/architecture/providers/README
+/docs/architecture/languages
+/docs/architecture/converters
 /pkg/codegen/README
 /docs/architecture/testing/README
 :::

--- a/docs/architecture/converters.md
+++ b/docs/architecture/converters.md
@@ -1,0 +1,235 @@
+(converters)=
+# Converters
+
+*Converter plugins*, or simply *converters*, are the means by which Pulumi is
+able to import, convert and migrate existing infrastructure as code (IaC)
+programs and state from other ecosystems, such as Terraform or CloudFormation,
+into Pulumi. Converters implement the [](pulumirpc.Converter) interface, which
+defines the [](pulumirpc.Converter.ConvertProgram) method for converting program
+source code and the [](pulumirpc.Converter.ConvertState) method for converting
+existing state.
+
+(program-conversion)=
+## Program conversion
+
+Program conversion is the process of converting an existing infrastructure as
+code program written in one language (e.g. Terraform HCL) into a Pulumi program
+that when run produces the same result. Program conversion is driven primarily
+by the `pulumi convert` command, and typically proceeds as follows:
+
+* A user runs `pulumi convert` on a *source program* written in a supported
+  *source language* (e.g. Terraform HCL). Among other things, this command
+  specifies a *target language* (e.g. TypeScript) and a *target directory* where
+  the converted program will be written. For example, if we run a command like:
+
+  ```bash
+  pulumi convert --from tf --language typescript --out converted .
+  ```
+
+  then:
+
+  * our source language will be Terraform HCL (as indicated by the `--from tf`
+    argument);
+  * our source program will be the current directory (`.`). In the case of
+    Terraform, this means we will load all the `.tf` files we can find in the
+    current directory and its subdirectories;
+  * our target language will be TypeScript (as indicated by the `--language
+    typescript` argument); and
+  * our target directory will be `/converted`.
+
+* `pulumi convert` ("the engine") loads a converter plugin based on the source
+  language. In this case, the source language is `terraform`, so Pulumi will
+  attempt to boot up a plugin named `pulumi-converter-terraform` (see [plugin
+  loading and execution](plugin-loading-execution) for more information on how
+  Pulumi loads plugins).
+
+* The converter's [](pulumirpc.Converter.ConvertProgram) method is called to
+  convert the source program into [PCL](pcl), Pulumi's intermediate
+  representation from which target code can be generated. Like several other
+  Pulumi processes, it is expected that the engine and the converter share a
+  filesystem and that the converter writes PCL files itself as part of the call;
+  the engine will send source and target directory information to the converter
+  to facilitate this. Additionally, the engine will send the following
+  information:
+
+  * Any additional converter-specific arguments that may have been passed to
+    `pulumi convert`
+  * An address to a gRPC server that implements the [](codegen.Loader)
+    interface, which the converter can use to load [schema](schema) for packages
+    in order to facilitate PCL generation. This will typically be the address of
+    the calling engine, which will broker calls to the appropriate
+    [providers](providers) offering the necessary schema.
+  * An address to a gRPC server that implements the [](codegen.Mapper)
+    interface, which the converter can use to map names from the source language
+    to names which match the relevant Pulumi schema. For instance, if converting
+    a Terraform program, the converter might need to map a resource type such as
+    `aws_s3_bucket` to the Pulumi type `aws:s3/bucket:Bucket`. Mapping is the
+    process by which this occurs. As with schema loading, this address will
+    typically be that of the calling engine, which will broker calls to the
+    appropriate providers. Mapping is discussed in more detail in [its own
+    section](converter-mapping) below.
+
+* The converter is expected to write PCL files to the target directory that
+  represent the source program in a language-agnostic way. As indicated above,
+  it may use the provided schema loading and mapping services to facilitate
+  generating PCL that references the appropriate PCL packages, types, property
+  names, and so on.
+
+* Once the call to [](pulumirpc.Converter.ConvertProgram) has completed, the
+  engine will have a set of PCL files that represent the source program in a
+  language-agnostic way. The engine will then call the appropriate [language
+  host's](language-hosts) ["programgen"](programgen) features to generate a
+  Pulumi program in the target language.
+
+The following diagram illustrates this process:
+
+```mermaid
+:zoom:
+
+sequenceDiagram
+    participant LH as Language host
+    participant P as Provider
+    box Engine
+        participant E as Engine
+        participant SL as Schema loader
+        participant M as Mapper
+    end
+    participant C as Converter
+
+    Note right of E: Conversion starts
+    Note right of E: PCL generation starts
+
+    E->>+C: ConvertProgram(source, target, args, SL, M)
+
+    loop As necessary
+        C->>+SL: GetSchema(package)
+        SL->>+P: GetSchema(package)
+        P->>-SL: Schema(package)
+        SL->>-C: Schema(package)
+
+        C->>+M: GetMapping(name, hint)
+
+        Note right of M: If supplied, use hint to find an appropriate plugin
+
+        M->>+P: GetMappings(name)
+        P->>-M: Mappings(name)
+        M->>+P: GetMapping(name)
+        P->>-M: Mapping(name)
+        M->>-C: Mapping(name)
+    end
+
+    C->>-E: Done(target PCL)
+
+    Note right of E: PCL generation completes
+    Note right of E: Target language code generation starts
+
+    E->>+LH: GenerateProject(target PCL)
+
+    loop As necessary
+        LH->>+E: GetSchema(package)
+        E->>+P: GetSchema(package)
+        P->>-E: Schema(package)
+        E->>-LH: Schema(package)
+    end
+
+    LH->>-E: Done(target program)
+
+    Note right of E: Target language code generation completes
+    Note right of E: Conversion completes
+```
+
+(state-conversion)=
+## State conversion
+
+(converter-schema-mapping)=
+(converter-schema)=
+(converter-mapping)=
+## Schema loading and mapping
+
+Suppose we want to convert the following Terraform program:
+
+```hcl
+resource "aws_s3_bucket" "foo" {
+    bucket_name = "my-bucket"
+}
+```
+
+We might expect the following PCL output:
+
+```hcl
+resource "aws:s3/bucket:Bucket" "foo" {
+    bucketName = "my-bucket"
+}
+```
+
+We know from other parts of this document that the `pulumi-converter-terraform`
+plugin will almost certainly be involved, but how is the plugin to know that:
+
+* The `aws_s3_bucket` resource has an equivalent provided by the Pulumi `aws`
+  package?
+* In the Pulumi `aws` package, the `aws:s3/bucket:Bucket` type is used to
+  represent an S3 bucket?
+
+This is where *schema loading* and *mapping* come in. Converting programs and
+state requires knowledge of various Pulumi identifiers and conventions, such as
+which Pulumi package maps to a given Terraform provider (e.g. Pulumi's `gcp` to
+Terraform's `google`), or how some source resource name must be transformed to
+produce a Pulumi equivalent (e.g. turning Terraform's `aws_s3_bucket` into
+Pulumi's `aws:s3/bucket:Bucket`). Rather than baking this knowledge into each
+converters, plugins are furnished with the addresses of [](codegen.Loader) and
+[](codegen.Mapper) gRPC servers that they can use to load schema and map names
+respectively. Since in general this sort of information is provider-specific
+(e.g. the `gcp` provider knows specifically that Terraform resources named
+`gcp_*` can be mapped to Pulumi types of the form `gpc:*/*:*`, etc.), the engine
+exposes implementations of these services that broker calls to the appropriate
+provider. Specifically, [providers](providers) (through the
+[](pulumirpc.ResourceProvider) interface) offer the following methods:
+
+* [](pulumirpc.ResourceProvider.GetSchema), which returns the schema for the
+  package offered by the provider
+* [](pulumirpc.ResourceProvider.GetMappings), which accepts a "conversion key"
+  (the source language being converted from, such as `terraform`) and returns a
+  list of names representing packages *in the source language* for which
+  mappings are available. So for instance, if the Pulumi `gcp` provider maps to
+  the Terraform `google` provider, calling `GetMappings("terraform")` on an
+  instance of the `gcp` plugin might return the list `["google"]`.
+* [](pulumirpc.ResourceProvider.GetMapping), which accepts a conversion key and
+  a *source language provider name*, and returns mapping information for that
+  name. So, for instance, calling `GetMapping("terraform", "google")` on the
+  `gcp` plugin would return mapping information for transforming Terraform
+  programs using `google_*` resources into Pulumi programs using the `gcp`
+  package. In this context, "mapping information" is converter-specific, but
+  will typically be some map from the various kinds of names in the source
+  language to their Pulumi equivalents.
+
+When the engine receives a request to load a schema or mapping from a converter,
+it will iterate through the set of plugins it knows about and do its best to
+pass back the most suitable match to the converter.
+
+### Parameterized plugins and hints
+
+On the surface, a request of the form "find me the mapping for the `aws`
+Terraform provider" is an easy one to satisfy -- the engine simply needs to find
+a plugin called `pulumi-resource-aws`, boot it up, call
+`GetMappings("terraform")`, see that `aws` is in the resulting list, call
+`GetMapping("terraform", "aws")`, and return the result. In the presence of
+[parameterized providers](parameterized-providers), however, things are not
+always so straightforward. For instance, if the `aws` package is provided by an
+instance of the `terraform-provider` plugin, which is [dynamically
+bridging](https://www.pulumi.com/blog/any-terraform-provider/) the Terraform AWS
+provider, then the plugin the engine needs to load is in fact
+`pulumi-resource-terraform-provider`. Moreover, after loading that plugin, the
+engine will need to make a [](pulumirpc.ResourceProvider.Parameterize) call to
+trigger the requisite bridging before requesting schema or mappings. We might
+ask then, how can the engine know whether to look for a package name literally,
+or to find another plugin and parameterize it?
+
+For loading schema, this problem is already solved with *package descriptors*,
+which can capture both a plugin name and an optional parameterization. For
+mappings, a slightly different approach is used, in the form of *hints* (e.g.
+[](codegen.MapperParameterizationHint) at the gRPC layer). Hints are
+instructions from a converter plugin that tell the engine where it might find
+the mappings being requested. These look similar to package descriptors, in that
+a hint may contain a plugin name and an optional parameterization. If the engine
+finds a plugin whose name matches that in the given hint, it will use the hint's
+parameterization (if present) before making the mapping request.

--- a/docs/architecture/plugins.md
+++ b/docs/architecture/plugins.md
@@ -17,9 +17,10 @@ following kinds of plugins:
 * *Analyzer plugins* are used to analyze Pulumi programs for potential issues
   before they are executed. Analyzers underpin [CrossGuard, Pulumi's Policy as
   Code](https://www.pulumi.com/docs/using-pulumi/crossguard/) product.
-* *Converter plugins* support the conversion of existing infrastructure as code
-  (e.g. [Terraform](https://github.com/pulumi/pulumi-converter-terraform)) to
-  Pulumi programs.
+* [*Converter plugins*](converters) support the conversion of existing
+  infrastructure as code (e.g.
+  [Terraform](https://github.com/pulumi/pulumi-converter-terraform)) to Pulumi
+  programs.
 * *Tool plugins* allow integrating Pulumi with arbitrary tools.
 
 (plugin-loading-execution)=

--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -18,7 +18,7 @@
 1921230328 1269 proto/pulumi/errors.proto
 881720039 27131 proto/pulumi/language.proto
 1674803920 2966 proto/pulumi/plugin.proto
-1142872678 57051 proto/pulumi/provider.proto
+3062123329 59444 proto/pulumi/provider.proto
 3423997446 18123 proto/pulumi/resource.proto
 607478140 1008 proto/pulumi/source.proto
 3670315643 2603 proto/pulumi/testing/language.proto

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -211,11 +211,35 @@ service ResourceProvider {
 
     // GetMapping fetches the mapping for this resource provider, if any. A provider should return an empty
     // response (not an error) if it doesn't have a mapping for the given key.
+
+    // `GetMapping` returns mappings designed to aid in [converting programs and state from other
+    // ecosystems](converters). It accepts a "conversion key", which effectively corresponds to a source language, such
+    // as `terraform`, and a *source provider name*, which is the name of the provider *in the source language*. Given
+    // these, it returns source-specific mapping data for the provider requested. As an example, the Pulumi AWS
+    // provider, which is bridged from the Terraform AWS provider and thus capable of mapping names between the two,
+    // might respond to a call with key `terraform` and source provider name `aws` with mapping data for transforming
+    // (among other things) Terraform AWS names such as `aws_s3_bucket` into Pulumi AWS types such as
+    // `aws:s3/bucket:Bucket`. If a provider only supports a single source provider, or has some sensible default, it
+    // may respond also to a call in which the source provider name is empty (`""`), which will be made when the engine
+    // does not have sufficient knowledge to work out which provider offers a specific mapping.
+    //
+    // In general, it is expected that providers implemented by bridging an equivalent provider from another ecosystem
+    // (such as bridged Terraform providers built atop the `pulumi-terraform-bridge`, for instance) implement
+    // `GetMapping` to support conversion from that ecosystem into Pulumi using the same logic that underpins the
+    // bridging itself.
     rpc GetMapping(GetMappingRequest) returns (GetMappingResponse) {}
 
-    // GetMappings is an optional method that returns what mappings (if any) a provider supports. If a provider does not
-    // implement this method the engine falls back to the old behaviour of just calling GetMapping without a name.
-    // If this method is implemented than the engine will then call GetMapping only with the names returned from this method.
+    // `GetMappings` is an optional method designed to aid in [converting programs and state from other
+    // ecosystems](converters). `GetMappings` accepts a "conversion key". This corresponds to a source language, for
+    // which we want to retrieve mappings for names etc. from that source language into Pulumi. An example key might
+    // therefore be `terraform` in the event that we wish to map e.g. Terraform resource names to Pulumi resource types.
+    // Given a key, `GetMappings` returns a list of *source provider names* for which calls to `GetMapping` will return
+    // mappings. So, continuing the Terraform example, the Pulumi AWS provider, which is bridged from the Terraform AWS
+    // provider and thus capable of mapping names between the two, might return the list `["aws"]` in response to a call
+    // with key `terraform`.
+    //
+    // If a provider does not implement `GetMappings`, the engine will fall back to calling `GetMapping` blindly without
+    // a source provider name (that is, with the value `""`).
     rpc GetMappings(GetMappingsRequest) returns (GetMappingsResponse) {}
 }
 
@@ -1012,39 +1036,40 @@ message ErrorResourceInitFailed {
 
 
 
-// GetMappingRequest allows providers to return ecosystem specific information to allow the provider to be
-// converted from a source markup to Pulumi. It's expected that provider bridges that target a given ecosystem
-// (e.g. Terraform, Kubernetes) would also publish a conversion plugin to convert markup from that ecosystem
-// to Pulumi, using the bridged providers.
+// `GetMappingRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.GetMapping) call.
 message GetMappingRequest {
-    // the conversion key for the mapping being requested.
+    // The conversion key for the mapping being requested. This typically corresponds to the source language, such as
+    // `terraform` in the case of mapping Terraform names to Pulumi names.
     string key = 1;
-    // the optional provider key for the mapping being requested, if this is empty the provider should assume this
-    // request is from an old engine from before GetMappings and should return it's "primary" mapping. If this is set
-    // then the `provider` field in GetMappingResponse should be the same.
+
+    // An optional *source provider key* for the mapping being requested. If this is empty, the provider should assume
+    // that this request is from an old engine prior to the introduction of [](pulumirpc.ResourceProvider.GetMappings).
+    // In these cases the request should be answered with the "primary" mapping. If this field is set, the `provider`
+    // field in the corresponding [](pulumirpc.GetMappingResponse) should contain the same value.
     string provider = 2;
 }
 
-// GetMappingResponse returns convert plugin specific data for this provider. This will normally be human
-// readable JSON, but the engine doesn't mandate any form.
+// `GetMappingResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.GetMapping) call. The data
+// within a `GetMappingResponse` will normally be human-readable JSON (e.g. an object mapping names from the source to
+// Pulumi), but the engine doesn't mandate any specific format.
 message GetMappingResponse {
-    // the provider key this is mapping for. For example the Pulumi provider "terraform-template" would return "template" for this.
+    // The *source provider key* that this mapping contains data for.
     string provider = 1;
 
-    // the conversion plugin specific data.
+    // Mapping data in a format specific to the conversion plugin/source language.
     bytes data = 2;
 }
 
-// GetMappingsRequest allows providers to return ecosystem specific information without having to send back large data
-// blobs for provider mappings that the engine doesn't then need.
+// `GetMappingsRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.GetMappings) call.
 message GetMappingsRequest {
-    // the conversion key for the mapping being requested.
+    // The conversion key for the mapping being requested. This typically corresponds to the source language, such as
+    // `terraform` in the case of mapping Terraform names to Pulumi names.
     string key = 1;
 }
 
-// GetMappingsRequest returns a list of providers that this provider can provide mapping information for.
+// `GetMappingsResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.GetMappings) call.
 message GetMappingsResponse {
-    // the provider keys this provider can supply mappings for. For example the Pulumi provider "terraform-template"
-    // would return ["template"] for this.
+    // The set of *source provider keys* this provider can supply mappings for. For example the Pulumi provider
+    // `terraform-template` would return `["template"]` for this.
     repeated string providers = 1;
 }

--- a/sdk/nodejs/proto/provider_grpc_pb.js
+++ b/sdk/nodejs/proto/provider_grpc_pb.js
@@ -736,6 +736,22 @@ attach: {
   },
   // GetMapping fetches the mapping for this resource provider, if any. A provider should return an empty
 // response (not an error) if it doesn't have a mapping for the given key.
+//
+// `GetMapping` returns mappings designed to aid in [converting programs and state from other
+// ecosystems](converters). It accepts a "conversion key", which effectively corresponds to a source language, such
+// as `terraform`, and a *source provider name*, which is the name of the provider *in the source language*. Given
+// these, it returns source-specific mapping data for the provider requested. As an example, the Pulumi AWS
+// provider, which is bridged from the Terraform AWS provider and thus capable of mapping names between the two,
+// might respond to a call with key `terraform` and source provider name `aws` with mapping data for transforming
+// (among other things) Terraform AWS names such as `aws_s3_bucket` into Pulumi AWS types such as
+// `aws:s3/bucket:Bucket`. If a provider only supports a single source provider, or has some sensible default, it
+// may respond also to a call in which the source provider name is empty (`""`), which will be made when the engine
+// does not have sufficient knowledge to work out which provider offers a specific mapping.
+//
+// In general, it is expected that providers implemented by bridging an equivalent provider from another ecosystem
+// (such as bridged Terraform providers built atop the `pulumi-terraform-bridge`, for instance) implement
+// `GetMapping` to support conversion from that ecosystem into Pulumi using the same logic that underpins the
+// bridging itself.
 getMapping: {
     path: '/pulumirpc.ResourceProvider/GetMapping',
     requestStream: false,
@@ -747,9 +763,17 @@ getMapping: {
     responseSerialize: serialize_pulumirpc_GetMappingResponse,
     responseDeserialize: deserialize_pulumirpc_GetMappingResponse,
   },
-  // GetMappings is an optional method that returns what mappings (if any) a provider supports. If a provider does not
-// implement this method the engine falls back to the old behaviour of just calling GetMapping without a name.
-// If this method is implemented than the engine will then call GetMapping only with the names returned from this method.
+  // `GetMappings` is an optional method designed to aid in [converting programs and state from other
+// ecosystems](converters). `GetMappings` accepts a "conversion key". This corresponds to a source language, for
+// which we want to retrieve mappings for names etc. from that source language into Pulumi. An example key might
+// therefore be `terraform` in the event that we wish to map e.g. Terraform resource names to Pulumi resource types.
+// Given a key, `GetMappings` returns a list of *source provider names* for which calls to `GetMapping` will return
+// mappings. So, continuing the Terraform example, the Pulumi AWS provider, which is bridged from the Terraform AWS
+// provider and thus capable of mapping names between the two, might return the list `["aws"]` in response to a call
+// with key `terraform`.
+//
+// If a provider does not implement `GetMappings`, the engine will fall back to calling `GetMapping` blindly without
+// a source provider name (that is, with the value `""`).
 getMappings: {
     path: '/pulumirpc.ResourceProvider/GetMappings',
     requestStream: false,

--- a/sdk/proto/go/provider.pb.go
+++ b/sdk/proto/go/provider.pb.go
@@ -2780,20 +2780,19 @@ func (x *ErrorResourceInitFailed) GetInputs() *structpb.Struct {
 	return nil
 }
 
-// GetMappingRequest allows providers to return ecosystem specific information to allow the provider to be
-// converted from a source markup to Pulumi. It's expected that provider bridges that target a given ecosystem
-// (e.g. Terraform, Kubernetes) would also publish a conversion plugin to convert markup from that ecosystem
-// to Pulumi, using the bridged providers.
+// `GetMappingRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.GetMapping) call.
 type GetMappingRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// the conversion key for the mapping being requested.
+	// The conversion key for the mapping being requested. This typically corresponds to the source language, such as
+	// `terraform` in the case of mapping Terraform names to Pulumi names.
 	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
-	// the optional provider key for the mapping being requested, if this is empty the provider should assume this
-	// request is from an old engine from before GetMappings and should return it's "primary" mapping. If this is set
-	// then the `provider` field in GetMappingResponse should be the same.
+	// An optional *source provider key* for the mapping being requested. If this is empty, the provider should assume
+	// that this request is from an old engine prior to the introduction of [](pulumirpc.ResourceProvider.GetMappings).
+	// In these cases the request should be answered with the "primary" mapping. If this field is set, the `provider`
+	// field in the corresponding [](pulumirpc.GetMappingResponse) should contain the same value.
 	Provider string `protobuf:"bytes,2,opt,name=provider,proto3" json:"provider,omitempty"`
 }
 
@@ -2843,16 +2842,17 @@ func (x *GetMappingRequest) GetProvider() string {
 	return ""
 }
 
-// GetMappingResponse returns convert plugin specific data for this provider. This will normally be human
-// readable JSON, but the engine doesn't mandate any form.
+// `GetMappingResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.GetMapping) call. The data
+// within a `GetMappingResponse` will normally be human-readable JSON (e.g. an object mapping names from the source to
+// Pulumi), but the engine doesn't mandate any specific format.
 type GetMappingResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// the provider key this is mapping for. For example the Pulumi provider "terraform-template" would return "template" for this.
+	// The *source provider key* that this mapping contains data for.
 	Provider string `protobuf:"bytes,1,opt,name=provider,proto3" json:"provider,omitempty"`
-	// the conversion plugin specific data.
+	// Mapping data in a format specific to the conversion plugin/source language.
 	Data []byte `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
 }
 
@@ -2902,14 +2902,14 @@ func (x *GetMappingResponse) GetData() []byte {
 	return nil
 }
 
-// GetMappingsRequest allows providers to return ecosystem specific information without having to send back large data
-// blobs for provider mappings that the engine doesn't then need.
+// `GetMappingsRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.GetMappings) call.
 type GetMappingsRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// the conversion key for the mapping being requested.
+	// The conversion key for the mapping being requested. This typically corresponds to the source language, such as
+	// `terraform` in the case of mapping Terraform names to Pulumi names.
 	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 }
 
@@ -2952,14 +2952,14 @@ func (x *GetMappingsRequest) GetKey() string {
 	return ""
 }
 
-// GetMappingsRequest returns a list of providers that this provider can provide mapping information for.
+// `GetMappingsResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.GetMappings) call.
 type GetMappingsResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// the provider keys this provider can supply mappings for. For example the Pulumi provider "terraform-template"
-	// would return ["template"] for this.
+	// The set of *source provider keys* this provider can supply mappings for. For example the Pulumi provider
+	// `terraform-template` would return `["template"]` for this.
 	Providers []string `protobuf:"bytes,1,rep,name=providers,proto3" json:"providers,omitempty"`
 }
 

--- a/sdk/proto/go/provider_grpc.pb.go
+++ b/sdk/proto/go/provider_grpc.pb.go
@@ -187,12 +187,33 @@ type ResourceProviderClient interface {
 	GetPluginInfo(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*PluginInfo, error)
 	// Attach sends the engine address to an already running plugin.
 	Attach(ctx context.Context, in *PluginAttach, opts ...grpc.CallOption) (*emptypb.Empty, error)
-	// GetMapping fetches the mapping for this resource provider, if any. A provider should return an empty
-	// response (not an error) if it doesn't have a mapping for the given key.
+	// `GetMapping` returns mappings designed to aid in [converting programs and state from other
+	// ecosystems](converters). It accepts a "conversion key", which effectively corresponds to a source language, such
+	// as `terraform`, and a *source provider name*, which is the name of the provider *in the source language*. Given
+	// these, it returns source-specific mapping data for the provider requested. As an example, the Pulumi AWS
+	// provider, which is bridged from the Terraform AWS provider and thus capable of mapping names between the two,
+	// might respond to a call with key `terraform` and source provider name `aws` with mapping data for transforming
+	// (among other things) Terraform AWS names such as `aws_s3_bucket` into Pulumi AWS types such as
+	// `aws:s3/bucket:Bucket`. If a provider only supports a single source provider, or has some sensible default, it
+	// may respond also to a call in which the source provider name is empty (`""`), which will be made when the engine
+	// does not have sufficient knowledge to work out which provider offers a specific mapping.
+	//
+	// In general, it is expected that providers implemented by bridging an equivalent provider from another ecosystem
+	// (such as bridged Terraform providers built atop the `pulumi-terraform-bridge`, for instance) implement
+	// `GetMapping` to support conversion from that ecosystem into Pulumi using the same logic that underpins the
+	// bridging itself.
 	GetMapping(ctx context.Context, in *GetMappingRequest, opts ...grpc.CallOption) (*GetMappingResponse, error)
-	// GetMappings is an optional method that returns what mappings (if any) a provider supports. If a provider does not
-	// implement this method the engine falls back to the old behaviour of just calling GetMapping without a name.
-	// If this method is implemented than the engine will then call GetMapping only with the names returned from this method.
+	// `GetMappings` is an optional method designed to aid in [converting programs and state from other
+	// ecosystems](converters). `GetMappings` accepts a "conversion key". This corresponds to a source language, for
+	// which we want to retrieve mappings for names etc. from that source language into Pulumi. An example key might
+	// therefore be `terraform` in the event that we wish to map e.g. Terraform resource names to Pulumi resource types.
+	// Given a key, `GetMappings` returns a list of *source provider names* for which calls to `GetMapping` will return
+	// mappings. So, continuing the Terraform example, the Pulumi AWS provider, which is bridged from the Terraform AWS
+	// provider and thus capable of mapping names between the two, might return the list `["aws"]` in response to a call
+	// with key `terraform`.
+	//
+	// If a provider does not implement `GetMappings`, the engine will fall back to calling `GetMapping` blindly without
+	// a source provider name (that is, with the value `""`).
 	GetMappings(ctx context.Context, in *GetMappingsRequest, opts ...grpc.CallOption) (*GetMappingsResponse, error)
 }
 
@@ -584,12 +605,33 @@ type ResourceProviderServer interface {
 	GetPluginInfo(context.Context, *emptypb.Empty) (*PluginInfo, error)
 	// Attach sends the engine address to an already running plugin.
 	Attach(context.Context, *PluginAttach) (*emptypb.Empty, error)
-	// GetMapping fetches the mapping for this resource provider, if any. A provider should return an empty
-	// response (not an error) if it doesn't have a mapping for the given key.
+	// `GetMapping` returns mappings designed to aid in [converting programs and state from other
+	// ecosystems](converters). It accepts a "conversion key", which effectively corresponds to a source language, such
+	// as `terraform`, and a *source provider name*, which is the name of the provider *in the source language*. Given
+	// these, it returns source-specific mapping data for the provider requested. As an example, the Pulumi AWS
+	// provider, which is bridged from the Terraform AWS provider and thus capable of mapping names between the two,
+	// might respond to a call with key `terraform` and source provider name `aws` with mapping data for transforming
+	// (among other things) Terraform AWS names such as `aws_s3_bucket` into Pulumi AWS types such as
+	// `aws:s3/bucket:Bucket`. If a provider only supports a single source provider, or has some sensible default, it
+	// may respond also to a call in which the source provider name is empty (`""`), which will be made when the engine
+	// does not have sufficient knowledge to work out which provider offers a specific mapping.
+	//
+	// In general, it is expected that providers implemented by bridging an equivalent provider from another ecosystem
+	// (such as bridged Terraform providers built atop the `pulumi-terraform-bridge`, for instance) implement
+	// `GetMapping` to support conversion from that ecosystem into Pulumi using the same logic that underpins the
+	// bridging itself.
 	GetMapping(context.Context, *GetMappingRequest) (*GetMappingResponse, error)
-	// GetMappings is an optional method that returns what mappings (if any) a provider supports. If a provider does not
-	// implement this method the engine falls back to the old behaviour of just calling GetMapping without a name.
-	// If this method is implemented than the engine will then call GetMapping only with the names returned from this method.
+	// `GetMappings` is an optional method designed to aid in [converting programs and state from other
+	// ecosystems](converters). `GetMappings` accepts a "conversion key". This corresponds to a source language, for
+	// which we want to retrieve mappings for names etc. from that source language into Pulumi. An example key might
+	// therefore be `terraform` in the event that we wish to map e.g. Terraform resource names to Pulumi resource types.
+	// Given a key, `GetMappings` returns a list of *source provider names* for which calls to `GetMapping` will return
+	// mappings. So, continuing the Terraform example, the Pulumi AWS provider, which is bridged from the Terraform AWS
+	// provider and thus capable of mapping names between the two, might return the list `["aws"]` in response to a call
+	// with key `terraform`.
+	//
+	// If a provider does not implement `GetMappings`, the engine will fall back to calling `GetMapping` blindly without
+	// a source provider name (that is, with the value `""`).
 	GetMappings(context.Context, *GetMappingsRequest) (*GetMappingsResponse, error)
 	mustEmbedUnimplementedResourceProviderServer()
 }

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
@@ -1753,22 +1753,21 @@ global___ErrorResourceInitFailed = ErrorResourceInitFailed
 
 @typing_extensions.final
 class GetMappingRequest(google.protobuf.message.Message):
-    """GetMappingRequest allows providers to return ecosystem specific information to allow the provider to be
-    converted from a source markup to Pulumi. It's expected that provider bridges that target a given ecosystem
-    (e.g. Terraform, Kubernetes) would also publish a conversion plugin to convert markup from that ecosystem
-    to Pulumi, using the bridged providers.
-    """
+    """`GetMappingRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.GetMapping) call."""
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     KEY_FIELD_NUMBER: builtins.int
     PROVIDER_FIELD_NUMBER: builtins.int
     key: builtins.str
-    """the conversion key for the mapping being requested."""
+    """The conversion key for the mapping being requested. This typically corresponds to the source language, such as
+    `terraform` in the case of mapping Terraform names to Pulumi names.
+    """
     provider: builtins.str
-    """the optional provider key for the mapping being requested, if this is empty the provider should assume this
-    request is from an old engine from before GetMappings and should return it's "primary" mapping. If this is set
-    then the `provider` field in GetMappingResponse should be the same.
+    """An optional *source provider key* for the mapping being requested. If this is empty, the provider should assume
+    that this request is from an old engine prior to the introduction of [](pulumirpc.ResourceProvider.GetMappings).
+    In these cases the request should be answered with the "primary" mapping. If this field is set, the `provider`
+    field in the corresponding [](pulumirpc.GetMappingResponse) should contain the same value.
     """
     def __init__(
         self,
@@ -1782,8 +1781,9 @@ global___GetMappingRequest = GetMappingRequest
 
 @typing_extensions.final
 class GetMappingResponse(google.protobuf.message.Message):
-    """GetMappingResponse returns convert plugin specific data for this provider. This will normally be human
-    readable JSON, but the engine doesn't mandate any form.
+    """`GetMappingResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.GetMapping) call. The data
+    within a `GetMappingResponse` will normally be human-readable JSON (e.g. an object mapping names from the source to
+    Pulumi), but the engine doesn't mandate any specific format.
     """
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
@@ -1791,9 +1791,9 @@ class GetMappingResponse(google.protobuf.message.Message):
     PROVIDER_FIELD_NUMBER: builtins.int
     DATA_FIELD_NUMBER: builtins.int
     provider: builtins.str
-    """the provider key this is mapping for. For example the Pulumi provider "terraform-template" would return "template" for this."""
+    """The *source provider key* that this mapping contains data for."""
     data: builtins.bytes
-    """the conversion plugin specific data."""
+    """Mapping data in a format specific to the conversion plugin/source language."""
     def __init__(
         self,
         *,
@@ -1806,15 +1806,15 @@ global___GetMappingResponse = GetMappingResponse
 
 @typing_extensions.final
 class GetMappingsRequest(google.protobuf.message.Message):
-    """GetMappingsRequest allows providers to return ecosystem specific information without having to send back large data
-    blobs for provider mappings that the engine doesn't then need.
-    """
+    """`GetMappingsRequest` is the type of requests sent as part of a [](pulumirpc.ResourceProvider.GetMappings) call."""
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     KEY_FIELD_NUMBER: builtins.int
     key: builtins.str
-    """the conversion key for the mapping being requested."""
+    """The conversion key for the mapping being requested. This typically corresponds to the source language, such as
+    `terraform` in the case of mapping Terraform names to Pulumi names.
+    """
     def __init__(
         self,
         *,
@@ -1826,15 +1826,15 @@ global___GetMappingsRequest = GetMappingsRequest
 
 @typing_extensions.final
 class GetMappingsResponse(google.protobuf.message.Message):
-    """GetMappingsRequest returns a list of providers that this provider can provide mapping information for."""
+    """`GetMappingsResponse` is the type of responses sent by a [](pulumirpc.ResourceProvider.GetMappings) call."""
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     PROVIDERS_FIELD_NUMBER: builtins.int
     @property
     def providers(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """the provider keys this provider can supply mappings for. For example the Pulumi provider "terraform-template"
-        would return ["template"] for this.
+        """The set of *source provider keys* this provider can supply mappings for. For example the Pulumi provider
+        `terraform-template` would return `["template"]` for this.
         """
     def __init__(
         self,

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
@@ -396,15 +396,39 @@ class ResourceProviderServicer(object):
     def GetMapping(self, request, context):
         """GetMapping fetches the mapping for this resource provider, if any. A provider should return an empty
         response (not an error) if it doesn't have a mapping for the given key.
+
+        `GetMapping` returns mappings designed to aid in [converting programs and state from other
+        ecosystems](converters). It accepts a "conversion key", which effectively corresponds to a source language, such
+        as `terraform`, and a *source provider name*, which is the name of the provider *in the source language*. Given
+        these, it returns source-specific mapping data for the provider requested. As an example, the Pulumi AWS
+        provider, which is bridged from the Terraform AWS provider and thus capable of mapping names between the two,
+        might respond to a call with key `terraform` and source provider name `aws` with mapping data for transforming
+        (among other things) Terraform AWS names such as `aws_s3_bucket` into Pulumi AWS types such as
+        `aws:s3/bucket:Bucket`. If a provider only supports a single source provider, or has some sensible default, it
+        may respond also to a call in which the source provider name is empty (`""`), which will be made when the engine
+        does not have sufficient knowledge to work out which provider offers a specific mapping.
+
+        In general, it is expected that providers implemented by bridging an equivalent provider from another ecosystem
+        (such as bridged Terraform providers built atop the `pulumi-terraform-bridge`, for instance) implement
+        `GetMapping` to support conversion from that ecosystem into Pulumi using the same logic that underpins the
+        bridging itself.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def GetMappings(self, request, context):
-        """GetMappings is an optional method that returns what mappings (if any) a provider supports. If a provider does not
-        implement this method the engine falls back to the old behaviour of just calling GetMapping without a name.
-        If this method is implemented than the engine will then call GetMapping only with the names returned from this method.
+        """`GetMappings` is an optional method designed to aid in [converting programs and state from other
+        ecosystems](converters). `GetMappings` accepts a "conversion key". This corresponds to a source language, for
+        which we want to retrieve mappings for names etc. from that source language into Pulumi. An example key might
+        therefore be `terraform` in the event that we wish to map e.g. Terraform resource names to Pulumi resource types.
+        Given a key, `GetMappings` returns a list of *source provider names* for which calls to `GetMapping` will return
+        mappings. So, continuing the Terraform example, the Pulumi AWS provider, which is bridged from the Terraform AWS
+        provider and thus capable of mapping names between the two, might return the list `["aws"]` in response to a call
+        with key `terraform`.
+
+        If a provider does not implement `GetMappings`, the engine will fall back to calling `GetMapping` blindly without
+        a source provider name (that is, with the value `""`).
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.pyi
@@ -272,14 +272,38 @@ class ResourceProviderStub:
     ]
     """GetMapping fetches the mapping for this resource provider, if any. A provider should return an empty
     response (not an error) if it doesn't have a mapping for the given key.
+
+    `GetMapping` returns mappings designed to aid in [converting programs and state from other
+    ecosystems](converters). It accepts a "conversion key", which effectively corresponds to a source language, such
+    as `terraform`, and a *source provider name*, which is the name of the provider *in the source language*. Given
+    these, it returns source-specific mapping data for the provider requested. As an example, the Pulumi AWS
+    provider, which is bridged from the Terraform AWS provider and thus capable of mapping names between the two,
+    might respond to a call with key `terraform` and source provider name `aws` with mapping data for transforming
+    (among other things) Terraform AWS names such as `aws_s3_bucket` into Pulumi AWS types such as
+    `aws:s3/bucket:Bucket`. If a provider only supports a single source provider, or has some sensible default, it
+    may respond also to a call in which the source provider name is empty (`""`), which will be made when the engine
+    does not have sufficient knowledge to work out which provider offers a specific mapping.
+
+    In general, it is expected that providers implemented by bridging an equivalent provider from another ecosystem
+    (such as bridged Terraform providers built atop the `pulumi-terraform-bridge`, for instance) implement
+    `GetMapping` to support conversion from that ecosystem into Pulumi using the same logic that underpins the
+    bridging itself.
     """
     GetMappings: grpc.UnaryUnaryMultiCallable[
         pulumi.provider_pb2.GetMappingsRequest,
         pulumi.provider_pb2.GetMappingsResponse,
     ]
-    """GetMappings is an optional method that returns what mappings (if any) a provider supports. If a provider does not
-    implement this method the engine falls back to the old behaviour of just calling GetMapping without a name.
-    If this method is implemented than the engine will then call GetMapping only with the names returned from this method.
+    """`GetMappings` is an optional method designed to aid in [converting programs and state from other
+    ecosystems](converters). `GetMappings` accepts a "conversion key". This corresponds to a source language, for
+    which we want to retrieve mappings for names etc. from that source language into Pulumi. An example key might
+    therefore be `terraform` in the event that we wish to map e.g. Terraform resource names to Pulumi resource types.
+    Given a key, `GetMappings` returns a list of *source provider names* for which calls to `GetMapping` will return
+    mappings. So, continuing the Terraform example, the Pulumi AWS provider, which is bridged from the Terraform AWS
+    provider and thus capable of mapping names between the two, might return the list `["aws"]` in response to a call
+    with key `terraform`.
+
+    If a provider does not implement `GetMappings`, the engine will fall back to calling `GetMapping` blindly without
+    a source provider name (that is, with the value `""`).
     """
 
 class ResourceProviderServicer(metaclass=abc.ABCMeta):
@@ -569,6 +593,22 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
     ) -> pulumi.provider_pb2.GetMappingResponse:
         """GetMapping fetches the mapping for this resource provider, if any. A provider should return an empty
         response (not an error) if it doesn't have a mapping for the given key.
+
+        `GetMapping` returns mappings designed to aid in [converting programs and state from other
+        ecosystems](converters). It accepts a "conversion key", which effectively corresponds to a source language, such
+        as `terraform`, and a *source provider name*, which is the name of the provider *in the source language*. Given
+        these, it returns source-specific mapping data for the provider requested. As an example, the Pulumi AWS
+        provider, which is bridged from the Terraform AWS provider and thus capable of mapping names between the two,
+        might respond to a call with key `terraform` and source provider name `aws` with mapping data for transforming
+        (among other things) Terraform AWS names such as `aws_s3_bucket` into Pulumi AWS types such as
+        `aws:s3/bucket:Bucket`. If a provider only supports a single source provider, or has some sensible default, it
+        may respond also to a call in which the source provider name is empty (`""`), which will be made when the engine
+        does not have sufficient knowledge to work out which provider offers a specific mapping.
+
+        In general, it is expected that providers implemented by bridging an equivalent provider from another ecosystem
+        (such as bridged Terraform providers built atop the `pulumi-terraform-bridge`, for instance) implement
+        `GetMapping` to support conversion from that ecosystem into Pulumi using the same logic that underpins the
+        bridging itself.
         """
     
     def GetMappings(
@@ -576,9 +616,17 @@ class ResourceProviderServicer(metaclass=abc.ABCMeta):
         request: pulumi.provider_pb2.GetMappingsRequest,
         context: grpc.ServicerContext,
     ) -> pulumi.provider_pb2.GetMappingsResponse:
-        """GetMappings is an optional method that returns what mappings (if any) a provider supports. If a provider does not
-        implement this method the engine falls back to the old behaviour of just calling GetMapping without a name.
-        If this method is implemented than the engine will then call GetMapping only with the names returned from this method.
+        """`GetMappings` is an optional method designed to aid in [converting programs and state from other
+        ecosystems](converters). `GetMappings` accepts a "conversion key". This corresponds to a source language, for
+        which we want to retrieve mappings for names etc. from that source language into Pulumi. An example key might
+        therefore be `terraform` in the event that we wish to map e.g. Terraform resource names to Pulumi resource types.
+        Given a key, `GetMappings` returns a list of *source provider names* for which calls to `GetMapping` will return
+        mappings. So, continuing the Terraform example, the Pulumi AWS provider, which is bridged from the Terraform AWS
+        provider and thus capable of mapping names between the two, might return the list `["aws"]` in response to a call
+        with key `terraform`.
+
+        If a provider does not implement `GetMappings`, the engine will fall back to calling `GetMapping` blindly without
+        a source provider name (that is, with the value `""`).
         """
 
 def add_ResourceProviderServicer_to_server(servicer: ResourceProviderServicer, server: typing.Union[grpc.Server, grpc.aio.Server]) -> None: ...


### PR DESCRIPTION
Following the recent work on `pulumi convert` and supporting more Terraform conversion than ever, this change bulks out the developer documentation on how conversion and converter plugins work under the hood, in order to capture some of the details discovered and introduced as part of this effort.