### PR TITLE
Stop installing `pulumi` on `make build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,12 +74,8 @@ generate::
 bin/pulumi: build_proto .make/ensure/go .make/ensure/phony
 	go build -C pkg -o ../$@ -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${PROJECT}
 
+.PHONY: build
 build:: bin/pulumi build_display_wasm
-ifneq (${GOBIN},)
-	cp $< ${GOBIN}/pulumi
-else
-	cp $< $(shell go env GOPATH)/bin/pulumi
-endif
 
 build_display_wasm:: .make/ensure/go
 	cd pkg && GOOS=js GOARCH=wasm go build -o ../bin/pulumi-display.wasm -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ./backend/display/wasm

--- a/build/common.mk
+++ b/build/common.mk
@@ -1,6 +1,6 @@
 # Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
 
-# common.mk provides most of the scalfholding for our build system. It
+# common.mk provides most of the scaffolding for our build system. It
 # provides default targets for each project we want to build.
 #
 # The default targets we use are:
@@ -8,9 +8,7 @@
 #  - ensure: restores any dependencies needed for the build from
 #            remote sources (e.g dep ensure or yarn install)
 #
-#  - build: builds a project but does not install it. In the case of
-#           go code, this usually means running go install (which
-#           would place them in `GOBIN`, but not `PULUMI_ROOT`
+#  - build: builds a project but does not install it.
 #
 #  - install: copies the bits we plan to ship into a layout in
 #             `PULUMI_ROOT` that looks like what a customer would get

--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -14,18 +14,23 @@ include ../../build/common.mk
 # `test_all` without the dependencies.
 TEST_ALL_DEPS ?= install
 
-gen::
+.PHONY: gen
+gen:
 	go generate ./pulumi/...
 
 ensure: .make/ensure/go
 
-build:: gen
-	go install -C pulumi-language-go \
-		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
+build:: gen ../../bin/pulumi-language-go
 
-install_plugin::
-	GOBIN=$(PULUMI_BIN) go install -C pulumi-language-go \
-		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
+.PHONY: ../../bin/pulumi-language-go
+../../bin/pulumi-language-go:
+	go build -C pulumi-language-go -o ../../../bin/pulumi-language-go \
+		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" \
+		${LANGHOST_PKG}
+
+.PHONY: install_plugin
+install_plugin: ../../bin/pulumi-language-go
+	cp $< $(PULUMI_BIN)/pulumi-language-go
 
 install:: install_plugin
 
@@ -40,9 +45,17 @@ test_fast:: $(TEST_ALL_DEPS)
 test_auto:: $(TEST_ALL_DEPS)
 	@$(GO_TEST) $(TEST_AUTO_PKGS)
 
-dist::
-	go install -C pulumi-language-go \
-		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
+dist:: ../../bin/pulumi-language-go
+ifneq (${GOBIN},)
+	@# We need to do this dance instead of just calling `cp` because `make build_local`
+	@# (from root) sets ${GOBIN} such that the copy is a no op.
+	@if ! [[ "$<" -ef ${GOBIN}/pulumi-language-go ]]; then \
+	echo cp -f $< ${GOBIN}/pulumi-language-go; \
+	cp $< ${GOBIN}/pulumi-language-go; \
+	fi
+else
+	cp -f $< $(shell go env GOPATH)/bin/pulumi-language-go
+endif
 
 brew:: BREW_VERSION := $(shell ../../scripts/get-version HEAD)
 brew::


### PR DESCRIPTION
Previously, we installed the `pulumi` binary when `make build` was run. `make build` should only *build* the binary, `make install` should *install* it. This commit brings `make build` back to what most developers expect.