### PR TITLE
typescript: fix resource reference imports with namespaces

### DIFF
--- a/changelog/pending/20250401--sdk-nodejs--fix-sdk-generation-for-components-that-use-resource-references-and-are-namespaced.yaml
+++ b/changelog/pending/20250401--sdk-nodejs--fix-sdk-generation-for-components-that-use-resource-references-and-are-namespaced.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix SDK generation for components that use resource references and are namespaced

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1487,11 +1487,7 @@ func (mod *modContext) getTypeImportsForResource(t schema.Type, recurse bool, ex
 		if imp, ok := nodePackageInfo.ProviderNameToModuleName[pkg]; ok {
 			externalImports.Add(fmt.Sprintf("import * as %s from \"%s\";", externalModuleName(pkg), imp))
 		} else {
-			namespace := "@pulumi"
-			if res != nil && res.PackageReference != nil && res.PackageReference.Namespace() != "" {
-				namespace = "@" + res.PackageReference.Namespace()
-			}
-			externalImports.Add(fmt.Sprintf("import * as %s from \"%s/%s\";", externalModuleName(pkg), namespace, pkg))
+			externalImports.Add(fmt.Sprintf("import * as %s from \"@pulumi/%s\";", externalModuleName(pkg), pkg))
 		}
 	}
 


### PR DESCRIPTION
When introducing namespaces we (I) were a little overzealous in typescript SDK gen, and we end up importing even pulumi packages from the package namespace.  Fix that.

Fixes https://github.com/pulumi/pulumi/issues/19054