### PR TITLE
Fix plugin resolution in convert.

### DIFF
--- a/changelog/pending/20250327--programgen--fix-plugin-resolution-in-convert.yaml
+++ b/changelog/pending/20250327--programgen--fix-plugin-resolution-in-convert.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Fix plugin resolution in convert

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -294,10 +294,12 @@ func runConvert(
 			return nil
 		}
 
-		pluginSpec := workspace.PluginSpec{
-			Name: pluginName,
-			Kind: apitype.ResourcePlugin,
+		pluginSpec, err := workspace.NewPluginSpec(pluginName, apitype.ResourcePlugin, nil, "", nil)
+		if err != nil {
+			pCtx.Diag.Errorf(diag.Message("", "failed to create plugin spec for %q: %v"), pluginName, err)
+			return nil
 		}
+
 		version, err := pkgWorkspace.InstallPlugin(pCtx.Base(), pluginSpec, log)
 		if err != nil {
 			pCtx.Diag.Warningf(diag.Message("", "failed to install provider %q: %v"), pluginName, err)

--- a/pkg/codegen/convert/base_plugin_mapper.go
+++ b/pkg/codegen/convert/base_plugin_mapper.go
@@ -235,17 +235,17 @@ func (m *basePluginMapper) GetMapping(
 	}
 
 	// Try the list of plugins we have and see if any of them produce a mapping we can return.
-	for _, pluginSpec := range m.pluginSpecs {
-		descriptor := workspace.PackageDescriptor{
-			PluginSpec: workspace.PluginSpec{
-				Name:    pluginSpec.name,
-				Version: &pluginSpec.version,
-			},
+	for _, mapperSpec := range m.pluginSpecs {
+		pluginSpec, err := workspace.NewPluginSpec(mapperSpec.name, apitype.ResourcePlugin, nil, "", nil)
+		if err != nil {
+			return nil, fmt.Errorf("could not create plugin spec for plugin %s: %w", pluginSpec.Name, err)
 		}
+
+		descriptor := workspace.NewPackageDescriptor(pluginSpec, nil)
 
 		// If the current plugin's name matches that which we are looking for, and we have a hint that includes
 		// parameterization information, we will pass that to the plugin as part of its instantiation.
-		if pluginSpec.name == pluginName && hint != nil && hint.Parameterization != nil {
+		if mapperSpec.name == pluginName && hint != nil && hint.Parameterization != nil {
 			descriptor.Parameterization = hint.Parameterization
 		}
 

--- a/pkg/codegen/convert/base_plugin_mapper_test.go
+++ b/pkg/codegen/convert/base_plugin_mapper_test.go
@@ -95,6 +95,7 @@ func TestBasePluginMapper_InstalledPluginMatches(t *testing.T) {
 
 	providerFactory := func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
 		assert.Equal(t, descriptor.Name, testProvider.pkg, "unexpected package")
+		assert.Equal(t, descriptor.Kind, apitype.ResourcePlugin, "unexpected kind")
 		return testProvider, nil
 	}
 
@@ -148,6 +149,7 @@ func TestBasePluginMapper_MappedNameDiffersFromPulumiName(t *testing.T) {
 
 	providerFactory := func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
 		assert.Equal(t, descriptor.Name, testProvider.pkg, "unexpected package")
+		assert.Equal(t, descriptor.Kind, apitype.ResourcePlugin, "unexpected kind")
 		return testProvider, nil
 	}
 
@@ -211,6 +213,7 @@ func TestBasePluginMapper_NoPluginMatches_ButCanBeInstalled(t *testing.T) {
 
 	providerFactory := func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
 		assert.Equal(t, descriptor.Name, testProvider.pkg, "unexpected package")
+		assert.Equal(t, descriptor.Kind, apitype.ResourcePlugin, "unexpected kind")
 		return testProvider, nil
 	}
 
@@ -274,6 +277,7 @@ func TestBasePluginMapper_UseMatchingNameFirst(t *testing.T) {
 
 	providerFactory := func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
 		assert.Equal(t, descriptor.Name, testProvider.pkg, "unexpected package")
+		assert.Equal(t, descriptor.Kind, apitype.ResourcePlugin, "unexpected kind")
 		return testProvider, nil
 	}
 
@@ -426,6 +430,7 @@ func TestBasePluginMapper_MappedNamesDifferFromPulumiNameWithHint(t *testing.T) 
 
 	providerFactory := func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
 		assert.Equal(t, descriptor.Name, testProvider.pkg, "unexpected package")
+		assert.Equal(t, descriptor.Kind, apitype.ResourcePlugin, "unexpected kind")
 		return testProvider, nil
 	}
 
@@ -488,6 +493,7 @@ func TestBasePluginMapper_MappedNamesDifferFromPulumiNameWithParameterizedHint(t
 
 	providerFactory := func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
 		assert.Equal(t, descriptor.Name, testProvider.pkg, "unexpected package")
+		assert.Equal(t, descriptor.Kind, apitype.ResourcePlugin, "unexpected kind")
 
 		assert.Equal(t, descriptor.Parameterization.Name, "gcp")
 		assert.Equal(t, descriptor.Parameterization.Version, semver.MustParse("2.0.0"))
@@ -554,6 +560,7 @@ func TestBasePluginMapper_MappedNamesDifferFromPulumiNameWithUnusableParameteriz
 
 	providerFactory := func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
 		assert.Equal(t, descriptor.Name, testProvider.pkg, "unexpected package")
+		assert.Equal(t, descriptor.Kind, apitype.ResourcePlugin, "unexpected kind")
 		assert.Nil(t, descriptor.Parameterization)
 
 		return testProvider, nil

--- a/pkg/codegen/convert/provider_factory.go
+++ b/pkg/codegen/convert/provider_factory.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -31,6 +32,10 @@ type ProviderFactory func(descriptor workspace.PackageDescriptor) (plugin.Provid
 // lifecycles.
 func ProviderFactoryFromHost(ctx context.Context, host plugin.Host) ProviderFactory {
 	return func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
+		if descriptor.Kind != apitype.ResourcePlugin {
+			return nil, fmt.Errorf("provider factory must be a resource plugin package, was %v", descriptor.Kind)
+		}
+
 		provider, err := host.Provider(descriptor)
 		if err != nil {
 			desc := descriptor.PackageName()

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -909,6 +909,13 @@ type PackageDescriptor struct {
 	Parameterization *Parameterization
 }
 
+func NewPackageDescriptor(spec PluginSpec, parameterization *Parameterization) PackageDescriptor {
+	return PackageDescriptor{
+		PluginSpec:       spec,
+		Parameterization: parameterization,
+	}
+}
+
 // PackageName returns the name of the package.
 func (pd PackageDescriptor) PackageName() string {
 	if pd.Parameterization != nil {


### PR DESCRIPTION
Change #18951  introduced more robust plugin resolution, but convert has
some quirks that didn't set the "kind" field so resolution was not
working.  This fixes that, adds some testing, and some helpers to help
avoid this.

In the long run it'd be nice if mappers and plugin resolution used the
same functions, but this at least fixes it for now.

fixes #19039