### PR TITLE
use usetesting linter instead of tenv

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,9 +25,9 @@ linters:
     - perfsprint
     - prealloc
     - revive
-    - tenv
     - unconvert
     - unused
+    - usetesting
     - wastedassign
     - whitespace
 

--- a/pkg/backend/display/display_test.go
+++ b/pkg/backend/display/display_test.go
@@ -37,7 +37,7 @@ func TestShowEvents(t *testing.T) {
 	stack, err := tokens.ParseStackName("stack")
 	assert.NoError(t, err)
 
-	eventLog, err := os.CreateTemp("", "event-log-")
+	eventLog, err := os.CreateTemp(t.TempDir(), "event-log-")
 	assert.NoError(t, err)
 
 	go func() {

--- a/pkg/secrets/passphrase/manager_test.go
+++ b/pkg/secrets/passphrase/manager_test.go
@@ -125,7 +125,7 @@ func TestPassphraseManagerEmptyPassphraseIsValid(t *testing.T) {
 func TestPassphraseManagerCorrectPassfileReturnsSecretsManager(t *testing.T) {
 	clearCachedSecretsManagers()
 
-	tmpFile, err := os.CreateTemp("", "pulumi-secret-test")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "pulumi-secret-test")
 	assert.NoError(t, err)
 	defer os.Remove(tmpFile.Name())
 	_, err = tmpFile.WriteString("password")

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -899,9 +899,7 @@ func newProgramTester(t *testing.T, opts *ProgramTestOptions) *ProgramTester {
 	if opts.PulumiHomeDir != "" {
 		home = opts.PulumiHomeDir
 	} else {
-		var err error
-		home, err = os.MkdirTemp("", "test-env-home")
-		assert.NoError(t, err, "creating temp PULUMI_HOME directory")
+		home = t.TempDir()
 	}
 	return &ProgramTester{
 		t:              t,

--- a/sdk/go/auto/git_test.go
+++ b/sdk/go/auto/git_test.go
@@ -122,6 +122,7 @@ func TestGitClone(t *testing.T) {
 				CommitHash: tc.commitHash,
 			}
 
+			//nolint:usetesting // Need to use a specific location for the tmp dir
 			tmp, err := os.MkdirTemp(tmpDir, "testcase") // i.e., under the tmp dir from earlier
 			assert.NoError(t, err)
 
@@ -177,6 +178,7 @@ func TestGitClone(t *testing.T) {
 				CommitHash: tc.commitHash,
 			}
 
+			//nolint:usetesting // Need to use a specific location for the tmp dir
 			tmp, err := os.MkdirTemp(tmpDir, "testcase") // i.e., under the tmp dir from earlier
 			assert.NoError(t, err)
 

--- a/sdk/go/auto/stack_test.go
+++ b/sdk/go/auto/stack_test.go
@@ -110,7 +110,7 @@ func TestUpdatePlans(t *testing.T) {
 	assert.NoError(t, s.Workspace().SaveStackSettings(ctx, stackName, stackConfig))
 
 	// -- pulumi preview --
-	tempFile, err := os.CreateTemp("", "update_plan.json")
+	tempFile, err := os.CreateTemp(t.TempDir(), "update_plan.json")
 	defer os.Remove(tempFile.Name())
 
 	_, err = s.Preview(ctx, optpreview.Plan(tempFile.Name()))

--- a/sdk/go/common/resource/asset_test.go
+++ b/sdk/go/common/resource/asset_test.go
@@ -123,7 +123,7 @@ func TestAssetSerialize(t *testing.T) {
 	t.Run("path asset", func(t *testing.T) {
 		t.Parallel()
 
-		f, err := os.CreateTemp("", "")
+		f, err := os.CreateTemp(t.TempDir(), "")
 		assert.NoError(t, err)
 		file := f.Name()
 		asset, err := rasset.FromPath(file)
@@ -567,7 +567,7 @@ func TestNestedArchive(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Write a ZIP of the AssetArchive to disk.
-	tmpFile, err := os.CreateTemp("", "")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	fileName := tmpFile.Name()
 	assert.NoError(t, err)
 	err = arch.Archive(rarchive.ZIPArchive, tmpFile)
@@ -607,7 +607,7 @@ func TestFileReferencedThroughMultiplePaths(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Write a ZIP of the AssetArchive to disk.
-	tmpFile, err := os.CreateTemp("", "")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	fileName := tmpFile.Name()
 	assert.NoError(t, err)
 	err = arch.Archive(rarchive.ZIPArchive, tmpFile)
@@ -640,7 +640,7 @@ func TestInvalidPathArchive(t *testing.T) {
 	t.Parallel()
 
 	// Create a temp file that is not an asset.
-	tmpFile, err := os.CreateTemp("", "")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	fileName := tmpFile.Name()
 	assert.NoError(t, err)
 	fmt.Fprintf(tmpFile, "foo\n")

--- a/sdk/go/common/resource/plugin/host_test.go
+++ b/sdk/go/common/resource/plugin/host_test.go
@@ -140,13 +140,11 @@ func TestNewDefaultHost_PackagesResolution(t *testing.T) {
 	t.Parallel()
 
 	// Create a temporary directory for our test
-	tempDir, err := os.MkdirTemp("", "pulumi-test-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	// Create a subdirectory to use as a local plugin path
 	localPluginDir := filepath.Join(tempDir, "local-plugin")
-	err = os.Mkdir(localPluginDir, 0o755)
+	err := os.Mkdir(localPluginDir, 0o755)
 	require.NoError(t, err)
 
 	// Create another subdirectory to use as a relative plugin path
@@ -205,13 +203,11 @@ func TestNewDefaultHost_BothPluginsAndPackages(t *testing.T) {
 	t.Parallel()
 
 	// Create a temporary directory for our test
-	tempDir, err := os.MkdirTemp("", "pulumi-test-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	// Create a subdirectory to use as a local plugin path
 	localPluginDir := filepath.Join(tempDir, "local-plugin")
-	err = os.Mkdir(localPluginDir, 0o755)
+	err := os.Mkdir(localPluginDir, 0o755)
 	require.NoError(t, err)
 
 	awsProviderDir := filepath.Join(tempDir, "aws-provider")

--- a/sdk/go/common/testing/environment.go
+++ b/sdk/go/common/testing/environment.go
@@ -76,13 +76,11 @@ func WriteYarnRCForTest(root string) error {
 
 // NewEnvironment returns a new Environment object, located in a temp directory.
 func NewEnvironment(t *testing.T) *Environment {
-	root, err := os.MkdirTemp("", "test-env")
-	assert.NoError(t, err, "creating temp directory")
+	root := t.TempDir()
 	assert.NoError(t, WriteYarnRCForTest(root), "writing .yarnrc file")
 
 	// We always use a clean PULUMI_HOME for each environment to avoid any potential conflicts with plugins or config.
-	home, err := os.MkdirTemp("", "test-env-home")
-	assert.NoError(t, err, "creating temp PULUMI_HOME directory")
+	home := t.TempDir()
 
 	t.Logf("Created new test environment:  %v", root)
 	return &Environment{

--- a/sdk/go/common/workspace/plugins_install_test.go
+++ b/sdk/go/common/workspace/plugins_install_test.go
@@ -270,8 +270,10 @@ func TestInstallCleansOldFiles(t *testing.T) {
 	//nolint:usetesting // Need to use a specific location for the tmp dir
 	tempDir1, err := os.MkdirTemp(dir, plugin.Dir()+".tmp")
 	assert.NoError(t, err)
+	//nolint:usetesting // Need to use a specific location for the tmp dir
 	tempDir2, err := os.MkdirTemp(dir, plugin.Dir()+".tmp")
 	assert.NoError(t, err)
+	//nolint:usetesting // Need to use a specific location for the tmp dir
 	tempDir3, err := os.MkdirTemp(dir, plugin.Dir()+".tmp")
 	assert.NoError(t, err)
 

--- a/sdk/go/common/workspace/plugins_install_test.go
+++ b/sdk/go/common/workspace/plugins_install_test.go
@@ -267,6 +267,7 @@ func TestInstallCleansOldFiles(t *testing.T) {
 	dir, tarball, plugin := prepareTestDir(t, nil)
 
 	// Leftover temp dirs.
+	//nolint:usetesting // Need to use a specific location for the tmp dir
 	tempDir1, err := os.MkdirTemp(dir, plugin.Dir()+".tmp")
 	assert.NoError(t, err)
 	tempDir2, err := os.MkdirTemp(dir, plugin.Dir()+".tmp")

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -162,7 +162,7 @@ func TestProjectValidationSucceedsForCorrectDefaultValueType(t *testing.T) {
 }
 
 func writeAndLoad(t *testing.T, str string) (*Project, error) {
-	tmp, err := os.CreateTemp("", "*.json")
+	tmp, err := os.CreateTemp(t.TempDir(), "*.json")
 	assert.NoError(t, err)
 	path := tmp.Name()
 	err = os.WriteFile(path, []byte(str), 0o600)
@@ -407,7 +407,7 @@ func deleteFile(t *testing.T, file *os.File) {
 }
 
 func loadProjectFromText(t *testing.T, content string) (*Project, error) {
-	tmp, err := os.CreateTemp("", "*.yaml")
+	tmp, err := os.CreateTemp(t.TempDir(), "*.yaml")
 	assert.NoError(t, err)
 	path := tmp.Name()
 	err = os.WriteFile(path, []byte(content), 0o600)
@@ -417,7 +417,7 @@ func loadProjectFromText(t *testing.T, content string) (*Project, error) {
 }
 
 func loadProjectStackFromText(t *testing.T, project *Project, content string) (*ProjectStack, error) {
-	tmp, err := os.CreateTemp("", "*.yaml")
+	tmp, err := os.CreateTemp(t.TempDir(), "*.yaml")
 	assert.NoError(t, err)
 	path := tmp.Name()
 	err = os.WriteFile(path, []byte(content), 0o600)
@@ -427,7 +427,7 @@ func loadProjectStackFromText(t *testing.T, project *Project, content string) (*
 }
 
 func loadProjectStackFromJSONText(t *testing.T, project *Project, content string) (*ProjectStack, error) {
-	tmp, err := os.CreateTemp("", "*.json")
+	tmp, err := os.CreateTemp(t.TempDir(), "*.json")
 	assert.NoError(t, err)
 	path := tmp.Name()
 	err = os.WriteFile(path, []byte(content), 0o600)
@@ -1322,7 +1322,7 @@ func TestProjectSaveLoadRoundtrip(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			tmp, err := os.CreateTemp("", "*.yaml")
+			tmp, err := os.CreateTemp(t.TempDir(), "*.yaml")
 			require.NoError(t, err)
 			defer deleteFile(t, tmp)
 
@@ -1376,7 +1376,7 @@ func TestProjectEditRoundtrip(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			tmp, err := os.CreateTemp("", "*.yaml")
+			tmp, err := os.CreateTemp(t.TempDir(), "*.yaml")
 			require.NoError(t, err)
 			defer deleteFile(t, tmp)
 

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -330,8 +330,6 @@ func TestStackCommands(t *testing.T) {
 //nolint:paralleltest // mutates environment variables
 func TestStackBackups(t *testing.T) {
 	t.Run("StackBackupCreatedSanityTest", func(t *testing.T) {
-		t.Parallel()
-
 		e := ptesting.NewEnvironment(t)
 		defer e.DeleteIfNotFailed()
 
@@ -340,10 +338,7 @@ func TestStackBackups(t *testing.T) {
 
 		// We're testing that backups are created so ensure backups aren't disabled.
 		disableCheckpointBackups := env.DIYBackendDisableCheckpointBackups.Var().Name()
-		if env := os.Getenv(disableCheckpointBackups); env != "" {
-			os.Unsetenv(disableCheckpointBackups)
-			defer os.Setenv(disableCheckpointBackups, env)
-		}
+		t.Setenv(disableCheckpointBackups, "")
 
 		const stackName = "imulup"
 


### PR DESCRIPTION
The `tenv` linter is deprecated, and `usetesting` is the suggested replacement.  Switch out the linters to get rid of the warning and fix up the places where `usetesting` complains.