### PR TITLE
implement log truncation in conformance tests

### DIFF
--- a/sdk/go/common/testing/util.go
+++ b/sdk/go/common/testing/util.go
@@ -17,6 +17,8 @@ package testing
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"os"
+	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
@@ -26,4 +28,16 @@ func RandomStackName() string {
 	_, err := rand.Read(b)
 	contract.AssertNoErrorf(err, "failed to generate random stack name")
 	return "test" + hex.EncodeToString(b)
+}
+
+// LogTruncated logs a message, truncating it if it is too long.  PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT can be set to
+// "true" to see the full log message.
+func LogTruncated(t *testing.T, name, message string) {
+	if os.Getenv("PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT") != "true" {
+		// Cut down logs so they don't overwhelm the test output
+		if len(message) > 1024 {
+			message = message[:1024] + "... (truncated, run with PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT=true to see full logs))"
+		}
+	}
+	t.Logf("%s: %s", name, message)
 }

--- a/sdk/go/pulumi-language-go/language_test.go
+++ b/sdk/go/pulumi-language-go/language_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	pbempty "google.golang.org/protobuf/types/known/emptypb"
 
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
@@ -259,8 +260,8 @@ func TestLanguage(t *testing.T) {
 			for _, msg := range result.Messages {
 				t.Log(msg)
 			}
-			t.Logf("stdout: %s", result.Stdout)
-			t.Logf("stderr: %s", result.Stderr)
+			ptesting.LogTruncated(t, "stdout", result.Stdout)
+			ptesting.LogTruncated(t, "stderr", result.Stderr)
 			assert.True(t, result.Success)
 		})
 	}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	pbempty "google.golang.org/protobuf/types/known/emptypb"
 
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
@@ -256,8 +257,8 @@ func TestLanguage(t *testing.T) {
 					for _, msg := range result.Messages {
 						t.Log(msg)
 					}
-					t.Logf("stdout: %s", result.Stdout)
-					t.Logf("stderr: %s", result.Stderr)
+					ptesting.LogTruncated(t, "stdout: %s", result.Stdout)
+					ptesting.LogTruncated(t, "stderr: %s", result.Stderr)
 					assert.True(t, result.Success)
 				})
 			}

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -33,6 +33,7 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	testingrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/testing"
@@ -291,8 +292,8 @@ func TestLanguage(t *testing.T) {
 					for _, msg := range result.Messages {
 						t.Log(msg)
 					}
-					t.Logf("stdout: %s", result.Stdout)
-					t.Logf("stderr: %s", result.Stderr)
+					ptesting.LogTruncated(t, "stdout: %s", result.Stdout)
+					ptesting.LogTruncated(t, "stderr: %s", result.Stderr)
 					assert.True(t, result.Success)
 				})
 			}


### PR DESCRIPTION
Similar to what we did in yaml in
https://github.com/pulumi/pulumi-yaml/pull/741, only log a truncated version of stdout/stderr for each test.  These log lines can get quite long, so if that conformance test fails, it will overload the GitHub runner with too much output, making it hard debug.  Logging only the first 1024 characters sidesteps that.