### PR TITLE
Serialize component description to the JSON schema

### DIFF
--- a/changelog/pending/20250401--sdk-python--serialize-component-description-to-the-json-schema.yaml
+++ b/changelog/pending/20250401--sdk-python--serialize-component-description-to-the-json-schema.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Serialize component description to the JSON schema

--- a/sdk/python/lib/pulumi/provider/experimental/schema.py
+++ b/sdk/python/lib/pulumi/provider/experimental/schema.py
@@ -153,6 +153,7 @@ class Resource(ObjectType):
             required=sorted(
                 [k for k, prop in component.outputs.items() if not prop.optional]
             ),
+            description=component.description,
         )
 
 

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1962,6 +1962,7 @@ func TestPythonComponentProviderGetSchema(t *testing.T) {
 	expectedJSON := `{
 		"isComponent": true,
 		"type": "object",
+		"description": "MyComponent is the best",
 		"properties": {
 			"optionalIntOutput": { "type": "integer" },
 			"strOutput": {


### PR DESCRIPTION
We properly infer the component description in the analysis code, but forgot to add it to the schema JSON.

Descriptions for complex types or fields worked correctly.
