### PR TITLE
make build_local with shells other than bash

### DIFF
--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -49,10 +49,11 @@ dist:: ../../bin/pulumi-language-go
 ifneq (${GOBIN},)
 	@# We need to do this dance instead of just calling `cp` because `make build_local`
 	@# (from root) sets ${GOBIN} such that the copy is a no op.
-	@if ! [[ "$<" -ef ${GOBIN}/pulumi-language-go ]]; then \
-	echo cp -f $< ${GOBIN}/pulumi-language-go; \
-	cp $< ${GOBIN}/pulumi-language-go; \
-	fi
+	@bash -c ' \
+	if ! [[ "$<" -ef ${GOBIN}/pulumi-language-go ]]; then \
+		echo cp -f $< ${GOBIN}/pulumi-language-go; \
+		cp $< ${GOBIN}/pulumi-language-go; \
+	fi'
 else
 	cp -f $< $(shell go env GOPATH)/bin/pulumi-language-go
 endif


### PR DESCRIPTION
We try to avoid copying the pulumi-lanugage-go binary if it the file is the same.  However this uses bash-isms, which don't work in every shell.  Make sure we run it in `bash` to avoid issues with it.