### PR TITLE
Update languages and conformance tests to use `T.Context()`

### DIFF
--- a/cmd/pulumi-test-language/go.mod
+++ b/cmd/pulumi-test-language/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/cmd/pulumi-test-language
 
-go 1.24
+go 1.24.1
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../../sdk
 

--- a/cmd/pulumi-test-language/go.mod
+++ b/cmd/pulumi-test-language/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/cmd/pulumi-test-language
 
-go 1.23.7
+go 1.24
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../../sdk
 

--- a/cmd/pulumi-test-language/interface_test.go
+++ b/cmd/pulumi-test-language/interface_test.go
@@ -63,7 +63,7 @@ func TestL1NoProviders(t *testing.T) {
 func TestNoInternalTests(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	engine := &languageTestServer{}
 
 	response, err := engine.GetLanguageTests(ctx, &testingrpc.GetLanguageTestsRequest{})
@@ -136,7 +136,7 @@ func TestProviderVersions(t *testing.T) {
 			version, err := getProviderVersion(provider)
 			require.NoError(t, err)
 
-			schema, err := provider.GetSchema(context.Background(), plugin.GetSchemaRequest{})
+			schema, err := provider.GetSchema(t.Context(), plugin.GetSchemaRequest{})
 			require.NoError(t, err)
 
 			var schemaJSON struct {
@@ -169,7 +169,7 @@ func TestProviderSchemas(t *testing.T) {
 				continue
 			}
 
-			resp, err := provider.GetSchema(context.Background(), plugin.GetSchemaRequest{})
+			resp, err := provider.GetSchema(t.Context(), plugin.GetSchemaRequest{})
 			require.NoError(t, err)
 
 			var pkg schema.PackageSpec

--- a/cmd/pulumi-test-language/internal_test.go
+++ b/cmd/pulumi-test-language/internal_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -31,7 +30,7 @@ import (
 func TestInvalidSchema(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
 	// We can just reuse the L1Empty host for this, it's not actually going to be used apart from prepare.

--- a/cmd/pulumi-test-language/l1_empty_test.go
+++ b/cmd/pulumi-test-language/l1_empty_test.go
@@ -177,7 +177,7 @@ func (h *L1EmptyLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 func TestL1Empty(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
 	runtime := &L1EmptyLanguageHost{tempDir: tempDir}
@@ -215,7 +215,7 @@ func TestL1Empty(t *testing.T) {
 func TestL1Empty_FailPrepare(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
 	runtime := &L1EmptyLanguageHost{
@@ -301,7 +301,7 @@ func TestL1Empty_FailPrepare(t *testing.T) {
 func TestL1Empty_BadSnapshot(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{DisableSnapshotWriting: true}
 	runtime := &L1EmptyLanguageHost{tempDir: tempDir}
@@ -341,7 +341,7 @@ func TestL1Empty_BadSnapshot(t *testing.T) {
 func TestL1Empty_MissingStack(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
 	runtime := &L1EmptyLanguageHost{
@@ -384,7 +384,7 @@ func TestL1Empty_MissingStack(t *testing.T) {
 func TestL1Empty_NoCoreSDK(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
 	runtime := &L1EmptyLanguageHost{

--- a/cmd/pulumi-test-language/l1_main_test.go
+++ b/cmd/pulumi-test-language/l1_main_test.go
@@ -191,7 +191,7 @@ func (h *L1MainLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest)
 func TestL1Main(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
 	runtime := &L1MainLanguageHost{tempDir: tempDir}

--- a/cmd/pulumi-test-language/l2_continue_on_error_test.go
+++ b/cmd/pulumi-test-language/l2_continue_on_error_test.go
@@ -270,7 +270,7 @@ func (h *L2ContinueOnErrorHost) Run(
 func TestL2ContinueOnError(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
 	runtime := &L2ContinueOnErrorHost{tempDir: tempDir}

--- a/cmd/pulumi-test-language/l2_destroy_test.go
+++ b/cmd/pulumi-test-language/l2_destroy_test.go
@@ -250,7 +250,7 @@ func (h *L2DestroyLanguageHost) Run(
 func TestL2Destroy(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
 	runtime := &L2DestroyLanguageHost{tempDir: tempDir}

--- a/cmd/pulumi-test-language/l2_large_test.go
+++ b/cmd/pulumi-test-language/l2_large_test.go
@@ -239,7 +239,7 @@ func (h *L2LargeLanguageHost) Run(
 //
 //nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL2LargeString(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
 	runtime := &L2LargeLanguageHost{tempDir: tempDir}

--- a/cmd/pulumi-test-language/l2_resource_asset_test.go
+++ b/cmd/pulumi-test-language/l2_resource_asset_test.go
@@ -343,7 +343,7 @@ func (h *L2ResourceAssetArchiveLanguageHost) Run(
 func TestL2ResourceAssetArchive(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
 	runtime := &L2ResourceAssetArchiveLanguageHost{tempDir: tempDir}

--- a/cmd/pulumi-test-language/l2_resource_simple_test.go
+++ b/cmd/pulumi-test-language/l2_resource_simple_test.go
@@ -265,7 +265,7 @@ func (h *L2ResourceSimpleLanguageHost) Run(
 func TestL2ResourceSimple(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
 	runtime := &L2ResourceSimpleLanguageHost{tempDir: tempDir}
@@ -303,7 +303,7 @@ func TestL2ResourceSimple(t *testing.T) {
 func TestL2SimpleResource_BadSnapshot(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{DisableSnapshotWriting: true}
 	runtime := &L2ResourceSimpleLanguageHost{tempDir: tempDir}
@@ -343,7 +343,7 @@ func TestL2SimpleResource_BadSnapshot(t *testing.T) {
 func TestL2SimpleResource_MissingResource(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
 	runtime := &L2ResourceSimpleLanguageHost{
@@ -386,7 +386,7 @@ func TestL2SimpleResource_MissingResource(t *testing.T) {
 func TestL2SimpleResource_MissingRequiredPlugins(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
 	runtime := &L2ResourceSimpleLanguageHost{
@@ -429,7 +429,7 @@ func TestL2SimpleResource_MissingRequiredPlugins(t *testing.T) {
 func TestL2ResourceSnapshotEdit(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
 	runtime := &L2ResourceSimpleLanguageHost{tempDir: tempDir}
@@ -473,7 +473,7 @@ func TestL2ResourceSnapshotEdit(t *testing.T) {
 func TestL2ResourceLanguageInfo(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
 	runtime := &L2ResourceSimpleLanguageHost{

--- a/cmd/pulumi-test-language/program_overrides_test.go
+++ b/cmd/pulumi-test-language/program_overrides_test.go
@@ -138,7 +138,7 @@ func TestProgramOverrides_DontGenerateProgram(t *testing.T) {
 	// Arrange.
 	tempDir := t.TempDir()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	engine := &languageTestServer{}
 
 	runtime := &ProgramOverridesLanguageHost{
@@ -219,7 +219,7 @@ func TestProgramOverrides_WorkWithMultipleRuns(t *testing.T) {
 	// Arrange.
 	tempDir := t.TempDir()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	engine := &languageTestServer{}
 
 	runtime := &ProgramOverridesLanguageHost{
@@ -395,7 +395,7 @@ func TestProgramOverrides_MustMatchRuns(t *testing.T) {
 	// Arrange.
 	tempDir := t.TempDir()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	engine := &languageTestServer{}
 
 	runtime := &ProgramOverridesLanguageHost{tempDir: tempDir}

--- a/cmd/pulumi-test-language/runtime_options_test.go
+++ b/cmd/pulumi-test-language/runtime_options_test.go
@@ -211,7 +211,7 @@ func (h *RuntimeOptionsLanguageHost) Run(
 func TestRuntimeOptions(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
 	runtime := &RuntimeOptionsLanguageHost{tempDir: tempDir}

--- a/sdk/go/pulumi-language-go/go.mod
+++ b/sdk/go/pulumi-language-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/sdk/go/pulumi-language-go/v3
 
-go 1.24
+go 1.24.1
 
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/sdk/go/pulumi-language-go/go.mod
+++ b/sdk/go/pulumi-language-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/sdk/go/pulumi-language-go/v3
 
-go 1.22
+go 1.24
 
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/sdk/go/pulumi-language-go/language_test.go
+++ b/sdk/go/pulumi-language-go/language_test.go
@@ -202,7 +202,7 @@ func TestLanguage(t *testing.T) {
 
 	engineAddress, engine := runTestingHost(t)
 
-	tests, err := engine.GetLanguageTests(context.Background(), &testingrpc.GetLanguageTestsRequest{})
+	tests, err := engine.GetLanguageTests(t.Context(), &testingrpc.GetLanguageTestsRequest{})
 	require.NoError(t, err)
 
 	cancel := make(chan bool)
@@ -224,7 +224,7 @@ func TestLanguage(t *testing.T) {
 	snapshotDir := "./testdata/"
 
 	// Prepare to run the tests
-	prepare, err := engine.PrepareLanguageTests(context.Background(), &testingrpc.PrepareLanguageTestsRequest{
+	prepare, err := engine.PrepareLanguageTests(t.Context(), &testingrpc.PrepareLanguageTestsRequest{
 		LanguagePluginName:   "go",
 		LanguagePluginTarget: fmt.Sprintf("127.0.0.1:%d", handle.Port),
 		TemporaryDirectory:   rootDir,
@@ -251,7 +251,7 @@ func TestLanguage(t *testing.T) {
 				t.Skipf("Skipping known failure: %s", expected)
 			}
 
-			result, err := engine.RunLanguageTest(context.Background(), &testingrpc.RunLanguageTestRequest{
+			result, err := engine.RunLanguageTest(t.Context(), &testingrpc.RunLanguageTestRequest{
 				Token: prepare.Token,
 				Test:  tt,
 			})

--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -412,7 +412,7 @@ func TestPluginsAndDependencies_subdir(t *testing.T) {
 
 func testPluginsAndDependencies(t *testing.T, progDir string) {
 	host := newLanguageHost("0.0.0.0:0", progDir, "")
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("GetRequiredPackages", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/sdk/nodejs/cmd/pulumi-language-nodejs/v3
 
-go 1.22
+go 1.24
 
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/sdk/nodejs/cmd/pulumi-language-nodejs/v3
 
-go 1.24
+go 1.24.1
 
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -183,7 +183,7 @@ func TestLanguage(t *testing.T) {
 
 	engineAddress, engine := runTestingHost(t)
 
-	tests, err := engine.GetLanguageTests(context.Background(), &testingrpc.GetLanguageTestsRequest{})
+	tests, err := engine.GetLanguageTests(t.Context(), &testingrpc.GetLanguageTestsRequest{})
 	require.NoError(t, err)
 
 	// We should run the nodejs tests twice. Once with tsc and once with ts-node.
@@ -217,7 +217,7 @@ func TestLanguage(t *testing.T) {
 			}
 
 			// Prepare to run the tests
-			prepare, err := engine.PrepareLanguageTests(context.Background(), &testingrpc.PrepareLanguageTestsRequest{
+			prepare, err := engine.PrepareLanguageTests(t.Context(), &testingrpc.PrepareLanguageTestsRequest{
 				LanguagePluginName:   "nodejs",
 				LanguagePluginTarget: fmt.Sprintf("127.0.0.1:%d", handle.Port),
 				TemporaryDirectory:   rootDir,
@@ -248,7 +248,7 @@ func TestLanguage(t *testing.T) {
 						t.Skipf("Skipping known failure: %s", expected)
 					}
 
-					result, err := engine.RunLanguageTest(context.Background(), &testingrpc.RunLanguageTestRequest{
+					result, err := engine.RunLanguageTest(t.Context(), &testingrpc.RunLanguageTestRequest{
 						Token: prepare.Token,
 						Test:  tt,
 					})

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -182,7 +181,7 @@ func TestGetRequiredPackages(t *testing.T) {
 	}
 
 	host := &nodeLanguageHost{}
-	resp, err := host.GetRequiredPackages(context.Background(), &pulumirpc.GetRequiredPackagesRequest{
+	resp, err := host.GetRequiredPackages(t.Context(), &pulumirpc.GetRequiredPackagesRequest{
 		Info: &pulumirpc.ProgramInfo{
 			RootDirectory:    dir,
 			ProgramDirectory: dir,
@@ -239,7 +238,7 @@ func TestGetRequiredPackagesSymlinkCycles(t *testing.T) {
 	require.NoError(t, err)
 
 	host := &nodeLanguageHost{}
-	resp, err := host.GetRequiredPackages(context.Background(), &pulumirpc.GetRequiredPackagesRequest{
+	resp, err := host.GetRequiredPackages(t.Context(), &pulumirpc.GetRequiredPackagesRequest{
 		Info: &pulumirpc.ProgramInfo{
 			RootDirectory:    dir,
 			ProgramDirectory: dir,
@@ -298,7 +297,7 @@ func TestGetRequiredPackagesSymlinkCycles2(t *testing.T) {
 	require.NoError(t, err)
 
 	host := &nodeLanguageHost{}
-	resp, err := host.GetRequiredPackages(context.Background(), &pulumirpc.GetRequiredPackagesRequest{
+	resp, err := host.GetRequiredPackages(t.Context(), &pulumirpc.GetRequiredPackagesRequest{
 		Info: &pulumirpc.ProgramInfo{
 			RootDirectory:    dir,
 			ProgramDirectory: dir,
@@ -353,7 +352,7 @@ func TestGetRequiredPackagesNestedPolicyPack(t *testing.T) {
 	}
 
 	host := &nodeLanguageHost{}
-	resp, err := host.GetRequiredPackages(context.Background(), &pulumirpc.GetRequiredPackagesRequest{
+	resp, err := host.GetRequiredPackages(t.Context(), &pulumirpc.GetRequiredPackagesRequest{
 		Info: &pulumirpc.ProgramInfo{
 			RootDirectory:    dir,
 			ProgramDirectory: dir,
@@ -406,7 +405,7 @@ func TestGetProgramDependencies(t *testing.T) {
 			},
 		})
 		host := &nodeLanguageHost{}
-		_, err := host.GetProgramDependencies(context.Background(), &pulumirpc.GetProgramDependenciesRequest{
+		_, err := host.GetProgramDependencies(t.Context(), &pulumirpc.GetProgramDependenciesRequest{
 			Program: testDir,
 			Info: &pulumirpc.ProgramInfo{
 				RootDirectory:    testDir,
@@ -431,7 +430,7 @@ func TestGetProgramDependencies(t *testing.T) {
 			},
 		})
 		host := &nodeLanguageHost{}
-		_, err := host.GetProgramDependencies(context.Background(), &pulumirpc.GetProgramDependenciesRequest{
+		_, err := host.GetProgramDependencies(t.Context(), &pulumirpc.GetProgramDependenciesRequest{
 			Program: testDir,
 			Info: &pulumirpc.ProgramInfo{
 				RootDirectory:    testDir,
@@ -467,7 +466,7 @@ func TestGetProgramDependencies(t *testing.T) {
 			},
 		})
 		host := &nodeLanguageHost{}
-		resp, err := host.GetProgramDependencies(context.Background(), &pulumirpc.GetProgramDependenciesRequest{
+		resp, err := host.GetProgramDependencies(t.Context(), &pulumirpc.GetProgramDependenciesRequest{
 			Program: testDir,
 			Info: &pulumirpc.ProgramInfo{
 				RootDirectory:    testDir,
@@ -507,7 +506,7 @@ func TestGetProgramDependencies(t *testing.T) {
 		})
 		subdir := filepath.Join(testDir, "subdir")
 		host := &nodeLanguageHost{}
-		resp, err := host.GetProgramDependencies(context.Background(), &pulumirpc.GetProgramDependenciesRequest{
+		resp, err := host.GetProgramDependencies(t.Context(), &pulumirpc.GetProgramDependenciesRequest{
 			Program: subdir,
 			Info: &pulumirpc.ProgramInfo{
 				RootDirectory:    subdir,
@@ -546,7 +545,7 @@ func TestGetProgramDependencies(t *testing.T) {
 			},
 		})
 		host := &nodeLanguageHost{}
-		resp, err := host.GetProgramDependencies(context.Background(), &pulumirpc.GetProgramDependenciesRequest{
+		resp, err := host.GetProgramDependencies(t.Context(), &pulumirpc.GetProgramDependenciesRequest{
 			Program: testDir,
 			Info: &pulumirpc.ProgramInfo{
 				RootDirectory:    testDir,
@@ -601,7 +600,7 @@ func TestGetProgramDependencies(t *testing.T) {
 			},
 		})
 		host := &nodeLanguageHost{}
-		resp, err := host.GetProgramDependencies(context.Background(), &pulumirpc.GetProgramDependenciesRequest{
+		resp, err := host.GetProgramDependencies(t.Context(), &pulumirpc.GetProgramDependenciesRequest{
 			Program: testDir,
 			Info: &pulumirpc.ProgramInfo{
 				RootDirectory:    testDir,
@@ -658,7 +657,7 @@ func TestGetProgramDependencies(t *testing.T) {
 
 		subdir := filepath.Join(testDir, "subdir")
 		host := &nodeLanguageHost{}
-		resp, err := host.GetProgramDependencies(context.Background(), &pulumirpc.GetProgramDependenciesRequest{
+		resp, err := host.GetProgramDependencies(t.Context(), &pulumirpc.GetProgramDependenciesRequest{
 			Program: subdir,
 			Info: &pulumirpc.ProgramInfo{
 				RootDirectory:    subdir,

--- a/sdk/python/cmd/pulumi-language-python/go.mod
+++ b/sdk/python/cmd/pulumi-language-python/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/sdk/python/cmd/pulumi-language-python/v3
 
-go 1.24
+go 1.24.1
 
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/sdk/python/cmd/pulumi-language-python/go.mod
+++ b/sdk/python/cmd/pulumi-language-python/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/sdk/python/cmd/pulumi-language-python/v3
 
-go 1.22
+go 1.24
 
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -179,7 +179,7 @@ func TestLanguage(t *testing.T) {
 	t.Parallel()
 	engineAddress, engine := runTestingHost(t)
 
-	tests, err := engine.GetLanguageTests(context.Background(), &testingrpc.GetLanguageTestsRequest{})
+	tests, err := engine.GetLanguageTests(t.Context(), &testingrpc.GetLanguageTestsRequest{})
 	require.NoError(t, err)
 
 	// We need to run the python tests multiple times. Once with TOML projects and once with setup.py. We also want to
@@ -254,7 +254,7 @@ func TestLanguage(t *testing.T) {
 			}
 
 			// Prepare to run the tests
-			prepare, err := engine.PrepareLanguageTests(context.Background(), &testingrpc.PrepareLanguageTestsRequest{
+			prepare, err := engine.PrepareLanguageTests(t.Context(), &testingrpc.PrepareLanguageTestsRequest{
 				LanguagePluginName:   "python",
 				LanguagePluginTarget: fmt.Sprintf("127.0.0.1:%d", handle.Port),
 				TemporaryDirectory:   rootDir,
@@ -283,7 +283,7 @@ func TestLanguage(t *testing.T) {
 				t.Run(tt, func(t *testing.T) {
 					t.Parallel()
 
-					result, err := engine.RunLanguageTest(context.Background(), &testingrpc.RunLanguageTestRequest{
+					result, err := engine.RunLanguageTest(t.Context(), &testingrpc.RunLanguageTestRequest{
 						Token: prepare.Token,
 						Test:  tt,
 					})

--- a/sdk/python/cmd/pulumi-language-python/main_test.go
+++ b/sdk/python/cmd/pulumi-language-python/main_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -196,7 +195,7 @@ in-project = true
 		} else if toolchainName == "pip" {
 			tc, err := toolchain.ResolveToolchain(opts)
 			require.NoError(t, err)
-			cmd, err := tc.ModuleCommand(context.Background(), "pip", "install", req)
+			cmd, err := tc.ModuleCommand(t.Context(), "pip", "install", req)
 			require.NoError(t, err)
 			out, err := cmd.CombinedOutput()
 			require.NoError(t, err, string(out))
@@ -236,7 +235,7 @@ func TestDeterminePulumiPackages(t *testing.T) {
 			// available Pulumi virtual environments.
 			createVenv(t, cwd, toolchainName, opts, pipDependency)
 
-			packages, err := determinePulumiPackages(context.Background(), opts)
+			packages, err := determinePulumiPackages(t.Context(), opts)
 
 			require.NoError(t, err)
 			require.Empty(t, packages)
@@ -249,7 +248,7 @@ func TestDeterminePulumiPackages(t *testing.T) {
 
 			createVenv(t, cwd, toolchainName, opts, pulumiWheel(t), "pulumi-random", "pip-install-test")
 
-			packages, err := determinePulumiPackages(context.Background(), opts)
+			packages, err := determinePulumiPackages(t.Context(), opts)
 
 			require.NoError(t, err)
 			require.NotEmpty(t, packages)
@@ -269,7 +268,7 @@ func TestDeterminePulumiPackages(t *testing.T) {
 			require.NoError(t, err)
 			// Find sitePackages folder in Python that contains pip_install_test subfolder.
 			var sitePackages string
-			cmd, err := tc.Command(context.Background(), "-c",
+			cmd, err := tc.Command(t.Context(), "-c",
 				"import site; import json; print(json.dumps(site.getsitepackages()))")
 			require.NoError(t, err)
 			possibleSitePackages, err := cmd.Output()
@@ -295,7 +294,7 @@ func TestDeterminePulumiPackages(t *testing.T) {
 			require.NoError(t, err)
 			t.Logf("Wrote pulumi-plugin.json file: %s", path)
 
-			packages, err := determinePulumiPackages(context.Background(), opts)
+			packages, err := determinePulumiPackages(t.Context(), opts)
 
 			require.NoError(t, err)
 			assert.Equal(t, 1, len(packages))
@@ -324,12 +323,12 @@ func TestDeterminePulumiPackages(t *testing.T) {
 			assert.NoError(t, err)
 			tc, err := toolchain.ResolveToolchain(opts)
 			require.NoError(t, err)
-			cmd, err := tc.ModuleCommand(context.Background(), "pip", "install", fooSdkDir)
+			cmd, err := tc.ModuleCommand(t.Context(), "pip", "install", fooSdkDir)
 			require.NoError(t, err)
 			require.NoError(t, cmd.Run())
 
 			// The package should be considered a Pulumi package since its name is prefixed with "pulumi_".
-			packages, err := determinePulumiPackages(context.Background(), opts)
+			packages, err := determinePulumiPackages(t.Context(), opts)
 			require.NoError(t, err)
 			assert.Equal(t, 1, len(packages))
 			assert.Equal(t, "pulumi_foo", packages[0].Name)
@@ -353,12 +352,12 @@ func TestDeterminePulumiPackages(t *testing.T) {
 			assert.NoError(t, err)
 			tc, err := toolchain.ResolveToolchain(opts)
 			require.NoError(t, err)
-			cmd, err := tc.ModuleCommand(context.Background(), "pip", "install", oldSdkDir)
+			cmd, err := tc.ModuleCommand(t.Context(), "pip", "install", oldSdkDir)
 			require.NoError(t, err)
 			require.NoError(t, cmd.Run())
 
 			// The package should be considered a Pulumi package since its name is prefixed with "pulumi_".
-			packages, err := determinePulumiPackages(context.Background(), opts)
+			packages, err := determinePulumiPackages(t.Context(), opts)
 			assert.NoError(t, err)
 			assert.NotEmpty(t, packages)
 			assert.Equal(t, 1, len(packages))
@@ -376,7 +375,7 @@ func TestDeterminePulumiPackages(t *testing.T) {
 
 			// The package should not be considered a Pulumi package since it is hardcoded not to be,
 			// since it does not have an associated plugin.
-			packages, err := determinePulumiPackages(context.Background(), opts)
+			packages, err := determinePulumiPackages(t.Context(), opts)
 			assert.NoError(t, err)
 			assert.Empty(t, packages)
 		})


### PR DESCRIPTION
This required updating these to go 1.24, but these aren't depended on as libraries so that should be fine.

One of the recommendations of https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize