### PR TITLE
Change default registry source to private

### DIFF
--- a/changelog/pending/20250407--cli-package--change-default-registry-source-to-private.yaml
+++ b/changelog/pending/20250407--cli-package--change-default-registry-source-to-private.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/package
+  description: Change default registry source to private

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -40,10 +40,11 @@ import (
 )
 
 const (
-	// The default package source is "pulumi" for packages published to the Pulumi Registry.
-	// This is the source that will be used if none is specified on the command line.
-	// Examples of other sources include "opentofu" for packages published to the OpenTofu Registry.
-	defaultPackageSource = "pulumi"
+	// The default package source is "private" for packages published to the Pulumi Registry. This corresponds to the
+	// private registry of an organization.
+	// Examples of other sources include "pulumi" for the public registry and "opentofu" for packages published to the
+	// OpenTofu Registry.
+	defaultPackageSource = "private"
 )
 
 type publishPackageArgs struct {
@@ -95,7 +96,7 @@ func newPackagePublishCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(
 		&args.source, "source", defaultPackageSource,
-		"The origin of the package (e.g., 'pulumi', 'opentofu'). Defaults to the current registry.")
+		"The origin of the package (e.g., 'pulumi', 'private', 'opentofu'). Defaults to the private registry.")
 
 	cmd.Flags().StringVar(
 		&args.publisher, "publisher", "",

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -97,10 +97,12 @@ func newPackagePublishCmd() *cobra.Command {
 	cmd.Flags().StringVar(
 		&args.source, "source", defaultPackageSource,
 		"The origin of the package (e.g., 'pulumi', 'private', 'opentofu'). Defaults to the private registry.")
-	// hide the source flag from the help output. Only registry administrators can set the source. Regular users can only
-	// publish private packages.
-	// ignore err, only happens if flag does not exist
-	_ = cmd.Flags().MarkHidden("source")
+	if !env.Dev.Value() {
+		// hide the source flag from the help output. Only registry administrators can set the source. Regular users can only
+		// publish private packages.
+		// ignore err, only happens if flag does not exist
+		_ = cmd.Flags().MarkHidden("source")
+	}
 
 	cmd.Flags().StringVar(
 		&args.publisher, "publisher", "",

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -97,6 +97,10 @@ func newPackagePublishCmd() *cobra.Command {
 	cmd.Flags().StringVar(
 		&args.source, "source", defaultPackageSource,
 		"The origin of the package (e.g., 'pulumi', 'private', 'opentofu'). Defaults to the private registry.")
+	// hide the source flag from the help output. Only registry administrators can set the source. Regular users can only
+	// publish private packages.
+	// ignore err, only happens if flag does not exist
+	_ = cmd.Flags().MarkHidden("source")
 
 	cmd.Flags().StringVar(
 		&args.publisher, "publisher", "",


### PR DESCRIPTION
This change switches the default registry source to "private" for `pulumi package publish`. It builds on top of https://github.com/pulumi/pulumi-service/pull/27247, which introduces the ability to publish private packages to the Pulumi Registry.