### PR TITLE
Add default orgs as an API capability

### DIFF
--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -37,7 +37,7 @@ const (
 	// Indicates whether the service supports a notion of providing an opinion on a
 	// default organization among the user's org memberships, if a default org has
 	// not been explicitly defined.
-	DefaultOrganization APICapability = "default-org"
+	DefaultOrg APICapability = "default-org"
 )
 
 type DeltaCheckpointUploadsConfigV2 struct {
@@ -72,7 +72,7 @@ type Capabilities struct {
 	// Indicates whether the service supports a notion of providing an opinion on a
 	// default organization among the user's org memberships, if a default org has
 	// not been explicitly defined.
-	DefaultOrgs bool
+	DefaultOrg bool
 }
 
 // Parse decodes the CapabilitiesResponse into a Capabilities struct for ease of use.
@@ -96,8 +96,8 @@ func (r CapabilitiesResponse) Parse() (Capabilities, error) {
 			}
 		case BatchEncrypt:
 			parsed.BatchEncryption = true
-		case DefaultOrganization:
-			parsed.DefaultOrgs = true
+		case DefaultOrg:
+			parsed.DefaultOrg = true
 		default:
 			continue
 		}

--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -33,6 +33,11 @@ const (
 
 	// Indicates that the service backend supports batch encryption.
 	BatchEncrypt APICapability = "batch-encrypt"
+
+	// Indicates whether the service supports a notion of providing an opinion on a
+	// default organization among the user's org memberships, if a default org has
+	// not been explicitly defined.
+	DefaultOrganization APICapability = "default-org"
 )
 
 type DeltaCheckpointUploadsConfigV2 struct {
@@ -63,6 +68,11 @@ type Capabilities struct {
 
 	// Indicates whether the service supports batch encryption.
 	BatchEncryption bool
+
+	// Indicates whether the service supports a notion of providing an opinion on a
+	// default organization among the user's org memberships, if a default org has
+	// not been explicitly defined.
+	DefaultOrgs bool
 }
 
 // Parse decodes the CapabilitiesResponse into a Capabilities struct for ease of use.
@@ -86,6 +96,8 @@ func (r CapabilitiesResponse) Parse() (Capabilities, error) {
 			}
 		case BatchEncrypt:
 			parsed.BatchEncryption = true
+		case DefaultOrganization:
+			parsed.DefaultOrgs = true
 		default:
 			continue
 		}


### PR DESCRIPTION
Fix https://github.com/pulumi/pulumi-service/issues/26811

Follow-up from [Slack conversation](https://pulumi.slack.com/archives/C02VCJEBT2N/p1741979075342809): Update the Capabilities API schema to include default orgs, to distinguish between backends that will support the new `GetDefaultOrg` API.

See https://github.com/pulumi/pulumi/pull/18908 for the `GetDefaultOrg` API response type.