### PR TITLE
dotnet: format namespace correctly in programgen

### DIFF
--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -471,7 +471,7 @@ func (g *generator) usingStatements(program *pcl.Program) programUsings {
 						info = csharpinfo
 					}
 					if info.RootNamespace == "" && r.Schema.PackageReference.Namespace() != "" {
-						info.RootNamespace = r.Schema.PackageReference.Namespace()
+						info.RootNamespace = namespaceName(nil, r.Schema.PackageReference.Namespace())
 					}
 				}
 				pulumiUsings.Add(fmt.Sprintf("%s = %[2]s.%[1]s", namespace, info.GetRootNamespace()))


### PR DESCRIPTION
https://github.com/pulumi/pulumi/pull/18932 fixed the right thing, but it wasn't complete.  We also need to bring the namespace into the right format.  Do so here.