### PR TITLE
Update Go program gen to target 1.23

### DIFF
--- a/changelog/pending/20250327--programgen-go--generated-go-programs-now-target-go-1-23.yaml
+++ b/changelog/pending/20250327--programgen-go--generated-go-programs-now-target-go-1-23.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/go
+  description: Generated Go programs now target Go 1.23

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -534,7 +534,10 @@ func GenerateProjectFiles(project workspace.Project, program *pcl.Program,
 	var gomod modfile.File
 	err = gomod.AddModuleStmt(project.Name.String())
 	contract.AssertNoErrorf(err, "could not add module statement to go.mod")
-	err = gomod.AddGoStmt("1.20")
+	// Target the older supported Go version. This should be updated as we drop support for older versions.
+	// i.e. If 1.19 and 1.20 were the currently supported version this would be 1.19, when 1.21 released and
+	// changed the support set to 1.20 and 1.21 this would change to 1.20.
+	err = gomod.AddGoStmt("1.23")
 	contract.AssertNoErrorf(err, "could not add Go statement to go.mod")
 
 	packagePaths := map[string]string{}

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-builtin-info/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-builtin-info/go.mod
@@ -1,6 +1,6 @@
 module l1-builtin-info
 
-go 1.20
+go 1.23
 
 require github.com/pulumi/pulumi/sdk/v3 v3.30.0
 

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-builtin-project-root/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-builtin-project-root/go.mod
@@ -1,6 +1,6 @@
 module l1-builtin-project-root
 
-go 1.20
+go 1.23
 
 require github.com/pulumi/pulumi/sdk/v3 v3.30.0
 

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-empty/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-empty/go.mod
@@ -1,6 +1,6 @@
 module l1-empty
 
-go 1.20
+go 1.23
 
 require github.com/pulumi/pulumi/sdk/v3 v3.30.0
 

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-main/subdir/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-main/subdir/go.mod
@@ -1,6 +1,6 @@
 module l1-main
 
-go 1.20
+go 1.23
 
 require github.com/pulumi/pulumi/sdk/v3 v3.30.0
 

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-output-array/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-output-array/go.mod
@@ -1,6 +1,6 @@
 module l1-output-array
 
-go 1.20
+go 1.23
 
 require github.com/pulumi/pulumi/sdk/v3 v3.30.0
 

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-output-bool/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-output-bool/go.mod
@@ -1,6 +1,6 @@
 module l1-output-bool
 
-go 1.20
+go 1.23
 
 require github.com/pulumi/pulumi/sdk/v3 v3.30.0
 

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-output-map/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-output-map/go.mod
@@ -1,6 +1,6 @@
 module l1-output-map
 
-go 1.20
+go 1.23
 
 require github.com/pulumi/pulumi/sdk/v3 v3.30.0
 

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-output-number/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-output-number/go.mod
@@ -1,6 +1,6 @@
 module l1-output-number
 
-go 1.20
+go 1.23
 
 require github.com/pulumi/pulumi/sdk/v3 v3.30.0
 

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-output-string/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-output-string/go.mod
@@ -1,6 +1,6 @@
 module l1-output-string
 
-go 1.20
+go 1.23
 
 require github.com/pulumi/pulumi/sdk/v3 v3.30.0
 

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-stack-reference/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-stack-reference/go.mod
@@ -1,6 +1,6 @@
 module l1-stack-reference
 
-go 1.20
+go 1.23
 
 require github.com/pulumi/pulumi/sdk/v3 v3.30.0
 

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-destroy/0/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-destroy/0/go.mod
@@ -1,6 +1,6 @@
 module l2-destroy
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-destroy/1/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-destroy/1/go.mod
@@ -1,6 +1,6 @@
 module l2-destroy
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-engine-update-options/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-engine-update-options/go.mod
@@ -1,6 +1,6 @@
 module l2-engine-update-options
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-explicit-parameterized-provider/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-explicit-parameterized-provider/go.mod
@@ -1,6 +1,6 @@
 module l2-explicit-parameterized-provider
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-explicit-provider/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-explicit-provider/go.mod
@@ -1,6 +1,6 @@
 module l2-explicit-provider
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-failed-create-continue-on-error/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-failed-create-continue-on-error/go.mod
@@ -1,6 +1,6 @@
 module l2-failed-create-continue-on-error
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-invoke-dependencies/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-invoke-dependencies/go.mod
@@ -1,6 +1,6 @@
 module l2-invoke-dependencies
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-invoke-options-depends-on/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-invoke-options-depends-on/go.mod
@@ -1,6 +1,6 @@
 module l2-invoke-options-depends-on
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-invoke-options/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-invoke-options/go.mod
@@ -1,6 +1,6 @@
 module l2-invoke-options
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-invoke-secrets/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-invoke-secrets/go.mod
@@ -1,6 +1,6 @@
 module l2-invoke-secrets
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-invoke-simple/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-invoke-simple/go.mod
@@ -1,6 +1,6 @@
 module l2-invoke-simple
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-invoke-variants/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-invoke-variants/go.mod
@@ -1,6 +1,6 @@
 module l2-invoke-variants
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-large-string/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-large-string/go.mod
@@ -1,6 +1,6 @@
 module l2-large-string
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-namespaced-provider/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-namespaced-provider/go.mod
@@ -1,6 +1,6 @@
 module l2-namespaced-provider
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-parameterized-resource/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-parameterized-resource/go.mod
@@ -1,6 +1,6 @@
 module l2-parameterized-resource
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-primitive-ref/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-primitive-ref/go.mod
@@ -1,6 +1,6 @@
 module l2-primitive-ref
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-provider-grpc-config-schema-secret/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-provider-grpc-config-schema-secret/go.mod
@@ -1,6 +1,6 @@
 module l2-provider-grpc-config-schema-secret
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-provider-grpc-config-secret/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-provider-grpc-config-secret/go.mod
@@ -1,6 +1,6 @@
 module l2-provider-grpc-config-secret
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-provider-grpc-config/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-provider-grpc-config/go.mod
@@ -1,6 +1,6 @@
 module l2-provider-grpc-config
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-ref-ref/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-ref-ref/go.mod
@@ -1,6 +1,6 @@
 module l2-ref-ref
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-resource-alpha/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-resource-alpha/go.mod
@@ -1,6 +1,6 @@
 module l2-resource-alpha
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-resource-asset-archive/subdir/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-resource-asset-archive/subdir/go.mod
@@ -1,6 +1,6 @@
 module l2-resource-asset-archive
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-resource-config/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-resource-config/go.mod
@@ -1,6 +1,6 @@
 module l2-resource-config
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-resource-keyword-overlap/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-resource-keyword-overlap/go.mod
@@ -1,6 +1,6 @@
 module l2-resource-keyword-overlap
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-resource-option-deleted-with/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-resource-option-deleted-with/go.mod
@@ -1,6 +1,6 @@
 module l2-resource-option-deleted-with
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-resource-option-protect/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-resource-option-protect/go.mod
@@ -1,6 +1,6 @@
 module l2-resource-option-protect
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-resource-option-retain-on-delete/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-resource-option-retain-on-delete/go.mod
@@ -1,6 +1,6 @@
 module l2-resource-option-retain-on-delete
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-resource-parent-inheritance/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-resource-parent-inheritance/go.mod
@@ -1,6 +1,6 @@
 module l2-resource-parent-inheritance
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-resource-primitives/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-resource-primitives/go.mod
@@ -1,6 +1,6 @@
 module l2-resource-primitives
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-resource-secret/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-resource-secret/go.mod
@@ -1,6 +1,6 @@
 module l2-resource-secret
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-resource-simple/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-resource-simple/go.mod
@@ -1,6 +1,6 @@
 module l2-resource-simple
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-rtti/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-rtti/go.mod
@@ -1,6 +1,6 @@
 module l2-rtti
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-target-up-with-new-dependency/0/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-target-up-with-new-dependency/0/go.mod
@@ -1,6 +1,6 @@
 module l2-target-up-with-new-dependency
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/sdk/go/pulumi-language-go/testdata/projects/l2-target-up-with-new-dependency/1/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l2-target-up-with-new-dependency/1/go.mod
@@ -1,6 +1,6 @@
 module l2-target-up-with-new-dependency
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0


### PR DESCRIPTION
We use program gen to generate programs for users as part of convert. We generally want these programs to be targeting recent versions of the language so that users can start building off them quickly with modern features. 
For example all our dotnet programs target dotnet 8.
Go was targeting 1.20 but there are a number of new features and language changes in later version of Go that we'd want users to be able to use easily, so this bumps program gen to target 1.23 (the older of the two Go versions we currently support).