### PR TITLE
Remove unused variable

### DIFF
--- a/sdk/python/cmd/pulumi-language-python-exec
+++ b/sdk/python/cmd/pulumi-language-python-exec
@@ -125,8 +125,6 @@ if __name__ == "__main__":
     if args.pwd is not None:
         os.chdir(args.pwd)
 
-    successful = False
-
     try:
         # The docs for get_running_loop are somewhat misleading because they state:
         # This function can only be called from a coroutine or a callback. However, if the function is


### PR DESCRIPTION
This was used prior to https://github.com/pulumi/pulumi/commit/04a1ad401b2748d46ff0db2310e70713fa497ca3#diff-b8839580270b1f9fe3d7d63308363495a30298391092e631b42c4c661099179fL119 and it looks like that PR missed removing the variable initialization here.
