### PR TITLE
Parse schema docs refs

### DIFF
--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -15,9 +15,14 @@
 package codegen
 
 import (
+	"net/url"
+	"regexp"
+	"strings"
+
 	"github.com/pgavlin/goldmark/ast"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
 // DocLanguageHelper is an interface for extracting language-specific information from a Pulumi schema.
@@ -99,4 +104,138 @@ func FilterExamples(description string, lang string) string {
 	parsed := schema.ParseDocs(source)
 	filterExamples(source, parsed, lang)
 	return schema.RenderDocsToString(source, parsed)
+}
+
+// Matches the format: <pulumi ref="..."/>, allowing for additional whitespace.
+var matchPulumiRef = regexp.MustCompile(`<pulumi\s+ref="([^"]*)"\s*\/>`)
+
+func InterpretPulumiRefs(description string, resolveRefToName func(ref DocRef) (string, bool)) string {
+	if description == "" {
+		return ""
+	}
+	return matchPulumiRef.ReplaceAllStringFunc(description, func(match string) string {
+		submatches := matchPulumiRef.FindStringSubmatch(match)
+		if len(submatches) > 1 {
+			ref := submatches[1]
+			docRef := parseDocRef(ref)
+			if name, ok := resolveRefToName(docRef); ok {
+				return name
+			}
+			// Fallback to a default of the property name or token display name
+			if docRef.Property != "" {
+				return docRef.Property
+			}
+			if docRef.Token != "" {
+				return docRef.Token.DisplayName()
+			}
+			return ref
+		}
+		return match
+	})
+}
+
+type DocRefType string
+
+const (
+	DocRefTypeUnknown                DocRefType = ""
+	DocRefTypeResource               DocRefType = "resource"
+	DocRefTypeFunction               DocRefType = "function"
+	DocRefTypeType                   DocRefType = "type"
+	DocRefTypeResourceProperty       DocRefType = "resourceProperty"
+	DocRefTypeResourceInputProperty  DocRefType = "resourceInputProperty"
+	DocRefTypeFunctionInputProperty  DocRefType = "functionInputProperty"
+	DocRefTypeFunctionOutputProperty DocRefType = "functionOutputProperty"
+	DocRefTypeTypeProperty           DocRefType = "typeProperty"
+)
+
+type DocRef struct {
+	// Original parsed ref
+	Ref string
+	// The type of the parsed ref
+	Type DocRefType
+	// The token of the resource, function, or type, or empty if not applicable.
+	Token tokens.Type
+	// The referenced property name, or empty if not applicable.
+	Property string
+}
+
+// Parses a doc reference string into a DocRef struct.
+// The supported formats of the ref is:
+//
+//	#/resources/{token}
+//	#/functions/{token}
+//	#/types/{token}
+//	#/resources/{token}/properties/{property}
+//	#/resources/{token}/inputProperties/{property}
+//	#/functions/{token}/inputProperties/{property}
+//	#/functions/{token}/outputProperties/{property}
+//	#/types/{token}/properties/{property}
+//
+// Note: Tokens containing a slash ("/") must be encoded as "%2F".
+func parseDocRef(ref string) DocRef {
+	docRefUnknown := DocRef{Ref: ref, Type: DocRefTypeUnknown}
+	parts := strings.Split(ref, "/")
+	if len(parts) < 3 || parts[0] != "#" {
+		return docRefUnknown
+	}
+	// Extract which top-level type the ref is referring to.
+	var topLevelType string
+	switch parts[1] {
+	case "resources", "functions", "types":
+		// Strip "s" from the end of the type.
+		topLevelType = parts[1][:len(parts[1])-1]
+	default:
+		return docRefUnknown
+	}
+	tokenString, err := url.PathUnescape(parts[2])
+	if err != nil || tokenString == "" {
+		return docRefUnknown
+	}
+	token, err := tokens.ParseTypeToken(tokenString)
+	if err != nil {
+		return docRefUnknown
+	}
+
+	if len(parts) == 3 {
+		return DocRef{Ref: ref, Type: DocRefType(topLevelType), Token: token}
+	}
+
+	if len(parts) != 5 {
+		return docRefUnknown
+	}
+
+	property, err := url.PathUnescape(parts[4])
+	if err != nil || property == "" {
+		return docRefUnknown
+	}
+
+	// Extract the property kind and name.
+	switch parts[3] {
+	case "properties":
+		switch topLevelType {
+		case "resource", "type":
+			return DocRef{Ref: ref, Type: DocRefType(topLevelType + "Property"), Token: token, Property: property}
+		default:
+			// Properties isn't a valid ref
+			return docRefUnknown
+		}
+	case "inputProperties":
+		switch topLevelType {
+		case "resource", "function":
+			return DocRef{Ref: ref, Type: DocRefType(topLevelType + "InputProperty"), Token: token, Property: property}
+		default:
+			// Properties isn't a valid ref
+			return docRefUnknown
+		}
+	case "outputProperties":
+		switch topLevelType {
+		case "function":
+			return DocRef{Ref: ref, Type: DocRefType(topLevelType + "OutputProperty"), Token: token, Property: property}
+		default:
+			// Properties isn't a valid ref
+			return docRefUnknown
+		}
+	default:
+		return docRefUnknown
+	}
 }

--- a/pkg/codegen/docs_test.go
+++ b/pkg/codegen/docs_test.go
@@ -119,3 +119,251 @@ func fakeFunc() {
 			"unexpected Example 2 section. section should have been excluded")
 	})
 }
+
+func TestInterpretPulumiRefs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ResolvesKnownRefs", func(t *testing.T) {
+		t.Parallel()
+
+		description := "This is a reference to <pulumi ref=\"#/resources/aws:s3:bucket\" /> and one to the " +
+			"<pulumi ref=\"#/resources/azure:storage:storageAccount/properties/region\" /> property."
+		expected := "This is a reference to s3.bucket and one to the region property."
+		result := InterpretPulumiRefs(description, func(ref DocRef) (string, bool) {
+			//nolint:exhaustive
+			switch ref.Type {
+			case DocRefTypeResource:
+				return ref.Token.Module().Name().String() + "." + ref.Token.Name().String(), true
+			default:
+				return "", false
+			}
+		})
+		assert.Equal(t, expected, result, "expected resolved references")
+	})
+
+	t.Run("FallsBackWhenNotMapped", func(t *testing.T) {
+		t.Parallel()
+
+		description := "This is a reference to <pulumi ref=\"#/resources/unknown:resource:type/properties/myProperty\"/>" +
+			" and to <pulumi ref=\"#/resources/unknown:resource:type\" />."
+		expected := "This is a reference to myProperty and to unknown:resource:type."
+		result := InterpretPulumiRefs(description, func(ref DocRef) (string, bool) {
+			return "", false
+		})
+		assert.Equal(t, expected, result, "expected fallback to last segment for unknown references")
+	})
+
+	t.Run("HandlesEmptyDescription", func(t *testing.T) {
+		t.Parallel()
+
+		description := ""
+		expected := ""
+		result := InterpretPulumiRefs(description, func(ref DocRef) (string, bool) {
+			return "ResolvedName", true
+		})
+		assert.Equal(t, expected, result, "expected empty result for empty description")
+	})
+
+	t.Run("HandlesNoRefsInDescription", func(t *testing.T) {
+		t.Parallel()
+
+		description := "This description has no Pulumi references."
+		expected := "This description has no Pulumi references."
+		result := InterpretPulumiRefs(description, func(ref DocRef) (string, bool) {
+			return "ResolvedName", true
+		})
+		assert.Equal(t, expected, result, "expected unchanged description when no refs are present")
+	})
+}
+
+func TestParseDocRef(t *testing.T) {
+	t.Parallel()
+
+	t.Run("InvalidUnknownTopLevelType", func(t *testing.T) {
+		t.Parallel()
+		ref := "#/unknown/aws:s3:bucket"
+		expected := DocRef{
+			Ref:  ref,
+			Type: DocRefTypeUnknown,
+		}
+		result := parseDocRef(ref)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("InvalidTopLevelOnly", func(t *testing.T) {
+		t.Parallel()
+		ref := "#/resources"
+		expected := DocRef{
+			Ref:  ref,
+			Type: DocRefTypeUnknown,
+		}
+		result := parseDocRef(ref)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("InvalidMissingToken", func(t *testing.T) {
+		t.Parallel()
+		ref := "#/resources/"
+		expected := DocRef{
+			Ref:  ref,
+			Type: DocRefTypeUnknown,
+		}
+		result := parseDocRef(ref)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("ResourceRef", func(t *testing.T) {
+		t.Parallel()
+		ref := "#/resources/aws:s3:bucket"
+		expected := DocRef{
+			Ref:   ref,
+			Type:  DocRefTypeResource,
+			Token: "aws:s3:bucket",
+		}
+		result := parseDocRef(ref)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("ResourceRefWithSlashInToken", func(t *testing.T) {
+		t.Parallel()
+		ref := "#/resources/aws:s3%2Fbucket:Bucket"
+		expected := DocRef{
+			Ref:   ref,
+			Type:  DocRefTypeResource,
+			Token: "aws:s3/bucket:Bucket",
+		}
+		result := parseDocRef(ref)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("FunctionRef", func(t *testing.T) {
+		t.Parallel()
+		ref := "#/functions/aws:ec2:getInstance"
+		expected := DocRef{
+			Ref:   ref,
+			Type:  DocRefTypeFunction,
+			Token: "aws:ec2:getInstance",
+		}
+		result := parseDocRef(ref)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("TypeRef", func(t *testing.T) {
+		t.Parallel()
+		ref := "#/types/aws:s3:BucketPolicy"
+		expected := DocRef{
+			Ref:   ref,
+			Type:  DocRefTypeType,
+			Token: "aws:s3:BucketPolicy",
+		}
+		result := parseDocRef(ref)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("InvalidUnknownPropertyKind", func(t *testing.T) {
+		t.Parallel()
+		ref := "#/resources/aws:s3:bucket/unknown/acl"
+		expected := DocRef{
+			Ref:  ref,
+			Type: DocRefTypeUnknown,
+		}
+		result := parseDocRef(ref)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("InvalidPropertiesOnly", func(t *testing.T) {
+		t.Parallel()
+		ref := "#/resources/aws:s3:bucket/properties"
+		expected := DocRef{
+			Ref:  ref,
+			Type: DocRefTypeUnknown,
+		}
+		result := parseDocRef(ref)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("InvalidMissingPropertyName", func(t *testing.T) {
+		t.Parallel()
+		ref := "#/resources/aws:s3:bucket/properties/"
+		expected := DocRef{
+			Ref:  ref,
+			Type: DocRefTypeUnknown,
+		}
+		result := parseDocRef(ref)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("ResourcePropertyRef", func(t *testing.T) {
+		t.Parallel()
+		ref := "#/resources/aws:s3:bucket/properties/acl"
+		expected := DocRef{
+			Ref:      ref,
+			Type:     DocRefTypeResourceProperty,
+			Token:    "aws:s3:bucket",
+			Property: "acl",
+		}
+		result := parseDocRef(ref)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("ResourceInputPropertyRef", func(t *testing.T) {
+		t.Parallel()
+		ref := "#/resources/aws:s3:bucket/inputProperties/acl"
+		expected := DocRef{
+			Ref:      ref,
+			Type:     DocRefTypeResourceInputProperty,
+			Token:    "aws:s3:bucket",
+			Property: "acl",
+		}
+		result := parseDocRef(ref)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("FunctionInputPropertyRef", func(t *testing.T) {
+		t.Parallel()
+		ref := "#/functions/aws:ec2:getInstance/inputProperties/instanceId"
+		expected := DocRef{
+			Ref:      ref,
+			Type:     DocRefTypeFunctionInputProperty,
+			Token:    "aws:ec2:getInstance",
+			Property: "instanceId",
+		}
+		result := parseDocRef(ref)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("FunctionOutputPropertyRef", func(t *testing.T) {
+		t.Parallel()
+		ref := "#/functions/aws:ec2:getInstance/outputProperties/publicIp"
+		expected := DocRef{
+			Ref:      ref,
+			Type:     DocRefTypeFunctionOutputProperty,
+			Token:    "aws:ec2:getInstance",
+			Property: "publicIp",
+		}
+		result := parseDocRef(ref)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("InvalidMissingHashPrefix", func(t *testing.T) {
+		t.Parallel()
+		ref := "/resources/aws:s3:bucket"
+		expected := DocRef{
+			Ref:  ref,
+			Type: DocRefTypeUnknown,
+		}
+		result := parseDocRef(ref)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("InvalidSubProperty", func(t *testing.T) {
+		t.Parallel()
+		ref := "#/resources/aws:s3:bucket/properties/acl/invalid"
+		expected := DocRef{
+			Ref:  ref,
+			Type: DocRefTypeUnknown,
+		}
+		result := parseDocRef(ref)
+		assert.Equal(t, expected, result)
+	})
+}


### PR DESCRIPTION
Fixes #16099 

Add a utility function to parse `<pulumi ref="" />` tags from description fields. Parse the ref itself into a struct which the specific codegen implementations can easy work from.