### PR TITLE
Update step counter atomicly

### DIFF
--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -192,7 +192,7 @@ func ConvertEngineEvent(e engine.Event, showSecrets bool) (apitype.EngineEvent, 
 		apiEvent.ResOpFailedEvent = &apitype.ResOpFailedEvent{
 			Metadata: convertStepEventMetadata(p.Metadata, showSecrets),
 			Status:   int(p.Status),
-			Steps:    p.Steps,
+			Steps:    int(p.Steps),
 		}
 
 	case engine.PolicyLoadEvent:
@@ -416,7 +416,7 @@ func ConvertJSONEvent(apiEvent apitype.EngineEvent) (engine.Event, error) {
 		event = engine.NewEvent(engine.ResourceOperationFailedPayload{
 			Metadata: convertJSONStepEventMetadata(p.Metadata),
 			Status:   resource.Status(p.Status),
-			Steps:    p.Steps,
+			Steps:    int32(p.Steps), //nolint:gosec // We only ever write int32 sized values to the API.
 		})
 
 	case apiEvent.PolicyLoadEvent != nil:

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -238,7 +238,7 @@ type SummaryEventPayload struct {
 type ResourceOperationFailedPayload struct {
 	Metadata StepEventMetadata
 	Status   resource.Status
-	Steps    int
+	Steps    int32
 }
 
 type ResourceOutputsEventPayload struct {
@@ -463,7 +463,7 @@ func (e *eventEmitter) sendEvent(event Event) {
 }
 
 func (e *eventEmitter) resourceOperationFailedEvent(
-	step deploy.Step, status resource.Status, steps int, debug, showSecrets bool,
+	step deploy.Step, status resource.Status, steps int32, debug, showSecrets bool,
 ) {
 	contract.Requiref(e != nil, "e", "!= nil")
 

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	resourceanalyzer "github.com/pulumi/pulumi/pkg/v3/resource/analyzer"
@@ -565,7 +566,7 @@ func abbreviateFilePath(path string) string {
 // updateActions pretty-prints the plan application process as it goes.
 type updateActions struct {
 	Context *Context
-	Steps   int
+	Steps   int32
 	Ops     map[display.StepOp]int
 	Seen    map[resource.URN]deploy.Step
 	MapLock sync.Mutex
@@ -645,7 +646,7 @@ func (acts *updateActions) OnResourceStepPost(
 		if record && !isInternalStep {
 			// Increment the counters.
 			acts.MapLock.Lock()
-			acts.Steps++
+			atomic.AddInt32(&acts.Steps, 1)
 			acts.Ops[op]++
 			acts.MapLock.Unlock()
 		}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/18884

Steps in `OnResourceStepPost` could be read or incremented. If these happened at the same time you'd get a data race. That data race didn't actually matter but it could trigger the go race detector in tests. Worse was you could potentially race in the increment logic losing count by one. 

This changes the increment to an atomic add to avoid all races.