### PR TITLE
API types & endpoint for managing cloud stack config

### DIFF
--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1195,6 +1195,12 @@ func (pc *Client) UpdateStackTags(
 	return pc.restCall(ctx, "PATCH", getStackPath(stack, "tags"), nil, tags, nil)
 }
 
+func (pc *Client) UpdateStackConfig(
+	ctx context.Context, stack StackIdentifier, config *apitype.StackConfig,
+) error {
+	return pc.restCall(ctx, "PUT", getStackPath(stack, "config"), nil, config, nil)
+}
+
 func (pc *Client) UpdateStackDeploymentSettings(ctx context.Context, stack StackIdentifier,
 	deployment apitype.DeploymentSettings,
 ) error {

--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -442,7 +442,31 @@ type Stack struct {
 	ActiveUpdate     string                  `json:"activeUpdate"`
 	Tags             map[StackTagName]string `json:"tags,omitempty"`
 
+	// Optional reference to ESC environment to use as stack configuration.
+	Environment string `json:"environment"`
+	// SecretsProvider is this stack's secrets provider. Only settable if environment is set.
+	SecretsProvider string `json:"secretsprovider,omitempty"`
+	// EncryptedKey is the KMS-encrypted ciphertext for the data key used for secrets encryption.
+	// Only used for cloud-based secrets providers. Only settable if environment is set.
+	EncryptedKey string `json:"encryptedkey,omitempty"`
+	// EncryptionSalt is this stack's base64 encoded encryption salt.  Only used for
+	// passphrase-based secrets providers. Only settable if environment is set.
+	EncryptionSalt string `json:"encryptionsalt,omitempty"`
+
 	Version int `json:"version"`
+}
+
+type StackConfig struct {
+	// Optional reference to ESC environment to use as stack configuration.
+	Environment string `json:"environment"`
+	// SecretsProvider is this stack's secrets provider. Only settable if environment is set.
+	SecretsProvider string `json:"secretsprovider,omitempty"`
+	// EncryptedKey is the KMS-encrypted ciphertext for the data key used for secrets encryption.
+	// Only used for cloud-based secrets providers. Only settable if environment is set.
+	EncryptedKey string `json:"encryptedkey,omitempty"`
+	// EncryptionSalt is this stack's base64 encoded encryption salt.  Only used for
+	// passphrase-based secrets providers. Only settable if environment is set.
+	EncryptionSalt string `json:"encryptionsalt,omitempty"`
 }
 
 // OperationStatus describes the state of an operation being performed on a Pulumi stack.

--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -442,30 +442,24 @@ type Stack struct {
 	ActiveUpdate     string                  `json:"activeUpdate"`
 	Tags             map[StackTagName]string `json:"tags,omitempty"`
 
-	// Optional reference to ESC environment to use as stack configuration.
-	Environment string `json:"environment"`
-	// SecretsProvider is this stack's secrets provider. Only settable if environment is set.
-	SecretsProvider string `json:"secretsprovider,omitempty"`
-	// EncryptedKey is the KMS-encrypted ciphertext for the data key used for secrets encryption.
-	// Only used for cloud-based secrets providers. Only settable if environment is set.
-	EncryptedKey string `json:"encryptedkey,omitempty"`
-	// EncryptionSalt is this stack's base64 encoded encryption salt.  Only used for
-	// passphrase-based secrets providers. Only settable if environment is set.
-	EncryptionSalt string `json:"encryptionsalt,omitempty"`
+	// Optional cloud-persisted stack configuration.
+	// If set, then the stack's configuration is loaded from the cloud and not a file on disk.
+	Config *StackConfig `json:"config,omitempty"`
 
 	Version int `json:"version"`
 }
 
+// StackConfig describes the configuration of a stack from Pulumi Cloud.
 type StackConfig struct {
-	// Optional reference to ESC environment to use as stack configuration.
+	// Reference to ESC environment to use as stack configuration.
 	Environment string `json:"environment"`
-	// SecretsProvider is this stack's secrets provider. Only settable if environment is set.
+	// SecretsProvider is this stack's secrets provider.
 	SecretsProvider string `json:"secretsprovider,omitempty"`
 	// EncryptedKey is the KMS-encrypted ciphertext for the data key used for secrets encryption.
-	// Only used for cloud-based secrets providers. Only settable if environment is set.
+	// Only used for cloud-based secrets providers.
 	EncryptedKey string `json:"encryptedkey,omitempty"`
-	// EncryptionSalt is this stack's base64 encoded encryption salt.  Only used for
-	// passphrase-based secrets providers. Only settable if environment is set.
+	// EncryptionSalt is this stack's base64 encoded encryption salt. Only used for
+	// passphrase-based secrets providers.
 	EncryptionSalt string `json:"encryptionsalt,omitempty"`
 }
 


### PR DESCRIPTION
Extend Pulumi Cloud stack model with optional environment and secrets provider fields to allow stack configs to be persisted without a file on disk - only referencing a single ESC environment.

There is no configuration map included as stacks managed through the cloud will source all configuration keys from the ESC environment to leverage the existing ESC editing experience.

The fields added to the Stack in Pulumi Cloud are the minimum required to produce a stack config file equivilent to the following, though it's never actually written to disk:

```yaml
secretsProvider: {stack.SecretsProvider}
encryptionKey: {stack.EncryptionKey}
encryptionSalt: {stack.EncryptionSalt}
environment:
- {stack.Environment}
```

This also introduces a new API route, reflected in the client (`UpdateStackConfig`) for updating the stack's configuration fields.