### PR TITLE
Add TODO to liftOperationType call

### DIFF
--- a/pkg/codegen/hcl2/model/expression.go
+++ b/pkg/codegen/hcl2/model/expression.go
@@ -1050,9 +1050,12 @@ func (x *FunctionCallExpression) Typecheck(typecheckOperands bool) hcl.Diagnosti
 	typecheckDiags := typecheckArgs(rng, x.Signature, x.Args...)
 	diagnostics = append(diagnostics, typecheckDiags...)
 
+	// TODO(https://github.com/pulumi/pulumi/issues/8439): This lifting is overly aggressive, we special case this for
+	// pulumiResourceName and pulumiResourceType as they should return a plain string even with an output input. But
+	// this should be covered more generally, only lifting when needed.
+	//
 	// Unless the function is already automatically using an Output-returning version, modify the signature to account
-	// for automatic lifting to Promise or Output. Note we skip this for pulumiResourceName and pulumiResourceType as
-	// they should return a plain string even with an output input.
+	// for automatic lifting to Promise or Output.
 	if x.Name != "pulumiResourceName" && x.Name != "pulumiResourceType" {
 		_, isOutput := x.Signature.ReturnType.(*OutputType)
 		if !isOutput {


### PR DESCRIPTION
I special cased this lift for pulumiResourceType/Name the other day and wrote a comment saying we were skipping them. But found we actually already had an issue that described how this lift was over eager and if we fixed this generally it would cover pulumiResourceType/Name as well. Rewording the comment and adding the link to the issue in so that we don't have to re-discover this.