### PR TITLE
use full Go version in pulumi-test-language/go.mod

### DIFF
--- a/cmd/pulumi-test-language/go.mod
+++ b/cmd/pulumi-test-language/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/cmd/pulumi-test-language
 
-go 1.23
+go 1.23.7
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../../sdk
 


### PR DESCRIPTION
When one does not have the correct Go version installed by default on the system, the version specified in the `go.mod` file needs to include the patch version for the Go tooling to automatically install the toolchain.  Make that so, so things don't break for people that have older Go versions still installed on the system.