### PR TITLE
Add --run-program to destroy

### DIFF
--- a/changelog/pending/20250327--cli--add-run-program-support-to-pulumi-destroy.yaml
+++ b/changelog/pending/20250327--cli--add-run-program-support-to-pulumi-destroy.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `--run-program` support to `pulumi destroy`

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1182,7 +1182,11 @@ func (b *diyBackend) apply(
 	case apitype.RefreshUpdate:
 		_, changes, updateErr = engine.Refresh(update, engineCtx, op.Opts.Engine, opts.DryRun)
 	case apitype.DestroyUpdate:
-		_, changes, updateErr = engine.Destroy(update, engineCtx, op.Opts.Engine, opts.DryRun)
+		if op.Opts.Engine.DestroyProgram {
+			_, changes, updateErr = engine.DestroyV2(update, engineCtx, op.Opts.Engine, opts.DryRun)
+		} else {
+			_, changes, updateErr = engine.Destroy(update, engineCtx, op.Opts.Engine, opts.DryRun)
+		}
 	case apitype.StackImportUpdate, apitype.RenameUpdate:
 		contract.Failf("unexpected %s event", kind)
 	default:

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1454,7 +1454,11 @@ func (b *cloudBackend) runEngineAction(
 	case apitype.RefreshUpdate:
 		_, changes, updateErr = engine.Refresh(u, engineCtx, op.Opts.Engine, dryRun)
 	case apitype.DestroyUpdate:
-		_, changes, updateErr = engine.Destroy(u, engineCtx, op.Opts.Engine, dryRun)
+		if op.Opts.Engine.DestroyProgram {
+			_, changes, updateErr = engine.DestroyV2(u, engineCtx, op.Opts.Engine, dryRun)
+		} else {
+			_, changes, updateErr = engine.Destroy(u, engineCtx, op.Opts.Engine, dryRun)
+		}
 	case apitype.StackImportUpdate, apitype.RenameUpdate:
 		contract.Failf("unexpected %s event", kind)
 	default:

--- a/pkg/cmd/pulumi/deployment/remote.go
+++ b/pkg/cmd/pulumi/deployment/remote.go
@@ -81,6 +81,7 @@ func ValidateUnsupportedRemoteFlags(
 	targetDependents bool,
 	planFilePath string,
 	stackConfigFile string,
+	runProgram bool,
 ) error {
 	if expectNop {
 		return errors.New("--expect-no-changes is not supported with --remote")
@@ -151,6 +152,9 @@ func ValidateUnsupportedRemoteFlags(
 	}
 	if stackConfigFile != "" {
 		return errors.New("--config-file is not supported with --remote")
+	}
+	if runProgram {
+		return errors.New("--run-program is not supported with --remote")
 	}
 
 	return nil

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -159,7 +159,7 @@ func NewDestroyCmd() *cobra.Command {
 				err = deployment.ValidateUnsupportedRemoteFlags(false, nil, false, "", jsonDisplay, nil,
 					nil, refresh, showConfig, false, showReplacementSteps, showSames, false,
 					suppressOutputs, "default", targets, nil, nil, nil,
-					targetDependents, "", cmdStack.ConfigFile)
+					targetDependents, "", cmdStack.ConfigFile, runProgram)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -47,6 +47,7 @@ import (
 )
 
 func NewDestroyCmd() *cobra.Command {
+	var runProgram bool
 	var debug bool
 	var remove bool
 	var stackName string
@@ -293,6 +294,7 @@ func NewDestroyCmd() *cobra.Command {
 				DisableOutputValues:       env.DisableOutputValues.Value(),
 				Experimental:              env.Experimental.Value(),
 				ContinueOnError:           continueOnError,
+				DestroyProgram:            runProgram,
 			}
 
 			_, destroyErr := s.Destroy(ctx, backend.UpdateOperation{
@@ -335,6 +337,10 @@ func NewDestroyCmd() *cobra.Command {
 			return destroyErr
 		},
 	}
+
+	cmd.PersistentFlags().BoolVar(
+		&runProgram, "run-program", false,
+		"Run the program to determine up-to date state for providers to destroy resources")
 
 	cmd.PersistentFlags().BoolVarP(
 		&debug, "debug", "d", false,

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -340,7 +340,7 @@ func NewDestroyCmd() *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(
 		&runProgram, "run-program", false,
-		"Run the program to determine up-to date state for providers to destroy resources")
+		"Run the program to determine up-to-date state for providers to destroy resources")
 
 	cmd.PersistentFlags().BoolVarP(
 		&debug, "debug", "d", false,

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -343,7 +343,7 @@ func NewPreviewCmd() *cobra.Command {
 				err := deployment.ValidateUnsupportedRemoteFlags(expectNop, configArray, configPath, client, jsonDisplay,
 					policyPackPaths, policyPackConfigPaths, refresh, showConfig, showPolicyRemediations,
 					showReplacementSteps, showSames, showReads, suppressOutputs, "default", &targets, nil, replaces,
-					targetReplaces, targetDependents, planFilePath, cmdStack.ConfigFile)
+					targetReplaces, targetDependents, planFilePath, cmdStack.ConfigFile, false)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -151,7 +151,7 @@ func NewRefreshCmd() *cobra.Command {
 				err = deployment.ValidateUnsupportedRemoteFlags(expectNop, nil, false, "", jsonDisplay, nil,
 					nil, "", showConfig, false, showReplacementSteps, showSames, false,
 					suppressOutputs, "default", targets, nil, nil, nil,
-					false, "", cmdStack.ConfigFile)
+					false, "", cmdStack.ConfigFile, false)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -567,7 +567,7 @@ func NewUpCmd() *cobra.Command {
 				err = deployment.ValidateUnsupportedRemoteFlags(expectNop, configArray, path, client, jsonDisplay, policyPackPaths,
 					policyPackConfigPaths, refresh, showConfig, showPolicyRemediations, showReplacementSteps, showSames,
 					showReads, suppressOutputs, secretsProvider, &targets, &excludes, replaces, targetReplaces,
-					targetDependents, planFilePath, cmdStack.ConfigFile)
+					targetDependents, planFilePath, cmdStack.ConfigFile, false)
 				if err != nil {
 					return err
 				}

--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -35,6 +35,7 @@ func Destroy(
 ) (*deploy.Plan, display.ResourceChanges, error) {
 	contract.Requiref(u != nil, "u", "cannot be nil")
 	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
+	contract.Requiref(!opts.DestroyProgram, "opts.DestroyProgram", "must be false")
 
 	defer func() { ctx.Events <- NewCancelEvent() }()
 


### PR DESCRIPTION
This adds `--run-program` to `pulumi destroy`.

When true this will cause the engine to run the users program as part of the destroy to update providers and component resources.