### PR TITLE
print all diagnostic errors when getting the schema failed

### DIFF
--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -15,10 +15,12 @@
 package packagecmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/hashicorp/hcl/v2"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -88,6 +90,10 @@ extension, Pulumi package schema is read from it directly:
 
 			pkg, err := SchemaFromSchemaSource(pctx, plugin, parameters)
 			if err != nil {
+				var diagErr hcl.Diagnostics
+				if errors.As(err, &diagErr) {
+					return fmt.Errorf("failed to get schema.  Diagnostics: %w", errors.Join(diagErr.Errs()...))
+				}
 				return fmt.Errorf("failed to get schema: %w", err)
 			}
 

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -92,7 +92,7 @@ extension, Pulumi package schema is read from it directly:
 			if err != nil {
 				var diagErr hcl.Diagnostics
 				if errors.As(err, &diagErr) {
-					return fmt.Errorf("failed to get schema.  Diagnostics: %w", errors.Join(diagErr.Errs()...))
+					return fmt.Errorf("failed to get schema. Diagnostics: %w", errors.Join(diagErr.Errs()...))
 				}
 				return fmt.Errorf("failed to get schema: %w", err)
 			}


### PR DESCRIPTION
When getting the schema fails and returns a diagnostics error we currently only print the first error, and say "x more diagnostics". This happens e.g. when the schema fails to validate against the pulumi.json schema.  It's often helpful to see the entire list of errors instead, as that helps seeing the whole picture.  Print the whole list instead.