### PR TITLE
Implement range for expression in component resources

### DIFF
--- a/changelog/pending/20250407--programgen-go-nodejs--fix-for-range-expression-code-generation-to-handle-pulumi-input-typing-by-converting-to-output.yaml
+++ b/changelog/pending/20250407--programgen-go-nodejs--fix-for-range-expression-code-generation-to-handle-pulumi-input-typing-by-converting-to-output.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go,nodejs
+  description: Fix for range expression code generation to handle pulumi.Input typing by converting to output

--- a/cmd/pulumi-test-language/tests/l2_resource_for_range.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_for_range.go
@@ -1,0 +1,48 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+)
+
+func init() {
+	LanguageTests["l2-resource-for-range"] = LanguageTest{
+		Providers: []plugin.Provider{&providers.SimpleProvider{}},
+		Runs: []TestRun{
+			{
+				Assert: func(l *L,
+					projectDirectory string, err error,
+					snap *deploy.Snapshot, changes display.ResourceChanges,
+				) {
+					RequireStackResource(l, err, changes)
+
+					_ = RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
+
+					RequireSingleNamedResource(l, snap.Resources, "res-0")
+					RequireSingleNamedResource(l, snap.Resources, "res-1")
+					RequireSingleNamedResource(l, snap.Resources, "res-2")
+					RequireSingleNamedResource(l, snap.Resources, "eventualRes-0")
+					RequireSingleNamedResource(l, snap.Resources, "eventualRes-1")
+					RequireSingleNamedResource(l, snap.Resources, "eventualRes-2")
+					RequireSingleNamedResource(l, snap.Resources, "submoduleComp")
+				},
+			},
+		},
+	}
+}

--- a/cmd/pulumi-test-language/tests/testdata/l2-resource-for-range/main.pp
+++ b/cmd/pulumi-test-language/tests/testdata/l2-resource-for-range/main.pp
@@ -1,0 +1,31 @@
+config "listVar" "list(string)" {
+  default = ["one", "two", "three"]
+}
+
+config "filterCond" "bool" {
+  default = true
+}
+
+resource "res" "simple:index:Resource" {
+    options {
+      range = { for k, v in listVar : k => v if filterCond }
+    }
+
+    value = true
+}
+
+eventualListVar = secret(listVar)
+
+resource "eventualRes" "simple:index:Resource" {
+    options {
+      range = { for k, v in eventualListVar : k => v if filterCond }
+    }
+
+    value = true
+}
+
+component "submoduleComp" "./submodule" {
+  submoduleListVar = ["one"]
+  submoduleFilterCond = true
+  submoduleFilterVariable = 1
+}

--- a/cmd/pulumi-test-language/tests/testdata/l2-resource-for-range/submodule/main.pp
+++ b/cmd/pulumi-test-language/tests/testdata/l2-resource-for-range/submodule/main.pp
@@ -1,0 +1,19 @@
+config "submoduleListVar" "list(string)" {}
+config "submoduleFilterCond" "bool" {}
+config "submoduleFilterVariable" "int" {}
+
+resource "submoduleRes" "simple:index:Resource" {
+    options {
+      range = { for k, v in submoduleListVar : k => v if submoduleFilterCond }
+    }
+
+    value = true
+}
+
+resource "submoduleResWithApplyFilter" "simple:index:Resource" {
+    options {
+      range = { for k, v in submoduleListVar : k => v if (submoduleFilterVariable == 1) }
+    }
+
+    value = true
+}

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -208,6 +208,14 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		output, isOutput := to.(*model.OutputType)
 		originalTo := to
 		if isOutput {
+			_, isFromOutput := from.Type().(*model.OutputType)
+			conversionKind := from.Type().ConversionFrom(output.ElementType)
+			if !isFromOutput && conversionKind == model.SafeConversion {
+				// If the from type is a union which contains the output element type, then this is just
+				// an explicit call to convert to an output type from an input union.
+				g.Fgenf(w, "pulumi.ToOutput(%v)", expr.Args[0])
+				return
+			}
 			to = output.ElementType
 		}
 		_, isFromOutput := from.Type().(*model.OutputType)

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -956,7 +956,7 @@ func (g *generator) genResourceDeclaration(w io.Writer, r *pcl.Resource, needsDe
 						for _, cvar := range cvars {
 							cvarNames = append(cvarNames, cvar.Name())
 						}
-						forExpr, diags := pcl.RewriteAsOutputs(n, cvarNames)
+						forExpr, diags := pcl.ConvertVariablesToOutputs(n, cvarNames)
 						return forExpr, diags
 					default:
 						return n, nil

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -941,7 +941,32 @@ func (g *generator) genResourceDeclaration(w io.Writer, r *pcl.Resource, needsDe
 	if r.Options != nil && r.Options.Range != nil {
 		rangeType := r.Options.Range.Type()
 		rangeExpr := r.Options.Range
-		if model.ContainsOutputs(r.Options.Range.Type()) {
+		if g.isComponent {
+			// In the case of a component, the range expression must treat Inputs as
+			// Outputs so code generation succeeds. This is because the component
+			// inputs may be outputs or promises, so we must explicitly cast them so
+			// code generation and apply lowering succeeds.
+			rangeExpr, diagnostics = model.VisitExpression(
+				rangeExpr,
+				model.IdentityVisitor, func(n model.Expression) (model.Expression, hcl.Diagnostics) {
+					switch n := n.(type) {
+					case *model.ForExpression:
+						cvars := g.program.ConfigVariables()
+						cvarNames := make([]string, len(cvars))
+						for _, cvar := range cvars {
+							cvarNames = append(cvarNames, cvar.Name())
+						}
+						forExpr, diags := pcl.RewriteAsOutputs(n, cvarNames)
+						return forExpr, diags
+					default:
+						return n, nil
+					}
+				})
+
+			g.diagnostics = append(g.diagnostics, diagnostics...)
+		}
+
+		if model.ContainsOutputs(rangeExpr.Type()) {
 			rangeExpr = g.lowerExpression(rangeExpr, rangeType)
 			if model.InputType(model.BoolType).ConversionFrom(rangeType) == model.SafeConversion {
 				g.Fgenf(w, "%slet %s: %s | undefined;\n", g.Indent, variableName, qualifiedMemberName)

--- a/pkg/codegen/pcl/functions.go
+++ b/pkg/codegen/pcl/functions.go
@@ -501,6 +501,26 @@ func pulumiBuiltins(options bindOptions) map[string]*model.Function {
 		"rootDirectory": model.NewFunction(model.StaticFunctionSignature{
 			ReturnType: model.StringType,
 		}),
+		"toOutput": model.NewFunction(model.GenericFunctionSignature(
+			func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
+				if len(args) != 1 {
+					return model.StaticFunctionSignature{}, hcl.Diagnostics{
+						errorf(args[0].SyntaxNode().Range(), "toOutput expects exactly one argument"),
+					}
+				}
+
+				argType := args[0].Type()
+
+				return model.StaticFunctionSignature{
+					Parameters: []model.Parameter{
+						{
+							Name: "arg",
+							Type: argType,
+						},
+					},
+					ReturnType: model.NewOutputType(argType),
+				}, nil
+			})),
 		// pulumiResourceType/Name takes a single argument, the resource, and returns a string. There isn't a good way
 		// to do this with a StaticFunctionSignature so we use a GenericFunctionSignature with a similar check for
 		// "resource type" as we do for `call` expressions.

--- a/pkg/codegen/pcl/functions.go
+++ b/pkg/codegen/pcl/functions.go
@@ -501,26 +501,6 @@ func pulumiBuiltins(options bindOptions) map[string]*model.Function {
 		"rootDirectory": model.NewFunction(model.StaticFunctionSignature{
 			ReturnType: model.StringType,
 		}),
-		"toOutput": model.NewFunction(model.GenericFunctionSignature(
-			func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
-				if len(args) != 1 {
-					return model.StaticFunctionSignature{}, hcl.Diagnostics{
-						errorf(args[0].SyntaxNode().Range(), "toOutput expects exactly one argument"),
-					}
-				}
-
-				argType := args[0].Type()
-
-				return model.StaticFunctionSignature{
-					Parameters: []model.Parameter{
-						{
-							Name: "arg",
-							Type: argType,
-						},
-					},
-					ReturnType: model.NewOutputType(argType),
-				}, nil
-			})),
 		// pulumiResourceType/Name takes a single argument, the resource, and returns a string. There isn't a good way
 		// to do this with a StaticFunctionSignature so we use a GenericFunctionSignature with a similar check for
 		// "resource type" as we do for `call` expressions.

--- a/pkg/codegen/pcl/intrinsics.go
+++ b/pkg/codegen/pcl/intrinsics.go
@@ -77,18 +77,8 @@ func NewApplyCall(args []model.Expression, then *model.AnonymousFunctionExpressi
 	}
 }
 
-func NewToOutputCall(arg model.Expression) *model.FunctionCallExpression {
-	return &model.FunctionCallExpression{
-		Name: "toOutput",
-		Signature: model.StaticFunctionSignature{
-			Parameters: []model.Parameter{{
-				Name: "arg",
-				Type: arg.Type(),
-			}},
-			ReturnType: model.NewOutputType(arg.Type()),
-		},
-		Args: []model.Expression{arg},
-	}
+func NewConvertToOutputCall(arg model.Expression) *model.FunctionCallExpression {
+	return NewConvertCall(arg, model.NewOutputType(arg.Type()))
 }
 
 // ParseApplyCall extracts the apply arguments and the continuation from a call to the apply intrinsic.

--- a/pkg/codegen/pcl/intrinsics.go
+++ b/pkg/codegen/pcl/intrinsics.go
@@ -77,6 +77,20 @@ func NewApplyCall(args []model.Expression, then *model.AnonymousFunctionExpressi
 	}
 }
 
+func NewToOutputCall(arg model.Expression) *model.FunctionCallExpression {
+	return &model.FunctionCallExpression{
+		Name: "toOutput",
+		Signature: model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "arg",
+				Type: arg.Type(),
+			}},
+			ReturnType: model.NewOutputType(arg.Type()),
+		},
+		Args: []model.Expression{arg},
+	}
+}
+
 // ParseApplyCall extracts the apply arguments and the continuation from a call to the apply intrinsic.
 func ParseApplyCall(c *model.FunctionCallExpression) (applyArgs []model.Expression,
 	then *model.AnonymousFunctionExpression,

--- a/pkg/codegen/pcl/rewrite_as_output.go
+++ b/pkg/codegen/pcl/rewrite_as_output.go
@@ -1,0 +1,124 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pcl
+
+import (
+	"slices"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+)
+
+// RewriteAsOutputs rewrites the given expression to replace any references to
+// the given variables with calls to `toOutput`. This is used in, for example,
+// a ForExpression inside a component to ensure all calls are correctly lifted
+// with apply.
+//
+// In typescript, for instance, all inputs to a component resource are of type
+// pulumi.Input<T> which can be either T, pulumi.Output<T> or Promise<T>. This
+// rewriter will convert all the pulumi.Input's to pulumi.Output so codegen
+// code is always valid.
+func RewriteAsOutputs(x model.Expression, variablesToRewrite []string) (model.Expression, hcl.Diagnostics) {
+	if x == nil {
+		return x, nil
+	}
+
+	var diags hcl.Diagnostics
+	switch x := x.(type) {
+	case *model.AnonymousFunctionExpression:
+		// If the function shadows a variable it is not an output so should not have it's type rewritten.
+		vars := make([]string, 0, len(variablesToRewrite))
+		for _, v := range variablesToRewrite {
+			if !slices.ContainsFunc(x.Parameters, func(param *model.Variable) bool {
+				return param.Name == v
+			}) {
+				vars = append(vars, v)
+			}
+		}
+
+		newBody, bDiags := RewriteAsOutputs(x.Body, vars)
+		x.Body = newBody
+		diags = append(diags, bDiags...)
+	case *model.BinaryOpExpression:
+		lo, lDiags := RewriteAsOutputs(x.LeftOperand, variablesToRewrite)
+		x.LeftOperand = lo
+		diags = append(diags, lDiags...)
+		ro, rDiags := RewriteAsOutputs(x.RightOperand, variablesToRewrite)
+		x.RightOperand = ro
+		diags = append(diags, rDiags...)
+	case *model.ScopeTraversalExpression:
+		if slices.Contains(variablesToRewrite, x.RootName) {
+			return NewToOutputCall(x), nil
+		}
+	case *model.ConditionalExpression:
+		cond, cDiags := RewriteAsOutputs(x.Condition, variablesToRewrite)
+		diags = append(diags, cDiags...)
+		x.Condition = cond
+		tru, tDiags := RewriteAsOutputs(x.TrueResult, variablesToRewrite)
+		diags = append(diags, tDiags...)
+		x.TrueResult = tru
+		fal, fDiags := RewriteAsOutputs(x.FalseResult, variablesToRewrite)
+		diags = append(diags, fDiags...)
+		x.FalseResult = fal
+	case *model.ForExpression:
+		col, cDiags := RewriteAsOutputs(x.Collection, variablesToRewrite)
+		diags = append(diags, cDiags...)
+		x.Collection = col
+		cond, condDiags := RewriteAsOutputs(x.Condition, variablesToRewrite)
+		diags = append(diags, condDiags...)
+		x.Condition = cond
+	case *model.FunctionCallExpression:
+		args := x.Args
+		x.Args = make([]model.Expression, 0, len(args))
+		for _, arg := range args {
+			arg, d := RewriteAsOutputs(arg, variablesToRewrite)
+			diags = append(diags, d...)
+			x.Args = append(x.Args, arg)
+		}
+	case *model.IndexExpression:
+		coll, cDiags := RewriteAsOutputs(x.Collection, variablesToRewrite)
+		diags = append(diags, cDiags...)
+		x.Collection = coll
+		key, kDiags := RewriteAsOutputs(x.Key, variablesToRewrite)
+		diags = append(diags, kDiags...)
+		x.Key = key
+	case *model.ObjectConsExpression:
+		for _, item := range x.Items {
+			key, kDiags := RewriteAsOutputs(item.Key, variablesToRewrite)
+			item.Key = key
+			diags = append(diags, kDiags...)
+			value, vDiags := RewriteAsOutputs(item.Value, variablesToRewrite)
+			item.Value = value
+			diags = append(diags, vDiags...)
+		}
+	case *model.TupleConsExpression:
+		exprs := x.Expressions
+		x.Expressions = make([]model.Expression, 0, len(exprs))
+		for _, arg := range exprs {
+			arg, d := RewriteAsOutputs(arg, variablesToRewrite)
+			diags = append(diags, d...)
+			x.Expressions = append(x.Expressions, arg)
+		}
+	case *model.UnaryOpExpression:
+		op, d := RewriteAsOutputs(x.Operand, variablesToRewrite)
+		diags = append(diags, d...)
+		x.Operand = op
+	}
+
+	typecheckDiags := x.Typecheck(false)
+	diags = append(diags, typecheckDiags...)
+
+	return x, diags
+}

--- a/sdk/go/pulumi-language-go/language_test.go
+++ b/sdk/go/pulumi-language-go/language_test.go
@@ -188,6 +188,7 @@ var expectedFailures = map[string]string{
 	"l2-component-component-resource-ref": "pulumi#18140: cannot use ref.Value (variable of type pulumi.StringOutput) as string value in return statement", //nolint:lll
 	"l2-component-call-simple":            "pulumi#18202: syntax error: unexpected / in parameter list; possibly missing comma or )",                       //nolint:lll
 	"l2-resource-invoke-dynamic-function": "pulumi#18423: pulumi.Interface{} unexpected {, expected )",                                                     //nolint:lll
+	"l2-resource-for-range":               "pulumi#12606: ForExpression not implemented in go",                                                             //nolint:lll
 }
 
 // Add program overrides here for programs that can't yet be generated correctly due to programgen bugs.

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -2571,6 +2571,13 @@ func (ctx *Context) NewOutput() (Output, func(interface{}), func(error)) {
 	return newAnyOutput(&ctx.state.join)
 }
 
+// ToOutput creates a new output associated with this context and resolves it to the given value.
+func (ctx *Context) ToOutput(in any) Output {
+	o, r, _ := ctx.NewOutput()
+	r(in)
+	return o
+}
+
 // Returns the source position of the Nth stack frame, where N is skip+1.
 //
 // This is used to compute the source position of the user code that instantiated a resource. The number of frames to

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-for-range/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-for-range/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-for-range/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-for-range/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: l2-resource-for-range
+runtime:
+  name: nodejs
+  options:
+    typescript: false

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-for-range/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-for-range/index.ts
@@ -1,0 +1,27 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as simple from "@pulumi/simple";
+import { Submodule } from "./submodule";
+
+const config = new pulumi.Config();
+const listVar = config.getObject<Array<string>>("listVar") || [
+    "one",
+    "two",
+    "three",
+];
+const filterCond = config.getBoolean("filterCond") || true;
+const res: simple.Resource[] = [];
+for (const range of Object.entries(listVar.map((v, k) => [k, v]).filter(([k, v]) => filterCond).reduce((__obj, [k, v]) => ({ ...__obj, [k]: v }))).map(([k, v]) => ({key: k, value: v}))) {
+    res.push(new simple.Resource(`res-${range.key}`, {value: true}));
+}
+const eventualListVar = pulumi.secret(listVar);
+const eventualRes: simple.Resource[] = [];
+eventualListVar.apply(eventualListVar => {
+    for (const range of Object.entries(eventualListVar.map((v, k) => [k, v]).filter(([k, v]) => filterCond).reduce((__obj, [k, v]) => ({ ...__obj, [k]: v }))).map(([k, v]) => ({key: k, value: v}))) {
+        eventualRes.push(new simple.Resource(`eventualRes-${range.key}`, {value: true}));
+    }
+});
+const submoduleComp = new Submodule("submoduleComp", {
+    submoduleListVar: ["one"],
+    submoduleFilterCond: true,
+    submoduleFilterVariable: 1,
+});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-for-range/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-for-range/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "l2-resource-for-range",
+	"devDependencies": {
+		"@types/node": "^18"
+	},
+	"dependencies": {
+		"typescript": "^4.0.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-for-range/submodule.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-for-range/submodule.ts
@@ -11,7 +11,7 @@ export class Submodule extends pulumi.ComponentResource {
     constructor(name: string, args: SubmoduleArgs, opts?: pulumi.ComponentResourceOptions) {
         super("components:index:Submodule", name, args, opts);
         const submoduleRes: simple.Resource[] = [];
-pulumi.output(args.submoduleListVar).apply(toOutput => toOutput.map((v, k) => [k, v]).filter(([k, v]) => pulumi.output(args.submoduleFilterCond)).reduce((__obj, [k, v]) => ({ ...__obj, [k]: v }))).apply(rangeBody => {
+pulumi.output(args.submoduleListVar).apply(__convert => __convert.map((v, k) => [k, v]).filter(([k, v]) => pulumi.output(args.submoduleFilterCond)).reduce((__obj, [k, v]) => ({ ...__obj, [k]: v }))).apply(rangeBody => {
             for (const range of Object.entries(rangeBody).map(([k, v]) => ({key: k, value: v}))) {
                 submoduleRes.push(new simple.Resource(`${name}-submoduleRes-${range.key}`, {value: true}, {
                 parent: this,
@@ -20,7 +20,7 @@ pulumi.output(args.submoduleListVar).apply(toOutput => toOutput.map((v, k) => [k
         });
 
         const submoduleResWithApplyFilter: simple.Resource[] = [];
-pulumi.all([pulumi.output(args.submoduleListVar), pulumi.output(args.submoduleFilterVariable)]).apply(([toOutput, toOutput1]) => toOutput.map((v, k) => [k, v]).filter(([k, v]) => toOutput1 == 1).reduce((__obj, [k, v]) => ({ ...__obj, [k]: v }))).apply(rangeBody => {
+pulumi.all([pulumi.output(args.submoduleListVar), pulumi.output(args.submoduleFilterVariable)]).apply(([__convert, __convert1]) => __convert.map((v, k) => [k, v]).filter(([k, v]) => __convert1 == 1).reduce((__obj, [k, v]) => ({ ...__obj, [k]: v }))).apply(rangeBody => {
             for (const range of Object.entries(rangeBody).map(([k, v]) => ({key: k, value: v}))) {
                 submoduleResWithApplyFilter.push(new simple.Resource(`${name}-submoduleResWithApplyFilter-${range.key}`, {value: true}, {
                 parent: this,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-for-range/submodule.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-for-range/submodule.ts
@@ -1,0 +1,33 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as simple from "@pulumi/simple";
+
+interface SubmoduleArgs {
+    submoduleListVar: pulumi.Input<string[]>,
+    submoduleFilterCond: pulumi.Input<boolean>,
+    submoduleFilterVariable: pulumi.Input<number>,
+}
+
+export class Submodule extends pulumi.ComponentResource {
+    constructor(name: string, args: SubmoduleArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("components:index:Submodule", name, args, opts);
+        const submoduleRes: simple.Resource[] = [];
+pulumi.output(args.submoduleListVar).apply(toOutput => toOutput.map((v, k) => [k, v]).filter(([k, v]) => pulumi.output(args.submoduleFilterCond)).reduce((__obj, [k, v]) => ({ ...__obj, [k]: v }))).apply(rangeBody => {
+            for (const range of Object.entries(rangeBody).map(([k, v]) => ({key: k, value: v}))) {
+                submoduleRes.push(new simple.Resource(`${name}-submoduleRes-${range.key}`, {value: true}, {
+                parent: this,
+            }));
+            }
+        });
+
+        const submoduleResWithApplyFilter: simple.Resource[] = [];
+pulumi.all([pulumi.output(args.submoduleListVar), pulumi.output(args.submoduleFilterVariable)]).apply(([toOutput, toOutput1]) => toOutput.map((v, k) => [k, v]).filter(([k, v]) => toOutput1 == 1).reduce((__obj, [k, v]) => ({ ...__obj, [k]: v }))).apply(rangeBody => {
+            for (const range of Object.entries(rangeBody).map(([k, v]) => ({key: k, value: v}))) {
+                submoduleResWithApplyFilter.push(new simple.Resource(`${name}-submoduleResWithApplyFilter-${range.key}`, {value: true}, {
+                parent: this,
+            }));
+            }
+        });
+
+        this.registerOutputs();
+    }
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-for-range/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-for-range/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2016",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts",
+		"submodule.ts"
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-for-range/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-for-range/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-for-range/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-for-range/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-for-range
+runtime: nodejs

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-for-range/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-for-range/index.ts
@@ -1,0 +1,27 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as simple from "@pulumi/simple";
+import { Submodule } from "./submodule";
+
+const config = new pulumi.Config();
+const listVar = config.getObject<Array<string>>("listVar") || [
+    "one",
+    "two",
+    "three",
+];
+const filterCond = config.getBoolean("filterCond") || true;
+const res: simple.Resource[] = [];
+for (const range of Object.entries(listVar.map((v, k) => [k, v]).filter(([k, v]) => filterCond).reduce((__obj, [k, v]) => ({ ...__obj, [k]: v }))).map(([k, v]) => ({key: k, value: v}))) {
+    res.push(new simple.Resource(`res-${range.key}`, {value: true}));
+}
+const eventualListVar = pulumi.secret(listVar);
+const eventualRes: simple.Resource[] = [];
+eventualListVar.apply(eventualListVar => {
+    for (const range of Object.entries(eventualListVar.map((v, k) => [k, v]).filter(([k, v]) => filterCond).reduce((__obj, [k, v]) => ({ ...__obj, [k]: v }))).map(([k, v]) => ({key: k, value: v}))) {
+        eventualRes.push(new simple.Resource(`eventualRes-${range.key}`, {value: true}));
+    }
+});
+const submoduleComp = new Submodule("submoduleComp", {
+    submoduleListVar: ["one"],
+    submoduleFilterCond: true,
+    submoduleFilterVariable: 1,
+});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-for-range/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-for-range/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "l2-resource-for-range",
+	"devDependencies": {
+		"@types/node": "^18"
+	},
+	"dependencies": {
+		"typescript": "^4.0.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-for-range/submodule.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-for-range/submodule.ts
@@ -11,7 +11,7 @@ export class Submodule extends pulumi.ComponentResource {
     constructor(name: string, args: SubmoduleArgs, opts?: pulumi.ComponentResourceOptions) {
         super("components:index:Submodule", name, args, opts);
         const submoduleRes: simple.Resource[] = [];
-pulumi.output(args.submoduleListVar).apply(toOutput => toOutput.map((v, k) => [k, v]).filter(([k, v]) => pulumi.output(args.submoduleFilterCond)).reduce((__obj, [k, v]) => ({ ...__obj, [k]: v }))).apply(rangeBody => {
+pulumi.output(args.submoduleListVar).apply(__convert => __convert.map((v, k) => [k, v]).filter(([k, v]) => pulumi.output(args.submoduleFilterCond)).reduce((__obj, [k, v]) => ({ ...__obj, [k]: v }))).apply(rangeBody => {
             for (const range of Object.entries(rangeBody).map(([k, v]) => ({key: k, value: v}))) {
                 submoduleRes.push(new simple.Resource(`${name}-submoduleRes-${range.key}`, {value: true}, {
                 parent: this,
@@ -20,7 +20,7 @@ pulumi.output(args.submoduleListVar).apply(toOutput => toOutput.map((v, k) => [k
         });
 
         const submoduleResWithApplyFilter: simple.Resource[] = [];
-pulumi.all([pulumi.output(args.submoduleListVar), pulumi.output(args.submoduleFilterVariable)]).apply(([toOutput, toOutput1]) => toOutput.map((v, k) => [k, v]).filter(([k, v]) => toOutput1 == 1).reduce((__obj, [k, v]) => ({ ...__obj, [k]: v }))).apply(rangeBody => {
+pulumi.all([pulumi.output(args.submoduleListVar), pulumi.output(args.submoduleFilterVariable)]).apply(([__convert, __convert1]) => __convert.map((v, k) => [k, v]).filter(([k, v]) => __convert1 == 1).reduce((__obj, [k, v]) => ({ ...__obj, [k]: v }))).apply(rangeBody => {
             for (const range of Object.entries(rangeBody).map(([k, v]) => ({key: k, value: v}))) {
                 submoduleResWithApplyFilter.push(new simple.Resource(`${name}-submoduleResWithApplyFilter-${range.key}`, {value: true}, {
                 parent: this,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-for-range/submodule.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-for-range/submodule.ts
@@ -1,0 +1,33 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as simple from "@pulumi/simple";
+
+interface SubmoduleArgs {
+    submoduleListVar: pulumi.Input<string[]>,
+    submoduleFilterCond: pulumi.Input<boolean>,
+    submoduleFilterVariable: pulumi.Input<number>,
+}
+
+export class Submodule extends pulumi.ComponentResource {
+    constructor(name: string, args: SubmoduleArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("components:index:Submodule", name, args, opts);
+        const submoduleRes: simple.Resource[] = [];
+pulumi.output(args.submoduleListVar).apply(toOutput => toOutput.map((v, k) => [k, v]).filter(([k, v]) => pulumi.output(args.submoduleFilterCond)).reduce((__obj, [k, v]) => ({ ...__obj, [k]: v }))).apply(rangeBody => {
+            for (const range of Object.entries(rangeBody).map(([k, v]) => ({key: k, value: v}))) {
+                submoduleRes.push(new simple.Resource(`${name}-submoduleRes-${range.key}`, {value: true}, {
+                parent: this,
+            }));
+            }
+        });
+
+        const submoduleResWithApplyFilter: simple.Resource[] = [];
+pulumi.all([pulumi.output(args.submoduleListVar), pulumi.output(args.submoduleFilterVariable)]).apply(([toOutput, toOutput1]) => toOutput.map((v, k) => [k, v]).filter(([k, v]) => toOutput1 == 1).reduce((__obj, [k, v]) => ({ ...__obj, [k]: v }))).apply(rangeBody => {
+            for (const range of Object.entries(rangeBody).map(([k, v]) => ({key: k, value: v}))) {
+                submoduleResWithApplyFilter.push(new simple.Resource(`${name}-submoduleResWithApplyFilter-${range.key}`, {value: true}, {
+                parent: this,
+            }));
+            }
+        });
+
+        this.registerOutputs();
+    }
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-for-range/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-for-range/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2016",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts",
+		"submodule.ts"
+	]
+}

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -177,10 +177,10 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 
 // Add test names here that are expected to fail and the reason why they are failing
 var expectedFailures = map[string]string{
-	"l1-builtin-try":      "Temporarily disabled until pr #18915 is submitted",
-	"l1-builtin-can":      "Temporarily disabled until pr #18916 is submitted",
+	"l1-builtin-try":        "Temporarily disabled until pr #18915 is submitted",
+	"l1-builtin-can":        "Temporarily disabled until pr #18916 is submitted",
 	"l2-resource-for-range": "Temporarily disabled until pr #19076 is submitted",
-	"l3-component-simple": " https://github.com/pulumi/pulumi/issues/19067",
+	"l3-component-simple":   " https://github.com/pulumi/pulumi/issues/19067",
 }
 
 func TestLanguage(t *testing.T) {

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -179,6 +179,7 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 var expectedFailures = map[string]string{
 	"l1-builtin-try":      "Temporarily disabled until pr #18915 is submitted",
 	"l1-builtin-can":      "Temporarily disabled until pr #18916 is submitted",
+	"l2-resource-for-range": "Temporarily disabled until pr #19076 is submitted",
 	"l3-component-simple": " https://github.com/pulumi/pulumi/issues/19067",
 }
 


### PR DESCRIPTION
Add a toOutput intrinsic to pcl and a tree rewriter to utilize it.

Currently ForExpressions as a part of ResourceComponents do not generate
correctly in typescript (and likely other languages).

This is because--at least in the typescript case--a pulumi.Input<T> can
be a T, pulumi.Output<T>, or Promise<T>.  toOutput forces the value to
always be treated as an output, since there is already a method in the
sdk to always convert any value to an output, and the generated code
will always work as expected (whether the input was an Output from
        another part of the program or just a normal variable).

This is accomplished with 3 parts:
1. Add a toOutput pcl intrinsic which will use the language SDK to
convert to an output.
1. When generating a for expression, if it is an output, generate the
appropriate apply calls.
1. When generating a component be sure to to tree rewriting to call
toOutput on all ForExpression variables which come from config
variables of the Component.

Fixes #19060
