### PR TITLE
use localname for plugin selection for tagged plugins as well

### DIFF
--- a/changelog/pending/20250325--cli-package--use-correct-local-path-for-git-based-components-with-a-version-tag.yaml
+++ b/changelog/pending/20250325--cli-package--use-correct-local-path-for-git-based-components-with-a-version-tag.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/package
+  description: Use correct local path for Git based components with a version tag

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -76,7 +76,8 @@ func TestLegacyPluginSelection_Prerelease(t *testing.T) {
 		},
 	}
 
-	result := LegacySelectCompatiblePlugin(candidatePlugins, apitype.ResourcePlugin, "myplugin", nil)
+	result := LegacySelectCompatiblePlugin(candidatePlugins,
+		PluginSpec{Kind: apitype.ResourcePlugin, Name: "myplugin", Version: nil})
 	assert.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Equal(t, "0.2.0", result.Version.String())
@@ -117,7 +118,8 @@ func TestLegacyPluginSelection_PrereleaseRequested(t *testing.T) {
 	}
 
 	v := semver.MustParse("0.2.0")
-	result := LegacySelectCompatiblePlugin(candidatePlugins, apitype.ResourcePlugin, "myplugin", &v)
+	result := LegacySelectCompatiblePlugin(candidatePlugins,
+		PluginSpec{Kind: apitype.ResourcePlugin, Name: "myplugin", Version: &v})
 	assert.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Equal(t, "0.3.0-alpha", result.Version.String())
@@ -157,8 +159,9 @@ func TestPluginSelection_ExactMatch(t *testing.T) {
 		},
 	}
 
-	requested := semver.MustParseRange("0.2.0")
-	result := SelectCompatiblePlugin(candidatePlugins, apitype.ResourcePlugin, "myplugin", requested)
+	version := semver.MustParse("0.2.0")
+	result := SelectCompatiblePlugin(candidatePlugins,
+		PluginSpec{Kind: apitype.ResourcePlugin, Name: "myplugin", Version: &version})
 	assert.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Equal(t, "0.2.0", result.Version.String())
@@ -198,56 +201,10 @@ func TestPluginSelection_ExactMatchNotFound(t *testing.T) {
 		},
 	}
 
-	requested := semver.MustParseRange("0.2.0")
-	result := SelectCompatiblePlugin(candidatePlugins, apitype.ResourcePlugin, "myplugin", requested)
+	version := semver.MustParse("0.2.0")
+	result := SelectCompatiblePlugin(candidatePlugins,
+		PluginSpec{Kind: apitype.ResourcePlugin, Name: "myplugin", Version: &version})
 	assert.Nil(t, result)
-}
-
-func TestPluginSelection_PatchVersionSlide(t *testing.T) {
-	t.Parallel()
-
-	v1 := semver.MustParse("0.1.0")
-	v2 := semver.MustParse("0.2.0")
-	v21 := semver.MustParse("0.2.1")
-	v3 := semver.MustParse("0.3.0")
-	candidatePlugins := []PluginInfo{
-		{
-			Name:    "myplugin",
-			Kind:    apitype.ResourcePlugin,
-			Version: &v1,
-		},
-		{
-			Name:    "myplugin",
-			Kind:    apitype.ResourcePlugin,
-			Version: &v2,
-		},
-		{
-			Name:    "myplugin",
-			Kind:    apitype.ResourcePlugin,
-			Version: &v21,
-		},
-		{
-			Name:    "myplugin",
-			Kind:    apitype.ResourcePlugin,
-			Version: &v3,
-		},
-		{
-			Name:    "notmyplugin",
-			Kind:    apitype.ResourcePlugin,
-			Version: &v3,
-		},
-		{
-			Name:    "myplugin",
-			Kind:    apitype.AnalyzerPlugin,
-			Version: &v3,
-		},
-	}
-
-	requested := semver.MustParseRange(">=0.2.0 <0.3.0")
-	result := SelectCompatiblePlugin(candidatePlugins, apitype.ResourcePlugin, "myplugin", requested)
-	assert.NotNil(t, result)
-	assert.Equal(t, "myplugin", result.Name)
-	assert.Equal(t, "0.2.1", result.Version.String())
 }
 
 func TestPluginSelection_EmptyVersionNoAlternatives(t *testing.T) {
@@ -289,8 +246,9 @@ func TestPluginSelection_EmptyVersionNoAlternatives(t *testing.T) {
 		},
 	}
 
-	requested := semver.MustParseRange("0.2.0")
-	result := SelectCompatiblePlugin(candidatePlugins, apitype.ResourcePlugin, "myplugin", requested)
+	version := semver.MustParse("0.2.0")
+	result := SelectCompatiblePlugin(candidatePlugins,
+		PluginSpec{Kind: apitype.ResourcePlugin, Name: "myplugin", Version: &version})
 	assert.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Nil(t, result.Version)
@@ -340,8 +298,9 @@ func TestPluginSelection_EmptyVersionWithAlternatives(t *testing.T) {
 		},
 	}
 
-	requested := semver.MustParseRange("0.2.0")
-	result := SelectCompatiblePlugin(candidatePlugins, apitype.ResourcePlugin, "myplugin", requested)
+	version := semver.MustParse("0.2.0")
+	result := SelectCompatiblePlugin(candidatePlugins,
+		PluginSpec{Kind: apitype.ResourcePlugin, Name: "myplugin", Version: &version})
 	assert.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Equal(t, "0.2.0", result.Version.String())

--- a/tests/integration/external_tagged_component/.gitignore
+++ b/tests/integration/external_tagged_component/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/tests/integration/external_tagged_component/Pulumi.yaml
+++ b/tests/integration/external_tagged_component/Pulumi.yaml
@@ -1,0 +1,12 @@
+name: external_tagged_component
+description: A minimal TypeScript Pulumi program
+packages:
+  random-plugin-component: github.com/pulumi/pulumi-yaml/pkg/tests/testdata/component/provider@v1.15.0
+runtime:
+  name: nodejs
+  options:
+    packagemanager: npm
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: typescript

--- a/tests/integration/external_tagged_component/index.ts
+++ b/tests/integration/external_tagged_component/index.ts
@@ -1,0 +1,8 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as randomPluginComponent from "@pulumi/random-plugin-component";
+
+let randomPetGenerator = new randomPluginComponent.RandomPetGenerator("pet", { length: 3, prefix: "test" });
+let randomStringGenerator = new randomPluginComponent.RandomStringGenerator("string", { length: 8 });
+
+export const randomPet = randomPetGenerator.pet;
+export const randomString = randomStringGenerator.string;

--- a/tests/integration/external_tagged_component/package.json
+++ b/tests/integration/external_tagged_component/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "external_tagged_component",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.113.0",
+        "@pulumi/random-plugin-component": "file:sdks/random-plugin-component"
+    }
+}

--- a/tests/integration/external_tagged_component/tsconfig.json
+++ b/tests/integration/external_tagged_component/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1505,3 +1505,36 @@ func TestOverrideComponentNameAndNamespace(t *testing.T) {
 	stdout, _ := e.RunCommand("pulumi", "install")
 	require.Contains(t, stdout, "import * as myComponent from \"@overridden-namespace/my-component\"")
 }
+
+func TestTaggedComponent(t *testing.T) {
+	t.Parallel()
+
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+
+	e.ImportDirectory(filepath.Join("external_tagged_component"))
+
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+
+	e.RunCommand("pulumi", "stack", "init", "organization/component-consumer/test")
+	e.Env = []string{"PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=false"}
+	e.RunCommand("pulumi", "install")
+	stdout, _ := e.RunCommand("pulumi", "plugin", "ls")
+	// Make sure we have exactly the plugin we expect installed
+	assert.Equal(t, 1, strings.Count(stdout, "github.com_pulumi_pulumi-yaml.git"))
+
+	e.Env = []string{}
+	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview", "--yes")
+
+	stdout, _ = e.RunCommand("pulumi", "plugin", "ls")
+	// Make sure we have no additional plugins after the up
+	assert.Equal(t, 1, strings.Count(stdout, "iaersntoiarsntoiarsntoairsetn"))
+
+	stdout, _ = e.RunCommand("pulumi", "stack", "output", "randomPet")
+	// We expect 4 words separated by dashes.
+	require.Equal(t, 4, len(strings.Split(stdout, "-")))
+	require.Equal(t, "test-", stdout[:5])
+
+	stdout, _ = e.RunCommand("pulumi", "stack", "output", "randomString")
+	require.Len(t, strings.TrimSuffix(stdout, "\n"), 8, fmt.Sprintf("expected %s to have 8 characters", stdout))
+}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1516,19 +1516,18 @@ func TestTaggedComponent(t *testing.T) {
 
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 
-	e.RunCommand("pulumi", "stack", "init", "organization/component-consumer/test")
+	e.RunCommand("pulumi", "stack", "init", "organization/external_tagged_component/test")
 	e.Env = []string{"PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=false"}
 	e.RunCommand("pulumi", "install")
 	stdout, _ := e.RunCommand("pulumi", "plugin", "ls")
 	// Make sure we have exactly the plugin we expect installed
 	assert.Equal(t, 1, strings.Count(stdout, "github.com_pulumi_pulumi-yaml.git"))
 
-	e.Env = []string{}
 	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview", "--yes")
 
 	stdout, _ = e.RunCommand("pulumi", "plugin", "ls")
 	// Make sure we have no additional plugins after the up
-	assert.Equal(t, 1, strings.Count(stdout, "iaersntoiarsntoiarsntoairsetn"))
+	assert.Equal(t, 1, strings.Count(stdout, "github.com_pulumi_pulumi-yaml.git"))
 
 	stdout, _ = e.RunCommand("pulumi", "stack", "output", "randomPet")
 	// We expect 4 words separated by dashes.


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/18951, we started passing through PluginSpec to get the plugin info, instead of relying on fixing up the name.  This works great, except that we missed the critical fact that those plugins can also have tagged versions, and the codepath to find those tagged plugins is different.

Make sure we also pick up the plugins using their local names for tagged plugins as well.

Part of https://github.com/pulumi/pulumi/issues/19022