### PR TITLE
[sdk/nodejs] Add comment about dependency

### DIFF
--- a/sdk/nodejs/queryable/index.ts
+++ b/sdk/nodejs/queryable/index.ts
@@ -15,6 +15,8 @@
 import { OutputInstance } from "../index";
 import { Resource } from "../resource";
 
+// Note: The @pulumi/policy npm package depends on ResolvedResource.
+
 /**
  * {@link ResolvedResource} is a {@link Resource} with all fields containing
  * {@link Output} values fully resolved.


### PR DESCRIPTION
Add a comment so it's more obvious that `@pulumi/policy` has a dependency on `@pulumi/pulumi/queryable`.

Follow-up from https://github.com/pulumi/pulumi/pull/19172#discussion_r2035540821