### PR TITLE
Use Mise config_root var instead of env.PWD

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [env]
-PULUMI_ROOT = "{{env.PWD}}/.root"
+PULUMI_ROOT = "{{config_root}}/.root"
 
 _.path = [
   "{{env.PULUMI_ROOT}}/bin",

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -37,8 +37,13 @@ which you can do as follows:
 4. `cd` into the root of this repository. Run `mise trust` to allow the
    repository to specify the required tools, all of which are listed in the
    top-level `.mise.toml` file. After this, you should find that the tools you
-   need are now available in your `PATH`.
+   need are now available in your `$PATH`.
 5. Run `mise install` to ensure all tools are up to date. You may need to re-run
    this if the tool list changes.
+
+When using Mise `$PULUMI_ROOT` is set to `$REPO/.root`. This is convenient for
+working with multiple Git worktrees, since each worktree will have its binaries
+installed in `$PULUMI_ROOT/bin`. To use these binaries, add `$REPO/.root/bin` to
+your `$PATH`.
 
 Use of Mise is currently experimental and optional.


### PR DESCRIPTION
Ensure that `$PULUMI_ROOT` is always set to `$REPO/.root`, even when running from a subfolder.