### PR TITLE
Fix protect inheritance in Go

### DIFF
--- a/changelog/pending/20250311--sdk-go--fix-overriding-protect-in-child-resources.yaml
+++ b/changelog/pending/20250311--sdk-go--fix-overriding-protect-in-child-resources.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fix overriding protect in child resources

--- a/cmd/pulumi-test-language/tests/l2_resource_parent_inheritance.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_parent_inheritance.go
@@ -47,8 +47,9 @@ func init() {
 					//
 					// 6. A parent with its protect flag set.
 					// 7. A child of the parent with its protect flag set.
-					// 8. An orphan without a parent or protect flag set.
-					require.Len(l, snap.Resources, 9, "expected 9 resources in snapshot")
+					// 8. A child of the parent explicitly setting its protect bit to false.
+					// 9. An orphan without a parent or protect flag set.
+					require.Len(l, snap.Resources, 10, "expected 10 resources in snapshot")
 
 					defaultProvider := RequireSingleNamedResource(l, snap.Resources, "default_2_0_0")
 					require.Equal(l, "pulumi:providers:simple", defaultProvider.Type.String(), "expected default simple provider")
@@ -82,11 +83,13 @@ func init() {
 
 					// Children should inherit protect flags.
 					protectParent := RequireSingleNamedResource(l, snap.Resources, "parent2")
-					protectChild := RequireSingleNamedResource(l, snap.Resources, "child2")
+					protectChild2 := RequireSingleNamedResource(l, snap.Resources, "child2")
+					protectChild3 := RequireSingleNamedResource(l, snap.Resources, "child3")
 					protectOrphan := RequireSingleNamedResource(l, snap.Resources, "orphan2")
 
 					require.True(l, protectParent.Protect, "expected parent to be protected")
-					require.True(l, protectChild.Protect, "expected child to inherit protect flag")
+					require.True(l, protectChild2.Protect, "expected child to inherit protect flag")
+					require.False(l, protectChild3.Protect, "expected child be able to override inherited protect flag")
 					require.False(l, protectOrphan.Protect, "expected orphan to not be protected")
 				},
 			},

--- a/cmd/pulumi-test-language/tests/testdata/l2-resource-parent-inheritance/main.pp
+++ b/cmd/pulumi-test-language/tests/testdata/l2-resource-parent-inheritance/main.pp
@@ -32,6 +32,14 @@ resource "child2" "simple:index:Resource" {
     }
 }
 
+resource "child3" "simple:index:Resource" {
+    value = true
+    options {
+        parent = parent2
+        protect = false
+    }
+}
+
 resource "orphan2" "simple:index:Resource" {
     value = true
 }

--- a/sdk/go/pulumi-language-go/language_test.go
+++ b/sdk/go/pulumi-language-go/language_test.go
@@ -176,10 +176,9 @@ var expectedFailures = map[string]string{
 	"l1-builtin-can": "pulumi#18570 Support can in Go program generation",
 
 	// pulumi/pulumi#18345
-	"l1-keyword-overlap":                  "outputs are not cast correctly from pcl to their pulumi types",                                           //nolint:lll
-	"l2-plain":                            "cannot use &plain.DataArgs{…} (value of type *plain.DataArgs) as plain.DataArgs value in struct literal", //nolint:lll
-	"l2-map-keys":                         "cannot use &plain.DataArgs{…} (value of type *plain.DataArgs) as plain.DataArgs value in struct literal", //nolint:lll
-	"l2-resource-parent-inheritance":      "not implemented yet",
+	"l1-keyword-overlap":                  "outputs are not cast correctly from pcl to their pulumi types",                                                 //nolint:lll
+	"l2-plain":                            "cannot use &plain.DataArgs{…} (value of type *plain.DataArgs) as plain.DataArgs value in struct literal",       //nolint:lll
+	"l2-map-keys":                         "cannot use &plain.DataArgs{…} (value of type *plain.DataArgs) as plain.DataArgs value in struct literal",       //nolint:lll
 	"l2-component-program-resource-ref":   "pulumi#18140: cannot use ref.Value (variable of type pulumi.StringOutput) as string value in return statement", //nolint:lll
 	"l2-component-component-resource-ref": "pulumi#18140: cannot use ref.Value (variable of type pulumi.StringOutput) as string value in return statement", //nolint:lll
 	"l2-component-call-simple":            "pulumi#18202: syntax error: unexpected / in parameter list; possibly missing comma or )",                       //nolint:lll

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-resource-parent-inheritance/main.go
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-resource-parent-inheritance/main.go
@@ -41,6 +41,12 @@ func main() {
 		if err != nil {
 			return err
 		}
+		_, err = simple.NewResource(ctx, "child3", &simple.ResourceArgs{
+			Value: pulumi.Bool(true),
+		}, pulumi.Parent(parent2), pulumi.Protect(false))
+		if err != nil {
+			return err
+		}
 		_, err = simple.NewResource(ctx, "orphan2", &simple.ResourceArgs{
 			Value: pulumi.Bool(true),
 		})

--- a/sdk/go/pulumi/provider.go
+++ b/sdk/go/pulumi/provider.go
@@ -117,7 +117,8 @@ func construct(ctx context.Context, req *pulumirpc.ConstructRequest, engineConn 
 		if len(dependencies) > 0 {
 			ro.DependsOn = append(ro.DependsOn, resourceDependencySet(dependencies))
 		}
-		ro.Protect = req.GetProtect()
+		protect := req.GetProtect()
+		ro.Protect = &protect
 		ro.Providers = providers
 		ro.Parent = parent
 

--- a/sdk/go/pulumi/resource.go
+++ b/sdk/go/pulumi/resource.go
@@ -61,7 +61,7 @@ type ResourceState struct {
 	children          resourceSet
 	providers         map[string]ProviderResource
 	provider          ProviderResource
-	protect           bool
+	protect           *bool
 	version           string
 	pluginDownloadURL string
 	aliases           []URNOutput
@@ -122,7 +122,7 @@ func (s *ResourceState) getProvider() ProviderResource {
 	return s.provider
 }
 
-func (s *ResourceState) getProtect() bool {
+func (s *ResourceState) getProtect() *bool {
 	return s.protect
 }
 
@@ -236,7 +236,7 @@ type Resource interface {
 	getProvider() ProviderResource
 
 	// getProtect returns the protect flag for the resource.
-	getProtect() bool
+	getProtect() *bool
 
 	// getVersion returns the version for the resource.
 	getVersion() string
@@ -435,7 +435,7 @@ type resourceOptions struct {
 	IgnoreChanges           []string
 	Import                  IDInput
 	Parent                  Resource
-	Protect                 bool
+	Protect                 *bool
 	Provider                ProviderResource
 	Providers               map[string]ProviderResource
 	ReplaceOnChanges        []string
@@ -482,6 +482,11 @@ func resourceOptionsSnapshot(ro *resourceOptions) *ResourceOptions {
 		})
 	}
 
+	var protect bool
+	if ro.Protect != nil {
+		protect = *ro.Protect
+	}
+
 	return &ResourceOptions{
 		AdditionalSecretOutputs: ro.AdditionalSecretOutputs,
 		Aliases:                 ro.Aliases,
@@ -492,7 +497,7 @@ func resourceOptionsSnapshot(ro *resourceOptions) *ResourceOptions {
 		IgnoreChanges:           ro.IgnoreChanges,
 		Import:                  ro.Import,
 		Parent:                  ro.Parent,
-		Protect:                 ro.Protect,
+		Protect:                 protect,
 		Provider:                ro.Provider,
 		Providers:               providers,
 		ReplaceOnChanges:        ro.ReplaceOnChanges,
@@ -803,7 +808,7 @@ func Parent(r Resource) ResourceOrInvokeOption {
 // Protect, when set to true, ensures that this resource cannot be deleted (without first setting it to false).
 func Protect(o bool) ResourceOption {
 	return resourceOption(func(ro *resourceOptions) {
-		ro.Protect = o
+		ro.Protect = &o
 	})
 }
 

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -238,7 +238,8 @@ func TestResourceOptionMergingProtect(t *testing.T) {
 
 	// last value wins
 	opts := merge(Protect(true), Protect(false))
-	assert.Equal(t, false, opts.Protect)
+	expected := false
+	assert.Equal(t, &expected, opts.Protect)
 }
 
 func TestResourceOptionMergingDeleteBeforeReplace(t *testing.T) {
@@ -251,6 +252,10 @@ func TestResourceOptionMergingDeleteBeforeReplace(t *testing.T) {
 
 func TestResourceOptionComposite(t *testing.T) {
 	t.Parallel()
+
+	ptr := func(b bool) *bool {
+		return &b
+	}
 
 	tests := []struct {
 		name  string
@@ -300,7 +305,7 @@ func TestResourceOptionComposite(t *testing.T) {
 			},
 			want: &resourceOptions{
 				DeleteBeforeReplace: true,
-				Protect:             true,
+				Protect:             ptr(true),
 			},
 		},
 	}

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -424,7 +424,7 @@ func TestResourceState(t *testing.T) {
 	assert.NoError(t, err)
 
 	var theResource testResource
-	state := ctx.makeResourceState("", "", &theResource, nil, nil, false, "", "", nil, nil)
+	state := ctx.makeResourceState("", "", &theResource, nil, nil, nil, "", "", nil, nil)
 
 	resolved, _, _, _ := marshalInputs(&testResourceInputs{
 		Any:     String("foo"),
@@ -898,7 +898,7 @@ func TestDependsOnComponent(t *testing.T) {
 
 	registerResource := func(name string, res Resource, custom bool, options ...ResourceOption) (Resource, []string) {
 		opts := merge(options...)
-		state := ctx.makeResourceState("", "", res, nil, nil, false, "", "", nil, nil)
+		state := ctx.makeResourceState("", "", res, nil, nil, nil, "", "", nil, nil)
 		state.resolve(ctx, nil, nil, name, "", &structpb.Struct{}, nil, false)
 
 		inputs, err := ctx.prepareResourceInputs(res, Map{}, "", opts, state, false, custom)

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-parent-inheritance/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-parent-inheritance/index.ts
@@ -15,4 +15,8 @@ const parent2 = new simple.Resource("parent2", {value: true}, {
 const child2 = new simple.Resource("child2", {value: true}, {
     parent: parent2,
 });
+const child3 = new simple.Resource("child3", {value: true}, {
+    parent: parent2,
+    protect: false,
+});
 const orphan2 = new simple.Resource("orphan2", {value: true});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-parent-inheritance/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-parent-inheritance/index.ts
@@ -15,4 +15,8 @@ const parent2 = new simple.Resource("parent2", {value: true}, {
 const child2 = new simple.Resource("child2", {value: true}, {
     parent: parent2,
 });
+const child3 = new simple.Resource("child3", {value: true}, {
+    parent: parent2,
+    protect: false,
+});
 const orphan2 = new simple.Resource("orphan2", {value: true});

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-parent-inheritance/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-parent-inheritance/__main__.py
@@ -11,4 +11,7 @@ parent2 = simple.Resource("parent2", value=True,
 opts = pulumi.ResourceOptions(protect=True))
 child2 = simple.Resource("child2", value=True,
 opts = pulumi.ResourceOptions(parent=parent2))
+child3 = simple.Resource("child3", value=True,
+opts = pulumi.ResourceOptions(parent=parent2,
+    protect=False))
 orphan2 = simple.Resource("orphan2", value=True)

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-parent-inheritance/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-parent-inheritance/__main__.py
@@ -11,4 +11,7 @@ parent2 = simple.Resource("parent2", value=True,
 opts = pulumi.ResourceOptions(protect=True))
 child2 = simple.Resource("child2", value=True,
 opts = pulumi.ResourceOptions(parent=parent2))
+child3 = simple.Resource("child3", value=True,
+opts = pulumi.ResourceOptions(parent=parent2,
+    protect=False))
 orphan2 = simple.Resource("orphan2", value=True)

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-parent-inheritance/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-parent-inheritance/__main__.py
@@ -11,4 +11,7 @@ parent2 = simple.Resource("parent2", value=True,
 opts = pulumi.ResourceOptions(protect=True))
 child2 = simple.Resource("child2", value=True,
 opts = pulumi.ResourceOptions(parent=parent2))
+child3 = simple.Resource("child3", value=True,
+opts = pulumi.ResourceOptions(parent=parent2,
+    protect=False))
 orphan2 = simple.Resource("orphan2", value=True)


### PR DESCRIPTION
Also add an override test to l2-resource-parent-inheritance.

This fixes the issue described in https://github.com/pulumi/pulumi/issues/18833 but does not fully fix the optionality of protect in transforms and construct. That will require wire protocol changes, and public api changes to the Go SDK.