### PR TITLE
Fold a couple of simple commands into just cobra runs

### DIFF
--- a/pkg/cmd/pulumi/packagecmd/package_pack_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_pack_sdk.go
@@ -15,7 +15,6 @@
 package packagecmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -28,49 +27,41 @@ import (
 )
 
 func newPackagePackCmd() *cobra.Command {
-	var packCmd packCmd
 	cmd := &cobra.Command{
 		Use:    "pack-sdk <language> <path>",
 		Args:   cobra.ExactArgs(2),
 		Short:  "Pack a package SDK to a language specific artifact.",
 		Hidden: !env.Dev.Value(),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			return packCmd.Run(ctx, args)
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("get current working directory: %w", err)
+			}
+
+			pCtx, err := NewPluginContext(cwd)
+			if err != nil {
+				return fmt.Errorf("create plugin context: %w", err)
+			}
+			defer contract.IgnoreClose(pCtx.Host)
+
+			language := args[0]
+			path := args[1]
+
+			programInfo := plugin.NewProgramInfo(pCtx.Root, cwd, ".", nil)
+			languagePlugin, err := pCtx.Host.LanguageRuntime(language, programInfo)
+			if err != nil {
+				return err
+			}
+
+			artifact, err := languagePlugin.Pack(path, cwd)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("%s", artifact)
+
+			return nil
 		},
 	}
 	return cmd
-}
-
-type packCmd struct{}
-
-func (cmd *packCmd) Run(ctx context.Context, args []string) error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("get current working directory: %w", err)
-	}
-
-	pCtx, err := NewPluginContext(cwd)
-	if err != nil {
-		return fmt.Errorf("create plugin context: %w", err)
-	}
-	defer contract.IgnoreClose(pCtx.Host)
-
-	language := args[0]
-	path := args[1]
-
-	programInfo := plugin.NewProgramInfo(pCtx.Root, cwd, ".", nil)
-	languagePlugin, err := pCtx.Host.LanguageRuntime(language, programInfo)
-	if err != nil {
-		return err
-	}
-
-	artifact, err := languagePlugin.Pack(path, cwd)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("%s", artifact)
-
-	return nil
 }

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -15,7 +15,6 @@
 package packagecmd
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -30,48 +29,39 @@ import (
 )
 
 func newPackagePublishCmd() *cobra.Command {
-	var publCmd publishCmd
+	var path string
 	cmd := &cobra.Command{
 		Use:    "publish-sdk <language>",
 		Args:   cobra.RangeArgs(0, 1),
 		Short:  "Publish a package SDK to supported package registries.",
 		Hidden: !env.Dev.Value(),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			return publCmd.Run(ctx, args)
+			lang := "all"
+			if len(args) > 0 {
+				lang = args[0]
+			}
+
+			switch lang {
+			case "nodejs":
+				err := publishToNPM(path)
+				if err != nil {
+					return err
+				}
+			case "all", "python", "java", "dotnet":
+				return fmt.Errorf("support for %q coming soon", lang)
+
+			default:
+				return fmt.Errorf("unsupported language %q", lang)
+			}
+
+			return nil
 		},
 	}
-	cmd.PersistentFlags().StringVar(&publCmd.Path, "path", "",
+	cmd.PersistentFlags().StringVar(&path, "path", "",
 		`The path to the root of your package.
 	Example: ./sdk/nodejs
 	`)
 	return cmd
-}
-
-type publishCmd struct {
-	Path string
-}
-
-func (cmd *publishCmd) Run(ctx context.Context, args []string) error {
-	lang := "all"
-	if len(args) > 0 {
-		lang = args[0]
-	}
-
-	switch lang {
-	case "nodejs":
-		err := publishToNPM(cmd.Path)
-		if err != nil {
-			return err
-		}
-	case "all", "python", "java", "dotnet":
-		return fmt.Errorf("support for %q coming soon", lang)
-
-	default:
-		return fmt.Errorf("unsupported language %q", lang)
-	}
-
-	return nil
 }
 
 func publishToNPM(path string) error {

--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -15,7 +15,6 @@
 package plugin
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -35,97 +34,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-type pluginRunCmd struct {
-	kind string
-}
-
-func (cmd *pluginRunCmd) run(ctx context.Context, args []string) error {
-	if !apitype.IsPluginKind(cmd.kind) {
-		return fmt.Errorf("unrecognized plugin kind: %s", cmd.kind)
-	}
-	kind := apitype.PluginKind(cmd.kind)
-
-	// Parse the name and version from the second argument in the form of "NAME[@VERSION]".
-	name := args[0]
-	var version *semver.Version
-	if namePart, versionPart, ok := strings.Cut(name, "@"); ok {
-		v, err := semver.ParseTolerant(versionPart)
-		if err != nil {
-			return fmt.Errorf("invalid plugin version %q: %w", versionPart, err)
-		}
-		name = namePart
-		version = &v
-	}
-
-	if !tokens.IsName(name) {
-		return fmt.Errorf("invalid plugin name %q", name)
-	}
-
-	pluginDesc := fmt.Sprintf("%s %s", kind, name)
-	if version != nil {
-		pluginDesc = fmt.Sprintf("%s@%s", pluginDesc, version)
-	}
-
-	d := diag.DefaultSink(os.Stdout, os.Stderr, diag.FormatOptions{Color: cmdutil.GetGlobalColorization()})
-
-	path, err := workspace.GetPluginPath(d, kind, name, version, nil)
-	if err != nil {
-		// Try to install the plugin, unless auto plugin installs are turned off.
-		var me *workspace.MissingError
-		if !errors.As(err, &me) || env.DisableAutomaticPluginAcquisition.Value() {
-			// Not a MissingError, return the original error.
-			return fmt.Errorf("could not get plugin path: %w", err)
-		}
-
-		// TODO: Add support for --server and --checksums.
-		pluginSpec, err := workspace.NewPluginSpec(args[0], kind, nil, "", nil)
-		if err != nil {
-			return err
-		}
-
-		log := func(sev diag.Severity, msg string) {
-			d.Logf(sev, diag.RawMessage("", msg))
-		}
-
-		_, err = pkgWorkspace.InstallPlugin(ctx, pluginSpec, log)
-		if err != nil {
-			return err
-		}
-
-		path, err = workspace.GetPluginPath(d, kind, name, version, nil)
-		if err != nil {
-			return fmt.Errorf("could not get plugin path: %w", err)
-		}
-	}
-
-	pluginArgs := args[1:]
-
-	pluginCmd := exec.Command(path, pluginArgs...)
-	pluginCmd.Stdout = os.Stdout
-	pluginCmd.Stderr = os.Stderr
-	pluginCmd.Stdin = os.Stdin
-	if err := pluginCmd.Run(); err != nil {
-		var pathErr *os.PathError
-		if errors.As(err, &pathErr) {
-			syscallErr, ok := pathErr.Err.(syscall.Errno)
-			if ok && syscallErr == syscall.ENOENT {
-				return fmt.Errorf("could not find execute plugin %s, binary not found at %s", pluginDesc, path)
-			}
-		}
-
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			os.Exit(exitErr.ExitCode())
-		}
-
-		return fmt.Errorf("could not execute plugin %s (%s): %w", pluginDesc, path, err)
-	}
-
-	return nil
-}
-
 func newPluginRunCmd() *cobra.Command {
-	var c pluginRunCmd
+	var kind string
 
 	cmd := &cobra.Command{
 		Use:    "run NAME[@VERSION] [ARGS]",
@@ -137,11 +47,93 @@ func newPluginRunCmd() *cobra.Command {
 			"Directly executes a plugin binary, if VERSION is not specified " +
 			"the latest installed plugin will be used.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return c.run(cmd.Context(), args)
+			ctx := cmd.Context()
+			if !apitype.IsPluginKind(kind) {
+				return fmt.Errorf("unrecognized plugin kind: %s", kind)
+			}
+			kind := apitype.PluginKind(kind)
+
+			// Parse the name and version from the second argument in the form of "NAME[@VERSION]".
+			name := args[0]
+			var version *semver.Version
+			if namePart, versionPart, ok := strings.Cut(name, "@"); ok {
+				v, err := semver.ParseTolerant(versionPart)
+				if err != nil {
+					return fmt.Errorf("invalid plugin version %q: %w", versionPart, err)
+				}
+				name = namePart
+				version = &v
+			}
+
+			if !tokens.IsName(name) {
+				return fmt.Errorf("invalid plugin name %q", name)
+			}
+
+			pluginDesc := fmt.Sprintf("%s %s", kind, name)
+			if version != nil {
+				pluginDesc = fmt.Sprintf("%s@%s", pluginDesc, version)
+			}
+
+			d := diag.DefaultSink(os.Stdout, os.Stderr, diag.FormatOptions{Color: cmdutil.GetGlobalColorization()})
+
+			path, err := workspace.GetPluginPath(d, kind, name, version, nil)
+			if err != nil {
+				// Try to install the plugin, unless auto plugin installs are turned off.
+				var me *workspace.MissingError
+				if !errors.As(err, &me) || env.DisableAutomaticPluginAcquisition.Value() {
+					// Not a MissingError, return the original error.
+					return fmt.Errorf("could not get plugin path: %w", err)
+				}
+
+				// TODO: Add support for --server and --checksums.
+				pluginSpec, err := workspace.NewPluginSpec(args[0], kind, nil, "", nil)
+				if err != nil {
+					return err
+				}
+
+				log := func(sev diag.Severity, msg string) {
+					d.Logf(sev, diag.RawMessage("", msg))
+				}
+
+				_, err = pkgWorkspace.InstallPlugin(ctx, pluginSpec, log)
+				if err != nil {
+					return err
+				}
+
+				path, err = workspace.GetPluginPath(d, kind, name, version, nil)
+				if err != nil {
+					return fmt.Errorf("could not get plugin path: %w", err)
+				}
+			}
+
+			pluginArgs := args[1:]
+
+			pluginCmd := exec.Command(path, pluginArgs...)
+			pluginCmd.Stdout = os.Stdout
+			pluginCmd.Stderr = os.Stderr
+			pluginCmd.Stdin = os.Stdin
+			if err := pluginCmd.Run(); err != nil {
+				var pathErr *os.PathError
+				if errors.As(err, &pathErr) {
+					syscallErr, ok := pathErr.Err.(syscall.Errno)
+					if ok && syscallErr == syscall.ENOENT {
+						return fmt.Errorf("could not find execute plugin %s, binary not found at %s", pluginDesc, path)
+					}
+				}
+
+				var exitErr *exec.ExitError
+				if errors.As(err, &exitErr) {
+					os.Exit(exitErr.ExitCode())
+				}
+
+				return fmt.Errorf("could not execute plugin %s (%s): %w", pluginDesc, path, err)
+			}
+
+			return nil
 		},
 	}
 
-	cmd.PersistentFlags().StringVar(&c.kind,
+	cmd.PersistentFlags().StringVar(&kind,
 		"kind", "tool", "The plugin kind")
 
 	return cmd


### PR DESCRIPTION
In the push to get rid of the "cmd" struct wrappers and just test directly against cobra, this gets rid of a couple of simple ones.