### PR TITLE
Make `whoami` just a cobra command

### DIFF
--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -47,6 +47,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/about"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ai"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/auth"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cancel"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/completion"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
@@ -369,7 +370,7 @@ func NewPulumiCmd() *cobra.Command {
 			Commands: []*cobra.Command{
 				auth.NewLoginCmd(),
 				auth.NewLogoutCmd(),
-				whoami.NewWhoAmICmd(),
+				whoami.NewWhoAmICmd(pkgWorkspace.Instance, cmdBackend.DefaultLoginManager),
 				org.NewOrgCmd(),
 				deployment.NewDeploymentCmd(),
 			},

--- a/pkg/cmd/pulumi/whoami/whoami.go
+++ b/pkg/cmd/pulumi/whoami/whoami.go
@@ -15,14 +15,10 @@
 package whoami
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"io"
-	"os"
 	"strings"
 
-	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
@@ -32,8 +28,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewWhoAmICmd() *cobra.Command {
-	var whocmd whoAmICmd
+func NewWhoAmICmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager) *cobra.Command {
+	var jsonOut bool
+	var verbose bool
+
 	cmd := &cobra.Command{
 		Use:   "whoami",
 		Short: "Display the current logged-in user",
@@ -42,94 +40,70 @@ func NewWhoAmICmd() *cobra.Command {
 			"Displays the username of the currently logged in user.",
 		Args: cmdutil.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return whocmd.Run(cmd.Context())
+			ctx := cmd.Context()
+			stdout := cmd.OutOrStdout()
+
+			opts := display.Options{
+				Color: cmdutil.GetGlobalColorization(),
+			}
+
+			// Try to read the current project
+			project, _, err := ws.ReadProject()
+			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+				return err
+			}
+
+			b, err := cmdBackend.CurrentBackend(ctx, ws, lm, project, opts)
+			if err != nil {
+				return err
+			}
+
+			name, orgs, tokenInfo, err := b.CurrentUser()
+			if err != nil {
+				return err
+			}
+
+			if jsonOut {
+				return ui.FprintJSON(stdout, whoAmIJSON{
+					User:             name,
+					Organizations:    orgs,
+					URL:              b.URL(),
+					TokenInformation: tokenInfo,
+				})
+			}
+
+			if verbose {
+				fmt.Fprintf(stdout, "User: %s\n", name)
+				fmt.Fprintf(stdout, "Organizations: %s\n", strings.Join(orgs, ", "))
+				fmt.Fprintf(stdout, "Backend URL: %s\n", b.URL())
+				if tokenInfo != nil {
+					tokenType := "unknown"
+					if tokenInfo.Team != "" {
+						tokenType = "team: " + tokenInfo.Team
+					} else if tokenInfo.Organization != "" {
+						tokenType = "organization: " + tokenInfo.Organization
+					}
+					fmt.Fprintf(stdout, "Token type: %s\n", tokenType)
+					fmt.Fprintf(stdout, "Token name: %s\n", tokenInfo.Name)
+				} else {
+					fmt.Fprintf(stdout, "Token type: personal\n")
+				}
+			} else {
+				fmt.Fprintf(stdout, "%s\n", name)
+			}
+
+			return nil
 		},
 	}
 
 	cmd.PersistentFlags().BoolVarP(
-		&whocmd.jsonOut, "json", "j", false, "Emit output as JSON")
+		&jsonOut, "json", "j", false, "Emit output as JSON")
 
 	cmd.PersistentFlags().BoolVarP(
-		&whocmd.verbose, "verbose", "v", false,
+		&verbose, "verbose", "v", false,
 		"Print detailed whoami information")
 
 	return cmd
-}
-
-type whoAmICmd struct {
-	jsonOut bool
-	verbose bool
-
-	Stdout io.Writer // defaults to os.Stdout
-
-	// currentBackend is a reference to the top-level currentBackend function.
-	// This is used to override the default implementation for testing purposes.
-	currentBackend func(
-		context.Context, pkgWorkspace.Context, cmdBackend.LoginManager, *workspace.Project, display.Options,
-	) (backend.Backend, error)
-}
-
-func (cmd *whoAmICmd) Run(ctx context.Context) error {
-	if cmd.Stdout == nil {
-		cmd.Stdout = os.Stdout
-	}
-
-	if cmd.currentBackend == nil {
-		cmd.currentBackend = cmdBackend.CurrentBackend
-	}
-	currentBackend := cmd.currentBackend // shadow the top-level function
-
-	opts := display.Options{
-		Color: cmdutil.GetGlobalColorization(),
-	}
-
-	// Try to read the current project
-	ws := pkgWorkspace.Instance
-	project, _, err := ws.ReadProject()
-	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
-		return err
-	}
-
-	b, err := currentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, opts)
-	if err != nil {
-		return err
-	}
-
-	name, orgs, tokenInfo, err := b.CurrentUser()
-	if err != nil {
-		return err
-	}
-
-	if cmd.jsonOut {
-		return ui.FprintJSON(cmd.Stdout, whoAmIJSON{
-			User:             name,
-			Organizations:    orgs,
-			URL:              b.URL(),
-			TokenInformation: tokenInfo,
-		})
-	}
-
-	if cmd.verbose {
-		fmt.Fprintf(cmd.Stdout, "User: %s\n", name)
-		fmt.Fprintf(cmd.Stdout, "Organizations: %s\n", strings.Join(orgs, ", "))
-		fmt.Fprintf(cmd.Stdout, "Backend URL: %s\n", b.URL())
-		if tokenInfo != nil {
-			tokenType := "unknown"
-			if tokenInfo.Team != "" {
-				tokenType = "team: " + tokenInfo.Team
-			} else if tokenInfo.Organization != "" {
-				tokenType = "organization: " + tokenInfo.Organization
-			}
-			fmt.Fprintf(cmd.Stdout, "Token type: %s\n", tokenType)
-			fmt.Fprintf(cmd.Stdout, "Token name: %s\n", tokenInfo.Name)
-		} else {
-			fmt.Fprintf(cmd.Stdout, "Token type: personal\n")
-		}
-	} else {
-		fmt.Fprintf(cmd.Stdout, "%s\n", name)
-	}
-
-	return nil
 }
 
 // whoAmIJSON is the shape of the --json output of this command.

--- a/pkg/cmd/pulumi/whoami/whoami_test.go
+++ b/pkg/cmd/pulumi/whoami/whoami_test.go
@@ -20,9 +20,10 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
-	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,21 +32,24 @@ import (
 func TestWhoAmICmd_default(t *testing.T) {
 	t.Parallel()
 
-	var buff bytes.Buffer
-	cmd := whoAmICmd{
-		Stdout: &buff,
-		currentBackend: func(
-			context.Context, pkgWorkspace.Context, cmdBackend.LoginManager, *workspace.Project, display.Options,
+	ws := &pkgWorkspace.MockContext{}
+	be := &backend.MockBackend{
+		CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
+			return "user1", []string{"org1", "org2"}, nil, nil
+		},
+	}
+	lm := &cmdBackend.MockLoginManager{
+		LoginF: func(
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, colors.Colorization,
 		) (backend.Backend, error) {
-			return &backend.MockBackend{
-				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
-					return "user1", []string{"org1", "org2"}, nil, nil
-				},
-			}, nil
+			return be, nil
 		},
 	}
 
-	err := cmd.Run(context.Background())
+	var buff bytes.Buffer
+	cmd := NewWhoAmICmd(ws, lm)
+	cmd.SetOut(&buff)
+	err := cmd.Execute()
 	require.NoError(t, err)
 
 	assert.Equal(t, "user1\n", buff.String())
@@ -54,25 +58,28 @@ func TestWhoAmICmd_default(t *testing.T) {
 func TestWhoAmICmd_verbose(t *testing.T) {
 	t.Parallel()
 
-	var buff bytes.Buffer
-	cmd := whoAmICmd{
-		verbose: true,
-		Stdout:  &buff,
-		currentBackend: func(
-			context.Context, pkgWorkspace.Context, cmdBackend.LoginManager, *workspace.Project, display.Options,
+	ws := &pkgWorkspace.MockContext{}
+	be := &backend.MockBackend{
+		CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
+			return "user2", []string{"org1", "org2"}, nil, nil
+		},
+		URLF: func() string {
+			return "https://pulumi.example.com"
+		},
+	}
+	lm := &cmdBackend.MockLoginManager{
+		LoginF: func(
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, colors.Colorization,
 		) (backend.Backend, error) {
-			return &backend.MockBackend{
-				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
-					return "user2", []string{"org1", "org2"}, nil, nil
-				},
-				URLF: func() string {
-					return "https://pulumi.example.com"
-				},
-			}, nil
+			return be, nil
 		},
 	}
 
-	err := cmd.Run(context.Background())
+	var buff bytes.Buffer
+	cmd := NewWhoAmICmd(ws, lm)
+	cmd.SetArgs([]string{"--verbose"})
+	cmd.SetOut(&buff)
+	err := cmd.Execute()
 	require.NoError(t, err)
 
 	stdout := buff.String()
@@ -85,25 +92,28 @@ func TestWhoAmICmd_verbose(t *testing.T) {
 func TestWhoAmICmd_json(t *testing.T) {
 	t.Parallel()
 
-	var buff bytes.Buffer
-	cmd := whoAmICmd{
-		jsonOut: true,
-		Stdout:  &buff,
-		currentBackend: func(
-			context.Context, pkgWorkspace.Context, cmdBackend.LoginManager, *workspace.Project, display.Options,
+	ws := &pkgWorkspace.MockContext{}
+	be := &backend.MockBackend{
+		CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
+			return "user3", []string{"org1", "org2"}, nil, nil
+		},
+		URLF: func() string {
+			return "https://pulumi.example.com"
+		},
+	}
+	lm := &cmdBackend.MockLoginManager{
+		LoginF: func(
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, colors.Colorization,
 		) (backend.Backend, error) {
-			return &backend.MockBackend{
-				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
-					return "user3", []string{"org1", "org2"}, nil, nil
-				},
-				URLF: func() string {
-					return "https://pulumi.example.com"
-				},
-			}, nil
+			return be, nil
 		},
 	}
 
-	err := cmd.Run(context.Background())
+	var buff bytes.Buffer
+	cmd := NewWhoAmICmd(ws, lm)
+	cmd.SetArgs([]string{"--json"})
+	cmd.SetOut(&buff)
+	err := cmd.Execute()
 	require.NoError(t, err)
 
 	assert.JSONEq(t, `{
@@ -116,28 +126,31 @@ func TestWhoAmICmd_json(t *testing.T) {
 func TestWhoAmICmd_verbose_teamToken(t *testing.T) {
 	t.Parallel()
 
-	var buff bytes.Buffer
-	cmd := whoAmICmd{
-		verbose: true,
-		Stdout:  &buff,
-		currentBackend: func(
-			context.Context, pkgWorkspace.Context, cmdBackend.LoginManager, *workspace.Project, display.Options,
-		) (backend.Backend, error) {
-			return &backend.MockBackend{
-				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
-					return "user2", []string{"org1", "org2"}, &workspace.TokenInformation{
-						Name: "team-token",
-						Team: "myTeam",
-					}, nil
-				},
-				URLF: func() string {
-					return "https://pulumi.example.com"
-				},
+	ws := &pkgWorkspace.MockContext{}
+	be := &backend.MockBackend{
+		CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
+			return "user2", []string{"org1", "org2"}, &workspace.TokenInformation{
+				Name: "team-token",
+				Team: "myTeam",
 			}, nil
+		},
+		URLF: func() string {
+			return "https://pulumi.example.com"
+		},
+	}
+	lm := &cmdBackend.MockLoginManager{
+		LoginF: func(
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, colors.Colorization,
+		) (backend.Backend, error) {
+			return be, nil
 		},
 	}
 
-	err := cmd.Run(context.Background())
+	var buff bytes.Buffer
+	cmd := NewWhoAmICmd(ws, lm)
+	cmd.SetArgs([]string{"--verbose"})
+	cmd.SetOut(&buff)
+	err := cmd.Execute()
 	require.NoError(t, err)
 
 	stdout := buff.String()
@@ -151,28 +164,31 @@ func TestWhoAmICmd_verbose_teamToken(t *testing.T) {
 func TestWhoAmICmd_json_teamToken(t *testing.T) {
 	t.Parallel()
 
-	var buff bytes.Buffer
-	cmd := whoAmICmd{
-		jsonOut: true,
-		Stdout:  &buff,
-		currentBackend: func(
-			context.Context, pkgWorkspace.Context, cmdBackend.LoginManager, *workspace.Project, display.Options,
-		) (backend.Backend, error) {
-			return &backend.MockBackend{
-				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
-					return "user3", []string{"org1", "org2"}, &workspace.TokenInformation{
-						Name: "team-token",
-						Team: "myTeam",
-					}, nil
-				},
-				URLF: func() string {
-					return "https://pulumi.example.com"
-				},
+	ws := &pkgWorkspace.MockContext{}
+	be := &backend.MockBackend{
+		CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
+			return "user3", []string{"org1", "org2"}, &workspace.TokenInformation{
+				Name: "team-token",
+				Team: "myTeam",
 			}, nil
+		},
+		URLF: func() string {
+			return "https://pulumi.example.com"
+		},
+	}
+	lm := &cmdBackend.MockLoginManager{
+		LoginF: func(
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, colors.Colorization,
+		) (backend.Backend, error) {
+			return be, nil
 		},
 	}
 
-	err := cmd.Run(context.Background())
+	var buff bytes.Buffer
+	cmd := NewWhoAmICmd(ws, lm)
+	cmd.SetArgs([]string{"--json"})
+	cmd.SetOut(&buff)
+	err := cmd.Execute()
 	require.NoError(t, err)
 
 	assert.JSONEq(t, `{
@@ -186,27 +202,30 @@ func TestWhoAmICmd_json_teamToken(t *testing.T) {
 func TestWhoAmICmd_verbose_unknownToken(t *testing.T) {
 	t.Parallel()
 
-	var buff bytes.Buffer
-	cmd := whoAmICmd{
-		verbose: true,
-		Stdout:  &buff,
-		currentBackend: func(
-			context.Context, pkgWorkspace.Context, cmdBackend.LoginManager, *workspace.Project, display.Options,
-		) (backend.Backend, error) {
-			return &backend.MockBackend{
-				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
-					return "user2", []string{"org1", "org2"}, &workspace.TokenInformation{
-						Name: "bad-token",
-					}, nil
-				},
-				URLF: func() string {
-					return "https://pulumi.example.com"
-				},
+	ws := &pkgWorkspace.MockContext{}
+	be := &backend.MockBackend{
+		CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
+			return "user2", []string{"org1", "org2"}, &workspace.TokenInformation{
+				Name: "bad-token",
 			}, nil
+		},
+		URLF: func() string {
+			return "https://pulumi.example.com"
+		},
+	}
+	lm := &cmdBackend.MockLoginManager{
+		LoginF: func(
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, colors.Colorization,
+		) (backend.Backend, error) {
+			return be, nil
 		},
 	}
 
-	err := cmd.Run(context.Background())
+	var buff bytes.Buffer
+	cmd := NewWhoAmICmd(ws, lm)
+	cmd.SetArgs([]string{"--verbose"})
+	cmd.SetOut(&buff)
+	err := cmd.Execute()
 	require.NoError(t, err)
 
 	stdout := buff.String()


### PR DESCRIPTION
This removes the `whoAmICmd` to replace it with just the cobra wrapper. 

There's three things worth calling out here.
1. We can still mock out stdout by using `cmd.OutOrStdout()` in the run function, and setting it explicitly in the tests. Otherwise cobra defaults it to `os.Stdout`. This will be the general way of mocking stdout in commands going forward.
2. We inject the `workspace.Context` and `backend.LoginManager` to the new function so we can mock them in tests. They were hardcoded in the run function to the singleton instances.
3. Because we're injecting those two types we can just use the global `CurrentBackground` function. If we do this everywhere we should be able to remove the global `BackendInstance` variable from that function eventually.