### PR TITLE
Install package SDKs on pulumi install

### DIFF
--- a/changelog/pending/20250318--cli-install-package--install-package-sdks-on-pulumi-install.yaml
+++ b/changelog/pending/20250318--cli-install-package--install-package-sdks-on-pulumi-install.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/install,package
+  description: Install package SDKs on `pulumi install`

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -48,7 +48,7 @@ func NewInstallCmd() *cobra.Command {
 			"\n" +
 			"This command is used to manually install packages and plugins required by your program or policy pack.\n" +
 			"If your Pulumi.yaml file contains a 'packages' section, this command will automatically install\n" +
-			"SDKs for all packages declared in that section.",
+			"SDKs for all packages declared in that section, similar to the 'pulumi package add' command.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -72,6 +72,14 @@ func InstallPackage(ws pkgWorkspace.Context, pctx *plugin.Context, language, roo
 		outName = pkg.Namespace + "-" + outName
 	}
 	out = filepath.Join(out, outName)
+
+	// If directory already exists, remove it completely before copying new files
+	if _, err := os.Stat(out); err == nil {
+		if err := os.RemoveAll(out); err != nil {
+			return fmt.Errorf("failed to clean existing SDK directory: %w", err)
+		}
+	}
+
 	err = CopyAll(out, filepath.Join(tempOut, language))
 	if err != nil {
 		return fmt.Errorf("failed to move SDK to project: %w", err)

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -28,6 +28,59 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// InstallPackage installs a package to the project by generating an SDK and linking it.
+// It returns the path to the installed package.
+func InstallPackage(ws pkgWorkspace.Context, pctx *plugin.Context, language, root,
+	schemaSource string, parameters []string,
+) error {
+	pkg, err := SchemaFromSchemaSource(pctx, schemaSource, parameters)
+	if err != nil {
+		var diagErr hcl.Diagnostics
+		if errors.As(err, &diagErr) {
+			return fmt.Errorf("failed to get schema. Diagnostics: %w", errors.Join(diagErr.Errs()...))
+		}
+		return fmt.Errorf("failed to get schema: %w", err)
+	}
+
+	tempOut, err := os.MkdirTemp("", "pulumi-package-")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+	defer os.RemoveAll(tempOut)
+
+	local := true
+
+	err = GenSDK(
+		language,
+		tempOut,
+		pkg,
+		"",    /*overlays*/
+		local, /*local*/
+	)
+	if err != nil {
+		return fmt.Errorf("failed to generate SDK: %w", err)
+	}
+
+	out := filepath.Join(root, "sdks")
+	err = os.MkdirAll(out, 0o755)
+	if err != nil {
+		return fmt.Errorf("failed to create directory for SDK: %w", err)
+	}
+
+	outName := pkg.Name
+	if pkg.Namespace != "" {
+		outName = pkg.Namespace + "-" + outName
+	}
+	out = filepath.Join(out, outName)
+	err = CopyAll(out, filepath.Join(tempOut, language))
+	if err != nil {
+		return fmt.Errorf("failed to move SDK to project: %w", err)
+	}
+
+	// Link the package to the project
+	return LinkPackage(ws, language, root, pkg, out)
+}
+
 // Constructs the `pulumi package add` command.
 func newPackageAddCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -88,55 +141,7 @@ extension, Pulumi package schema is read from it directly:
 			plugin := args[0]
 			parameters := args[1:]
 
-			pkg, err := SchemaFromSchemaSource(pctx, plugin, parameters)
-			if err != nil {
-				var diagErr hcl.Diagnostics
-				if errors.As(err, &diagErr) {
-					return fmt.Errorf("failed to get schema. Diagnostics: %w", errors.Join(diagErr.Errs()...))
-				}
-				return fmt.Errorf("failed to get schema: %w", err)
-			}
-
-			tempOut, err := os.MkdirTemp("", "pulumi-package-add-")
-			if err != nil {
-				return fmt.Errorf("failed to create temporary directory: %w", err)
-			}
-
-			local := true
-
-			err = GenSDK(
-				language,
-				tempOut,
-				pkg,
-				"",    /*overlays*/
-				local, /*local*/
-			)
-			if err != nil {
-				return fmt.Errorf("failed to generate SDK: %w", err)
-			}
-
-			out := filepath.Join(root, "sdks")
-			err = os.MkdirAll(out, 0o755)
-			if err != nil {
-				return fmt.Errorf("failed to create directory for SDK: %w", err)
-			}
-
-			outName := pkg.Name
-			if pkg.Namespace != "" {
-				outName = pkg.Namespace + "-" + outName
-			}
-			out = filepath.Join(out, outName)
-			err = CopyAll(out, filepath.Join(tempOut, language))
-			if err != nil {
-				return fmt.Errorf("failed to move SDK to project: %w", err)
-			}
-
-			err = os.RemoveAll(tempOut)
-			if err != nil {
-				return fmt.Errorf("failed to remove temporary directory: %w", err)
-			}
-
-			return LinkPackage(ws, language, root, pkg, out)
+			return InstallPackage(ws, pctx, language, root, plugin, parameters)
 		},
 	}
 

--- a/tests/integration/packages-install/Pulumi.dev.yaml
+++ b/tests/integration/packages-install/Pulumi.dev.yaml
@@ -1,0 +1,4 @@
+config:
+  forceDelete: true
+  lifecyclePolicy:
+    skip: true

--- a/tests/integration/packages-install/Pulumi.yaml
+++ b/tests/integration/packages-install/Pulumi.yaml
@@ -1,0 +1,8 @@
+name: package-install-test
+description: A TypeScript program that declares a dependency on a remote package
+packages:
+  tls-self-signed-cert: github.com/pulumi/component-test-providers/test-provider@d47cf0910e0450400775594609ee82566d1fb355
+runtime:
+  name: nodejs
+  options:
+    packagemanager: yarn

--- a/tests/integration/packages-install/index.ts
+++ b/tests/integration/packages-install/index.ts
@@ -1,0 +1,11 @@
+import * as tls from "tls-self-signed-cert";
+
+const cert = new tls.SelfSignedCertificate("mycert", {
+    subject: {
+        organization: "Example Org"
+    },
+    dnsName: "example.com",
+    validityPeriodHours: 24,
+    localValidityPeriodHours: 24,
+});
+export const certPem = cert.pem;

--- a/tests/integration/packages-install/package.json
+++ b/tests/integration/packages-install/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "comp-as-comp",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.113.0",
+        "tls-self-signed-cert": "file:sdks/tls-self-signed-cert"
+    }
+}

--- a/tests/integration/packages-install/tsconfig.json
+++ b/tests/integration/packages-install/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "emitDecoratorMetadata": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
This change adds a new step to `pulumi install`: it will list all packages from the `packages` section and install SDKs for each of them. This will happen on each run of `pulumi install`, there is no check if SDKs are already present or not, but this is supposed to be idempotent.

`package add` has no functional changes yet, it's just refactored to expose a helper function.

I added a test with the `packages` section that runs `pulumi install` and checks that the right thing was dowloaded. The `codecov` number sucks but it looks like we only have integration level tests for pulumi install and packages?

Also, a small cleanup - remove the existing folder before copying the generated SDKs, so there is no dirty files left. Fixes https://github.com/pulumi/pulumi-yaml/issues/755

Part of https://github.com/pulumi/pulumi/issues/18918
Fixes https://github.com/pulumi/pulumi-yaml/issues/755