### PR TITLE
Add the `--preview-only` option for `destroy` in the NodeJS API

### DIFF
--- a/changelog/pending/20250326--auto-nodejs--add-the-preview-only-option-for-destroy-in-the-nodejs-automation-api.yaml
+++ b/changelog/pending/20250326--auto-nodejs--add-the-preview-only-option-for-destroy-in-the-nodejs-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/nodejs
+  description: Add the `--preview-only` option for `destroy` in the NodeJS Automation API

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -514,9 +514,9 @@ Event: ${line}\n${e.toString()}`);
         const args = ["destroy"];
 
         if (opts?.previewOnly) {
-          args.push("--preview-only")
+            args.push("--preview-only");
         } else {
-          args.push("--yes", "--skip-preview")
+            args.push("--yes", "--skip-preview");
         }
 
         args.push(...this.remoteArgs());

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -511,7 +511,13 @@ Event: ${line}\n${e.toString()}`);
      *  Options to customize the behavior of the destroy.
      */
     async destroy(opts?: DestroyOptions): Promise<DestroyResult> {
-        const args = ["destroy", "--yes", "--skip-preview"];
+        const args = ["destroy"];
+
+        if (opts?.previewOnly) {
+          args.push("--preview-only")
+        } else {
+          args.push("--yes", "--skip-preview")
+        }
 
         args.push(...this.remoteArgs());
 
@@ -1601,6 +1607,11 @@ export interface DestroyOptions extends GlobalOpts {
      * Continue the operation to completion even if errors occur.
      */
     continueOnError?: boolean;
+
+    /**
+     * Only show a preview of the destroy, but don't perform the destroy itself.
+     */
+    previewOnly?: boolean;
 
     /**
      * Remove the stack and its configuration after all resources in the stack have been deleted.

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -606,9 +606,12 @@ describe("LocalWorkspace", () => {
         await stack.workspace.removeStack(stackName);
     });
     it(`previews a destroy without executing it`, async () => {
-        const stackName = fullyQualifiedStackName(getTestOrg(), "testproj", `int_test${getTestSuffix()}`);
-        const workDir = upath.joinSafe(__dirname, "data", "testproj");
-        const stack = await LocalWorkspace.createStack({ stackName, workDir }, withTestBackend({}));
+        const stackName = fullyQualifiedStackName(getTestOrg(), "testproj_dotnet", `int_test${getTestSuffix()}`);
+        const workDir = upath.joinSafe(__dirname, "data", "testproj_dotnet");
+        const stack = await LocalWorkspace.createStack(
+            { stackName, workDir },
+            withTestBackend({}, "testproj_dotnet", "", "dotnet"),
+        );
 
         // pulumi up
         const upRes = await stack.up({ userAgent });

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -605,6 +605,27 @@ describe("LocalWorkspace", () => {
 
         await stack.workspace.removeStack(stackName);
     });
+    it(`previews a destroy without executing it`, async () => {
+        const stackName = fullyQualifiedStackName(getTestOrg(), "testproj", `int_test${getTestSuffix()}`);
+        const workDir = upath.joinSafe(__dirname, "data", "testproj");
+        const stack = await LocalWorkspace.createStack({ stackName, workDir }, withTestBackend({}));
+
+        // pulumi up
+        const upRes = await stack.up({ userAgent });
+        assert.strictEqual(upRes.summary.kind, "update");
+        assert.strictEqual(upRes.summary.result, "succeeded");
+
+        // pulumi preview
+        const preRes = await stack.preview({ userAgent });
+        assert.strictEqual(preRes.changeSummary.same, 1);
+
+        // pulumi destroy
+        const destroyRes = await stack.destroy({ userAgent });
+        assert.strictEqual(destroyRes.summary.kind, "update");
+        assert.strictEqual(destroyRes.summary.result, "succeeded");
+
+        await stack.workspace.removeStack(stackName);
+    });
     it(`runs through the stack lifecycle with a local dotnet program`, async () => {
         const stackName = fullyQualifiedStackName(getTestOrg(), "testproj_dotnet", `int_test${getTestSuffix()}`);
         const workDir = upath.joinSafe(__dirname, "data", "testproj_dotnet");

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -618,12 +618,8 @@ describe("LocalWorkspace", () => {
         assert.strictEqual(upRes.summary.kind, "update");
         assert.strictEqual(upRes.summary.result, "succeeded");
 
-        // pulumi preview
-        const preRes = await stack.preview({ userAgent });
-        assert.strictEqual(preRes.changeSummary.same, 1);
-
         // pulumi destroy
-        const destroyRes = await stack.destroy({ userAgent });
+        const destroyRes = await stack.destroy({ userAgent, previewOnly: true });
         assert.strictEqual(destroyRes.summary.kind, "update");
         assert.strictEqual(destroyRes.summary.result, "succeeded");
 


### PR DESCRIPTION
Part of #18725. This PR adds the ability to run destroy `--preview-only` via the NodeJS automation API.