### PR TITLE
Enable 'pulumi package publish' to detect README files

### DIFF
--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -263,8 +263,10 @@ func login(ctx context.Context, project *workspace.Project) (backend.Backend, er
 }
 
 // findReadme attempts to find a readme file in the given package source.
-// It first checks if the source is a directory and then checks if the installed plugin directory contains a readme.
-// If no readme is found, it returns an empty string.
+// It tries to find a readme in the following order and returns the path to the first one it finds:
+// 1. The package source if it is a directory
+// 2. The installed plugin directory
+// If no readme is found, an empty string is returned.
 func (cmd *packagePublishCmd) findReadme(packageSrc string) (string, error) {
 	findReadmeInDir := func(dir string) string {
 		info, err := os.Stat(dir)

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -153,7 +153,8 @@ func (cmd *packagePublishCmd) Run(
 		args.readmePath = readmePath
 	}
 	if args.readmePath == "" {
-		return errors.New("no README found. Please add one named README.md to the package, or use --readme to specify the path")
+		return errors.New("no README found. Please add one named README.md to the package, " +
+			"or use --readme to specify the path")
 	}
 
 	var publisher string
@@ -258,7 +259,7 @@ func login(ctx context.Context, project *workspace.Project) (backend.Backend, er
 	return b, nil
 }
 
-// findReadme attempts to find a readme file in the given package source.
+// findReadme attempts to find a file named README.md (case insensitive) in the given package source.
 // It tries to find a readme in the following order and returns the path to the first one it finds:
 // 1. The package source if it is a directory
 // 2. The installed plugin directory
@@ -288,6 +289,10 @@ func (cmd *packagePublishCmd) findReadme(packageSrc string) (string, error) {
 		return ""
 	}
 
+	if ext := filepath.Ext(packageSrc); ext == ".json" || ext == ".yaml" || ext == ".yml" {
+		// If the package source is a schema file, there's no README.md to be found.
+		return "", nil
+	}
 	// If the source is a directory, check if it contains a readme.
 	if readmeFromPackage := findReadmeInDir(packageSrc); readmeFromPackage != "" {
 		return readmeFromPackage, nil

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -118,10 +118,6 @@ func (cmd *packagePublishCmd) Run(
 	packageSrc string,
 	packageParams []string,
 ) error {
-	if args.readmePath == "" {
-		return errors.New("no readme specified, please provide the path to the readme file")
-	}
-
 	project, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return fmt.Errorf("failed to determine current project: %w", err)

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -153,7 +153,7 @@ func (cmd *packagePublishCmd) Run(
 		args.readmePath = readmePath
 	}
 	if args.readmePath == "" {
-		return errors.New("no readme specified, please provide the path to the readme file or add one to the package")
+		return errors.New("no README found. Please add one named README.md to the package, or use --readme to specify the path")
 	}
 
 	var publisher string

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -260,7 +260,7 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 				Version:  &version,
 				Provider: &schema.Resource{},
 			},
-			expectedErr: "no readme specified, please provide the path to the readme file or add one to the package",
+			expectedErr: "no README found. Please add one named README.md to the package, or use --readme to specify the path",
 		},
 		{
 			name: "error when publish fails",

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -669,6 +669,17 @@ func TestFindReadme(t *testing.T) {
 		assert.NoError(t, err, "Should not return error when source is a file")
 	})
 
+	t.Run("SchemaFile", func(t *testing.T) {
+		t.Parallel()
+		schemaPath := filepath.Join(tmpDir, "schema.json")
+		err := os.WriteFile(schemaPath, []byte("{}"), 0o600)
+		require.NoError(t, err)
+
+		readme, err := cmd.findReadme(schemaPath)
+		assert.Empty(t, readme)
+		assert.NoError(t, err, "Should not return error when source is a schema file")
+	})
+
 	t.Run("DirectoryWithoutReadme", func(t *testing.T) {
 		t.Parallel()
 		dirPath := filepath.Join(tmpDir, "no-readme-dir")

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -30,6 +30,7 @@ import (
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,6 +53,8 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 		expectedErr         string
 		readmeContent       string
 		installContent      string
+		sourceDir      func(t *testing.T) string
+		pluginDir      func(t *testing.T) string
 	}{
 		{
 			name: "successful publish with publisher from schema",
@@ -115,6 +118,54 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 				Provider: &schema.Resource{},
 			},
 			readmeContent: "# Test README\nThis is a test readme.",
+		},
+		{
+			name: "loads readme from package source",
+			args: publishPackageArgs{
+				source:    "pulumi",
+				publisher: "publisher",
+			},
+			mockSchema: &schema.Package{
+				Name:     "testpkg",
+				Version:  &version,
+				Provider: &schema.Resource{},
+			},
+			sourceDir: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				readmeFile, err := os.Create(path.Join(dir, "README.md"))
+				require.NoError(t, err)
+				defer contract.IgnoreClose(readmeFile)
+				_, err = readmeFile.WriteString("# README from the package source\nThis is a test readme.")
+				require.NoError(t, err)
+				return dir
+			},
+		},
+		{
+			name: "loads readme from installed plugin",
+			args: publishPackageArgs{
+				source:    "pulumi",
+				publisher: "publisher",
+			},
+			packageParams: []string{},
+			mockSchema: &schema.Package{
+				Name:     "testpkg",
+				Version:  &version,
+				Provider: &schema.Resource{},
+			},
+			pluginDir: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				testPlugin := path.Join(dir, "resource-testpackage")
+				err := os.MkdirAll(testPlugin, 0o755)
+				require.NoError(t, err)
+				readmeFile, err := os.Create(path.Join(testPlugin, "README.md"))
+				require.NoError(t, err)
+				defer contract.IgnoreClose(readmeFile)
+				_, err = readmeFile.WriteString("# README from the installed plugin\nThis is a test readme.")
+				require.NoError(t, err)
+				return dir
+			},
 		},
 		{
 			name: "error when no publisher available",
@@ -207,7 +258,7 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 				Version:  &version,
 				Provider: &schema.Resource{},
 			},
-			expectedErr: "no readme specified, please provide the path to the readme file",
+			expectedErr: "no readme specified, please provide the path to the readme file or add one to the package",
 		},
 		{
 			name: "error when publish fails",
@@ -249,7 +300,9 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir := t.TempDir()
 
+			packageSource := "testpackage"
 			var readmePath string
+			var expectedReadmeContent string
 			if tt.readmeContent != "" {
 				readmeFile, err := os.Create(path.Join(tempDir, "readme.md"))
 				require.NoError(t, err)
@@ -258,6 +311,27 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 				require.NoError(t, readmeFile.Close())
 				readmePath = readmeFile.Name()
 				tt.args.readmePath = readmePath
+				expectedReadmeContent = tt.readmeContent
+			}
+			if tt.sourceDir != nil {
+				packageSource = tt.sourceDir(t)
+
+				readmePath = path.Join(packageSource, "README.md")
+				if readmeFile, err := os.Stat(readmePath); err == nil && !readmeFile.IsDir() {
+					readmeData, err := os.ReadFile(readmePath)
+					require.NoError(t, err)
+					expectedReadmeContent = string(readmeData)
+				}
+			}
+			var pluginDir string
+			if tt.pluginDir != nil {
+				pluginDir = tt.pluginDir(t)
+				readmePath = path.Join(pluginDir, "resource-"+tt.packageSource, "README.md")
+				if readmeFile, err := os.Stat(readmePath); err == nil && !readmeFile.IsDir() {
+					readmeData, err := os.ReadFile(readmePath)
+					require.NoError(t, err)
+					expectedReadmeContent = string(readmeData)
+				}
 			}
 
 			var installDocsPath string
@@ -291,17 +365,17 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 					require.NoError(t, err)
 					assert.Equal(t, expectedSpec, packageSpec, "package schema should match input package spec")
 
-					// Verify readme and install docs content
-					if tt.args.readmePath != "" {
-						actualContents, err := io.ReadAll(op.Readme)
-						require.NoError(t, err)
-						assert.Equal(t, tt.readmeContent, string(actualContents), "readme should match the provided markdown file")
-					}
-					if tt.args.installDocsPath != "" {
-						actualContents, err := io.ReadAll(op.InstallDocs)
-						require.NoError(t, err)
-						assert.Equal(t, tt.installContent, string(actualContents), "install docs should match the provided markdown file")
-					}
+				// Verify readme and install docs content
+				if tt.args.readmePath != "" {
+					actualContents, err := io.ReadAll(op.Readme)
+					require.NoError(t, err)
+					assert.Equal(t, expectedReadmeContent, string(actualContents), "readme should match the provided markdown file")
+				}
+				if tt.args.installDocsPath != "" {
+					actualContents, err := io.ReadAll(op.InstallDocs)
+					require.NoError(t, err)
+					assert.Equal(t, tt.installContent, string(actualContents), "install docs should match the provided markdown file")
+				}
 
 					// Verify publisher is set correctly
 					if tt.args.publisher != "" {
@@ -334,9 +408,10 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 					}
 					return tt.mockSchema, tt.schemaExtractionErr
 				},
+				pluginDir: pluginDir,
 			}
 
-			err := cmd.Run(context.Background(), tt.args, tt.packageSource, tt.packageParams)
+			err := cmd.Run(context.Background(), tt.args, packageSource, tt.packageParams)
 			if tt.expectedErr != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedErr)

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -53,8 +53,8 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 		expectedErr         string
 		readmeContent       string
 		installContent      string
-		sourceDir      func(t *testing.T) string
-		pluginDir      func(t *testing.T) string
+		sourceDir           func(t *testing.T) string
+		pluginDir           func(t *testing.T) string
 	}{
 		{
 			name: "successful publish with publisher from schema",

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -365,17 +365,17 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 					require.NoError(t, err)
 					assert.Equal(t, expectedSpec, packageSpec, "package schema should match input package spec")
 
-				// Verify readme and install docs content
-				if tt.args.readmePath != "" {
-					actualContents, err := io.ReadAll(op.Readme)
-					require.NoError(t, err)
-					assert.Equal(t, expectedReadmeContent, string(actualContents), "readme should match the provided markdown file")
-				}
-				if tt.args.installDocsPath != "" {
-					actualContents, err := io.ReadAll(op.InstallDocs)
-					require.NoError(t, err)
-					assert.Equal(t, tt.installContent, string(actualContents), "install docs should match the provided markdown file")
-				}
+					// Verify readme and install docs content
+					if tt.args.readmePath != "" {
+						actualContents, err := io.ReadAll(op.Readme)
+						require.NoError(t, err)
+						assert.Equal(t, expectedReadmeContent, string(actualContents), "readme should match the provided markdown file")
+					}
+					if tt.args.installDocsPath != "" {
+						actualContents, err := io.ReadAll(op.InstallDocs)
+						require.NoError(t, err)
+						assert.Equal(t, tt.installContent, string(actualContents), "install docs should match the provided markdown file")
+					}
 
 					// Verify publisher is set correctly
 					if tt.args.publisher != "" {


### PR DESCRIPTION
This change builds on top of https://github.com/pulumi/pulumi/pull/18818 to automatically slurp up `README.md` files from the package source (e.g. when publishing a component).
That way users do not manually have to specify their READMEs