### PR TITLE
Loader: use descriptor name when loading package references

### DIFF
--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -211,6 +211,7 @@ func (l *pluginLoader) LoadPackageReferenceV2(
 	if err != nil {
 		return nil, err
 	}
+	p.def.Name = descriptor.Name
 	return p, nil
 }
 


### PR DESCRIPTION
The descriptor name is the source of truth for package naming, especially in light of Git plugins, where the name of the plugin on disk doesn't necessarily match the schema anymore.  Make the schema loader respect that.

Part of fixing https://github.com/pulumi/pulumi/issues/18805