### PR TITLE
Use dotnet language host based codegen

### DIFF
--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -33,7 +33,6 @@ import (
 
 	cmdDiag "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/diag"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/cgstrings"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 	go_gen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/python"
@@ -59,92 +58,56 @@ func GenSDK(language, out string, pkg *schema.Package, overlays string, local bo
 		return fmt.Errorf("get current working directory: %w", err)
 	}
 
-	writeWrapper := func(
-		generatePackage func(string, *schema.Package, map[string][]byte) (map[string][]byte, error),
-	) func(string, *schema.Package, map[string][]byte) error {
-		return func(directory string, p *schema.Package, extraFiles map[string][]byte) error {
-			m, err := generatePackage("pulumi", p, extraFiles)
-			if err != nil {
-				return err
-			}
-
-			err = os.RemoveAll(directory)
-			if err != nil && !os.IsNotExist(err) {
-				return err
-			}
-			for k, v := range m {
-				path := filepath.Join(directory, k)
-				err := os.MkdirAll(filepath.Dir(path), 0o700)
-				if err != nil {
-					return err
-				}
-				err = os.WriteFile(path, v, 0o600)
-				if err != nil {
-					return err
-				}
-			}
-			return nil
+	generatePackage := func(directory string, pkg *schema.Package, extraFiles map[string][]byte) error {
+		// Ensure the target directory is clean, but created.
+		err = os.RemoveAll(directory)
+		if err != nil && !os.IsNotExist(err) {
+			return err
 		}
-	}
-
-	var generatePackage func(string, *schema.Package, map[string][]byte) error
-	switch language {
-	case "dotnet":
-		generatePackage = writeWrapper(func(t string, p *schema.Package, e map[string][]byte) (map[string][]byte, error) {
-			return dotnet.GeneratePackage(t, p, e, nil)
-		})
-	default:
-		generatePackage = func(directory string, pkg *schema.Package, extraFiles map[string][]byte) error {
-			// Ensure the target directory is clean, but created.
-			err = os.RemoveAll(directory)
-			if err != nil && !os.IsNotExist(err) {
-				return err
-			}
-			err := os.MkdirAll(directory, 0o700)
-			if err != nil {
-				return err
-			}
-
-			jsonBytes, err := pkg.MarshalJSON()
-			if err != nil {
-				return err
-			}
-
-			pCtx, err := NewPluginContext(cwd)
-			if err != nil {
-				return fmt.Errorf("create plugin context: %w", err)
-			}
-			defer contract.IgnoreClose(pCtx.Host)
-			programInfo := plugin.NewProgramInfo(cwd, cwd, ".", nil)
-			languagePlugin, err := pCtx.Host.LanguageRuntime(language, programInfo)
-			if err != nil {
-				return err
-			}
-
-			loader := schema.NewPluginLoader(pCtx.Host)
-			loaderServer := schema.NewLoaderServer(loader)
-			grpcServer, err := plugin.NewServer(pCtx, schema.LoaderRegistration(loaderServer))
-			if err != nil {
-				return err
-			}
-			defer contract.IgnoreClose(grpcServer)
-
-			diags, err := languagePlugin.GeneratePackage(directory, string(jsonBytes), extraFiles, grpcServer.Addr(), nil, local)
-			if err != nil {
-				return err
-			}
-
-			// These diagnostics come directly from the converter and so _should_ be user friendly. So we're just
-			// going to print them.
-			cmdDiag.PrintDiagnostics(pCtx.Diag, diags)
-			if diags.HasErrors() {
-				// If we've got error diagnostics then package generation failed, we've printed the error above so
-				// just return a plain message here.
-				return errors.New("generation failed")
-			}
-
-			return nil
+		err := os.MkdirAll(directory, 0o700)
+		if err != nil {
+			return err
 		}
+
+		jsonBytes, err := pkg.MarshalJSON()
+		if err != nil {
+			return err
+		}
+
+		pCtx, err := NewPluginContext(cwd)
+		if err != nil {
+			return fmt.Errorf("create plugin context: %w", err)
+		}
+		defer contract.IgnoreClose(pCtx.Host)
+		programInfo := plugin.NewProgramInfo(cwd, cwd, ".", nil)
+		languagePlugin, err := pCtx.Host.LanguageRuntime(language, programInfo)
+		if err != nil {
+			return err
+		}
+
+		loader := schema.NewPluginLoader(pCtx.Host)
+		loaderServer := schema.NewLoaderServer(loader)
+		grpcServer, err := plugin.NewServer(pCtx, schema.LoaderRegistration(loaderServer))
+		if err != nil {
+			return err
+		}
+		defer contract.IgnoreClose(grpcServer)
+
+		diags, err := languagePlugin.GeneratePackage(directory, string(jsonBytes), extraFiles, grpcServer.Addr(), nil, local)
+		if err != nil {
+			return err
+		}
+
+		// These diagnostics come directly from the converter and so _should_ be user friendly. So we're just
+		// going to print them.
+		cmdDiag.PrintDiagnostics(pCtx.Diag, diags)
+		if diags.HasErrors() {
+			// If we've got error diagnostics then package generation failed, we've printed the error above so
+			// just return a plain message here.
+			return errors.New("generation failed")
+		}
+
+		return nil
 	}
 
 	extraFiles := make(map[string][]byte)


### PR DESCRIPTION
We should be using the language host codegen in all cases now. This fixes the last hardlink we had to dotnet codegen in GenSDK.