### PR TITLE
Add HCL2 support for importID resource option serialization

### DIFF
--- a/changelog/pending/20250409--programgen--add-import-to-hcl2-serialization-as-well-as-other-missing-functions.yaml
+++ b/changelog/pending/20250409--programgen--add-import-to-hcl2-serialization-as-well-as-other-missing-functions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen
+  description: Add import to HCL2 serialization as well as other missing functions

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -499,6 +499,9 @@ func bindResourceOptions(options *model.Block) (*ResourceOptions, hcl.Diagnostic
 			case "deletedWith":
 				t = model.DynamicType
 				resourceOptions.DeletedWith = item.Value
+			case "import":
+				t = model.StringType
+				resourceOptions.ImportID = item.Value
 			default:
 				diagnostics = append(diagnostics, unsupportedAttribute(item.Name, item.Syntax.NameRange))
 				continue

--- a/pkg/codegen/pcl/binder_resource_test.go
+++ b/pkg/codegen/pcl/binder_resource_test.go
@@ -37,10 +37,22 @@ func TestBindResourceOptions(t *testing.T) {
 		Name: "foo",
 		Provider: &schema.Resource{
 			Token: "foo:index:Foo",
+			InputProperties: []*schema.Property{
+				{Name: "property", Type: schema.StringType},
+			},
+			Properties: []*schema.Property{
+				{Name: "property", Type: schema.StringType},
+			},
 		},
 		Resources: []*schema.Resource{
 			{
 				Token: "foo:index:Foo",
+				InputProperties: []*schema.Property{
+					{Name: "property", Type: schema.StringType},
+				},
+				Properties: []*schema.Property{
+					{Name: "property", Type: schema.StringType},
+				},
 			},
 		},
 	}
@@ -75,6 +87,21 @@ func TestBindResourceOptions(t *testing.T) {
 			src:  `pluginDownloadURL = "https://example.com/whatever"`,
 			want: cty.StringVal("https://example.com/whatever"),
 		},
+		{
+			name: "ImportID",
+			src:  `import = "abc123"`,
+			want: cty.StringVal("abc123"),
+		},
+		{
+			name: "IgnoreChanges",
+			src:  `ignoreChanges = [property]`,
+			want: cty.TupleVal([]cty.Value{cty.DynamicVal}),
+		},
+		{
+			name: "DeletedWith",
+			src:  `deletedWith = "abc123"`,
+			want: cty.StringVal("abc123"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -84,6 +111,7 @@ func TestBindResourceOptions(t *testing.T) {
 
 			var sb strings.Builder
 			fmt.Fprintln(&sb, `resource foo "foo:index:Foo" {`)
+			fmt.Fprintln(&sb, "	property = \"42\"")
 			fmt.Fprintln(&sb, "	options {")
 			fmt.Fprintln(&sb, "		"+tt.src)
 			fmt.Fprintln(&sb, "	}")

--- a/pkg/codegen/pcl/resource.go
+++ b/pkg/codegen/pcl/resource.go
@@ -49,6 +49,8 @@ type ResourceOptions struct {
 	// If set, the provider's Delete method will not be called for this resource if the specified resource is being
 	// deleted as well.
 	DeletedWith model.Expression
+	// If the resource was imported, the id that was imported.
+	ImportID model.Expression
 }
 
 // Resource represents a resource instantiation inside of a program or component.

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -263,17 +263,36 @@ func TestGenerateHCL2Definition(t *testing.T) {
 
 			snapshot := []*resource.State{
 				{
-					ID:     "123",
-					Custom: true,
-					Type:   "pulumi:providers:aws",
-					URN:    "urn:pulumi:stack::project::pulumi:providers:aws::default_123",
+					ID:             "123",
+					ImportID:       "abc",
+					Custom:         true,
+					Type:           "pulumi:providers:aws",
+					RetainOnDelete: true,
+					IgnoreChanges:  []string{"fooIgnore"},
+					DeletedWith:    "123",
+					URN:            "urn:pulumi:stack::project::pulumi:providers:aws::default_123",
 				},
 				{
-					ID:     "123",
-					Custom: true,
-					Type:   "pulumi:providers:random",
-					URN:    "urn:pulumi:stack::project::pulumi:providers:random::default_123",
+					ID:             "123",
+					ImportID:       "abc",
+					Custom:         true,
+					Type:           "pulumi:providers:random",
+					RetainOnDelete: true,
+					IgnoreChanges:  []string{"fooIgnore"},
+					DeletedWith:    "123",
+					URN:            "urn:pulumi:stack::project::pulumi:providers:random::default_123",
 				},
+				{
+					ID:             "id",
+					ImportID:       "abc",
+					Custom:         true,
+					Type:           "pulumi:providers:pkg",
+					RetainOnDelete: true,
+					IgnoreChanges:  []string{"fooIgnore"},
+					DeletedWith:    "123",
+					URN:            "urn:pulumi:stack::project::pulumi:providers:pkg::provider",
+				},
+				// One test that ensures unset values still pass.
 				{
 					ID:     "id",
 					Custom: true,
@@ -318,6 +337,10 @@ func TestGenerateHCL2Definition(t *testing.T) {
 			assert.Equal(t, state.Type, actualState.Type)
 			assert.Equal(t, state.URN, actualState.URN)
 			assert.Equal(t, state.Parent, actualState.Parent)
+			assert.Equal(t, state.ImportID, actualState.ImportID)
+			assert.Equal(t, state.RetainOnDelete, actualState.RetainOnDelete)
+			assert.Equal(t, state.IgnoreChanges, actualState.IgnoreChanges)
+			assert.Equal(t, state.DeletedWith, actualState.DeletedWith)
 			if !strings.Contains(state.Provider, "::default_") {
 				assert.Equal(t, state.Provider, actualState.Provider)
 			}


### PR DESCRIPTION
Needed for interactive import.

Also adds support for a number of other values which are bound in
`bindResourceOptions` when binding pcl.

* retainOnDelete
* IgnoreChanges
* DeletedWith
* ImportID (as well as adding this to `bindResourceOptions`)

Related #19037
Related #19038
