### PR TITLE
pin jlumbroso/free-disk-space action

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -102,7 +102,7 @@ jobs:
     steps:
       - if: contains(inputs.platform, 'ubuntu')
         name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           tool-cache: false
           swap-storage: false


### PR DESCRIPTION
Having this action unpinned means we'll pick up any push to main. This action hasn't changed in two years, so just pin it to the latest commit, so it won't move under our feet.

Just noticed this while looking at some actions output.