### PR TITLE
make dist target not depend on build and fix PULUMI_INTEGRATION_REBUILD_BINARIES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ developer_docs::
 
 install_all:: install
 
-dist:: build
+dist::
 	cd pkg && go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${PROJECT}
 
 .PHONY: brew


### PR DESCRIPTION
`make dist` currently depends on `build`, even though it doens't use any of its artifacts.  At the same time `dist` is also used in `make build_local`, which is used for rebuilding binaries for integration tests. However since we're setting GOBIN to `$repo_root/bin`, `build` now tries to copy the pulumi binary to the same directory as the `dist` command does, and the same directory the binary is being built in.

We still want to use `make dist` for `build_local`, because it also builds the language plugins, which are used in the integration tests. Just remove the `build` target from the dependency list of `dist`. `go install` already does that job, and we don't need to build the wasm bits, as `dist` is expected to install binaries not just build them anyway.

(This was accidentally broken in https://github.com/pulumi/pulumi/pull/18728)