### PR TITLE
Remove unused QueryOptions structs

### DIFF
--- a/pkg/cmd/pulumi/org/org_search.go
+++ b/pkg/cmd/pulumi/org/org_search.go
@@ -130,8 +130,7 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 	}
 	currentBackend := cmd.currentBackend // shadow the top-level function
 
-	opts := backend.QueryOptions{}
-	opts.Display = display.Options{
+	displayOpts := display.Options{
 		Color:         cmdutil.GetGlobalColorization(),
 		IsInteractive: interactive,
 		Type:          display.DisplayQuery,
@@ -143,7 +142,7 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	backend, err := currentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, opts.Display)
+	backend, err := currentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, displayOpts)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/org/org_search_ai.go
+++ b/pkg/cmd/pulumi/org/org_search_ai.go
@@ -21,7 +21,6 @@ import (
 	"os"
 
 	"github.com/pkg/browser"
-	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
@@ -53,8 +52,7 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 	}
 	currentBackend := cmd.currentBackend // shadow the top-level function
 
-	opts := backend.QueryOptions{}
-	opts.Display = display.Options{
+	displayOpts := display.Options{
 		Color:         cmdutil.GetGlobalColorization(),
 		IsInteractive: interactive,
 		Type:          display.DisplayQuery,
@@ -66,7 +64,7 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	backend, err := currentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, opts.Display)
+	backend, err := currentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, displayOpts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix two locations where we made a `QueryOptions` struct just to set it's display field, and then only looked at the display field.

Replaced with just a display options variable.