### PR TITLE
[python/components] Map input names recursively

### DIFF
--- a/changelog/pending/20250311--sdk-python--fix-mapping-input-names-in-construct-recursively-in-component-providers.yaml
+++ b/changelog/pending/20250311--sdk-python--fix-mapping-input-names-in-construct-recursively-in-component-providers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix mapping input names in Construct recursively in component providers

--- a/sdk/python/lib/pulumi/provider/experimental/provider.py
+++ b/sdk/python/lib/pulumi/provider/experimental/provider.py
@@ -89,8 +89,9 @@ class ComponentProvider(Provider):
         if not prop.ref:
             raise ValueError(f"property {prop} is not a complex type")
 
-        # Handle built-in types like Asset and Archive
-        if prop.ref in ("pulumi.json#/Asset", "pulumi.json#/Archive"):
+        # Handle built-in types that don't have a colon in their reference
+        # This includes types like Any, Asset, Archive, etc. (e.g. pulumi.json#/Asset)
+        if ":" not in prop.ref:
             return None
 
         name = prop.ref.split(":")[-1]
@@ -122,6 +123,12 @@ class ComponentProvider(Provider):
         and validate required properties are present.
 
         This handles both top-level inputs and nested complex types.
+
+        :param inputs: The inputs to map.
+        :param properties: The property definitions that define the shape of the inputs.
+        :param mapping: The mapping from schema property names to Python property names.
+        :param component_name: The name of the component these inputs belong to.
+        :param property_path: The path to the current property being mapped, used for error messages.
         """
         mapped_value: dict[str, Input[Any]] = {}
         for schema_name, prop in properties.items():

--- a/sdk/python/lib/pulumi/provider/experimental/provider.py
+++ b/sdk/python/lib/pulumi/provider/experimental/provider.py
@@ -80,10 +80,19 @@ class ComponentProvider(Provider):
         state = self.get_state(comp_instance, component_def)
         return ConstructResult(comp_instance.urn, state)
 
-    def get_type_definition(self, prop: PropertyDefinition) -> TypeDefinition:
-        """Gets the type definition for a property with a type reference."""
+    def get_type_definition(self, prop: PropertyDefinition) -> Optional[TypeDefinition]:
+        """
+        Gets the type definition for a property with a type reference.
+
+        Returns None for built-in types like Asset and Archive.
+        """
         if not prop.ref:
             raise ValueError(f"property {prop} is not a complex type")
+
+        # Handle built-in types like Asset and Archive
+        if prop.ref in ("pulumi.json#/Asset", "pulumi.json#/Archive"):
+            return None
+
         name = prop.ref.split(":")[-1]
         return self._type_defs[name]
 
@@ -92,71 +101,126 @@ class ComponentProvider(Provider):
         Maps the input's names from the schema into Python names and
         validates that required inputs are present.
         """
-        mapped_input: dict[str, Input[Any]] = {}
-        for schema_name, prop in component_def.inputs.items():
-            input_val = inputs.get(schema_name, None)
-            if input_val is None:
-                if not prop.optional:
-                    raise InputPropertyError(
-                        schema_name,
-                        f"Missing required input '{schema_name}' on '{component_def.name}'",
-                    )
-                continue
-            py_name = component_def.inputs_mapping[schema_name]
-            if prop.ref:
-                if prop.ref in ("pulumi.json#/Asset", "pulumi.json#/Archive"):
-                    mapped_input[py_name] = input_val
-                    continue
-                type_def = self.get_type_definition(prop)
-                mapped_input[py_name] = self.map_complex_input(
-                    input_val,  # type: ignore
-                    type_def,
-                    component_def,
-                    schema_name,
-                )
-            else:
-                mapped_input[py_name] = input_val
-        return mapped_input
+        return self.map_input_properties(
+            inputs,
+            component_def.inputs,
+            component_def.inputs_mapping,
+            component_def.name,
+            "",
+        )
 
-    def map_complex_input(
+    def map_input_properties(
         self,
         inputs: Inputs,
-        type_def: TypeDefinition,
-        component_def: ComponentDefinition,
-        property_name: str,
+        properties: dict[str, PropertyDefinition],
+        mapping: dict[str, str],
+        component_name: str,
+        property_path: str,
     ) -> Inputs:
         """
-        Recursively maps the names of a complex type from schema to Python names
-        and validates that required inputs are present.
+        Generic helper to map property names from schema to Python names
+        and validate required properties are present.
 
-        :param inputs: The inputs for the complex type.
-        :param type_def: The type definition for the complex type.
-        :param component_def: The current component definition, which has a property of this complex type.
-        :param property_name: The name of the property in the component definition that has this complex type.
+        This handles both top-level inputs and nested complex types.
         """
         mapped_value: dict[str, Input[Any]] = {}
-        for schema_name, prop in type_def.properties.items():
-            input_val = inputs.get(schema_name, None)
+        for schema_name, prop in properties.items():
+            input_val = (
+                inputs.get(schema_name, None) if isinstance(inputs, dict) else None
+            )
             if input_val is None:
                 if not prop.optional:
-                    property_path = f"{property_name}.{schema_name}"
+                    full_path = (
+                        schema_name
+                        if not property_path
+                        else f"{property_path}.{schema_name}"
+                    )
                     raise InputPropertyError(
-                        property_path,
-                        f"Missing required input '{property_path}' on '{component_def.name}'",
+                        full_path,
+                        f"Missing required input '{full_path}' on '{component_name}'",
                     )
                 continue
-            py_name = type_def.properties_mapping[schema_name]
+
+            py_name = mapping[schema_name]
+
+            # Handle complex types (named types)
             if prop.ref:
-                # A nested complex type, get the type definition and recursively map it.
-                nested_type_def = self.get_type_definition(prop)
-                mapped_value[py_name] = self.map_complex_input(
-                    input_val,  # type: ignore
-                    nested_type_def,
-                    component_def,
-                    property_name + "." + schema_name,
+                # Get the type definition for the complex type
+                type_def = self.get_type_definition(prop)
+                if type_def is None:
+                    mapped_value[py_name] = input_val
+                    continue
+
+                # Recursively map the complex type
+                next_path = (
+                    f"{property_path}.{schema_name}" if property_path else schema_name
                 )
-            else:
-                mapped_value[py_name] = input_val
+                mapped_value[py_name] = self.map_input_properties(
+                    input_val if isinstance(input_val, dict) else {},
+                    type_def.properties,
+                    type_def.properties_mapping,
+                    component_name,
+                    next_path,
+                )
+                continue
+
+            # Special handling for arrays of complex types
+            if isinstance(input_val, list) and prop.items and prop.items.ref:
+                type_def = self.get_type_definition(prop.items)
+                if type_def is None:
+                    mapped_value[py_name] = input_val
+                    continue
+
+                mapped_list = []
+                for i, item in enumerate(input_val):
+                    item_path = (
+                        f"{property_path}.{schema_name}[{i}]"
+                        if property_path
+                        else f"{schema_name}[{i}]"
+                    )
+                    mapped_item = self.map_input_properties(
+                        item,
+                        type_def.properties,
+                        type_def.properties_mapping,
+                        component_name,
+                        item_path,
+                    )
+                    mapped_list.append(mapped_item)
+
+                mapped_value[py_name] = mapped_list
+                continue
+
+            # Handle dictionary of complex types
+            if (
+                isinstance(input_val, dict)
+                and prop.additional_properties
+                and prop.additional_properties.ref
+            ):
+                type_def = self.get_type_definition(prop.additional_properties)
+                if type_def is None:
+                    mapped_value[py_name] = input_val
+                    continue
+
+                mapped_dict = {}
+                for key, value in input_val.items():
+                    item_path = (
+                        f"{property_path}.{schema_name}.{key}"
+                        if property_path
+                        else f"{schema_name}.{key}"
+                    )
+                    mapped_dict[key] = self.map_input_properties(
+                        value,
+                        type_def.properties,
+                        type_def.properties_mapping,
+                        component_name,
+                        item_path,
+                    )
+                mapped_value[py_name] = mapped_dict
+                continue
+
+            # Simple type, just map the name
+            mapped_value[py_name] = input_val
+
         return mapped_value
 
     def get_state(
@@ -169,11 +233,13 @@ class ComponentProvider(Provider):
             if instance_val is None:
                 continue
             if prop.ref:
-                if prop.ref in ("pulumi.json#/Asset", "pulumi.json#/Archive"):
+                # Get the type definition for the complex type
+                type_def = self.get_type_definition(prop)
+                if type_def is None:
                     state[k] = instance_val
                     continue
-                # It's a complex type, get the type definition and map it
-                type_def = self.get_type_definition(prop)
+
+                # It's a complex type, map it
                 state[k] = self.map_complex_output(instance_val, type_def)  # type: ignore
             else:
                 state[k] = instance_val
@@ -198,6 +264,9 @@ class ComponentProvider(Provider):
                 continue
             if prop.ref:
                 nested_type_def = self.get_type_definition(prop)
+                if nested_type_def is None:
+                    r[schema_name] = val
+                    continue
                 r[schema_name] = self.map_complex_output(val, nested_type_def)
             else:
                 r[schema_name] = val

--- a/sdk/python/lib/test/provider/experimental/test_provider.py
+++ b/sdk/python/lib/test/provider/experimental/test_provider.py
@@ -56,3 +56,60 @@ def test_map_inputs():
         assert False, "expected an error"
     except InputPropertyError as e:
         assert e.reason == "Missing required input 'a.b.c' on 'MyComponent'"
+
+
+def test_map_complex_inputs():
+    provider = ComponentProvider(
+        Metadata("test-provider", "0.0.1"),
+        Path(Path(__file__).parent, "testdata", "complex-args"),
+    )
+    component_def = provider._component_defs["MyComponent"]  # type: ignore
+
+    inputs = {
+        "stringProp": "hello",
+        "intProp": 42,
+        "listProp": [
+            {"twoWords": "bla", "inputProp": "list1opt"},
+            {"twoWords": "value2"},
+        ],
+        "objectProp": {
+            "key1": {"twoWords": "bla", "inputProp": "obj1opt"},
+            "key2": {"twoWords": "value2"},
+        },
+        "complexProp": {
+            "oneItem": {"twoWords": "one", "inputProp": "complex1opt"},
+            "manyItems": [
+                {"twoWords": "many1", "optionalProp": "many1opt"},
+                {"twoWords": "many2", "inputProp": "complex2opt"},
+            ],
+            "keyItems": {
+                "key1": {"twoWords": "key1", "optionalProp": "key1opt"},
+                "key2": {"twoWords": "key2", "inputProp": "complex3opt"},
+            },
+        },
+    }
+
+    mapped = provider.map_inputs(inputs, component_def)
+    assert mapped == {
+        "string_prop": "hello",
+        "int_prop": 42,
+        "list_prop": [
+            {"two_words": "bla", "input_prop": "list1opt"},
+            {"two_words": "value2"},
+        ],
+        "object_prop": {
+            "key1": {"two_words": "bla", "input_prop": "obj1opt"},
+            "key2": {"two_words": "value2"},
+        },
+        "complex_prop": {
+            "one_item": {"two_words": "one", "input_prop": "complex1opt"},
+            "many_items": [
+                {"two_words": "many1", "optional_prop": "many1opt"},
+                {"two_words": "many2", "input_prop": "complex2opt"},
+            ],
+            "key_items": {
+                "key1": {"two_words": "key1", "optional_prop": "key1opt"},
+                "key2": {"two_words": "key2", "input_prop": "complex3opt"},
+            },
+        },
+    }

--- a/sdk/python/lib/test/provider/experimental/test_provider.py
+++ b/sdk/python/lib/test/provider/experimental/test_provider.py
@@ -79,7 +79,11 @@ def test_map_complex_inputs():
         "complexProp": {
             "oneItem": {"twoWords": "one", "inputProp": "complex1opt"},
             "manyItems": [
-                {"twoWords": "many1", "optionalProp": "many1opt"},
+                {
+                    "twoWords": "many1",
+                    "optionalProp": "many1opt",
+                    "anyProp": "anything",
+                },
                 {"twoWords": "many2", "inputProp": "complex2opt"},
             ],
             "keyItems": {
@@ -104,7 +108,11 @@ def test_map_complex_inputs():
         "complex_prop": {
             "one_item": {"two_words": "one", "input_prop": "complex1opt"},
             "many_items": [
-                {"two_words": "many1", "optional_prop": "many1opt"},
+                {
+                    "two_words": "many1",
+                    "optional_prop": "many1opt",
+                    "any_prop": "anything",
+                },
                 {"two_words": "many2", "input_prop": "complex2opt"},
             ],
             "key_items": {

--- a/sdk/python/lib/test/provider/experimental/testdata/complex-args/__init__.py
+++ b/sdk/python/lib/test/provider/experimental/testdata/complex-args/__init__.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Dict, TypedDict
+from typing import Any, List, Optional, Dict, TypedDict
 import pulumi
 
 
@@ -6,6 +6,7 @@ class SubArgs(TypedDict):
     two_words: str
     optional_prop: Optional[str]
     input_prop: pulumi.Input[Optional[str]]
+    any_prop: Optional[Any]
 
 
 class ComplexSubArgs(TypedDict):

--- a/sdk/python/lib/test/provider/experimental/testdata/complex-args/__init__.py
+++ b/sdk/python/lib/test/provider/experimental/testdata/complex-args/__init__.py
@@ -1,0 +1,32 @@
+from typing import List, Optional, Dict, TypedDict
+import pulumi
+
+
+class SubArgs(TypedDict):
+    two_words: str
+    optional_prop: Optional[str]
+    input_prop: pulumi.Input[Optional[str]]
+
+
+class ComplexSubArgs(TypedDict):
+    one_item: SubArgs
+    many_items: List[SubArgs]
+    key_items: dict[str, SubArgs]
+
+
+class MyComponentArgs(TypedDict):
+    string_prop: str
+    int_prop: pulumi.Input[int]
+    list_prop: pulumi.Input[List[SubArgs]]
+    object_prop: pulumi.Input[dict[str, SubArgs]]
+    complex_prop: ComplexSubArgs
+
+
+class MyComponent(pulumi.ComponentResource):
+    def __init__(
+        self,
+        name: str,
+        args: MyComponentArgs,
+        opts: Optional[pulumi.ResourceOptions] = None,
+    ):
+        super().__init__("mycomp:index:MyComponent", name, {}, opts)


### PR DESCRIPTION
Fix https://github.com/pulumi/pulumi/issues/18846

Python component host maps snake_case to camelCase while calculating the schema and seems to have good tests for that. At runtime during Construct invocation, we need to do the reverse camelCase to snake_case for actual component values. A basic version of this was in place, but it did not happen for types within lists/maps. This PR tries to fix this.

I'm surprised there are no tests around this tricky area. I added a test but I don't have high confidence I covered everything. I will also open a follow-up issue to do the same for outputs.

cc @julienp when you are back to check my PR too and chime in on adding test coverage.