### PR TITLE
Cleanup aliases in schema

### DIFF
--- a/changelog/pending/20250318--sdkgen--aliases-in-provider-schemas-can-now-be-set-with-just-an-array-of-strings-for-the-aliased-types.yaml
+++ b/changelog/pending/20250318--sdkgen--aliases-in-provider-schemas-can-now-be-set-with-just-an-array-of-strings-for-the-aliased-types.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen
+  description: Aliases in provider schemas can now be set with just an array of strings for the aliased types

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -1079,9 +1079,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 		fmt.Fprintf(w, "                {\n")
 		for _, alias := range r.Aliases {
 			fmt.Fprintf(w, "                    ")
-			if alias.Type != nil {
-				fmt.Fprintf(w, "new global::Pulumi.Alias { Type = \"%v\" },\n", *alias.Type)
-			}
+			fmt.Fprintf(w, "new global::Pulumi.Alias { Type = \"%v\" },\n", alias.Type)
 		}
 		fmt.Fprintf(w, "                },\n")
 	}

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -2259,9 +2259,7 @@ func (pkg *pkgContext) genResource(
 		fmt.Fprintf(w, "\taliases := pulumi.Aliases([]pulumi.Alias{\n")
 		for _, alias := range r.Aliases {
 			s := "\t\t{\n"
-			if alias.Type != nil {
-				s += fmt.Sprintf("\t\t\tType: pulumi.String(%q),\n", *alias.Type)
-			}
+			s += fmt.Sprintf("\t\t\tType: pulumi.String(%q),\n", alias.Type)
 			s += "\t\t},\n"
 			fmt.Fprint(w, s)
 		}

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -882,11 +882,9 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 	if len(r.Aliases) > 0 {
 		fmt.Fprintf(w, "        const aliasOpts = { aliases: [")
 		for i, alias := range r.Aliases {
-			if alias.Type != nil {
-				fmt.Fprintf(w, "{ type: \"%v\" }", *alias.Type)
-				if i != len(r.Aliases)-1 {
-					fmt.Fprintf(w, ", ")
-				}
+			fmt.Fprintf(w, "{ type: \"%v\" }", alias.Type)
+			if i != len(r.Aliases)-1 {
+				fmt.Fprintf(w, ", ")
 			}
 		}
 		fmt.Fprintf(w, "] };\n")

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1519,11 +1519,9 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 		fmt.Fprintf(w, `        alias_opts = pulumi.ResourceOptions(aliases=[`)
 
 		for i, alias := range res.Aliases {
-			if alias.Type != nil {
-				fmt.Fprintf(w, "pulumi.Alias(type_=\"%v\")", *alias.Type)
-				if i != len(res.Aliases)-1 {
-					fmt.Fprintf(w, ", ")
-				}
+			fmt.Fprintf(w, "pulumi.Alias(type_=\"%v\")", alias.Type)
+			if i != len(res.Aliases)-1 {
+				fmt.Fprintf(w, ", ")
 			}
 		}
 

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -1526,7 +1526,7 @@ func (t *types) bindResourceDetails(path, token string, spec ResourceSpec, decl 
 
 	aliases := slice.Prealloc[*Alias](len(spec.Aliases))
 	for _, a := range spec.Aliases {
-		aliases = append(aliases, &Alias{Name: a.Name, Project: a.Project, Type: a.Type})
+		aliases = append(aliases, &Alias{compatibility: a.compatibility, Type: a.Type})
 	}
 
 	language := make(map[string]interface{})

--- a/pkg/codegen/schema/pulumi.json
+++ b/pkg/codegen/schema/pulumi.json
@@ -538,16 +538,8 @@
                     "type": "array",
                     "items": {
                         "title": "Alias Definition",
-                        "type": "object",
+                        "type": ["object", "string"],
                         "properties": {
-                            "name": {
-                                "description": "The name portion of the alias, if any",
-                                "type": "string"
-                            },
-                            "project": {
-                                "description": "The project portion of the alias, if any",
-                                "type": "string"
-                            },
                             "type": {
                                 "description": "The type portion of the alias, if any",
                                 "type": "string"

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -1931,3 +1931,47 @@ func TestProviderVersionIsAnError(t *testing.T) {
 	assert.False(t, diags.HasErrors())
 	assert.NotNil(t, pkg)
 }
+
+func TestRoundtripAliasesJSON(t *testing.T) {
+	t.Parallel()
+
+	testdataPath := filepath.Join("..", "testing", "test", "testdata")
+	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	pkgSpec := readSchemaFile("aliases-1.0.0.json")
+	pkg, diags, err := BindSpec(pkgSpec, loader)
+	require.NoError(t, err)
+	assert.Empty(t, diags)
+	newSpec, err := pkg.MarshalSpec()
+	require.NoError(t, err)
+	require.NotNil(t, newSpec)
+
+	jsonData, err := json.Marshal(&newSpec)
+	require.NoError(t, err)
+
+	schemaBytes, err := os.ReadFile(filepath.Join("..", "testing", "test", "testdata", "aliases-1.0.0.json"))
+	require.NoError(t, err)
+
+	assert.JSONEq(t, string(schemaBytes), string(jsonData))
+}
+
+func TestRoundtripAliasesYAML(t *testing.T) {
+	t.Parallel()
+
+	testdataPath := filepath.Join("..", "testing", "test", "testdata")
+	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	pkgSpec := readSchemaFile("aliases-1.0.0.yaml")
+	pkg, diags, err := BindSpec(pkgSpec, loader)
+	require.NoError(t, err)
+	assert.Empty(t, diags)
+	newSpec, err := pkg.MarshalSpec()
+	require.NoError(t, err)
+	require.NotNil(t, newSpec)
+
+	yamlData, err := yaml.Marshal(&newSpec)
+	require.NoError(t, err)
+
+	schemaBytes, err := os.ReadFile(filepath.Join("..", "testing", "test", "testdata", "aliases-1.0.0.yaml"))
+	require.NoError(t, err)
+
+	assert.YAMLEq(t, string(schemaBytes), string(yamlData))
+}

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -125,5 +125,7 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 		SchemaProvider{"plain-properties", "1.0.0"},
 		SchemaProvider{"recursive", "1.0.0"},
 		SchemaProvider{"aws-static-website", "0.4.0"},
+
+		SchemaProvider{"aliases", "1.0.0"},
 	)
 }

--- a/tests/testdata/codegen/aliases-1.0.0.json
+++ b/tests/testdata/codegen/aliases-1.0.0.json
@@ -1,0 +1,21 @@
+{
+  "name": "aliases",
+  "version": "1.0.0",
+  "meta": {
+    "moduleFormat": "(.*)"
+  },
+  "config": {},
+  "provider": {
+    "type": "object"
+  },
+  "resources": {
+    "aliases:index:First": {
+      "aliases": ["aliases:index:OldFirst"],
+      "type": "object"
+    },
+    "aliases:index:Second": {
+      "aliases": [{"type": "aliases:index:OldSecond"}],
+      "type": "object"
+    }
+  }
+}

--- a/tests/testdata/codegen/aliases-1.0.0.yaml
+++ b/tests/testdata/codegen/aliases-1.0.0.yaml
@@ -1,0 +1,16 @@
+name: aliases
+version: 1.0.0
+meta:
+  moduleFormat: (.*)
+config: {}
+provider: 
+  type: object
+resources:
+  aliases:index:First:
+    aliases:
+      - aliases:index:OldFirst
+    type: object
+  aliases:index:Second:
+    aliases:
+      - type: aliases:index:OldSecond
+    type: object


### PR DESCRIPTION
When we added aliases to schemas we added them with the project and name aliases that programs can specify as well. 
Codegen was never hooked up to use these fields, and it doesn't really make sense for a schema to say "resources of this type always used to come from the X project".

Providers team asked about these the other day, and rather than re-explaining their dead code again this just gets rid of them. It also simplifies the "aliases" property to allow just strings. So rather than:
```
"aliases": [{"type": "pkg:index::OldType"}],
```

You can now just do:
```
"aliases": ["pkg:index::OldType"],
```

A mixture of forms also works. I've added tests to ensure that we roundtrip these in the same format we read them. Schemas built from PackageSpecs will continue to default to object form. Most providers use this method to build their schemas and we don't want them to suddenly start emitting schemas that old engines don't understand. 

The string form can be moved to once we feel enough time has passed that no one will be on old engine versions pre this change.