### PR TITLE
Check for typescript errors in components plugin

### DIFF
--- a/changelog/pending/20250321--sdk-nodejs--check-for-typescript-errors-in-components-plugin.yaml
+++ b/changelog/pending/20250321--sdk-nodejs--check-for-typescript-errors-in-components-plugin.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Check for typescript errors in components plugin

--- a/sdk/nodejs/biome.json
+++ b/sdk/nodejs/biome.json
@@ -14,6 +14,7 @@
             "cmd/pulumi-language-nodejs",
             "tests/mockpackage/lib/",
             "tests/runtime/testdata/closure-tests",
+            "tests/provider/experimental/testdata/syntax-error/index.ts",
             "vendor/"
         ]
     },

--- a/sdk/nodejs/provider/experimental/analyzer.ts
+++ b/sdk/nodejs/provider/experimental/analyzer.ts
@@ -88,6 +88,23 @@ export class Analyzer {
     }
 
     public analyze(): AnalyzeResult {
+        // Check for any errors in the source files
+        const diagnostics = ts.getPreEmitDiagnostics(this.program);
+        if (diagnostics.length > 0) {
+            const formattedDiagnostics = diagnostics
+                .map((diagnostic) => {
+                    const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+                    if (diagnostic.file) {
+                        const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start!);
+                        const fileName = path.relative(this.program.getCurrentDirectory(), diagnostic.file.fileName);
+                        return `${fileName}(${line + 1},${character + 1}): ${message}`;
+                    }
+                    return message;
+                })
+                .join("\n");
+            throw new Error(`TypeScript errors detected:\n${formattedDiagnostics}`);
+        }
+
         const sourceFiles = this.program.getSourceFiles();
         for (const sourceFile of sourceFiles) {
             if (sourceFile.fileName.includes("node_modules") || sourceFile.fileName.endsWith(".d.ts")) {

--- a/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
@@ -371,6 +371,19 @@ describe("Analyzer", function () {
         );
     });
 
+    it("errors nicely syntax errors", async function () {
+        const dir = path.join(__dirname, "testdata", "syntax-error");
+        const analyzer = new Analyzer(dir, "provider");
+        assert.throws(
+            () => analyzer.analyze(),
+            (err) =>
+                err.message.startsWith(
+                    "TypeScript errors detected:\n" +
+                        "bin/tests/provider/experimental/testdata/syntax-error/index.ts(15,1): Cannot find name 'syntax'.",
+                ),
+        );
+    });
+
     it("infers component description", async function () {
         const dir = path.join(__dirname, "testdata", "component-description");
         const analyzer = new Analyzer(dir, "provider");

--- a/sdk/nodejs/tests/provider/experimental/testdata/syntax-error/index.ts
+++ b/sdk/nodejs/tests/provider/experimental/testdata/syntax-error/index.ts
@@ -2,9 +2,14 @@
 
 import * as pulumi from "@pulumi/pulumi";
 
+export interface MyComponentArgs {
+    a: pulumi.Input<string>;
+}
+
 export class MyComponent extends pulumi.ComponentResource {
-    constructor(name: string, args: number, opts?: pulumi.ComponentResourceOptions) {
-        // @ts-ignore
+    constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
         super("provider:index:MyComponent", name, args, opts);
     }
 }
+
+syntax error here


### PR DESCRIPTION
When analyzing a components plugin, check for TypeScript errors and report them to the user.

Part of https://github.com/pulumi/pulumi/issues/18692