### PR TITLE
fix nodejs PackageName usage in LinkPackage

### DIFF
--- a/changelog/pending/20250318--cli-package--fix-explicitly-named-package-names-in-nodejs.yaml
+++ b/changelog/pending/20250318--cli-package--fix-explicitly-named-package-names-in-nodejs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/package
+  description: Fix explicitly named package names in NodeJS

--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link_test.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link_test.go
@@ -38,12 +38,12 @@ func TestPrintNodeJsImportInstructions(t *testing.T) {
 				Name: "aws-native",
 				Language: map[string]interface{}{
 					"nodejs": nodejs.NodePackageInfo{
-						PackageName: "awsnative",
+						PackageName: "@pulumi/aws-native-renamed",
 					},
 				},
 			},
 			options:        map[string]interface{}{},
-			wantImportLine: "import * as awsnative from \"@pulumi/aws-native\";\n",
+			wantImportLine: "import * as awsNative from \"@pulumi/aws-native-renamed\";\n",
 		},
 		{
 			name: "falls back to camelCase when no package info",


### PR DESCRIPTION
In `pulumi.json` PackageName is documented as `NPM package name (includes @namespace)`.  However in LinkPackage we're using it to specify the importname of the package, which is not correct.  Fix that, and fix up the test as well.