### PR TITLE
Support Copilot summarizing errors discovered in the preview phase of an update

### DIFF
--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -230,7 +230,7 @@ func confirmBeforeUpdating(kind apitype.UpdateKind, stack Stack,
 }
 
 func PreviewThenPromptThenExecute(ctx context.Context, kind apitype.UpdateKind, stack Stack,
-	op UpdateOperation, apply Applier, events chan<- engine.Event,
+	op UpdateOperation, apply Applier,
 ) (sdkDisplay.ResourceChanges, error) {
 	// Preview the operation to the user and ask them if they want to proceed.
 
@@ -269,7 +269,7 @@ func PreviewThenPromptThenExecute(ctx context.Context, kind apitype.UpdateKind, 
 	// No need to generate a plan at this stage, there's no way for the system or user to extract the plan
 	// after here.
 	op.Opts.Engine.GeneratePlan = false
-	_, changes, res := apply(ctx, kind, stack, op, opts, events)
+	_, changes, res := apply(ctx, kind, stack, op, opts, nil /*events*/)
 	return changes, res
 }
 

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -428,10 +428,7 @@ func (r *CaptureProgressEvents) OutputIncludesFailure() bool {
 	// If its a preview we need to check the resource rows for any failures
 	for _, row := range r.display.resourceRows {
 		diagInfo := row.DiagInfo()
-		if diagInfo == nil {
-			continue
-		}
-		if diagInfo.ErrorCount > 0 {
+		if diagInfo != nil && diagInfo.ErrorCount > 0 {
 			return true
 		}
 	}

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -357,6 +357,8 @@ func NewCaptureProgressEvents(
 	stack tokens.StackName,
 	proj tokens.PackageName,
 	opts Options,
+	isPreview bool,
+	action apitype.UpdateKind,
 ) *CaptureProgressEvents {
 	buffer := bytes.NewBuffer([]byte{})
 	width, height := 200, 80
@@ -370,8 +372,6 @@ func NewCaptureProgressEvents(
 	o.Stderr = io.Discard
 	o.term = terminal.NewSimpleTerminal(buffer, width, height)
 
-	isPreview := false
-	action := apitype.UpdateUpdate
 	permalink := ""
 
 	printPermalinkInteractive(o.term, o, permalink, "")
@@ -420,7 +420,23 @@ func (r *CaptureProgressEvents) Output() []string {
 }
 
 func (r *CaptureProgressEvents) OutputIncludesFailure() bool {
-	return r.display.failed
+	// If its an actual update we can use the failed flag
+	if !r.display.isPreview {
+		return r.display.failed
+	}
+
+	// If its a preview we need to check the resource rows for any failures
+	for _, row := range r.display.resourceRows {
+		diagInfo := row.DiagInfo()
+		if diagInfo == nil {
+			continue
+		}
+		if diagInfo.ErrorCount > 0 {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (display *ProgressDisplay) println(line string) {

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1009,7 +1009,7 @@ func (b *diyBackend) Update(ctx context.Context, stack backend.Stack,
 	}
 	defer b.Unlock(ctx, stack.Ref())
 
-	return backend.PreviewThenPromptThenExecute(ctx, apitype.UpdateUpdate, stack, op, b.apply, nil /*events*/)
+	return backend.PreviewThenPromptThenExecute(ctx, apitype.UpdateUpdate, stack, op, b.apply)
 }
 
 func (b *diyBackend) Import(ctx context.Context, stack backend.Stack,
@@ -1036,7 +1036,7 @@ func (b *diyBackend) Import(ctx context.Context, stack backend.Stack,
 		return changes, err
 	}
 
-	return backend.PreviewThenPromptThenExecute(ctx, apitype.ResourceImportUpdate, stack, op, b.apply, nil /*events*/)
+	return backend.PreviewThenPromptThenExecute(ctx, apitype.ResourceImportUpdate, stack, op, b.apply)
 }
 
 func (b *diyBackend) Refresh(ctx context.Context, stack backend.Stack,
@@ -1061,7 +1061,7 @@ func (b *diyBackend) Refresh(ctx context.Context, stack backend.Stack,
 		return changes, err
 	}
 
-	return backend.PreviewThenPromptThenExecute(ctx, apitype.RefreshUpdate, stack, op, b.apply, nil /*events*/)
+	return backend.PreviewThenPromptThenExecute(ctx, apitype.RefreshUpdate, stack, op, b.apply)
 }
 
 func (b *diyBackend) Destroy(ctx context.Context, stack backend.Stack,
@@ -1086,7 +1086,7 @@ func (b *diyBackend) Destroy(ctx context.Context, stack backend.Stack,
 		return changes, err
 	}
 
-	return backend.PreviewThenPromptThenExecute(ctx, apitype.DestroyUpdate, stack, op, b.apply, nil /*events*/)
+	return backend.PreviewThenPromptThenExecute(ctx, apitype.DestroyUpdate, stack, op, b.apply)
 }
 
 func (b *diyBackend) Watch(ctx context.Context, stk backend.Stack,

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1234,7 +1234,7 @@ func (b *cloudBackend) PromptAI(
 	return res, nil
 }
 
-func (b *cloudBackend) renderAndSummarizeOuput(
+func (b *cloudBackend) renderAndSummarizeOutput(
 	ctx context.Context, kind apitype.UpdateKind, stack backend.Stack, op backend.UpdateOperation, events []engine.Event,
 ) {
 	renderer := display.NewCaptureProgressEvents(
@@ -1451,7 +1451,7 @@ func (b *cloudBackend) apply(
 		defer func() {
 			close(eventsChannel)
 			<-done
-			b.renderAndSummarizeOuput(ctx, kind, stack, op, renderEvents)
+			b.renderAndSummarizeOutput(ctx, kind, stack, op, renderEvents)
 		}()
 	}
 

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1431,6 +1431,7 @@ func (b *cloudBackend) apply(
 		events = eventsChannel
 
 		var renderEvents []engine.Event
+		done := make(chan bool)
 		go func() {
 			for e := range eventsChannel {
 				// Forward all events from the engine to the original channel
@@ -1445,9 +1446,11 @@ func (b *cloudBackend) apply(
 				}
 				renderEvents = append(renderEvents, e)
 			}
+			done <- true
 		}()
 		defer func() {
 			close(eventsChannel)
+			<-done
 			b.renderAndSummarizeOuput(ctx, kind, stack, op, renderEvents)
 		}()
 	}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1434,7 +1434,7 @@ func (b *cloudBackend) apply(
 		done := make(chan bool)
 		go func() {
 			for e := range eventsChannel {
-				// Forward all events from the engine to the original channel
+				// Forward all events from the engine to the original channel.
 				// (e.g. PreviewThenPrompt also saves events to be able to generate a diff on request).
 				if originalEvents != nil {
 					originalEvents <- e


### PR DESCRIPTION
Follows https://github.com/pulumi/pulumi/pull/17956

Behaviour changes:
- We now show copilot summary if an error happens during a preview-of-an-update, as well as the update itself.
- If Copilot is disabled in the org we skip the code path (instead of showing message: "Copilot not enabled")

Code changes:
- Moves the Copilot summary code into `apply`, this allows it to respond to errors found in the preview-of-update.
- Reworks logic to capture events first, then go and render them, feels a bit cleaner, though memory implications etc?