### PR TITLE
Rename SDK publishing commands to reflect that they're operating on SDKs

### DIFF
--- a/pkg/cmd/pulumi/packagecmd/package.go
+++ b/pkg/cmd/pulumi/packagecmd/package.go
@@ -32,8 +32,8 @@ Install and configure Pulumi packages and their plugins and SDKs.`,
 		newExtractSchemaCommand(),
 		newExtractMappingCommand(),
 		newGenSdkCommand(),
-		newPackagePublishCmd(),
-		newPackagePackCmd(),
+		newPackagePublishSdkCmd(),
+		newPackagePackSdkCmd(),
 		newPackageAddCmd(),
 	)
 	return cmd

--- a/pkg/cmd/pulumi/packagecmd/package_pack_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_pack_sdk.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-func newPackagePackCmd() *cobra.Command {
+func newPackagePackSdkCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "pack-sdk <language> <path>",
 		Args:   cobra.ExactArgs(2),

--- a/pkg/cmd/pulumi/packagecmd/package_publish_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_sdk.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newPackagePublishCmd() *cobra.Command {
+func newPackagePublishSdkCmd() *cobra.Command {
 	var path string
 	cmd := &cobra.Command{
 		Use:    "publish-sdk <language>",


### PR DESCRIPTION
This renames the existing files/methods of the dev-only SDK publishing commands. It's in preparation of https://github.com/pulumi/pulumi/pull/18818 which actually concerns itself with publishing packages