### PR TITLE
Don't recursively call `make` as part of `make build_local`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,9 @@ endif
 build_display_wasm:: .make/ensure/go
 	cd pkg && GOOS=js GOARCH=wasm go build -o ../bin/pulumi-display.wasm -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ./backend/display/wasm
 
-build_local:: build_proto .make/ensure/go
-	export GOBIN=$(shell realpath ./bin) && make dist
+.PHONY: build_local
+build_local: export GOBIN=$(shell realpath ./bin)
+build_local: build_proto .make/ensure/go dist
 
 install:: bin/pulumi
 	cp $< $(PULUMI_BIN)/pulumi


### PR DESCRIPTION
This makes the Makefile simpler *and* more performant. The only semantic change is marking `build_local` as `PHONY`.