### PR TITLE
Log safely in Python in the presence of `PULUMI_ERROR_OUTPUT_STRING`

### DIFF
--- a/changelog/pending/20250314--sdk-python--log-safely-in-python-in-the-presence-of-pulumi_error_output_string.yaml
+++ b/changelog/pending/20250314--sdk-python--log-safely-in-python-in-the-presence-of-pulumi_error_output_string.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Log safely in Python in the presence of `PULUMI_ERROR_OUTPUT_STRING`

--- a/sdk/python/lib/pulumi/_output.py
+++ b/sdk/python/lib/pulumi/_output.py
@@ -1,0 +1,43 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+
+class _OutputToStringError(Exception):
+    """_OutputToStringError is the class of errors raised when __str__ is called
+    on a Pulumi Output."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            """Calling __str__ on an Output[T] is not supported.
+
+To get the value of an Output[T] as an Output[str] consider:
+1. o.apply(lambda v: f"prefix{v}suffix")
+
+See https://www.pulumi.com/docs/concepts/inputs-outputs for more details."""
+        )
+
+
+def _safe_str(v: Any) -> str:
+    """_safe_str returns the string representation of v if possible. If v is an
+    Output, _safe_str catches the error and returns a fallback string. _safe_str
+    is designed for use in e.g. logging and debugging contexts where it's useful
+    to print all the information that can be reasonably obtained, without
+    falling afoul of things like PULUMI_ERROR_OUTPUT_STRING."""
+
+    try:
+        return str(v)
+    except _OutputToStringError:
+        return "Output[T]"

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -37,6 +37,7 @@ from typing import (
 )
 
 from . import log
+from . import _output
 from . import _types
 from .runtime import rpc
 from .runtime.sync_await import _sync_await
@@ -835,14 +836,10 @@ class Output(Generic[T_co]):
         return s_output.apply(loads)
 
     def __str__(self) -> str:
-        msg = """Calling __str__ on an Output[T] is not supported.
-
-To get the value of an Output[T] as an Output[str] consider:
-1. o.apply(lambda v: f"prefix{v}suffix")
-
-See https://www.pulumi.com/docs/concepts/inputs-outputs for more details."""
+        err = _output._OutputToStringError()
         if os.getenv("PULUMI_ERROR_OUTPUT_STRING", "").lower() in ["1", "true"]:
-            raise TypeError(msg)
+            raise err
+        msg = str(err)
         log.warn(msg)
         msg += "\nThis function may throw in a future version of Pulumi."
         return msg

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -37,6 +37,7 @@ from google.protobuf import struct_pb2
 from .. import _types, log
 from .. import urn as urn_util
 from ..output import Input, Output
+from .._output import _safe_str
 from ..runtime.proto import alias_pb2, resource_pb2, source_pb2, callback_pb2
 from . import known_types, rpc, settings
 from ._depends_on import _resolve_depends_on_urns
@@ -725,7 +726,7 @@ def read_resource(
     if opts.id is None:
         raise Exception("Cannot read resource whose options are lacking an ID value")
 
-    log.debug(f"reading resource: ty={ty}, name={name}, id={opts.id}")
+    log.debug(f"reading resource: ty={ty}, name={name}, id={_safe_str(opts.id)}")
     monitor = settings.get_monitor()
 
     # If we have type information, we'll use its and the resource's type/name metadata
@@ -764,7 +765,7 @@ def read_resource(
             # provider sense, because a read resource already exists. We do not need to track this
             # dependency.
             resolved_id = await rpc.serialize_property(opts.id, [], None)
-            log.debug(f"read prepared: ty={ty}, name={name}, id={opts.id}")
+            log.debug(f"read prepared: ty={ty}, name={name}, id={_safe_str(opts.id)}")
 
             # These inputs will end up in the snapshot, so if there are any additional secret
             # outputs, record them here.


### PR DESCRIPTION
Attempting to convert an `Output` to a string is a common pitfall Pulumi users face -- since an `Output` value may not be available yet (akin to a `Promise` in NodeJS, for instance), it's not in general possible or safe to serialize an `Output` to a string in all cases. To this end, the various language SDKs override string serialization for `Output` so that an informative message is printed, which hopefully helps the user achieve what they set out to (e.g. via `__str__` in Python, `toString` in Java, and so on).

For users that want their programs to throw a hard error when they mistakenly try to stringify an `Output`, Pulumi offers the `PULUMI_ERROR_OUTPUT_STRING` environment variable. If this is set, the relevant implementations (`__str__`, etc.) will crash if called. This is all well and good, as long as we (Pulumi itself) don't mistakenly invoke these methods and break user programs.

Alas, this is precisely what happens in #18863. Here, some debug logging statements in the Python SDK include a value that _could_ be an `Output` (`opts.id`). As a result, if a suitable program is run with `PULUMI_ERROR_OUTPUT_STRING` set, Pulumi will throw an error despite the user having done nothing wrong.

The fix is much the same as adopted in #18016 for NodeJS. We introduce a bespoke error type for throwing when `Output.__str__` is called, and a `_safe_str` helper function that catches that error type (and only that error type). We can then use `_safe_str` in the affected logging statements (and any others we add or identify in future) to add best-effort logging that is safe in the presence of `PULUMI_ERROR_OUTPUT_STRING`.

Fixes #18863