### PR TITLE
    Add output verison of try generation nodejs

### DIFF
--- a/cmd/pulumi-test-language/tests/l2_builtin_can_with_output.go
+++ b/cmd/pulumi-test-language/tests/l2_builtin_can_with_output.go
@@ -1,0 +1,66 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	LanguageTests["l2-builtin-can-with-output"] = LanguageTest{
+		Providers: []plugin.Provider{&providers.ComponentProvider{}},
+		Runs: []TestRun{
+			{
+				Config: config.Map{
+					config.MustMakeKey("l2-builtin-can-with-output", "object"): config.NewObjectValue("{}"),
+				},
+				Assert: func(l *L,
+					projectDirectory string, err error,
+					snap *deploy.Snapshot, changes display.ResourceChanges,
+				) {
+					RequireStackResource(l, err, changes)
+
+					require.NotEmpty(l, snap.Resources, "expected at least 1 resource")
+					stack := snap.Resources[0]
+					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
+
+					outputs := stack.Outputs
+
+					_ = RequireSingleNamedResource(l, snap.Resources, "component1")
+
+					assert.Len(l, outputs, 2, "expected 2 outputs")
+					AssertPropertyMapMember(
+						l,
+						outputs,
+						"canWithOutput",
+						resource.NewBoolProperty(true))
+					AssertPropertyMapMember(
+						l,
+						outputs,
+						"canScalar",
+						resource.NewBoolProperty(true),
+					)
+				},
+			},
+		},
+	}
+}

--- a/cmd/pulumi-test-language/tests/l2_builtin_try_with_output.go
+++ b/cmd/pulumi-test-language/tests/l2_builtin_try_with_output.go
@@ -1,0 +1,70 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	LanguageTests["l2-builtin-try-with-output"] = LanguageTest{
+		Providers: []plugin.Provider{&providers.ComponentProvider{}},
+		Runs: []TestRun{
+			{
+				Config: config.Map{
+					config.MustMakeKey("l2-builtin-try-with-output", "object"): config.NewObjectValue("{}"),
+				},
+				Assert: func(l *L,
+					projectDirectory string, err error,
+					snap *deploy.Snapshot, changes display.ResourceChanges,
+				) {
+					RequireStackResource(l, err, changes)
+
+					require.NotEmpty(l, snap.Resources, "expected at least 1 resource")
+					stack := snap.Resources[0]
+					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
+
+					outputs := stack.Outputs
+
+					_ = RequireSingleNamedResource(l, snap.Resources, "component1")
+
+					assert.Len(l, outputs, 2, "expected 2 outputs")
+					AssertPropertyMapMember(
+						l,
+						outputs,
+						"tryWithOutput",
+						resource.NewPropertyValue(resource.NewPropertyMapFromMap(map[string]interface{}{
+							"id":    "id-foo-bar-baz",
+							"urn":   "urn:pulumi:test::l2-builtin-try-with-output::component:index:ComponentCustomRefOutput$component:index:Custom::component1-child",
+							"value": "foo-bar-baz",
+						})))
+					AssertPropertyMapMember(
+						l,
+						outputs,
+						"tryScalar",
+						resource.NewStringProperty("str"),
+					)
+				},
+			},
+		},
+	}
+}

--- a/cmd/pulumi-test-language/tests/l2_builtin_try_with_output.go
+++ b/cmd/pulumi-test-language/tests/l2_builtin_try_with_output.go
@@ -47,7 +47,7 @@ func init() {
 
 					_ = RequireSingleNamedResource(l, snap.Resources, "component1")
 
-					assert.Len(l, outputs, 2, "expected 2 outputs")
+					assert.Len(l, outputs, 3, "expected 3 outputs")
 					AssertPropertyMapMember(
 						l,
 						outputs,

--- a/cmd/pulumi-test-language/tests/l2_builtin_try_with_output.go
+++ b/cmd/pulumi-test-language/tests/l2_builtin_try_with_output.go
@@ -47,16 +47,13 @@ func init() {
 
 					_ = RequireSingleNamedResource(l, snap.Resources, "component1")
 
-					assert.Len(l, outputs, 3, "expected 3 outputs")
+					assert.Len(l, outputs, 4, "expected 4 outputs")
 					AssertPropertyMapMember(
 						l,
 						outputs,
 						"tryWithOutput",
-						resource.NewPropertyValue(resource.NewPropertyMapFromMap(map[string]interface{}{
-							"id":    "id-foo-bar-baz",
-							"urn":   "urn:pulumi:test::l2-builtin-try-with-output::component:index:ComponentCustomRefOutput$component:index:Custom::component1-child",
-							"value": "foo-bar-baz",
-						})))
+						resource.NewPropertyValue(resource.NewStringProperty("foo-bar-baz")),
+					)
 					AssertPropertyMapMember(
 						l,
 						outputs,

--- a/cmd/pulumi-test-language/tests/l2_builtin_try_with_output.go
+++ b/cmd/pulumi-test-language/tests/l2_builtin_try_with_output.go
@@ -27,7 +27,7 @@ import (
 
 func init() {
 	LanguageTests["l2-builtin-try-with-output"] = LanguageTest{
-		Providers: []plugin.Provider{&providers.ComponentProvider{}},
+		Providers: []plugin.Provider{&providers.ComponentProvider{}, &providers.SimpleInvokeProvider{}},
 		Runs: []TestRun{
 			{
 				Config: config.Map{

--- a/cmd/pulumi-test-language/tests/testdata/l2-builtin-can-with-output/main.pp
+++ b/cmd/pulumi-test-language/tests/testdata/l2-builtin-can-with-output/main.pp
@@ -1,0 +1,17 @@
+resource "component1" "component:index:ComponentCustomRefOutput" {
+  value = "foo-bar-baz"
+}
+
+output "canWithOutput" {
+  value = can(component1.ref)
+}
+
+str = "str"
+
+# Include one more "regular" non nested output can. In this case, 2 can
+# functions may be generated in the tested language, one for returning pulumi output of type bool
+# and the other for a regular bool
+output "canScalar" {
+  value = can(str)
+}
+

--- a/cmd/pulumi-test-language/tests/testdata/l2-builtin-try-with-output/main.pp
+++ b/cmd/pulumi-test-language/tests/testdata/l2-builtin-try-with-output/main.pp
@@ -6,6 +6,22 @@ output "tryWithOutput" {
   value = try(component1.ref, "failure")
 }
 
+# This should result in a try who's result is an output. 
+# It seems to generate the correct function, likely due to checking independently when generating 
+# the call site, but when generating it is treated as a regular value, and not an output that would require .apply.
+# The generated code is marked with this comment.
+# Ideas? Debugging Tips?
+resultContainingOutput = try(invoke("simple-invoke:index:myInvoke", {value="hello"}))
+output "hello" {
+  value = resultContainingOutput.result
+}
+
+# This generates fine but without a null check, so perhaps it is actually a non output after all?
+resultContaingOutputWithoutTry = invoke("simple-invoke:index:myInvoke", {value="hello"})
+output "helloNoTry" {
+  value = resultContaingOutputWithoutTry.result
+}
+
 str = "str"
 
 # Include one more "regular" non nested output try. In this case, 2 try

--- a/cmd/pulumi-test-language/tests/testdata/l2-builtin-try-with-output/main.pp
+++ b/cmd/pulumi-test-language/tests/testdata/l2-builtin-try-with-output/main.pp
@@ -3,6 +3,10 @@ resource "component1" "component:index:ComponentCustomRefOutput" {
 }
 
 # When accessing an output of a component inside a direct call to try we should have to use apply.
+#
+# TODO(pulumi/pulumi#18895) When value is directly a scope traversal inside the
+# output this fails to generate the "apply" call. eg if the output's internals
+# are `value = componentTried.value`
 componentTried = try(component1.ref, "fallback").value
 output "tryWithOutput" {
   value = componentTried

--- a/cmd/pulumi-test-language/tests/testdata/l2-builtin-try-with-output/main.pp
+++ b/cmd/pulumi-test-language/tests/testdata/l2-builtin-try-with-output/main.pp
@@ -1,0 +1,17 @@
+resource "component1" "component:index:ComponentCustomRefOutput" {
+  value = "foo-bar-baz"
+}
+
+output "tryWithOutput" {
+  value = try(component1.ref, "failure")
+}
+
+str = "str"
+
+# Include one more "regular" non nested output try. In this case, 2 try
+# functions may be generated in the tested language, one for returning outputs
+# and the other for a regular value "any"
+output "tryScalar" {
+  value = try(str, "fallback")
+}
+

--- a/cmd/pulumi-test-language/tests/testdata/l2-builtin-try-with-output/main.pp
+++ b/cmd/pulumi-test-language/tests/testdata/l2-builtin-try-with-output/main.pp
@@ -6,20 +6,9 @@ output "tryWithOutput" {
   value = try(component1.ref, "failure")
 }
 
-# This should result in a try who's result is an output. 
-# It seems to generate the correct function, likely due to checking independently when generating 
-# the call site, but when generating it is treated as a regular value, and not an output that would require .apply.
-# The generated code is marked with this comment.
-# Ideas? Debugging Tips?
-resultContainingOutput = try(invoke("simple-invoke:index:myInvoke", {value="hello"}))
+resultContainingOutput = try(invoke("simple-invoke:index:myInvoke", {value="hello"})).result
 output "hello" {
-  value = resultContainingOutput.result
-}
-
-# This generates fine but without a null check, so perhaps it is actually a non output after all?
-resultContaingOutputWithoutTry = invoke("simple-invoke:index:myInvoke", {value="hello"})
-output "helloNoTry" {
-  value = resultContaingOutputWithoutTry.result
+  value = resultContainingOutput
 }
 
 str = "str"

--- a/cmd/pulumi-test-language/tests/testdata/l2-builtin-try-with-output/main.pp
+++ b/cmd/pulumi-test-language/tests/testdata/l2-builtin-try-with-output/main.pp
@@ -2,20 +2,30 @@ resource "component1" "component:index:ComponentCustomRefOutput" {
   value = "foo-bar-baz"
 }
 
+# When accessing an output of a component inside a direct call to try we should have to use apply.
+componentTried = try(component1.ref, "fallback").value
 output "tryWithOutput" {
-  value = try(component1.ref, "failure")
+  value = componentTried
 }
 
-resultContainingOutput = try(invoke("simple-invoke:index:myInvoke", {value="hello"})).result
+componentTriedNested = try(component1.ref.value, "fallback")
+output "tryWithOutputNested" {
+  value = componentTriedNested
+}
+
+# Invokes produces outputs.  This output will have apply called on it and try
+# utilized within the apply.  The result of this apply is already an output
+# which has apply called on it again to pull out `result`
+resultContainingOutput = try(invoke("simple-invoke:index:myInvoke", {value="hello"}), "fakefallback").result
 output "hello" {
   value = resultContainingOutput
 }
 
 str = "str"
 
-# Include one more "regular" non nested output try. In this case, 2 try
-# functions may be generated in the tested language, one for returning outputs
-# and the other for a regular value "any"
+# This is a regular "try" which will not result in an output producing try.
+# Both versions of try which return outputs and non outputs may be produced
+# depending on language implementation.
 output "tryScalar" {
   value = try(str, "fallback")
 }

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -410,7 +410,7 @@ func (g *generator) collectProgramImports(program *pcl.Program) programImports {
 						importSet.Add(importPackage)
 					}
 				}
-				if helperMethodBody, ok := getHelperMethodIfNeeded(call.Name, g.Indent); ok {
+				if helperMethodBody, ok := getHelperMethodIfNeeded(call.Name, call.Args, g.Indent); ok {
 					preambleHelperMethods.Add(helperMethodBody)
 				}
 			}

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -621,10 +621,16 @@ func (g *generator) genTry(w io.Writer, args []model.Expression) {
 // which returns a bool indicating if the closure ran successfully.
 func (g *generator) genCan(w io.Writer, args []model.Expression) {
 	contract.Assertf(len(args) == 1, "expected exactly one argument to can")
+	shouldUseOutputCan := pcl.TypeContainsOutput(pcl.TryReturnTypeFromArgs(args))
+
+	functionName := "can_"
+	if shouldUseOutputCan {
+		functionName = "canOutput_"
+	}
 
 	arg := args[0]
 	g.Fprintf(w, "// @ts-ignore")
-	g.Fgenf(w, "\ncan_(() => %v)", g.lowerExpression(arg, arg.Type()))
+	g.Fgenf(w, "\n%s(() => %v)", functionName, g.lowerExpression(arg, arg.Type()))
 }
 
 func (g *generator) genRootDirectory(w io.Writer) {

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -586,8 +586,14 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 //	)
 func (g *generator) genTry(w io.Writer, args []model.Expression) {
 	contract.Assertf(len(args) > 0, "expected at least one argument to try")
+	shouldUseOutputTry := pcl.TypeContainsOutput(pcl.TryReturnTypeFromArgs(args))
 
-	g.Fprintf(w, "try_(")
+	functionName := "try_"
+	if shouldUseOutputTry {
+		functionName = "tryOutput_"
+	}
+
+	g.Fprintf(w, "%s(", functionName)
 	for i, arg := range args {
 		g.Indented(func() {
 			g.Fgenf(w, "\n%s// @ts-ignore", g.Indent)

--- a/pkg/codegen/nodejs/gen_program_utils.go
+++ b/pkg/codegen/nodejs/gen_program_utils.go
@@ -14,13 +14,18 @@
 
 package nodejs
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
+)
 
 // Provides code for a method which will be placed in the program preamble if deemed
 // necessary. Because many tasks in Go such as reading a file require extensive error
 // handling, it is much prettier to encapsulate that error handling boilerplate as its
 // own function in the preamble.
-func getHelperMethodIfNeeded(functionName string, indent string) (string, bool) {
+func getHelperMethodIfNeeded(functionName string, functionArgs []model.Expression, indent string) (string, bool) {
 	switch functionName {
 	case "filebase64sha256":
 		return `function computeFilebase64sha256(path: string): string {
@@ -45,31 +50,7 @@ func getHelperMethodIfNeeded(functionName string, indent string) (string, bool) 
 %s    throw new Error("mimeType not implemented, use the mime or mime-types package instead");
 %s}`, indent, indent, indent), true
 	case "try":
-		// During code generation, it's possible that we'll generate expression code that is "too safe" as arguments to try.
-		// E.g. given some PCL code `try(a.b.c, "fallback")`, where perhaps `a.b` is not defined, we'd ideally generate
-		// `a.b.c` in TypeScript, which will throw and hit the `catch` block. However, depending on the inferred optionality
-		// of the expressions involved, we may generate e.g. `a?.b?.c`, which instead of throwing will return `undefined`.
-		// We thus check for this explicitly in our helper. This should be safe, since `undefined` is _not_ strictly equal
-		// to `null`, and `null` is the "official no-value" value for PCL.
-		return fmt.Sprintf(`%[1]sfunction try_(
-%[1]s    ...fns: Array<() => unknown>
-%[1]s): any {
-%[1]s    for (const fn of fns) {
-%[1]s        try {
-%[1]s            const result = fn();
-%[1]s            if (result === undefined) {
-%[1]s                continue;
-%[1]s            }
-%[1]s            return result;
-%[1]s        } catch (e) {
-%[1]s            continue;
-%[1]s        }
-%[1]s    }
-%[1]s    return undefined;
-%[1]s}
-`,
-			indent,
-		), true
+		return generateTryFunction(functionArgs, indent)
 	case "can":
 		// Much like try, but instead of returning the result only returns true or
 		// false if the one argument has no error.  The "too safe" problem
@@ -93,4 +74,44 @@ func getHelperMethodIfNeeded(functionName string, indent string) (string, bool) 
 	default:
 		return "", false
 	}
+}
+
+// During code generation, it's possible that we'll generate expression code that is "too safe" as arguments to try.
+// E.g. given some PCL code `try(a.b.c, "fallback")`, where perhaps `a.b` is not defined, we'd ideally generate
+// `a.b.c` in TypeScript, which will throw and hit the `catch` block. However, depending on the inferred optionality
+// of the expressions involved, we may generate e.g. `a?.b?.c`, which instead of throwing will return `undefined`.
+// We thus check for this explicitly in our helper. This should be safe, since `undefined` is _not_ strictly equal
+// to `null`, and `null` is the "official no-value" value for PCL.
+func generateTryFunction(functionArgs []model.Expression, indent string) (string, bool) {
+	returnType := pcl.TryReturnTypeFromArgs(functionArgs)
+	shouldReturnOutput := pcl.TypeContainsOutput(returnType)
+
+	functionName := "try_"
+	returnTypeString := "any"
+	returnValue := "result"
+	if shouldReturnOutput {
+		functionName = "tryOutput_"
+		returnTypeString = "pulumi.Output<any>"
+		returnValue = "pulumi.output(result)"
+	}
+
+	return fmt.Sprintf(`%[1]sfunction %[4]s(
+%[1]s    ...fns: Array<() => unknown>
+%[1]s): %[2]s {
+%[1]s    for (const fn of fns) {
+%[1]s        try {
+%[1]s            const result = fn();
+%[1]s            if (result === undefined) {
+%[1]s                continue;
+%[1]s            }
+%[1]s            return %[3]s;
+%[1]s        } catch (e) {
+%[1]s            continue;
+%[1]s        }
+%[1]s    }
+%[1]s    throw new Error("try: all parameters failed");
+%[1]s}
+`,
+		indent, returnTypeString, returnValue, functionName,
+	), true
 }

--- a/pkg/codegen/pcl/functions.go
+++ b/pkg/codegen/pcl/functions.go
@@ -443,7 +443,7 @@ func pulumiBuiltins(options bindOptions) map[string]*model.Function {
 				// Return a type that is a union of all argument types.
 				returnType := TryReturnTypeFromArgs(args)
 				// If this results in a union of a dynamic type and another type, we should just return output dynamic.
-				if TypeContainsDynamic(returnType) {
+				if TypeContainsDynamic(returnType) || TypeContainsOutput(returnType) {
 					returnType = model.NewOutputType(model.DynamicType)
 				}
 
@@ -485,7 +485,7 @@ func pulumiBuiltins(options bindOptions) map[string]*model.Function {
 				// but otherwise we can return a plain bool
 				var returnType model.Type
 				returnType = model.BoolType
-				if isOutput(argType) || argType == model.DynamicType {
+				if TypeContainsOutput(argType) || argType == model.DynamicType {
 					returnType = model.NewOutputType(returnType)
 				}
 
@@ -527,17 +527,4 @@ func TypeContainsDynamic(t model.Type) bool {
 		return TypeContainsDynamic(o.ElementType)
 	}
 	return t == model.DynamicType
-}
-
-func TypeContainsOutput(t model.Type) bool {
-	if u, ok := t.(*model.UnionType); ok {
-		if slices.ContainsFunc(u.ElementTypes, TypeContainsOutput) {
-			return true
-		}
-	}
-	if _, ok := t.(*model.OutputType); ok {
-		return true
-	}
-
-	return false
 }

--- a/pkg/codegen/pcl/intrinsics.go
+++ b/pkg/codegen/pcl/intrinsics.go
@@ -26,7 +26,7 @@ const (
 	IntrinsicConvert = "__convert"
 )
 
-func isOutput(t model.Type) bool {
+func TypeContainsOutput(t model.Type) bool {
 	switch t := t.(type) {
 	case *model.OutputType:
 		return true
@@ -50,7 +50,7 @@ func NewApplyCall(args []model.Expression, then *model.AnonymousFunctionExpressi
 	exprs := make([]model.Expression, len(args)+1)
 	for i, a := range args {
 		exprs[i] = a
-		if isOutput := isOutput(a.Type()); isOutput {
+		if isOutput := TypeContainsOutput(a.Type()); isOutput {
 			returnsOutput = true
 		}
 		signature.Parameters[i] = model.Parameter{

--- a/pkg/codegen/pcl/rewrite_apply.go
+++ b/pkg/codegen/pcl/rewrite_apply.go
@@ -155,6 +155,9 @@ func (r *applyRewriter) inspectsEventualValues(x model.Expression) bool {
 	case *model.ForExpression:
 		return r.hasEventualElements(x.Collection)
 	case *model.FunctionCallExpression:
+		// TODO(pulumi/pulumi##18896) instead of a special case we should correctly
+		// handle binding functions which can take in output expressions.
+		//
 		// special case toJSON function because we map it to pulumi.jsonStringify which accepts anything
 		// such that it doesn't have to rewrite its subexpressions to apply but can be used directly
 		if r.skipToJSON && x.Name == "toJSON" {
@@ -199,17 +202,14 @@ func (r *applyRewriter) observesEventualValues(x model.Expression) bool {
 		_, collectionIsEventual := r.isEventualType(x.Collection.Type())
 		return collectionIsEventual
 	case *model.FunctionCallExpression:
+		// TODO(pulumi/pulumi##18896) instead of a special case we should correctly
+		// handle binding functions which can take in output expressions.
+		//
 		// special case toJSON function because we map it to pulumi.jsonStringify which accepts anything
 		// such that it doesn't have to rewrite its subexpressions to apply but can be used directly
 		if r.skipToJSON && x.Name == "toJSON" {
 			return false
 		}
-
-		// TODO THIS and then probably fix the debt and make it so we have tests for NOT adding apply when unneeded.
-		// then fix it
-		// if x.Name == "try" {
-		// 	return false
-		// }
 
 		for i, arg := range x.Args {
 			if !r.isPromptArg(x.Signature.Parameters[i].Type, arg) {

--- a/pkg/codegen/pcl/rewrite_apply.go
+++ b/pkg/codegen/pcl/rewrite_apply.go
@@ -116,18 +116,6 @@ func (r *applyRewriter) hasEventualElements(x model.Expression) bool {
 	return r.hasEventualTypes(t)
 }
 
-// isOutputProducingTry will traverse backward out of the scope of this
-// output-producing try call and return true of an attribute or index is
-// accessed on it's return value.
-func (r *applyRewriter) isOutputProducingTry(x *model.FunctionCallExpression) bool {
-	if x.Name != "try" {
-		return false
-	}
-
-	_, ok := x.Signature.ReturnType.(*model.OutputType)
-	return ok
-}
-
 func (r *applyRewriter) isPromptArg(paramType model.Type, arg model.Expression) bool {
 	if !r.hasEventualValues(arg) {
 		return true
@@ -217,9 +205,11 @@ func (r *applyRewriter) observesEventualValues(x model.Expression) bool {
 			return false
 		}
 
-		if r.isOutputProducingTry(x) {
-			return true
-		}
+		// TODO THIS and then probably fix the debt and make it so we have tests for NOT adding apply when unneeded.
+		// then fix it
+		// if x.Name == "try" {
+		// 	return false
+		// }
 
 		for i, arg := range x.Args {
 			if !r.isPromptArg(x.Signature.Parameters[i].Type, arg) {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-can-with-output/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-can-with-output/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-can-with-output/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-can-with-output/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: l2-builtin-can-with-output
+runtime:
+  name: nodejs
+  options:
+    typescript: false

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-can-with-output/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-can-with-output/index.ts
@@ -1,0 +1,39 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as component from "@pulumi/component";
+
+function canOutput_(
+    fn: () => unknown
+): pulumi.Output<boolean> {
+    try {
+        const result = fn();
+        if (result === undefined) {
+            return pulumi.output(false)
+        }
+        return pulumi.output(true)
+    } catch (e) {
+        return pulumi.output(false)
+    }
+}
+
+
+function can_(
+    fn: () => unknown
+): boolean {
+    try {
+        const result = fn();
+        if (result === undefined) {
+            return false
+        }
+        return true
+    } catch (e) {
+        return false
+    }
+}
+
+
+const component1 = new component.ComponentCustomRefOutput("component1", {value: "foo-bar-baz"});
+export const canWithOutput = // @ts-ignore
+canOutput_(() => component1.ref);
+const str = "str";
+export const canScalar = // @ts-ignore
+can_(() => str);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-can-with-output/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-can-with-output/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "l2-builtin-can-with-output",
+	"devDependencies": {
+		"@types/node": "^14"
+	},
+	"dependencies": {
+		"typescript": "^4.0.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/component": "ROOT/artifacts/pulumi-component-13.3.7.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-can-with-output/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-can-with-output/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2016",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: l2-builtin-try-with-output
+runtime:
+  name: nodejs
+  options:
+    typescript: false

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/index.ts
@@ -39,18 +39,32 @@ function try_(
 
 
 const component1 = new component.ComponentCustomRefOutput("component1", {value: "foo-bar-baz"});
-export const tryWithOutput = component1.ref.apply(ref => try_(
+// When accessing an output of a component inside a direct call to try we should have to use apply.
+const componentTried = tryOutput_(
     // @ts-ignore
-    () => ref,
+    () => component1.ref,
     // @ts-ignore
-    () => "failure"
-));
-const resultContainingOutput = simple_invoke.myInvokeOutput({
-    value: "hello",
-}).apply(invoke => try_(
+    () => "fallback"
+).apply(_try => _try.value);
+export const tryWithOutput = componentTried;
+const componentTriedNested = tryOutput_(
     // @ts-ignore
-    () => invoke
-)).apply(_try => _try.result);
+    () => component1.ref.value,
+    // @ts-ignore
+    () => "fallback"
+);
+export const tryWithOutputNested = componentTriedNested;
+// Invokes produces outputs.  This output will have apply called on it and try
+// utilized within the apply.  The result of this apply is already an output
+// which has apply called on it again to pull out `result`
+const resultContainingOutput = tryOutput_(
+    // @ts-ignore
+    () => simple_invoke.myInvokeOutput({
+        value: "hello",
+    }),
+    // @ts-ignore
+    () => "fakefallback"
+).apply(_try => _try.result);
 export const hello = resultContainingOutput;
 const str = "str";
 export const tryScalar = try_(

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/index.ts
@@ -1,0 +1,53 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as component from "@pulumi/component";
+
+function tryOutput_(
+    ...fns: Array<() => unknown>
+): pulumi.Output<any> {
+    for (const fn of fns) {
+        try {
+            const result = fn();
+            if (result === undefined) {
+                continue;
+            }
+            return pulumi.output(result);
+        } catch (e) {
+            continue;
+        }
+    }
+    throw new Error("try: all parameters failed");
+}
+
+
+function try_(
+    ...fns: Array<() => unknown>
+): any {
+    for (const fn of fns) {
+        try {
+            const result = fn();
+            if (result === undefined) {
+                continue;
+            }
+            return result;
+        } catch (e) {
+            continue;
+        }
+    }
+    throw new Error("try: all parameters failed");
+}
+
+
+const component1 = new component.ComponentCustomRefOutput("component1", {value: "foo-bar-baz"});
+export const tryWithOutput = tryOutput_(
+    // @ts-ignore
+    () => component1.ref,
+    // @ts-ignore
+    () => "failure"
+);
+const str = "str";
+export const tryScalar = try_(
+    // @ts-ignore
+    () => str,
+    // @ts-ignore
+    () => "fallback"
+);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/index.ts
@@ -1,5 +1,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as component from "@pulumi/component";
+import * as simple_invoke from "@pulumi/simple-invoke";
 
 function tryOutput_(
     ...fns: Array<() => unknown>
@@ -44,6 +45,23 @@ export const tryWithOutput = tryOutput_(
     // @ts-ignore
     () => "failure"
 );
+// This should result in a try who's result is an output. 
+// It seems to generate the correct function, likely due to checking independently when generating 
+// the call site, but when generating it is treated as a regular value, and not an output that would require .apply.
+// The generated code is marked with this comment.
+// Ideas? Debugging Tips?
+const resultContainingOutput = tryOutput_(
+    // @ts-ignore
+    () => simple_invoke.myInvokeOutput({
+        value: "hello",
+    })
+);
+export const hello = resultContainingOutput?.result;
+const resultContaingOutputWithoutTry = simple_invoke.myInvokeOutput({
+    value: "hello",
+});
+// This generates fine but without a null check, so perhaps it is actually a non output after all?
+export const helloNoTry = resultContaingOutputWithoutTry.result;
 const str = "str";
 export const tryScalar = try_(
     // @ts-ignore

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/index.ts
@@ -39,29 +39,19 @@ function try_(
 
 
 const component1 = new component.ComponentCustomRefOutput("component1", {value: "foo-bar-baz"});
-export const tryWithOutput = tryOutput_(
+export const tryWithOutput = component1.ref.apply(ref => try_(
     // @ts-ignore
-    () => component1.ref,
+    () => ref,
     // @ts-ignore
     () => "failure"
-);
-// This should result in a try who's result is an output. 
-// It seems to generate the correct function, likely due to checking independently when generating 
-// the call site, but when generating it is treated as a regular value, and not an output that would require .apply.
-// The generated code is marked with this comment.
-// Ideas? Debugging Tips?
-const resultContainingOutput = tryOutput_(
-    // @ts-ignore
-    () => simple_invoke.myInvokeOutput({
-        value: "hello",
-    })
-);
-export const hello = resultContainingOutput?.result;
-const resultContaingOutputWithoutTry = simple_invoke.myInvokeOutput({
+));
+const resultContainingOutput = simple_invoke.myInvokeOutput({
     value: "hello",
-});
-// This generates fine but without a null check, so perhaps it is actually a non output after all?
-export const helloNoTry = resultContaingOutputWithoutTry.result;
+}).apply(invoke => try_(
+    // @ts-ignore
+    () => invoke
+)).apply(_try => _try.result);
+export const hello = resultContainingOutput;
 const str = "str";
 export const tryScalar = try_(
     // @ts-ignore

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/index.ts
@@ -40,6 +40,10 @@ function try_(
 
 const component1 = new component.ComponentCustomRefOutput("component1", {value: "foo-bar-baz"});
 // When accessing an output of a component inside a direct call to try we should have to use apply.
+//
+// TODO(pulumi/pulumi#18895) When value is directly a scope traversal inside the
+// output this fails to generate the "apply" call. eg if the output's internals
+// are `value = componentTried.value`
 const componentTried = tryOutput_(
     // @ts-ignore
     () => component1.ref,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/package.json
@@ -6,6 +6,7 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
-		"@pulumi/component": "ROOT/artifacts/pulumi-component-13.3.7.tgz"
+		"@pulumi/component": "ROOT/artifacts/pulumi-component-13.3.7.tgz",
+		"@pulumi/simple-invoke": "ROOT/artifacts/pulumi-simple-invoke-10.0.0.tgz"
 	}
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "l2-builtin-try-with-output",
+	"devDependencies": {
+		"@types/node": "^14"
+	},
+	"dependencies": {
+		"typescript": "^4.0.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/component": "ROOT/artifacts/pulumi-component-13.3.7.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-builtin-try-with-output/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2016",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-can-with-output/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-can-with-output/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-can-with-output/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-can-with-output/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-builtin-can-with-output
+runtime: nodejs

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-can-with-output/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-can-with-output/index.ts
@@ -1,0 +1,39 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as component from "@pulumi/component";
+
+function canOutput_(
+    fn: () => unknown
+): pulumi.Output<boolean> {
+    try {
+        const result = fn();
+        if (result === undefined) {
+            return pulumi.output(false)
+        }
+        return pulumi.output(true)
+    } catch (e) {
+        return pulumi.output(false)
+    }
+}
+
+
+function can_(
+    fn: () => unknown
+): boolean {
+    try {
+        const result = fn();
+        if (result === undefined) {
+            return false
+        }
+        return true
+    } catch (e) {
+        return false
+    }
+}
+
+
+const component1 = new component.ComponentCustomRefOutput("component1", {value: "foo-bar-baz"});
+export const canWithOutput = // @ts-ignore
+canOutput_(() => component1.ref);
+const str = "str";
+export const canScalar = // @ts-ignore
+can_(() => str);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-can-with-output/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-can-with-output/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "l2-builtin-can-with-output",
+	"devDependencies": {
+		"@types/node": "^14"
+	},
+	"dependencies": {
+		"typescript": "^4.0.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/component": "ROOT/artifacts/pulumi-component-13.3.7.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-can-with-output/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-can-with-output/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2016",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-builtin-try-with-output
+runtime: nodejs

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/index.ts
@@ -39,18 +39,32 @@ function try_(
 
 
 const component1 = new component.ComponentCustomRefOutput("component1", {value: "foo-bar-baz"});
-export const tryWithOutput = component1.ref.apply(ref => try_(
+// When accessing an output of a component inside a direct call to try we should have to use apply.
+const componentTried = tryOutput_(
     // @ts-ignore
-    () => ref,
+    () => component1.ref,
     // @ts-ignore
-    () => "failure"
-));
-const resultContainingOutput = simple_invoke.myInvokeOutput({
-    value: "hello",
-}).apply(invoke => try_(
+    () => "fallback"
+).apply(_try => _try.value);
+export const tryWithOutput = componentTried;
+const componentTriedNested = tryOutput_(
     // @ts-ignore
-    () => invoke
-)).apply(_try => _try.result);
+    () => component1.ref.value,
+    // @ts-ignore
+    () => "fallback"
+);
+export const tryWithOutputNested = componentTriedNested;
+// Invokes produces outputs.  This output will have apply called on it and try
+// utilized within the apply.  The result of this apply is already an output
+// which has apply called on it again to pull out `result`
+const resultContainingOutput = tryOutput_(
+    // @ts-ignore
+    () => simple_invoke.myInvokeOutput({
+        value: "hello",
+    }),
+    // @ts-ignore
+    () => "fakefallback"
+).apply(_try => _try.result);
 export const hello = resultContainingOutput;
 const str = "str";
 export const tryScalar = try_(

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/index.ts
@@ -1,0 +1,53 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as component from "@pulumi/component";
+
+function tryOutput_(
+    ...fns: Array<() => unknown>
+): pulumi.Output<any> {
+    for (const fn of fns) {
+        try {
+            const result = fn();
+            if (result === undefined) {
+                continue;
+            }
+            return pulumi.output(result);
+        } catch (e) {
+            continue;
+        }
+    }
+    throw new Error("try: all parameters failed");
+}
+
+
+function try_(
+    ...fns: Array<() => unknown>
+): any {
+    for (const fn of fns) {
+        try {
+            const result = fn();
+            if (result === undefined) {
+                continue;
+            }
+            return result;
+        } catch (e) {
+            continue;
+        }
+    }
+    throw new Error("try: all parameters failed");
+}
+
+
+const component1 = new component.ComponentCustomRefOutput("component1", {value: "foo-bar-baz"});
+export const tryWithOutput = tryOutput_(
+    // @ts-ignore
+    () => component1.ref,
+    // @ts-ignore
+    () => "failure"
+);
+const str = "str";
+export const tryScalar = try_(
+    // @ts-ignore
+    () => str,
+    // @ts-ignore
+    () => "fallback"
+);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/index.ts
@@ -1,5 +1,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as component from "@pulumi/component";
+import * as simple_invoke from "@pulumi/simple-invoke";
 
 function tryOutput_(
     ...fns: Array<() => unknown>
@@ -44,6 +45,22 @@ export const tryWithOutput = tryOutput_(
     // @ts-ignore
     () => "failure"
 );
+// This should result in a try who's result is an output. 
+// It seems to generate the correct function, likely due to checking independently when generating 
+// the call site, but when generating it is treated as a regular value, and not an output that would require .apply.
+// The generated code is marked with this comment.
+// Ideas? Debugging Tips?
+const resultContainingOutput = tryOutput_(
+    // @ts-ignore
+    () => simple_invoke.myInvokeOutput({
+        value: "hello",
+    })
+);
+export const hello = resultContainingOutput?.result;
+const resultContaingOutputWithoutTry = simple_invoke.myInvokeOutput({
+    value: "hello",
+});
+export const helloNoTry = resultContaingOutputWithoutTry.result;
 const str = "str";
 export const tryScalar = try_(
     // @ts-ignore

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/index.ts
@@ -39,28 +39,19 @@ function try_(
 
 
 const component1 = new component.ComponentCustomRefOutput("component1", {value: "foo-bar-baz"});
-export const tryWithOutput = tryOutput_(
+export const tryWithOutput = component1.ref.apply(ref => try_(
     // @ts-ignore
-    () => component1.ref,
+    () => ref,
     // @ts-ignore
     () => "failure"
-);
-// This should result in a try who's result is an output. 
-// It seems to generate the correct function, likely due to checking independently when generating 
-// the call site, but when generating it is treated as a regular value, and not an output that would require .apply.
-// The generated code is marked with this comment.
-// Ideas? Debugging Tips?
-const resultContainingOutput = tryOutput_(
-    // @ts-ignore
-    () => simple_invoke.myInvokeOutput({
-        value: "hello",
-    })
-);
-export const hello = resultContainingOutput?.result;
-const resultContaingOutputWithoutTry = simple_invoke.myInvokeOutput({
+));
+const resultContainingOutput = simple_invoke.myInvokeOutput({
     value: "hello",
-});
-export const helloNoTry = resultContaingOutputWithoutTry.result;
+}).apply(invoke => try_(
+    // @ts-ignore
+    () => invoke
+)).apply(_try => _try.result);
+export const hello = resultContainingOutput;
 const str = "str";
 export const tryScalar = try_(
     // @ts-ignore

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/index.ts
@@ -40,6 +40,10 @@ function try_(
 
 const component1 = new component.ComponentCustomRefOutput("component1", {value: "foo-bar-baz"});
 // When accessing an output of a component inside a direct call to try we should have to use apply.
+//
+// TODO(pulumi/pulumi#18895) When value is directly a scope traversal inside the
+// output this fails to generate the "apply" call. eg if the output's internals
+// are `value = componentTried.value`
 const componentTried = tryOutput_(
     // @ts-ignore
     () => component1.ref,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/package.json
@@ -6,6 +6,7 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
-		"@pulumi/component": "ROOT/artifacts/pulumi-component-13.3.7.tgz"
+		"@pulumi/component": "ROOT/artifacts/pulumi-component-13.3.7.tgz",
+		"@pulumi/simple-invoke": "ROOT/artifacts/pulumi-simple-invoke-10.0.0.tgz"
 	}
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "l2-builtin-try-with-output",
+	"devDependencies": {
+		"@types/node": "^14"
+	},
+	"dependencies": {
+		"typescript": "^4.0.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/component": "ROOT/artifacts/pulumi-component-13.3.7.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-builtin-try-with-output/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2016",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts",
+	]
+}


### PR DESCRIPTION
Add output verison of can generation nodejs

For more details see: [the doc](https://docs.google.com/document/d/1s0Ns6HppEch1_nc02zZwsVuDOR5LIMI3REXVTemhlmU)

TLDR we currently have the "can" function defined to dynamically bind in
PCL to either pulumi outputs or regular dynamic values, but we do not
generate canOutput in any language.  This adds canOutput generation so
codegen into nodejs will generate outputty functions for `can`.
