### PR TITLE
install dependencies in python conformance tests using uv

### DIFF
--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -303,7 +303,7 @@ func (g *generator) genComponentDefinition(w io.Writer, component *pcl.Component
 func GenerateProject(
 	directory string, project workspace.Project,
 	program *pcl.Program, localDependencies map[string]string,
-	typechecker string,
+	typechecker, toolchain string,
 ) error {
 	files, diagnostics, err := GenerateProgram(program)
 	if err != nil {
@@ -336,6 +336,13 @@ func GenerateProject(
 			options = map[string]interface{}{}
 		}
 		options["typechecker"] = typechecker
+	}
+
+	if toolchain != "" {
+		if options == nil {
+			options = map[string]interface{}{}
+		}
+		options["toolchain"] = toolchain
 	}
 
 	// Set the runtime to "python" then marshal to Pulumi.yaml

--- a/pkg/codegen/python/gen_program_test.go
+++ b/pkg/codegen/python/gen_program_test.go
@@ -63,7 +63,7 @@ func TestGenerateProgramVersionSelection(t *testing.T) {
 			directory string, project workspace.Project,
 			program *pcl.Program, localDependencies map[string]string,
 		) error {
-			return GenerateProject(directory, project, program, localDependencies, "")
+			return GenerateProject(directory, project, program, localDependencies, "", "")
 		},
 	)
 }

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -200,6 +201,7 @@ func TestLanguage(t *testing.T) {
 		useTOML     bool
 		inputTypes  string
 		typechecker string
+		toolchain   string
 	}{
 		{
 			name:        "default",
@@ -207,6 +209,7 @@ func TestLanguage(t *testing.T) {
 			useTOML:     false,
 			inputTypes:  "",
 			typechecker: "mypy",
+			toolchain:   "uv",
 		},
 		{
 			name:        "toml",
@@ -214,6 +217,7 @@ func TestLanguage(t *testing.T) {
 			useTOML:     true,
 			inputTypes:  "classes-and-dicts",
 			typechecker: "pyright",
+			toolchain:   "uv",
 		},
 		{
 			name:        "classes",
@@ -221,6 +225,7 @@ func TestLanguage(t *testing.T) {
 			useTOML:     false,
 			inputTypes:  "classes",
 			typechecker: "pyright",
+			toolchain:   "uv",
 		},
 	}
 
@@ -235,8 +240,11 @@ func TestLanguage(t *testing.T) {
 			// Run the language plugin
 			handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 				Init: func(srv *grpc.Server) error {
-					pythonExec := "../pulumi-language-python-exec"
-					host := newLanguageHost(pythonExec, engineAddress, "", config.typechecker)
+					pythonExec, err := filepath.Abs("../pulumi-language-python-exec")
+					if err != nil {
+						return err
+					}
+					host := newLanguageHost(pythonExec, engineAddress, "", config.typechecker, config.toolchain)
 					pulumirpc.RegisterLanguageRuntimeServer(srv, host)
 					return nil
 				},

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -170,7 +170,7 @@ func main() {
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Cancel: cancelChannel,
 		Init: func(srv *grpc.Server) error {
-			host := newLanguageHost(pythonExec, engineAddress, tracing, "")
+			host := newLanguageHost(pythonExec, engineAddress, tracing, "", "")
 			pulumirpc.RegisterLanguageRuntimeServer(srv, host)
 			return nil
 		},
@@ -200,6 +200,8 @@ type pythonLanguageHost struct {
 
 	// This is used by conformance testing to set the typechecker to use in ProgramGen.
 	typechecker string
+	// This is used by conformance testing to set the toolchain to use in ProgramGen.
+	toolchain string
 }
 
 func parseOptions(root string, programDir string, options map[string]interface{}) (toolchain.PythonOptions, error) {
@@ -251,13 +253,14 @@ func parseOptions(root string, programDir string, options map[string]interface{}
 	return pythonOptions, nil
 }
 
-func newLanguageHost(exec, engineAddress, tracing, typechecker string,
+func newLanguageHost(exec, engineAddress, tracing, typechecker, toolchain string,
 ) pulumirpc.LanguageRuntimeServer {
 	return &pythonLanguageHost{
 		exec:          exec,
 		engineAddress: engineAddress,
 		tracing:       tracing,
 		typechecker:   typechecker,
+		toolchain:     toolchain,
 	}
 }
 
@@ -1431,7 +1434,8 @@ func (host *pythonLanguageHost) GenerateProject(
 		return nil, err
 	}
 
-	err = codegen.GenerateProject(req.TargetDirectory, project, program, req.LocalDependencies, host.typechecker)
+	err = codegen.GenerateProject(
+		req.TargetDirectory, project, program, req.LocalDependencies, host.typechecker, host.toolchain)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-builtin-info/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-builtin-info/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-builtin-info
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-builtin-project-root/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-builtin-project-root/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-builtin-project-root
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-config-types/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-config-types/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-config-types
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-empty/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-empty/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-empty
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-keyword-overlap/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-keyword-overlap/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-keyword-overlap
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-main/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-main/Pulumi.yaml
@@ -2,6 +2,7 @@ name: l1-main
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv
 main: subdir

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-array/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-array/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-output-array
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-bool/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-bool/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-output-bool
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-map/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-map/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-output-map
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-null/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-null/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-output-null
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-number/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-number/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-output-number
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-string/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-output-string/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-output-string
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-proxy-index/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-proxy-index/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-proxy-index
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-stack-reference/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-stack-reference/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-stack-reference
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-component-call-simple/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-component-call-simple/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-component-call-simple
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-component-component-resource-ref/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-component-component-resource-ref/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-component-component-resource-ref
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-component-program-resource-ref/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-component-program-resource-ref/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-component-program-resource-ref
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-component-property-deps/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-component-property-deps/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-component-property-deps
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-destroy/0/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-destroy/0/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-destroy
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-destroy/1/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-destroy/1/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-destroy
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-engine-update-options/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-engine-update-options/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-engine-update-options
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-explicit-parameterized-provider/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-explicit-parameterized-provider/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-explicit-parameterized-provider
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-explicit-provider/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-explicit-provider/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-explicit-provider
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-failed-create-continue-on-error/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-failed-create-continue-on-error/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-failed-create-continue-on-error
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-dependencies/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-dependencies/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-invoke-dependencies
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-options-depends-on/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-options-depends-on/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-invoke-options-depends-on
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-options/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-options/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-invoke-options
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-secrets/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-secrets/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-invoke-secrets
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-simple/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-simple/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-invoke-simple
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-variants/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-invoke-variants/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-invoke-variants
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-large-string/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-large-string/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-large-string
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-map-keys/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-map-keys/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-map-keys
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-namespaced-provider/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-namespaced-provider/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-namespaced-provider
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-parameterized-resource/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-parameterized-resource/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-parameterized-resource
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-plain/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-plain/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-plain
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-primitive-ref/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-primitive-ref/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-primitive-ref
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-provider-call-explicit/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-provider-call-explicit/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-provider-call-explicit
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-provider-call/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-provider-call/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-provider-call
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-provider-grpc-config-schema-secret/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-provider-grpc-config-schema-secret/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-provider-grpc-config-schema-secret
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-provider-grpc-config-secret/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-provider-grpc-config-secret/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-provider-grpc-config-secret
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-provider-grpc-config/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-provider-grpc-config/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-provider-grpc-config
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-proxy-index/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-proxy-index/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-proxy-index
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-ref-ref/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-ref-ref/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-ref-ref
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-alpha/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-alpha/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-alpha
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-asset-archive/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-asset-archive/Pulumi.yaml
@@ -2,6 +2,7 @@ name: l2-resource-asset-archive
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv
 main: subdir

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-config/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-config/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-config
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-invoke-dynamic-function/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-invoke-dynamic-function/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-invoke-dynamic-function
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-keyword-overlap/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-keyword-overlap/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-keyword-overlap
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-option-deleted-with/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-option-deleted-with/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-option-deleted-with
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-option-protect/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-option-protect/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-option-protect
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-option-retain-on-delete/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-option-retain-on-delete/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-option-retain-on-delete
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-parent-inheritance/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-parent-inheritance/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-parent-inheritance
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-primitives/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-primitives/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-primitives
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-secret/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-secret/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-secret
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-simple/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-resource-simple/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-simple
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-rtti/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-rtti/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-rtti
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-target-up-with-new-dependency/0/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-target-up-with-new-dependency/0/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-target-up-with-new-dependency
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-target-up-with-new-dependency/1/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-target-up-with-new-dependency/1/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-target-up-with-new-dependency
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-builtin-info/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-builtin-info/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-builtin-info
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-builtin-project-root/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-builtin-project-root/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-builtin-project-root
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-config-types/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-config-types/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-config-types
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-empty/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-empty/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-empty
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-keyword-overlap/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-keyword-overlap/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-keyword-overlap
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-main/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-main/Pulumi.yaml
@@ -2,6 +2,7 @@ name: l1-main
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv
 main: subdir

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-array/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-array/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-output-array
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-bool/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-bool/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-output-bool
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-map/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-map/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-output-map
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-null/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-null/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-output-null
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-number/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-number/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-output-number
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-string/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-string/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-output-string
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-proxy-index/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-proxy-index/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-proxy-index
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-stack-reference/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-stack-reference/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-stack-reference
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-component-call-simple/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-component-call-simple/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-component-call-simple
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-component-component-resource-ref/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-component-component-resource-ref/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-component-component-resource-ref
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-component-program-resource-ref/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-component-program-resource-ref/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-component-program-resource-ref
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-component-property-deps/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-component-property-deps/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-component-property-deps
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-destroy/0/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-destroy/0/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-destroy
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-destroy/1/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-destroy/1/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-destroy
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-engine-update-options/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-engine-update-options/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-engine-update-options
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-explicit-parameterized-provider/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-explicit-parameterized-provider/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-explicit-parameterized-provider
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-explicit-provider/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-explicit-provider/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-explicit-provider
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-failed-create-continue-on-error/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-failed-create-continue-on-error/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-failed-create-continue-on-error
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-dependencies/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-dependencies/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-invoke-dependencies
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-options-depends-on/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-options-depends-on/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-invoke-options-depends-on
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-options/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-options/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-invoke-options
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-secrets/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-secrets/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-invoke-secrets
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-simple/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-simple/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-invoke-simple
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-variants/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-invoke-variants/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-invoke-variants
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-large-string/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-large-string/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-large-string
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-map-keys/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-map-keys/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-map-keys
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-namespaced-provider/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-namespaced-provider/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-namespaced-provider
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-parameterized-resource/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-parameterized-resource/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-parameterized-resource
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-plain/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-plain/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-plain
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-primitive-ref/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-primitive-ref/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-primitive-ref
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-provider-call-explicit/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-provider-call-explicit/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-provider-call-explicit
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-provider-call/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-provider-call/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-provider-call
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-provider-grpc-config-schema-secret/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-provider-grpc-config-schema-secret/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-provider-grpc-config-schema-secret
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-provider-grpc-config-secret/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-provider-grpc-config-secret/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-provider-grpc-config-secret
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-provider-grpc-config/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-provider-grpc-config/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-provider-grpc-config
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-proxy-index/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-proxy-index/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-proxy-index
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-ref-ref/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-ref-ref/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-ref-ref
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-alpha/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-alpha/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-alpha
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-asset-archive/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-asset-archive/Pulumi.yaml
@@ -2,6 +2,7 @@ name: l2-resource-asset-archive
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv
 main: subdir

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-config/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-config/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-config
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-invoke-dynamic-function/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-invoke-dynamic-function/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-invoke-dynamic-function
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-keyword-overlap/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-keyword-overlap/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-keyword-overlap
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-option-deleted-with/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-option-deleted-with/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-option-deleted-with
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-option-protect/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-option-protect/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-option-protect
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-option-retain-on-delete/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-option-retain-on-delete/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-option-retain-on-delete
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-parent-inheritance/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-parent-inheritance/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-parent-inheritance
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-primitives/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-primitives/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-primitives
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-secret/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-secret/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-secret
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-simple/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-simple/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-simple
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-rtti/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-rtti/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-rtti
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-target-up-with-new-dependency/0/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-target-up-with-new-dependency/0/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-target-up-with-new-dependency
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-target-up-with-new-dependency/1/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-target-up-with-new-dependency/1/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-target-up-with-new-dependency
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: mypy
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-builtin-info/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-builtin-info/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-builtin-info
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-builtin-project-root/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-builtin-project-root/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-builtin-project-root
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-config-types/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-config-types/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-config-types
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-empty/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-empty/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-empty
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-keyword-overlap/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-keyword-overlap/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-keyword-overlap
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-main/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-main/Pulumi.yaml
@@ -2,6 +2,7 @@ name: l1-main
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv
 main: subdir

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-array/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-array/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-output-array
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-bool/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-bool/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-output-bool
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-map/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-map/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-output-map
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-null/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-null/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-output-null
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-number/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-number/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-output-number
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-string/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-string/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-output-string
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-proxy-index/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-proxy-index/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-proxy-index
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-stack-reference/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-stack-reference/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l1-stack-reference
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-component-call-simple/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-component-call-simple/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-component-call-simple
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-component-component-resource-ref/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-component-component-resource-ref/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-component-component-resource-ref
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-component-program-resource-ref/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-component-program-resource-ref/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-component-program-resource-ref
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-component-property-deps/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-component-property-deps/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-component-property-deps
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-destroy/0/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-destroy/0/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-destroy
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-destroy/1/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-destroy/1/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-destroy
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-engine-update-options/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-engine-update-options/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-engine-update-options
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-explicit-parameterized-provider/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-explicit-parameterized-provider/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-explicit-parameterized-provider
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-explicit-provider/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-explicit-provider/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-explicit-provider
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-failed-create-continue-on-error/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-failed-create-continue-on-error/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-failed-create-continue-on-error
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-dependencies/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-dependencies/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-invoke-dependencies
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-options-depends-on/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-options-depends-on/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-invoke-options-depends-on
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-options/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-options/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-invoke-options
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-secrets/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-secrets/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-invoke-secrets
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-simple/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-simple/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-invoke-simple
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-variants/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-invoke-variants/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-invoke-variants
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-large-string/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-large-string/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-large-string
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-map-keys/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-map-keys/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-map-keys
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-namespaced-provider/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-namespaced-provider/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-namespaced-provider
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-parameterized-resource/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-parameterized-resource/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-parameterized-resource
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-plain/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-plain/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-plain
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-primitive-ref/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-primitive-ref/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-primitive-ref
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-provider-call-explicit/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-provider-call-explicit/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-provider-call-explicit
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-provider-call/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-provider-call/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-provider-call
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-provider-grpc-config-schema-secret/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-provider-grpc-config-schema-secret/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-provider-grpc-config-schema-secret
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-provider-grpc-config-secret/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-provider-grpc-config-secret/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-provider-grpc-config-secret
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-provider-grpc-config/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-provider-grpc-config/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-provider-grpc-config
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-proxy-index/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-proxy-index/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-proxy-index
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-ref-ref/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-ref-ref/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-ref-ref
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-alpha/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-alpha/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-alpha
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-asset-archive/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-asset-archive/Pulumi.yaml
@@ -2,6 +2,7 @@ name: l2-resource-asset-archive
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv
 main: subdir

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-config/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-config/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-config
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-invoke-dynamic-function/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-invoke-dynamic-function/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-invoke-dynamic-function
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-keyword-overlap/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-keyword-overlap/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-keyword-overlap
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-option-deleted-with/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-option-deleted-with/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-option-deleted-with
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-option-protect/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-option-protect/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-option-protect
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-option-retain-on-delete/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-option-retain-on-delete/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-option-retain-on-delete
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-parent-inheritance/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-parent-inheritance/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-parent-inheritance
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-primitives/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-primitives/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-primitives
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-secret/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-secret/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-secret
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-simple/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-simple/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-resource-simple
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-rtti/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-rtti/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-rtti
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-target-up-with-new-dependency/0/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-target-up-with-new-dependency/0/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-target-up-with-new-dependency
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-target-up-with-new-dependency/1/Pulumi.yaml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-target-up-with-new-dependency/1/Pulumi.yaml
@@ -2,5 +2,6 @@ name: l2-target-up-with-new-dependency
 runtime:
   name: python
   options:
+    toolchain: uv
     typechecker: pyright
     virtualenv: venv


### PR DESCRIPTION
In previous PRs we started using `uv` more in conformance tests, e.g. for building the Python wheel, which got us to run the conformance tests in 24 minutes in CI.  That still seemed kinda slow, so I did some more digging, and found that we are still installing all our dependencies using `pip`.  

This PR changes the python conformance tests, so they install dependencies via `uv` instead.  This assumes `uv` is available, but I expect that to be the case in developer environments.

This brings the total time for the CI job running the conformance tests to ~16min, shaving off another 8 minutes.

