### PR TITLE
Avoid creating a main.py file when chosing the uv toolchain

### DIFF
--- a/changelog/pending/20250408--cli-new--avoid-creating-a-main-py-file-when-chosing-the-uv-toolchain.yaml
+++ b/changelog/pending/20250408--cli-new--avoid-creating-a-main-py-file-when-chosing-the-uv-toolchain.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Avoid creating a main.py file when chosing the uv toolchain

--- a/sdk/python/toolchain/uv_test.go
+++ b/sdk/python/toolchain/uv_test.go
@@ -94,12 +94,12 @@ func TestUvVersion(t *testing.T) {
 		"uv 0.4.26 (Homebrew 2024-10-23)",
 		"uv 0.4.26 (d2cd09bbd 2024-10-25)",
 	} {
-		v, err := uv.uvVersion(versionString)
+		v, err := uv.parseUvVersion(versionString)
 		require.NoError(t, err)
 		require.Equal(t, semver.MustParse("0.4.26"), v)
 	}
 
-	_, err = uv.uvVersion("uv 0.4.25")
+	_, err = uv.parseUvVersion("uv 0.4.25")
 	require.ErrorContains(t, err, "less than the minimum required version")
 }
 

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -684,6 +684,9 @@ func TestNewPythonChooseUv(t *testing.T) {
 	require.True(t, e.PathExists("uv.lock"))
 	require.True(t, e.PathExists("pyproject.toml"))
 	require.False(t, e.PathExists("requirements.txt"))
+	// By default uv creates a `main.py` file, or a `hello.py` when running uv < 0.6.0.
+	require.False(t, e.PathExists("hello.py"))
+	require.False(t, e.PathExists("main.py"))
 }
 
 //nolint:paralleltest // Poetry causes issues when run in parallel on windows. See pulumi/pulumi#17183


### PR DESCRIPTION
We run `uv init` to create the `pyproject.toml` file when using the uv as the toolchain. Before version 0.6 this would always create a `hello.py` file, which we then delete. With version 0.6 this changed to `main.py`, but this also introduced a new `--bare` option to avoid creating such a file altogether.

Fixes https://github.com/pulumi/pulumi/issues/19153
