### PR TITLE
speed up python performance tests with this one simple trick

### DIFF
--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -381,7 +381,7 @@ func (host *pythonLanguageHost) Pack(ctx context.Context, req *pulumirpc.PackReq
 		}
 	}
 
-	buildCmd, err := tc.ModuleCommand(ctx, "build", "--outdir", tmp)
+	buildCmd, err := tc.ModuleCommand(ctx, "build", "-w", "--outdir", tmp)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -381,7 +381,7 @@ func (host *pythonLanguageHost) Pack(ctx context.Context, req *pulumirpc.PackReq
 		}
 	}
 
-	buildCmd, err := tc.ModuleCommand(ctx, "build", "-w", "--outdir", tmp)
+	buildCmd, err := tc.ModuleCommand(ctx, "build", "--wheel", "--outdir", tmp)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In the python conformance tests we build wheels for the Python SDK, and the SDK for every provider.  We use `python build` for this. `python build` builds a sdist and then a wheel from that by default. However we don't need the source distribution at all in conformance tests and only care about the wheel. Instructing `python build` to only build the wheel cuts the build time roughly in half.  This brings the time to run a single python conformance test locally from 48 seconds to 27 seconds.