### PR TITLE
Use go.uber.org/automaxprocs to respect cgroup cpu limits

### DIFF
--- a/changelog/pending/20250306--engine--engine-will-respect-cgroup-limits-for-parallel.yaml
+++ b/changelog/pending/20250306--engine--engine-will-respect-cgroup-limits-for-parallel.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Engine will respect cgroup limits for --parallel

--- a/pkg/cmd/pulumi/main.go
+++ b/pkg/cmd/pulumi/main.go
@@ -53,7 +53,7 @@ func panicHandler(finished *bool) {
 
 func main() {
 	// Fix for https://github.com/pulumi/pulumi/issues/18814, set GOMAXPROCs to the number of CPUs available
-	// taking into account quotes and cgroup limits.
+	// taking into account quotas and cgroup limits.
 	maxprocs.Set() //nolint:errcheck // we don't care if this fails
 
 	finished := new(bool)

--- a/pkg/cmd/pulumi/main.go
+++ b/pkg/cmd/pulumi/main.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
+
+	"go.uber.org/automaxprocs/maxprocs"
 )
 
 // panicHandler displays an emergency error message to the user and a stack trace to
@@ -50,6 +52,10 @@ func panicHandler(finished *bool) {
 }
 
 func main() {
+	// Fix for https://github.com/pulumi/pulumi/issues/18814, set GOMAXPROCs to the number of CPUs available
+	// taking into account quotes and cgroup limits.
+	maxprocs.Set()
+
 	finished := new(bool)
 	defer panicHandler(finished)
 

--- a/pkg/cmd/pulumi/main.go
+++ b/pkg/cmd/pulumi/main.go
@@ -54,7 +54,7 @@ func panicHandler(finished *bool) {
 func main() {
 	// Fix for https://github.com/pulumi/pulumi/issues/18814, set GOMAXPROCs to the number of CPUs available
 	// taking into account quotes and cgroup limits.
-	maxprocs.Set()
+	maxprocs.Set() //nolint:errcheck // we don't care if this fails
 
 	finished := new(bool)
 	defer panicHandler(finished)

--- a/pkg/cmd/pulumi/operations/flags_test.go
+++ b/pkg/cmd/pulumi/operations/flags_test.go
@@ -67,7 +67,7 @@ func TestContinueOnErrorEnvVar(t *testing.T) {
 
 //nolint:paralleltest // Changes environment variables
 func TestParallelEnvVar(t *testing.T) {
-	osDefaultParallel := int32(runtime.NumCPU()) * 4 //nolint:gosec
+	osDefaultParallel := int32(runtime.GOMAXPROCS(0)) * 4 //nolint:gosec
 	commands := []func() *cobra.Command{
 		NewUpCmd,
 		NewPreviewCmd,

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -54,8 +54,8 @@ import (
 
 func defaultParallel() int32 {
 	// Initialize parallel from environment if available, otherwise use defaultParallel
-	osDefaultParallel := int32(runtime.NumCPU()) * 4 //nolint:gosec // NumCPU is an int32 internally,
-	// but the NumCPU function returns an int.
+	osDefaultParallel := int32(runtime.GOMAXPROCS(0)) * 4 //nolint:gosec
+	// GOMAXPROCS is an int32 internally, but the GOMAXPROCS function returns an int.
 	var defaultParallel int32
 	if p := env.Parallel.Value(); p > 0 {
 		if p > math.MaxInt32 {
@@ -66,7 +66,7 @@ func defaultParallel() int32 {
 			defaultParallel = int32(p) //nolint:gosec
 		}
 	} else {
-		defaultParallel = osDefaultParallel //nolint:gosec
+		defaultParallel = osDefaultParallel
 	}
 
 	return defaultParallel

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -103,6 +103,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.22.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.pennock.tech/tabular v1.1.3
+	go.uber.org/automaxprocs v1.6.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/mod v0.19.0
 	golang.org/x/sys v0.28.0

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -528,6 +528,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
+github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435cARxCW6q9gc0S/Yxz7Mkd38pOb0=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
@@ -655,6 +657,8 @@ go.pennock.tech/tabular v1.1.3 h1:JYN3TdVkTjOWdZz2FwKcW7f69vRhPl4NAQqJ8RZAsmY=
 go.pennock.tech/tabular v1.1.3/go.mod h1:UzyxF5itNqTCS1ZGXfwDwbFgYj/lS+e67Fid68QOYZ0=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
+go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 gocloud.dev v0.37.0 h1:XF1rN6R0qZI/9DYjN16Uy0durAmSlf58DHOcb28GPro=

--- a/sdk/go/common/util/cmdutil/trace.go
+++ b/sdk/go/common/util/cmdutil/trace.go
@@ -215,6 +215,10 @@ func rootSpanTags() []opentracing.Tag {
 			Value: runtime.GOARCH,
 		},
 		{
+			Key:   "runtime.GOMAXPROCS",
+			Value: runtime.GOMAXPROCS(0),
+		},
+		{
 			Key:   "runtime.NumCPU",
 			Value: runtime.NumCPU(),
 		},

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -3690,6 +3690,7 @@ go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/automaxprocs v1.5.1/go.mod h1:BF4eumQw0P9GtnuxxovUd06vwm1o18oMzFtK66vU6XU=
 go.uber.org/automaxprocs v1.5.3/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnwa1WM0=
+go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.1.11-0.20210813005559-691160354723/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -1037,7 +1037,9 @@ func TestParallelCgroups(t *testing.T) {
 	path = filepath.Dir(path)
 
 	// Runs `pulumi up --help` inside a limited CPU context
-	cmd := exec.Command("docker", "run", "--rm", "--cpus=1", "-v", path+":/mnt", "ubuntu", "/mnt/pulumi", "up", "--help")
+	cmd := exec.Command( //nolint:gosec
+		"docker", "run", "--rm", "--cpus=1", "-v", path+":/mnt", "ubuntu",
+		"/mnt/pulumi", "up", "--help")
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err)
 	limitedParallel := getParallelCount(string(output))

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -1015,6 +1015,11 @@ func TestImportParameterizedSmokeFreshState(t *testing.T) {
 func TestParallelCgroups(t *testing.T) {
 	t.Parallel()
 
+	// This test mounts the pulumi binary into a linux docker container so the host needs to be linux as well.
+	if runtime.GOOS != "linux" {
+		t.Skip("skipping test on non-linux host")
+	}
+
 	// This test uses docker so skip if we can't find that
 	_, err := exec.LookPath("docker")
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/18814

Nice small fix thanks to Uber's libraries. This will override GOMAXPROC, and then uses that to decide the value for --parallel.