### PR TITLE
[components/nodejs] Discover component types through re-exports

### DIFF
--- a/sdk/nodejs/provider/experimental/analyzer.ts
+++ b/sdk/nodejs/provider/experimental/analyzer.ts
@@ -221,35 +221,59 @@ Please ensure these components are properly imported to your package's entry poi
     private collectImportedFiles(sourceFile: typescript.SourceFile): typescript.SourceFile[] {
         const importedFiles: typescript.SourceFile[] = [];
 
-        // Find all import declarations
         sourceFile.forEachChild((node) => {
-            if (!ts.isImportDeclaration(node)) {
-                return;
-            }
+            // Handle import declarations
+            if (ts.isImportDeclaration(node)) {
+                const moduleSpecifier = node.moduleSpecifier;
+                if (!ts.isStringLiteral(moduleSpecifier)) {
+                    return;
+                }
+                const importPath = moduleSpecifier.text;
 
-            // Get the module specifier (the string in the import)
-            const moduleSpecifier = node.moduleSpecifier;
-            if (!ts.isStringLiteral(moduleSpecifier)) {
-                return;
-            }
-            const importPath = moduleSpecifier.text;
+                // Resolve the import path relative to the current file
+                const resolvedModule = ts.resolveModuleName(
+                    importPath,
+                    sourceFile.fileName,
+                    this.program.getCompilerOptions(),
+                    ts.sys,
+                );
+                if (!resolvedModule.resolvedModule) {
+                    return;
+                }
 
-            // Resolve the import path relative to the current file
-            const resolvedModule = ts.resolveModuleName(
-                importPath,
-                sourceFile.fileName,
-                this.program.getCompilerOptions(),
-                ts.sys,
-            );
-            if (!resolvedModule.resolvedModule) {
-                return;
+                // Find the source file for this import
+                const resolvedFileName = resolvedModule.resolvedModule.resolvedFileName;
+                const importedFile = this.program.getSourceFile(resolvedFileName);
+                if (importedFile && this.programFiles.has(importedFile.fileName)) {
+                    importedFiles.push(importedFile);
+                }
             }
+            // Handle export declarations
+            else if (ts.isExportDeclaration(node)) {
+                // Skip export declarations without a module specifier (e.g., export { foo })
+                if (!node.moduleSpecifier || !ts.isStringLiteral(node.moduleSpecifier)) {
+                    return;
+                }
 
-            // Find the source file for this import
-            const resolvedFileName = resolvedModule.resolvedModule.resolvedFileName;
-            const importedFile = this.program.getSourceFile(resolvedFileName);
-            if (importedFile && this.programFiles.has(importedFile.fileName)) {
-                importedFiles.push(importedFile);
+                const exportPath = node.moduleSpecifier.text;
+
+                // Resolve the export path relative to the current file
+                const resolvedModule = ts.resolveModuleName(
+                    exportPath,
+                    sourceFile.fileName,
+                    this.program.getCompilerOptions(),
+                    ts.sys,
+                );
+                if (!resolvedModule.resolvedModule) {
+                    return;
+                }
+
+                // Find the source file for this export
+                const resolvedFileName = resolvedModule.resolvedModule.resolvedFileName;
+                const exportedFile = this.program.getSourceFile(resolvedFileName);
+                if (exportedFile && this.programFiles.has(exportedFile.fileName)) {
+                    importedFiles.push(exportedFile);
+                }
             }
         });
 

--- a/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
@@ -612,6 +612,32 @@ describe("Analyzer", function () {
             },
         );
     });
+
+    it("finds components through re-exports", async function () {
+        const dir = path.join(__dirname, "testdata", "re-exports");
+        const analyzer = new Analyzer(dir, packageJSON, new Set(["MyComponent", "AnotherComponent"]));
+        const { components } = analyzer.analyze();
+        assert.deepStrictEqual(components, {
+            MyComponent: {
+                name: "MyComponent",
+                inputs: {
+                    message: { type: "string", plain: true },
+                },
+                outputs: {
+                    output: { type: "string" },
+                },
+            },
+            AnotherComponent: {
+                name: "AnotherComponent",
+                inputs: {
+                    count: { type: "number", plain: true },
+                },
+                outputs: {
+                    result: { type: "number" },
+                },
+            },
+        });
+    });
 });
 
 describe("formatErrorContext", () => {

--- a/sdk/nodejs/tests/provider/experimental/testdata/re-exports/anotherComponent.ts
+++ b/sdk/nodejs/tests/provider/experimental/testdata/re-exports/anotherComponent.ts
@@ -1,0 +1,14 @@
+import * as pulumi from "@pulumi/pulumi";
+
+export interface AnotherComponentArgs {
+    count: number;
+}
+
+export class AnotherComponent extends pulumi.ComponentResource {
+    public readonly result: pulumi.Output<number>;
+
+    constructor(name: string, args: AnotherComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("test:index:AnotherComponent", name, {}, opts);
+        this.result = pulumi.output(args.count).apply((n) => n * 2);
+    }
+}

--- a/sdk/nodejs/tests/provider/experimental/testdata/re-exports/components.ts
+++ b/sdk/nodejs/tests/provider/experimental/testdata/re-exports/components.ts
@@ -1,0 +1,2 @@
+export { MyComponent } from "./myComponent";
+export { AnotherComponent } from "./anotherComponent";

--- a/sdk/nodejs/tests/provider/experimental/testdata/re-exports/index.ts
+++ b/sdk/nodejs/tests/provider/experimental/testdata/re-exports/index.ts
@@ -1,0 +1,1 @@
+export * from "./components";

--- a/sdk/nodejs/tests/provider/experimental/testdata/re-exports/myComponent.ts
+++ b/sdk/nodejs/tests/provider/experimental/testdata/re-exports/myComponent.ts
@@ -1,0 +1,14 @@
+import * as pulumi from "@pulumi/pulumi";
+
+export interface MyComponentArgs {
+    message: string;
+}
+
+export class MyComponent extends pulumi.ComponentResource {
+    public readonly output: pulumi.Output<string>;
+
+    constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("test:index:MyComponent", name, {}, opts);
+        this.output = pulumi.output(args.message).apply((m) => `Hello ${m}!`);
+    }
+}


### PR DESCRIPTION
Found a case when Analyzer fails to find TypeScript classes. It's a re-export:

```ts
export { MyComponent } from "./myComponent"; 
```

This PR adds a case for re-exports in schema analyzer.