### PR TITLE
Fix this being incorrectly renamed in typescript when instantiating resources

### DIFF
--- a/changelog/pending/20250327--programgen-nodejs--fix-references-to-variables-that-were-renamed-due-to-keyword-overlap-etc-in-resource-attributes.yaml
+++ b/changelog/pending/20250327--programgen-nodejs--fix-references-to-variables-that-were-renamed-due-to-keyword-overlap-etc-in-resource-attributes.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/nodejs
+  description: Fix references to variables that were renamed due to keyword overlap etc in resource attributes

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -915,13 +915,20 @@ func (g *generator) genResourceDeclaration(w io.Writer, r *pcl.Resource, needsDe
 					propertyName = fmt.Sprintf("%q", propertyName)
 				}
 
+				// Rewrite variable names separate from lowering to avoid rewriting
+				// keywords that are generated elsewhere (e.g. `this` in the case of
+				// setting a resource parent).
+				x, diagnostics := g.RewriteVariableRenames(attr.Value, attr.Value.Type())
+				g.diagnostics = append(g.diagnostics, diagnostics...)
+
 				if r.Schema != nil {
 					destType, diagnostics := r.InputType.Traverse(hcl.TraverseAttr{Name: attr.Name})
 					g.diagnostics = append(g.diagnostics, diagnostics...)
+
 					g.Fgenf(w, fmtString, propertyName,
-						g.lowerExpression(attr.Value, destType.(model.Type)))
+						g.lowerExpression(x, destType.(model.Type)))
 				} else {
-					g.Fgenf(w, fmtString, propertyName, attr.Value)
+					g.Fgenf(w, fmtString, propertyName, x)
 				}
 			}
 		})

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -241,6 +241,12 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		SkipCompile: codegen.NewStringSet(TestNodeJS, TestDotnet, TestGo),
 	},
 	{
+		Directory: "this-keyword-resource-attr",
+		Description: "ensure that the this keyword is rewritten when it is a variable but kept as is" +
+			"when it is a reference to this pointer in nodejs",
+		Skip: codegen.NewStringSet(TestDotnet, TestPython, TestGo),
+	},
+	{
 		Directory:   "invalid-go-sprintf",
 		Description: "Regress invalid Go",
 		Skip:        codegen.NewStringSet(TestPython, TestNodeJS, TestDotnet),

--- a/tests/testdata/codegen/this-keyword-resource-attr-pp/nodejs/submodule.ts
+++ b/tests/testdata/codegen/this-keyword-resource-attr-pp/nodejs/submodule.ts
@@ -1,0 +1,63 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+interface SubmoduleArgs {
+    name: pulumi.Input<string>,
+}
+
+export class Submodule extends pulumi.ComponentResource {
+    public someOutput: pulumi.Output<string>;
+    constructor(name: string, args: SubmoduleArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("components:index:Submodule", name, args, opts);
+        const path = "fake/path";
+
+        const forceDestroy = true;
+
+        const pgpKey = "fakekey";
+
+        const passwordLength = 16;
+
+        const passwordResetRequired = true;
+
+        const iamAccessKeyStatus = "Active";
+
+        const _this: aws.iam.User[] = [];
+        for (const range = {value: 0}; range.value < 1; range.value++) {
+            _this.push(new aws.iam.User(`${name}-this-${range.value}`, {
+                name: args.name,
+                path: path,
+                forceDestroy: forceDestroy,
+            }, {
+            parent: this,
+        }));
+        }
+
+        const thisUserLoginProfile: aws.iam.UserLoginProfile[] = [];
+        for (const range = {value: 0}; range.value < 1; range.value++) {
+            thisUserLoginProfile.push(new aws.iam.UserLoginProfile(`${name}-this-${range.value}`, {
+                user: _this[0].name,
+                pgpKey: pgpKey,
+                passwordLength: passwordLength,
+                passwordResetRequired: passwordResetRequired,
+            }, {
+            parent: this,
+        }));
+        }
+
+        const thisAccessKey: aws.iam.AccessKey[] = [];
+        for (const range = {value: 0}; range.value < 1; range.value++) {
+            thisAccessKey.push(new aws.iam.AccessKey(`${name}-this-${range.value}`, {
+                user: _this[0].name,
+                pgpKey: pgpKey,
+                status: iamAccessKeyStatus,
+            }, {
+            parent: this,
+        }));
+        }
+
+        this.someOutput = thisAccessKey[0].id;
+        this.registerOutputs({
+            someOutput: thisAccessKey[0].id,
+        });
+    }
+}

--- a/tests/testdata/codegen/this-keyword-resource-attr-pp/nodejs/this-keyword-resource-attr.ts
+++ b/tests/testdata/codegen/this-keyword-resource-attr-pp/nodejs/this-keyword-resource-attr.ts
@@ -1,0 +1,6 @@
+import * as pulumi from "@pulumi/pulumi";
+import { Submodule } from "./submodule";
+
+// Make this a component/submodule so that parent references are generated in TS
+const test = new Submodule("test", {name: "fakename"});
+export const foo = test.someOutput;

--- a/tests/testdata/codegen/this-keyword-resource-attr-pp/submodule/main.pp
+++ b/tests/testdata/codegen/this-keyword-resource-attr-pp/submodule/main.pp
@@ -1,0 +1,42 @@
+config "name" "string" { }
+
+path = "fake/path"
+forceDestroy = true
+pgpKey = "fakekey"
+passwordLength = 16
+passwordResetRequired = true
+iamAccessKeyStatus = "Active"
+
+resource "this" "aws:iam/user:User" {
+  options {
+    range = 1
+  }
+  name                = name
+  path                = path
+  forceDestroy        = forceDestroy
+}
+
+resource "thisUserLoginProfile" "aws:iam/userLoginProfile:UserLoginProfile" {
+  __logicalName = "this"
+  options {
+    range = 1
+  }
+  user                  = this[0].name
+  pgpKey                = pgpKey
+  passwordLength        = passwordLength
+  passwordResetRequired = passwordResetRequired
+}
+
+resource "thisAccessKey" "aws:iam/accessKey:AccessKey" {
+  __logicalName = "this"
+  options {
+    range = 1
+  }
+  user   = this[0].name
+  pgpKey = pgpKey
+  status = iamAccessKeyStatus
+}
+
+output "someOutput" {
+  value = thisAccessKey[0].id
+}

--- a/tests/testdata/codegen/this-keyword-resource-attr-pp/this-keyword-resource-attr.pp
+++ b/tests/testdata/codegen/this-keyword-resource-attr-pp/this-keyword-resource-attr.pp
@@ -1,0 +1,8 @@
+# Make this a component/submodule so that parent references are generated in TS
+component "test" "./submodule" {
+  name = "fakename"
+}
+
+output "foo" {
+  value = test.someOutput
+}


### PR DESCRIPTION
When creating resources/variables when generating typescript from PCL,
the instantiation is renamed but references is when assigning attributes
specifically were overlooked.  Simply always renaming within lowering is
not acceptable since it will rewrite legitamate references to `this`.

Instead, specifically when referencing pcl attribute assigns (which
cannot reference `this` in the typescript sense, as these are only
doable when generating code as in the case of parent assign) rename
variables with valid names.

Fixes #18542
