### PR TITLE
pass through pluginspec for finding plugins

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -140,6 +140,10 @@ jobs:
           } >> "$GITHUB_ENV"
           # For debugging:
           ps aux
+      - name: Install tsc on windows and macos
+        if: ${{ runner.os == 'windows' || runner.os == 'macOS' }}
+        run: |
+          npm install typescript -g
       - name: "macOS use coreutils"
         if: ${{ runner.os == 'macOS' }}
         run: |

--- a/cmd/pulumi-test-language/test_host.go
+++ b/cmd/pulumi-test-language/test_host.go
@@ -173,30 +173,30 @@ func (h *testHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plugin.Fl
 }
 
 func (h *testHost) ResolvePlugin(
-	kind apitype.PluginKind, name string, version *semver.Version,
+	spec workspace.PluginSpec,
 ) (*workspace.PluginInfo, error) {
-	if kind == apitype.ResourcePlugin {
+	if spec.Kind == apitype.ResourcePlugin {
 		for _, provider := range h.providers {
 			pkg := provider.Pkg()
 			providerVersion, err := getProviderVersion(provider)
 			if err != nil {
 				return nil, fmt.Errorf("get provider version %s: %w", pkg, err)
 			}
-			if name == string(pkg) && version == nil || version.EQ(providerVersion) {
+			if spec.Name == string(pkg) && spec.Version == nil || spec.Version.EQ(providerVersion) {
 				return &workspace.PluginInfo{
-					Name:    name,
-					Kind:    kind,
-					Version: version,
+					Name:    spec.Name,
+					Kind:    spec.Kind,
+					Version: spec.Version,
 				}, nil
 			}
 		}
-		return nil, fmt.Errorf("unknown provider %s@%s", name, version)
+		return nil, fmt.Errorf("unknown provider %s@%s", spec.Name, spec.Version)
 	}
 
 	return &workspace.PluginInfo{
-		Name:    name,
-		Kind:    kind,
-		Version: version,
+		Name:    spec.Name,
+		Kind:    spec.Kind,
+		Version: spec.Version,
 	}, nil
 }
 

--- a/pkg/cmd/pulumi/plugin/plugin.go
+++ b/pkg/cmd/pulumi/plugin/plugin.go
@@ -102,7 +102,7 @@ func resolvePlugins(plugins []workspace.PluginSpec) ([]workspace.PluginInfo, err
 	// a plugin required by the project hasn't yet been installed, we will simply skip any errors we encounter.
 	var results []workspace.PluginInfo
 	for _, plugin := range plugins {
-		info, err := workspace.GetPluginInfo(d, plugin.Kind, plugin.Name, plugin.Version, ctx.Host.GetProjectPlugins())
+		info, err := workspace.GetPluginInfo(d, plugin, ctx.Host.GetProjectPlugins())
 		if err != nil {
 			contract.IgnoreError(err)
 		}

--- a/pkg/codegen/schema/loader_test.go
+++ b/pkg/codegen/schema/loader_test.go
@@ -164,15 +164,15 @@ func TestLoadParameterized(t *testing.T) {
 			assert.Equal(t, semver.MustParse("1.0.0"), *descriptor.Version)
 			return mockProvider, nil
 		},
-		ResolvePluginF: func(kind apitype.PluginKind, name string, version *semver.Version) (*workspace.PluginInfo, error) {
-			assert.Equal(t, apitype.ResourcePlugin, kind)
-			assert.Equal(t, "terraform-provider", name)
-			assert.Equal(t, semver.MustParse("1.0.0"), *version)
+		ResolvePluginF: func(spec workspace.PluginSpec) (*workspace.PluginInfo, error) {
+			assert.Equal(t, apitype.ResourcePlugin, spec.Kind)
+			assert.Equal(t, "terraform-provider", spec.Name)
+			assert.Equal(t, semver.MustParse("1.0.0"), *spec.Version)
 
 			return &workspace.PluginInfo{
 				Name:    "terraform-provider",
 				Kind:    apitype.ResourcePlugin,
-				Version: version,
+				Version: spec.Version,
 			}, nil
 		},
 	}
@@ -230,7 +230,7 @@ func TestLoadNameMismatch(t *testing.T) {
 		ProviderF: func(workspace.PackageDescriptor) (plugin.Provider, error) {
 			return provider, nil
 		},
-		ResolvePluginF: func(apitype.PluginKind, string, *semver.Version) (*workspace.PluginInfo, error) {
+		ResolvePluginF: func(workspace.PluginSpec) (*workspace.PluginInfo, error) {
 			return &workspace.PluginInfo{
 				Name:    notPkg,
 				Kind:    apitype.ResourcePlugin,
@@ -301,7 +301,7 @@ func TestLoadVersionMismatch(t *testing.T) {
 		ProviderF: func(workspace.PackageDescriptor) (plugin.Provider, error) {
 			return provider, nil
 		},
-		ResolvePluginF: func(apitype.PluginKind, string, *semver.Version) (*workspace.PluginInfo, error) {
+		ResolvePluginF: func(workspace.PluginSpec) (*workspace.PluginInfo, error) {
 			return &workspace.PluginInfo{
 				Name:    pkg,
 				Kind:    apitype.ResourcePlugin,

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -345,7 +345,7 @@ func EnsurePluginsAreInstalled(ctx context.Context, opts *deploymentOptions, d d
 			continue
 		}
 
-		path, err := workspace.GetPluginPath(d, plug.Kind, plug.Name, plug.Version, projectPlugins)
+		path, err := workspace.GetPluginPath(d, plug, projectPlugins)
 		if err == nil && path != "" {
 			logging.V(preparePluginLog).Infof(
 				"ensurePluginsAreInstalled(): plugin %s %s already installed", plug.Name, plug.Version)

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -466,7 +466,7 @@ func (host *pluginHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plug
 }
 
 func (host *pluginHost) ResolvePlugin(
-	kind apitype.PluginKind, name string, version *semver.Version,
+	spec workspace.PluginSpec,
 ) (*workspace.PluginInfo, error) {
 	plugins := slice.Prealloc[workspace.PluginInfo](len(host.pluginLoaders))
 
@@ -483,16 +483,16 @@ func (host *pluginHost) ResolvePlugin(
 	}
 
 	var semverRange semver.Range
-	if version == nil {
+	if spec.Version == nil {
 		semverRange = func(v semver.Version) bool {
 			return true
 		}
 	} else {
 		// Require an exact match:
-		semverRange = version.EQ
+		semverRange = spec.Version.EQ
 	}
 
-	match := workspace.SelectCompatiblePlugin(plugins, kind, name, semverRange)
+	match := workspace.SelectCompatiblePlugin(plugins, spec.Kind, spec.Name, semverRange)
 	if match == nil {
 		return nil, errors.New("could not locate a compatible plugin in deploytest, the makefile and " +
 			"& constructor of the plugin host must define the location of the schema")

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -812,7 +812,11 @@ func TestLoadProvider_missingError(t *testing.T) {
 	loader := newLoader(t, "myplugin", "1.2.3",
 		func(p tokens.Package, v semver.Version) (plugin.Provider, error) {
 			return nil, workspace.NewMissingError(
-				apitype.ResourcePlugin, "myplugin", &version, "", false /* ambient */)
+				workspace.PluginSpec{
+					Kind:    apitype.ResourcePlugin,
+					Name:    "myplugin",
+					Version: &version,
+				}, false /* ambient */)
 		})
 	host := newPluginHost(t, []*providerLoader{loader})
 

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -93,7 +93,7 @@ func (host *testPluginHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds 
 }
 
 func (host *testPluginHost) ResolvePlugin(
-	kind apitype.PluginKind, name string, version *semver.Version,
+	spec workspace.PluginSpec,
 ) (*workspace.PluginInfo, error) {
 	return nil, nil
 }
@@ -812,7 +812,7 @@ func TestLoadProvider_missingError(t *testing.T) {
 	loader := newLoader(t, "myplugin", "1.2.3",
 		func(p tokens.Package, v semver.Version) (plugin.Provider, error) {
 			return nil, workspace.NewMissingError(
-				apitype.ResourcePlugin, "myplugin", &version, false /* ambient */)
+				apitype.ResourcePlugin, "myplugin", &version, "", false /* ambient */)
 		})
 	host := newPluginHost(t, []*providerLoader{loader})
 

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -59,9 +59,7 @@ var _ Analyzer = (*analyzer)(nil)
 // could not be found by name on the PATH, or an error occurs while creating the child process, an error is returned.
 func NewAnalyzer(host Host, ctx *Context, name tokens.QName) (Analyzer, error) {
 	// Load the plugin's path by using the standard workspace logic.
-	path, err := workspace.GetPluginPath(ctx.Diag,
-		apitype.AnalyzerPlugin, strings.ReplaceAll(string(name), tokens.QNameDelimiter, "_"),
-		nil, host.GetProjectPlugins())
+	path, err := workspace.GetPluginPath(ctx.Diag, workspace.NewAnalyzerPlugin(name, nil), host.GetProjectPlugins())
 	if err != nil {
 		return nil, rpcerror.Convert(err)
 	}
@@ -103,8 +101,8 @@ func NewPolicyAnalyzer(
 	}
 
 	// Load the policy-booting analyzer plugin (i.e., `pulumi-analyzer-${policyAnalyzerName}`).
-	pluginPath, err := workspace.GetPluginPath(ctx.Diag,
-		apitype.AnalyzerPlugin, policyAnalyzerName, nil, host.GetProjectPlugins())
+	pluginPath, err := workspace.GetPluginPath(
+		ctx.Diag, workspace.NewAnalyzerPlugin(tokens.QName(policyAnalyzerName), nil), host.GetProjectPlugins())
 
 	var e *workspace.MissingError
 	if errors.As(err, &e) {

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -59,7 +59,13 @@ var _ Analyzer = (*analyzer)(nil)
 // could not be found by name on the PATH, or an error occurs while creating the child process, an error is returned.
 func NewAnalyzer(host Host, ctx *Context, name tokens.QName) (Analyzer, error) {
 	// Load the plugin's path by using the standard workspace logic.
-	path, err := workspace.GetPluginPath(ctx.Diag, workspace.NewAnalyzerPlugin(name, nil), host.GetProjectPlugins())
+	path, err := workspace.GetPluginPath(
+		ctx.Diag,
+		workspace.PluginSpec{
+			Name: strings.ReplaceAll(string(name), tokens.QNameDelimiter, "_"),
+			Kind: apitype.AnalyzerPlugin,
+		},
+		host.GetProjectPlugins())
 	if err != nil {
 		return nil, rpcerror.Convert(err)
 	}
@@ -102,7 +108,7 @@ func NewPolicyAnalyzer(
 
 	// Load the policy-booting analyzer plugin (i.e., `pulumi-analyzer-${policyAnalyzerName}`).
 	pluginPath, err := workspace.GetPluginPath(
-		ctx.Diag, workspace.NewAnalyzerPlugin(tokens.QName(policyAnalyzerName), nil), host.GetProjectPlugins())
+		ctx.Diag, workspace.PluginSpec{Name: policyAnalyzerName, Kind: apitype.AnalyzerPlugin}, host.GetProjectPlugins())
 
 	var e *workspace.MissingError
 	if errors.As(err, &e) {

--- a/sdk/go/common/resource/plugin/converter_plugin.go
+++ b/sdk/go/common/resource/plugin/converter_plugin.go
@@ -45,7 +45,8 @@ func NewConverter(ctx *Context, name string, version *semver.Version) (Converter
 	prefix := fmt.Sprintf("%v (converter)", name)
 
 	// Load the plugin's path by using the standard workspace logic.
-	path, err := workspace.GetPluginPath(ctx.Diag, apitype.ConverterPlugin, name, version, ctx.Host.GetProjectPlugins())
+	path, err := workspace.GetPluginPath(
+		ctx.Diag, workspace.NewConverterPlugin(name, version), ctx.Host.GetProjectPlugins())
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/common/resource/plugin/converter_plugin.go
+++ b/sdk/go/common/resource/plugin/converter_plugin.go
@@ -46,7 +46,9 @@ func NewConverter(ctx *Context, name string, version *semver.Version) (Converter
 
 	// Load the plugin's path by using the standard workspace logic.
 	path, err := workspace.GetPluginPath(
-		ctx.Diag, workspace.NewConverterPlugin(name, version), ctx.Host.GetProjectPlugins())
+		ctx.Diag,
+		workspace.PluginSpec{Name: name, Version: version, Kind: apitype.ConverterPlugin},
+		ctx.Host.GetProjectPlugins())
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -106,7 +107,10 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime, workingDirectory strin
 	} else {
 		path, err := workspace.GetPluginPath(
 			ctx.Diag,
-			workspace.NewLanguagePlugin(runtime, nil),
+			workspace.PluginSpec{
+				Name: strings.ReplaceAll(runtime, tokens.QNameDelimiter, "_"),
+				Kind: apitype.LanguagePlugin,
+			},
 			host.GetProjectPlugins(),
 		)
 		if err != nil {

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -297,20 +297,14 @@ func (h *langhost) GetRequiredPackages(info ProgramInfo) ([]workspace.PackageDes
 			}
 		}
 
-		source := info.Name
-		if strings.HasPrefix(info.Server, "git://") {
-			source = strings.TrimPrefix(info.Server, "git://")
-			info.Server = ""
-		}
-
-		pluginSpec, err := workspace.NewPluginSpec(
-			source, apitype.PluginKind(info.Kind), version, info.Server, info.Checksums)
-		if err != nil {
-			return nil, err
-		}
-
 		results = append(results, workspace.PackageDescriptor{
-			PluginSpec:       pluginSpec,
+			PluginSpec: workspace.PluginSpec{
+				Name:              info.Name,
+				Kind:              apitype.PluginKind(info.Kind),
+				Version:           version,
+				PluginDownloadURL: info.Server,
+				Checksums:         info.Checksums,
+			},
 			Parameterization: parameterization,
 		})
 	}

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -35,7 +35,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -107,9 +106,7 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime, workingDirectory strin
 	} else {
 		path, err := workspace.GetPluginPath(
 			ctx.Diag,
-			apitype.LanguagePlugin,
-			strings.ReplaceAll(runtime, tokens.QNameDelimiter, "_"),
-			nil,
+			workspace.NewLanguagePlugin(runtime, nil),
 			host.GetProjectPlugins(),
 		)
 		if err != nil {

--- a/sdk/go/common/resource/plugin/langruntime_test.go
+++ b/sdk/go/common/resource/plugin/langruntime_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/require"
 
@@ -54,9 +53,6 @@ func TestMakeExecutablePromptChoices(t *testing.T) {
 type MockLanguageRuntimeClient struct {
 	RunPluginF (func(ctx context.Context, info *pulumirpc.RunPluginRequest,
 	) (pulumirpc.LanguageRuntime_RunPluginClient, error))
-
-	GetRequiredPackagesF (func(ctx context.Context, in *pulumirpc.GetRequiredPackagesRequest,
-		opts ...grpc.CallOption) (*pulumirpc.GetRequiredPackagesResponse, error))
 }
 
 func (m *MockLanguageRuntimeClient) RunPlugin(
@@ -68,9 +64,6 @@ func (m *MockLanguageRuntimeClient) RunPlugin(
 func (m *MockLanguageRuntimeClient) GetRequiredPackages(
 	ctx context.Context, in *pulumirpc.GetRequiredPackagesRequest, opts ...grpc.CallOption,
 ) (*pulumirpc.GetRequiredPackagesResponse, error) {
-	if m.GetRequiredPackagesF != nil {
-		return m.GetRequiredPackagesF(ctx, in, opts...)
-	}
 	panic("not implemented")
 }
 
@@ -173,47 +166,4 @@ func TestRunPluginPassesCorrectPwd(t *testing.T) {
 		WorkingDirectory: "/tmp",
 	})
 	require.Equal(t, returnErr, err)
-}
-
-func TestRequiredPackagesReturnsCorrectNameForGitPlugins(t *testing.T) {
-	t.Parallel()
-
-	mockLanguageRuntime := &MockLanguageRuntimeClient{
-		GetRequiredPackagesF: func(
-			ctx context.Context, in *pulumirpc.GetRequiredPackagesRequest, _ ...grpc.CallOption,
-		) (*pulumirpc.GetRequiredPackagesResponse, error) {
-			gitPackage := pulumirpc.PackageDependency{
-				Name:    "test",
-				Kind:    "resource",
-				Version: "v0.0.1",
-				Server:  "git://github.com/pulumi/test",
-			}
-			otherPackage := pulumirpc.PackageDependency{
-				Name:    "another",
-				Kind:    "resource",
-				Version: "v0.0.2",
-				Server:  "https://github.com/pulumi/another",
-			}
-			return &pulumirpc.GetRequiredPackagesResponse{
-				Packages: []*pulumirpc.PackageDependency{&gitPackage, &otherPackage},
-			}, nil
-		},
-	}
-	pCtx, err := NewContext(nil, nil, nil, nil, "", nil, false, nil)
-	require.NoError(t, err)
-	host := &langhost{
-		ctx:     pCtx,
-		runtime: "go",
-		plug:    nil,
-		client:  mockLanguageRuntime,
-	}
-	descriptors, err := host.GetRequiredPackages(ProgramInfo{})
-	require.NoError(t, err)
-	require.Equal(t, 2, len(descriptors))
-	require.Equal(t, "github.com_pulumi_test.git", descriptors[0].Name)
-	require.Equal(t, apitype.PluginKind("resource"), descriptors[0].Kind)
-	require.Equal(t, "git://github.com/pulumi/test", descriptors[0].PluginDownloadURL)
-	require.Equal(t, "another", descriptors[1].Name)
-	require.Equal(t, apitype.PluginKind("resource"), descriptors[1].Kind)
-	require.Equal(t, "https://github.com/pulumi/another", descriptors[1].PluginDownloadURL)
 }

--- a/sdk/go/common/resource/plugin/mock.go
+++ b/sdk/go/common/resource/plugin/mock.go
@@ -17,9 +17,7 @@ package plugin
 import (
 	"context"
 
-	"github.com/blang/semver"
 	"github.com/pkg/errors"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -37,7 +35,7 @@ type MockHost struct {
 	CloseProviderF      func(provider Provider) error
 	LanguageRuntimeF    func(runtime string, info ProgramInfo) (LanguageRuntime, error)
 	EnsurePluginsF      func(plugins []workspace.PluginSpec, kinds Flags) error
-	ResolvePluginF      func(kind apitype.PluginKind, name string, version *semver.Version) (*workspace.PluginInfo, error)
+	ResolvePluginF      func(spec workspace.PluginSpec) (*workspace.PluginInfo, error)
 	GetProjectPluginsF  func() []workspace.ProjectPlugin
 	SignalCancellationF func() error
 	CloseF              func() error
@@ -115,10 +113,10 @@ func (m *MockHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds Flags) er
 }
 
 func (m *MockHost) ResolvePlugin(
-	kind apitype.PluginKind, name string, version *semver.Version,
+	spec workspace.PluginSpec,
 ) (*workspace.PluginInfo, error) {
 	if m.ResolvePluginF != nil {
-		return m.ResolvePluginF(kind, name, version)
+		return m.ResolvePluginF(spec)
 	}
 	return nil, errors.New("ResolvePlugin not implemented")
 }

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -159,20 +159,15 @@ func GetProviderAttachPort(pkg tokens.Package) (*int, error) {
 
 // NewProvider attempts to bind to a given package's resource plugin and then creates a gRPC connection to it.  If the
 // plugin could not be found, or an error occurs while creating the child process, an error is returned.
-func NewProvider(host Host, ctx *Context, pkg tokens.Package, version *semver.Version,
-	options map[string]interface{}, disableProviderPreview bool, jsonConfig string,
-	projectName tokens.PackageName,
-) (Provider, error) {
-	return NewProviderFromSubdir(host, ctx, pkg, "", version, options, disableProviderPreview, jsonConfig, projectName)
-}
-
-func NewProviderFromSubdir(host Host, ctx *Context, pkg tokens.Package, subdir string, version *semver.Version,
+func NewProvider(host Host, ctx *Context, spec workspace.PluginSpec,
 	options map[string]interface{}, disableProviderPreview bool, jsonConfig string,
 	projectName tokens.PackageName,
 ) (Provider, error) {
 	// See if this is a provider we just want to attach to
 	var plug *plugin
 	var handshakeRes *ProviderHandshakeResponse
+
+	pkg := tokens.Package(spec.Name)
 
 	attachPort, err := GetProviderAttachPort(pkg)
 	if err != nil {
@@ -212,9 +207,7 @@ func NewProviderFromSubdir(host Host, ctx *Context, pkg tokens.Package, subdir s
 		}
 	} else {
 		// Load the plugin's path by using the standard workspace logic.
-		path, err := workspace.GetPluginPathWithSubdir(ctx.Diag,
-			apitype.ResourcePlugin, strings.ReplaceAll(string(pkg), tokens.QNameDelimiter, "_"), subdir,
-			version, host.GetProjectPlugins())
+		path, err := workspace.GetPluginPath(ctx.Diag, spec, host.GetProjectPlugins())
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1040,7 +1040,7 @@ func NewPluginSpec(
 			// a consistent experience once the plugin is installed, and won't have any problems when the repo
 			// is updated.  The version will then be added to the plugins SDK, and will be reused when the NewPluginSpec
 			// is used, so the user gets a consistent experience.
-			if versionStr == "" && version == nil {
+			if versionStr == "" {
 				var err error
 				version, err = gitutil.GetLatestTagOrHash(context.Background(), url)
 				if err != nil {

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1489,7 +1489,13 @@ func TestMissingErrorText(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			err := NewMissingError(
-				tt.Plugin.Kind, tt.Plugin.Name, tt.Plugin.Version, tt.PluginDownloadURL, tt.IncludeAmbient)
+				PluginSpec{
+					Kind:              tt.Plugin.Kind,
+					Name:              tt.Plugin.Name,
+					Version:           tt.Plugin.Version,
+					PluginDownloadURL: tt.PluginDownloadURL,
+				},
+				tt.IncludeAmbient)
 			assert.EqualError(t, err, tt.ExpectedError)
 		})
 	}
@@ -1522,13 +1528,13 @@ func TestBundledPluginSearch(t *testing.T) {
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(d, NewLanguagePlugin("nodejs", nil), nil)
+	path, err := GetPluginPath(d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, ambientPath, path)
 
 	// Lookup the plugin with ambient search turned off
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "true")
-	path, err = GetPluginPath(d, NewLanguagePlugin("nodejs", nil), nil)
+	path, err = GetPluginPath(d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, bundledPath, path)
 }
@@ -1591,7 +1597,7 @@ func TestAmbientBundledPluginsWarn(t *testing.T) {
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(d, NewLanguagePlugin("nodejs", nil), nil)
+	path, err := GetPluginPath(d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, ambientPath, path)
 
@@ -1628,7 +1634,7 @@ func TestBundledPluginsDoNotWarn(t *testing.T) {
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(d, NewLanguagePlugin("nodejs", nil), nil)
+	path, err := GetPluginPath(d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, bundledPath, path)
 
@@ -1669,7 +1675,7 @@ func TestSymlinkPathPluginsDoNotWarn(t *testing.T) {
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(d, NewLanguagePlugin("nodejs", nil), nil)
+	path, err := GetPluginPath(d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
 	require.NoError(t, err)
 	// We expect the ambient path to be returned, but not to warn because it resolves to the same file as the
 	// bundled path.

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1452,3 +1452,28 @@ func TestPulumiNewLocalTemplatePath(t *testing.T) {
 	require.Empty(t, stderr)
 	require.Contains(t, stdout, "Your new project is ready to go")
 }
+
+func TestPulumiInstallInstallsPackagesIntoTheCorrectDirectory(t *testing.T) {
+	t.Parallel()
+	e := ptesting.NewEnvironment(t)
+
+	e.ImportDirectory("packageadd-remote")
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.Env = append(e.Env, "PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=false")
+	e.RunCommand("pulumi", "stack", "select", "organization/packageadd-remote", "--create")
+
+	e.RunCommand("pulumi", "package", "add",
+		"github.com/pulumi/component-test-providers/test-provider")
+
+	// Remove the plugin from the local cache and try to install it using `pulumi install`
+	e.RunCommand("pulumi", "plugin", "rm", "--all", "--yes")
+	stdout, _ := e.RunCommand("pulumi", "plugin", "ls")
+	require.NotContains(t, stdout, "github.com_pulumi_component-test-providers")
+
+	e.RunCommand("pulumi", "install")
+	stdout, _ = e.RunCommand("pulumi", "plugin", "ls")
+	require.Contains(t, stdout, "github.com_pulumi_component-test-providers")
+	require.Contains(t, stdout, "0.0.0-xb39e20e4e33600e33073ccb2df0ddb46388641dc")
+
+	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview")
+}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1463,7 +1463,7 @@ func TestPulumiInstallInstallsPackagesIntoTheCorrectDirectory(t *testing.T) {
 	e.RunCommand("pulumi", "stack", "select", "organization/packageadd-remote", "--create")
 
 	e.RunCommand("pulumi", "package", "add",
-		"github.com/pulumi/component-test-providers/test-provider")
+		"github.com/pulumi/component-test-providers/test-provider@b39e20e4e33600e33073ccb2df0ddb46388641dc")
 
 	// Remove the plugin from the local cache and try to install it using `pulumi install`
 	e.RunCommand("pulumi", "plugin", "rm", "--all", "--yes")


### PR DESCRIPTION
When trying to find plugins we currently pass its kind, name and version through.  However that's not enough to fully specify a plugin, especially given the way git plugins work.  Also pass through the PluginDownloadURL, so we can fully identify a plugin, and find the right one.