### PR TITLE
fix usage of rootnamespace in dotnet programgen

### DIFF
--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -470,6 +470,9 @@ func (g *generator) usingStatements(program *pcl.Program) programUsings {
 					if csharpinfo, ok := def.Language["csharp"].(CSharpPackageInfo); ok {
 						info = csharpinfo
 					}
+					if info.RootNamespace == "" && r.Schema.PackageReference.Namespace() != "" {
+						info.RootNamespace = r.Schema.PackageReference.Namespace()
+					}
 				}
 				pulumiUsings.Add(fmt.Sprintf("%s = %[2]s.%[1]s", namespace, info.GetRootNamespace()))
 			}


### PR DESCRIPTION
Discovered in https://github.com/pulumi/pulumi-dotnet/pull/545. Hopefully this will fix the conformance test.