### PR TITLE
Support `GetRequiredPackages` in the Python Automation API

### DIFF
--- a/changelog/pending/20250325--sdk-python--add-getrequiredpackages-to-the-python-automation-api.yaml
+++ b/changelog/pending/20250325--sdk-python--add-getrequiredpackages-to-the-python-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Add `GetRequiredPackages` to the Python Automation API

--- a/changelog/pending/20250325--sdk-python--add-getrequiredpackages-to-the-python-automation-api.yaml
+++ b/changelog/pending/20250325--sdk-python--add-getrequiredpackages-to-the-python-automation-api.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: sdk/python
-  description: Add `GetRequiredPackages` to the Python Automation API
+  description: Avoid error messages due to missing a missing implementation of `GetRequiredPackages` in the Python Automation API server

--- a/sdk/python/lib/pulumi/automation/_server.py
+++ b/sdk/python/lib/pulumi/automation/_server.py
@@ -37,6 +37,9 @@ class LanguageServer(LanguageRuntimeServicer):
     def GetRequiredPlugins(self, request, context):
         return language_pb2.GetRequiredPluginsResponse()
 
+    def GetRequiredPackages(self, request, context):
+        return language_pb2.GetRequiredPackagesResponse()
+
     def _exception_handler(self, loop, context):
         # Exception are normally handler deeper in the stack. If this class of
         # exception bubble up to here, something is wrong and we should stop


### PR DESCRIPTION
This command is used as part of `create_or_select_stack`, which has caused problems such as #18955. This PR adds the command to the API, which then fixes the error.

Fixes #18955.