### PR TITLE
Delete unused `DeleteEnvironmentFallible` method

### DIFF
--- a/sdk/go/common/testing/environment.go
+++ b/sdk/go/common/testing/environment.go
@@ -16,7 +16,6 @@ package testing
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -131,15 +130,6 @@ func (e *Environment) DeleteEnvironment() {
 			e.Logf("error cleaning up test directory %q: %v", path, err)
 		}
 	}
-}
-
-// DeleteEnvironment deletes the environment's HomePath and RootPath, and everything
-// underneath them. It tolerates failing to delete the environment.
-func (e *Environment) DeleteEnvironmentFallible() error {
-	e.Helper()
-	err1 := os.RemoveAll(e.HomePath)
-	err2 := os.RemoveAll(e.RootPath)
-	return errors.Join(err1, err2)
 }
 
 // DeleteIfNotFailed deletes the environment's HomePath and RootPath if the test hasn't failed. Otherwise


### PR DESCRIPTION
This method was added when `DeleteEnvironment` used to assert it did not fail ([see](https://github.com/pulumi/pulumi/commit/59f88030b72b7c621b302b1890d2df34538daf1d)). `DeleteEnvironment` was later changed to allow failures, which can happen in CI, particularly on Windows.

`DeleteEnvironmentFallible` is no longer used anywhere ([see](https://github.com/search?q=DeleteEnvironmentFallible+NOT+is%3Afork&type=code); only shows up in old forks).

This change removes the dead code.

Follow-up from https://github.com/pulumi/pulumi/pull/19017#discussion_r2011970183