### PR TITLE
Wait longer for sentinel file in TestRunCanceled

### DIFF
--- a/sdk/go/auto/cmd_test.go
+++ b/sdk/go/auto/cmd_test.go
@@ -289,6 +289,7 @@ func TestRunCanceled(t *testing.T) {
 		path := filepath.Join(e.RootPath, "ready")
 		for range 60 {
 			if _, err := os.Stat(path); err == nil {
+				t.Logf("Found %s", path)
 				break
 			}
 			time.Sleep(1 * time.Second)

--- a/sdk/go/auto/cmd_test.go
+++ b/sdk/go/auto/cmd_test.go
@@ -287,11 +287,11 @@ func TestRunCanceled(t *testing.T) {
 
 	go func() {
 		path := filepath.Join(e.RootPath, "ready")
-		for i := 0; i < 100; i++ {
+		for range 60 {
 			if _, err := os.Stat(path); err == nil {
 				break
 			}
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(1 * time.Second)
 		}
 		cancel()
 	}()


### PR DESCRIPTION
This test continues to be flaky, however I’ve been unable to reproduce this locally. Presumably it flakes under heavy load/resource contention.

When I looked into this previously, I concluded (possibly wrongly) that we get `signal: interrupt` when we cancel the context before the operation has started. If we cancel after the operation has started we get the expected exit status.

The previous attempt in https://github.com/pulumi/pulumi/pull/18178/files to unflake this test used a sentinel file that we look for so that we know we’ve started the operation. This waited for up to 10 seconds for this file. This PR increases this to a full minute.

We can the flake rate and most recent occurence  here https://app.codecov.io/gh/pulumi/pulumi/tests/master?term=TestRunCanceled

We should hold off on closing https://github.com/pulumi/pulumi/issues/19132 until we see this stop flaking in codecov.