### PR TITLE
cache SDK artifacts in conformance tests

### DIFF
--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -71,6 +71,13 @@ type LanguageTestServer interface {
 	Done() error
 }
 
+func newLanguageTestServer() *languageTestServer {
+	return &languageTestServer{
+		sdkLock:     make(map[string]*sync.Mutex),
+		artifactMap: make(map[string]string),
+	}
+}
+
 func Start(ctx context.Context) (LanguageTestServer, error) {
 	// New up an engine RPC server.
 	server := &languageTestServer{

--- a/cmd/pulumi-test-language/interface_test.go
+++ b/cmd/pulumi-test-language/interface_test.go
@@ -64,7 +64,7 @@ func TestNoInternalTests(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 
 	response, err := engine.GetLanguageTests(ctx, &testingrpc.GetLanguageTestsRequest{})
 	require.NoError(t, err)

--- a/cmd/pulumi-test-language/internal_test.go
+++ b/cmd/pulumi-test-language/internal_test.go
@@ -32,7 +32,7 @@ func TestInvalidSchema(t *testing.T) {
 
 	ctx := t.Context()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 	// We can just reuse the L1Empty host for this, it's not actually going to be used apart from prepare.
 	runtime := &L1EmptyLanguageHost{tempDir: tempDir}
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{

--- a/cmd/pulumi-test-language/l1_empty_test.go
+++ b/cmd/pulumi-test-language/l1_empty_test.go
@@ -179,7 +179,7 @@ func TestL1Empty(t *testing.T) {
 
 	ctx := t.Context()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 	runtime := &L1EmptyLanguageHost{tempDir: tempDir}
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Init: func(srv *grpc.Server) error {
@@ -217,7 +217,7 @@ func TestL1Empty_FailPrepare(t *testing.T) {
 
 	ctx := t.Context()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 	runtime := &L1EmptyLanguageHost{
 		tempDir:  tempDir,
 		failPack: true,
@@ -303,7 +303,8 @@ func TestL1Empty_BadSnapshot(t *testing.T) {
 
 	ctx := t.Context()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{DisableSnapshotWriting: true}
+	engine := newLanguageTestServer()
+	engine.DisableSnapshotWriting = true
 	runtime := &L1EmptyLanguageHost{tempDir: tempDir}
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Init: func(srv *grpc.Server) error {
@@ -343,7 +344,7 @@ func TestL1Empty_MissingStack(t *testing.T) {
 
 	ctx := t.Context()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 	runtime := &L1EmptyLanguageHost{
 		tempDir:   tempDir,
 		skipStack: true,
@@ -386,7 +387,7 @@ func TestL1Empty_NoCoreSDK(t *testing.T) {
 
 	ctx := t.Context()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 	runtime := &L1EmptyLanguageHost{
 		tempDir:     tempDir,
 		skipStack:   true,

--- a/cmd/pulumi-test-language/l1_main_test.go
+++ b/cmd/pulumi-test-language/l1_main_test.go
@@ -193,7 +193,7 @@ func TestL1Main(t *testing.T) {
 
 	ctx := t.Context()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 	runtime := &L1MainLanguageHost{tempDir: tempDir}
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Init: func(srv *grpc.Server) error {

--- a/cmd/pulumi-test-language/l2_continue_on_error_test.go
+++ b/cmd/pulumi-test-language/l2_continue_on_error_test.go
@@ -272,7 +272,7 @@ func TestL2ContinueOnError(t *testing.T) {
 
 	ctx := t.Context()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 	runtime := &L2ContinueOnErrorHost{tempDir: tempDir}
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Init: func(srv *grpc.Server) error {

--- a/cmd/pulumi-test-language/l2_destroy_test.go
+++ b/cmd/pulumi-test-language/l2_destroy_test.go
@@ -252,7 +252,7 @@ func TestL2Destroy(t *testing.T) {
 
 	ctx := t.Context()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 	runtime := &L2DestroyLanguageHost{tempDir: tempDir}
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Init: func(srv *grpc.Server) error {

--- a/cmd/pulumi-test-language/l2_large_test.go
+++ b/cmd/pulumi-test-language/l2_large_test.go
@@ -241,7 +241,7 @@ func (h *L2LargeLanguageHost) Run(
 func TestL2LargeString(t *testing.T) {
 	ctx := t.Context()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 	runtime := &L2LargeLanguageHost{tempDir: tempDir}
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Init: func(srv *grpc.Server) error {

--- a/cmd/pulumi-test-language/l2_resource_asset_test.go
+++ b/cmd/pulumi-test-language/l2_resource_asset_test.go
@@ -345,7 +345,7 @@ func TestL2ResourceAssetArchive(t *testing.T) {
 
 	ctx := t.Context()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 	runtime := &L2ResourceAssetArchiveLanguageHost{tempDir: tempDir}
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Init: func(srv *grpc.Server) error {

--- a/cmd/pulumi-test-language/l2_resource_simple_test.go
+++ b/cmd/pulumi-test-language/l2_resource_simple_test.go
@@ -267,7 +267,7 @@ func TestL2ResourceSimple(t *testing.T) {
 
 	ctx := t.Context()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 	runtime := &L2ResourceSimpleLanguageHost{tempDir: tempDir}
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Init: func(srv *grpc.Server) error {
@@ -305,7 +305,8 @@ func TestL2SimpleResource_BadSnapshot(t *testing.T) {
 
 	ctx := t.Context()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{DisableSnapshotWriting: true}
+	engine := newLanguageTestServer()
+	engine.DisableSnapshotWriting = true
 	runtime := &L2ResourceSimpleLanguageHost{tempDir: tempDir}
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Init: func(srv *grpc.Server) error {
@@ -345,7 +346,7 @@ func TestL2SimpleResource_MissingResource(t *testing.T) {
 
 	ctx := t.Context()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 	runtime := &L2ResourceSimpleLanguageHost{
 		tempDir:      tempDir,
 		skipResource: true,
@@ -388,7 +389,7 @@ func TestL2SimpleResource_MissingRequiredPlugins(t *testing.T) {
 
 	ctx := t.Context()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 	runtime := &L2ResourceSimpleLanguageHost{
 		tempDir:             tempDir,
 		skipRequiredPlugins: true,
@@ -431,7 +432,7 @@ func TestL2ResourceSnapshotEdit(t *testing.T) {
 
 	ctx := t.Context()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 	runtime := &L2ResourceSimpleLanguageHost{tempDir: tempDir}
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Init: func(srv *grpc.Server) error {
@@ -475,7 +476,7 @@ func TestL2ResourceLanguageInfo(t *testing.T) {
 
 	ctx := t.Context()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 	runtime := &L2ResourceSimpleLanguageHost{
 		tempDir:            tempDir,
 		expectLanguageInfo: true,

--- a/cmd/pulumi-test-language/program_overrides_test.go
+++ b/cmd/pulumi-test-language/program_overrides_test.go
@@ -139,7 +139,7 @@ func TestProgramOverrides_DontGenerateProgram(t *testing.T) {
 	tempDir := t.TempDir()
 
 	ctx := t.Context()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 
 	runtime := &ProgramOverridesLanguageHost{
 		tempDir: tempDir,
@@ -220,7 +220,7 @@ func TestProgramOverrides_WorkWithMultipleRuns(t *testing.T) {
 	tempDir := t.TempDir()
 
 	ctx := t.Context()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 
 	runtime := &ProgramOverridesLanguageHost{
 		tempDir: tempDir,
@@ -396,7 +396,7 @@ func TestProgramOverrides_MustMatchRuns(t *testing.T) {
 	tempDir := t.TempDir()
 
 	ctx := t.Context()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 
 	runtime := &ProgramOverridesLanguageHost{tempDir: tempDir}
 

--- a/cmd/pulumi-test-language/runtime_options_test.go
+++ b/cmd/pulumi-test-language/runtime_options_test.go
@@ -213,7 +213,7 @@ func TestRuntimeOptions(t *testing.T) {
 
 	ctx := t.Context()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{}
+	engine := newLanguageTestServer()
 	runtime := &RuntimeOptionsLanguageHost{tempDir: tempDir}
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Init: func(srv *grpc.Server) error {

--- a/pkg/util/gsync/syncmap.go
+++ b/pkg/util/gsync/syncmap.go
@@ -46,6 +46,15 @@ func (m *Map[K, V]) Load(k K) (value V, ok bool) {
 	return
 }
 
+// LoadOrStore returns the existing value for the key if present. Otherwise, it stores and returns the given value. The
+// loaded result is true if the value was loaded, false if stored.
+func (m *Map[K, V]) LoadOrStore(k K, v V) (value V, ok bool) {
+	var s any
+	s, ok = m.m.LoadOrStore(k, v)
+	value = s.(V)
+	return
+}
+
 // Range calls f sequentially for each key and value present in the map. If f returns false, range stops the iteration.
 //
 // Range does not necessarily correspond to any consistent snapshot of the Map's contents: no key will be visited more


### PR DESCRIPTION
In conformance tests we curently generate all the SDKs once, but we re-pack them for each test run.  This seems unnecessary, as the packed artifacts shouldn't change.  Only pack them once, to save time. Also `uv` seems to be non-deterministic when packing these artifacts, which seems to result in flakes in https://github.com/pulumi/pulumi/pull/19109.

Cache the artifacts instead, and re-use them for various tests.

Note that we currently simply overwrite artifacts in the same directory, so if the artifacts were any different, our tests would already be broken, since any test we're running would get a random artifact to use.

I expect this brings some performance improvements in all languages.  Let's see what CI says.

Fixes #16079