### PR TITLE
Return an InputPropertyError for invalid enum values

### DIFF
--- a/changelog/pending/20250404--sdk-python--return-an-inputpropertyerror-for-invalid-enum-values.yaml
+++ b/changelog/pending/20250404--sdk-python--return-an-inputpropertyerror-for-invalid-enum-values.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Return an InputPropertyError for invalid enum values

--- a/sdk/python/lib/pulumi/provider/experimental/provider.py
+++ b/sdk/python/lib/pulumi/provider/experimental/provider.py
@@ -166,7 +166,18 @@ class ComponentProvider(Provider):
                     continue
 
                 if type_def.enum:
-                    mapped_value[py_name] = type_def.python_type(input_val)
+                    try:
+                        mapped_value[py_name] = type_def.python_type(input_val)
+                    except ValueError as e:
+                        full_path = (
+                            schema_name
+                            if not property_path
+                            else f"{property_path}.{schema_name}"
+                        )
+                        raise InputPropertyError(
+                            full_path,
+                            f"Invalid value {input_val} of type {type(input_val)} for enum '{type_def.name}'",
+                        ) from e
                     continue
 
                 # Recursively map the complex type


### PR DESCRIPTION
Return a nicer error message when a user sets a bad value for an enum typed property. Using InputPropertyError ensures we display actionable error information, for example:
```
error: provider:index:MyComponent resource 'comp' has a problem:
                - property enumInput with value '{7}' has a problem: Invalid value 7.0 of type <class 'float'> for enum 'Emu'
```
