### PR TITLE
Re-add provider error

### DIFF
--- a/changelog/pending/20250311--engine--return-an-error-on-malformed-provider-references-rather-than-ignoring-them.yaml
+++ b/changelog/pending/20250311--engine--return-an-error-on-malformed-provider-references-rather-than-ignoring-them.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Return an error on malformed provider references rather than ignoring them

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -812,14 +812,11 @@ func (rm *resmon) getProviderReference(defaultProviders *defaultProviders, req p
 	rawProviderRef string,
 ) (providers.Reference, error) {
 	if rawProviderRef != "" {
-		// Check if this is a real provider ref (URN::ID) or a package reference (a dashed uuid)
-		if strings.Contains(rawProviderRef, "::") {
-			ref, err := providers.ParseReference(rawProviderRef)
-			if err != nil {
-				return providers.Reference{}, fmt.Errorf("could not parse provider reference: %w", err)
-			}
-			return ref, nil
+		ref, err := providers.ParseReference(rawProviderRef)
+		if err != nil {
+			return providers.Reference{}, fmt.Errorf("could not parse provider reference: %w", err)
 		}
+		return ref, nil
 	}
 
 	ref, err := defaultProviders.getDefaultProviderRef(req)


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/16241/ we originally added package references via the `provider` field. We would check to see if the field contained a "::" and if so treat it as an explicit provider reference, else we'd treat it as a package reference. If either of these failed to parse/lookup it would return an error.

In https://github.com/pulumi/pulumi/pull/16458/ we added a new explicit package ref field and stopped using the `provider` field to transmit the package reference. When we did this we removed the case from provider parsing for package refs, but we left in the check to see if the field contained a "::".

So before both these changes if you sent a malformed field like "hi" it would error, but after these two changes it would just ignore the provider field and use the default provider instead.