### PR TITLE
Load Steps variable with atomic

### DIFF
--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -631,7 +631,8 @@ func (acts *updateActions) OnResourceStepPost(
 
 		// Issue a true, bonafide error.
 		acts.Opts.Diag.Errorf(diag.GetResourceOperationFailedError(errorURN), err)
-		acts.Opts.Events.resourceOperationFailedEvent(step, status, acts.Steps, acts.Opts.Debug, acts.Opts.ShowSecrets)
+		steps := atomic.LoadInt32(&acts.Steps)
+		acts.Opts.Events.resourceOperationFailedEvent(step, status, steps, acts.Opts.Debug, acts.Opts.ShowSecrets)
 	} else {
 		op, record := step.Op(), step.Logical()
 		if acts.Opts.isRefresh && op == deploy.OpRefresh {


### PR DESCRIPTION
Turns out https://github.com/pulumi/pulumi/pull/18886 wasn't enough, we need to explicitly do an atomic load of this Steps variable as well.