### PR TITLE
Update from exp/maps to maps in the conformance tests

### DIFF
--- a/cmd/pulumi-test-language/go.mod
+++ b/cmd/pulumi-test-language/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/cmd/pulumi-test-language
 
-go 1.22
+go 1.23
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../../sdk
 
@@ -17,7 +17,6 @@ require (
 	github.com/pulumi/pulumi/sdk/v3 v3.154.0
 	github.com/segmentio/encoding v0.3.6
 	github.com/stretchr/testify v1.10.0
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	google.golang.org/grpc v1.67.1
 	google.golang.org/protobuf v1.35.1
 	gopkg.in/yaml.v2 v2.4.0
@@ -185,6 +184,7 @@ require (
 	gocloud.dev v0.37.0 // indirect
 	gocloud.dev/secrets/hashivault v0.37.0 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.19.0 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect

--- a/cmd/pulumi-test-language/providers/component_property_deps_provider.go
+++ b/cmd/pulumi-test-language/providers/component_property_deps_provider.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"slices"
 
 	"github.com/blang/semver"
@@ -28,7 +29,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"golang.org/x/exp/maps"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -80,11 +80,8 @@ func (p *ComponentPropertyDepsProvider) GetSchema(
 			inputs map[string]schema.PropertySpec,
 			outputs map[string]schema.PropertySpec,
 		) schema.ResourceSpec {
-			requiredInputs := maps.Keys(inputs)
-			slices.Sort(requiredInputs)
-
-			requiredOutputs := maps.Keys(outputs)
-			slices.Sort(requiredOutputs)
+			requiredInputs := slices.Sorted(maps.Keys(inputs))
+			requiredOutputs := slices.Sorted(maps.Keys(outputs))
 
 			return schema.ResourceSpec{
 				IsComponent: isComponent,
@@ -108,8 +105,7 @@ func (p *ComponentPropertyDepsProvider) GetSchema(
 		inputs map[string]schema.PropertySpec,
 		returnType schema.ReturnTypeSpec,
 	) schema.FunctionSpec {
-		requiredInputs := maps.Keys(inputs)
-		slices.Sort(requiredInputs)
+		requiredInputs := slices.Sorted(maps.Keys(inputs))
 
 		return schema.FunctionSpec{
 			Description: description,

--- a/cmd/pulumi-test-language/providers/component_provider.go
+++ b/cmd/pulumi-test-language/providers/component_provider.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"slices"
 
 	"github.com/blang/semver"
@@ -28,7 +29,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"golang.org/x/exp/maps"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -93,11 +93,8 @@ func (p *ComponentProvider) GetSchema(context.Context, plugin.GetSchemaRequest) 
 			inputs map[string]schema.PropertySpec,
 			outputs map[string]schema.PropertySpec,
 		) schema.ResourceSpec {
-			requiredInputs := maps.Keys(inputs)
-			slices.Sort(requiredInputs)
-
-			requiredOutputs := maps.Keys(outputs)
-			slices.Sort(requiredOutputs)
+			requiredInputs := slices.Sorted(maps.Keys(inputs))
+			requiredOutputs := slices.Sorted(maps.Keys(outputs))
 
 			return schema.ResourceSpec{
 				IsComponent: isComponent,

--- a/cmd/pulumi-test-language/providers/plain_provider.go
+++ b/cmd/pulumi-test-language/providers/plain_provider.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 
 	"github.com/blang/semver"
-	"golang.org/x/exp/maps"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"

--- a/cmd/pulumi-test-language/providers/ref_ref_provider.go
+++ b/cmd/pulumi-test-language/providers/ref_ref_provider.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 
 	"github.com/blang/semver"
-	"golang.org/x/exp/maps"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"


### PR DESCRIPTION
These changes require Go 1.23 which should be fine to upgrade conformance tests to. We could make similar changes across pkg and sdk but might be a bit aggressive forcing them to 1.23 this soon (1.24 only just came out, so even though 1.22 technicaly isn't in our support list anymore we probably don't want to be too quick to force 1.23 on people).