### PR TITLE
ci: Use the latest version of baptiste0928/cargo-install

### DIFF
--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -27,7 +27,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Install b3sum
-        uses: baptiste0928/cargo-install@bf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: b3sum
           version: 1.3.0


### PR DESCRIPTION
The current version of `baptiste0928/cargo-install` we're using to install `b3sum` is failing for all merge attempts in the merge queue:

```
Attempt to load from cache ...
Error: Cache service responded with 422
    at Object.<anonymous> (/home/runner/work/_actions/baptiste0928/cargo-install/bf6758885262d0e6f61089a9d8c8790d3ac3368f/dist/index.js:555:19)
    at Generator.next (<anonymous>)
    at fulfilled (/home/runner/work/_actions/baptiste0928/cargo-install/bf6758885262d0e6f61089a9d8c8790d3ac3368f/dist/index.js:482:58)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

https://github.com/baptiste0928/cargo-install mentions:

> **Versions prior to v3.2 will stop working on February 1st, 2025**, due to GitHub changing their cache service APIs. See the [@actions/cache package deprecation notice](https://github.com/actions/toolkit/discussions/1890).

This change updates to the latest version of `baptiste0928/cargo-install`, which hopefully addresses the problem.