### PR TITLE
Add get_resource_type/name to Resource in Python and TS

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -390,6 +390,28 @@ export abstract class Resource {
     }
 
     /**
+     * The type assigned to the resource at construction.
+     */
+    public getResourceType(): string {
+        // This is a method and not a property to not collide with potential subclass property names.
+        return this.__pulumiType;
+    }
+
+    /**
+     * The name assigned to the resource at construction.
+     */
+    public getResourceName(): string {
+        // This is a method and not a property to not collide with potential subclass property names.
+        if (this.__name === undefined) {
+            throw new ResourceError(
+                "Resource name is not available, this resource instance must have been constructed by an old SDK",
+                this,
+            );
+        }
+        return this.__name;
+    }
+
+    /**
      * Creates and registers a new resource object. `t` is the fully qualified
      * type token and `name` is the "name" part to use in creating a stable and
      * globally unique URN for the object. `dependsOn` is an optional list of

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -1040,6 +1040,20 @@ class Resource:
 
         return provider, providers
 
+    def get_resource_type(self) -> str:
+        """
+        The type assigned to the resource at construction.
+        """
+        # This is a method and not a property to not collide with potential subclass property names.
+        return self._type
+
+    def get_resource_name(self) -> str:
+        """
+        The name assigned to the resource at construction.
+        """
+        # This is a method and not a property to not collide with potential subclass property names.
+        return self._name
+
     @property
     def urn(self) -> "Output[str]":
         """


### PR DESCRIPTION
Python and TypeScript parts for https://github.com/pulumi/pulumi/issues/15890

Copying the dotnet implementation of having a separate method named something more unique than "name"/"type" to try and avoid conflicts with subclass property names.