### PR TITLE
[components/nodejs] Fix schema inference for optional boolean properties

### DIFF
--- a/changelog/pending/20250407--components-nodejs--fix-schema-inference-for-optional-boolean-properties.yaml
+++ b/changelog/pending/20250407--components-nodejs--fix-schema-inference-for-optional-boolean-properties.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: components/nodejs
+  description: Fix schema inference for optional boolean properties

--- a/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
@@ -66,10 +66,14 @@ describe("Analyzer", function () {
                 inputs: {
                     optionalNumber: { type: "number", optional: true, plain: true },
                     optionalNumberType: { type: "number", optional: true, plain: true },
+                    optionalBoolean: { type: "boolean", optional: true, plain: true },
+                    optionalBooleanType: { type: "boolean", optional: true, plain: true },
                 },
                 outputs: {
                     optionalOutputNumber: { type: "number", optional: true },
                     optionalOutputType: { type: "number", optional: true },
+                    optionalOutputBoolean: { type: "boolean", optional: true },
+                    optionalOutputBooleanType: { type: "boolean", optional: true },
                 },
             },
         });

--- a/sdk/nodejs/tests/provider/experimental/testdata/optional-types/index.ts
+++ b/sdk/nodejs/tests/provider/experimental/testdata/optional-types/index.ts
@@ -5,11 +5,15 @@ import * as pulumi from "@pulumi/pulumi";
 export interface MyComponentArgs {
     optionalNumber?: number;
     optionalNumberType: number | undefined;
+    optionalBoolean?: boolean;
+    optionalBooleanType: boolean | undefined;
 }
 
 export class MyComponent extends pulumi.ComponentResource {
     optionalOutputNumber?: pulumi.Output<number>;
     optionalOutputType?: pulumi.Output<number | undefined>;
+    optionalOutputBoolean?: pulumi.Output<boolean>;
+    optionalOutputBooleanType?: pulumi.Output<boolean | undefined>;
 
     constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
         super("provider:index:MyComponent", name, args, opts);


### PR DESCRIPTION
TypeScript represents optional booleans as `true | false | undefined` and our current code isn't prepared to handle 3-case unions. This PR introduces a new check to handle this situation as it should.

Fix https://github.com/pulumi/pulumi/issues/19064