### PR TITLE
Introduce the packages section in Pulumi.yaml

### DIFF
--- a/changelog/pending/20250317--yaml--introduce-the-packages-section-in-pulumi-yaml.yaml
+++ b/changelog/pending/20250317--yaml--introduce-the-packages-section-in-pulumi-yaml.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: yaml
+  description: Introduce the packages section in Pulumi.yaml

--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -338,7 +338,7 @@ func (eng *languageTestServer) PrepareLanguageTests(
 	})
 
 	// Start up a plugin context
-	pctx, err := plugin.NewContextWithContext(ctx, snk, snk, nil, "", "", nil, false, nil, nil, nil, nil)
+	pctx, err := plugin.NewContextWithContext(ctx, snk, snk, nil, "", "", nil, false, nil, nil, nil, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("setup plugin context: %w", err)
 	}
@@ -480,7 +480,7 @@ func (eng *languageTestServer) RunLanguageTest(
 
 	// Start up a plugin context
 	pctx, err := plugin.NewContextWithContext(
-		ctx, snk, snk, nil, token.TemporaryDirectory, token.TemporaryDirectory, nil, false, nil, nil, nil, nil)
+		ctx, snk, snk, nil, token.TemporaryDirectory, token.TemporaryDirectory, nil, false, nil, nil, nil, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("setup plugin context: %w", err)
 	}

--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -776,18 +776,13 @@ func ProviderFromSource(pctx *plugin.Context, packageSource string) (plugin.Prov
 		return info.Mode()&0o111 != 0 && !info.IsDir()
 	}
 
-	// We check based on the name and pluginDownload URL whether we should try to load
-	// the plugin from the provider host, or whether we should try to get a local plugin.
-	// If the plugin matches the plugin regexp, we try to load it from the provider host,
-	// and similarly if we have a pluginDownloadURL that starts with 'git://', as we know
-	// that's going to be a downloadable plugin.
+	// For all plugins except for file paths, we try to load it from the provider host.
 	//
 	// Note that if a local folder has a name that could match an downloadable plugin, we
 	// prefer the downloadable plugin.  The user can disambiguate by prepending './' to the
 	// name.
-	if strings.HasPrefix(descriptor.PluginDownloadURL, "git://") ||
-		workspace.PluginNameRegexp.MatchString(descriptor.Name) {
-		host, err := plugin.NewDefaultHost(pctx, nil, false, nil, nil, nil, "")
+	if !plugin.IsLocalPluginPath(packageSource) {
+		host, err := plugin.NewDefaultHost(pctx, nil, false, nil, nil, nil, nil, "")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/pulumi/policy/policy_publish.go
+++ b/pkg/cmd/pulumi/policy/policy_publish.go
@@ -119,7 +119,7 @@ func (cmd *policyPublishCmd) Run(ctx context.Context, lm cmdBackend.LoginManager
 	}
 
 	plugctx, err := plugin.NewContextWithRoot(cmdutil.Diag(), cmdutil.Diag(), nil, pwd, projinfo.Root,
-		projinfo.Proj.Runtime.Options(), false, nil, nil, nil, nil)
+		projinfo.Proj.Runtime.Options(), false, nil, nil, nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -55,7 +55,8 @@ func ProjectInfoContext(projinfo *Projinfo, host plugin.Host,
 
 	// Create a context for plugins.
 	ctx, err := plugin.NewContextWithRoot(diag, statusDiag, host, pwd, projinfo.Root,
-		projinfo.Proj.Runtime.Options(), disableProviderPreview, tracingSpan, projinfo.Proj.Plugins, config, debugging)
+		projinfo.Proj.Runtime.Options(), disableProviderPreview, tracingSpan, projinfo.Proj.Plugins,
+		projinfo.Proj.GetPackageSpecs(), config, debugging)
 	if err != nil {
 		return "", "", nil, err
 	}

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/blang/semver"
@@ -96,10 +97,35 @@ type Host interface {
 	Close() error
 }
 
+// IsLocalPluginPath determines if a plugin source refers to a local path rather than a downloadable plugin.
+// A plugin is considered local if it doesn't match the plugin name regexp and doesn't have a download URL.
+func IsLocalPluginPath(source string) bool {
+	// If the source starts with ./ or ../ or / it's definitely a local path
+	if strings.HasPrefix(source, "./") || strings.HasPrefix(source, "..") || strings.HasPrefix(source, "/") {
+		return true
+	}
+
+	// If the source starts with git://, it's definitely not a local path
+	if strings.HasPrefix(source, "git://") {
+		return false
+	}
+
+	// For other cases, we need to be careful about how we interpret the source, so let's parse the spec
+	// and check if it has a download URL.
+	pluginSpec, err := workspace.NewPluginSpec(source, apitype.ResourcePlugin, nil, "", nil)
+	if err != nil {
+		// If we can't parse it as a plugin spec, assume it's a local path
+		return true
+	}
+
+	// If there is a download URL or the name matches the plugin name regexp after parsing, it's not a local path
+	return pluginSpec.PluginDownloadURL == "" && !workspace.PluginNameRegexp.MatchString(pluginSpec.Name)
+}
+
 // NewDefaultHost implements the standard plugin logic, using the standard installation root to find them.
 func NewDefaultHost(ctx *Context, runtimeOptions map[string]interface{},
-	disableProviderPreview bool, plugins *workspace.Plugins, config map[config.Key]string,
-	debugging DebugEventEmitter, projectName tokens.PackageName,
+	disableProviderPreview bool, plugins *workspace.Plugins, packages map[string]workspace.PackageSpec,
+	config map[config.Key]string, debugging DebugEventEmitter, projectName tokens.PackageName,
 ) (Host, error) {
 	// Create plugin info from providers
 	projectPlugins := make([]workspace.ProjectPlugin, 0)
@@ -125,6 +151,26 @@ func NewDefaultHost(ctx *Context, runtimeOptions map[string]interface{},
 			}
 			projectPlugins = append(projectPlugins, info)
 		}
+	}
+
+	for name, pkg := range packages {
+		// Skip downloadable plugins, so that only local folder paths remain.
+		if !IsLocalPluginPath(pkg.Source) {
+			continue
+		}
+
+		// Resolve the absolute path to the plugin folder.
+		path, err := resolvePluginPath(ctx.Root, pkg.Source)
+		if err != nil {
+			return nil, err
+		}
+
+		// Add the plugin to the project plugins list.
+		projectPlugins = append(projectPlugins, workspace.ProjectPlugin{
+			Kind: apitype.ResourcePlugin,
+			Name: name,
+			Path: path,
+		})
 	}
 
 	host := &defaultHost{
@@ -170,6 +216,28 @@ func NewDefaultHost(ctx *Context, runtimeOptions map[string]interface{},
 	return host, nil
 }
 
+func resolvePluginPath(root string, path string) (string, error) {
+	// The path is relative to the project root. Make it absolute here so we don't need to track that everywhere its used.
+	var err error
+	if !filepath.IsAbs(path) {
+		path, err = filepath.Abs(filepath.Join(root, path))
+		if err != nil {
+			return "", fmt.Errorf("getting absolute path for plugin path %s: %w", path, err)
+		}
+	}
+
+	stat, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return "", fmt.Errorf("no folder at path '%s'", path)
+	} else if err != nil {
+		return "", fmt.Errorf("checking provider folder: %w", err)
+	} else if !stat.IsDir() {
+		return "", fmt.Errorf("provider folder '%s' is not a directory", path)
+	}
+
+	return path, nil
+}
+
 func parsePluginOpts(
 	root string, providerOpts workspace.PluginOptions, k apitype.PluginKind,
 ) (workspace.ProjectPlugin, error) {
@@ -189,22 +257,9 @@ func parsePluginOpts(
 		v = &ver
 	}
 
-	stat, err := os.Stat(providerOpts.Path)
-	if os.IsNotExist(err) {
-		return handleErr("no folder at path '%s'", providerOpts.Path)
-	} else if err != nil {
-		return handleErr("checking provider folder: %w", err)
-	} else if !stat.IsDir() {
-		return handleErr("provider folder '%s' is not a directory", providerOpts.Path)
-	}
-
-	// The path is relative to the project root. Make it absolute here so we don't need to track that everywhere its used.
-	path := providerOpts.Path
-	if !filepath.IsAbs(path) {
-		path, err = filepath.Abs(filepath.Join(root, path))
-		if err != nil {
-			return handleErr("getting absolute path for plugin path %s: %w", providerOpts.Path, err)
-		}
+	path, err := resolvePluginPath(root, providerOpts.Path)
+	if err != nil {
+		return handleErr(err.Error())
 	}
 
 	pluginInfo := workspace.ProjectPlugin{

--- a/sdk/go/common/resource/plugin/host_test.go
+++ b/sdk/go/common/resource/plugin/host_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,10 +15,16 @@
 package plugin
 
 import (
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,4 +54,207 @@ func TestClosePanic(t *testing.T) {
 	require.NoError(t, err)
 
 	wg.Wait()
+}
+
+func TestIsLocalPluginPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "explicit relative path with ./",
+			path:     "./my-plugin",
+			expected: true,
+		},
+		{
+			name:     "explicit relative path with ../",
+			path:     "../my-plugin",
+			expected: true,
+		},
+		{
+			name:     "absolute path",
+			path:     "/path/to/my-plugin",
+			expected: true,
+		},
+		{
+			name:     "windows absolute path",
+			path:     "C:\\path\\to\\my-plugin",
+			expected: true, // This will be true because it doesn't match plugin name regexp
+		},
+		{
+			name:     "standard plugin name",
+			path:     "aws",
+			expected: false, // Standard plugin names match the regexp
+		},
+		{
+			name:     "standard plugin name with version",
+			path:     "aws@v4.0.0",
+			expected: false,
+		},
+		{
+			name:     "git URL",
+			path:     "git://github.com/pulumi/pulumi-aws",
+			expected: false,
+		},
+		{
+			name:     "github URL",
+			path:     "github.com/pulumi/pulumi-aws",
+			expected: false,
+		},
+		{
+			name:     "github HTTPS URL",
+			path:     "https://github.com/pulumi/pulumi-aws",
+			expected: false,
+		},
+		{
+			name:     "plugin name",
+			path:     "my-provider",
+			expected: false,
+		},
+		{
+			name:     "local path that looks like a plugin name",
+			path:     "_my_local_path", // Doesn't match plugin name regexp
+			expected: true,
+		},
+		{
+			name:     "empty string",
+			path:     "", // Can't be a valid plugin name
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := IsLocalPluginPath(tt.path)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewDefaultHost_PackagesResolution(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary directory for our test
+	tempDir, err := os.MkdirTemp("", "pulumi-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create a subdirectory to use as a local plugin path
+	localPluginDir := filepath.Join(tempDir, "local-plugin")
+	err = os.Mkdir(localPluginDir, 0o755)
+	require.NoError(t, err)
+
+	// Create another subdirectory to use as a relative plugin path
+	relativePluginDir := filepath.Join(tempDir, "relative-path")
+	err = os.Mkdir(relativePluginDir, 0o755)
+	require.NoError(t, err)
+
+	// Create a context for testing
+	ctx := &Context{
+		Root: tempDir,
+		Diag: diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{
+			Color: colors.Never,
+		}),
+	}
+
+	// Create packages map with various types of sources
+	packages := map[string]workspace.PackageSpec{
+		"local-plugin":    {Source: localPluginDir},
+		"relative-plugin": {Source: "./relative-path"},
+		"aws":             {Source: "aws"},                                // This should be skipped as it's not a local path
+		"azure":           {Source: "azure@v4.0.0"},                       // This should be skipped as it's not a local path
+		"git-plugin":      {Source: "git://github.com/pulumi/pulumi-aws"}, // This should be skipped
+	}
+
+	// Create the host with our packages
+	host, err := NewDefaultHost(ctx, nil, false, nil, packages, nil, nil, "")
+	require.NoError(t, err)
+	defer host.Close()
+
+	// Get the project plugins
+	projectPlugins := host.GetProjectPlugins()
+
+	// We should have 2 plugins (local-plugin and relative-plugin)
+	assert.Equal(t, 2, len(projectPlugins))
+
+	// Create a map of plugin names to paths for easier verification
+	pluginMap := make(map[string]string)
+	for _, plugin := range projectPlugins {
+		pluginMap[plugin.Name] = plugin.Path
+	}
+
+	// Verify the expected plugins are present with correct paths
+	assert.Contains(t, pluginMap, "local-plugin")
+	assert.Contains(t, pluginMap, "relative-plugin")
+	assert.Equal(t, localPluginDir, pluginMap["local-plugin"])
+	assert.Equal(t, filepath.Join(tempDir, "relative-path"), pluginMap["relative-plugin"])
+
+	// Verify the unexpected plugins are not present
+	assert.NotContains(t, pluginMap, "aws")
+	assert.NotContains(t, pluginMap, "azure")
+	assert.NotContains(t, pluginMap, "git-plugin")
+}
+
+// TestNewDefaultHost_BothPluginsAndPackages tests the combined resolution of plugins and packages
+func TestNewDefaultHost_BothPluginsAndPackages(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary directory for our test
+	tempDir, err := os.MkdirTemp("", "pulumi-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create a subdirectory to use as a local plugin path
+	localPluginDir := filepath.Join(tempDir, "local-plugin")
+	err = os.Mkdir(localPluginDir, 0o755)
+	require.NoError(t, err)
+
+	awsProviderDir := filepath.Join(tempDir, "aws-provider")
+	err = os.Mkdir(awsProviderDir, 0o755)
+	require.NoError(t, err)
+
+	// Create a context for testing
+	ctx := &Context{
+		Root: tempDir,
+		Diag: diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{
+			Color: colors.Never,
+		}),
+	}
+
+	// Create test plugins
+	plugins := &workspace.Plugins{
+		Providers: []workspace.PluginOptions{
+			{Name: "aws", Path: "./aws-provider"},
+		},
+	}
+
+	// Create test packages
+	packages := map[string]workspace.PackageSpec{
+		"local-plugin": {Source: localPluginDir},
+		"azure":        {Source: "azure"}, // This should be skipped as it's not a local path
+	}
+
+	host, err := NewDefaultHost(ctx, nil, false, plugins, packages, nil, nil, "")
+	require.NoError(t, err)
+	defer host.Close()
+
+	projectPlugins := host.GetProjectPlugins()
+
+	// We should have 2 plugins (1 from plugins, 1 from packages)
+	assert.Equal(t, 2, len(projectPlugins))
+
+	// Check that all expected plugins are present
+	pluginNames := map[string]bool{}
+	for _, plugin := range projectPlugins {
+		pluginNames[plugin.Name] = true
+	}
+
+	assert.True(t, pluginNames["aws"])
+	assert.True(t, pluginNames["local-plugin"])
+	assert.False(t, pluginNames["azure"])
 }

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -101,6 +101,89 @@ type PluginOptions struct {
 	Path    string `json:"path" yaml:"path"`
 }
 
+// PackageSpec defines the structured format for a package dependency
+type PackageSpec struct {
+	Source     string   `json:"source" yaml:"source"`
+	Version    string   `json:"version,omitempty" yaml:"version,omitempty"`
+	Parameters []string `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+}
+
+// packageValue can be either a string or a PackageSpec
+// This is a private implementation type that handles the dual-format parsing
+type packageValue struct {
+	// The underlying value, either a string or a PackageSpec
+	value interface{}
+}
+
+// Spec returns the package as a PackageSpec if it's a PackageSpec,
+// or creates a simple PackageSpec from its string representation.
+func (pv *packageValue) Spec() PackageSpec {
+	switch v := pv.value.(type) {
+	case PackageSpec:
+		return v
+	case string:
+		// Check if the string contains a version specifier in the format "source@version"
+		parts := strings.Split(v, "@")
+		if len(parts) == 2 {
+			return PackageSpec{
+				Source:  parts[0],
+				Version: parts[1],
+			}
+		}
+		return PackageSpec{Source: v}
+	default:
+		panic("unexpected type in PackageValue")
+	}
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface
+func (pv *packageValue) UnmarshalJSON(data []byte) error {
+	// First try to unmarshal as a string
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		pv.value = s
+		return nil
+	}
+
+	// If that fails, try to unmarshal as a PackageSpec
+	var spec PackageSpec
+	if err := json.Unmarshal(data, &spec); err == nil {
+		pv.value = spec
+		return nil
+	}
+
+	return errors.New("package must be either a string or a package specification object")
+}
+
+// MarshalJSON implements the json.Marshaler interface
+func (pv packageValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal(pv.value)
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+func (pv *packageValue) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// First try to unmarshal as a string
+	var s string
+	if err := unmarshal(&s); err == nil {
+		pv.value = s
+		return nil
+	}
+
+	// If that fails, try to unmarshal as a PackageSpec
+	var spec PackageSpec
+	if err := unmarshal(&spec); err == nil {
+		pv.value = spec
+		return nil
+	}
+
+	return errors.New("package must be either a string or a package specification object")
+}
+
+// MarshalYAML implements the yaml.Marshaler interface
+func (pv packageValue) MarshalYAML() (interface{}, error) {
+	return pv.value, nil
+}
+
 type Plugins struct {
 	Providers []PluginOptions `json:"providers,omitempty" yaml:"providers,omitempty"`
 	Languages []PluginOptions `json:"languages,omitempty" yaml:"languages,omitempty"`
@@ -176,6 +259,9 @@ type Project struct {
 	// Options is an optional set of project options
 	Options *ProjectOptions `json:"options,omitempty" yaml:"options,omitempty"`
 
+	// Packages is a map of package dependencies that can be either strings or PackageSpecs
+	Packages map[string]packageValue `json:"packages,omitempty" yaml:"packages,omitempty"`
+
 	Plugins *Plugins `json:"plugins,omitempty" yaml:"plugins,omitempty"`
 
 	// Handle additional keys, albeit in a way that will remove comments and trivia.
@@ -187,6 +273,19 @@ type Project struct {
 
 func (proj Project) RawValue() []byte {
 	return proj.raw
+}
+
+// GetPackageSpecs returns a map of package names to their corresponding PackageSpecs
+func (proj *Project) GetPackageSpecs() map[string]PackageSpec {
+	if proj.Packages == nil {
+		return nil
+	}
+
+	result := make(map[string]PackageSpec)
+	for name, packageValue := range proj.Packages {
+		result[name] = packageValue.Spec()
+	}
+	return result
 }
 
 func isPrimitiveValue(value interface{}) bool {

--- a/sdk/go/common/workspace/project.json
+++ b/sdk/go/common/workspace/project.json
@@ -218,6 +218,21 @@
             },
             "additionalProperties":false
         },
+        "packages":{
+            "description":"Package dependencies for this Pulumi project.",
+            "type":"object",
+            "additionalProperties":{
+                "oneOf": [
+                    {
+                        "type": "string",
+                        "description": "Package source in a string format, optionally with `@version` suffix"
+                    },
+                    {
+                        "$ref":"#/$defs/packageSpec"
+                    }
+                ]
+            }
+        },
         "plugins":{
             "description":"Override for the plugin selection. Intended for use in developing pulumi plugins.",
             "type":"object",
@@ -252,6 +267,31 @@
     ],
     "additionalProperties":true,
     "$defs":{
+        "packageSpec":{
+            "title":"PackageSpec",
+            "type":"object",
+            "additionalProperties":false,
+            "required":[
+                "source"
+            ],
+            "properties":{
+                "source":{
+                    "type":"string",
+                    "description":"Source of the package, which can be a URL scheme like 'github://', 'git://', a file path './local/path', or a name like 'terraform-provider'"
+                },
+                "version":{
+                    "type":"string",
+                    "description":"Version of the package to use"
+                },
+                "parameters":{
+                    "type":"array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description":"Additional parameters for parameterized providers"
+                }
+            }
+        },
         "pluginOptions":{
             "title":"PluginOptions",
             "type":"object",

--- a/tests/integration/run_plugin/go/main.go
+++ b/tests/integration/run_plugin/go/main.go
@@ -67,7 +67,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		host, err := plugin.NewDefaultHost(pCtx, nil, false, nil, nil, nil, tokens.PackageName("test"))
+		host, err := plugin.NewDefaultHost(pCtx, nil, false, nil, nil, nil, nil, tokens.PackageName("test"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR introduces a new optional section to Pulumi.yaml called `packages`. The section can give names to package dependencies and provide sources, versions, and arguments for those dependencies. Two forms are supported: short and explicit:

```yaml
packages:
  planetscale:
    source: terraform-provider
    version: 0.3.0
    parameters:
    - planetscale/planetscale
  mylocalprovider: ./local/path
  agithubpackage: github.com/myorg/myrepo@v0.1.0
```

An internal type `packageValue` is defined so that we could support deserialization of both strings and structured specs.

I've tried to keep the local folder resolution logic consistent with what `pulumi package` does today. For that, I refactored a `IsLocalPluginPath` helper function that is able to tell whether a given source is a folder path or something else (remote source). If it's a folder path, then `NewDefaultHost` will resolve those folders relative to `ctx.Root` and add folders to the list of `projectPlugins`, similar to what already happens for `plugins/providers`. This is currently the only observable change in behavior.

It's the first step towards https://github.com/pulumi/pulumi/issues/18918. Next steps:

- Update pulumi-yaml to use the new context that includes packages
- Update `pulumi install` to generate SDKs for each entry in `packages`
- Run `pulumi install` automatically for YAML runtimes?
- Update `pulumi package add` to add entries to `packages`