### PR TITLE
Tidy up CI linting

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -52,11 +52,3 @@ jobs:
       - name: Check Protobufs
         run: |
           make check_proto
-
-  sdk-lint:
-    name: Lint SDKs
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Ensure
-        run: |
-          make ensure

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -20,59 +20,6 @@ env:
   GOLANGCI_LINT_VERSION: v1.64.2
 
 jobs:
-  golangci:
-    name: Lint Go
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ fromJson(inputs.version-set).go }}
-          check-latest: true
-          # golangci-lint-action handles all the caching for Go.
-          cache: false
-
-      # We leverage the golangci-lint action to install
-      # and maintain the cache,
-      # but we want to run the command ourselves.
-      # The action doesn't have an install-only mode,
-      # so we'll ask it to print its help output instead.
-      - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v4
-        with:
-          version: ${{ env.GOLANGCI_LINT_VERSION }}
-          args: --help
-
-      - name: Run golangci-lint
-        # Print GitHub Actions-friendly output so that errors get marked
-        # in the pull request.
-        run: make lint_golang GOLANGCI_LINT_ARGS=--out-format=colored-line-number
-
-  tidy:
-    name: go mod tidy
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ fromJson(inputs.version-set).go }}
-          check-latest: true
-      - name: Run go mod tidy
-        run: make tidy
-      - name: Fail if go mod not tidy
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "::error go.mod not tidy"
-            echo "::error Please run 'make tidy'"
-            exit 1
-          fi
-
   gen:
     name: Generate Go SDK
     runs-on: ubuntu-22.04
@@ -110,66 +57,6 @@ jobs:
     name: Lint SDKs
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ fromJson(inputs.version-set).go }}
-          check-latest: true
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          cache-dependency-glob: sdk/python/uv.lock
-      - name: Set up Python ${{ fromJson(inputs.version-set).python }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ fromJson(inputs.version-set).python }}
-      - name: Set up Node ${{ fromJson(inputs.version-set).nodejs }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ fromJson(inputs.version-set).nodejs }}
-          cache: yarn
-          cache-dependency-path: sdk/nodejs/yarn.lock
-      - name: Install Python deps
-        run: |
-          python -m pip install --upgrade pip requests wheel urllib3 chardet
-      - name: Setup git
-        run: |
-          git config --global user.email "you@example.com"
-          git config --global user.name "Your Name"
-      - name: Update path
-        run: |
-          echo "$RUNNER_TEMP/opt/pulumi/bin" >> "$GITHUB_PATH"
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
-      - name: Set Go Dep path
-        run: |
-          echo "PULUMI_GO_DEP_ROOT=$(dirname "$(pwd)")" >> "$GITHUB_ENV"
       - name: Ensure
         run: |
           make ensure
-      - name: Lint Node
-        run: |
-          cd sdk/nodejs && make lint
-      - name: Lint Python
-        run: |
-          cd sdk/python && make lint
-
-  actionlint:
-    name: Lint GHA
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ fromJson(inputs.version-set).go }}
-          check-latest: true
-      - run: |
-          make lint_actions

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           eslint: true
           eslint_dir: ./sdk/nodejs
+          eslint_args: --ext .ts
 
       # Go
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
       - if: ${{ steps.changes.outputs.typescript == 'true' }}
         uses: actionsx/prettier@v2
         with:
-          args: --check **/*.{j,t}s
+          args: --check "**/*.js" --check "**/*.ts"
 
       - if: ${{ steps.changes.outputs.python == 'true' }}
         uses: ricardochaves/python-lint@v1.4.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
         uses: wearerequired/lint-action@v2
         with:
           eslint: true
-          linter_dir: ./sdk/nodejs
+          eslint_dir: ./sdk/nodejs
 
       # Go
 
@@ -74,6 +74,7 @@ jobs:
         name: Lint Python
         uses: wearerequired/lint-action@v2
         with:
+          pylint_dir: ./sdk/python
           pylint: true
 
       # Actions

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,12 @@ jobs:
             actions:
               - '.github/workflows/*'
 
+      - if: ${{ steps.changes.outputs.typescript == 'true' }}
+        name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 23
+
       - if: ${{ steps.changes.outputs.go == 'true' }}
         name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,11 +33,22 @@ jobs:
             actions:
               - '.github/workflows/*'
 
+      # JavaScript / TypeScript
+
       - if: ${{ steps.changes.outputs.typescript == 'true' }}
-        name: Setup Node
+        name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
           node-version: 23
+
+      - if: ${{ steps.changes.outputs.typescript == 'true' }}
+        name: Lint NodeJS
+        uses: wearerequired/lint-action@v2
+        with:
+          eslint: true
+          linter_dir: ./sdk/nodejs
+
+      # Go
 
       - if: ${{ steps.changes.outputs.go == 'true' }}
         name: Setup Go
@@ -51,25 +62,27 @@ jobs:
         with:
           working-directory: pkg
 
-      - if: ${{ steps.changes.outputs.typescript == 'true' }}
-        name: Lint JS/TS
-        run: |
-          yarn install
-          yarn run eslint . -c .eslintrc.js --ext .js,.jsx,.ts,.tsx
-        working-directory: ./sdk/nodejs
+      # Python
+
+      - if: ${{ steps.changes.outputs.python == 'true' }}
+        name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
 
       - if: ${{ steps.changes.outputs.python == 'true' }}
         name: Lint Python
-        uses: ricardochaves/python-lint@v1.4.0
+        uses: wearerequired/lint-action@v2
         with:
-          use-pycodestyle: false
-          use-flake8: false
-          use-black: false
-          use-mypy: false
+          pylint: true
+
+      # Actions
 
       - if: ${{ steps.changes.outputs.actions == 'true' }}
         name: Lint Actions
         uses: devops-actions/actionlint@v0.1.9
+
+      # ... and, last but not least, go.mod
 
       - if: ${{ steps.changes.outputs.gomods == 'true' }}
         name: Lint go.mod

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,21 +34,23 @@ jobs:
               - '.github/workflows/*'
 
       - if: ${{ steps.changes.outputs.go == 'true' }}
+        name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: stable
 
       - if: ${{ steps.changes.outputs.go == 'true' }}
+        name: Lint Go
         uses: golangci/golangci-lint-action@v6.5.0
         with:
           working-directory: pkg
 
       - if: ${{ steps.changes.outputs.typescript == 'true' }}
-        uses: actionsx/prettier@v2
-        with:
-          args: --check "**/*.js" --check "**/*.ts"
+        name: Lint JS/TS
+        run: eslint . -c sdk/nodejs/.eslintrc.js --ext .js,.jsx,.ts,.tsx
 
       - if: ${{ steps.changes.outputs.python == 'true' }}
+        name: Lint Python
         uses: ricardochaves/python-lint@v1.4.0
         with:
           use-pycodestyle: false
@@ -57,9 +59,11 @@ jobs:
           use-mypy: false
 
       - if: ${{ steps.changes.outputs.actions == 'true' }}
+        name: Lint Actions
         uses: devops-actions/actionlint@v0.1.9
 
       - if: ${{ steps.changes.outputs.gomods == 'true' }}
+        name: Lint go.mod
         uses: evantorrie/mott-the-tidier@v1-beta
         with:
           gomods: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,6 +42,12 @@ jobs:
           node-version: 23
 
       - if: ${{ steps.changes.outputs.typescript == 'true' }}
+        name: Install dependencies
+        run: yarn
+        with:
+          working-directory: ./sdk/nodejs
+
+      - if: ${{ steps.changes.outputs.typescript == 'true' }}
         name: Lint NodeJS
         uses: wearerequired/lint-action@v2
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,55 @@
+name: Lint
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            workflow:
+              - '.github/workflows/lint.yml'
+            go:
+              - '**/*.go'
+            gomods:
+              - '**/go.mod'
+            python:
+              - '**/*.py'
+            typescript:
+              - '**/*.js'
+              - '**/*.ts'
+            actions:
+              - '.github/workflows/*'
+
+      - if: steps.changes.outputs.go == 'true' || steps.changes.outputs.workflow == 'true'
+        uses: golangci/golangci-lint-action@v4
+
+      - if: steps.changes.outputs.typescript == 'true' || steps.changes.outputs.workflow == 'true'
+        uses: actionsx/prettier@v2
+        with:
+          args: --check .
+
+      - if: steps.changes.outputs.python == 'true' || steps.changes.outputs.workflow == 'true'
+        uses: ricardochaves/python-lint@v1.4.0
+        with:
+          use-pycodestyle: false
+          use-flake8: false
+          use-black: false
+          use-mypy: false
+          use-mypy: false
+
+      - if: steps.changes.outputs.actions == 'true'
+        uses: devops-actions/actionlint@v0.1.9
+
+      - if: steps.changens.outputs.gomods == 'true'
+        uses: evantorrie/mott-the-tider@v1-beta
+        with:
+          gomods: |
+            **/go.mod

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           eslint: true
           eslint_dir: ./sdk/nodejs
-          eslint_args: --ext .ts
+          eslint_extensions: ts
 
       # Go
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,8 +44,7 @@ jobs:
       - if: ${{ steps.changes.outputs.typescript == 'true' }}
         name: Install dependencies
         run: yarn
-        with:
-          working-directory: ./sdk/nodejs
+        working-directory: ./sdk/nodejs
 
       - if: ${{ steps.changes.outputs.typescript == 'true' }}
         name: Lint NodeJS

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,34 +17,38 @@ jobs:
         id: changes
         with:
           filters: |
-            workflow:
-              - '.github/workflows/lint.yml'
             go:
+              - '.github/workflows/lint.yml'
               - '**/*.go'
             gomods:
+              - '.github/workflows/lint.yml'
               - '**/go.mod'
             python:
+              - '.github/workflows/lint.yml'
               - '**/*.py'
             typescript:
+              - '.github/workflows/lint.yml'
               - '**/*.js'
               - '**/*.ts'
             actions:
               - '.github/workflows/*'
 
-      - if: ${{ (steps.changes.outputs.go == 'true') || (steps.changes.outputs.workflow == 'true') }}
+      - if: ${{ steps.changes.outputs.go == 'true' }}
         uses: actions/setup-go@v5
         with:
           go-version: stable
 
-      - if: ${{ (steps.changes.outputs.go == 'true') || (steps.changes.outputs.workflow == 'true') }}
+      - if: ${{ steps.changes.outputs.go == 'true' }}
         uses: golangci/golangci-lint-action@v6.5.0
+        with:
+          working-directory: pkg
 
-      - if: ${{ (steps.changes.outputs.typescript == 'true') || (steps.changes.outputs.workflow == 'true') }}
+      - if: ${{ steps.changes.outputs.typescript == 'true' }}
         uses: actionsx/prettier@v2
         with:
           args: --check .
 
-      - if: ${{ (steps.changes.outputs.python == 'true') || (steps.changes.outputs.workflow == 'true') }}
+      - if: ${{ steps.changes.outputs.python == 'true' }}
         uses: ricardochaves/python-lint@v1.4.0
         with:
           use-pycodestyle: false
@@ -55,7 +59,7 @@ jobs:
       - if: ${{ steps.changes.outputs.actions == 'true' }}
         uses: devops-actions/actionlint@v0.1.9
 
-      - if: ${{ steps.changes.outputs.gomods == 'true' || steps.changes.outputs.workflow == 'true' }}
+      - if: ${{ steps.changes.outputs.gomods == 'true' }}
         uses: evantorrie/mott-the-tidier@v1-beta
         with:
           gomods: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,15 +31,20 @@ jobs:
             actions:
               - '.github/workflows/*'
 
-      - if: steps.changes.outputs.go == 'true' || steps.changes.outputs.workflow == 'true'
+      - if: ${{ (steps.changes.outputs.go == 'true') || (steps.changes.outputs.workflow == 'true') }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - if: ${{ (steps.changes.outputs.go == 'true') || (steps.changes.outputs.workflow == 'true') }}
         uses: golangci/golangci-lint-action@v6.5.0
 
-      - if: steps.changes.outputs.typescript == 'true' || steps.changes.outputs.workflow == 'true'
+      - if: ${{ (steps.changes.outputs.typescript == 'true') || (steps.changes.outputs.workflow == 'true') }}
         uses: actionsx/prettier@v2
         with:
           args: --check .
 
-      - if: steps.changes.outputs.python == 'true' || steps.changes.outputs.workflow == 'true'
+      - if: ${{ (steps.changes.outputs.python == 'true') || (steps.changes.outputs.workflow == 'true') }}
         uses: ricardochaves/python-lint@v1.4.0
         with:
           use-pycodestyle: false
@@ -47,10 +52,10 @@ jobs:
           use-black: false
           use-mypy: false
 
-      - if: steps.changes.outputs.actions == 'true'
+      - if: ${{ steps.changes.outputs.actions == 'true' }}
         uses: devops-actions/actionlint@v0.1.9
 
-      - if: steps.changens.outputs.gomods == 'true'
+      - if: ${{ steps.changes.outputs.gomods == 'true' || steps.changes.outputs.workflow == 'true' }}
         uses: evantorrie/mott-the-tidier@v1-beta
         with:
           gomods: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,6 @@ jobs:
           use-flake8: false
           use-black: false
           use-mypy: false
-          use-mypy: false
 
       - if: steps.changes.outputs.actions == 'true'
         uses: devops-actions/actionlint@v0.1.9

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,7 +53,8 @@ jobs:
 
       - if: ${{ steps.changes.outputs.typescript == 'true' }}
         name: Lint JS/TS
-        run: eslint . -c sdk/nodejs/.eslintrc.js --ext .js,.jsx,.ts,.tsx
+        run: npx eslint . -c .eslintrc.js --ext .js,.jsx,.ts,.tsx
+        working-directory: sdk/nodejs
 
       - if: ${{ steps.changes.outputs.python == 'true' }}
         name: Lint Python

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,8 +53,10 @@ jobs:
 
       - if: ${{ steps.changes.outputs.typescript == 'true' }}
         name: Lint JS/TS
-        run: yarn run eslint . -c .eslintrc.js --ext .js,.jsx,.ts,.tsx
-        working-directory: sdk/nodejs
+        run: |
+          yarn install
+          yarn run eslint . -c .eslintrc.js --ext .js,.jsx,.ts,.tsx
+        working-directory: ./sdk/nodejs
 
       - if: ${{ steps.changes.outputs.python == 'true' }}
         name: Lint Python

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
         uses: devops-actions/actionlint@v0.1.9
 
       - if: steps.changens.outputs.gomods == 'true'
-        uses: evantorrie/mott-the-tider@v1-beta
+        uses: evantorrie/mott-the-tidier@v1-beta
         with:
           gomods: |
             **/go.mod

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,11 +15,12 @@ jobs:
 
       # Setup
 
-      - uses: actions/setup-node@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
           node-version: 23
 
-      - name: Install dependencies
+      - name: Install Node dependencies
         run: yarn
         working-directory: ./sdk/nodejs
 
@@ -32,6 +33,9 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
+
+      - name: Install Python dependencies
+        run: pip install pylint
 
       # Linting
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ name: Lint
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
@@ -29,7 +32,7 @@ jobs:
               - '.github/workflows/*'
 
       - if: steps.changes.outputs.go == 'true' || steps.changes.outputs.workflow == 'true'
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6.5.0
 
       - if: steps.changes.outputs.typescript == 'true' || steps.changes.outputs.workflow == 'true'
         uses: actionsx/prettier@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,6 +44,7 @@ jobs:
       - if: ${{ steps.changes.outputs.typescript == 'true' }}
         name: Install dependencies
         run: yarn
+        working-directory: ./sdk/nodejs
 
       - if: ${{ steps.changes.outputs.typescript == 'true' }}
         name: ESLint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,17 +42,17 @@ jobs:
           node-version: 23
 
       - if: ${{ steps.changes.outputs.typescript == 'true' }}
-        name: Setup Biome
-        uses: biomejs/setup-biome@v2
-        with:
-          node-version: 23
-
-      - if: ${{ steps.changes.outputs.typescript == 'true' }}
         name: Install dependencies
         run: yarn
 
       - if: ${{ steps.changes.outputs.typescript == 'true' }}
-        run: eslint --ext .ts .
+        name: ESLint
+        run: yarn eslint --ext .ts .
+        working-directory: ./sdk/nodejs
+
+      - if: ${{ steps.changes.outputs.typescript == 'true' }}
+        name: Biome
+        run: yarn biome ci
         working-directory: ./sdk/nodejs
 
       # Go

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,86 +13,42 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-            go:
-              - '.github/workflows/lint.yml'
-              - '**/*.go'
-            gomods:
-              - '.github/workflows/lint.yml'
-              - '**/go.mod'
-            python:
-              - '.github/workflows/lint.yml'
-              - '**/*.py'
-            typescript:
-              - '.github/workflows/lint.yml'
-              - '**/*.js'
-              - '**/*.ts'
-            actions:
-              - '.github/workflows/*'
+      # Setup
 
-      # JavaScript / TypeScript
-
-      - if: ${{ steps.changes.outputs.typescript == 'true' }}
-        name: Setup NodeJS
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 23
 
-      - if: ${{ steps.changes.outputs.typescript == 'true' }}
-        name: Install dependencies
+      - name: Install dependencies
         run: yarn
         working-directory: ./sdk/nodejs
 
-      - if: ${{ steps.changes.outputs.typescript == 'true' }}
-        name: Lint NodeJS
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      # Linting
+
+      - name: Lint NodeJS
         uses: wearerequired/lint-action@v2
         with:
           eslint: true
           eslint_dir: ./sdk/nodejs
           eslint_extensions: ts
 
-      # Go
-
-      - if: ${{ steps.changes.outputs.go == 'true' }}
-        name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: stable
-
-      - if: ${{ steps.changes.outputs.go == 'true' }}
-        name: Lint Go
-        uses: golangci/golangci-lint-action@v6.5.0
-        with:
-          working-directory: pkg
-
-      # Python
-
-      - if: ${{ steps.changes.outputs.python == 'true' }}
-        name: Set up Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.8
-
-      - if: ${{ steps.changes.outputs.python == 'true' }}
-        name: Lint Python
-        uses: wearerequired/lint-action@v2
-        with:
           pylint_dir: ./sdk/python
           pylint: true
 
-      # Actions
-
-      - if: ${{ steps.changes.outputs.actions == 'true' }}
-        name: Lint Actions
+      - name: Lint Actions
         uses: devops-actions/actionlint@v0.1.9
 
-      # ... and, last but not least, go.mod
-
-      - if: ${{ steps.changes.outputs.gomods == 'true' }}
-        name: Lint go.mod
+      - name: Lint go.mod
         uses: evantorrie/mott-the-tidier@v1-beta
         with:
           gomods: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
       - if: ${{ steps.changes.outputs.typescript == 'true' }}
         uses: actionsx/prettier@v2
         with:
-          args: --check .
+          args: --check **/*.{j,t}s
 
       - if: ${{ steps.changes.outputs.python == 'true' }}
         uses: ricardochaves/python-lint@v1.4.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,46 +13,87 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Setup
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            go:
+              - '.github/workflows/lint.yml'
+              - '**/*.go'
+            gomods:
+              - '.github/workflows/lint.yml'
+              - '**/go.mod'
+            python:
+              - '.github/workflows/lint.yml'
+              - '**/*.py'
+            typescript:
+              - '.github/workflows/lint.yml'
+              - '**/*.js'
+              - '**/*.ts'
+            actions:
+              - '.github/workflows/*'
 
-      - name: Setup Node
+      # JavaScript / TypeScript
+
+      - if: ${{ steps.changes.outputs.typescript == 'true' }}
+        name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
           node-version: 23
 
-      - name: Install Node dependencies
+      - if: ${{ steps.changes.outputs.typescript == 'true' }}
+        name: Setup Biome
+        uses: biomejs/setup-biome@v2
+        with:
+          node-version: 23
+
+      - if: ${{ steps.changes.outputs.typescript == 'true' }}
+        name: Install dependencies
         run: yarn
+
+      - if: ${{ steps.changes.outputs.typescript == 'true' }}
+        run: eslint --ext .ts .
         working-directory: ./sdk/nodejs
 
-      - name: Setup Go
+      # Go
+
+      - if: ${{ steps.changes.outputs.go == 'true' }}
+        name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: stable
 
-      - name: Set up Python
+      - if: ${{ steps.changes.outputs.go == 'true' }}
+        name: Lint Go
+        uses: golangci/golangci-lint-action@v6.5.0
+        with:
+          working-directory: pkg
+
+      # Python
+
+      - if: ${{ steps.changes.outputs.python == 'true' }}
+        name: Set up Python
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
 
-      - name: Install Python dependencies
-        run: pip install pylint
-
-      # Linting
-
-      - name: Lint NodeJS
+      - if: ${{ steps.changes.outputs.python == 'true' }}
+        name: Lint Python
         uses: wearerequired/lint-action@v2
         with:
-          eslint: true
-          eslint_dir: ./sdk/nodejs
-          eslint_extensions: ts
-
           pylint_dir: ./sdk/python
           pylint: true
 
-      - name: Lint Actions
+      # Actions
+
+      - if: ${{ steps.changes.outputs.actions == 'true' }}
+        name: Lint Actions
         uses: devops-actions/actionlint@v0.1.9
 
-      - name: Lint go.mod
+      # ... and, last but not least, go.mod
+
+      - if: ${{ steps.changes.outputs.gomods == 'true' }}
+        name: Lint go.mod
         uses: evantorrie/mott-the-tidier@v1-beta
         with:
           gomods: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,7 +53,7 @@ jobs:
 
       - if: ${{ steps.changes.outputs.typescript == 'true' }}
         name: Lint JS/TS
-        run: npx eslint . -c .eslintrc.js --ext .js,.jsx,.ts,.tsx
+        run: yarn run eslint . -c .eslintrc.js --ext .js,.jsx,.ts,.tsx
         working-directory: sdk/nodejs
 
       - if: ${{ steps.changes.outputs.python == 'true' }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+**/.venv
+**/test*
+**/codegen

--- a/sdk/nodejs/.eslintrc.js
+++ b/sdk/nodejs/.eslintrc.js
@@ -3,7 +3,6 @@ module.exports = {
         es6: true,
         node: true,
     },
-    files: ["**/*.ts"],
     parser: "@typescript-eslint/parser",
     parserOptions: {
         project: "tsconfig.json",

--- a/sdk/nodejs/.eslintrc.js
+++ b/sdk/nodejs/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     },
     parser: "@typescript-eslint/parser",
     parserOptions: {
-        project: "tsconfig.json",
+        project: true,
         tsconfigRootDir: __dirname,
         sourceType: "module",
     },

--- a/sdk/nodejs/.eslintrc.js
+++ b/sdk/nodejs/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
         es6: true,
         node: true,
     },
+    files: ["**/*.ts"],
     parser: "@typescript-eslint/parser",
     parserOptions: {
         project: "tsconfig.json",
@@ -17,7 +18,6 @@ module.exports = {
         "tests/automation/data/tcfg/*.ts",
         "tests/sxs_ts_test/*.ts",
         "tests/runtime/testdata/closure-tests/**/*.ts",
-        "tests/runtime/testdata/closure-tests/**/*.js",
         "tests/provider/experimental/testdata/**/*.ts",
         "vendor/",
     ],


### PR DESCRIPTION
The `ci-lint.yml` file:
- Lints Go code
- Runs `go mod tidy`
- **Generates the Go SDK**
- **Calculates Protobuf checksums**
- Runs `make ensure`, which runs `go mod download` within some packages
- Lints JS/TS
- Lints Python
- Lints GitHub Actions

Two steps stand out here as not really "lint" jobs. This. PR divides `ci-lint.yml` into `lint.yml` - things that are definitely linting - and `ci-lint.yml` - things that are not really linting. The plan in the next PR is to inline these jobs into the relevant callsites and delete `ci-lint.yml`, but I try to limit myself to one hot take per PR. If this PR is merged, the `lint` job will need to be added as a required check for merging PRs.