### PR TITLE
pass in valid info/error writers in test

### DIFF
--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1318,7 +1318,8 @@ func TestPolicyPluginExtraArguments(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, tc.InstallDependencies(context.Background(),
-		filepath.Join(e.CWD, "python_policy_pack"), false /*useLanguageVersionTools*/, false /*showOutput */, nil, nil))
+		filepath.Join(e.CWD, "python_policy_pack"), false /*useLanguageVersionTools*/, false, /*showOutput */
+		os.Stdout, os.Stderr))
 	sdkDir, err := filepath.Abs(filepath.Join("..", "..", "sdk", "python"))
 	require.NoError(t, err)
 	gotSdk, err := test.PathExists(sdkDir)


### PR DESCRIPTION
We pass in nil for the info/error writers in InstallDependencies, which means that if there is an actual error we panic and don't have any valid error output.  Fix that by passing in `os.Stdout` and `os.Stderr`, which go test will then print.

*Something* fails when trying to merge https://github.com/pulumi/pulumi/actions/runs/14039014408/job/39304652576, but it's impossible to see what because of the panic.