### PR TITLE
exclude virtualenv from being checked by mypy

### DIFF
--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -949,21 +949,15 @@ func (host *pythonLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 		logging.V(5).Infoln("Language host launching process: ", host.exec, commandStr)
 	}
 
-	// Now simply spawn a process to execute the requested program, wiring up stdout/stderr directly.
-	mkCmd := func(args []string) (*exec.Cmd, error) {
-		tc, err := toolchain.ResolveToolchain(opts)
-		if err != nil {
-			return nil, err
-		}
-
-		if err := tc.ValidateVenv(ctx); err != nil {
-			return nil, err
-		}
-
-		return tc.Command(ctx, args...)
+	tc, err := toolchain.ResolveToolchain(opts)
+	if err != nil {
+		return nil, err
 	}
 
-	cmd, err := mkCmd(args)
+	if err := tc.ValidateVenv(ctx); err != nil {
+		return nil, err
+	}
+	cmd, err := tc.Command(ctx, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -996,7 +990,17 @@ func (host *pythonLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 	}
 
 	if typechecker != "" {
-		typecheckerCmd, err := mkCmd([]string{"-m", typechecker, req.Info.ProgramDirectory})
+		typecheckerArgs := []string{"-m", typechecker}
+		if typechecker == "mypy" {
+			virtualenvPath, err := tc.VirtualEnvPath(ctx)
+			if err != nil {
+				return nil, err
+			}
+			typecheckerArgs = append(typecheckerArgs, "--exclude",
+				strings.TrimPrefix(virtualenvPath, req.Info.ProgramDirectory+"/"))
+		}
+		typecheckerArgs = append(typecheckerArgs, req.Info.ProgramDirectory)
+		typecheckerCmd, err := tc.Command(ctx, typecheckerArgs...)
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -996,8 +996,11 @@ func (host *pythonLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 			if err != nil {
 				return nil, err
 			}
-			typecheckerArgs = append(typecheckerArgs, "--exclude",
-				strings.TrimPrefix(virtualenvPath, req.Info.ProgramDirectory+"/"))
+			relPath, err := filepath.Rel(req.Info.ProgramDirectory, virtualenvPath)
+			if err != nil {
+				return nil, err
+			}
+			typecheckerArgs = append(typecheckerArgs, "--exclude", relPath)
 		}
 		typecheckerArgs = append(typecheckerArgs, req.Info.ProgramDirectory)
 		typecheckerCmd, err := tc.Command(ctx, typecheckerArgs...)

--- a/sdk/python/toolchain/pip.go
+++ b/sdk/python/toolchain/pip.go
@@ -178,6 +178,10 @@ func (p *pip) EnsureVenv(ctx context.Context, cwd string, useLanguageVersionTool
 	return nil
 }
 
+func (p *pip) VirtualEnvPath(_ context.Context) (string, error) {
+	return p.virtualenvPath, nil
+}
+
 // IsVirtualEnv returns true if the specified directory contains a python binary.
 func IsVirtualEnv(dir string) bool {
 	pyBin := filepath.Join(dir, virtualEnvBinDirName(), "python")

--- a/sdk/python/toolchain/poetry.go
+++ b/sdk/python/toolchain/poetry.go
@@ -168,7 +168,7 @@ func (p *poetry) ListPackages(ctx context.Context, transitive bool) ([]PythonPac
 }
 
 func (p *poetry) Command(ctx context.Context, args ...string) (*exec.Cmd, error) {
-	virtualenvPath, err := p.virtualenvPath(ctx)
+	virtualenvPath, err := p.VirtualEnvPath(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +214,7 @@ func (p *poetry) About(ctx context.Context) (Info, error) {
 }
 
 func (p *poetry) ValidateVenv(ctx context.Context) error {
-	virtualenvPath, err := p.virtualenvPath(ctx)
+	virtualenvPath, err := p.VirtualEnvPath(ctx)
 	if err != nil {
 		return err
 	}
@@ -227,7 +227,7 @@ func (p *poetry) ValidateVenv(ctx context.Context) error {
 func (p *poetry) EnsureVenv(ctx context.Context, cwd string, useLanguageVersionTools,
 	showOutput bool, infoWriter, errorWriter io.Writer,
 ) error {
-	_, err := p.virtualenvPath(ctx)
+	_, err := p.VirtualEnvPath(ctx)
 	if err != nil {
 		// Couldn't get the virtualenv path, this means it does not exist. Let's create it.
 		return p.InstallDependencies(ctx, cwd, useLanguageVersionTools, showOutput, infoWriter, errorWriter)
@@ -235,7 +235,7 @@ func (p *poetry) EnsureVenv(ctx context.Context, cwd string, useLanguageVersionT
 	return nil
 }
 
-func (p *poetry) virtualenvPath(ctx context.Context) (string, error) {
+func (p *poetry) VirtualEnvPath(ctx context.Context) (string, error) {
 	pathCmd := exec.CommandContext(ctx, p.poetryExecutable, "env", "info", "--path") //nolint:gosec
 	pathCmd.Dir = p.directory
 	out, err := pathCmd.Output()

--- a/sdk/python/toolchain/toolchain.go
+++ b/sdk/python/toolchain/toolchain.go
@@ -92,6 +92,8 @@ type Toolchain interface {
 	ModuleCommand(ctx context.Context, module string, args ...string) (*exec.Cmd, error)
 	// About returns information about the python executable of the toolchain.
 	About(ctx context.Context) (Info, error)
+	// VirtualEnvPath returns the path of the virtual env used by the toolchain.
+	VirtualEnvPath(ctx context.Context) (string, error)
 }
 
 func Name(tc toolchain) string {

--- a/sdk/python/toolchain/uv.go
+++ b/sdk/python/toolchain/uv.go
@@ -342,3 +342,7 @@ func (u *uv) pythonExecutable() (string, string) {
 	}
 	return name, filepath.Join(u.virtualenvPath, virtualEnvBinDirName(), name)
 }
+
+func (u *uv) VirtualEnvPath(_ context.Context) (string, error) {
+	return u.virtualenvPath, nil
+}


### PR DESCRIPTION
Mypy doesn't exclude the virtualenv by default when typechecking. It does exclude only hidden files, starting with a `.`.  At the same time, `uv` installs a file into the virtualenv that doesn't typecheck correctly.

By default that's fine, as `uv` uses `.venv` as its virtualenv location, but it breaks when someone uses a custom venv location, and uses mypy.  For example in conformance tests, we use `venv` as the virtual env location, which in turn makes the tests fail because of `mypy`.  This could also happen to someone using a custom venv location with `uv`.