### PR TITLE
Don't Exit in ArgsFunc

### DIFF
--- a/sdk/go/common/util/cmdutil/args.go
+++ b/sdk/go/common/util/cmdutil/args.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/spf13/cobra"
 )
 

--- a/sdk/go/common/util/cmdutil/args.go
+++ b/sdk/go/common/util/cmdutil/args.go
@@ -28,10 +28,8 @@ func ArgsFunc(argsValidator cobra.PositionalArgs) cobra.PositionalArgs {
 		err := argsValidator(cmd, args)
 		if err != nil {
 			contract.IgnoreError(cmd.Help())
-			Exit(err)
 		}
-
-		return nil
+		return err
 	}
 }
 

--- a/sdk/go/common/util/cmdutil/args.go
+++ b/sdk/go/common/util/cmdutil/args.go
@@ -15,6 +15,7 @@
 package cmdutil
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"

--- a/sdk/go/common/util/cmdutil/args.go
+++ b/sdk/go/common/util/cmdutil/args.go
@@ -27,7 +27,7 @@ func ArgsFunc(argsValidator cobra.PositionalArgs) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		err := argsValidator(cmd, args)
 		if err != nil {
-			contract.IgnoreError(cmd.Help())
+			return errors.Join(cmd.Help(), err)
 		}
 		return err
 	}


### PR DESCRIPTION
Following on from https://github.com/pulumi/pulumi/pull/18767 we no longer need to Exit in our args validation function. We can't totally get rid of our custom validator here because it prints help text for bad arguments, while cobra either prints help text for _all_ errors, or no help text if SuppressUsage is set (we set that).

This does unlock being able to unit test command parsing.