### PR TITLE
`pulumi package gen-sdk`: newline character

### DIFF
--- a/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
@@ -88,14 +88,14 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 						return err
 					}
 				}
-				fmt.Fprintf(os.Stderr, "SDKs have been written to %s", out)
+				fmt.Fprintf(os.Stderr, "SDKs have been written to %s\n", out)
 				return nil
 			}
 			err = GenSDK(language, out, pkg, overlays, local)
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(os.Stderr, "SDK has been written to %s", filepath.Join(out, language))
+			fmt.Fprintf(os.Stderr, "SDK has been written to %s\n", filepath.Join(out, language))
 			return nil
 		},
 	}


### PR DESCRIPTION
A fix for a formatting issue with the `gen-sdk` command.  Given a make routine that generates SDK code before running some gotests, we see the phrase `SDK has been written to sdk/go` with improper formatting:
```plain
❯ make examples/random-login/test
go build -C examples/random-login -o ../../bin/examples/pulumi-resource-random-login github.com/pulumi/pulumi-go-provider/examples/random-login
pulumi package get-schema ./bin/examples/pulumi-resource-random-login > examples/random-login/schema.json
SDK has been written to sdk/gook        github.com/pulumi/pulumi-go-provider/examples/random-login      (cached)
?       github.com/pulumi/pulumi-go-provider/examples/random-login/sdk/go/randomlogin   [no test files]
?       github.com/pulumi/pulumi-go-provider/examples/random-login/sdk/go/randomlogin/config    [no test files]
?       github.com/pulumi/pulumi-go-provider/examples/random-login/sdk/go/randomlogin/internal  [no test files]
```