### PR TITLE
gitutil: use access tokens from environment if possible

### DIFF
--- a/changelog/pending/20250321--cli-package--support-github_token-and-gitlab_token-in-pulumi-package-add-for-git-packages.yaml
+++ b/changelog/pending/20250321--cli-package--support-github_token-and-gitlab_token-in-pulumi-package-add-for-git-packages.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/package
+  description: Support GITHUB_TOKEN and GITLAB_TOKEN in `pulumi package add` for Git packages

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -356,6 +356,11 @@ func getAuthForURL(url string) (string, transport.AuthMethod, error) {
 				Username: "oauth2",
 				Password: os.Getenv("GITLAB_TOKEN"),
 			}
+		} else if os.Getenv("GIT_USERNAME") != "" || os.Getenv("GIT_PASSWORD") != "" {
+			auth = &http.BasicAuth{
+				Username: os.Getenv("GIT_USERNAME"),
+				Password: os.Getenv("GIT_PASSWORD"),
+			}
 		}
 	}
 

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -435,7 +435,9 @@ func TestParseAuthURL(t *testing.T) {
 	})
 
 	t.Run("with basic auth user", func(t *testing.T) {
-		t.Parallel()
+		t.Setenv("GITHUB_TOKEN", "")
+		t.Setenv("GITLAB_TOKEN", "")
+
 		url, auth, err := getAuthForURL("http://user@github.com/pulumi/templates")
 		assert.NoError(t, err)
 		assert.Equal(t, &http.BasicAuth{Username: "user"}, auth)
@@ -463,6 +465,7 @@ func TestParseAuthURL(t *testing.T) {
 
 	t.Run("with GITLAB_TOKEN set in environment", func(t *testing.T) {
 		t.Setenv("GITLAB_TOKEN", "token-1")
+		t.Setenv("GITHUB_TOKEN", "")
 		_, auth, err := getAuthForURL("http://gitlab.com/pulumi/templates")
 		assert.NoError(t, err)
 		assert.Equal(t, &http.BasicAuth{Username: "oauth2", Password: "token-1"}, auth)

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -428,7 +428,9 @@ func TestParseAuthURL(t *testing.T) {
 	}
 
 	t.Run("with no auth", func(t *testing.T) {
-		t.Parallel()
+		t.Setenv("GITHUB_TOKEN", "")
+		t.Setenv("GITLAB_TOKEN", "")
+
 		_, auth, err := getAuthForURL("http://github.com/pulumi/templates")
 		assert.NoError(t, err)
 		assert.Nil(t, auth)
@@ -473,6 +475,14 @@ func TestParseAuthURL(t *testing.T) {
 		_, auth, err = getAuthForURL("http://github.com/pulumi/templates")
 		assert.NoError(t, err)
 		assert.Nil(t, auth)
+	})
+
+	t.Run("with GIT_USERNAME/GIT_PASSWORD set in environment", func(t *testing.T) {
+		t.Setenv("GIT_USERNAME", "user")
+		t.Setenv("GIT_PASSWORD", "password")
+		_, auth, err := getAuthForURL("http://example.com/pulumi/templates")
+		assert.NoError(t, err)
+		assert.Equal(t, &http.BasicAuth{Username: "user", Password: "password"}, auth)
 	})
 
 	//nolint:paralleltest // global environment variables


### PR DESCRIPTION
When cloning using our gitutil, we try to paste the URL and get access tokens.  However we currently don't support such URLs in `package add`, and it's often more convenient to set the authentication in the environment.  Allow setting the `GITHUB_TOKEN` and `GITLAB_TOKEN` environment variables for authentication.