### PR TITLE
Improve parameterize docs

### DIFF
--- a/docs/architecture/providers/parameterized.md
+++ b/docs/architecture/providers/parameterized.md
@@ -1,5 +1,5 @@
 (parameterized-providers)=
-# Parameterized providers
+# Parameterized Providers
 
 *Parameterized providers* are a provider feature where a user can generate and
 use a custom SDK based on some custom input.

--- a/docs/architecture/providers/parameterized.md
+++ b/docs/architecture/providers/parameterized.md
@@ -1,35 +1,66 @@
 (parameterized-providers)=
 # Parameterized Providers
 
-*Parameterized providers* are a provider feature where a user can generate and
-use a custom SDK based on some custom input.
+*Parameterized providers* are a Pulumi feature that allows a user to change a
+provider's behaviour at runtime. The user generates an SDK by running
+`pulumi package add` or `pulumi package gen-sdk` with additional command-line
+arguments (`args`). The provider is passed the arguments and generates an SDK
+for the user, which also includes custom provider metadata. When the SDK is used
+from a Pulumi program, the provider is "parameterized" with the metadata from
+within the generated SDK so it's ready to use.
 
-Key rules:
+Therefore, when starting a provider to be parameterized, the parameterization
+call can take two forms:
+
+* When generating an SDK (e.g. using a `pulumi package add` command), we need to
+  boot up a provider and parameterize it using only information from the
+  command-line invocation. In this case, the parameter is a string array
+  representing the command-line arguments (`args`).
+* When interacting with a provider as part of program execution, the parameter
+  is *embedded in the SDK*, so as to free the program author from having to know
+  whether a provider is parameterized or not. In this case, the parameter is a
+  provider-specific bytestring (`value`). This is intended to allow a provider
+  to store arbitrary data that may be more efficient or practical at program
+  execution time, after SDK generation has taken place. This value is
+  base-64-encoded when embedded in the SDK.
+
+(provider-implementation)=
+## Provider implementation
+
+Requirements and conditions for "replacement" parameterization:
 
 * Each provider parameterization is run in its own provider instance.
 * Parameterized package names must be unique within the program where its added.
-* Parameterize is always called before Configure.
-* Parameterize is always called before GetSchema.
+* Parameterization is either via CLI args *or* embedded metadata.
+* [](pulumirpc.ResourceProvider.Parameterize) is always called before [](pulumirpc.ResourceProvider.Configure).
+* [](pulumirpc.ResourceProvider.Parameterize) is always called before [](pulumirpc.ResourceProvider.GetSchema).
+
+:::{note}
+Currently, we only support "replacement" parameterization where generated SDKs
+don't reference the provider's original SDK. See
+[Replacement and extension parameterization](#replacement-extension-parameterization)
+for discussion of what alternative implementations might be possible in the future.
+:::
 
 For a provider to support parameterization it must implement the
 [](pulumirpc.ResourceProvider.Parameterize) call. The
 [](pulumirpc.ParameterizeRequest) will either contain the args passed via the
-CLI from `pulumi package add` or `pulumi package gen-sdk`; or will be passed a
-previous parameterization result (a binary blob). Parameterize will always be
-called before either Configure or GetSchema are called.
-[](pulumirpc.ParameterizeResponse) must return a response with the *package*
-name and version, which must match the generated SDK (from the schema). The name
-of the parameterized package must be unique and will be used as the first part of
-all resource tokens and used to route RegisterResourceRequests back to the
-Parameterized provider instance. The version of the parameterized package can be
-anything the provider would like and does not have to align to the version of the
-base provider. The version does not have any specific purpose right now - it's
-purely informational, but is required to be set.
+CLI from `pulumi package add` or `pulumi package gen-sdk`; or will be passed the
+previous generated metadata binary blob. [](pulumirpc.ResourceProvider.Parameterize)
+will always be called before either [](pulumirpc.ResourceProvider.Configure)
+or [](pulumirpc.ResourceProvider.GetSchema) are called.
+[](pulumirpc.ParameterizeResponse) must return a response with the *parameterized
+package* name and version. The name of the parameterized package must be unique
+and will be used as the first part of all resource tokens and used to route
+RegisterResourceRequests back to the parameterized provider instance. The
+version of the parameterized package can be anything the provider would like and
+does not have to align to the version of the base provider. The version does not
+have any specific purpose right now - it's purely informational, but is
+required to be set and to match the parameterized schema too.
 
-Once [](pulumirpc.ResourceProvider.Parameterize) has been called (in either mode)
-the engine must be able to call GetSchema and Configure to start to use the
-provider or generate the SDK. For replacement parameterization, once Parameterize
-has been called, the provider will only be used in its parameterized form.
+Once [](pulumirpc.ResourceProvider.Parameterize) has been called (with either CLI
+args or the binary metadata) that provider instance will only be used with that
+specific parameterization. It will not be re-parameterized or un-parameterized.
 
 Once parameterized, GetSchema can be called by the engine. The GetSchema request
 will contain the same name and version information as was returned from
@@ -39,6 +70,10 @@ name and version as the SubpackageName and SubpackageVersion. GetSchema must be
 callable after either the "args" or "value" mode of parameterize was called. It's
 expected that GetSchema doesn't have to be fast and that the engine will cache
 schemas as required.
+
+Once parameterized, the engine may then resume the usual provider lifecycle
+operations such as [](pulumirpc.ResourceProvider.Configure) and start interacting
+with resources.
 
 ## Example uses of parameterization
 
@@ -73,7 +108,7 @@ schemas as required.
 
 :::{warning}
 In the absence of parameterized providers, it is generally safe to assume that a
-resource's package name matches exactly the name of the provider
+resource's package name exactly matches exactly the name of the provider
 [plugin](plugins) that provides that package. For example, an `aws:s3:Bucket`
 resource could be expected to be managed by the `aws` provider plugin, which in
 turn would live in a binary named `pulumi-resource-aws`. In the presence of
@@ -84,21 +119,15 @@ the `terraform` provider plugin (with a parameter of `aws:<version>` or similar,
 for example).
 :::
 
-(replacement-extension-providers)=
+(replacement-extension-parameterization)=
 ## Replacement and extension parameterization
 
 Currently, the only kind of parameterization is *replacement parameterization*.
-In this mode, once the provider has been parameterized, it will only be used for
-that parameter only; and not without the parameter or with another parameter.
+In this mode, once the provider has been parameterized, it will be used for that
+parameter only; and not without the parameter or with another parameter.
 
-In the future we might creation the option for a parameterization to be an
+Future enhancements may include the option for a parameterization to be an
 "extension" of the original schema. Details are yet to be worked out here, but we
-expect the following differences from the replacement parameterization:
-
-* The provider for the extension SDK might have to be the same as the base provider
-* Tokens in the extension schema must have the same provider name as the base
-  schema & SDKs.
-* The same instance of the provider will be used from both the base SDK and the
-  extension SDKs.
-* GetSchema might be called multiple times - once for each of the extensions.
-* Parameterize will be called once for each extension.
+expect a number of semantic differences from the replacement parameterization, but
+this mode would be explicitly opted into by providers, so there are no concerns
+around backward compatibility.

--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -76,35 +76,55 @@ type ProviderHandshakeResponse struct {
 	SupportsAutonamingConfiguration bool
 }
 
+// ParameterizeParameters can either be of concrete type ParameterizeArgs or ParameterizeValue, for when parameterizing
+// a provider from either the command line or from within a Pulumi program, respectively.
 type ParameterizeParameters interface {
 	isParameterizeParameters()
 }
 
 type (
+	// ParameterizeArgs is used when parameterizing a provider from command line arguments.
 	ParameterizeArgs struct {
+		// The arguments passed on the command line following the provider name.
 		Args []string
 	}
 
+	// ParameterizeValue is used when parameterizing a provider from within a Pulumi program.
 	ParameterizeValue struct {
-		Name    string
+		// The name of the parameterization.
+		Name string
+		// The version of the parameterization.
 		Version semver.Version
-		Value   []byte
+		// The provider metadata embedded in the parameterization.
+		Value []byte
 	}
 )
 
-func (*ParameterizeArgs) isParameterizeParameters()  {}
+// isParameterizeParameters is a no-op method that marks ParameterizeArgs as implementing ParameterizeParameters.
+func (*ParameterizeArgs) isParameterizeParameters() {}
+
+// isParameterizeParameters is a no-op method that marks ParameterizeValue as implementing ParameterizeParameters.
 func (*ParameterizeValue) isParameterizeParameters() {}
 
+// The type of requests sent as part of a Parameterize call.
 type ParameterizeRequest struct {
+	// The parameters to use when parameterizing the provider instance.
 	Parameters ParameterizeParameters
 }
 
+// The type of responses sent as part of a Parameterize call.
 type ParameterizeResponse struct {
-	Name    string
+	// The name of the parameterization. This must be unique in the context of a program.
+	// If the request parameter was a ParameterizeValue, then this field must match the input name.
+	Name string
+	// The version of the parameterization. This is required to be set by the provider. It does not have to match
+	// the version of the provider itself, but can be used however the provider sees fit.
 	Version semver.Version
 }
 
+// GetSchemaResponse is the response to a GetSchema call.
 type GetSchemaResponse struct {
+	// The bytes of the JSON serialized Pulumi schema for generating the provider's SDK.
 	Schema []byte
 }
 

--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -95,7 +95,9 @@ type (
 		Name string
 		// The version of the parameterization.
 		Version semver.Version
-		// The provider metadata embedded in the parameterization.
+		// The binary parameterization value as returned from a previous parameterization call.
+		// This can be any data the provider needs to parameterize itself - such as the data needed to turn resource
+		// requests into API calls.
 		Value []byte
 	}
 )
@@ -117,8 +119,9 @@ type ParameterizeResponse struct {
 	// The name of the parameterization. This must be unique in the context of a program.
 	// If the request parameter was a ParameterizeValue, then this field must match the input name.
 	Name string
-	// The version of the parameterization. This is required to be set by the provider. It does not have to match
-	// the version of the provider itself, but can be used however the provider sees fit.
+	// The version of the parameterization. This is required to be set by the provider. It does not have to match the
+	// version of the provider itself, but can be used however the provider sees fit. If the request parameter was a
+	// ParameterizeValue, then this field must match the input version.
 	Version semver.Version
 }
 


### PR DESCRIPTION
- Clarify key facts people need to know.
- Add the point of view of what a provider author needs to know.
- Add godocs for Parameterization types to help provider implementers.