### PR TITLE
pytest-watch is a dev dependency

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     'pyyaml~=6.0',
     'debugpy~=1.8.7',
     'pip>=24.3.1,<26',
-    "pytest-watch>=4.2.0",
 ]
 
 [dependency-groups]
@@ -45,6 +44,7 @@ dev = [
     'ruff==0.8.0',
     "build>=1.2.2.post1",
     "twine>=6.0.1",
+    "pytest-watch>=4.2.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
`pytest-watch` is a dev dependency, not a regular dependency, as pointed out here: https://github.com/pulumi/pulumi/commit/1c880e26ddcae0287b535a0ae6b5193059cd5ccd#r154029991