### PR TITLE
use `spec.IsGitPlugin()` consistently

### DIFF
--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -642,7 +642,7 @@ func NewPluginContext(cwd string) (*plugin.Context, error) {
 }
 
 func setSpecNamespace(spec *schema.PackageSpec, pluginSpec workspace.PluginSpec) {
-	if spec.Namespace == "" && strings.HasPrefix(pluginSpec.PluginDownloadURL, "git://") {
+	if spec.Namespace == "" && pluginSpec.IsGitPlugin() {
 		namespaceRegex := regexp.MustCompile(`git://[^/]+/([^/]+)/`)
 		matches := namespaceRegex.FindStringSubmatch(pluginSpec.PluginDownloadURL)
 		if len(matches) == 2 {

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -105,17 +105,17 @@ func IsLocalPluginPath(source string) bool {
 		return true
 	}
 
-	// If the source starts with git://, it's definitely not a local path
-	if strings.HasPrefix(source, "git://") {
-		return false
-	}
-
 	// For other cases, we need to be careful about how we interpret the source, so let's parse the spec
 	// and check if it has a download URL.
 	pluginSpec, err := workspace.NewPluginSpec(source, apitype.ResourcePlugin, nil, "", nil)
 	if err != nil {
 		// If we can't parse it as a plugin spec, assume it's a local path
 		return true
+	}
+
+	if pluginSpec.IsGitPlugin() {
+		// If it's a git plugin, it's not a local path
+		return false
 	}
 
 	// If there is a download URL or the name matches the plugin name regexp after parsing, it's not a local path

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1025,10 +1025,11 @@ func NewPluginSpec(
 	}
 
 	urlRegex := regexp.MustCompile(`^[^\./].*\.[a-z]+/[a-zA-Z0-9-/]*[a-zA-Z0-9/]$`)
-	if strings.HasPrefix(name, "https://") || urlRegex.MatchString(name) {
+	if strings.HasPrefix(name, "https://") || strings.HasPrefix(name, "git://") || urlRegex.MatchString(name) {
 		// We support URLs with and without the https:// prefix.  Standardize them here, so we can work with
 		// them uniformly.
 		name = strings.TrimPrefix(name, "https://")
+		name = strings.TrimPrefix(name, "git://")
 		u, err := url.Parse(name)
 		// If we don't have a URL, we just treat it as a normal plugin name.
 		if err == nil {

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1099,7 +1099,7 @@ func (spec PluginSpec) IsGitPlugin() bool {
 // LocalName returns the local name of the plugin, which is used in the directory name, and a path
 // within that directory if the plugin is located in a subdirectory.
 func (spec PluginSpec) LocalName() (string, string) {
-	if strings.HasPrefix(spec.PluginDownloadURL, "git://") {
+	if spec.IsGitPlugin() {
 		trimmed := strings.TrimPrefix(spec.PluginDownloadURL, "git://")
 		url, path, err := gitutil.ParseGitRepoURL("https://" + strings.TrimPrefix(trimmed, "git://"))
 		if err != nil {


### PR DESCRIPTION
We introduced this helper in https://github.com/pulumi/pulumi/pull/19043.  Use it everywhere instead of the string comparison as a cleanup.