### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/pkg/cmd/pulumi/deployment/deployment_settings_utils_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_utils_test.go
@@ -218,12 +218,7 @@ func TestDSFileParsing(t *testing.T) {
 }
 
 func setUpGitWorkspace(ctx context.Context, t *testing.T) string {
-	workDir, err := os.MkdirTemp("", "pulumi_deployment_settings")
-	assert.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(workDir)
-	})
+	workDir := t.TempDir()
 
 	cloneOptions := &git.CloneOptions{
 		RemoteName:    "origin",
@@ -233,7 +228,7 @@ func setUpGitWorkspace(ctx context.Context, t *testing.T) string {
 		ReferenceName: plumbing.ReferenceName("master"),
 	}
 
-	_, err = git.PlainCloneContext(ctx, workDir, false, cloneOptions)
+	_, err := git.PlainCloneContext(ctx, workDir, false, cloneOptions)
 	assert.NoError(t, err)
 
 	return workDir

--- a/sdk/go/auto/cmd_test.go
+++ b/sdk/go/auto/cmd_test.go
@@ -71,12 +71,11 @@ func TestOptionDefaults(t *testing.T) {
 func TestInstallTwice(t *testing.T) {
 	t.Parallel()
 
-	dir, err := os.MkdirTemp("", "automation-test-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
+
 	version := semver.Version{Major: 3, Minor: 98, Patch: 0}
 
-	_, err = InstallPulumiCommand(context.Background(), &PulumiCommandOptions{Root: dir, Version: version})
+	_, err := InstallPulumiCommand(context.Background(), &PulumiCommandOptions{Root: dir, Version: version})
 
 	require.NoError(t, err)
 	pulumiPath := filepath.Join(dir, "bin", "pulumi")
@@ -99,11 +98,9 @@ func TestInstallTwice(t *testing.T) {
 func TestErrorIncompatibleVersion(t *testing.T) {
 	t.Parallel()
 
-	dir, err := os.MkdirTemp("", "automation-test-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	installedVersion := semver.Version{Major: 3, Minor: 98, Patch: 0}
-	_, err = InstallPulumiCommand(context.Background(), &PulumiCommandOptions{Root: dir, Version: installedVersion})
+	_, err := InstallPulumiCommand(context.Background(), &PulumiCommandOptions{Root: dir, Version: installedVersion})
 	require.NoError(t, err)
 	requestedVersion := semver.Version{Major: 3, Minor: 101, Patch: 0}
 
@@ -120,13 +117,11 @@ func TestErrorIncompatibleVersion(t *testing.T) {
 
 //nolint:paralleltest // mutates environment variables
 func TestNoGlobalPulumi(t *testing.T) {
-	dir, err := os.MkdirTemp("", "automation-test-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	version := semver.Version{Major: 3, Minor: 98, Patch: 0}
 
 	// Install before we mutate path, we need some system binaries available to run the install script.
-	_, err = InstallPulumiCommand(context.Background(), &PulumiCommandOptions{Root: dir, Version: version})
+	_, err := InstallPulumiCommand(context.Background(), &PulumiCommandOptions{Root: dir, Version: version})
 	require.NoError(t, err)
 
 	t.Setenv("PATH", "") // Clear path so we don't have access to a globally installed pulumi command.

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -580,11 +580,9 @@ func TestGitCloneAndCheckoutRevision(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
-			dir, err := os.MkdirTemp("", "pulumi-git-test")
-			require.NoError(t, err)
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
-			err = GitCloneAndCheckoutRevision(context.Background(), "testdata/revision-test.git", c.revision, dir)
+			err := GitCloneAndCheckoutRevision(context.Background(), "testdata/revision-test.git", c.revision, dir)
 			if c.expectedError != "" {
 				require.ErrorContains(t, err, c.expectedError)
 				return


### PR DESCRIPTION
 TempDir returns a temporary directory for the test to use.The directory is automatically removed when the test and
all its subtests complete. More info  https://pkg.go.dev/testing#B.TempDir
