### PR TITLE
Avoid duplicate packages in requirements.txt

### DIFF
--- a/changelog/pending/20250320--cli-install-package--dont-add-duplicate-sdks-to-requirements-txt.yaml
+++ b/changelog/pending/20250320--cli-install-package--dont-add-duplicate-sdks-to-requirements-txt.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/install,package
+  description: Avoid duplicate packages in requirements.txt

--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -298,11 +298,13 @@ func linkPythonPackage(ws pkgWorkspace.Context, root string, pkg *schema.Package
 
 		lines := regexp.MustCompile("\r?\n").Split(string(fBytes), -1)
 		if !slices.Contains(lines, packageSpecifier) {
-			if runtime.GOOS == "windows" {
-				fBytes = []byte(packageSpecifier + "\r\n" + string(fBytes))
-			} else {
-				fBytes = []byte(packageSpecifier + "\n" + string(fBytes))
+			// Match the file's line endings when adding the package specifier.
+			usesCRLF := strings.Contains(string(fBytes), "\r\n")
+			lineEnding := "\n"
+			if usesCRLF {
+				lineEnding = "\r\n"
 			}
+			fBytes = []byte(packageSpecifier + lineEnding + string(fBytes))
 			err = os.WriteFile(fPath, fBytes, 0o600)
 			if err != nil {
 				return fmt.Errorf("could not write requirements.txt: %w", err)

--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -27,6 +27,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 
 	cmdDiag "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/diag"
@@ -294,10 +295,13 @@ func linkPythonPackage(ws pkgWorkspace.Context, root string, pkg *schema.Package
 			return fmt.Errorf("error opening requirments.txt: %w", err)
 		}
 
-		fBytes = []byte(packageSpecifier + "\n" + string(fBytes))
-		err = os.WriteFile(fPath, fBytes, 0o600)
-		if err != nil {
-			return fmt.Errorf("could not write requirments: %w", err)
+		lines := strings.Split(string(fBytes), "\n")
+		if !slices.Contains(lines, packageSpecifier) {
+			fBytes = []byte(packageSpecifier + "\n" + string(fBytes))
+			err = os.WriteFile(fPath, fBytes, 0o600)
+			if err != nil {
+				return fmt.Errorf("could not write requirements.txt: %w", err)
+			}
 		}
 
 		tc, err := toolchain.ResolveToolchain(toolchain.PythonOptions{

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1516,15 +1516,15 @@ func TestPackageAddPython(t *testing.T) {
 
 				assert.Equal(t, "sdks/random", pf)
 			} else {
-				b, err := os.ReadFile(filepath.Join(e.CWD, "requirements.txt"))
+				b1, err := os.ReadFile(filepath.Join(e.CWD, "requirements.txt"))
 				assert.NoError(t, err)
-				assert.Contains(t, string(b), "sdks/random")
+				assert.Contains(t, string(b1), "sdks/random")
 
 				// Run the command again to ensure it doesn't add the dependency twice to requirements.txt
 				_, _ = e.RunCommand("pulumi", "package", "add", "random")
-				b, err = os.ReadFile(filepath.Join(e.CWD, "requirements.txt"))
+				b2, err := os.ReadFile(filepath.Join(e.CWD, "requirements.txt"))
 				assert.NoError(t, err)
-				lines := strings.Split(string(b), "\n")
+				lines := strings.Split(string(b2), "\n")
 				var sdksRandomCount int
 				for _, line := range lines {
 					if strings.Contains(line, "sdks/random") {
@@ -1532,6 +1532,7 @@ func TestPackageAddPython(t *testing.T) {
 					}
 				}
 				assert.Equal(t, 1, sdksRandomCount, "sdks/random should only appear once in requirements.txt")
+				assert.Equal(t, b1, b2, "requirements.txt should not change")
 			}
 		})
 	}

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1519,6 +1519,19 @@ func TestPackageAddPython(t *testing.T) {
 				b, err := os.ReadFile(filepath.Join(e.CWD, "requirements.txt"))
 				assert.NoError(t, err)
 				assert.Contains(t, string(b), "sdks/random")
+
+				// Run the command again to ensure it doesn't add the dependency twice to requirements.txt
+				_, _ = e.RunCommand("pulumi", "package", "add", "random")
+				b, err = os.ReadFile(filepath.Join(e.CWD, "requirements.txt"))
+				assert.NoError(t, err)
+				lines := strings.Split(string(b), "\n")
+				var sdksRandomCount int
+				for _, line := range lines {
+					if strings.Contains(line, "sdks/random") {
+						sdksRandomCount++
+					}
+				}
+				assert.Equal(t, 1, sdksRandomCount, "sdks/random should only appear once in requirements.txt")
 			}
 		})
 	}

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1524,7 +1524,7 @@ func TestPackageAddPython(t *testing.T) {
 				_, _ = e.RunCommand("pulumi", "package", "add", "random")
 				b2, err := os.ReadFile(filepath.Join(e.CWD, "requirements.txt"))
 				assert.NoError(t, err)
-				lines := strings.Split(string(b2), "\n")
+				lines := regexp.MustCompile("\r?\n").Split(string(b2), -1)
 				var sdksRandomCount int
 				for _, line := range lines {
 					if strings.Contains(line, "sdks/random") {


### PR DESCRIPTION
Check if the package is already present in requirements.txt before adding it.

Fixes https://github.com/pulumi/pulumi/issues/18969
Fixes https://github.com/pulumi/pulumi-terraform-module/issues/207