### PR TITLE
Run lifecycle tests with parallelism

### DIFF
--- a/pkg/engine/lifecycletest/framework/framework.go
+++ b/pkg/engine/lifecycletest/framework/framework.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -552,6 +553,11 @@ func (o TestUpdateOptions) Options() engine.UpdateOptions {
 	if o.HostF != nil {
 		opts.Host = o.HostF()
 	}
+	// Set a sensible parallel count because most tests leave this zero.
+	if opts.Parallel == 0 {
+		opts.Parallel = int32(runtime.NumCPU()) //nolint:gosec // NumCPU isn't going to overflow int32
+	}
+
 	return opts
 }
 


### PR DESCRIPTION
Noticed this while working on parallel diff. Most of the lifecycle tests leave `Parallel` as zero, which eventually makes its way down to step executor setup which sets it to 1. So none of our lifecycle tests are really testing any parallelism in the system.

This sets `Parallel` to `runtime.NumCPU()` so that tests will start seeing operations happen in parallel, hopefully proving out more of the system.

N.B. This isn't the same as what we default `--parallel` to, we respect cgroup limits there but I figure for tests this is fine and saves moving that code to be shared by lifecycle tests.