### PR TITLE
Feature/Added checks to handle wrong login url for pulumi login

### DIFF
--- a/pkg/cmd/pulumi/auth/login_test.go
+++ b/pkg/cmd/pulumi/auth/login_test.go
@@ -1,0 +1,31 @@
+package auth
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCheckHttpCloudBackendUrlWithAppPulumi calls checkHttpCloudBackenUrl with a
+// wrong pulumi cloud url, checking
+// for a valid return value.
+func TestCheckHttpCloudBackendUrlWithAppPulumi(t *testing.T) {
+	cloudUrl := "https://app.pulumi.com"
+	want := "https://api.pulumi.com"
+	url, err := checkHttpCloudBackenUrl(cloudUrl)
+
+	assert.NoError(t, err)
+	assert.Equal(t, want, url)
+}
+
+// TestCheckHttpCloudBackendUrlWithAppWhatever calls checkHttpCloudBackenUrl with a wrong url,
+// checking for an error.
+func TestCheckHttpCloudBackendUrlWithAppWhatever(t *testing.T) {
+	cloudUrl := "https://app.pulumi.test.com"
+	url, err := checkHttpCloudBackenUrl(cloudUrl)
+	assert.Empty(t, url)
+	if assert.Error(t, err) {
+		assert.EqualError(t, err, fmt.Sprintf("did you mean %s ?", "https://api.pulumi.test.com"))
+	}
+}


### PR DESCRIPTION
### Added checks to handle wrong login url for pulumi login:

- Added check if user provides any wrong url ending with pulumi.com it will considered as api.pulumi.com
- Added check if user provides any wrong url ending with app.whatever.com:
   - it will throw an error saying `did you mean api.whatever.com ?`
- Added test cases in `login_test.go` to test the new functionality

Fixes: #18665 