### PR TITLE
Minimum dotnet version is now 8, not 6

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -144,18 +144,12 @@ ALL_VERSION_SET = {
 
 MINIMUM_SUPPORTED_VERSION_SET = {
     "name": "minimum",
-    "dotnet": ALL_VERSION_SET["dotnet"][0],
-    "go": ALL_VERSION_SET["go"][0],
-    "nodejs": ALL_VERSION_SET["nodejs"][0],
-    "python":   ALL_VERSION_SET["python"][0],
+    **{lang: versions[0] for lang, versions in ALL_VERSION_SET.items()}
 }
 
 CURRENT_VERSION_SET = {
     "name": "current",
-    "dotnet": ALL_VERSION_SET["dotnet"][-1],
-    "go": ALL_VERSION_SET["go"][-1],
-    "nodejs": ALL_VERSION_SET["nodejs"][-1],
-    "python": ALL_VERSION_SET["python"][-1],
+    **{lang: versions[-1] for lang, versions in ALL_VERSION_SET.items()}
 }
 
 

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -133,29 +133,29 @@ ALL_PLATFORMS = ["ubuntu-22.04", "windows-latest", "macos-latest"]
 # versions in the the pulumi-docker-containers repo by updating the file
 # https://github.com/pulumi/pulumi-docker-containers/blob/main/.github/scripts/matrix/versions.py
 
-MINIMUM_SUPPORTED_VERSION_SET = {
-    "name": "minimum",
-    "dotnet": "6",
-    "go": "1.23.x",
-    "nodejs": "18.x",
-    # When updating the minimum Python version here, also update `pyproject.toml`, including the
-    # `mypy` and `ruff` sections.
-    "python": "3.9.x",
-}
-
 ALL_VERSION_SET = {
-    "dotnet": ["6", "8", "9"],
+    "dotnet": ["8", "9"],
     "go": ["1.23.x", "1.24.x"],
     "nodejs": ["18.x", "20.x", "22.x", "23.x"],
+    # When updating the minimum Python version here, also update `pyproject.toml`, including the
+    # `mypy` and `ruff` sections.
     "python": ["3.9.x", "3.10.x", "3.11.x", "3.12.x", "3.13.x"],
+}
+
+MINIMUM_SUPPORTED_VERSION_SET = {
+    "name": "minimum",
+    "dotnet": ALL_VERSION_SET["dotnet"][0],
+    "go": ALL_VERSION_SET["go"][0],
+    "nodejs": ALL_VERSION_SET["nodejs"][0],
+    "python":   ALL_VERSION_SET["python"][0],
 }
 
 CURRENT_VERSION_SET = {
     "name": "current",
-    "dotnet": "9",
-    "go": "1.24.x",
-    "nodejs": "23.x",
-    "python": "3.13.x",
+    "dotnet": ALL_VERSION_SET["dotnet"][-1],
+    "go": ALL_VERSION_SET["go"][-1],
+    "nodejs": ALL_VERSION_SET["nodejs"][-1],
+    "python": ALL_VERSION_SET["python"][-1],
 }
 
 


### PR DESCRIPTION
dotnet 6 is no longer in support, we can move tests to just test against 8 and 9.

Also rewrote the version sets to not repeat the version numbers in each set.