### PR TITLE
Properties used in component outputs are never plain

### DIFF
--- a/changelog/pending/20250407--sdk-python--properties-used-in-component-outputs-are-never-plain.yaml
+++ b/changelog/pending/20250407--sdk-python--properties-used-in-component-outputs-are-never-plain.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Properties used in component outputs are never plain

--- a/sdk/python/lib/pulumi/provider/experimental/analyzer.py
+++ b/sdk/python/lib/pulumi/provider/experimental/analyzer.py
@@ -153,7 +153,7 @@ class Analyzer:
     def __init__(self, name: str):
         self.name = name
         self.type_definitions: dict[str, TypeDefinition] = {}
-        # For unresolved types, we need to keep track of wether we saw them in a
+        # For unresolved types, we need to keep track of whether we saw them in a
         # component output or an input.
         self.unresolved_forward_refs: dict[
             str,
@@ -319,8 +319,8 @@ class Analyzer:
         :param arg: the type of the property we are analyzing
         :param typ: the type this property belongs to
         :param name: the name of the property
-        :param can_be_plain: wether the property can be plain
-        :param is_component_output: wether the property is in a component output
+        :param can_be_plain: whether the property can be plain
+        :param is_component_output: whether the property is in a component output
         :param optional: whether the property is optional or not
 
         For properties of a type that's used as a component output, can_be_plain

--- a/sdk/python/lib/pulumi/provider/experimental/component.py
+++ b/sdk/python/lib/pulumi/provider/experimental/component.py
@@ -15,7 +15,7 @@
 import builtins
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 
 class PropertyType(Enum):
@@ -42,7 +42,7 @@ class PropertyDefinition:
     description: Optional[str] = None
     items: Optional["PropertyDefinition"] = None
     additional_properties: Optional["PropertyDefinition"] = None
-    plain: bool = False
+    plain: Optional[Literal[True]] = None
 
 
 @dataclass

--- a/sdk/python/lib/test/provider/experimental/test_analyzer.py
+++ b/sdk/python/lib/test/provider/experimental/test_analyzer.py
@@ -180,17 +180,15 @@ def test_analyze_component_plain_types():
             "aInputList": PropertyDefinition(
                 type=PropertyType.ARRAY,
                 items=PropertyDefinition(type=PropertyType.STRING, plain=True),
-                plain=False,
             ),
             "aListInput": PropertyDefinition(
                 type=PropertyType.ARRAY,
-                items=PropertyDefinition(type=PropertyType.STRING, plain=False),
+                items=PropertyDefinition(type=PropertyType.STRING),
                 plain=True,
             ),
             "aInputListInput": PropertyDefinition(
                 type=PropertyType.ARRAY,
-                items=PropertyDefinition(type=PropertyType.STRING, plain=False),
-                plain=False,
+                items=PropertyDefinition(type=PropertyType.STRING),
             ),
             "aDict": PropertyDefinition(
                 type=PropertyType.OBJECT,
@@ -201,9 +199,7 @@ def test_analyze_component_plain_types():
             ),
             "aDictInput": PropertyDefinition(
                 type=PropertyType.OBJECT,
-                additional_properties=PropertyDefinition(
-                    type=PropertyType.INTEGER, plain=False
-                ),
+                additional_properties=PropertyDefinition(type=PropertyType.INTEGER),
                 plain=True,
             ),
             "aInputDict": PropertyDefinition(
@@ -211,14 +207,10 @@ def test_analyze_component_plain_types():
                 additional_properties=PropertyDefinition(
                     type=PropertyType.INTEGER, plain=True
                 ),
-                plain=False,
             ),
             "aInputDictInput": PropertyDefinition(
                 type=PropertyType.OBJECT,
-                additional_properties=PropertyDefinition(
-                    type=PropertyType.INTEGER, plain=False
-                ),
-                plain=False,
+                additional_properties=PropertyDefinition(type=PropertyType.INTEGER),
             ),
             "aComplexType": PropertyDefinition(
                 ref="#/types/plain-types:index:ComplexTypeInput",
@@ -246,25 +238,20 @@ def test_analyze_component_plain_types():
             "aInputComplexType": "a_input_complex_type",
         },
         outputs={
-            "aInt": PropertyDefinition(type=PropertyType.INTEGER, plain=False),
-            "aStr": PropertyDefinition(type=PropertyType.STRING, plain=False),
-            "aFloat": PropertyDefinition(type=PropertyType.NUMBER, plain=False),
-            "aBool": PropertyDefinition(type=PropertyType.BOOLEAN, plain=False),
-            "aOptional": PropertyDefinition(
-                type=PropertyType.STRING, plain=True, optional=True
-            ),
+            "aInt": PropertyDefinition(type=PropertyType.INTEGER),
+            "aStr": PropertyDefinition(type=PropertyType.STRING),
+            "aFloat": PropertyDefinition(type=PropertyType.NUMBER),
+            "aBool": PropertyDefinition(type=PropertyType.BOOLEAN),
+            "aOptional": PropertyDefinition(type=PropertyType.STRING, optional=True),
             "aOutputList": PropertyDefinition(
                 type=PropertyType.ARRAY,
-                items=PropertyDefinition(type=PropertyType.STRING, plain=True),
-                plain=False,
+                items=PropertyDefinition(type=PropertyType.STRING),
             ),
             "aOutputComplex": PropertyDefinition(
                 ref="#/types/plain-types:index:ComplexTypeOutput",
             ),
             "aOptionalOutputComplex": PropertyDefinition(
-                ref="#/types/plain-types:index:ComplexTypeOutput",
-                plain=False,
-                optional=True,
+                ref="#/types/plain-types:index:ComplexTypeOutput", optional=True
             ),
         },
         outputs_mapping={
@@ -301,11 +288,10 @@ def test_analyze_component_plain_types():
             properties={
                 "aOutputListStr": PropertyDefinition(
                     type=PropertyType.ARRAY,
-                    items=PropertyDefinition(type=PropertyType.STRING, plain=True),
+                    items=PropertyDefinition(type=PropertyType.STRING),
                     optional=True,
-                    plain=False,
                 ),
-                "aStr": PropertyDefinition(type=PropertyType.STRING, plain=True),
+                "aStr": PropertyDefinition(type=PropertyType.STRING),
             },
             properties_mapping={"aOutputListStr": "a_output_list_str", "aStr": "a_str"},
             python_type=ComplexTypeOutput,
@@ -353,18 +339,16 @@ def test_analyze_list_simple():
         outputs={
             "listOutput": PropertyDefinition(
                 type=PropertyType.ARRAY,
-                items=PropertyDefinition(
-                    type=PropertyType.STRING, optional=True, plain=True
-                ),
+                items=PropertyDefinition(type=PropertyType.STRING, optional=True),
                 optional=True,
             ),
             "typingListOutput": PropertyDefinition(
                 type=PropertyType.ARRAY,
-                items=PropertyDefinition(type=PropertyType.STRING, plain=True),
+                items=PropertyDefinition(type=PropertyType.STRING),
             ),
             "abcSequenceOutput": PropertyDefinition(
                 type=PropertyType.ARRAY,
-                items=PropertyDefinition(type=PropertyType.STRING, plain=True),
+                items=PropertyDefinition(type=PropertyType.STRING),
             ),
         },
         outputs_mapping={
@@ -408,7 +392,7 @@ def test_analyze_list_complex():
             "listOutput": PropertyDefinition(
                 type=PropertyType.ARRAY,
                 items=PropertyDefinition(
-                    ref="#/types/list-complex:index:ComplexTypeOutput", plain=True
+                    ref="#/types/list-complex:index:ComplexTypeOutput"
                 ),
             )
         },
@@ -438,7 +422,7 @@ def test_analyze_list_complex():
             properties={
                 "name": PropertyDefinition(
                     type=PropertyType.ARRAY,
-                    items=PropertyDefinition(type=PropertyType.STRING, plain=True),
+                    items=PropertyDefinition(type=PropertyType.STRING),
                     optional=True,
                 ),
             },
@@ -545,21 +529,17 @@ def test_analyze_dict_simple():
             "dictOutput": PropertyDefinition(
                 type=PropertyType.OBJECT,
                 additional_properties=PropertyDefinition(
-                    type=PropertyType.INTEGER, optional=True, plain=True
+                    type=PropertyType.INTEGER, optional=True
                 ),
                 optional=True,
             ),
             "typingDictOutput": PropertyDefinition(
                 type=PropertyType.OBJECT,
-                additional_properties=PropertyDefinition(
-                    type=PropertyType.INTEGER, plain=True
-                ),
+                additional_properties=PropertyDefinition(type=PropertyType.INTEGER),
             ),
             "abcMappingOutput": PropertyDefinition(
                 type=PropertyType.OBJECT,
-                additional_properties=PropertyDefinition(
-                    type=PropertyType.INTEGER, plain=True
-                ),
+                additional_properties=PropertyDefinition(type=PropertyType.INTEGER),
             ),
         },
         outputs_mapping={
@@ -605,7 +585,6 @@ def test_analyze_dict_complex():
                 additional_properties=PropertyDefinition(
                     ref="#/types/dict-complex:index:ComplexTypeOutput",
                     optional=True,
-                    plain=True,
                 ),
                 optional=True,
             ),
@@ -641,7 +620,6 @@ def test_analyze_dict_complex():
                     type=PropertyType.OBJECT,
                     additional_properties=PropertyDefinition(
                         type=PropertyType.INTEGER,
-                        plain=True,
                     ),
                     optional=True,
                 ),
@@ -838,7 +816,6 @@ def test_analyze_descriptions():
                 "value": PropertyDefinition(
                     description="value doc string",
                     type=PropertyType.STRING,
-                    plain=True,
                 ),
             },
             properties_mapping={"value": "value"},
@@ -1160,7 +1137,7 @@ def test_analyze_component_self_recursive_complex_type():
                     optional=True,
                     ref="#/types/recursive:index:RecursiveTypeOutput",
                 ),
-                "value": PropertyDefinition(type=PropertyType.STRING, plain=True),
+                "value": PropertyDefinition(type=PropertyType.STRING),
             },
             properties_mapping={"rec": "rec", "value": "value"},
             python_type=RecursiveTypeOutput,

--- a/sdk/python/lib/test/provider/experimental/testdata/docstrings/component.py
+++ b/sdk/python/lib/test/provider/experimental/testdata/docstrings/component.py
@@ -28,6 +28,13 @@ class ComplexType(TypedDict):
     another_value: pulumi.Input[NestedComplexType]
 
 
+class ComplexTypeOutput(TypedDict):
+    """ComplexTypeOutput doc string"""
+
+    value: str
+    """value doc string"""
+
+
 class Args(TypedDict):
     """Args doc string"""
 
@@ -47,7 +54,7 @@ class Args(TypedDict):
 class Component(pulumi.ComponentResource):
     """Component doc string"""
 
-    complex_output: pulumi.Output[ComplexType]
+    complex_output: pulumi.Output[ComplexTypeOutput]
     """complex_output doc string"""
 
     def __init__(self, args: Args): ...

--- a/tests/integration/component_provider/python/component-provider-host/provider/component.py
+++ b/tests/integration/component_provider/python/component-provider-host/provider/component.py
@@ -39,6 +39,15 @@ class Complex(TypedDict):
     nested_input: pulumi.Input[Nested]
 
 
+class NestedOutput(TypedDict):
+    value: str
+
+
+class ComplexOutput(TypedDict):
+    str_value: str
+    nested_value: pulumi.Output[NestedOutput]
+
+
 class Args(TypedDict):
     str_input: pulumi.Input[str]
     """This is a string input"""
@@ -57,7 +66,7 @@ class MyComponent(pulumi.ComponentResource):
     str_output: pulumi.Output[str]
     """This is a string output"""
     optional_int_output: Optional[pulumi.Output[int]]
-    complex_output: Optional[pulumi.Output[Complex]]
+    complex_output: Optional[pulumi.Output[ComplexOutput]]
     list_output: pulumi.Output[list[str]]
     dict_output: pulumi.Output[dict[str, int]]
     asset_output: pulumi.Output[pulumi.Asset]
@@ -74,10 +83,10 @@ class MyComponent(pulumi.ComponentResource):
         ).apply(lambda x: x * 2 if x else 7)
         self.complex_output = pulumi.Output.from_input(
             {
-                "str_input": "complex_str_input_value",
-                "nested_input": pulumi.Output.from_input(
+                "str_value": "complex_str_output_value",
+                "nested_value": pulumi.Output.from_input(
                     {
-                        "str_plain": "nested_str_plain_value",
+                        "value": "nested_str_plain_value",
                     }
                 ),
             }

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1892,13 +1892,13 @@ func TestPythonComponentProviderRun(t *testing.T) {
 					if runtime == "python" {
 						// The output is stored in the stack as a plain object,
 						// but that means for Python the keys are snake_case.
-						require.Equal(t, "complex_str_input_value", complexOutput["str_input"].(string))
-						nested := complexOutput["nested_input"].(map[string]interface{})
-						require.Equal(t, "nested_str_plain_value", nested["str_plain"].(string))
+						require.Equal(t, "complex_str_output_value", complexOutput["str_value"].(string))
+						nested := complexOutput["nested_value"].(map[string]interface{})
+						require.Equal(t, "nested_str_plain_value", nested["value"].(string))
 					} else {
-						require.Equal(t, "complex_str_input_value", complexOutput["strInput"].(string))
-						nested := complexOutput["nestedInput"].(map[string]interface{})
-						require.Equal(t, "nested_str_plain_value", nested["strPlain"].(string))
+						require.Equal(t, "complex_str_output_value", complexOutput["strValue"].(string))
+						nested := complexOutput["nestedValue"].(map[string]interface{})
+						require.Equal(t, "nested_str_plain_value", nested["value"].(string))
 					}
 					require.Equal(t, []interface{}{"A", "B", "C"}, stack.Outputs["listOutput"].([]interface{}))
 					require.Equal(t, map[string]interface{}{
@@ -1970,7 +1970,7 @@ func TestPythonComponentProviderGetSchema(t *testing.T) {
 				"type": "string",
 				"description": "This is a string output"
 			},
-			"complexOutput": { "$ref": "#/types/provider:index:Complex" },
+			"complexOutput": { "$ref": "#/types/provider:index:ComplexOutput" },
 			"listOutput": {
 				"type": "array",
 				"items": {
@@ -2053,6 +2053,29 @@ func TestPythonComponentProviderGetSchema(t *testing.T) {
 			},
 			"type": "object",
 			"required": ["strPlain"]
+		},
+		"provider:index:ComplexOutput": {
+			"properties": {
+				"strValue": {
+					"type": "string",
+					"plain": true
+				},
+				"nestedValue": {
+					"$ref": "#/types/provider:index:NestedOutput"
+				}
+			},
+			"type": "object",
+			"required": ["nestedValue", "strValue"]
+		},
+		"provider:index:NestedOutput": {
+			"properties": {
+				"value": {
+					"type": "string",
+					"plain": true
+				}
+			},
+			"type": "object",
+			"required": ["value"]
 		},
 		"provider:index:Emu": {
 			"description": "A or B",

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -2057,8 +2057,7 @@ func TestPythonComponentProviderGetSchema(t *testing.T) {
 		"provider:index:ComplexOutput": {
 			"properties": {
 				"strValue": {
-					"type": "string",
-					"plain": true
+					"type": "string"
 				},
 				"nestedValue": {
 					"$ref": "#/types/provider:index:NestedOutput"
@@ -2070,8 +2069,7 @@ func TestPythonComponentProviderGetSchema(t *testing.T) {
 		"provider:index:NestedOutput": {
 			"properties": {
 				"value": {
-					"type": "string",
-					"plain": true
+					"type": "string"
 				}
 			},
 			"type": "object",


### PR DESCRIPTION
The plain attribute is only relevant for inputs. When generating the
schema for a component, we need to track wether we are currently looking
at a type used as an input or an output of the component. The properties
of types used as component inputs, including nested types, as well as
list items and dictionary values, can potentially be plain, unless they
are within an input. The properties of types used as component outputs
can never be plain.

There is some churn in the tests because we were previously sharing
complex types for both inputs and outputs, but that's not possible due
to the restriction on the plain property.

Fixes https://github.com/pulumi/pulumi/issues/18694
