### PR TITLE
set version to 0.0.0 for local plugins; fudge warning

### DIFF
--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -735,6 +735,8 @@ func SchemaFromSchemaSource(pctx *plugin.Context, packageSource string, args []s
 	}
 	if pluginSpec.Version != nil {
 		spec.Version = pluginSpec.Version.String()
+	} else if spec.Version == "" {
+		spec.Version = "0.0.0"
 	}
 	setSpecNamespace(&spec, pluginSpec)
 	return bind(spec)

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -462,7 +462,7 @@ func (host *defaultHost) Provider(descriptor workspace.PackageDescriptor) (Provi
 
 			// Warn if the plugin version was not what we expected
 			if version != nil && !env.Dev.Value() {
-				if info.Version == nil || !info.Version.GTE(*version) {
+				if info.Version != nil && !info.Version.GTE(*version) {
 					var v string
 					if info.Version != nil {
 						v = info.Version.String()

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2534,7 +2534,7 @@ func TestNodejsComponentProviderGetSchema(t *testing.T) {
 	var schema map[string]interface{}
 	require.NoError(t, json.Unmarshal([]byte(stdout), &schema))
 	require.Equal(t, "nodejs-component-provider", schema["name"].(string))
-	require.Nil(t, schema["version"])
+	require.Equal(t, "0.0.0", schema["version"])
 	require.Equal(t, "Node.js Sample Components", schema["description"].(string))
 
 	// Check the component schema


### PR DESCRIPTION
For Git based components we decided to always use the Git version, and not send back a version in the schema at all.  This version is then used for codegen, both for example for `package.json`, and also in the utilities file, so the engine can be told which version of the plugin it needs.

However this doesn't work for local components, as they don't have a "Git version". We currently try to generate the SDK with a `nil` version, which results e.g. in TypeScript in a version field set to ${VERSION}, which makes the package not work at all.

Override the version for codegen purposes.

This also means however that the CLI will now warn users because the version is expected to be >= 0.0.0, but we don't actually have a valid version.  Avoid this by silencing the warning in this case.