### PR TITLE
upgrade pulumi dotnet to 3.76.1

### DIFF
--- a/changelog/pending/20250311--sdk-dotnet--upgrade-pulumi-dotnet-to-3-76-1.yaml
+++ b/changelog/pending/20250311--sdk-dotnet--upgrade-pulumi-dotnet-to-3-76-1.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/dotnet
+  description: Upgrade pulumi dotnet to 3.76.1

--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -378,4 +378,4 @@ const (
 )
 
 // PulumiDotnetSDKVersion is the version of the Pulumi .NET SDK to use in program-gen tests
-const PulumiDotnetSDKVersion = "3.75.2"
+const PulumiDotnetSDKVersion = "3.76.1"

--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -28,7 +28,7 @@ download_release() {
 # * When updating .Net, you should also update PulumiDotnetSDKVersion in pulumi/pkg/codegen/testing/test/helpers.go
 #
 # shellcheck disable=SC2043
-for i in "github.com/pulumi/pulumi-java java v1.3.0" "github.com/pulumi/pulumi-yaml yaml v1.14.1" "github.com/pulumi/pulumi-dotnet dotnet v3.75.2"; do
+for i in "github.com/pulumi/pulumi-java java v1.3.0" "github.com/pulumi/pulumi-yaml yaml v1.14.1" "github.com/pulumi/pulumi-dotnet dotnet v3.76.1"; do
   set -- $i # treat strings in loop as args
   REPO="$1"
   PULUMI_LANG="$2"


### PR DESCRIPTION
This has been released and Awsx has started to rely on it, so our tests break without this being updated.