### PR TITLE
Speed up workspace.DetectProjectFromPath

### DIFF
--- a/changelog/pending/20250401--cli-plugin--f-ix-slowness-of-workspace-detectprojectfrompath-affecting-pulumi-convert-timings.yaml
+++ b/changelog/pending/20250401--cli-plugin--f-ix-slowness-of-workspace-detectprojectfrompath-affecting-pulumi-convert-timings.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/plugin
+  description: Fix slowness of workspace.DetectProjectFromPath affecting pulumi convert timings

--- a/changelog/pending/20250401--cli-plugin--f-ix-slowness-of-workspace-detectprojectfrompath-affecting-pulumi-convert-timings.yaml
+++ b/changelog/pending/20250401--cli-plugin--f-ix-slowness-of-workspace-detectprojectfrompath-affecting-pulumi-convert-timings.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: cli/plugin
-  description: Fix slowness of workspace.DetectProjectFromPath affecting pulumi convert timings
+  description: Fix slowness of workspace.DetectProjectFromPath affecting pulumi convert timings

--- a/sdk/go/common/util/fsutil/walkup_test.go
+++ b/sdk/go/common/util/fsutil/walkup_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func Test_WalkUpDirs(t *testing.T) {
+	t.Parallel()
 	d1, err := filepath.Abs(t.TempDir())
 	assert.NoError(t, err)
 	d2 := filepath.Join(d1, "a")
@@ -47,6 +48,8 @@ func Test_WalkUpDirs(t *testing.T) {
 	}
 
 	t.Run("walks from a sub-directory", func(t *testing.T) {
+		t.Parallel()
+
 		_, d4Up := walkUpDirsCollect(d4, nil)
 		assert.Contains(t, d4Up, d4)
 		assert.Contains(t, d4Up, d3)
@@ -55,6 +58,8 @@ func Test_WalkUpDirs(t *testing.T) {
 	})
 
 	t.Run("walks from a file path", func(t *testing.T) {
+		t.Parallel()
+
 		f1 := filepath.Join(d4, "hello.txt")
 		err = os.WriteFile(f1, []byte("hello world"), 0o600)
 		require.NoError(t, err)
@@ -67,6 +72,8 @@ func Test_WalkUpDirs(t *testing.T) {
 	})
 
 	t.Run("terminates the walk early if requested", func(t *testing.T) {
+		t.Parallel()
+
 		f1 := filepath.Join(d4, "hello.txt")
 		err = os.WriteFile(f1, []byte("hello world"), 0o600)
 		require.NoError(t, err)

--- a/sdk/go/common/util/fsutil/walkup_test.go
+++ b/sdk/go/common/util/fsutil/walkup_test.go
@@ -1,0 +1,80 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_WalkUpDirs(t *testing.T) {
+	d1, err := filepath.Abs(t.TempDir())
+	assert.NoError(t, err)
+	d2 := filepath.Join(d1, "a")
+	d3 := filepath.Join(d2, "b")
+	d4 := filepath.Join(d3, "c")
+
+	err = os.MkdirAll(d4, 0o700)
+	require.NoError(t, err)
+
+	walkUpDirsCollect := func(path string, checkDir func(dir string) bool) (string, []string) {
+		var result []string
+		found, err := WalkUpDirs(path, func(dir string) bool {
+			result = append(result, dir)
+			if checkDir == nil {
+				return false
+			}
+			return checkDir(dir)
+		})
+		assert.NoError(t, err)
+		return found, result
+	}
+
+	t.Run("walks from a sub-directory", func(t *testing.T) {
+		_, d4Up := walkUpDirsCollect(d4, nil)
+		assert.Contains(t, d4Up, d4)
+		assert.Contains(t, d4Up, d3)
+		assert.Contains(t, d4Up, d2)
+		assert.Contains(t, d4Up, d1)
+	})
+
+	t.Run("walks from a file path", func(t *testing.T) {
+		f1 := filepath.Join(d4, "hello.txt")
+		err = os.WriteFile(f1, []byte("hello world"), 0o600)
+		require.NoError(t, err)
+
+		_, f1Up := walkUpDirsCollect(f1, nil)
+		assert.Contains(t, f1Up, d4)
+		assert.Contains(t, f1Up, d3)
+		assert.Contains(t, f1Up, d2)
+		assert.Contains(t, f1Up, d1)
+	})
+
+	t.Run("terminates the walk early if requested", func(t *testing.T) {
+		f1 := filepath.Join(d4, "hello.txt")
+		err = os.WriteFile(f1, []byte("hello world"), 0o600)
+		require.NoError(t, err)
+
+		found, visited := walkUpDirsCollect(f1, func(dir string) bool {
+			return dir == d2
+		})
+		assert.Equal(t, d2, found)
+		assert.Equal(t, visited, []string{d4, d3, d2})
+	})
+}

--- a/sdk/go/common/workspace/paths_test.go
+++ b/sdk/go/common/workspace/paths_test.go
@@ -221,9 +221,11 @@ func TestDetectProjectPathFrom(t *testing.T) {
 
 	indexTs := filepath.Join(d4, "index.ts")
 	err = os.WriteFile(indexTs, []byte("..."), 0o600)
+	assert.NoError(t, err)
 
 	f1 := filepath.Join(d2, "Pulumi.yaml")
 	err = os.WriteFile(f1, []byte("..."), 0o600)
+	assert.NoError(t, err)
 
 	for _, path := range []string{
 		filepath.Join(d4, "index.ts"),

--- a/sdk/go/common/workspace/paths_test.go
+++ b/sdk/go/common/workspace/paths_test.go
@@ -205,3 +205,38 @@ func TestDetectPolicyPackPathAt(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "", path)
 }
+
+func TestDetectProjectPathFrom(t *testing.T) {
+	t.Parallel()
+	tmpDir := mkTempDir(t)
+
+	d1, err := filepath.Abs(tmpDir)
+	assert.NoError(t, err)
+	d2 := filepath.Join(d1, "a")
+	d3 := filepath.Join(d2, "b")
+	d4 := filepath.Join(d3, "c")
+
+	err = os.MkdirAll(d4, 0o700)
+	require.NoError(t, err)
+
+	indexTs := filepath.Join(d4, "index.ts")
+	err = os.WriteFile(indexTs, []byte("..."), 0o600)
+
+	f1 := filepath.Join(d2, "Pulumi.yaml")
+	err = os.WriteFile(f1, []byte("..."), 0o600)
+
+	for _, path := range []string{
+		filepath.Join(d4, "index.ts"),
+		d4,
+		d3,
+		d2,
+	} {
+		pulumiYamlPath, err := DetectProjectPathFrom(path)
+		assert.NoError(t, err)
+		assert.Equal(t, f1, pulumiYamlPath)
+	}
+
+	negative, err := DetectProjectPathFrom(d1)
+	assert.ErrorContains(t, err, "no Pulumi.yaml project file found")
+	assert.Equal(t, "", negative)
+}


### PR DESCRIPTION
There is a utility function workspace.DetectProjectFromPath that attempts to scan the file system starting at a given path to find the deepest containing ancestor directory that appears to have a Pulumi.yaml or a similar project file present.

Before this change it did not scale well for situations where ancestor folders have a lot of entries. It would scan each ancestor directory and examine every entry to test it for being the Pulumi project file.

For example, in a `pulumi convert` scenario a Mac M3 Pro was taking 10-15 seconds to perform 300000 file system checks here in a situation where tempdirs had a lot of entries, dominating the cost of any other calls.

With this change the function no longer scans directories but instead probes for possible Pulumi.yaml file locations more directly.