### PR TITLE
Refactor: Structured error for missing an env required when non-interactive use

### DIFF
--- a/pkg/backend/errors.go
+++ b/pkg/backend/errors.go
@@ -16,10 +16,12 @@ package backend
 
 import (
 	"fmt"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 )
 
 // ConflictingUpdateError represents an error which occurred while starting an update/destroy operation.
-// Another update of the same stack was in progress, so the operation got cancelled due to this conflict.
+// Another update of the same stack was in progress, so the operation got canceled due to this conflict.
 type ConflictingUpdateError struct {
 	Err error // The error that occurred while starting the operation.
 }
@@ -27,4 +29,14 @@ type ConflictingUpdateError struct {
 func (c ConflictingUpdateError) Error() string {
 	return fmt.Sprintf("%s\nTo learn more about possible reasons and resolution, visit "+
 		"https://www.pulumi.com/docs/troubleshooting/#conflict", c.Err)
+}
+
+// MissingEnvVarForNonInteractiveError represents a situation where the CLI is run in
+// non-interactive mode and that requires certain env vars to be set.
+type MissingEnvVarForNonInteractiveError struct {
+	Var env.Var
+}
+
+func (err MissingEnvVarForNonInteractiveError) Error() string {
+	return err.Var.Name() + " must be set for login during non-interactive CLI sessions"
 }

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -66,8 +66,6 @@ import (
 const (
 	// defaultAPIEnvVar can be set to override the default cloud chosen, if `--cloud` is not present.
 	defaultURLEnvVar = "PULUMI_API"
-	// AccessTokenEnvVar is the environment variable used to bypass a prompt on login.
-	AccessTokenEnvVar = "PULUMI_ACCESS_TOKEN"
 )
 
 type PulumiAILanguage string
@@ -375,7 +373,7 @@ func (m defaultLoginManager) Current(
 
 	// We intentionally don't accept command-line args for the user's access token. Having it in
 	// .bash_history is not great, and specifying it via flag isn't of much use.
-	accessToken := os.Getenv(AccessTokenEnvVar)
+	accessToken := env.AccessToken.Value()
 
 	// If we have a saved access token, and it is valid, and it
 	// either matches PULUMI_ACCESS_TOKEN or PULUMI_ACCESS_TOKEN
@@ -421,7 +419,7 @@ func (m defaultLoginManager) Current(
 	}
 
 	// If there's already a token from the environment, use it.
-	_, err = fmt.Fprintf(os.Stderr, "Logging in using access token from %s\n", AccessTokenEnvVar)
+	_, err = fmt.Fprintf(os.Stderr, "Logging in using access token from %s\n", env.AccessToken.Var().Name())
 	contract.IgnoreError(err)
 
 	// Try and use the credentials to see if they are valid.
@@ -474,7 +472,7 @@ func (m defaultLoginManager) Login(
 	if !cmdutil.Interactive() {
 		// If interactive mode isn't enabled, the only way to specify a token is through the environment variable.
 		// Fail the attempt to login.
-		return nil, fmt.Errorf("%s must be set for login during non-interactive CLI sessions", AccessTokenEnvVar)
+		return nil, backend.MissingEnvVarForNonInteractiveError{Var: env.AccessToken.Var()}
 	}
 
 	// If no access token is available from the environment, and we are interactive, prompt and offer to

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -105,6 +105,9 @@ var FallbackToStateSecretsManager = env.Bool("FALLBACK_TO_STATE_SECRETS_MANAGER"
 var Parallel = env.Int("PARALLEL",
 	"Allow P resource operations to run in parallel at once (1 for no parallelism)")
 
+var AccessToken = env.String("ACCESS_TOKEN",
+	"The access token used to authenticate with the Pulumi Service.")
+
 // List of overrides for Plugin Download URLs. The expected format is `regexp=URL`, and multiple pairs can
 // be specified separated by commas, e.g. `regexp1=URL1,regexp2=URL2`
 //


### PR DESCRIPTION
This PR was spun off of https://github.com/pulumi/pulumi/pull/18627. The new structured error is consumed there.