### PR TITLE
[sdk/go] Ensure RegisterResourceOutputs is Idempotent

### DIFF
--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -707,12 +707,12 @@ func TestRegisterResourceOutputs(t *testing.T) {
 	mocks := &testMonitor{
 		RegisterResourceOutputsF: func() (*emptypb.Empty, error) {
 			resp := &emptypb.Empty{}
-			if count.Load() > 2 {
+			if c := count.Load(); c > 2 {
 				// Note: the first call registers the stack outputs for urn:
 				//  - urn:pulumi:stack::project::pulumi:pulumi:Stack::project-stack
 				// The second call registers the resource outputs for the component resource:
 				//  - urn:pulumi:stack::project::test:go:NewLoggingTestResource::res
-				return resp, fmt.Errorf("RegisterResourceOutputs called more than twice: %d", count.Load())
+				return resp, fmt.Errorf("RegisterResourceOutputs called %d times; expected only 2 calls", c)
 			}
 
 			count.Add(1)

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -17,14 +17,17 @@ package pulumi
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
@@ -690,4 +693,52 @@ func TestInvokePlainWithOutputArgument(t *testing.T) {
 		return ctx.Invoke("test:invoke:success", args, &res)
 	}, WithMocks("project", "stack", mocks))
 	require.ErrorContains(t, err, "cannot marshal an input of type")
+}
+
+// This test ensures that ctx.RegisterResourceOutputs is a no-op on subsequent
+// calls. This is important because user programs may call this method multiple
+// times, and we don't want to error out if they do.
+func TestRegisterResourceOutputs(t *testing.T) {
+	t.Parallel()
+
+	// Keep track of the number of times [monitor.RegisterResourceOutputs] is called.
+	var count atomic.Int32
+
+	mocks := &testMonitor{
+		RegisterResourceOutputsF: func() (*emptypb.Empty, error) {
+			resp := &emptypb.Empty{}
+			if count.Load() > 2 {
+				// Note: the first call registers the stack outputs for urn:
+				//  - urn:pulumi:stack::project::pulumi:pulumi:Stack::project-stack
+				// The second call registers the resource outputs for the component resource:
+				//  - urn:pulumi:stack::project::test:go:NewLoggingTestResource::res
+				return resp, fmt.Errorf("RegisterResourceOutputs called more than twice: %d", count.Load())
+			}
+
+			count.Add(1)
+			return resp, nil
+		},
+	}
+
+	var _ mockResourceMonitorWithRegisterResourceOutput = mocks // Surface compile-time error if the interface changes.
+
+	err := RunErr(func(ctx *Context) error {
+		resource, err := NewLoggingTestResource(t, ctx, "res", String("A"))
+		require.NoError(t, err)
+
+		// Attempt to register outputs again, it should be a no-op.
+		err = ctx.RegisterResourceOutputs(resource, Map(map[string]Input{
+			"testOutput": resource.TestOutput,
+		}))
+		require.NoError(t, err)
+
+		// Attempt to register outputs again, it should be a no-op.
+		err = ctx.RegisterResourceOutputs(resource, Map(map[string]Input{
+			"testOutput": resource.TestOutput,
+		}))
+		require.NoError(t, err)
+		return nil
+	}, WithMocks("project", "stack", mocks))
+	assert.NoError(t, err)
+	require.Equal(t, int32(2), count.Load(), "RegisterResourceOutputs should be called exactly twice")
 }

--- a/sdk/go/pulumi/run_test.go
+++ b/sdk/go/pulumi/run_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 // WithDryRun is an internal, test-only option
@@ -48,8 +49,9 @@ func WrapResourceMonitorClient(
 }
 
 type testMonitor struct {
-	CallF        func(args MockCallArgs) (resource.PropertyMap, error)
-	NewResourceF func(args MockResourceArgs) (string, resource.PropertyMap, error)
+	CallF                    func(args MockCallArgs) (resource.PropertyMap, error)
+	NewResourceF             func(args MockResourceArgs) (string, resource.PropertyMap, error)
+	RegisterResourceOutputsF func() (*emptypb.Empty, error)
 }
 
 func (m *testMonitor) Call(args MockCallArgs) (resource.PropertyMap, error) {
@@ -64,6 +66,13 @@ func (m *testMonitor) NewResource(args MockResourceArgs) (string, resource.Prope
 		return args.Name, resource.PropertyMap{}, nil
 	}
 	return m.NewResourceF(args)
+}
+
+func (m *testMonitor) RegisterResourceOutputs() (*emptypb.Empty, error) {
+	if m.RegisterResourceOutputsF == nil {
+		return &emptypb.Empty{}, nil
+	}
+	return m.RegisterResourceOutputsF()
 }
 
 type testResource2 struct {


### PR DESCRIPTION
This PR builds on #19019 by adding additional unit tests and slight refactoring. This work ensures that `RegisterResourceOutputs` can be called multiple times for the same resource URN without triggering multiple RPC calls. Any subsequent calls become no-ops, preventing provider failures caused by redundant output registrations.  

While a broader fix at the engine level is desirable, this SDK-level change is necessary to support the components work in `pulumi-go-provider`. Previously, the `pulumi-go-provider``infer` framework handled output registration for components. However, a recent update allows converting existing Pulumi component programs into providers, where outputs may already be explicitly registered within the program code. This can result in duplicate calls to `RegisterResourceOutputs`.  

Since we cannot remove automatic output registration in `pulumi-go-provider` without breaking existing users, and requiring manual changes for new users would introduce friction when they convert existing component programs to providers, handling this issue at the SDK level ensures compatibility—even if the built provider is running against an older Pulumi engine version.  