### PR TITLE
further speed up python conformance tests when uv is available

### DIFF
--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -344,7 +344,8 @@ func (host *pythonLanguageHost) Pack(ctx context.Context, req *pulumirpc.PackReq
 		Toolchain:  toolchain.Uv,
 		Virtualenv: venv,
 	})
-	if err == nil {
+	useUv := err == nil
+	if useUv {
 		// `uv` is available, use it to create our virtual environment.
 		logging.V(5).Infof("Creating virtual environment using uv at %s", venv)
 		cmd := exec.CommandContext(ctx, "uv", "venv", venv)
@@ -382,7 +383,7 @@ func (host *pythonLanguageHost) Pack(ctx context.Context, req *pulumirpc.PackReq
 	}
 
 	args := []string{"--wheel", "--outdir", tmp}
-	if err == nil {
+	if useUv {
 		args = append(args, "--installer", "uv")
 	}
 

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -381,7 +381,12 @@ func (host *pythonLanguageHost) Pack(ctx context.Context, req *pulumirpc.PackReq
 		}
 	}
 
-	buildCmd, err := tc.ModuleCommand(ctx, "build", "--wheel", "--outdir", tmp)
+	args := []string{"--wheel", "--outdir", tmp}
+	if err == nil {
+		args = append(args, "--installer", "uv")
+	}
+
+	buildCmd, err := tc.ModuleCommand(ctx, "build", args...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/19099 we made some progress speeding up python conformance tests.  If we have uv available we can go one step further, and use that to build the wheel.  This gets a single test to run in 20 seconds instead of 27 locally on my machine.

The benefit is even bigger when running more tests, as `pip` seems to have some internal locking against other instances, which `uv` doesn't suffer from.