### PR TITLE
[python/components] Better error message for a missing type

### DIFF
--- a/sdk/python/lib/pulumi/provider/experimental/analyzer.py
+++ b/sdk/python/lib/pulumi/provider/experimental/analyzer.py
@@ -482,7 +482,7 @@ class Analyzer:
                 description=self.get_docstring(typ.__name__, name),
             )
         else:
-            raise ValueError(f"unsupported type {arg}")
+            raise ValueError(f"Unsupported type '{arg}' for '{typ.__name__}.{name}'")
 
     def find_docstrings(self, path: Path) -> dict[str, dict[str, str]]:
         """


### PR DESCRIPTION
I audited the python analyzer and it looks like error messages are already decent (on the level of TypeScript). We can definitely do better but at least we give the context of type/property names most of the time.

I found just one exception - so here is a tiny change towards https://github.com/pulumi/pulumi/issues/18692