### PR TITLE
Update @types/node version in codegen to ^18 (lowest still maintained version)

### DIFF
--- a/changelog/pending/20250318--sdkgen-nodejs--change-node-js-code-generation-to-use-attypes-node-of-version-18-instead-of-14.yaml
+++ b/changelog/pending/20250318--sdkgen-nodejs--change-node-js-code-generation-to-use-attypes-node-of-version-18-instead-of-14.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/nodejs
+  description: Change Node.js code generation to use @types/node of version 18 instead of 14

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -49,7 +49,7 @@ const (
 	// The minimum version of @pulumi/pulumi compatible with the generated SDK.
 	MinimumValidSDKVersion   string = "^3.142.0"
 	MinimumTypescriptVersion string = "^4.3.5"
-	MinimumNodeTypesVersion  string = "^14"
+	MinimumNodeTypesVersion  string = "^18"
 )
 
 type typeDetails struct {

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -212,11 +212,11 @@ func GenerateProject(
 	fmt.Fprintf(&packageJSON, `{
 	"name": "%s",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "%s"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",
-		`, project.Name.String())
+		`, project.Name.String(), MinimumNodeTypesVersion)
 
 	// Check if pulumi is a local dependency, else add it as a normal range dependency
 	if pulumiArtifact, has := localDependencies[PulumiToken]; has {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-builtin-can/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-builtin-can/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-builtin-can",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-builtin-info/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-builtin-info/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-builtin-info",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-builtin-project-root/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-builtin-project-root/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-builtin-project-root",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-builtin-try/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-builtin-try/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-builtin-try",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-empty/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-empty/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-empty",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-keyword-overlap/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-keyword-overlap/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-keyword-overlap",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-main/subdir/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-main/subdir/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-main",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-output-array/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-output-array/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-output-array",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-output-bool/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-output-bool/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-output-bool",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-output-map/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-output-map/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-output-map",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-output-number/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-output-number/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-output-number",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-output-string/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-output-string/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-output-string",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-stack-reference/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-stack-reference/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-stack-reference",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-component-call-simple/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-component-call-simple/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-component-call-simple",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-component-component-resource-ref/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-component-component-resource-ref/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-component-component-resource-ref",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-component-program-resource-ref/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-component-program-resource-ref/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-component-program-resource-ref",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-component-property-deps/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-component-property-deps/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-component-property-deps",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-destroy/0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-destroy/0/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-destroy",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-destroy/1/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-destroy/1/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-destroy",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-engine-update-options/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-engine-update-options/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-engine-update-options",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-explicit-parameterized-provider/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-explicit-parameterized-provider/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-explicit-parameterized-provider",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-explicit-provider/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-explicit-provider/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-explicit-provider",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-failed-create-continue-on-error/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-failed-create-continue-on-error/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-failed-create-continue-on-error",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-dependencies/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-dependencies/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-invoke-dependencies",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-options-depends-on/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-options-depends-on/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-invoke-options-depends-on",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-options/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-options/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-invoke-options",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-secrets/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-secrets/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-invoke-secrets",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-simple/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-simple/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-invoke-simple",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-variants/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-invoke-variants/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-invoke-variants",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-large-string/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-large-string/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-large-string",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-map-keys/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-map-keys/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-map-keys",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-parameterized-resource/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-parameterized-resource/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-parameterized-resource",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-plain/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-plain/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-plain",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-primitive-ref/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-primitive-ref/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-primitive-ref",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-provider-grpc-config-schema-secret/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-provider-grpc-config-schema-secret/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-provider-grpc-config-schema-secret",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-provider-grpc-config-secret/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-provider-grpc-config-secret/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-provider-grpc-config-secret",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-provider-grpc-config/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-provider-grpc-config/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-provider-grpc-config",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-ref-ref/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-ref-ref/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-ref-ref",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-alpha/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-alpha/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-alpha",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-asset-archive/subdir/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-asset-archive/subdir/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-asset-archive",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-config/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-config/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-config",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-invoke-dynamic-function/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-invoke-dynamic-function/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-invoke-dynamic-function",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-keyword-overlap/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-keyword-overlap/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-keyword-overlap",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-option-deleted-with/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-option-deleted-with/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-option-deleted-with",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-option-protect/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-option-protect/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-option-protect",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-option-retain-on-delete/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-option-retain-on-delete/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-option-retain-on-delete",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-parent-inheritance/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-parent-inheritance/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-parent-inheritance",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-primitives/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-primitives/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-primitives",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-secret/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-secret/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-secret",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-simple/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-simple/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-simple",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-target-up-with-new-dependency/0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-target-up-with-new-dependency/0/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-target-up-with-new-dependency",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-target-up-with-new-dependency/1/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-target-up-with-new-dependency/1/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-target-up-with-new-dependency",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/alpha-3.0.0-alpha.1.internal/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/alpha-3.0.0-alpha.1.internal/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/any-type-function-15.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/any-type-function-15.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/asset-archive-5.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/asset-archive-5.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/component-13.3.7/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/component-13.3.7/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/component-property-deps-1.33.7/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/component-property-deps-1.33.7/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/config-9.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/config-9.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/config-grpc-1.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/config-grpc-1.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/fail_on_create-4.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/fail_on_create-4.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/goodbye-2.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/goodbye-2.0.0/package.json
@@ -9,7 +9,7 @@
         "async-mutex": "^0.5.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/large-4.3.2/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/large-4.3.2/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/plain-13.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/plain-13.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/primitive-7.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/primitive-7.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/primitive-ref-11.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/primitive-ref-11.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/ref-ref-12.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/ref-ref-12.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/secret-14.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/secret-14.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/simple-2.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/simple-2.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/simple-invoke-10.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/simple-invoke-10.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/subpackage-2.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/subpackage-2.0.0/package.json
@@ -9,7 +9,7 @@
         "async-mutex": "^0.5.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-builtin-can/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-builtin-can/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-builtin-can",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-builtin-info/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-builtin-info/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-builtin-info",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-builtin-project-root/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-builtin-project-root/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-builtin-project-root",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-builtin-try/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-builtin-try/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-builtin-try",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-empty/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-empty/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-empty",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-keyword-overlap/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-keyword-overlap/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-keyword-overlap",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-main/subdir/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-main/subdir/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-main",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-output-array/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-output-array/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-output-array",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-output-bool/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-output-bool/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-output-bool",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-output-map/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-output-map/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-output-map",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-output-number/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-output-number/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-output-number",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-output-string/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-output-string/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-output-string",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-stack-reference/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-stack-reference/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l1-stack-reference",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-component-call-simple/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-component-call-simple/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-component-call-simple",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-component-component-resource-ref/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-component-component-resource-ref/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-component-component-resource-ref",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-component-program-resource-ref/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-component-program-resource-ref/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-component-program-resource-ref",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-component-property-deps/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-component-property-deps/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-component-property-deps",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-destroy/0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-destroy/0/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-destroy",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-destroy/1/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-destroy/1/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-destroy",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-engine-update-options/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-engine-update-options/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-engine-update-options",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-explicit-parameterized-provider/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-explicit-parameterized-provider/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-explicit-parameterized-provider",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-explicit-provider/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-explicit-provider/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-explicit-provider",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-failed-create-continue-on-error/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-failed-create-continue-on-error/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-failed-create-continue-on-error",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-dependencies/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-dependencies/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-invoke-dependencies",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-options-depends-on/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-options-depends-on/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-invoke-options-depends-on",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-options/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-options/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-invoke-options",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-secrets/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-secrets/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-invoke-secrets",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-simple/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-simple/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-invoke-simple",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-variants/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-invoke-variants/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-invoke-variants",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-large-string/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-large-string/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-large-string",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-map-keys/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-map-keys/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-map-keys",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-parameterized-resource/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-parameterized-resource/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-parameterized-resource",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-plain/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-plain/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-plain",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-primitive-ref/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-primitive-ref/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-primitive-ref",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-provider-grpc-config-schema-secret/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-provider-grpc-config-schema-secret/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-provider-grpc-config-schema-secret",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-provider-grpc-config-secret/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-provider-grpc-config-secret/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-provider-grpc-config-secret",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-provider-grpc-config/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-provider-grpc-config/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-provider-grpc-config",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-ref-ref/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-ref-ref/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-ref-ref",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-alpha/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-alpha/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-alpha",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-asset-archive/subdir/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-asset-archive/subdir/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-asset-archive",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-config/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-config/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-config",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-invoke-dynamic-function/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-invoke-dynamic-function/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-invoke-dynamic-function",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-keyword-overlap/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-keyword-overlap/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-keyword-overlap",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-option-deleted-with/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-option-deleted-with/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-option-deleted-with",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-option-protect/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-option-protect/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-option-protect",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-option-retain-on-delete/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-option-retain-on-delete/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-option-retain-on-delete",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-parent-inheritance/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-parent-inheritance/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-parent-inheritance",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-primitives/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-primitives/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-primitives",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-secret/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-secret/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-secret",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-simple/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-simple/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-resource-simple",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-target-up-with-new-dependency/0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-target-up-with-new-dependency/0/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-target-up-with-new-dependency",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-target-up-with-new-dependency/1/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-target-up-with-new-dependency/1/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "l2-target-up-with-new-dependency",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/alpha-3.0.0-alpha.1+exp.sha.5114f85/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/alpha-3.0.0-alpha.1+exp.sha.5114f85/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/alpha-3.0.0-alpha.1.internal/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/alpha-3.0.0-alpha.1.internal/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/any-type-function-15.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/any-type-function-15.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/asset-archive-5.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/asset-archive-5.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/component-13.3.7/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/component-13.3.7/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/component-property-deps-1.33.7/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/component-property-deps-1.33.7/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/config-9.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/config-9.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/config-grpc-1.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/config-grpc-1.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/fail_on_create-4.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/fail_on_create-4.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/goodbye-2.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/goodbye-2.0.0/package.json
@@ -9,7 +9,7 @@
         "async-mutex": "^0.5.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/large-4.3.2/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/large-4.3.2/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/plain-13.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/plain-13.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/primitive-7.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/primitive-7.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/primitive-ref-11.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/primitive-ref-11.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/ref-ref-12.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/ref-ref-12.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/secret-14.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/secret-14.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/simple-2.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/simple-2.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/simple-invoke-10.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/simple-invoke-10.0.0/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/subpackage-2.0.0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/subpackage-2.0.0/package.json
@@ -9,7 +9,7 @@
         "async-mutex": "^0.5.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/tests/integration/nodejs/parameterized/sdk/nodejs/package.json
+++ b/tests/integration/nodejs/parameterized/sdk/nodejs/package.json
@@ -11,7 +11,7 @@
         "async-mutex": "^0.5.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/tests/integration/packageadd-remote/provider/pulumi-ts-provider/src/schema.ts
+++ b/tests/integration/packageadd-remote/provider/pulumi-ts-provider/src/schema.ts
@@ -91,7 +91,7 @@ export function generateSchema(pack: any, path: string): schema.PulumiPackage {
             nodejs: {
                 dependencies: {},
                 devDependencies: {
-                    "typescript": "^3.7.0",
+                    "typescript": "^4.6.0",
                 },
                 respectSchemaVersion: true,
             },

--- a/tests/integration/tsconfig/package.json
+++ b/tests/integration/tsconfig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tsconfig",
   "devDependencies": {
-    "@types/node": "^14"
+    "@types/node": "^18"
   },
   "dependencies": {
     "@pulumi/pulumi": "^3.0.0"

--- a/tests/testdata/codegen/assets-and-archives/nodejs/package.json
+++ b/tests/testdata/codegen/assets-and-archives/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.142.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/tests/testdata/codegen/aws-static-website-0.4.0.json
+++ b/tests/testdata/codegen/aws-static-website-0.4.0.json
@@ -33,7 +33,7 @@
         "@pulumi/pulumi": "^3.37.0"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {

--- a/tests/testdata/codegen/azure-native-nested-types/nodejs/package.json
+++ b/tests/testdata/codegen/azure-native-nested-types/nodejs/package.json
@@ -18,7 +18,7 @@
         "@pulumi/pulumi": "^3.0.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/tests/testdata/codegen/config-variables/nodejs/package.json
+++ b/tests/testdata/codegen/config-variables/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.142.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/tests/testdata/codegen/cyclic-types/nodejs/package.json
+++ b/tests/testdata/codegen/cyclic-types/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/cyclic-types/nodejs/package.json
+++ b/tests/testdata/codegen/cyclic-types/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/cyclic-types/schema.yaml
+++ b/tests/testdata/codegen/cyclic-types/schema.yaml
@@ -50,6 +50,6 @@ language:
   nodejs:
     {
       "dependencies": { "@pulumi/pulumi": "^3.12" },
-      "devDependencies": { "typescript": "^3.7.0" },
+      "devDependencies": { "typescript": "^4.6.0" },
     }
   python: {}

--- a/tests/testdata/codegen/dash-named-schema/nodejs/package.json
+++ b/tests/testdata/codegen/dash-named-schema/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/dash-named-schema/nodejs/package.json
+++ b/tests/testdata/codegen/dash-named-schema/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/dash-named-schema/schema.json
+++ b/tests/testdata/codegen/dash-named-schema/schema.json
@@ -54,7 +54,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {}

--- a/tests/testdata/codegen/dashed-import-schema/nodejs/package.json
+++ b/tests/testdata/codegen/dashed-import-schema/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/dashed-import-schema/nodejs/package.json
+++ b/tests/testdata/codegen/dashed-import-schema/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/dashed-import-schema/schema.json
+++ b/tests/testdata/codegen/dashed-import-schema/schema.json
@@ -252,7 +252,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {

--- a/tests/testdata/codegen/different-enum/nodejs/package.json
+++ b/tests/testdata/codegen/different-enum/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/different-enum/nodejs/package.json
+++ b/tests/testdata/codegen/different-enum/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/different-enum/schema.json
+++ b/tests/testdata/codegen/different-enum/schema.json
@@ -255,7 +255,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {

--- a/tests/testdata/codegen/different-package-name-conflict/schema.json
+++ b/tests/testdata/codegen/different-package-name-conflict/schema.json
@@ -258,7 +258,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {}

--- a/tests/testdata/codegen/embedded-crd-types/nodejs/package.json
+++ b/tests/testdata/codegen/embedded-crd-types/nodejs/package.json
@@ -9,7 +9,7 @@
         "@pulumi/pulumi": "^3.142.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/tests/testdata/codegen/enum-reference-python/nodejs/package.json
+++ b/tests/testdata/codegen/enum-reference-python/nodejs/package.json
@@ -10,8 +10,8 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "ts3.7",
-        "typescript": "^3.7.0"
+        "@types/node": "^18",
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/enum-reference-python/schema.json
+++ b/tests/testdata/codegen/enum-reference-python/schema.json
@@ -60,8 +60,8 @@
                 "@pulumi/google-native": "^0.20.0"
             },
             "devDependencies": {
-                "typescript": "^3.7.0",
-                "@types/node": "ts3.7"
+                "typescript": "^4.6.0",
+                "@types/node": "^18"
             }
         },
         "go": {

--- a/tests/testdata/codegen/enum-reference/nodejs/package.json
+++ b/tests/testdata/codegen/enum-reference/nodejs/package.json
@@ -9,8 +9,8 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "ts3.7",
-        "typescript": "^3.7.0"
+        "@types/node": "^18",
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/enum-reference/schema.json
+++ b/tests/testdata/codegen/enum-reference/schema.json
@@ -29,8 +29,8 @@
                 "@pulumi/google-native": "^0.20.0"
             },
             "devDependencies": {
-                "typescript": "^3.7.0",
-                "@types/node": "ts3.7"
+                "typescript": "^4.6.0",
+                "@types/node": "^18"
             }
         },
         "go": {

--- a/tests/testdata/codegen/external-enum/nodejs/package.json
+++ b/tests/testdata/codegen/external-enum/nodejs/package.json
@@ -9,8 +9,8 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "ts3.7",
-        "typescript": "^3.7.0"
+        "@types/node": "^18",
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/external-enum/schema.json
+++ b/tests/testdata/codegen/external-enum/schema.json
@@ -46,8 +46,8 @@
         "@pulumi/google-native": "^0.20.0"
       },
       "devDependencies": {
-        "typescript": "^3.7.0",
-        "@types/node": "ts3.7"
+        "typescript": "^4.6.0",
+        "@types/node": "^18"
       },
       "respectSchemaVersion": true
     },

--- a/tests/testdata/codegen/external-node-compatibility/nodejs/package.json
+++ b/tests/testdata/codegen/external-node-compatibility/nodejs/package.json
@@ -9,7 +9,7 @@
         "@pulumi/pulumi": "^3.142.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/tests/testdata/codegen/external-resource-schema/nodejs/package.json
+++ b/tests/testdata/codegen/external-resource-schema/nodejs/package.json
@@ -11,7 +11,7 @@
         "@pulumi/random": "^4.2.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/tests/testdata/codegen/hyphen-url/nodejs/package.json
+++ b/tests/testdata/codegen/hyphen-url/nodejs/package.json
@@ -10,7 +10,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/hyphen-url/nodejs/package.json
+++ b/tests/testdata/codegen/hyphen-url/nodejs/package.json
@@ -9,7 +9,7 @@
         "@pulumi/pulumi": "^3.7.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/hyphen-url/schema.json
+++ b/tests/testdata/codegen/hyphen-url/schema.json
@@ -45,7 +45,7 @@
         "@pulumi/azure-native": "^1.28.0"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {

--- a/tests/testdata/codegen/kubernetes20/nodejs/package.json
+++ b/tests/testdata/codegen/kubernetes20/nodejs/package.json
@@ -24,7 +24,7 @@
         "tmp": "^0.0.33"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/tests/testdata/codegen/legacy-names/nodejs/package.json
+++ b/tests/testdata/codegen/legacy-names/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.142.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/tests/testdata/codegen/methods-return-plain-resource/nodejs/package.json
+++ b/tests/testdata/codegen/methods-return-plain-resource/nodejs/package.json
@@ -9,7 +9,7 @@
         "@pulumi/tls": "4.10"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/tests/testdata/codegen/naming-collisions/nodejs/package.json
+++ b/tests/testdata/codegen/naming-collisions/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/naming-collisions/nodejs/package.json
+++ b/tests/testdata/codegen/naming-collisions/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/naming-collisions/schema.json
+++ b/tests/testdata/codegen/naming-collisions/schema.json
@@ -92,7 +92,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {}

--- a/tests/testdata/codegen/nested-module-thirdparty/nodejs/package.json
+++ b/tests/testdata/codegen/nested-module-thirdparty/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/nested-module-thirdparty/nodejs/package.json
+++ b/tests/testdata/codegen/nested-module-thirdparty/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/nested-module-thirdparty/schema.json
+++ b/tests/testdata/codegen/nested-module-thirdparty/schema.json
@@ -24,7 +24,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {

--- a/tests/testdata/codegen/nested-module/nodejs/package.json
+++ b/tests/testdata/codegen/nested-module/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/nested-module/nodejs/package.json
+++ b/tests/testdata/codegen/nested-module/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/nested-module/schema.json
+++ b/tests/testdata/codegen/nested-module/schema.json
@@ -33,7 +33,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {}

--- a/tests/testdata/codegen/other-owned/schema.json
+++ b/tests/testdata/codegen/other-owned/schema.json
@@ -262,7 +262,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {}

--- a/tests/testdata/codegen/plain-and-default-go-generics-only/schema.json
+++ b/tests/testdata/codegen/plain-and-default-go-generics-only/schema.json
@@ -137,7 +137,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {}

--- a/tests/testdata/codegen/plain-and-default/nodejs/package.json
+++ b/tests/testdata/codegen/plain-and-default/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/plain-and-default/nodejs/package.json
+++ b/tests/testdata/codegen/plain-and-default/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/plain-and-default/schema.json
+++ b/tests/testdata/codegen/plain-and-default/schema.json
@@ -137,7 +137,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {}

--- a/tests/testdata/codegen/plain-object-defaults/nodejs/package.json
+++ b/tests/testdata/codegen/plain-object-defaults/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/plain-object-defaults/nodejs/package.json
+++ b/tests/testdata/codegen/plain-object-defaults/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/plain-object-defaults/schema.json
+++ b/tests/testdata/codegen/plain-object-defaults/schema.json
@@ -225,7 +225,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {}

--- a/tests/testdata/codegen/plain-object-disable-defaults/nodejs/package.json
+++ b/tests/testdata/codegen/plain-object-disable-defaults/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/plain-object-disable-defaults/nodejs/package.json
+++ b/tests/testdata/codegen/plain-object-disable-defaults/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/plain-object-disable-defaults/schema.json
+++ b/tests/testdata/codegen/plain-object-disable-defaults/schema.json
@@ -225,7 +225,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {}

--- a/tests/testdata/codegen/plain-schema-gh6957/nodejs/package.json
+++ b/tests/testdata/codegen/plain-schema-gh6957/nodejs/package.json
@@ -5,12 +5,12 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/aws": "^3.7.0",
+        "@pulumi/aws": "^4.6.0",
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/plain-schema-gh6957/nodejs/package.json
+++ b/tests/testdata/codegen/plain-schema-gh6957/nodejs/package.json
@@ -9,7 +9,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/plain-schema-gh6957/schema.json
+++ b/tests/testdata/codegen/plain-schema-gh6957/schema.json
@@ -53,10 +53,10 @@
     "nodejs": {
       "dependencies": {
         "@pulumi/pulumi": "^3.12",
-        "@pulumi/aws": "^3.7.0"
+        "@pulumi/aws": "^4.6.0"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {

--- a/tests/testdata/codegen/provider-config-schema/nodejs/package.json
+++ b/tests/testdata/codegen/provider-config-schema/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/provider-config-schema/nodejs/package.json
+++ b/tests/testdata/codegen/provider-config-schema/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/provider-config-schema/schema.json
+++ b/tests/testdata/codegen/provider-config-schema/schema.json
@@ -140,7 +140,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {}

--- a/tests/testdata/codegen/provider-type-schema/nodejs/package.json
+++ b/tests/testdata/codegen/provider-type-schema/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/provider-type-schema/nodejs/package.json
+++ b/tests/testdata/codegen/provider-type-schema/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/provider-type-schema/schema.json
+++ b/tests/testdata/codegen/provider-type-schema/schema.json
@@ -27,7 +27,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {}

--- a/tests/testdata/codegen/regress-8403/nodejs/package.json
+++ b/tests/testdata/codegen/regress-8403/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/regress-8403/nodejs/package.json
+++ b/tests/testdata/codegen/regress-8403/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/regress-8403/schema.json
+++ b/tests/testdata/codegen/regress-8403/schema.json
@@ -25,7 +25,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "go": {

--- a/tests/testdata/codegen/regress-py-12546/schema.json
+++ b/tests/testdata/codegen/regress-py-12546/schema.json
@@ -244,7 +244,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {

--- a/tests/testdata/codegen/replace-on-change/nodejs/package.json
+++ b/tests/testdata/codegen/replace-on-change/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/replace-on-change/nodejs/package.json
+++ b/tests/testdata/codegen/replace-on-change/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/replace-on-change/schema.json
+++ b/tests/testdata/codegen/replace-on-change/schema.json
@@ -144,7 +144,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {}

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/nodejs/package.json
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/nodejs/package.json
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/schema.json
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/schema.json
@@ -62,7 +62,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {}

--- a/tests/testdata/codegen/resource-args-python/nodejs/package.json
+++ b/tests/testdata/codegen/resource-args-python/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/resource-args-python/nodejs/package.json
+++ b/tests/testdata/codegen/resource-args-python/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/resource-args-python/schema.json
+++ b/tests/testdata/codegen/resource-args-python/schema.json
@@ -62,7 +62,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {}

--- a/tests/testdata/codegen/resource-property-overlap/nodejs/package.json
+++ b/tests/testdata/codegen/resource-property-overlap/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/resource-property-overlap/nodejs/package.json
+++ b/tests/testdata/codegen/resource-property-overlap/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/resource-property-overlap/schema.json
+++ b/tests/testdata/codegen/resource-property-overlap/schema.json
@@ -21,7 +21,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {}

--- a/tests/testdata/codegen/simple-enum-schema/nodejs/package.json
+++ b/tests/testdata/codegen/simple-enum-schema/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/simple-enum-schema/nodejs/package.json
+++ b/tests/testdata/codegen/simple-enum-schema/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/simple-enum-schema/schema.json
+++ b/tests/testdata/codegen/simple-enum-schema/schema.json
@@ -258,7 +258,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       },
       "respectSchemaVersion": true
     },

--- a/tests/testdata/codegen/simple-methods-schema/nodejs/package.json
+++ b/tests/testdata/codegen/simple-methods-schema/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/simple-methods-schema/nodejs/package.json
+++ b/tests/testdata/codegen/simple-methods-schema/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/simple-methods-schema/schema.json
+++ b/tests/testdata/codegen/simple-methods-schema/schema.json
@@ -139,7 +139,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {}

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/nodejs/package.json
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/nodejs/package.json
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/schema.json
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/schema.json
@@ -124,7 +124,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {}

--- a/tests/testdata/codegen/simple-plain-schema/nodejs/package.json
+++ b/tests/testdata/codegen/simple-plain-schema/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/simple-plain-schema/nodejs/package.json
+++ b/tests/testdata/codegen/simple-plain-schema/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/simple-plain-schema/schema.json
+++ b/tests/testdata/codegen/simple-plain-schema/schema.json
@@ -144,7 +144,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {}

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/nodejs/package.json
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/nodejs/package.json
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/schema.json
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/schema.json
@@ -129,7 +129,7 @@
         "@pulumi/pulumi": "^3.12"
       },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
       }
     },
     "python": {

--- a/tests/testdata/codegen/simple-resource-with-aliases/nodejs/package.json
+++ b/tests/testdata/codegen/simple-resource-with-aliases/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/simple-resource-with-aliases/nodejs/package.json
+++ b/tests/testdata/codegen/simple-resource-with-aliases/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/simple-resource-with-aliases/schema.json
+++ b/tests/testdata/codegen/simple-resource-with-aliases/schema.json
@@ -72,7 +72,7 @@
           "@pulumi/pulumi": "^3.12"
         },
         "devDependencies": {
-          "typescript": "^3.7.0"
+          "typescript": "^4.6.0"
         }
       },
       "python": {}

--- a/tests/testdata/codegen/simple-yaml-schema/nodejs/package.json
+++ b/tests/testdata/codegen/simple-yaml-schema/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/tests/testdata/codegen/simple-yaml-schema/nodejs/package.json
+++ b/tests/testdata/codegen/simple-yaml-schema/nodejs/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@types/node": "^18",
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.0"
     },
     "pulumi": {
         "resource": true,

--- a/tests/testdata/codegen/simple-yaml-schema/schema.yaml
+++ b/tests/testdata/codegen/simple-yaml-schema/schema.yaml
@@ -149,6 +149,6 @@ language:
   nodejs:
     {
       "dependencies": { "@pulumi/pulumi": "^3.12" },
-      "devDependencies": { "typescript": "^3.7.0" },
+      "devDependencies": { "typescript": "^4.6.0" },
     }
   python: {}

--- a/tests/testdata/codegen/simplified-invokes/nodejs/package.json
+++ b/tests/testdata/codegen/simplified-invokes/nodejs/package.json
@@ -10,7 +10,7 @@
         "@pulumi/pulumi": "^3.0.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/tests/testdata/codegen/unions-inline/nodejs/package.json
+++ b/tests/testdata/codegen/unions-inline/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.142.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/tests/testdata/codegen/unions-inside-arrays/nodejs/package.json
+++ b/tests/testdata/codegen/unions-inside-arrays/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.142.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/tests/testdata/codegen/urn-id-properties/nodejs/package.json
+++ b/tests/testdata/codegen/urn-id-properties/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.142.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/tests/testdata/codegen/using-shared-types-in-config/nodejs/package.json
+++ b/tests/testdata/codegen/using-shared-types-in-config/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/pulumi": "^3.142.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {


### PR DESCRIPTION
Node 18 is currently the lowest maintained version (see [here](https://nodejs.org/en/about/previous-releases)) and it's what we put in our templates (see [here](https://github.com/pulumi/templates/blob/master/aws-typescript/package.json#L5)). This discrepancy is causing some incompatibility issues: https://github.com/pulumi/pulumi/issues/18778

This PR changes two things:

- Updates codegen and programgen to use types of Node version ^18
- Updates schema examples that reference an old 3.7 TypeScript version to 4.6 (one that was released after Node 18), this should have no external effects

Since this is codegen only, it shouldn't break anyone unless some tests explicitly rely on ^14 being generated, or they similarly rely on outdated tooling like old TypeScript versions.

Fix https://github.com/pulumi/pulumi/issues/18778