### PR TITLE
[nodejs] Stop returning a version from componentProviderHost

### DIFF
--- a/sdk/nodejs/provider/experimental/provider.ts
+++ b/sdk/nodejs/provider/experimental/provider.ts
@@ -40,8 +40,6 @@ export class ComponentProvider implements Provider {
     private path: string;
     private analyzer: Analyzer;
 
-    version: string;
-
     public static validateResourceType(packageName: string, resourceType: string): void {
         const parts = resourceType.split(":");
         if (parts.length !== 3) {
@@ -65,7 +63,6 @@ export class ComponentProvider implements Provider {
         const absDir = path.resolve(dir);
         const packStr = readFileSync(`${absDir}/package.json`, { encoding: "utf-8" });
         this.packageJSON = JSON.parse(packStr);
-        this.version = this.packageJSON.version;
         this.path = absDir;
         this.analyzer = new Analyzer(this.path, this.packageJSON.name);
     }

--- a/sdk/nodejs/provider/experimental/schema.ts
+++ b/sdk/nodejs/provider/experimental/schema.ts
@@ -79,7 +79,6 @@ export function generateSchema(
     const providerName = packageJSON.name;
     const result: PackageSpec = {
         name: providerName,
-        version: packageJSON.version,
         description: packageJSON.description,
         resources: {},
         types: {},

--- a/sdk/nodejs/provider/provider.ts
+++ b/sdk/nodejs/provider/provider.ts
@@ -179,7 +179,7 @@ export interface Provider {
     /**
      * The version of the provider. Must be valid semver.
      */
-    version: string;
+    version?: string;
 
     /**
      * The JSON-encoded schema for this provider's package.

--- a/sdk/nodejs/tests/provider/experimental/schema.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/schema.spec.ts
@@ -20,7 +20,6 @@ describe("Schema", function () {
     it("should generate schema with correct language dependencies", function () {
         const packageJSON = {
             name: "test-provider",
-            version: "1.0.0",
             description: "Test provider for Pulumi",
         };
 

--- a/tests/integration/component_provider/nodejs/component-provider-host/provider/package.json
+++ b/tests/integration/component_provider/nodejs/component-provider-host/provider/package.json
@@ -1,7 +1,6 @@
 {
     "name": "nodejs-component-provider",
     "description": "Node.js Sample Components",
-    "version": "1.2.3",
     "dependencies": {
         "@pulumi/random": "^4.18.0"
     }

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2537,7 +2537,7 @@ func TestNodejsComponentProviderGetSchema(t *testing.T) {
 	var schema map[string]interface{}
 	require.NoError(t, json.Unmarshal([]byte(stdout), &schema))
 	require.Equal(t, "nodejs-component-provider", schema["name"].(string))
-	require.Equal(t, "1.2.3", schema["version"].(string))
+	require.Nil(t, schema["version"])
 	require.Equal(t, "Node.js Sample Components", schema["description"].(string))
 
 	// Check the component schema


### PR DESCRIPTION
We decided to lead with git tags for source-based plugins and ignore anything language specific, like the version set in package.json. For a local package, we'll return an nil version. This PR removes our dependency on the package version. I also had to modify the base Provider class to make `version` nullable.

Resolve https://github.com/pulumi/pulumi/issues/18967