### PR TITLE
Use RequireSingleResource consistently through conformance tests

### DIFF
--- a/cmd/pulumi-test-language/tests/l1_builtin_can.go
+++ b/cmd/pulumi-test-language/tests/l1_builtin_can.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -35,10 +34,7 @@ func init() {
 					snap *deploy.Snapshot, changes display.ResourceChanges,
 				) {
 					RequireStackResource(l, err, changes)
-
-					require.NotEmpty(l, snap.Resources, "expected at least 1 resource")
-					stack := snap.Resources[0]
-					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 
 					outputs := stack.Outputs
 

--- a/cmd/pulumi-test-language/tests/l1_builtin_info.go
+++ b/cmd/pulumi-test-language/tests/l1_builtin_info.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -31,10 +30,7 @@ func init() {
 					snap *deploy.Snapshot, changes display.ResourceChanges,
 				) {
 					RequireStackResource(l, err, changes)
-
-					require.NotEmpty(l, snap.Resources, "expected at least 1 resource")
-					stack := snap.Resources[0]
-					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 
 					outputs := stack.Outputs
 

--- a/cmd/pulumi-test-language/tests/l1_builtin_project_root.go
+++ b/cmd/pulumi-test-language/tests/l1_builtin_project_root.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -35,10 +34,7 @@ func init() {
 					snap *deploy.Snapshot, changes display.ResourceChanges,
 				) {
 					RequireStackResource(l, err, changes)
-
-					require.NotEmpty(l, snap.Resources, "expected at least 1 resource")
-					stack := snap.Resources[0]
-					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 
 					outputs := stack.Outputs
 

--- a/cmd/pulumi-test-language/tests/l1_builtin_try.go
+++ b/cmd/pulumi-test-language/tests/l1_builtin_try.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -36,10 +35,7 @@ func init() {
 					snap *deploy.Snapshot, changes display.ResourceChanges,
 				) {
 					RequireStackResource(l, err, changes)
-
-					require.NotEmpty(l, snap.Resources, "expected at least 1 resource")
-					stack := snap.Resources[0]
-					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 
 					outputs := stack.Outputs
 

--- a/cmd/pulumi-test-language/tests/l1_config_types.go
+++ b/cmd/pulumi-test-language/tests/l1_config_types.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -39,10 +38,7 @@ func init() {
 					snap *deploy.Snapshot, changes display.ResourceChanges,
 				) {
 					RequireStackResource(l, err, changes)
-
-					require.NotEmpty(l, snap.Resources, "expected at least 1 resource")
-					stack := snap.Resources[0]
-					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 
 					outputs := stack.Outputs
 

--- a/cmd/pulumi-test-language/tests/l1_keyword_overlap.go
+++ b/cmd/pulumi-test-language/tests/l1_keyword_overlap.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -30,10 +29,7 @@ func init() {
 					snap *deploy.Snapshot, changes display.ResourceChanges,
 				) {
 					RequireStackResource(l, err, changes)
-
-					require.NotEmpty(l, snap.Resources, "expected at least 1 resource")
-					stack := snap.Resources[0]
-					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 
 					outputs := stack.Outputs
 

--- a/cmd/pulumi-test-language/tests/l1_main.go
+++ b/cmd/pulumi-test-language/tests/l1_main.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -31,11 +30,9 @@ func init() {
 					snap *deploy.Snapshot, changes display.ResourceChanges,
 				) {
 					RequireStackResource(l, err, changes)
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 
 					// Check we have an output in the stack for true
-					require.NotEmpty(l, snap.Resources, "expected at least 1 resource")
-					stack := snap.Resources[0]
-					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
 
 					outputs := stack.Outputs
 

--- a/cmd/pulumi-test-language/tests/l1_output_array.go
+++ b/cmd/pulumi-test-language/tests/l1_output_array.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -31,10 +30,7 @@ func init() {
 					snap *deploy.Snapshot, changes display.ResourceChanges,
 				) {
 					RequireStackResource(l, err, changes)
-
-					require.NotEmpty(l, snap.Resources, "expected at least 1 resource")
-					stack := snap.Resources[0]
-					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 
 					outputs := stack.Outputs
 

--- a/cmd/pulumi-test-language/tests/l1_output_bool.go
+++ b/cmd/pulumi-test-language/tests/l1_output_bool.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -30,11 +29,9 @@ func init() {
 					snap *deploy.Snapshot, changes display.ResourceChanges,
 				) {
 					RequireStackResource(l, err, changes)
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 
 					// Check we have two outputs in the stack for true and false
-					require.NotEmpty(l, snap.Resources, "expected at least 1 resource")
-					stack := snap.Resources[0]
-					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
 
 					outputs := stack.Outputs
 

--- a/cmd/pulumi-test-language/tests/l1_output_map.go
+++ b/cmd/pulumi-test-language/tests/l1_output_map.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -31,10 +30,7 @@ func init() {
 					snap *deploy.Snapshot, changes display.ResourceChanges,
 				) {
 					RequireStackResource(l, err, changes)
-
-					require.NotEmpty(l, snap.Resources, "expected at least 1 resource")
-					stack := snap.Resources[0]
-					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 
 					outputs := stack.Outputs
 

--- a/cmd/pulumi-test-language/tests/l1_output_number.go
+++ b/cmd/pulumi-test-language/tests/l1_output_number.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -33,10 +32,7 @@ func init() {
 					snap *deploy.Snapshot, changes display.ResourceChanges,
 				) {
 					RequireStackResource(l, err, changes)
-
-					require.NotEmpty(l, snap.Resources, "expected at least 1 resource")
-					stack := snap.Resources[0]
-					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 
 					outputs := stack.Outputs
 

--- a/cmd/pulumi-test-language/tests/l1_output_string.go
+++ b/cmd/pulumi-test-language/tests/l1_output_string.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -33,10 +32,7 @@ func init() {
 					snap *deploy.Snapshot, changes display.ResourceChanges,
 				) {
 					RequireStackResource(l, err, changes)
-
-					require.NotEmpty(l, snap.Resources, "expected at least 1 resource")
-					stack := snap.Resources[0]
-					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 
 					outputs := stack.Outputs
 

--- a/cmd/pulumi-test-language/tests/l1_proxy_index.go
+++ b/cmd/pulumi-test-language/tests/l1_proxy_index.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -36,10 +35,7 @@ func init() {
 					snap *deploy.Snapshot, changes display.ResourceChanges,
 				) {
 					RequireStackResource(l, err, changes)
-
-					require.NotEmpty(l, snap.Resources, "expected at least 1 resource")
-					stack := snap.Resources[0]
-					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 
 					outputs := stack.Outputs
 

--- a/cmd/pulumi-test-language/tests/l1_stack_reference.go
+++ b/cmd/pulumi-test-language/tests/l1_stack_reference.go
@@ -37,14 +37,11 @@ func init() {
 					snap *deploy.Snapshot, changes display.ResourceChanges,
 				) {
 					RequireStackResource(l, err, changes)
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 
 					require.Len(l, snap.Resources, 3, "expected at least 3 resources")
-					stack := snap.Resources[0]
-					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
-					prov := snap.Resources[1]
-					require.Equal(l, "pulumi:providers:pulumi", prov.Type.String(), "expected a default pulumi provider resource")
-					ref := snap.Resources[2]
-					require.Equal(l, "pulumi:pulumi:StackReference", ref.Type.String(), "expected a stack reference resource")
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:pulumi")
+					RequireSingleResource(l, snap.Resources, "pulumi:pulumi:StackReference")
 
 					outputs := stack.Outputs
 

--- a/cmd/pulumi-test-language/tests/l2_component_call_simple.go
+++ b/cmd/pulumi-test-language/tests/l2_component_call_simple.go
@@ -57,7 +57,7 @@ func init() {
 						"expected default component provider",
 					)
 
-					stack := snap.Resources[0]
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 					component1 := RequireSingleNamedResource(l, snap.Resources, "component1")
 
 					// component1 should satisfy the following properties:

--- a/cmd/pulumi-test-language/tests/l2_destroy.go
+++ b/cmd/pulumi-test-language/tests/l2_destroy.go
@@ -15,8 +15,6 @@
 package tests
 
 import (
-	"sort"
-
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -38,22 +36,12 @@ func init() {
 					require.Len(l, snap.Resources, 4, "expected 4 resources in snapshot")
 
 					// check that both expected resources are in the snapshot
-					provider := snap.Resources[1]
-					assert.Equal(l, "pulumi:providers:simple", provider.Type.String(), "expected simple provider")
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:simple")
 
-					// Make sure we can assert the resource names in a consistent order
-					sort.Slice(snap.Resources[2:4], func(i, j int) bool {
-						i = i + 2
-						j = j + 2
-						return snap.Resources[i].URN.Name() < snap.Resources[j].URN.Name()
-					})
-
-					simple := snap.Resources[2]
+					simple := RequireSingleNamedResource(l, snap.Resources, "aresource")
 					assert.Equal(l, "simple:index:Resource", simple.Type.String(), "expected simple resource")
-					assert.Equal(l, "aresource", simple.URN.Name(), "expected aresource resource")
-					simple2 := snap.Resources[3]
+					simple2 := RequireSingleNamedResource(l, snap.Resources, "other")
 					assert.Equal(l, "simple:index:Resource", simple2.Type.String(), "expected simple resource")
-					assert.Equal(l, "other", simple2.URN.Name(), "expected other resource")
 				},
 			},
 			{
@@ -64,13 +52,11 @@ func init() {
 					assert.Equal(l, 1, changes[deploy.OpDelete], "expected a delete operation")
 					require.Len(l, snap.Resources, 3, "expected 3 resources in snapshot")
 
-					// No need to sort here, since we have only resources that depend on each other in a chain.
-					provider := snap.Resources[1]
-					assert.Equal(l, "pulumi:providers:simple", provider.Type.String(), "expected simple provider")
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:simple")
+
 					// check that only the expected resource is left in the snapshot
-					simple := snap.Resources[2]
+					simple := RequireSingleNamedResource(l, snap.Resources, "aresource")
 					assert.Equal(l, "simple:index:Resource", simple.Type.String(), "expected simple resource")
-					assert.Equal(l, "aresource", simple.URN.Name(), "expected aresource resource")
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l2_engine_update_options.go
+++ b/cmd/pulumi-test-language/tests/l2_engine_update_options.go
@@ -19,9 +19,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,12 +41,9 @@ func init() {
 					require.Len(l, snap.Resources, 3, "expected 2 resource in snapshot")
 
 					// Check that we have the target in the snapshot, but not the other resource.
-					stack := snap.Resources[0]
-					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
-					provider := snap.Resources[1]
-					assert.Equal(l, "pulumi:providers:simple", provider.Type.String(), "expected simple provider")
-					target := snap.Resources[2]
-					require.Equal(l, "simple:index:Resource", target.Type.String(), "expected simple resource")
+					RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:simple")
+					target := RequireSingleResource(l, snap.Resources, "simple:index:Resource")
 					require.Equal(l, "target", target.URN.Name(), "expected target resource")
 				},
 			},

--- a/cmd/pulumi-test-language/tests/l2_explicit_parameterized_provider.go
+++ b/cmd/pulumi-test-language/tests/l2_explicit_parameterized_provider.go
@@ -38,19 +38,16 @@ func init() {
 					// Check we have the one resource in the snapshot, its provider and the stack.
 					require.Len(l, snap.Resources, 3, "expected 3 resources in snapshot")
 
-					stack := snap.Resources[0]
-					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 					require.Equal(l,
 						resource.NewStringProperty("Goodbye World"),
 						stack.Outputs["parameterValue"],
 						"parameter value and provider config should be correct")
 
-					provider := snap.Resources[1]
-					assert.Equal(l, "pulumi:providers:goodbye", provider.Type.String(), "expected goodbye provider")
+					provider := RequireSingleResource(l, snap.Resources, "pulumi:providers:goodbye")
 					assert.Equal(l, "prov", provider.URN.Name(), "expected explicit provider resource")
 
-					simple := snap.Resources[2]
-					assert.Equal(l, "goodbye:index:Goodbye", simple.Type.String(), "expected Goodbye resource")
+					simple := RequireSingleResource(l, snap.Resources, "goodbye:index:Goodbye")
 					assert.Equal(l, string(provider.URN)+"::"+string(provider.ID), simple.Provider)
 				},
 			},

--- a/cmd/pulumi-test-language/tests/l2_explicit_provider.go
+++ b/cmd/pulumi-test-language/tests/l2_explicit_provider.go
@@ -38,12 +38,10 @@ func init() {
 					// Check we have the one simple resource in the snapshot, its provider and the stack.
 					require.Len(l, snap.Resources, 3, "expected 3 resources in snapshot")
 
-					provider := snap.Resources[1]
-					assert.Equal(l, "pulumi:providers:simple", provider.Type.String(), "expected simple provider")
+					provider := RequireSingleResource(l, snap.Resources, "pulumi:providers:simple")
 					assert.Equal(l, "prov", provider.URN.Name(), "expected explicit provider resource")
 
-					simple := snap.Resources[2]
-					assert.Equal(l, "simple:index:Resource", simple.Type.String(), "expected simple resource")
+					simple := RequireSingleResource(l, snap.Resources, "simple:index:Resource")
 					assert.Equal(l, string(provider.URN)+"::"+string(provider.ID), simple.Provider)
 
 					want := resource.NewPropertyMapFromMap(map[string]any{"value": true})

--- a/cmd/pulumi-test-language/tests/l2_large_string.go
+++ b/cmd/pulumi-test-language/tests/l2_large_string.go
@@ -39,8 +39,7 @@ func init() {
 
 					// Check that the large string is in the snapshot
 					largeString := resource.NewStringProperty(strings.Repeat("hello world", 9532509))
-					large := snap.Resources[2]
-					require.Equal(l, "large:index:String", large.Type.String(), "expected large string resource")
+					large := RequireSingleResource(l, snap.Resources, "large:index:String")
 					require.Equal(l,
 						resource.NewStringProperty("hello world"),
 						large.Inputs["value"],
@@ -51,7 +50,7 @@ func init() {
 					)
 
 					// Check the stack output value is as well
-					stack := snap.Resources[0]
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
 					require.Equal(l, largeString, stack.Outputs["output"], "expected large string stack output")
 				},

--- a/cmd/pulumi-test-language/tests/l2_namespaced_provider.go
+++ b/cmd/pulumi-test-language/tests/l2_namespaced_provider.go
@@ -37,10 +37,10 @@ func init() {
 					// Check we have the one resource of the namespaced provider in the snapshot, its provider and the stack.
 					require.Len(l, snap.Resources, 3, "expected 3 resources in snapshot")
 
-					provider := snap.Resources[1]
+					provider := RequireSingleResource(l, snap.Resources, "pulumi:providers:namespaced")
 					require.Equal(l, "pulumi:providers:namespaced", provider.Type.String(), "expected namespaced provider")
 
-					namespaced := snap.Resources[2]
+					namespaced := RequireSingleResource(l, snap.Resources, "namespaced:index:Resource")
 					require.Equal(l, "namespaced:index:Resource", namespaced.Type.String(), "expected namespaced resource")
 
 					want := resource.NewPropertyMapFromMap(map[string]interface{}{"value": true})

--- a/cmd/pulumi-test-language/tests/l2_parameterized_resource.go
+++ b/cmd/pulumi-test-language/tests/l2_parameterized_resource.go
@@ -33,8 +33,7 @@ func init() {
 					snap *deploy.Snapshot, changes display.ResourceChanges,
 				) {
 					RequireStackResource(l, err, changes)
-					stack := snap.Resources[0]
-					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 					require.Equal(l,
 						resource.NewStringProperty("HelloWorld"),
 						stack.Outputs["parameterValue"],

--- a/cmd/pulumi-test-language/tests/l2_plain.go
+++ b/cmd/pulumi-test-language/tests/l2_plain.go
@@ -38,11 +38,8 @@ func init() {
 					// Check we have the one simple resource in the snapshot, its provider and the stack.
 					require.Len(l, snap.Resources, 3, "expected 3 resources in snapshot")
 
-					provider := snap.Resources[1]
-					assert.Equal(l, "pulumi:providers:plain", provider.Type.String(), "expected plain provider")
-
-					plain := snap.Resources[2]
-					assert.Equal(l, "plain:index:Resource", plain.Type.String(), "expected plain resource")
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:plain")
+					plain := RequireSingleResource(l, snap.Resources, "plain:index:Resource")
 
 					want := resource.NewPropertyMapFromMap(map[string]any{
 						"data": resource.NewPropertyMapFromMap(map[string]any{

--- a/cmd/pulumi-test-language/tests/l2_primitive_ref.go
+++ b/cmd/pulumi-test-language/tests/l2_primitive_ref.go
@@ -38,11 +38,8 @@ func init() {
 					// Check we have the one simple resource in the snapshot, its provider and the stack.
 					require.Len(l, snap.Resources, 3, "expected 3 resources in snapshot")
 
-					provider := snap.Resources[1]
-					assert.Equal(l, "pulumi:providers:primitive-ref", provider.Type.String(), "expected primitive-ref provider")
-
-					simple := snap.Resources[2]
-					assert.Equal(l, "primitive-ref:index:Resource", simple.Type.String(), "expected primitive-ref resource")
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:primitive-ref")
+					simple := RequireSingleResource(l, snap.Resources, "primitive-ref:index:Resource")
 
 					want := resource.NewPropertyMapFromMap(map[string]any{
 						"data": resource.NewPropertyMapFromMap(map[string]any{

--- a/cmd/pulumi-test-language/tests/l2_provider_call.go
+++ b/cmd/pulumi-test-language/tests/l2_provider_call.go
@@ -59,7 +59,7 @@ func init() {
 						"expected default call provider",
 					)
 
-					stack := snap.Resources[0]
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 
 					// The stack should have the following outputs:
 					//

--- a/cmd/pulumi-test-language/tests/l2_proxy_index.go
+++ b/cmd/pulumi-test-language/tests/l2_proxy_index.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -34,10 +33,7 @@ func init() {
 					snap *deploy.Snapshot, changes display.ResourceChanges,
 				) {
 					RequireStackResource(l, err, changes)
-
-					require.NotEmpty(l, snap.Resources, "expected at least 1 resource")
-					stack := snap.Resources[0]
-					require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 
 					outputs := stack.Outputs
 

--- a/cmd/pulumi-test-language/tests/l2_ref_ref.go
+++ b/cmd/pulumi-test-language/tests/l2_ref_ref.go
@@ -38,11 +38,8 @@ func init() {
 					// Check we have the one simple resource in the snapshot, its provider and the stack.
 					require.Len(l, snap.Resources, 3, "expected 3 resources in snapshot")
 
-					provider := snap.Resources[1]
-					assert.Equal(l, "pulumi:providers:ref-ref", provider.Type.String(), "expected ref-ref provider")
-
-					simple := snap.Resources[2]
-					assert.Equal(l, "ref-ref:index:Resource", simple.Type.String(), "expected ref-ref resource")
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:ref-ref")
+					simple := RequireSingleResource(l, snap.Resources, "ref-ref:index:Resource")
 
 					want := resource.NewPropertyMapFromMap(map[string]any{
 						"data": resource.NewPropertyMapFromMap(map[string]any{

--- a/cmd/pulumi-test-language/tests/l2_resource_alpha.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_alpha.go
@@ -38,15 +38,12 @@ func init() {
 					// Check we have the one simple resource in the snapshot, its provider and the stack.
 					require.Len(l, snap.Resources, 3, "expected 3 resources in snapshot")
 
-					provider := snap.Resources[1]
-					assert.Equal(l, "pulumi:providers:alpha", provider.Type.String(), "expected alpha provider")
-
-					simple := snap.Resources[2]
-					assert.Equal(l, "alpha:index:Resource", simple.Type.String(), "expected alpha resource")
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:alpha")
+					alpha := RequireSingleResource(l, snap.Resources, "alpha:index:Resource")
 
 					want := resource.NewPropertyMapFromMap(map[string]any{"value": true})
-					assert.Equal(l, want, simple.Inputs, "expected inputs to be {value: true}")
-					assert.Equal(l, simple.Inputs, simple.Outputs, "expected inputs and outputs to match")
+					assert.Equal(l, want, alpha.Inputs, "expected inputs to be {value: true}")
+					assert.Equal(l, alpha.Inputs, alpha.Outputs, "expected inputs and outputs to match")
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l2_resource_asset_archive.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_asset_archive.go
@@ -41,8 +41,7 @@ func init() {
 					// Check we have the the asset, archive, and folder resources in the snapshot, the provider and the stack.
 					require.Len(l, snap.Resources, 7, "expected 7 resources in snapshot")
 
-					provider := snap.Resources[1]
-					assert.Equal(l, "pulumi:providers:asset-archive", provider.Type.String(), "expected asset-archive provider")
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:asset-archive")
 
 					// We don't know what order the resources will be in so we map by name
 					resources := map[string]*resource.State{}

--- a/cmd/pulumi-test-language/tests/l2_resource_config.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_config.go
@@ -40,7 +40,7 @@ func init() {
 					RequireStackResource(l, err, changes)
 					require.Len(l, snap.Resources, 4, "expected 4 resources in snapshot")
 
-					explicitProvider := snap.Resources[1]
+					explicitProvider := RequireSingleNamedResource(l, snap.Resources, "prov")
 					require.Equal(l, "pulumi:providers:config", explicitProvider.Type.String(), "expected explicit provider resource")
 					expectedOutputs := resource.NewPropertyMapFromMap(map[string]interface{}{
 						"name":              "my config",
@@ -56,9 +56,8 @@ func init() {
 					require.Equal(l, expectedInputs, explicitProvider.Inputs)
 					require.Equal(l, expectedOutputs, explicitProvider.Outputs)
 
-					defaultProvider := snap.Resources[2]
+					defaultProvider := RequireSingleNamedResource(l, snap.Resources, "default_9_0_0_http_/example.com")
 					require.Equal(l, "pulumi:providers:config", defaultProvider.Type.String(), "expected default provider resource")
-					require.Equal(l, "default_9_0_0_http_/example.com", defaultProvider.URN.Name())
 					expectedOutputs = resource.NewPropertyMapFromMap(map[string]interface{}{
 						"version": "9.0.0",
 						"name":    "hello",

--- a/cmd/pulumi-test-language/tests/l2_resource_keyword_overlap.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_keyword_overlap.go
@@ -33,8 +33,7 @@ func init() {
 				) {
 					RequireStackResource(l, err, changes)
 
-					provider := snap.Resources[1]
-					assert.Equal(l, "pulumi:providers:simple", provider.Type.String(), "expected simple provider")
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:simple")
 
 					classRes := RequireSingleNamedResource(l, snap.Resources, "class")
 					assert.Equal(l, "simple:index:Resource", classRes.Type.String())

--- a/cmd/pulumi-test-language/tests/l2_resource_primitives.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_primitives.go
@@ -38,11 +38,8 @@ func init() {
 					// Check we have the one simple resource in the snapshot, its provider and the stack.
 					require.Len(l, snap.Resources, 3, "expected 3 resources in snapshot")
 
-					provider := snap.Resources[1]
-					assert.Equal(l, "pulumi:providers:primitive", provider.Type.String(), "expected primitive provider")
-
-					simple := snap.Resources[2]
-					assert.Equal(l, "primitive:index:Resource", simple.Type.String(), "expected primitive resource")
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:primitive")
+					prim := RequireSingleResource(l, snap.Resources, "primitive:index:Resource")
 
 					want := resource.NewPropertyMapFromMap(map[string]any{
 						"boolean":     true,
@@ -52,8 +49,8 @@ func init() {
 						"numberArray": []interface{}{-1.0, 0.0, 1.0},
 						"booleanMap":  map[string]interface{}{"t": true, "f": false},
 					})
-					assert.Equal(l, want, simple.Inputs, "expected inputs to be %v", want)
-					assert.Equal(l, simple.Inputs, simple.Outputs, "expected inputs and outputs to match")
+					assert.Equal(l, want, prim.Inputs, "expected inputs to be %v", want)
+					assert.Equal(l, prim.Inputs, prim.Outputs, "expected inputs and outputs to match")
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l2_resource_secret.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_secret.go
@@ -38,11 +38,8 @@ func init() {
 					// Check we have the one simple resource in the snapshot, its provider and the stack.
 					require.Len(l, snap.Resources, 3, "expected 3 resources in snapshot")
 
-					provider := snap.Resources[1]
-					assert.Equal(l, "pulumi:providers:secret", provider.Type.String(), "expected secret provider")
-
-					simple := snap.Resources[2]
-					assert.Equal(l, "secret:index:Resource", simple.Type.String(), "expected secret resource")
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:secret")
+					secret := RequireSingleResource(l, snap.Resources, "secret:index:Resource")
 
 					want := resource.NewPropertyMapFromMap(map[string]any{
 						"public":  "open",
@@ -59,8 +56,8 @@ func init() {
 							"private": "closed",
 						}))),
 					})
-					assert.Equal(l, want, simple.Inputs, "expected inputs to be %v", want)
-					assert.Equal(l, simple.Inputs, simple.Outputs, "expected inputs and outputs to match")
+					assert.Equal(l, want, secret.Inputs, "expected inputs to be %v", want)
+					assert.Equal(l, secret.Inputs, secret.Outputs, "expected inputs and outputs to match")
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l2_resource_simple.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_simple.go
@@ -38,11 +38,8 @@ func init() {
 					// Check we have the one simple resource in the snapshot, its provider and the stack.
 					require.Len(l, snap.Resources, 3, "expected 3 resources in snapshot")
 
-					provider := snap.Resources[1]
-					assert.Equal(l, "pulumi:providers:simple", provider.Type.String(), "expected simple provider")
-
-					simple := snap.Resources[2]
-					assert.Equal(l, "simple:index:Resource", simple.Type.String(), "expected simple resource")
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:simple")
+					simple := RequireSingleResource(l, snap.Resources, "simple:index:Resource")
 
 					want := resource.NewPropertyMapFromMap(map[string]any{"value": true})
 					assert.Equal(l, want, simple.Inputs, "expected inputs to be {value: true}")

--- a/cmd/pulumi-test-language/tests/l2_target_up_with_new_dependency.go
+++ b/cmd/pulumi-test-language/tests/l2_target_up_with_new_dependency.go
@@ -15,8 +15,6 @@
 package tests
 
 import (
-	"sort"
-
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -39,16 +37,11 @@ func init() {
 					err = snap.VerifyIntegrity()
 					require.NoError(l, err, "expected snapshot to be valid")
 
-					sort.Slice(snap.Resources, func(i, j int) bool {
-						return snap.Resources[i].URN.Name() < snap.Resources[j].URN.Name()
-					})
-
-					target := snap.Resources[2]
+					target := RequireSingleNamedResource(l, snap.Resources, "targetOnly")
 					require.Equal(l, "simple:index:Resource", target.Type.String(), "expected simple resource")
-					require.Equal(l, "targetOnly", target.URN.Name(), "expected target resource")
-					unrelated := snap.Resources[3]
+
+					unrelated := RequireSingleNamedResource(l, snap.Resources, "unrelated")
 					require.Equal(l, "simple:index:Resource", unrelated.Type.String(), "expected simple resource")
-					require.Equal(l, "unrelated", unrelated.URN.Name(), "expected target resource")
 					require.Equal(l, 0, len(unrelated.Dependencies), "expected no dependencies")
 				},
 			},
@@ -64,16 +57,10 @@ func init() {
 				) {
 					require.Len(l, snap.Resources, 4, "expected 4 resources in snapshot")
 
-					sort.Slice(snap.Resources, func(i, j int) bool {
-						return snap.Resources[i].URN.Name() < snap.Resources[j].URN.Name()
-					})
-
-					target := snap.Resources[2]
+					target := RequireSingleNamedResource(l, snap.Resources, "targetOnly")
 					require.Equal(l, "simple:index:Resource", target.Type.String(), "expected simple resource")
-					require.Equal(l, "targetOnly", target.URN.Name(), "expected target resource")
-					unrelated := snap.Resources[3]
+					unrelated := RequireSingleNamedResource(l, snap.Resources, "unrelated")
 					require.Equal(l, "simple:index:Resource", unrelated.Type.String(), "expected simple resource")
-					require.Equal(l, "unrelated", unrelated.URN.Name(), "expected target resource")
 					require.Equal(l, 0, len(unrelated.Dependencies), "expected still no dependencies")
 				},
 			},


### PR DESCRIPTION
This removes all the explicit indexing into the Resource snapshot (and the associated sorts that were sometimes required to make that work) and instead consistently uses the search functions `RequireSingleResource` and `RequireSingleNamedResource`.