### PR TITLE
fix names in type references when namespaces are defined in package.json

### DIFF
--- a/changelog/pending/20250328--sdk-nodejs--fix-names-in-type-references-in-components.yaml
+++ b/changelog/pending/20250328--sdk-nodejs--fix-names-in-type-references-in-components.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix names in type references in components

--- a/sdk/nodejs/provider/experimental/analyzer.ts
+++ b/sdk/nodejs/provider/experimental/analyzer.ts
@@ -77,13 +77,13 @@ export class Analyzer {
     private componentNames: Set<string>;
     private programFiles: Set<string>;
 
-    constructor(dir: string, packageJSON: Record<string, any>, componentNames: Set<string>) {
+    constructor(dir: string, name: string, packageJSON: Record<string, any>, componentNames: Set<string>) {
         if (componentNames.size === 0) {
             throw new Error("componentNames cannot be empty - at least one component name must be provided");
         }
         this.dir = dir;
         this.packageJSON = packageJSON;
-        this.providerName = packageJSON.name;
+        this.providerName = name;
         const configPath = `${dir}/tsconfig.json`;
         const config = ts.readConfigFile(configPath, ts.sys.readFile);
         const parsedConfig = ts.parseJsonConfigFileContent(config.config, ts.sys, path.dirname(configPath));
@@ -147,7 +147,7 @@ export class Analyzer {
 
         // Check if all components were found
         if (componentNames.size > 0) {
-            throw new Error(`Failed to find the following components: ${Array.from(componentNames).join(", ")}. 
+            throw new Error(`Failed to find the following components: ${Array.from(componentNames).join(", ")}.
 Please ensure these components are properly imported to your package's entry point.`);
         }
 

--- a/sdk/nodejs/provider/experimental/provider.ts
+++ b/sdk/nodejs/provider/experimental/provider.ts
@@ -162,7 +162,12 @@ export class ComponentProvider implements Provider {
     }
 
     async getSchema(): Promise<string> {
-        const analyzer = new Analyzer(this.path, this.packageJSON, new Set(Object.keys(this.componentConstructors)));
+        const analyzer = new Analyzer(
+            this.path,
+            this.name,
+            this.packageJSON,
+            new Set(Object.keys(this.componentConstructors)),
+        );
         const { components, typeDefinitions, packageReferences } = analyzer.analyze();
         const schema = generateSchema(
             this.name,

--- a/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
@@ -66,7 +66,6 @@ describe("Analyzer", function () {
                 inputs: {
                     optionalNumber: { type: "number", optional: true, plain: true },
                     optionalNumberType: { type: "number", optional: true, plain: true },
-                    optionalBool: { type: "boolean", optional: true, plain: true },
                 },
                 outputs: {
                     optionalOutputNumber: { type: "number", optional: true },

--- a/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
@@ -18,7 +18,7 @@ import * as execa from "execa";
 import { Analyzer } from "../../../provider/experimental/analyzer";
 import { InputOutput } from "../../../provider/experimental/analyzer";
 
-const packageJSON = { name: "provider" };
+const packageJSON = { name: "@my-namespace/provider" };
 
 describe("Analyzer", function () {
     before(() => {
@@ -37,7 +37,7 @@ describe("Analyzer", function () {
 
     it("infers simple types", async function () {
         const dir = path.join(__dirname, "testdata", "simple-types");
-        const analyzer = new Analyzer(dir, packageJSON, new Set(["MyComponent"]));
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
         const { components } = analyzer.analyze();
         assert.deepStrictEqual(components, {
             MyComponent: {
@@ -58,7 +58,7 @@ describe("Analyzer", function () {
 
     it("infers optional types", async function () {
         const dir = path.join(__dirname, "testdata", "optional-types");
-        const analyzer = new Analyzer(dir, packageJSON, new Set(["MyComponent"]));
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
         const { components } = analyzer.analyze();
         assert.deepStrictEqual(components, {
             MyComponent: {
@@ -66,6 +66,7 @@ describe("Analyzer", function () {
                 inputs: {
                     optionalNumber: { type: "number", optional: true, plain: true },
                     optionalNumberType: { type: "number", optional: true, plain: true },
+                    optionalBool: { type: "boolean", optional: true, plain: true },
                 },
                 outputs: {
                     optionalOutputNumber: { type: "number", optional: true },
@@ -77,7 +78,7 @@ describe("Analyzer", function () {
 
     it("infers input types", async function () {
         const dir = path.join(__dirname, "testdata", "input-types");
-        const analyzer = new Analyzer(dir, packageJSON, new Set(["MyComponent"]));
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
         const { components } = analyzer.analyze();
         assert.deepStrictEqual(components, {
             MyComponent: {
@@ -93,7 +94,7 @@ describe("Analyzer", function () {
 
     it("infers complex types", async function () {
         const dir = path.join(__dirname, "testdata", "complex-types");
-        const analyzer = new Analyzer(dir, packageJSON, new Set(["MyComponent"]));
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
         const { components, typeDefinitions } = analyzer.analyze();
         assert.deepStrictEqual(components, {
             MyComponent: {
@@ -122,7 +123,7 @@ describe("Analyzer", function () {
 
     it("infers self recursive complex types", async function () {
         const dir = path.join(__dirname, "testdata", "recursive-complex-types");
-        const analyzer = new Analyzer(dir, packageJSON, new Set(["MyComponent"]));
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
         const { components, typeDefinitions } = analyzer.analyze();
         assert.deepStrictEqual(components, {
             MyComponent: {
@@ -145,7 +146,7 @@ describe("Analyzer", function () {
 
     it("infers mutually recursive complex types", async function () {
         const dir = path.join(__dirname, "testdata", "mutually-recursive-types");
-        const analyzer = new Analyzer(dir, packageJSON, new Set(["MyComponent"]));
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
         const { components, typeDefinitions } = analyzer.analyze();
         assert.deepStrictEqual(components, {
             MyComponent: {
@@ -172,7 +173,7 @@ describe("Analyzer", function () {
 
     it("rejects bad args", async function () {
         const dir = path.join(__dirname, "testdata", "bad-args");
-        const analyzer = new Analyzer(dir, packageJSON, new Set(["MyComponent"]));
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
         assert.throws(
             () => analyzer.analyze(),
             /Error: Component 'MyComponent' constructor 'args' parameter must be an interface/,
@@ -181,7 +182,7 @@ describe("Analyzer", function () {
 
     it("infers array types", async function () {
         const dir = path.join(__dirname, "testdata", "array-types");
-        const analyzer = new Analyzer(dir, packageJSON, new Set(["MyComponent"]));
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
         const { components } = analyzer.analyze();
         assert.deepStrictEqual(components, {
             MyComponent: {
@@ -224,7 +225,7 @@ describe("Analyzer", function () {
 
     it("infers map types", async function () {
         const dir = path.join(__dirname, "testdata", "map-types");
-        const analyzer = new Analyzer(dir, packageJSON, new Set(["MyComponent"]));
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
         const { components } = analyzer.analyze();
         assert.deepStrictEqual(components, {
             MyComponent: {
@@ -265,7 +266,7 @@ describe("Analyzer", function () {
 
     it("infers any type", async function () {
         const dir = path.join(__dirname, "testdata", "any-type");
-        const analyzer = new Analyzer(dir, packageJSON, new Set(["MyComponent"]));
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
         const { components } = analyzer.analyze();
         assert.deepStrictEqual(components, {
             MyComponent: {
@@ -283,7 +284,7 @@ describe("Analyzer", function () {
 
     it("infers asset/archive types", async function () {
         const dir = path.join(__dirname, "testdata", "asset-archive-types");
-        const analyzer = new Analyzer(dir, packageJSON, new Set(["MyComponent"]));
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
         const { components } = analyzer.analyze();
         assert.deepStrictEqual(components, {
             MyComponent: {
@@ -304,7 +305,7 @@ describe("Analyzer", function () {
 
     it("infers resource references", async function () {
         const dir = path.join(__dirname, "testdata", "resource-reference");
-        const analyzer = new Analyzer(dir, packageJSON, new Set(["MyComponent"]));
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
         const { components, packageReferences } = analyzer.analyze();
         assert.deepStrictEqual(components, {
             MyComponent: {
@@ -344,7 +345,7 @@ describe("Analyzer", function () {
 
     it("errors nicely for invalid property types for top-level properties", async function () {
         const dir = path.join(__dirname, "testdata", "bad-property-type", "top-level");
-        const analyzer = new Analyzer(dir, packageJSON, new Set(["MyComponent"]));
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
         assert.throws(
             () => analyzer.analyze(),
             (err) =>
@@ -355,7 +356,7 @@ describe("Analyzer", function () {
 
     it("errors nicely for invalid property types for sub-type properties", async function () {
         const dir = path.join(__dirname, "testdata", "bad-property-type", "sub-type");
-        const analyzer = new Analyzer(dir, packageJSON, new Set(["MyComponent"]));
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
         assert.throws(
             () => analyzer.analyze(),
             (err) =>
@@ -366,7 +367,7 @@ describe("Analyzer", function () {
 
     it("infers component description", async function () {
         const dir = path.join(__dirname, "testdata", "component-description");
-        const analyzer = new Analyzer(dir, packageJSON, new Set(["MyComponent"]));
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
         const { components, typeDefinitions } = analyzer.analyze();
         assert.deepStrictEqual(components, {
             MyComponent: {
@@ -435,6 +436,7 @@ describe("Analyzer", function () {
         const dir = path.join(__dirname, "testdata", "uncommon-main");
         const analyzer = new Analyzer(
             dir,
+            "provider",
             { name: "provider", exports: "./src/mymain.js" },
             new Set(["MainComponent"]),
         );
@@ -456,6 +458,7 @@ describe("Analyzer", function () {
         const dir = path.join(__dirname, "testdata", "uncommon-main");
         const analyzer = new Analyzer(
             dir,
+            "provider",
             {
                 name: "provider",
                 exports: {
@@ -482,6 +485,7 @@ describe("Analyzer", function () {
         const dir = path.join(__dirname, "testdata", "uncommon-main");
         const analyzer = new Analyzer(
             dir,
+            "provider",
             {
                 name: "provider",
                 exports: {
@@ -510,7 +514,12 @@ describe("Analyzer", function () {
 
     it("finds entry point from package.json main property", async function () {
         const dir = path.join(__dirname, "testdata", "uncommon-main");
-        const analyzer = new Analyzer(dir, { name: "provider", main: "./src/mymain.js" }, new Set(["MainComponent"]));
+        const analyzer = new Analyzer(
+            dir,
+            "provider",
+            { name: "provider", main: "./src/mymain.js" },
+            new Set(["MainComponent"]),
+        );
         const { components } = analyzer.analyze();
         assert.deepStrictEqual(components, {
             MainComponent: {
@@ -529,6 +538,7 @@ describe("Analyzer", function () {
         const dir = path.join(__dirname, "testdata", "uncommon-main");
         const analyzer = new Analyzer(
             dir,
+            "provider",
             {
                 name: "provider",
                 exports: "./src/mymain.ts",
@@ -552,7 +562,7 @@ describe("Analyzer", function () {
 
     it("throws error when no entry points found", async function () {
         const tempDir = path.join(__dirname, "testdata", "no-entry");
-        const analyzer = new Analyzer(tempDir, { name: "provider" }, new Set(["MainComponent"]));
+        const analyzer = new Analyzer(tempDir, "provider", { name: "provider" }, new Set(["MainComponent"]));
 
         assert.throws(
             () => analyzer.analyze(),
@@ -567,7 +577,7 @@ describe("Analyzer", function () {
 
     it("resolves components through complex import chains", async function () {
         const dir = path.join(__dirname, "testdata", "complex-imports");
-        const analyzer = new Analyzer(dir, packageJSON, new Set(["DeepComponent"]));
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["DeepComponent"]));
         const { components } = analyzer.analyze();
         assert.deepStrictEqual(components, {
             DeepComponent: {
@@ -587,6 +597,7 @@ describe("Analyzer", function () {
         const dir = path.join(__dirname, "testdata", "simple-types");
         const analyzer = new Analyzer(
             dir,
+            "provider",
             packageJSON,
             new Set(["MyComponent", "NonExistentComponent", "AnotherMissingOne"]),
         );
@@ -606,7 +617,7 @@ describe("Analyzer", function () {
     it("throws error when componentNames is empty", async function () {
         const dir = path.join(__dirname, "testdata", "simple-types");
         assert.throws(
-            () => new Analyzer(dir, packageJSON, new Set()),
+            () => new Analyzer(dir, "provider", packageJSON, new Set()),
             (err) => {
                 return err.message === "componentNames cannot be empty - at least one component name must be provided";
             },
@@ -615,7 +626,7 @@ describe("Analyzer", function () {
 
     it("finds components through re-exports", async function () {
         const dir = path.join(__dirname, "testdata", "re-exports");
-        const analyzer = new Analyzer(dir, packageJSON, new Set(["MyComponent", "AnotherComponent"]));
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent", "AnotherComponent"]));
         const { components } = analyzer.analyze();
         assert.deepStrictEqual(components, {
             MyComponent: {
@@ -642,7 +653,7 @@ describe("Analyzer", function () {
 
 describe("formatErrorContext", () => {
     // We need to create an analyzer instance to test the private method
-    const analyzer = new Analyzer(__dirname, packageJSON, new Set(["MyComponent"]));
+    const analyzer = new Analyzer(__dirname, "provider", packageJSON, new Set(["MyComponent"]));
     // Use any to access private method
     const formatErrorContext = (analyzer as any).formatErrorContext.bind(analyzer);
 

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2706,4 +2706,11 @@ func TestNodeComponentNamespaceInference(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(stdout), &packageSpec))
 	require.Equal(t, "namespaced-component", packageSpec.Name)
 	require.Equal(t, "my-namespace", packageSpec.Namespace)
+
+	res, ok := packageSpec.Resources["namespaced-component:index:MyComponent"]
+	require.True(t, ok, fmt.Sprintf("missing expected resource in %v", packageSpec.Resources))
+
+	input, ok := res.InputProperties["anInput"]
+	require.True(t, ok, fmt.Sprintf("missing expected input property in %v", res.InputProperties))
+	require.Equal(t, "#/types/namespaced-component:index:Nested", input.Ref)
 }

--- a/tests/integration/namespaced_component/index.ts
+++ b/tests/integration/namespaced_component/index.ts
@@ -2,8 +2,11 @@
 
 import * as pulumi from "@pulumi/pulumi"
 
+export interface Nested {
+}
+
 export interface MyComponentArgs {
-    // Define the inputs to your component here
+    anInput: Nested;
 }
 
 export class MyComponent extends pulumi.ComponentResource {


### PR DESCRIPTION
When we introduced namespaces in TypeScript, we missed that the Analyzer was still using `packageJSON.name` to generate type references. This meant types would be generated with just the name, but references would be broken, because they would use the full name field from `package.json`, which can include the namespace.

Fix that by passing the name through correctly.

Fixes https://github.com/pulumi/pulumi/issues/19055