### PR TITLE
Add experimental package publishing command

### DIFF
--- a/changelog/pending/20250306--cli-package--add-experimental-package-publishing-command.yaml
+++ b/changelog/pending/20250306--cli-package--add-experimental-package-publishing-command.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/package
+  description: Add experimental package publishing command

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -262,7 +262,7 @@ type Backend interface {
 	// to ListTemplates.
 	DownloadTemplate(ctx context.Context, orgName, sourceURL string) (TarReaderCloser, error)
 
-	// GetPackageRegistry returns a PackageRegistry object tied to this backend, or nil if it cannot be found.
+	// GetPackageRegistry returns a PackageRegistry object tied to this backend
 	GetPackageRegistry() (PackageRegistry, error)
 }
 

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -261,6 +261,9 @@ type Backend interface {
 	// Templates are valid to download if and only if they would be returned by a call
 	// to ListTemplates.
 	DownloadTemplate(ctx context.Context, orgName, sourceURL string) (TarReaderCloser, error)
+
+	// GetPackageRegistry returns a PackageRegistry object tied to this backend, or nil if it cannot be found.
+	GetPackageRegistry() (PackageRegistry, error)
 }
 
 // EnvironmentsBackend is an interface that defines an optional capability for a backend to work with environments.

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1499,3 +1499,7 @@ func (b *diyBackend) getParallel() int {
 	}
 	return parallel
 }
+
+func (b *diyBackend) GetPackageRegistry() (backend.PackageRegistry, error) {
+	return nil, errors.New("package registry is not supported by diy backends")
+}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -2150,3 +2150,7 @@ func (b *cloudBackend) DefaultSecretManager(*workspace.ProjectStack) (secrets.Ma
 	// been created.
 	return nil, nil
 }
+
+func (b *cloudBackend) GetPackageRegistry() (backend.PackageRegistry, error) {
+	return newCloudPackageRegistry(b.client), nil
+}

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -17,14 +17,18 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
@@ -312,4 +316,20 @@ func TestDisableIntegrityChecking(t *testing.T) {
 	snap, err = s.Snapshot(ctx, b64.Base64SecretsProvider)
 	require.NoError(t, err)
 	assert.NotNil(t, snap)
+}
+
+func TestCloudBackend_GetPackageRegistry(t *testing.T) {
+	t.Parallel()
+	mockClient := &client.Client{}
+	b := &cloudBackend{
+		client: mockClient,
+		d:      diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never}),
+	}
+
+	registry, err := b.GetPackageRegistry()
+	assert.NoError(t, err)
+	assert.NotNil(t, registry)
+
+	_, ok := registry.(*cloudPackageRegistry)
+	assert.True(t, ok, "expected registry to be a cloudPackageRegistry")
 }

--- a/pkg/backend/httpstate/client/api_endpoints.go
+++ b/pkg/backend/httpstate/client/api_endpoints.go
@@ -122,4 +122,8 @@ func init() {
 	// APIs for managing Search capabilities
 	addEndpoint("GET", "/api/orgs/{orgName}/search/resources", "getSearchResources")
 	addEndpoint("GET", "/api/orgs/{orgName}/search/resources/parse", "getSearchResourcesParse")
+
+	// APIs for interacting with the Package Registry
+	addEndpoint("POST", "/api/preview/registry/packages/{source}/{publisher}/{name}/versions", "publishPackage")
+	addEndpoint("POST", "/api/preview/registry/packages/{source}/{publisher}/{name}/versions/{version}/complete", "completePackagePublish")
 }

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1416,16 +1416,16 @@ func (pc *Client) PublishPackage(ctx context.Context, input PublishPackageInput)
 		return nil
 	}
 
-	err = uploadFile(resp.UploadUrls.Schema, input.Schema, "schema")
+	err = uploadFile(resp.UploadURLs.Schema, input.Schema, "schema")
 	if err != nil {
 		return err
 	}
-	err = uploadFile(resp.UploadUrls.Index, input.Readme, "index")
+	err = uploadFile(resp.UploadURLs.Index, input.Readme, "index")
 	if err != nil {
 		return err
 	}
 	if input.InstallDocs != nil {
-		err = uploadFile(resp.UploadUrls.InstallationConfiguration, input.InstallDocs, "installation configuration")
+		err = uploadFile(resp.UploadURLs.InstallationConfiguration, input.InstallDocs, "installation configuration")
 		if err != nil {
 			return err
 		}

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1371,19 +1371,21 @@ func (pc *Client) SubmitAIPrompt(ctx context.Context, requestBody interface{}) (
 }
 
 type PublishPackageInput struct {
-	// Source represents package source in the registry system (e.g., 'pulumi', 'opentofu')
+	// Source is the source of the package. Typically this is 'pulumi' for packages published to the Pulumi Registry.
+	// Packages loaded from other registries (e.g. 'opentofu') will point to the origin of the package.
 	Source string
-	// Publisher is the organization that is publishing the package
+	// Publisher is the organization that is publishing the package.
 	Publisher string
-	// Name is the URL friendly name of the package (e.g., 'aws')
+	// Name is the URL-safe name of the package.
 	Name string
-	// Version is the SemVer version of the package
+	// Version is the semantic version of the package that should get published.
 	Version semver.Version
-	// Schema is the schema of the package
+	// Schema is a reader containing the JSON schema of the package.
 	Schema io.Reader
-	// Readme is the readme of the package
+	// Readme is a reader containing the markdown content of the package's README.
 	Readme io.Reader
-	// InstallDocs is the installation docs of the package
+	// InstallDocs is a reader containing the markdown content of the package's installation documentation.
+	// This is optional, and if omitted, the package will not have installation documentation.
 	InstallDocs io.Reader
 }
 

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1388,8 +1388,11 @@ type PublishPackageInput struct {
 }
 
 func (pc *Client) PublishPackage(ctx context.Context, input PublishPackageInput) error {
+	req := apitype.StartPackagePublishRequest{
+		Version: input.Version.String(),
+	}
 	var resp apitype.StartPackagePublishResponse
-	err := pc.restCall(ctx, "POST", publishPackagePath(input.Source, input.Publisher, input.Name), nil, nil, &resp)
+	err := pc.restCall(ctx, "POST", publishPackagePath(input.Source, input.Publisher, input.Name), nil, req, &resp)
 	if err != nil {
 		return fmt.Errorf("publish package failed: %w", err)
 	}

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1412,7 +1412,11 @@ func (pc *Client) PublishPackage(ctx context.Context, input PublishPackageInput)
 		if err != nil {
 			return fmt.Errorf("failed to upload %s: %w", fileType, err)
 		} else if uploadResp.StatusCode >= 400 {
-			return fmt.Errorf("failed to upload %s: %s", fileType, uploadResp.Status)
+			body, bodyErr := readBody(uploadResp)
+			if bodyErr != nil {
+				return fmt.Errorf("failed to upload %s: %s", fileType, uploadResp.Status)
+			}
+			return fmt.Errorf("failed to upload %s: %s - %s", fileType, uploadResp.Status, string(body))
 		}
 
 		return nil

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1370,26 +1370,7 @@ func (pc *Client) SubmitAIPrompt(ctx context.Context, requestBody interface{}) (
 	return res, err
 }
 
-type PublishPackageInput struct {
-	// Source is the source of the package. Typically this is 'pulumi' for packages published to the Pulumi Registry.
-	// Packages loaded from other registries (e.g. 'opentofu') will point to the origin of the package.
-	Source string
-	// Publisher is the organization that is publishing the package.
-	Publisher string
-	// Name is the URL-safe name of the package.
-	Name string
-	// Version is the semantic version of the package that should get published.
-	Version semver.Version
-	// Schema is a reader containing the JSON schema of the package.
-	Schema io.Reader
-	// Readme is a reader containing the markdown content of the package's README.
-	Readme io.Reader
-	// InstallDocs is a reader containing the markdown content of the package's installation documentation.
-	// This is optional, and if omitted, the package will not have installation documentation.
-	InstallDocs io.Reader
-}
-
-func (pc *Client) PublishPackage(ctx context.Context, input PublishPackageInput) error {
+func (pc *Client) PublishPackage(ctx context.Context, input apitype.PackagePublishOp) error {
 	req := apitype.StartPackagePublishRequest{
 		Version: input.Version.String(),
 	}

--- a/pkg/backend/httpstate/client/client_package_test.go
+++ b/pkg/backend/httpstate/client/client_package_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"

--- a/pkg/backend/httpstate/client/client_package_test.go
+++ b/pkg/backend/httpstate/client/client_package_test.go
@@ -39,7 +39,7 @@ type testCase struct {
 	name             string
 	setupServer      func(blobStorage *httptest.Server) *httptest.Server
 	setupBlobStorage func() *httptest.Server
-	input            *PublishPackageInput
+	input            *apitype.PackagePublishOp
 	errorMessage     string
 	httpClient       *http.Client
 }
@@ -274,7 +274,7 @@ func TestPublishPackage(t *testing.T) {
 					}
 				}))
 			},
-			input: &PublishPackageInput{
+			input: &apitype.PackagePublishOp{
 				Source:      "pulumi",
 				Publisher:   "test-publisher",
 				Name:        "test-package",
@@ -390,11 +390,11 @@ func TestPublishPackage(t *testing.T) {
 				},
 			}
 
-			var input PublishPackageInput
+			var input apitype.PackagePublishOp
 			if tt.input != nil {
 				input = *tt.input
 			} else {
-				input = PublishPackageInput{
+				input = apitype.PackagePublishOp{
 					Source:      "pulumi",
 					Publisher:   "test-publisher",
 					Name:        "test-package",

--- a/pkg/backend/httpstate/client/client_package_test.go
+++ b/pkg/backend/httpstate/client/client_package_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2025, Pulumi Corporation.
+// Copyright 2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/backend/httpstate/client/client_package_test.go
+++ b/pkg/backend/httpstate/client/client_package_test.go
@@ -60,7 +60,7 @@ func TestPublishPackage(t *testing.T) {
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
-							UploadUrls: apitype.PackageUpload{
+							UploadURLs: apitype.PackageUpload{
 								Schema:                    blobStorage.URL + "/upload/schema",
 								Index:                     blobStorage.URL + "/upload/index",
 								InstallationConfiguration: blobStorage.URL + "/upload/install",
@@ -113,7 +113,7 @@ func TestPublishPackage(t *testing.T) {
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
-							UploadUrls: apitype.PackageUpload{
+							UploadURLs: apitype.PackageUpload{
 								Schema:                    blobStorage.URL + "/upload/schema",
 								Index:                     blobStorage.URL + "/upload/index",
 								InstallationConfiguration: blobStorage.URL + "/upload/install",
@@ -146,7 +146,7 @@ func TestPublishPackage(t *testing.T) {
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
-							UploadUrls: apitype.PackageUpload{
+							UploadURLs: apitype.PackageUpload{
 								Schema:                    blobStorage.URL + "/upload/schema",
 								Index:                     blobStorage.URL + "/upload/index",
 								InstallationConfiguration: blobStorage.URL + "/upload/install",
@@ -179,7 +179,7 @@ func TestPublishPackage(t *testing.T) {
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
-							UploadUrls: apitype.PackageUpload{
+							UploadURLs: apitype.PackageUpload{
 								Schema:                    blobStorage.URL + "/upload/schema",
 								Index:                     blobStorage.URL + "/upload/index",
 								InstallationConfiguration: blobStorage.URL + "/upload/install",
@@ -208,7 +208,7 @@ func TestPublishPackage(t *testing.T) {
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
-							UploadUrls: apitype.PackageUpload{
+							UploadURLs: apitype.PackageUpload{
 								Schema:                    blobStorage.URL + "/upload/schema",
 								Index:                     blobStorage.URL + "/upload/index",
 								InstallationConfiguration: blobStorage.URL + "/upload/install",
@@ -246,7 +246,7 @@ func TestPublishPackage(t *testing.T) {
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
-							UploadUrls: apitype.PackageUpload{
+							UploadURLs: apitype.PackageUpload{
 								Schema:                    blobStorage.URL + "/upload/schema",
 								Index:                     blobStorage.URL + "/upload/index",
 								InstallationConfiguration: blobStorage.URL + "/upload/install",

--- a/pkg/backend/httpstate/client/client_package_test.go
+++ b/pkg/backend/httpstate/client/client_package_test.go
@@ -1,0 +1,324 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testSchemaData  = []byte(`{"name": "test-package", "version": "1.0.0"}`)
+	testReadmeData  = []byte("# Test Package\nThis is a test package")
+	testInstallData = []byte("# Installation\nHow to install this package")
+)
+
+type testCase struct {
+	name             string
+	setupServer      func(blobStorage *httptest.Server) *httptest.Server
+	setupBlobStorage func() *httptest.Server
+	input            *PublishPackageInput
+	errorMessage     string
+}
+
+func TestPublishPackage(t *testing.T) {
+	t.Parallel()
+
+	tests := []testCase{
+		{
+			name: "SuccessfulPublish",
+			setupBlobStorage: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}))
+			},
+			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+						w.WriteHeader(http.StatusAccepted)
+						response := apitype.StartPackagePublishResponse{
+							OperationID: "test-operation-id",
+							UploadUrls: apitype.PackageUpload{
+								Schema:                    blobStorage.URL + "/upload/schema",
+								Index:                     blobStorage.URL + "/upload/index",
+								InstallationConfiguration: blobStorage.URL + "/upload/install",
+							},
+							RequiredHeaders: map[string]string{
+								"Content-Type": "application/octet-stream",
+							},
+						}
+						require.NoError(t, json.NewEncoder(w).Encode(response))
+
+					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions/1.0.0/complete":
+						w.WriteHeader(http.StatusCreated)
+					}
+				}))
+			},
+		},
+		{
+			name: "FailedStartPublish",
+			setupBlobStorage: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}))
+			},
+			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions" {
+						w.WriteHeader(http.StatusInternalServerError)
+						_, err := w.Write([]byte("Internal Server Error"))
+						require.NoError(t, err)
+					}
+				}))
+			},
+			errorMessage: "publish package failed",
+		},
+		{
+			name: "FailedSchemaUpload",
+			setupBlobStorage: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/upload/schema" {
+						w.WriteHeader(http.StatusForbidden)
+					} else {
+						w.WriteHeader(http.StatusOK)
+					}
+				}))
+			},
+			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+						w.WriteHeader(http.StatusAccepted)
+						response := apitype.StartPackagePublishResponse{
+							OperationID: "test-operation-id",
+							UploadUrls: apitype.PackageUpload{
+								Schema:                    blobStorage.URL + "/upload/schema",
+								Index:                     blobStorage.URL + "/upload/index",
+								InstallationConfiguration: blobStorage.URL + "/upload/install",
+							},
+							RequiredHeaders: map[string]string{
+								"Content-Type": "application/octet-stream",
+							},
+						}
+						require.NoError(t, json.NewEncoder(w).Encode(response))
+					}
+				}))
+			},
+			errorMessage: "failed to upload schema",
+		},
+		{
+			name: "FailedReadmeUpload",
+			setupBlobStorage: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/upload/index" {
+						w.WriteHeader(http.StatusForbidden)
+					} else {
+						w.WriteHeader(http.StatusOK)
+					}
+				}))
+			},
+			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+						w.WriteHeader(http.StatusAccepted)
+						response := apitype.StartPackagePublishResponse{
+							OperationID: "test-operation-id",
+							UploadUrls: apitype.PackageUpload{
+								Schema:                    blobStorage.URL + "/upload/schema",
+								Index:                     blobStorage.URL + "/upload/index",
+								InstallationConfiguration: blobStorage.URL + "/upload/install",
+							},
+							RequiredHeaders: map[string]string{
+								"Content-Type": "application/octet-stream",
+							},
+						}
+						require.NoError(t, json.NewEncoder(w).Encode(response))
+					}
+				}))
+			},
+			errorMessage: "failed to upload index",
+		},
+		{
+			name: "FailedInstallDocsUpload",
+			setupBlobStorage: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/upload/install" {
+						w.WriteHeader(http.StatusForbidden)
+					} else {
+						w.WriteHeader(http.StatusOK)
+					}
+				}))
+			},
+			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+						w.WriteHeader(http.StatusAccepted)
+						response := apitype.StartPackagePublishResponse{
+							OperationID: "test-operation-id",
+							UploadUrls: apitype.PackageUpload{
+								Schema:                    blobStorage.URL + "/upload/schema",
+								Index:                     blobStorage.URL + "/upload/index",
+								InstallationConfiguration: blobStorage.URL + "/upload/install",
+							},
+							RequiredHeaders: map[string]string{
+								"Content-Type": "application/octet-stream",
+							},
+						}
+						require.NoError(t, json.NewEncoder(w).Encode(response))
+					}
+				}))
+			},
+			errorMessage: "failed to upload installation configuration",
+		},
+		{
+			name: "FailedCompletePublish",
+			setupBlobStorage: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}))
+			},
+			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+						w.WriteHeader(http.StatusAccepted)
+						response := apitype.StartPackagePublishResponse{
+							OperationID: "test-operation-id",
+							UploadUrls: apitype.PackageUpload{
+								Schema:                    blobStorage.URL + "/upload/schema",
+								Index:                     blobStorage.URL + "/upload/index",
+								InstallationConfiguration: blobStorage.URL + "/upload/install",
+							},
+							RequiredHeaders: map[string]string{
+								"Content-Type": "application/octet-stream",
+							},
+						}
+						require.NoError(t, json.NewEncoder(w).Encode(response))
+					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions/1.0.0/complete":
+						w.WriteHeader(http.StatusInternalServerError)
+						_, err := w.Write([]byte("Failed to complete"))
+						require.NoError(t, err)
+					}
+				}))
+			},
+			errorMessage: "failed to complete package publishing operation",
+		},
+		{
+			name: "PublishWithoutInstallDocs",
+			setupBlobStorage: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/upload/install" {
+						// prevent uploading the install docs. If it's attempted the test will fail
+						w.WriteHeader(http.StatusForbidden)
+					} else {
+						w.WriteHeader(http.StatusCreated)
+					}
+				}))
+			},
+			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+						w.WriteHeader(http.StatusAccepted)
+						response := apitype.StartPackagePublishResponse{
+							OperationID: "test-operation-id",
+							UploadUrls: apitype.PackageUpload{
+								Schema:                    blobStorage.URL + "/upload/schema",
+								Index:                     blobStorage.URL + "/upload/index",
+								InstallationConfiguration: blobStorage.URL + "/upload/install",
+							},
+							RequiredHeaders: map[string]string{
+								"Content-Type": "application/octet-stream",
+							},
+						}
+						require.NoError(t, json.NewEncoder(w).Encode(response))
+
+					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions/1.0.0/complete":
+						w.WriteHeader(http.StatusCreated)
+					}
+				}))
+			},
+			input: &PublishPackageInput{
+				Source:      "pulumi",
+				Publisher:   "test-publisher",
+				Name:        "test-package",
+				Version:     semver.MustParse("1.0.0"),
+				Schema:      bytes.NewReader(testSchemaData),
+				Readme:      bytes.NewReader(testReadmeData),
+				InstallDocs: nil, // No install docs
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			blobStorage := tt.setupBlobStorage()
+			defer blobStorage.Close()
+			server := tt.setupServer(blobStorage)
+			defer server.Close()
+
+			// Create client pointing to our test server
+			client := &Client{
+				apiURL:     server.URL,
+				apiToken:   "fake-token",
+				httpClient: http.DefaultClient,
+				restClient: &defaultRESTClient{
+					client: &defaultHTTPClient{
+						client: http.DefaultClient,
+					},
+				},
+			}
+
+			var input PublishPackageInput
+			if tt.input != nil {
+				input = *tt.input
+			} else {
+				input = PublishPackageInput{
+					Source:      "pulumi",
+					Publisher:   "test-publisher",
+					Name:        "test-package",
+					Version:     semver.MustParse("1.0.0"),
+					Schema:      bytes.NewReader(testSchemaData),
+					Readme:      bytes.NewReader(testReadmeData),
+					InstallDocs: bytes.NewReader(testInstallData),
+				}
+			}
+
+			// Call the function
+			err := client.PublishPackage(context.Background(), input)
+
+			// Check results
+			if tt.errorMessage != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMessage)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/backend/httpstate/mock.go
+++ b/pkg/backend/httpstate/mock.go
@@ -43,6 +43,7 @@ type MockHTTPBackend struct {
 		deploymentInitiator string,
 		suppressStreamLogs bool,
 	) error
+	FGetPackageRegistry func() (backend.PackageRegistry, error)
 }
 
 func (b *MockHTTPBackend) Client() *client.Client {
@@ -88,6 +89,10 @@ func (b *MockHTTPBackend) Search(
 
 func (b *MockHTTPBackend) Capabilities(context.Context) apitype.Capabilities {
 	return apitype.Capabilities{}
+}
+
+func (b *MockHTTPBackend) GetPackageRegistry() (backend.PackageRegistry, error) {
+	return b.FGetPackageRegistry()
 }
 
 var _ Backend = (*MockHTTPBackend)(nil)

--- a/pkg/backend/httpstate/package_registry.go
+++ b/pkg/backend/httpstate/package_registry.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
 type cloudPackageRegistry struct {
@@ -33,14 +34,6 @@ func newCloudPackageRegistry(cl *client.Client) *cloudPackageRegistry {
 
 var _ backend.PackageRegistry = (*cloudPackageRegistry)(nil)
 
-func (r *cloudPackageRegistry) Publish(ctx ctx.Context, op backend.PackagePublishOp) error {
-	return r.cl.PublishPackage(ctx, client.PublishPackageInput{
-		Source:      op.Source,
-		Publisher:   op.Publisher,
-		Name:        op.Name,
-		Version:     op.Version,
-		Schema:      op.Schema,
-		Readme:      op.Readme,
-		InstallDocs: op.InstallDocs,
-	})
+func (r *cloudPackageRegistry) Publish(ctx ctx.Context, op apitype.PackagePublishOp) error {
+	return r.cl.PublishPackage(ctx, op)
 }

--- a/pkg/backend/httpstate/package_registry.go
+++ b/pkg/backend/httpstate/package_registry.go
@@ -1,10 +1,10 @@
-// Copyright (\d{4}-)?\d{4}, Pulumi Corporation.
+// Copyright 2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// \s*http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/backend/httpstate/package_registry.go
+++ b/pkg/backend/httpstate/package_registry.go
@@ -1,0 +1,46 @@
+// Copyright (\d{4}-)?\d{4}, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// \s*http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpstate
+
+import (
+	ctx "context"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+)
+
+type cloudPackageRegistry struct {
+	cl *client.Client
+}
+
+func newCloudPackageRegistry(cl *client.Client) *cloudPackageRegistry {
+	return &cloudPackageRegistry{
+		cl: cl,
+	}
+}
+
+var _ backend.PackageRegistry = (*cloudPackageRegistry)(nil)
+
+func (r *cloudPackageRegistry) Publish(ctx ctx.Context, op backend.PackagePublishOp) error {
+	return r.cl.PublishPackage(ctx, client.PublishPackageInput{
+		Source:      op.Source,
+		Publisher:   op.Publisher,
+		Name:        op.Name,
+		Version:     op.Version,
+		Schema:      op.Schema,
+		Readme:      op.Readme,
+		InstallDocs: op.InstallDocs,
+	})
+}

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -840,12 +840,12 @@ func (m MockTarReader) Tar() *tar.Reader {
 }
 
 type MockPackageRegistry struct {
-	PublishF func(context.Context, PackagePublishOp) error
+	PublishF func(context.Context, apitype.PackagePublishOp) error
 }
 
 var _ PackageRegistry = (*MockPackageRegistry)(nil)
 
-func (mr *MockPackageRegistry) Publish(ctx context.Context, op PackagePublishOp) error {
+func (mr *MockPackageRegistry) Publish(ctx context.Context, op apitype.PackagePublishOp) error {
 	if mr.PublishF != nil {
 		return mr.PublishF(ctx, op)
 	}

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -96,10 +96,10 @@ type MockBackend struct {
 
 	DefaultSecretManagerF func(ps *workspace.ProjectStack) (secrets.Manager, error)
 
-	SupportsTemplatesF func() bool
-	ListTemplatesF     func(_ context.Context, orgName string) (apitype.ListOrgTemplatesResponse, error)
-	DownloadTemplateF  func(_ context.Context, orgName, templateSource string) (TarReaderCloser, error)
-	GetPackageRegistryF   func() (PackageRegistry, error)
+	SupportsTemplatesF  func() bool
+	ListTemplatesF      func(_ context.Context, orgName string) (apitype.ListOrgTemplatesResponse, error)
+	DownloadTemplateF   func(_ context.Context, orgName, templateSource string) (TarReaderCloser, error)
+	GetPackageRegistryF func() (PackageRegistry, error)
 }
 
 var _ Backend = (*MockBackend)(nil)

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -99,6 +99,7 @@ type MockBackend struct {
 	SupportsTemplatesF func() bool
 	ListTemplatesF     func(_ context.Context, orgName string) (apitype.ListOrgTemplatesResponse, error)
 	DownloadTemplateF  func(_ context.Context, orgName, templateSource string) (TarReaderCloser, error)
+	GetPackageRegistryF   func() (PackageRegistry, error)
 }
 
 var _ Backend = (*MockBackend)(nil)
@@ -468,6 +469,13 @@ func (be *MockBackend) DownloadTemplate(ctx context.Context, orgName, templateSo
 	panic("not implemented")
 }
 
+func (be *MockBackend) GetPackageRegistry() (PackageRegistry, error) {
+	if be.GetPackageRegistryF != nil {
+		return be.GetPackageRegistryF()
+	}
+	panic("not implemented")
+}
+
 var _ = EnvironmentsBackend((*MockEnvironmentsBackend)(nil))
 
 type MockEnvironmentsBackend struct {
@@ -829,4 +837,17 @@ func (m MockTarReader) Tar() *tar.Reader {
 
 	contract.AssertNoErrorf(w.Close(), "impossible")
 	return tar.NewReader(&b)
+}
+
+type MockPackageRegistry struct {
+	PublishF func(context.Context, PackagePublishOp) error
+}
+
+var _ PackageRegistry = (*MockPackageRegistry)(nil)
+
+func (mr *MockPackageRegistry) Publish(ctx context.Context, op PackagePublishOp) error {
+	if mr.PublishF != nil {
+		return mr.PublishF(ctx, op)
+	}
+	panic("not implemented")
 }

--- a/pkg/backend/package_registry.go
+++ b/pkg/backend/package_registry.go
@@ -22,12 +22,21 @@ import (
 )
 
 type PackagePublishOp struct {
-	Source      string
-	Publisher   string
-	Name        string
-	Version     semver.Version
-	Schema      io.Reader
-	Readme      io.Reader
+	// Source is the source of the package. Typically this is 'pulumi' for packages published to the Pulumi Registry.
+	// Packages loaded from other registries (e.g. 'opentofu') will point to the origin of the package.
+	Source string
+	// Publisher is the name of the publisher of the package. I.e. the organization name.
+	Publisher string
+	// Name is the URL-safe name of the package.
+	Name string
+	// Version is the semantic version of the package that should get published.
+	Version semver.Version
+	// Schema is a reader containing the JSON schema of the package.
+	Schema io.Reader
+	// Readme is a reader containing the markdown content of the package's README.
+	Readme io.Reader
+	// InstallDocs is a reader containing the markdown content of the package's installation documentation.
+	// This is optional, and if omitted, the package will not have installation documentation.
 	InstallDocs io.Reader
 }
 

--- a/pkg/backend/package_registry.go
+++ b/pkg/backend/package_registry.go
@@ -25,7 +25,7 @@ type PackagePublishOp struct {
 	// Source is the source of the package. Typically this is 'pulumi' for packages published to the Pulumi Registry.
 	// Packages loaded from other registries (e.g. 'opentofu') will point to the origin of the package.
 	Source string
-	// Publisher is the name of the publisher of the package. I.e. the organization name.
+	// Publisher is the organization that is publishing the package.
 	Publisher string
 	// Name is the URL-safe name of the package.
 	Name string

--- a/pkg/backend/package_registry.go
+++ b/pkg/backend/package_registry.go
@@ -1,0 +1,37 @@
+// Copyright (\d{4}-)?\d{4}, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// \s*http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	ctx "context"
+	"io"
+
+	"github.com/blang/semver"
+)
+
+type PackagePublishOp struct {
+	Source      string
+	Publisher   string
+	Name        string
+	Version     semver.Version
+	Schema      io.Reader
+	Readme      io.Reader
+	InstallDocs io.Reader
+}
+
+type PackageRegistry interface {
+	// Publish publishes a package to the package registry.
+	Publish(ctx ctx.Context, op PackagePublishOp) error
+}

--- a/pkg/backend/package_registry.go
+++ b/pkg/backend/package_registry.go
@@ -1,10 +1,10 @@
-// Copyright (\d{4}-)?\d{4}, Pulumi Corporation.
+// Copyright 2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// \s*http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/backend/package_registry.go
+++ b/pkg/backend/package_registry.go
@@ -16,31 +16,11 @@ package backend
 
 import (
 	ctx "context"
-	"io"
 
-	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
-
-type PackagePublishOp struct {
-	// Source is the source of the package. Typically this is 'pulumi' for packages published to the Pulumi Registry.
-	// Packages loaded from other registries (e.g. 'opentofu') will point to the origin of the package.
-	Source string
-	// Publisher is the organization that is publishing the package.
-	Publisher string
-	// Name is the URL-safe name of the package.
-	Name string
-	// Version is the semantic version of the package that should get published.
-	Version semver.Version
-	// Schema is a reader containing the JSON schema of the package.
-	Schema io.Reader
-	// Readme is a reader containing the markdown content of the package's README.
-	Readme io.Reader
-	// InstallDocs is a reader containing the markdown content of the package's installation documentation.
-	// This is optional, and if omitted, the package will not have installation documentation.
-	InstallDocs io.Reader
-}
 
 type PackageRegistry interface {
 	// Publish publishes a package to the package registry.
-	Publish(ctx ctx.Context, op PackagePublishOp) error
+	Publish(ctx ctx.Context, op apitype.PackagePublishOp) error
 }

--- a/pkg/cmd/pulumi/packagecmd/package.go
+++ b/pkg/cmd/pulumi/packagecmd/package.go
@@ -35,6 +35,7 @@ Install and configure Pulumi packages and their plugins and SDKs.`,
 		newPackagePublishSdkCmd(),
 		newPackagePackSdkCmd(),
 		newPackageAddCmd(),
+		newPackagePublishCmd(),
 	)
 	return cmd
 }

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -60,7 +60,7 @@ func newPackagePublishCmd() *cobra.Command {
 	var pkgPublishCmd packagePublishCmd
 
 	cmd := &cobra.Command{
-		Use:   "publish <provider|schema> --readme <path> [provider-parameter...]",
+		Use:   "publish <provider|schema> --readme <path> [--] [provider-parameter...]",
 		Args:  cmdutil.MinimumNArgs(1),
 		Short: "Publish a package to the Pulumi Registry",
 		Long: "Publish a package to the Pulumi Registry.\n\n" +

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -1,0 +1,237 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packagecmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/spf13/cobra"
+)
+
+const (
+	// The default package source is "pulumi" for packages published to the Pulumi Registry.
+	// This is the source that will be used if none is specified on the command line.
+	// Examples of other sources include "opentofu" for packages published to the OpenTofu Registry.
+	defaultPackageSource = "pulumi"
+)
+
+type publishPackageArgs struct {
+	source          string
+	publisher       string
+	readmePath      string
+	installDocsPath string
+}
+
+type packagePublishCmd struct {
+	defaultOrg    func(*workspace.Project) (string, error)
+	extractSchema func(pctx *plugin.Context, packageSource string, args []string) (*schema.Package, error)
+}
+
+func newPackagePublishCmd() *cobra.Command {
+	args := publishPackageArgs{}
+	var pkgPublishCmd packagePublishCmd
+
+	cmd := &cobra.Command{
+		Use:   "publish <provider|schema> --readme <path> [provider-parameter...]",
+		Args:  cmdutil.MinimumNArgs(1),
+		Short: "Publish a package to the Pulumi Registry",
+		Long: "Publish a package to the Pulumi Registry.\n\n" +
+			"This command publishes a package to the Pulumi Registry. The package can be a provider " +
+			"or a schema.\n\n" +
+			"When <provider> is specified as a PLUGIN[@VERSION] reference, Pulumi attempts to " +
+			"resolve a resource plugin first, installing it on-demand, similarly to:\n\n" +
+			"  pulumi plugin install resource PLUGIN [VERSION]\n\n" +
+			"When <provider> is specified as a local path, Pulumi executes the provider " +
+			"binary to extract its package schema.\n\n" +
+			"For parameterized providers, parameters may be specified as additional " +
+			"arguments. The exact format of parameters is provider-specific; consult the " +
+			"provider's documentation for more information. If the parameters include flags " +
+			"that begin with dashes, you may need to use '--' to separate the provider name " +
+			"from the parameters, as in:\n\n" +
+			"  pulumi package publish <provider> --readme ./README.md -- --provider-parameter-flag value\n\n" +
+			"When <schema> is a path to a local file with a '.json', '.yml' or '.yaml' " +
+			"extension, Pulumi package schema is read from it directly:\n\n" +
+			"  pulumi package publish ./my/schema.json --readme ./README.md",
+		Hidden: !env.Experimental.Value(),
+		RunE: func(cmd *cobra.Command, cliArgs []string) error {
+			ctx := cmd.Context()
+			pkgPublishCmd.defaultOrg = pkgWorkspace.GetBackendConfigDefaultOrg
+			pkgPublishCmd.extractSchema = SchemaFromSchemaSource
+			return pkgPublishCmd.Run(ctx, args, cliArgs[0], cliArgs[1:])
+		},
+	}
+
+	cmd.Flags().StringVar(
+		&args.source, "source", defaultPackageSource,
+		"The origin of the package (e.g., 'pulumi', 'opentofu'). Defaults to the current registry.")
+
+	cmd.Flags().StringVar(
+		&args.publisher, "publisher", "",
+		"The publisher of the package (e.g., 'pulumi'). Defaults to the publisher set in the package "+
+			"schema or the default organization in your pulumi config.")
+
+	cmd.Flags().StringVar(
+		&args.readmePath, "readme", "",
+		"Path to the package readme/index markdown file")
+	if err := cmd.MarkFlagRequired("readme"); err != nil {
+		panic("failed to mark 'readme' as a required flag")
+	}
+	cmd.Flags().StringVar(
+		&args.installDocsPath, "installation-configuration", "",
+		"Path to the installation configuration markdown file")
+
+	return cmd
+}
+
+func (cmd *packagePublishCmd) Run(
+	ctx context.Context,
+	args publishPackageArgs,
+	packageSrc string,
+	packageParams []string,
+) error {
+	if args.readmePath == "" {
+		return errors.New("no readme specified, please provide the path to the readme file")
+	}
+
+	b, err := login(ctx)
+	if err != nil {
+		return err
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	sink := cmdutil.Diag()
+	pctx, err := plugin.NewContext(sink, sink, nil, nil, wd, nil, false, nil)
+	if err != nil {
+		return err
+	}
+	defer contract.IgnoreClose(pctx)
+
+	pkg, err := cmd.extractSchema(pctx, packageSrc, packageParams)
+	if err != nil {
+		return fmt.Errorf("failed to get schema: %w", err)
+	}
+
+	var publisher string
+	// If the publisher is set on the command line, use it.
+	if args.publisher != "" {
+		publisher = args.publisher
+	} else if pkg.Publisher != "" { // Otherwise, fall back to the publisher set in the package schema.
+		publisher = pkg.Publisher
+	} else { // As a last resort, try to determine the publisher from the default organization or fail if none is found.
+		ws := pkgWorkspace.Instance
+		project, _, err := ws.ReadProject()
+		if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+			return fmt.Errorf("failed to determine default organization: %w", err)
+		}
+		publisher, err = cmd.defaultOrg(project)
+		if err != nil {
+			return fmt.Errorf("failed to determine default organization: %w", err)
+		}
+		if publisher == "" {
+			return errors.New("no publisher specified and no default organization found, please set a publisher in " +
+				"the package schema or set a default organization in your pulumi config")
+		}
+	}
+
+	name := pkg.Name
+	if name == "" {
+		return errors.New("no package name specified, please set one in the package schema")
+	}
+	var version semver.Version
+	if pkg.Version != nil {
+		version = *pkg.Version
+	} else {
+		return errors.New("no version specified, please set a version in the package schema")
+	}
+
+	json, err := pkg.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("failed to marshal schema: %w", err)
+	}
+
+	registry, err := b.GetPackageRegistry()
+	if err != nil {
+		return fmt.Errorf("failed to get package registry: %w", err)
+	}
+
+	// In the future we could slurp up the readme from the package source and add the necessary markdown headers.
+	readme, err := os.Open(args.readmePath)
+	if err != nil {
+		return fmt.Errorf("failed to open readme file: %w", err)
+	}
+	defer contract.IgnoreClose(readme)
+
+	var installDocs *os.File
+	if args.installDocsPath != "" {
+		installDocs, err = os.Open(args.installDocsPath)
+		if err != nil {
+			return fmt.Errorf("failed to open install docs file: %w", err)
+		}
+		defer contract.IgnoreClose(installDocs)
+	}
+
+	err = registry.Publish(ctx, backend.PackagePublishOp{
+		Source:      args.source,
+		Publisher:   publisher,
+		Name:        name,
+		Version:     version,
+		Schema:      bytes.NewReader(json),
+		Readme:      readme,
+		InstallDocs: installDocs,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to publish package: %w", err)
+	}
+
+	fmt.Printf("Successfully published package %s/%s@%s\n", publisher, name, version)
+
+	return nil
+}
+
+func login(ctx context.Context) (backend.Backend, error) {
+	// Try to read the current project. If we can't find a project, we'll use the default cloud URL.
+	ws := pkgWorkspace.Instance
+	project, _, err := ws.ReadProject()
+	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+		return nil, err
+	}
+
+	b, err := cmdBackend.CurrentBackend(
+		ctx, ws, cmdBackend.DefaultLoginManager, project,
+		display.Options{Color: cmdutil.GetGlobalColorization()})
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -28,6 +28,7 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -204,7 +205,7 @@ func (cmd *packagePublishCmd) Run(
 		return fmt.Errorf("failed to read readme file: %w", err)
 	}
 
-	publishInput := backend.PackagePublishOp{
+	publishInput := apitype.PackagePublishOp{
 		Source:    args.source,
 		Publisher: publisher,
 		Name:      name,

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -198,7 +198,6 @@ func (cmd *packagePublishCmd) Run(
 
 	var installDocsBytes *bytes.Buffer
 	if args.installDocsPath != "" {
-		fmt.Printf("installDocsPath: %s\n", args.installDocsPath)
 		installDocs, err := os.Open(args.installDocsPath)
 		if err != nil {
 			return fmt.Errorf("failed to open install docs file: %w", err)

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -33,9 +33,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//nolint:paralleltest // This test uses the global backendInstance variable
 func TestPackagePublishCmd_Run(t *testing.T) {
-	t.Parallel()
-
 	version := semver.MustParse("1.0.0")
 
 	tests := []struct {
@@ -258,7 +257,7 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 					schemaBytes, err := io.ReadAll(op.Schema)
 					require.NoError(t, err)
 					packageSpec, err := unmarshalSchema(schemaBytes)
-	
+
 					if len(packageSpec.Types) == 0 {
 						packageSpec.Types = map[string]schema.ComplexTypeSpec{}
 					}
@@ -272,7 +271,7 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 					expectedSpec, err := tt.mockSchema.MarshalSpec()
 					require.NoError(t, err)
 					assert.Equal(t, expectedSpec, packageSpec, "package schema should match input package spec")
-	
+
 					// Verify readme and install docs content
 					if tt.args.readmePath != "" {
 						actualContents, err := io.ReadAll(op.Readme)
@@ -284,7 +283,7 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 						require.NoError(t, err)
 						assert.Equal(t, tt.installContent, string(actualContents), "install docs should match the provided markdown file")
 					}
-	
+
 					// Verify publisher is set correctly
 					if tt.args.publisher != "" {
 						assert.Equal(t, tt.args.publisher, op.Publisher, "publisher should match command line argument")

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -28,6 +28,7 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
@@ -271,7 +272,7 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 			}
 
 			mockPackageRegistry := &backend.MockPackageRegistry{
-				PublishF: func(ctx context.Context, op backend.PackagePublishOp) error {
+				PublishF: func(ctx context.Context, op apitype.PackagePublishOp) error {
 					schemaBytes, err := io.ReadAll(op.Schema)
 					require.NoError(t, err)
 					packageSpec, err := unmarshalSchema(schemaBytes)
@@ -411,7 +412,7 @@ func TestPackagePublishCmd_IOErrors(t *testing.T) {
 			mockBackendInstance(t, &backend.MockBackend{
 				GetPackageRegistryF: func() (backend.PackageRegistry, error) {
 					return &backend.MockPackageRegistry{
-						PublishF: func(ctx context.Context, op backend.PackagePublishOp) error {
+						PublishF: func(ctx context.Context, op apitype.PackagePublishOp) error {
 							return nil
 						},
 					}, nil

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -375,28 +375,6 @@ func TestPackagePublishCmd_IOErrors(t *testing.T) {
 			expectedErrStr: "failed to open readme file",
 		},
 		{
-			name: "readme file cannot be read (permission denied)",
-			args: publishPackageArgs{
-				source:    "pulumi",
-				publisher: "publisher",
-			},
-			mockSchema: validSchema,
-			setupTest: func(t *testing.T) (string, string) {
-				tempDir := t.TempDir()
-				readmePath := path.Join(tempDir, "unreadable.md")
-
-				err := os.WriteFile(readmePath, []byte("# Test README"), 0o600)
-				require.NoError(t, err)
-
-				// Make it unreadable
-				err = os.Chmod(readmePath, 0o000)
-				require.NoError(t, err)
-
-				return readmePath, ""
-			},
-			expectedErrStr: "failed to open readme file",
-		},
-		{
 			name: "install docs file not found",
 			args: publishPackageArgs{
 				source:          "pulumi",
@@ -412,32 +390,6 @@ func TestPackagePublishCmd_IOErrors(t *testing.T) {
 				require.NoError(t, err)
 
 				return readmePath, ""
-			},
-			expectedErrStr: "failed to open install docs file",
-		},
-		{
-			name: "install docs file cannot be read (permission denied)",
-			args: publishPackageArgs{
-				source:    "pulumi",
-				publisher: "publisher",
-			},
-			mockSchema: validSchema,
-			setupTest: func(t *testing.T) (string, string) {
-				tempDir := t.TempDir()
-				readmePath := path.Join(tempDir, "readme.md")
-				installPath := path.Join(tempDir, "unreadable-install.md")
-
-				err := os.WriteFile(readmePath, []byte("# Test README"), 0o600)
-				require.NoError(t, err)
-
-				err = os.WriteFile(installPath, []byte("# Installation"), 0o600)
-				require.NoError(t, err)
-
-				// Make install docs unreadable
-				err = os.Chmod(installPath, 0o000)
-				require.NoError(t, err)
-
-				return readmePath, installPath
 			},
 			expectedErrStr: "failed to open install docs file",
 		},
@@ -476,7 +428,7 @@ func TestPackagePublishCmd_IOErrors(t *testing.T) {
 			}
 
 			err := cmd.Run(context.Background(), tt.args, "testpackage", []string{})
-			assert.Error(t, err)
+			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expectedErrStr)
 		})
 	}

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -1,0 +1,338 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packagecmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackagePublishCmd_Run(t *testing.T) {
+	t.Parallel()
+
+	version := semver.MustParse("1.0.0")
+
+	tests := []struct {
+		name           string
+		args           publishPackageArgs
+		packageSource  string
+		packageParams  []string
+		mockSchema     *schema.Package
+		mockOrg        string
+		mockOrgErr     error
+		publishErr     error
+		expectedErr    string
+		readmeContent  string
+		installContent string
+	}{
+		{
+			name: "successful publish with publisher from schema",
+			args: publishPackageArgs{
+				source: "pulumi",
+			},
+			packageSource: "testpackage",
+			packageParams: []string{},
+			mockSchema: &schema.Package{
+				Name:      "testpkg",
+				Publisher: "testpublisher",
+				Version:   &version,
+				Provider:  &schema.Resource{},
+			},
+			readmeContent:  "# Test README\nThis is a test readme.",
+			installContent: "# Installation\nHow to install this package.",
+		},
+		{
+			name: "successful publish with publisher from command line",
+			args: publishPackageArgs{
+				source:    "pulumi",
+				publisher: "cmdpublisher",
+			},
+			packageSource: "testpackage",
+			packageParams: []string{},
+			mockSchema: &schema.Package{
+				Name:     "testpkg",
+				Version:  &version,
+				Provider: &schema.Resource{},
+			},
+			readmeContent:  "# Test README\nThis is a test readme.",
+			installContent: "# Installation\nHow to install this package.",
+		},
+		{
+			name: "successful publish with default org",
+			args: publishPackageArgs{
+				source: "pulumi",
+			},
+			packageSource: "testpackage",
+			packageParams: []string{},
+			mockSchema: &schema.Package{
+				Name:     "testpkg",
+				Version:  &version,
+				Provider: &schema.Resource{},
+			},
+			mockOrg:        "defaultorg",
+			readmeContent:  "# Test README\nThis is a test readme.",
+			installContent: "# Installation\nHow to install this package.",
+		},
+		{
+			name: "error when no publisher available",
+			args: publishPackageArgs{
+				source: "pulumi",
+			},
+			packageSource: "testpackage",
+			packageParams: []string{},
+			mockSchema: &schema.Package{
+				Name:     "testpkg",
+				Version:  &version,
+				Provider: &schema.Resource{},
+			},
+			expectedErr:    "no publisher specified and no default organization found",
+			readmeContent:  "# Test README\nThis is a test readme.",
+			installContent: "# Installation\nHow to install this package.",
+		},
+		{
+			name: "error when extracting schema fails",
+			args: publishPackageArgs{
+				source:    "pulumi",
+				publisher: "publisher",
+			},
+			packageSource:  "testpackage",
+			packageParams:  []string{},
+			mockSchema:     nil,
+			expectedErr:    "failed to get schema",
+			readmeContent:  "# Test README\nThis is a test readme.",
+			installContent: "# Installation\nHow to install this package.",
+		},
+		{
+			name: "error when no package name in schema",
+			args: publishPackageArgs{
+				source:    "pulumi",
+				publisher: "publisher",
+			},
+			packageSource: "testpackage",
+			packageParams: []string{},
+			mockSchema: &schema.Package{
+				Version:  &version,
+				Provider: &schema.Resource{},
+			},
+			expectedErr:    "no package name specified",
+			readmeContent:  "# Test README\nThis is a test readme.",
+			installContent: "# Installation\nHow to install this package.",
+		},
+		{
+			name: "error when no version in schema",
+			args: publishPackageArgs{
+				source:    "pulumi",
+				publisher: "publisher",
+			},
+			packageSource: "testpackage",
+			packageParams: []string{},
+			mockSchema: &schema.Package{
+				Name:     "testpkg",
+				Provider: &schema.Resource{},
+			},
+			expectedErr:    "no version specified",
+			readmeContent:  "# Test README\nThis is a test readme.",
+			installContent: "# Installation\nHow to install this package.",
+		},
+		{
+			name: "error when readme is omitted",
+			args: publishPackageArgs{
+				source:    "pulumi",
+				publisher: "publisher",
+			},
+			packageSource: "testpackage",
+			packageParams: []string{},
+			mockSchema: &schema.Package{
+				Name:     "testpkg",
+				Version:  &version,
+				Provider: &schema.Resource{},
+			},
+			expectedErr: "no readme specified, please provide the path to the readme file",
+		},
+		{
+			name: "error when publish fails",
+			args: publishPackageArgs{
+				source:    "pulumi",
+				publisher: "publisher",
+			},
+			packageSource: "testpackage",
+			packageParams: []string{},
+			mockSchema: &schema.Package{
+				Name:     "testpkg",
+				Version:  &version,
+				Provider: &schema.Resource{},
+			},
+			publishErr:     errors.New("publish failed"),
+			expectedErr:    "failed to publish package",
+			readmeContent:  "# Test README\nThis is a test readme.",
+			installContent: "# Installation\nHow to install this package.",
+		},
+		{
+			name: "successful publish without installation docs",
+			args: publishPackageArgs{
+				source:    "pulumi",
+				publisher: "publisher",
+			},
+			packageSource: "testpackage",
+			packageParams: []string{},
+			mockSchema: &schema.Package{
+				Name:     "testpkg",
+				Version:  &version,
+				Provider: &schema.Resource{},
+			},
+			readmeContent: "# Test README\nThis is a test readme.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tempDir := t.TempDir()
+
+			var readmePath string
+			if tt.readmeContent != "" {
+				readmeFile, err := os.Create(path.Join(tempDir, "readme.md"))
+				require.NoError(t, err)
+				_, err = readmeFile.WriteString(tt.readmeContent)
+				require.NoError(t, err)
+				require.NoError(t, readmeFile.Close())
+				readmePath = readmeFile.Name()
+				tt.args.readmePath = readmePath
+			}
+
+			var installDocsPath string
+			if tt.installContent != "" {
+				installDocsFile, err := os.Create(path.Join(tempDir, "install.md"))
+				require.NoError(t, err)
+				_, err = installDocsFile.WriteString(tt.installContent)
+				require.NoError(t, err)
+				require.NoError(t, installDocsFile.Close())
+				installDocsPath = installDocsFile.Name()
+				tt.args.installDocsPath = installDocsPath
+			}
+
+			mockPackageRegistry := &backend.MockPackageRegistry{}
+			mockBackend := &backend.MockBackend{
+				GetPackageRegistryF: func() (backend.PackageRegistry, error) {
+					return mockPackageRegistry, nil
+				},
+			}
+
+			lm := &cmdBackend.MockLoginManager{
+				LoginF: func(
+					ctx context.Context,
+					ws pkgWorkspace.Context,
+					sink diag.Sink,
+					url string,
+					project *workspace.Project,
+					setCurrent bool,
+					color colors.Colorization,
+				) (backend.Backend, error) {
+					return mockBackend, nil
+				},
+			}
+
+			// Setup defaultOrg mock
+			defaultOrg := func(project *workspace.Project) (string, error) {
+				return tt.mockOrg, tt.mockOrgErr
+			}
+
+			mockPackageRegistry.PublishF = func(ctx context.Context, op backend.PackagePublishOp) error {
+				schemaBytes, err := io.ReadAll(op.Schema)
+				require.NoError(t, err)
+				packageSpec, err := unmarshalSchema(schemaBytes)
+
+				if len(packageSpec.Types) == 0 {
+					packageSpec.Types = map[string]schema.ComplexTypeSpec{}
+				}
+				if len(packageSpec.Resources) == 0 {
+					packageSpec.Resources = map[string]schema.ResourceSpec{}
+				}
+				if len(packageSpec.Functions) == 0 {
+					packageSpec.Functions = map[string]schema.FunctionSpec{}
+				}
+				require.NoError(t, err)
+				expectedSpec, err := tt.mockSchema.MarshalSpec()
+				require.NoError(t, err)
+				assert.Equal(t, expectedSpec, packageSpec, "package schema should match input package spec")
+
+				// Verify readme and install docs content
+				if tt.args.readmePath != "" {
+					actualContents, err := io.ReadAll(op.Readme)
+					require.NoError(t, err)
+					assert.Equal(t, tt.readmeContent, string(actualContents), "readme should match the provided markdown file")
+				}
+				if tt.args.installDocsPath != "" {
+					actualContents, err := io.ReadAll(op.InstallDocs)
+					require.NoError(t, err)
+					assert.Equal(t, tt.installContent, string(actualContents), "install docs should match the provided markdown file")
+				}
+
+				// Verify publisher is set correctly
+				if tt.args.publisher != "" {
+					assert.Equal(t, tt.args.publisher, op.Publisher, "publisher should match command line argument")
+				} else if tt.mockSchema.Publisher != "" {
+					assert.Equal(t, tt.mockSchema.Publisher, op.Publisher, "publisher should match schema publisher")
+				} else {
+					assert.Equal(t, tt.mockOrg, op.Publisher, "publisher should match default org")
+				}
+				return tt.publishErr
+			}
+
+			cmd := &packagePublishCmd{
+				defaultOrg: defaultOrg,
+				extractSchema: func(pctx *plugin.Context, packageSource string, args []string) (*schema.Package, error) {
+					if tt.mockSchema == nil {
+						return nil, errors.New("mock schema extraction failed")
+					}
+					return tt.mockSchema, nil
+				},
+				loginManager: lm,
+			}
+
+			err := cmd.Run(context.Background(), tt.args, tt.packageSource, tt.packageParams)
+			if tt.expectedErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func unmarshalSchema(schemaBytes []byte) (*schema.PackageSpec, error) {
+	var spec schema.PackageSpec
+
+	err := json.Unmarshal(schemaBytes, &spec)
+	return &spec, err
+}

--- a/sdk/go/common/apitype/package.go
+++ b/sdk/go/common/apitype/package.go
@@ -26,7 +26,7 @@ type StartPackagePublishResponse struct {
 	OperationID string `json:"operationID"`
 
 	// UploadUrls is a collection of URLs for uploading package artifacts.
-	UploadUrls PackageUpload `json:"uploadUrls"`
+	UploadURLs PackageUpload `json:"uploadURLs"`
 
 	// RequiredHeaders represents headers that the CLI must set in order
 	// for the uploads to succeed.

--- a/sdk/go/common/apitype/package.go
+++ b/sdk/go/common/apitype/package.go
@@ -1,0 +1,45 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+// StartPackagePublishResponse is the response from initiating a package publish.
+// It returns presigned URLs to upload package artifacts.
+type StartPackagePublishResponse struct {
+	// OperationID is the ID uniquely identifying the publishing operation.
+	OperationID string `json:"operationID"`
+
+	// UploadUrls is a collection of URLs for uploading package artifacts.
+	UploadUrls PackageUpload `json:"uploadUrls"`
+
+	// RequiredHeaders represents headers that the CLI must set in order
+	// for the uploads to succeed.
+	RequiredHeaders map[string]string `json:"requiredHeaders,omitempty"`
+}
+
+type PackageUpload struct {
+	// Schema is the URL for uploading the schema file.
+	Schema string `json:"schema"`
+	// Index is the URL for uploading the README file.
+	Index string `json:"index"`
+	// InstallationConfiguration is the URL for uploading the installation docs.
+	InstallationConfiguration string `json:"installationConfiguration"`
+}
+
+// CompletePackagePublishRequest defines the request body for completing a package
+// publish operation after all artifacts have been uploaded.
+type CompletePackagePublishRequest struct {
+	// OperationID is the ID uniquely identifying the publishing operation.
+	OperationID string `json:"operationID"`
+}

--- a/sdk/go/common/apitype/package.go
+++ b/sdk/go/common/apitype/package.go
@@ -14,6 +14,12 @@
 
 package apitype
 
+import (
+	"io"
+
+	"github.com/blang/semver"
+)
+
 type StartPackagePublishRequest struct {
 	// Version is the semver-compliant version of the package to publish.
 	Version string `json:"version"`
@@ -47,4 +53,24 @@ type PackageUpload struct {
 type CompletePackagePublishRequest struct {
 	// OperationID is the ID uniquely identifying the publishing operation.
 	OperationID string `json:"operationID"`
+}
+
+// PackagePublishOp contains the information needed to publish a package to the registry.
+type PackagePublishOp struct {
+	// Source is the source of the package. Typically this is 'pulumi' for packages published to the Pulumi Registry.
+	// Packages loaded from other registries (e.g. 'opentofu') will point to the origin of the package.
+	Source string
+	// Publisher is the organization that is publishing the package.
+	Publisher string
+	// Name is the URL-safe name of the package.
+	Name string
+	// Version is the semantic version of the package that should get published.
+	Version semver.Version
+	// Schema is a reader containing the JSON schema of the package.
+	Schema io.Reader
+	// Readme is a reader containing the markdown content of the package's README.
+	Readme io.Reader
+	// InstallDocs is a reader containing the markdown content of the package's installation documentation.
+	// This is optional, and if omitted, the package will not have installation documentation.
+	InstallDocs io.Reader
 }

--- a/sdk/go/common/apitype/package.go
+++ b/sdk/go/common/apitype/package.go
@@ -14,6 +14,11 @@
 
 package apitype
 
+type StartPackagePublishRequest struct {
+	// Version is the semver-compliant version of the package to publish.
+	Version string `json:"version"`
+}
+
 // StartPackagePublishResponse is the response from initiating a package publish.
 // It returns presigned URLs to upload package artifacts.
 type StartPackagePublishResponse struct {


### PR DESCRIPTION
## Overview

This PR introduces a new `pulumi package publish` command that enables direct publishing of packages to the Pulumi Registry. The command allows publishing both providers (including components) and schemas (json and yaml).
The command has similar semantics to `pulumi package add` or `pulumi package get-schema` in terms of how the schema is extracted/fetched.
This feature is currently hidden behind the experimental flag.

This depends on https://github.com/pulumi/pulumi-service/pull/26396
Fixes https://github.com/pulumi/pulumi-service/issues/26018

## Usage Examples
```
~ pulumi package publish path/to/schema.json --readme ./docs/_index.md

~ pulumi package publish https://github.com/flostadler/aws-k8s@v0.0.5 --readme README.md
```

This stacked PR https://github.com/pulumi/pulumi/pull/18857 adds the necessary functionality for slurping up README's from the package source instead of requiring users to provide it.