### PR TITLE
python: set name and namespace via component_provider_host

### DIFF
--- a/changelog/pending/20250326--sdk-python--set-name-and-namespace-via-component_provider_host.yaml
+++ b/changelog/pending/20250326--sdk-python--set-name-and-namespace-via-component_provider_host.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Set name and namespace via component_provider_host

--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -733,6 +733,9 @@ func SchemaFromSchemaSource(pctx *plugin.Context, packageSource string, args []s
 	if pluginSpec.PluginDownloadURL != "" {
 		spec.PluginDownloadURL = pluginSpec.PluginDownloadURL
 	}
+	if pluginSpec.Version != nil {
+		spec.Version = pluginSpec.Version.String()
+	}
 	setSpecNamespace(&spec, pluginSpec)
 	return bind(spec)
 }

--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -733,9 +733,6 @@ func SchemaFromSchemaSource(pctx *plugin.Context, packageSource string, args []s
 	if pluginSpec.PluginDownloadURL != "" {
 		spec.PluginDownloadURL = pluginSpec.PluginDownloadURL
 	}
-	if pluginSpec.Version != nil {
-		spec.Version = pluginSpec.Version.String()
-	}
 	setSpecNamespace(&spec, pluginSpec)
 	return bind(spec)
 }

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -2085,26 +2085,26 @@ func (p *provider) GetPluginInfo(ctx context.Context) (workspace.PluginInfo, err
 	label := p.label() + ".GetPluginInfo()"
 	logging.V(7).Infof("%s executing", label)
 
-	// Calling GetPluginInfo happens immediately after loading, and does not require configuration to proceed.
-	// Thus, we access the clientRaw property, rather than calling getClient.
-	resp, err := p.clientRaw.GetPluginInfo(p.requestContext(), &emptypb.Empty{})
-	if err != nil {
-		rpcError := rpcerror.Convert(err)
-		logging.V(7).Infof("%s failed: err=%v", label, rpcError.Message())
-		return workspace.PluginInfo{}, rpcError
-	}
-
 	var version *semver.Version
-	if v := resp.Version; v != "" {
-		sv, err := semver.ParseTolerant(v)
-		if err != nil {
-			return workspace.PluginInfo{}, err
-		}
-		version = &sv
-	}
-
 	if p.overrideVersion != nil {
 		version = p.overrideVersion
+	} else {
+		// Calling GetPluginInfo happens immediately after loading, and does not require configuration to proceed.
+		// Thus, we access the clientRaw property, rather than calling getClient.
+		resp, err := p.clientRaw.GetPluginInfo(p.requestContext(), &emptypb.Empty{})
+		if err != nil {
+			rpcError := rpcerror.Convert(err)
+			logging.V(7).Infof("%s failed: err=%v", label, rpcError.Message())
+			return workspace.PluginInfo{}, rpcError
+		}
+
+		if v := resp.Version; v != "" {
+			sv, err := semver.ParseTolerant(v)
+			if err != nil {
+				return workspace.PluginInfo{}, err
+			}
+			version = &sv
+		}
 	}
 
 	path := ""

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -80,7 +80,9 @@ type provider struct {
 	clientRaw              pulumirpc.ResourceProviderClient // the raw provider client; usually unsafe to use directly.
 	disableProviderPreview bool                             // true if previews for Create and Update are disabled.
 	legacyPreview          bool                             // enables legacy behavior for unconfigured provider previews.
-	overrideVersion        *semver.Version                  // The version to use for the provider if given. Used for Git sources.
+
+	// The version to use for the provider if given. Used for Git sources.
+	overrideVersion *semver.Version
 
 	// Protocol information for the provider.
 	protocol *pluginProtocol
@@ -416,6 +418,19 @@ func NewProviderWithClient(ctx *Context, pkg tokens.Package, client pulumirpc.Re
 		clientRaw:              client,
 		disableProviderPreview: disableProviderPreview,
 		configSource:           &promise.CompletionSource[pluginConfig]{},
+	}
+}
+
+func NewProviderWithVersionOverride(ctx *Context, pkg tokens.Package, client pulumirpc.ResourceProviderClient,
+	disableProviderPreview bool, version *semver.Version,
+) Provider {
+	return &provider{
+		ctx:                    ctx,
+		pkg:                    pkg,
+		clientRaw:              client,
+		disableProviderPreview: disableProviderPreview,
+		configSource:           &promise.CompletionSource[pluginConfig]{},
+		overrideVersion:        version,
 	}
 }
 

--- a/sdk/go/common/resource/plugin/provider_plugin_test.go
+++ b/sdk/go/common/resource/plugin/provider_plugin_test.go
@@ -16,12 +16,14 @@ package plugin
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"reflect"
 	"testing"
 
+	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -790,10 +792,12 @@ func newTestContext(t testing.TB) *Context {
 type stubClient struct {
 	pulumirpc.ResourceProviderClient
 
-	DiffConfigF func(*pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error)
-	ConstructF  func(*pulumirpc.ConstructRequest) (*pulumirpc.ConstructResponse, error)
-	ConfigureF  func(*pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error)
-	DeleteF     func(*pulumirpc.DeleteRequest) error
+	DiffConfigF    func(*pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error)
+	ConstructF     func(*pulumirpc.ConstructRequest) (*pulumirpc.ConstructResponse, error)
+	ConfigureF     func(*pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error)
+	DeleteF        func(*pulumirpc.DeleteRequest) error
+	GetSchemaF     func(*pulumirpc.GetSchemaRequest) (*pulumirpc.GetSchemaResponse, error)
+	GetPluginInfoF func() (*pulumirpc.PluginInfo, error)
 }
 
 func (c *stubClient) DiffConfig(
@@ -839,6 +843,28 @@ func (c *stubClient) Delete(
 		return &emptypb.Empty{}, err
 	}
 	return c.ResourceProviderClient.Delete(ctx, req, opts...)
+}
+
+func (c *stubClient) GetSchema(
+	ctx context.Context,
+	req *pulumirpc.GetSchemaRequest,
+	opts ...grpc.CallOption,
+) (*pulumirpc.GetSchemaResponse, error) {
+	if f := c.GetSchemaF; f != nil {
+		return f(req)
+	}
+	return c.ResourceProviderClient.GetSchema(ctx, req, opts...)
+}
+
+func (c *stubClient) GetPluginInfo(
+	ctx context.Context,
+	in *emptypb.Empty,
+	opts ...grpc.CallOption,
+) (*pulumirpc.PluginInfo, error) {
+	if f := c.GetPluginInfoF; f != nil {
+		return f()
+	}
+	return c.ResourceProviderClient.GetPluginInfo(ctx, in, opts...)
 }
 
 // Test for https://github.com/pulumi/pulumi/issues/14529, ensure a kubernetes DiffConfig error is ignored
@@ -898,6 +924,38 @@ func TestKubernetesDiffError(t *testing.T) {
 		nil,
 	})
 	assert.ErrorContains(t, err, "some other error")
+}
+
+func TestOverrideVersion(t *testing.T) {
+	t.Parallel()
+
+	client := &stubClient{
+		GetPluginInfoF: func() (*pulumirpc.PluginInfo, error) {
+			return &pulumirpc.PluginInfo{
+				Version: "0.0.0",
+			}, nil
+		},
+		GetSchemaF: func(req *pulumirpc.GetSchemaRequest) (*pulumirpc.GetSchemaResponse, error) {
+			schema := `{"name": "test", "version": "0.0.0"}`
+			return &pulumirpc.GetSchemaResponse{
+				Schema: schema,
+			}, nil
+		},
+	}
+
+	version := semver.MustParse("1.2.3")
+
+	prov := NewProviderWithVersionOverride(newTestContext(t), "azure", client, false /* disablePreview */, &version)
+	resp, err := prov.GetPluginInfo(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, &version, resp.Version)
+
+	schema, err := prov.GetSchema(context.Background(), GetSchemaRequest{})
+	require.NoError(t, err)
+
+	var unmarshalledSchema map[string]any
+	err = json.Unmarshal([]byte(schema.Schema), &unmarshalledSchema)
+	require.Equal(t, "1.2.3", unmarshalledSchema["version"])
 }
 
 //nolint:paralleltest // using t.Setenv which is incompatible with t.Parallel

--- a/sdk/go/common/resource/plugin/provider_plugin_test.go
+++ b/sdk/go/common/resource/plugin/provider_plugin_test.go
@@ -954,7 +954,8 @@ func TestOverrideVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	var unmarshalledSchema map[string]any
-	err = json.Unmarshal([]byte(schema.Schema), &unmarshalledSchema)
+	err = json.Unmarshal(schema.Schema, &unmarshalledSchema)
+	require.NoError(t, err)
 	require.Equal(t, "1.2.3", unmarshalledSchema["version"])
 }
 

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1084,6 +1084,11 @@ func NewPluginSpec(
 	}, nil
 }
 
+// IsGitPlugin returns if the plugin comes from the git source
+func (spec PluginSpec) IsGitPlugin() bool {
+	return strings.HasPrefix(spec.PluginDownloadURL, "git://")
+}
+
 // LocalName returns the local name of the plugin, which is used in the directory name, and a path
 // within that directory if the plugin is located in a subdirectory.
 func (spec PluginSpec) LocalName() (string, string) {

--- a/sdk/nodejs/provider/experimental/provider.ts
+++ b/sdk/nodejs/provider/experimental/provider.ts
@@ -119,7 +119,7 @@ export class ComponentProvider implements Provider {
     private componentConstructors: Record<string, ComponentResourceConstructor>;
     private name: string;
     private namespace?: string;
-    private version: string;
+    public version: string;
 
     public static validateResourceType(packageName: string, resourceType: string): void {
         const parts = resourceType.split(":");

--- a/sdk/nodejs/provider/experimental/schema.ts
+++ b/sdk/nodejs/provider/experimental/schema.ts
@@ -73,6 +73,7 @@ export interface PackageSpec {
 
 export function generateSchema(
     providerName: string,
+    version: string,
     description: string,
     components: Record<string, ComponentDefinition>,
     typeDefinitions: Record<string, TypeDefinition>,
@@ -81,6 +82,7 @@ export function generateSchema(
 ): PackageSpec {
     const result: PackageSpec = {
         name: providerName,
+        version: version,
         description: description,
         namespace: namespace,
         resources: {},

--- a/sdk/nodejs/tests/provider/experimental/schema.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/schema.spec.ts
@@ -31,6 +31,7 @@ describe("Schema", function () {
         // Generate schema
         const schema = generateSchema(
             "test-provider",
+            "1.0.0",
             "Test provider for Pulumi",
             components,
             typeDefinitions,
@@ -74,6 +75,7 @@ describe("Schema", function () {
 
         const schema = generateSchema(
             "test-provider",
+            "1.0.0",
             "my-description",
             components,
             typeDefinitions,

--- a/sdk/python/lib/pulumi/provider/experimental/ComponentProvider.md
+++ b/sdk/python/lib/pulumi/provider/experimental/ComponentProvider.md
@@ -44,16 +44,16 @@ class MyComponent(pulumi.ComponentResource):
 Next, create a `__main__.py` file to host the provider:
 
 ```python
-from pulumi.provider.experimental import Metadata, component_provider_host
+from pulumi.provider.experimental import component_provider_host
 
 if __name__ == "__main__":
-    component_provider_host(Metadata(name="my-provider", version="1.0.0"))
+    component_provider_host(name="my-provider", namespace="my-namespace")
 ```
 
 > [!NOTE]
-> The name passed to `Metadata` must exactly match the package name in the type string of your component.
+> The name specified must exactly match the package name in the type string of your component.
 
-The call to `component_provider_host` will start the provider and listen for RPC requests from the Pulumi engine. Any subclasses of `pulumi.ComponentResource` found in any Python source code files in the provider's directory will be exposed as resources by the provider.
+The call to `component_provider_host` will start the provider and listen for RPC requests from the Pulumi engine. Any subclasses of `pulumi.ComponentResource` found in any Python source code files in the provider's directory will be exposed as resources by the provider. The namespace parameter is optional, and is used to provide namespacing in the component. If none is given, the default "pulumi" namespace will be used.
 
 At this point, we can run the provider, but it does not yet do anything useful. To get data in and out of the provider we need to define the inputs and outputs of the component. Inputs are infered from the `args` parameter of the component's constructor. Add a new type `MyComponentArgs` derived from `TypedDict` to represent the arguments, and add it as an argument to the constructor.
 

--- a/sdk/python/lib/pulumi/provider/experimental/ComponentProvider.md
+++ b/sdk/python/lib/pulumi/provider/experimental/ComponentProvider.md
@@ -47,7 +47,11 @@ Next, create a `__main__.py` file to host the provider:
 from pulumi.provider.experimental import component_provider_host
 
 if __name__ == "__main__":
-    component_provider_host(name="my-provider", namespace="my-namespace")
+    component_provider_host(
+        components=[MyComponent],
+        name="my-provider",
+        namespace="my-namespace
+    )
 ```
 
 > [!NOTE]

--- a/sdk/python/lib/pulumi/provider/experimental/__init__.py
+++ b/sdk/python/lib/pulumi/provider/experimental/__init__.py
@@ -13,6 +13,5 @@
 # limitations under the License.
 
 from .host import component_provider_host
-from .metadata import Metadata
 
-__all__ = ["component_provider_host", "Metadata"]
+__all__ = ["component_provider_host"]

--- a/sdk/python/lib/pulumi/provider/experimental/analyzer.py
+++ b/sdk/python/lib/pulumi/provider/experimental/analyzer.py
@@ -43,7 +43,6 @@ from .component import (
     PropertyType,
     TypeDefinition,
 )
-from .metadata import Metadata
 from .util import camel_case
 
 _NoneType = type(None)  # Available as typing.NoneType in >= 3.10
@@ -149,8 +148,8 @@ class Analyzer:
     source code and parse that to retrieve the docstrings.
     """
 
-    def __init__(self, metadata: Metadata):
-        self.metadata = metadata
+    def __init__(self, name: str):
+        self.name = name
         self.type_definitions: dict[str, TypeDefinition] = {}
         self.unresolved_forward_refs: dict[str, TypeDefinition] = {}
         self.docstrings: dict[str, dict[str, str]] = {}
@@ -363,7 +362,7 @@ class Analyzer:
                 if type_def.module != module:
                     raise DuplicateTypeError(module, type_def)
                 # Forward ref to a type we saw before, return a reference to it.
-                ref = f"#/types/{self.metadata.name}:index:{ref_name}"
+                ref = f"#/types/{self.name}:index:{ref_name}"
                 return PropertyDefinition(
                     ref=ref,
                     optional=optional,
@@ -386,7 +385,7 @@ class Analyzer:
                 )
                 self.unresolved_forward_refs[ref_name] = type_def
                 self.type_definitions[type_def.name] = type_def
-                ref = f"#/types/{self.metadata.name}:index:{type_def.name}"
+                ref = f"#/types/{self.name}:index:{type_def.name}"
                 return PropertyDefinition(
                     ref=ref,
                     optional=optional,
@@ -442,7 +441,7 @@ class Analyzer:
             type_def.properties_mapping = properties_mapping
             if type_def.name in self.unresolved_forward_refs:
                 del self.unresolved_forward_refs[type_def.name]
-            ref = f"#/types/{self.metadata.name}:index:{type_def.name}"
+            ref = f"#/types/{self.name}:index:{type_def.name}"
             return PropertyDefinition(
                 ref=ref,
                 optional=optional,

--- a/sdk/python/lib/pulumi/provider/experimental/host.py
+++ b/sdk/python/lib/pulumi/provider/experimental/host.py
@@ -48,5 +48,7 @@ def component_provider_host(
     # to the plugin's installation directory. This is followed by the engine
     # address and other optional arguments flags, like `--logtostderr`.
     args = sys.argv[1:]
-
-    main(ComponentProvider(components, name, namespace), args)
+    # Default the version to "0.0.0" for now, otherwise SDK codegen gets
+    # confused without a version.
+    version = "0.0.0"
+    main(ComponentProvider(components, name, namespace, version), args)

--- a/sdk/python/lib/pulumi/provider/experimental/host.py
+++ b/sdk/python/lib/pulumi/provider/experimental/host.py
@@ -13,19 +13,19 @@
 # limitations under the License.
 
 import sys
-from pathlib import Path
 from typing import Optional
 
 from ...resource import ComponentResource
 from ...provider import main
-from .metadata import Metadata
 from .provider import ComponentProvider
 
 is_hosting = False
 
 
 def component_provider_host(
-    components: list[type[ComponentResource]], metadata: Optional[Metadata] = None
+    components: list[type[ComponentResource]],
+    name: str,
+    namespace: Optional[str] = None,
 ):
     """
     component_provider_host starts the provider and hosts the passed in components.
@@ -47,10 +47,6 @@ def component_provider_host(
     # When the languge runtime runs the plugin, the first argument is the path
     # to the plugin's installation directory. This is followed by the engine
     # address and other optional arguments flags, like `--logtostderr`.
-    path = Path(sys.argv[0])
     args = sys.argv[1:]
 
-    if metadata is None:
-        metadata = Metadata(path.absolute().name, "0.0.1")
-
-    main(ComponentProvider(metadata, components), args)
+    main(ComponentProvider(components, name, namespace), args)

--- a/sdk/python/lib/pulumi/provider/experimental/provider.py
+++ b/sdk/python/lib/pulumi/provider/experimental/provider.py
@@ -46,6 +46,7 @@ class ComponentProvider(Provider):
         components: list[type[ComponentResource]],
         name: str,
         namespace: Optional[str] = None,
+        version: str = "0.0.0",
     ) -> None:
         self._name = name
         self.analyzer = Analyzer(name)
@@ -55,6 +56,7 @@ class ComponentProvider(Provider):
         self._type_defs = type_definitions
         schema = generate_schema(
             name,
+            version,
             namespace,
             self._component_defs,
             self._type_defs,

--- a/sdk/python/lib/pulumi/provider/experimental/provider.py
+++ b/sdk/python/lib/pulumi/provider/experimental/provider.py
@@ -24,7 +24,6 @@ from ...resource import ComponentResource, ResourceOptions
 from ..provider import ConstructResult, Provider
 from .analyzer import Analyzer
 from .component import ComponentDefinition, PropertyDefinition, TypeDefinition
-from .metadata import Metadata
 from .schema import generate_schema
 
 
@@ -36,28 +35,31 @@ class ComponentProvider(Provider):
 
     path: Path
     """The path to the Python source code."""
-    metadata: Metadata
-    """The metadata for the provider, such as the name and version."""
 
     _type_defs: dict[str, TypeDefinition]
     _component_defs: dict[str, ComponentDefinition]
     _components: dict[str, type[ComponentResource]]
+    _name: str
 
     def __init__(
-        self, metadata: Metadata, components: list[type[ComponentResource]]
+        self,
+        components: list[type[ComponentResource]],
+        name: str,
+        namespace: Optional[str] = None,
     ) -> None:
-        self.metadata = metadata
-        self.analyzer = Analyzer(self.metadata)
+        self._name = name
+        self.analyzer = Analyzer(name)
         (components_defs, type_definitions) = self.analyzer.analyze(components)
         self._components = {component.__name__: component for component in components}
         self._component_defs = components_defs
         self._type_defs = type_definitions
         schema = generate_schema(
-            metadata,
+            name,
+            namespace,
             self._component_defs,
             self._type_defs,
         )
-        super().__init__(metadata.version, json.dumps(schema.to_json()))
+        super().__init__("", json.dumps(schema.to_json()))
 
     def construct(
         self,
@@ -66,7 +68,7 @@ class ComponentProvider(Provider):
         inputs: Inputs,
         options: Optional[ResourceOptions] = None,
     ) -> ConstructResult:
-        self.validate_resource_type(self.metadata.name, resource_type)
+        self.validate_resource_type(self._name, resource_type)
         component_name = resource_type.split(":")[-1]
         constructor = self._components[component_name]
         component_def = self._component_defs[component_name]

--- a/sdk/python/lib/pulumi/provider/experimental/provider.py
+++ b/sdk/python/lib/pulumi/provider/experimental/provider.py
@@ -61,7 +61,7 @@ class ComponentProvider(Provider):
             self._component_defs,
             self._type_defs,
         )
-        super().__init__("", json.dumps(schema.to_json()))
+        super().__init__(version, json.dumps(schema.to_json()))
 
     def construct(
         self,

--- a/sdk/python/lib/pulumi/provider/experimental/schema.py
+++ b/sdk/python/lib/pulumi/provider/experimental/schema.py
@@ -21,7 +21,6 @@ from .component import (
     PropertyType,
     TypeDefinition,
 )
-from .metadata import Metadata
 
 
 @dataclass
@@ -163,7 +162,7 @@ class PackageSpec:
 
     name: str
     displayName: str
-    version: Optional[str]
+    namespace: Optional[str]
     resources: dict[str, Resource]
     types: dict[str, ComplexType]
     language: dict[str, dict[str, Any]]
@@ -173,7 +172,7 @@ class PackageSpec:
             {
                 "name": self.name,
                 "displayName": self.displayName,
-                "version": self.version,
+                "namespace": self.namespace,
                 "resources": {k: v.to_json() for k, v in self.resources.items()},
                 "types": {k: v.to_json() for k, v in self.types.items()},
                 "language": self.language,
@@ -182,14 +181,15 @@ class PackageSpec:
 
 
 def generate_schema(
-    metadata: Metadata,
+    name: str,
+    namespace: Optional[str],
     components: dict[str, ComponentDefinition],
     type_definitions: dict[str, TypeDefinition],
 ) -> PackageSpec:
     pkg = PackageSpec(
-        name=metadata.name,
-        version=metadata.version,
-        displayName=metadata.display_name or metadata.name,
+        name=name,
+        displayName=name,
+        namespace=namespace,
         resources={},
         types={},
         language={
@@ -211,13 +211,12 @@ def generate_schema(
         },
     )
     for component_name, component in components.items():
-        name = f"{metadata.name}:index:{component_name}"
-        pkg.resources[name] = Resource.from_definition(component)
+        pkg.resources[f"{name}:index:{component_name}"] = Resource.from_definition(
+            component
+        )
 
     for type_name, type in type_definitions.items():
-        pkg.types[f"{metadata.name}:index:{type_name}"] = ComplexType.from_definition(
-            type
-        )
+        pkg.types[f"{name}:index:{type_name}"] = ComplexType.from_definition(type)
 
     return pkg
 

--- a/sdk/python/lib/pulumi/provider/experimental/schema.py
+++ b/sdk/python/lib/pulumi/provider/experimental/schema.py
@@ -161,6 +161,7 @@ class PackageSpec:
     """https://www.pulumi.com/docs/iac/using-pulumi/pulumi-packages/schema/#package"""
 
     name: str
+    version: str
     displayName: str
     namespace: Optional[str]
     resources: dict[str, Resource]
@@ -171,6 +172,7 @@ class PackageSpec:
         return remove_none(
             {
                 "name": self.name,
+                "version": self.version,
                 "displayName": self.displayName,
                 "namespace": self.namespace,
                 "resources": {k: v.to_json() for k, v in self.resources.items()},
@@ -182,12 +184,14 @@ class PackageSpec:
 
 def generate_schema(
     name: str,
+    version: str,
     namespace: Optional[str],
     components: dict[str, ComponentDefinition],
     type_definitions: dict[str, TypeDefinition],
 ) -> PackageSpec:
     pkg = PackageSpec(
         name=name,
+        version=version,
         displayName=name,
         namespace=namespace,
         resources={},

--- a/sdk/python/lib/test/provider/experimental/test_analyzer.py
+++ b/sdk/python/lib/test/provider/experimental/test_analyzer.py
@@ -21,7 +21,6 @@ import typing
 from typing import Any, Optional, TypedDict, Union
 
 import pulumi
-from pulumi.provider.experimental.metadata import Metadata
 from pulumi.provider.experimental.analyzer import (
     Analyzer,
     DuplicateTypeError,
@@ -42,8 +41,6 @@ from pulumi.provider.experimental.component import (
 )
 from pulumi.resource import ComponentResource
 
-metadata = Metadata("my-component", "0.0.1")
-
 
 def test_analyze_component():
     class SelfSignedCertificateArgs(TypedDict):
@@ -60,7 +57,7 @@ def test_analyze_component():
 
         def __init__(self, args: SelfSignedCertificateArgs): ...
 
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("component")
     component = analyzer.analyze_component(SelfSignedCertificate)
     assert component == ComponentDefinition(
         name="SelfSignedCertificate",
@@ -92,7 +89,7 @@ def test_analyze_component():
 def test_analyze_component_no_args():
     class NoArgs(pulumi.ComponentResource): ...
 
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("no-args")
     try:
         component = analyzer.analyze_component(NoArgs)
         assert False, f"expected an exception, got {component}"
@@ -107,7 +104,7 @@ def test_analyze_component_empty():
     class Empty(pulumi.ComponentResource):
         def __init__(self, args: dict[str, Any]): ...
 
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("empty")
     component = analyzer.analyze_component(Empty)
     assert component == ComponentDefinition(
         name="Empty",
@@ -153,7 +150,7 @@ def test_analyze_component_plain_types():
 
         def __init__(self, args: Args): ...
 
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("plain-types")
     component = analyzer.analyze_component(Component)
     assert component == ComponentDefinition(
         name="Component",
@@ -215,11 +212,11 @@ def test_analyze_component_plain_types():
                 plain=False,
             ),
             "aComplexType": PropertyDefinition(
-                ref="#/types/my-component:index:ComplexType",
+                ref="#/types/plain-types:index:ComplexType",
                 plain=True,
             ),
             "aInputComplexType": PropertyDefinition(
-                ref="#/types/my-component:index:ComplexType",
+                ref="#/types/plain-types:index:ComplexType",
                 plain=False,
             ),
         },
@@ -254,10 +251,10 @@ def test_analyze_component_plain_types():
                 plain=False,
             ),
             "aOutputComplex": PropertyDefinition(
-                ref="#/types/my-component:index:ComplexType", plain=False
+                ref="#/types/plain-types:index:ComplexType", plain=False
             ),
             "aOptionalOutputComplex": PropertyDefinition(
-                ref="#/types/my-component:index:ComplexType", plain=False, optional=True
+                ref="#/types/plain-types:index:ComplexType", plain=False, optional=True
             ),
         },
         outputs_mapping={
@@ -302,7 +299,7 @@ def test_analyze_list_simple():
 
         def __init__(self, args: Args): ...
 
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("list-simple")
     component = analyzer.analyze_component(Component)
     assert component == ComponentDefinition(
         name="Component",
@@ -363,7 +360,7 @@ def test_analyze_list_complex():
 
         def __init__(self, args: Args): ...
 
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("list-complex")
     component = analyzer.analyze_component(Component)
     assert component == ComponentDefinition(
         name="Component",
@@ -372,7 +369,7 @@ def test_analyze_list_complex():
             "listInput": PropertyDefinition(
                 type=PropertyType.ARRAY,
                 items=PropertyDefinition(
-                    ref="#/types/my-component:index:ComplexType", plain=True
+                    ref="#/types/list-complex:index:ComplexType", plain=True
                 ),
             )
         },
@@ -381,7 +378,7 @@ def test_analyze_list_complex():
             "listOutput": PropertyDefinition(
                 type=PropertyType.ARRAY,
                 items=PropertyDefinition(
-                    ref="#/types/my-component:index:ComplexType", plain=True
+                    ref="#/types/list-complex:index:ComplexType", plain=True
                 ),
             )
         },
@@ -413,7 +410,7 @@ def test_analyze_list_missing_type():
     class Component(pulumi.ComponentResource):
         def __init__(self, args: Args): ...
 
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("missing-type")
     try:
         analyzer.analyze_component(Component)
     except InvalidListTypeError as e:
@@ -430,7 +427,7 @@ def test_analyze_dict_non_str_key():
     class Component(pulumi.ComponentResource):
         def __init__(self, args: Args): ...
 
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("dict-non-str-key")
     try:
         analyzer.analyze_component(Component)
     except InvalidMapKeyError as e:
@@ -444,7 +441,7 @@ def test_analyze_dice_no_types():
     class Component(pulumi.ComponentResource):
         def __init__(self, args: Args): ...
 
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("dict-no-types")
     try:
         analyzer.analyze_component(Component)
     except InvalidMapTypeError as e:
@@ -467,7 +464,7 @@ def test_analyze_dict_simple():
 
         def __init__(self, args: Args): ...
 
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("dict-simple")
     component = analyzer.analyze_component(Component)
     assert component == ComponentDefinition(
         name="Component",
@@ -538,7 +535,7 @@ def test_analyze_dict_complex():
 
         def __init__(self, args: Args): ...
 
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("dict-complex")
     component = analyzer.analyze_component(Component)
     assert component == ComponentDefinition(
         name="Component",
@@ -547,7 +544,7 @@ def test_analyze_dict_complex():
             "dictInput": PropertyDefinition(
                 type=PropertyType.OBJECT,
                 additional_properties=PropertyDefinition(
-                    ref="#/types/my-component:index:ComplexType", plain=True
+                    ref="#/types/dict-complex:index:ComplexType", plain=True
                 ),
             )
         },
@@ -556,7 +553,7 @@ def test_analyze_dict_complex():
             "dictOutput": PropertyDefinition(
                 type=PropertyType.OBJECT,
                 additional_properties=PropertyDefinition(
-                    ref="#/types/my-component:index:ComplexType",
+                    ref="#/types/dict-complex:index:ComplexType",
                     optional=True,
                     plain=True,
                 ),
@@ -600,20 +597,20 @@ def test_analyze_component_complex_type():
 
         def __init__(self, args: Args): ...
 
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("complex-type")
     component = analyzer.analyze_component(Component)
     assert component == ComponentDefinition(
         name="Component",
         module="test_analyzer",
         inputs={
             "someComplexType": PropertyDefinition(
-                ref="#/types/my-component:index:ComplexType"
+                ref="#/types/complex-type:index:ComplexType"
             ),
         },
         inputs_mapping={"someComplexType": "some_complex_type"},
         outputs={
             "complexOutput": PropertyDefinition(
-                ref="#/types/my-component:index:ComplexType"
+                ref="#/types/complex-type:index:ComplexType"
             )
         },
         outputs_mapping={"complexOutput": "complex_output"},
@@ -646,7 +643,7 @@ def test_analyze_archive():
 
         def __init__(self, args: Args): ...
 
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("archive")
     component = analyzer.analyze_component(Component)
     assert component == ComponentDefinition(
         name="Component",
@@ -667,7 +664,7 @@ def test_analyze_asset():
 
         def __init__(self, args: Args): ...
 
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("asset")
     component = analyzer.analyze_component(Component)
     assert component == ComponentDefinition(
         name="Component",
@@ -689,7 +686,7 @@ def test_analyze_any():
 
         def __init__(self, args: Args): ...
 
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("any")
     component = analyzer.analyze_component(Component)
     assert component == ComponentDefinition(
         name="Component",
@@ -705,7 +702,7 @@ def test_analyze_any():
 
 
 def test_analyze_descriptions():
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("descriptions")
     (components, type_definitions) = analyzer.analyze(
         components=load_components(Path("testdata", "docstrings")),
     )
@@ -718,7 +715,7 @@ def test_analyze_descriptions():
             inputs={
                 "someComplexType": PropertyDefinition(
                     description="some_complex_type doc string",
-                    ref="#/types/my-component:index:ComplexType",
+                    ref="#/types/descriptions:index:ComplexType",
                 ),
                 "inputWithCommentAndDescription": PropertyDefinition(
                     description="input_with_comment_and_description doc string",
@@ -732,7 +729,7 @@ def test_analyze_descriptions():
             outputs={
                 "complexOutput": PropertyDefinition(
                     description="complex_output doc string",
-                    ref="#/types/my-component:index:ComplexType",
+                    ref="#/types/descriptions:index:ComplexType",
                 )
             },
             outputs_mapping={"complexOutput": "complex_output"},
@@ -751,7 +748,7 @@ def test_analyze_descriptions():
                     plain=True,
                 ),
                 "anotherValue": PropertyDefinition(
-                    ref="#/types/my-component:index:NestedComplexType",
+                    ref="#/types/descriptions:index:NestedComplexType",
                     description=None,
                 ),
             },
@@ -782,7 +779,7 @@ def test_analyze_resource_ref():
     class Component(pulumi.ComponentResource):
         def __init__(self, args: Args): ...
 
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("resource-ref")
     try:
         analyzer.analyze_component(Component)
     except Exception as e:
@@ -793,7 +790,7 @@ def test_analyze_resource_ref():
 
 
 def test_analyze_bad_type():
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("bad-type")
 
     try:
         analyzer.analyze(
@@ -808,7 +805,7 @@ def test_analyze_bad_type():
 
 
 def test_analyze_union_type():
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("union-type")
 
     try:
         analyzer.analyze(
@@ -825,7 +822,7 @@ def test_analyze_union_type():
 
 
 def test_analyze_enum_type():
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("enum-type")
 
     try:
         analyzer.analyze(
@@ -841,7 +838,7 @@ def test_analyze_enum_type():
 
 
 def test_analyze_syntax_error():
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("syntax-error")
 
     try:
         analyzer.analyze(
@@ -860,7 +857,7 @@ def test_analyze_syntax_error():
 
 
 def test_analyze_duplicate_type():
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("duplicate-type")
 
     try:
         analyzer.analyze(
@@ -879,7 +876,7 @@ def test_analyze_duplicate_type():
 
 
 def test_analyze_duplicate_components():
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("duplicate-components")
 
     try:
         analyzer.analyze(
@@ -898,7 +895,7 @@ def test_analyze_duplicate_components():
 
 
 def test_analyze_no_components():
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("no-components")
 
     try:
         analyzer.analyze(components=[])
@@ -919,7 +916,7 @@ def test_analyze_component_self_recursive_complex_type():
 
         def __init__(self, args: Args): ...
 
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("recursive")
     component = analyzer.analyze_component(Component)
     assert analyzer.type_definitions == {
         "RecursiveType": TypeDefinition(
@@ -929,7 +926,7 @@ def test_analyze_component_self_recursive_complex_type():
             properties={
                 "rec": PropertyDefinition(
                     optional=True,
-                    ref="#/types/my-component:index:RecursiveType",
+                    ref="#/types/recursive:index:RecursiveType",
                 )
             },
             properties_mapping={"rec": "rec"},
@@ -938,12 +935,10 @@ def test_analyze_component_self_recursive_complex_type():
     assert component == ComponentDefinition(
         name="Component",
         module="test_analyzer",
-        inputs={
-            "rec": PropertyDefinition(ref="#/types/my-component:index:RecursiveType")
-        },
+        inputs={"rec": PropertyDefinition(ref="#/types/recursive:index:RecursiveType")},
         inputs_mapping={"rec": "rec"},
         outputs={
-            "rec": PropertyDefinition(ref="#/types/my-component:index:RecursiveType")
+            "rec": PropertyDefinition(ref="#/types/recursive:index:RecursiveType")
         },
         outputs_mapping={"rec": "rec"},
     )
@@ -971,7 +966,7 @@ def test_analyze_component_mutually_recursive_complex_types_inline():
 
         def __init__(self, args: Args): ...
 
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("mutually-recursive")
     component = analyzer.analyze_component(Component)
     assert analyzer.type_definitions == {
         "RecursiveTypeA": TypeDefinition(
@@ -981,7 +976,7 @@ def test_analyze_component_mutually_recursive_complex_types_inline():
             properties={
                 "b": PropertyDefinition(
                     optional=True,
-                    ref="#/types/my-component:index:RecursiveTypeB",
+                    ref="#/types/mutually-recursive:index:RecursiveTypeB",
                 )
             },
             properties_mapping={"b": "b"},
@@ -993,7 +988,7 @@ def test_analyze_component_mutually_recursive_complex_types_inline():
             properties={
                 "a": PropertyDefinition(
                     optional=True,
-                    ref="#/types/my-component:index:RecursiveTypeA",
+                    ref="#/types/mutually-recursive:index:RecursiveTypeA",
                 )
             },
             properties_mapping={"a": "a"},
@@ -1003,18 +998,22 @@ def test_analyze_component_mutually_recursive_complex_types_inline():
         name="Component",
         module="test_analyzer",
         inputs={
-            "rec": PropertyDefinition(ref="#/types/my-component:index:RecursiveTypeA")
+            "rec": PropertyDefinition(
+                ref="#/types/mutually-recursive:index:RecursiveTypeA"
+            )
         },
         inputs_mapping={"rec": "rec"},
         outputs={
-            "rec": PropertyDefinition(ref="#/types/my-component:index:RecursiveTypeB")
+            "rec": PropertyDefinition(
+                ref="#/types/mutually-recursive:index:RecursiveTypeB"
+            )
         },
         outputs_mapping={"rec": "rec"},
     )
 
 
 def test_analyze_component_mutually_recursive_complex_types_file():
-    analyzer = Analyzer(metadata)
+    analyzer = Analyzer("mutually-recursive")
 
     (components, type_definitions) = analyzer.analyze(
         components=load_components(Path("testdata", "mutually-recursive")),
@@ -1027,7 +1026,7 @@ def test_analyze_component_mutually_recursive_complex_types_file():
             properties={
                 "b": PropertyDefinition(
                     optional=True,
-                    ref="#/types/my-component:index:RecursiveTypeB",
+                    ref="#/types/mutually-recursive:index:RecursiveTypeB",
                 )
             },
             properties_mapping={"b": "b"},
@@ -1039,7 +1038,7 @@ def test_analyze_component_mutually_recursive_complex_types_file():
             properties={
                 "a": PropertyDefinition(
                     optional=True,
-                    ref="#/types/my-component:index:RecursiveTypeA",
+                    ref="#/types/mutually-recursive:index:RecursiveTypeA",
                 )
             },
             properties_mapping={"a": "a"},
@@ -1051,13 +1050,13 @@ def test_analyze_component_mutually_recursive_complex_types_file():
             module="mutually_recursive",
             inputs={
                 "rec": PropertyDefinition(
-                    ref="#/types/my-component:index:RecursiveTypeA"
+                    ref="#/types/mutually-recursive:index:RecursiveTypeA"
                 )
             },
             inputs_mapping={"rec": "rec"},
             outputs={
                 "rec": PropertyDefinition(
-                    ref="#/types/my-component:index:RecursiveTypeA"
+                    ref="#/types/mutually-recursive:index:RecursiveTypeA"
                 )
             },
             outputs_mapping={"rec": "rec"},

--- a/sdk/python/lib/test/provider/experimental/test_provider.py
+++ b/sdk/python/lib/test/provider/experimental/test_provider.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
 from typing import Any, Optional, TypedDict
 from pulumi.errors import InputPropertyError
 from pulumi.output import Input
-from pulumi.provider.experimental.metadata import Metadata
 from pulumi.provider.experimental.provider import ComponentProvider
 from pulumi.resource import ComponentResource, ResourceOptions
 
@@ -50,7 +48,7 @@ def test_map_inputs():
             super().__init__("component:index:MyComponent", name, {}, opts)
             self.register_outputs({})
 
-    provider = ComponentProvider(Metadata("test-provider", "0.0.1"), [MyComponent])
+    provider = ComponentProvider([MyComponent], "my-provider")
     component_def = provider._component_defs["MyComponent"]  # type: ignore
 
     try:
@@ -100,7 +98,7 @@ def test_map_complex_inputs():
         ):
             super().__init__("mycomp:index:MyComponent", name, {}, opts)
 
-    provider = ComponentProvider(Metadata("test-provider", "0.0.1"), [MyComponent])
+    provider = ComponentProvider([MyComponent], "my-provider")
     component_def = provider._component_defs["MyComponent"]  # type: ignore
 
     inputs = {

--- a/sdk/python/lib/test/provider/experimental/test_schema.py
+++ b/sdk/python/lib/test/provider/experimental/test_schema.py
@@ -16,12 +16,12 @@ from pulumi.provider.experimental.schema import generate_schema
 
 
 def test_generate_schema_with_namespace():
-    schema = generate_schema("name", "namespace", {}, {})
+    schema = generate_schema("name", "1.2.3", "namespace", {}, {})
     assert schema.name == "name"
     assert schema.namespace == "namespace"
 
 
 def test_generate_schema_no_namespace():
-    schema = generate_schema("name", None, {}, {})
+    schema = generate_schema("name", "1.2.3", None, {}, {})
     assert schema.name == "name"
     assert schema.namespace is None

--- a/sdk/python/lib/test/provider/experimental/test_schema.py
+++ b/sdk/python/lib/test/provider/experimental/test_schema.py
@@ -12,19 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
-from typing import Optional
+from pulumi.provider.experimental.schema import generate_schema
 
 
-@dataclass
-class Metadata:
-    """
-    Metadata about the provider, such as the name and version.
-    """
+def test_generate_schema_with_namespace():
+    schema = generate_schema("name", "namespace", {}, {})
+    assert schema.name == "name"
+    assert schema.namespace == "namespace"
 
-    name: str
-    """The name of the provider"""
-    version: Optional[str] = None
-    """The version of the provider"""
-    display_name: Optional[str] = None
-    """The display name of the provider"""
+
+def test_generate_schema_no_namespace():
+    schema = generate_schema("name", None, {}, {})
+    assert schema.name == "name"
+    assert schema.namespace is None

--- a/sdk/python/lib/test/provider/experimental/testdata/complex-args/PulumiPlugin.yaml
+++ b/sdk/python/lib/test/provider/experimental/testdata/complex-args/PulumiPlugin.yaml
@@ -1,0 +1,2 @@
+runtime: python
+name: complex-args

--- a/sdk/python/lib/test/provider/experimental/testdata/missing-input/PulumiPlugin.yaml
+++ b/sdk/python/lib/test/provider/experimental/testdata/missing-input/PulumiPlugin.yaml
@@ -1,0 +1,2 @@
+runtime: python
+name: missing-input

--- a/tests/integration/component_provider/python/component-provider-host/provider/__main__.py
+++ b/tests/integration/component_provider/python/component-provider-host/provider/__main__.py
@@ -13,15 +13,8 @@
 # limitations under the License.
 
 
-from pulumi.provider.experimental import Metadata, component_provider_host
+from pulumi.provider.experimental import component_provider_host
 from component import MyComponent
 
 if __name__ == "__main__":
-    component_provider_host(
-        [MyComponent],
-        Metadata(
-            name="provider",
-            version="1.2.3",
-            display_name="My Component Provider",
-        ),
-    )
+    component_provider_host([MyComponent], "provider")

--- a/tests/integration/component_provider/python/exception/provider/__main__.py
+++ b/tests/integration/component_provider/python/exception/provider/__main__.py
@@ -17,4 +17,4 @@ from pulumi.provider.experimental import component_provider_host
 from component import MyComponent
 
 if __name__ == "__main__":
-    component_provider_host([MyComponent], "exception")
+    component_provider_host([MyComponent], "provider")

--- a/tests/integration/component_provider/python/exception/provider/__main__.py
+++ b/tests/integration/component_provider/python/exception/provider/__main__.py
@@ -17,4 +17,4 @@ from pulumi.provider.experimental import component_provider_host
 from component import MyComponent
 
 if __name__ == "__main__":
-    component_provider_host([MyComponent])
+    component_provider_host([MyComponent], "exception")

--- a/tests/integration/component_provider/python/recursive-types/provider/__main__.py
+++ b/tests/integration/component_provider/python/recursive-types/provider/__main__.py
@@ -17,4 +17,4 @@ from pulumi.provider.experimental import component_provider_host
 from component import MyComponent
 
 if __name__ == "__main__":
-    component_provider_host([MyComponent], "recursive-types")
+    component_provider_host([MyComponent], "provider")

--- a/tests/integration/component_provider/python/recursive-types/provider/__main__.py
+++ b/tests/integration/component_provider/python/recursive-types/provider/__main__.py
@@ -13,13 +13,8 @@
 # limitations under the License.
 
 
-from pulumi.provider.experimental import Metadata, component_provider_host
+from pulumi.provider.experimental import component_provider_host
 from component import MyComponent
 
 if __name__ == "__main__":
-    component_provider_host(
-        [MyComponent],
-        Metadata(
-            name="provider", version="1.2.3", display_name="My Component Provider"
-        ),
-    )
+    component_provider_host([MyComponent], "recursive-types")

--- a/tests/integration/component_test/python-component/__main__.py
+++ b/tests/integration/component_test/python-component/__main__.py
@@ -1,0 +1,7 @@
+from pulumi.provider.experimental import Metadata, component_provider_host
+from component import MyComponent
+
+if __name__ == "__main__":
+    component_provider_host(
+        [MyComponent], Metadata(name="my-component", version="1.0.0")
+    )

--- a/tests/integration/component_test/python-component/__main__.py
+++ b/tests/integration/component_test/python-component/__main__.py
@@ -1,7 +1,0 @@
-from pulumi.provider.experimental import Metadata, component_provider_host
-from component import MyComponent
-
-if __name__ == "__main__":
-    component_provider_host(
-        [MyComponent], Metadata(name="my-component", version="1.0.0")
-    )

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2534,7 +2534,7 @@ func TestNodejsComponentProviderGetSchema(t *testing.T) {
 	var schema map[string]interface{}
 	require.NoError(t, json.Unmarshal([]byte(stdout), &schema))
 	require.Equal(t, "nodejs-component-provider", schema["name"].(string))
-	require.Nil(t, schema["version"])
+	require.Equal(t, "0.0.0", schema["version"].(string))
 	require.Equal(t, "Node.js Sample Components", schema["description"].(string))
 
 	// Check the component schema

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2541,6 +2541,7 @@ func TestNodejsComponentProviderGetSchema(t *testing.T) {
 	expectedJSON := `{
 		"isComponent": true,
 		"type": "object",
+
 		"inputProperties": {
 			"aNumber": {
 				"type": "number",

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1955,8 +1955,7 @@ func TestPythonComponentProviderGetSchema(t *testing.T) {
 	var schema map[string]interface{}
 	require.NoError(t, json.Unmarshal([]byte(stdout), &schema))
 	require.Equal(t, "provider", schema["name"].(string))
-	require.Equal(t, "1.2.3", schema["version"].(string))
-	require.Equal(t, "My Component Provider", schema["displayName"].(string))
+	require.Equal(t, "provider", schema["displayName"].(string))
 
 	// Check the component schema
 	expectedJSON := `{

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1955,6 +1955,7 @@ func TestPythonComponentProviderGetSchema(t *testing.T) {
 	var schema map[string]interface{}
 	require.NoError(t, json.Unmarshal([]byte(stdout), &schema))
 	require.Equal(t, "provider", schema["name"].(string))
+	require.Equal(t, "0.0.0", schema["version"].(string))
 	require.Equal(t, "provider", schema["displayName"].(string))
 
 	// Check the component schema


### PR DESCRIPTION
Explicitly set the name (and optionally namespace) in `component_provider_host`, and remove `Metadata`.

A future boostrap-less mode will be able to infer the name from `pyproject.toml` (provided we support python packages).