### PR TITLE
Fix ReplaceOnChanges and IgnoreChanges being respected during DBR diffs

### DIFF
--- a/changelog/pending/20250410--engine--fix-replaceonchanges-being-respected-during-deletebeforereplace-checks.yaml
+++ b/changelog/pending/20250410--engine--fix-replaceonchanges-being-respected-during-deletebeforereplace-checks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix ReplaceOnChanges being respected during deleteBeforeReplace checks

--- a/pkg/backend/display/json.go
+++ b/pkg/backend/display/json.go
@@ -87,7 +87,8 @@ func stateForJSONOutput(s *resource.State, opts Options) *resource.State {
 	return resource.NewState(s.Type, s.URN, s.Custom, s.Delete, s.ID, inputs,
 		outputs, s.Parent, s.Protect, s.External, s.Dependencies, s.InitErrors, s.Provider,
 		s.PropertyDependencies, s.PendingReplacement, s.AdditionalSecretOutputs, s.Aliases, &s.CustomTimeouts,
-		s.ImportID, s.RetainOnDelete, s.DeletedWith, s.Created, s.Modified, s.SourcePosition, s.IgnoreChanges)
+		s.ImportID, s.RetainOnDelete, s.DeletedWith, s.Created, s.Modified, s.SourcePosition, s.IgnoreChanges,
+		s.ReplaceOnChanges)
 }
 
 // ShowJSONEvents renders incremental engine events to stdout.

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -218,7 +218,7 @@ func (i *importer) getOrCreateStackResource(ctx context.Context) (resource.URN, 
 	typ, name := resource.RootStackType, fmt.Sprintf("%s-%s", projectName, stackName)
 	urn := resource.NewURN(stackName.Q(), projectName, "", typ, name)
 	state := resource.NewState(typ, urn, false, false, "", resource.PropertyMap{}, nil, "", false, false, nil, nil, "",
-		nil, false, nil, nil, nil, "", false, "", nil, nil, "", nil)
+		nil, false, nil, nil, nil, "", false, "", nil, nil, "", nil, nil)
 	// TODO(seqnum) should stacks be created with 1? When do they ever get recreated/replaced?
 	if !i.executeSerial(ctx, NewCreateStep(i.deployment, noopEvent(0), state)) {
 		return "", false, false
@@ -327,7 +327,7 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 		}
 
 		state := resource.NewState(typ, urn, true, false, "", inputs, nil, "", false, false, nil, nil, "", nil, false,
-			nil, nil, nil, "", false, "", nil, nil, "", nil)
+			nil, nil, nil, "", false, "", nil, nil, "", nil, nil)
 		// TODO(seqnum) should default providers be created with 1? When do they ever get recreated/replaced?
 		if issueCheckErrors(i.deployment, state, urn, resp.Failures) {
 			return nil, false, nil
@@ -428,7 +428,7 @@ func (i *importer) importResources(ctx context.Context) error {
 		// Create the new desired state. Note that the resource is protected. Provider might be "" at this point.
 		new := resource.NewState(
 			urn.Type(), urn, !imp.Component, false, imp.ID, resource.PropertyMap{}, nil, parent, imp.Protect,
-			false, nil, nil, provider, nil, false, nil, nil, nil, "", false, "", nil, nil, "", nil)
+			false, nil, nil, provider, nil, false, nil, nil, nil, "", false, "", nil, nil, "", nil, nil)
 		// Set a dummy goal so the resource is tracked as managed.
 		i.deployment.goals.Store(urn, &resource.Goal{})
 

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -181,7 +181,7 @@ func fixedProgram(steps []RegisterResourceEvent) deploytest.ProgramFunc {
 			s.Done(&RegisterResult{
 				State: resource.NewState(g.Type, resp.URN, g.Custom, false, resp.ID, g.Properties, resp.Outputs, g.Parent,
 					protect, false, g.Dependencies, nil, g.Provider, g.PropertyDependencies, false, nil, nil, nil,
-					"", false, "", nil, nil, "", nil),
+					"", false, "", nil, nil, "", nil, nil),
 			})
 		}
 		return nil
@@ -354,7 +354,7 @@ func TestRegisterNoDefaultProviders(t *testing.T) {
 		reg.Done(&RegisterResult{
 			State: resource.NewState(goal.Type, urn, goal.Custom, false, id, goal.Properties, resource.PropertyMap{},
 				goal.Parent, protect, false, goal.Dependencies, nil, goal.Provider, goal.PropertyDependencies,
-				false, nil, nil, nil, "", false, "", nil, nil, "", nil),
+				false, nil, nil, nil, "", false, "", nil, nil, "", nil, nil),
 		})
 
 		processed++
@@ -455,7 +455,7 @@ func TestRegisterDefaultProviders(t *testing.T) {
 		reg.Done(&RegisterResult{
 			State: resource.NewState(goal.Type, urn, goal.Custom, false, id, goal.Properties, resource.PropertyMap{},
 				goal.Parent, protect, false, goal.Dependencies, nil, goal.Provider, goal.PropertyDependencies,
-				false, nil, nil, nil, "", false, "", nil, nil, "", nil),
+				false, nil, nil, nil, "", false, "", nil, nil, "", nil, nil),
 		})
 
 		processed++
@@ -550,7 +550,7 @@ func TestReadInvokeNoDefaultProviders(t *testing.T) {
 		read.Done(&ReadResult{
 			State: resource.NewState(read.Type(), urn, true, false, read.ID(), read.Properties(),
 				resource.PropertyMap{}, read.Parent(), false, false, read.Dependencies(), nil, read.Provider(), nil,
-				false, nil, nil, nil, "", false, "", nil, nil, "", nil),
+				false, nil, nil, nil, "", false, "", nil, nil, "", nil, nil),
 		})
 		reads++
 	}
@@ -645,7 +645,7 @@ func TestReadInvokeDefaultProviders(t *testing.T) {
 			e.Done(&RegisterResult{
 				State: resource.NewState(goal.Type, urn, goal.Custom, false, id, goal.Properties, resource.PropertyMap{},
 					goal.Parent, protect, false, goal.Dependencies, nil, goal.Provider, goal.PropertyDependencies,
-					false, nil, nil, nil, "", false, "", nil, nil, "", nil),
+					false, nil, nil, nil, "", false, "", nil, nil, "", nil, nil),
 			})
 			registers++
 
@@ -654,7 +654,7 @@ func TestReadInvokeDefaultProviders(t *testing.T) {
 			e.Done(&ReadResult{
 				State: resource.NewState(e.Type(), urn, true, false, e.ID(), e.Properties(),
 					resource.PropertyMap{}, e.Parent(), false, false, e.Dependencies(), nil, e.Provider(), nil, false,
-					nil, nil, nil, "", false, "", nil, nil, "", nil),
+					nil, nil, nil, "", false, "", nil, nil, "", nil, nil),
 			})
 			reads++
 		}
@@ -812,7 +812,7 @@ func TestDisableDefaultProviders(t *testing.T) {
 					event.Done(&ReadResult{
 						State: resource.NewState(event.Type(), urn, true, false, event.ID(), event.Properties(),
 							resource.PropertyMap{}, event.Parent(), false, false, event.Dependencies(), nil, event.Provider(), nil,
-							false, nil, nil, nil, "", false, "", nil, nil, "", nil),
+							false, nil, nil, nil, "", false, "", nil, nil, "", nil, nil),
 					})
 					reads++
 				case RegisterResourceEvent:
@@ -820,7 +820,7 @@ func TestDisableDefaultProviders(t *testing.T) {
 					event.Done(&RegisterResult{
 						State: resource.NewState(event.Goal().Type, urn, true, false, "id", event.Goal().Properties,
 							resource.PropertyMap{}, event.Goal().Parent, false, false, event.Goal().Dependencies, nil,
-							event.Goal().Provider, nil, false, nil, nil, nil, "", false, "", nil, nil, "", nil),
+							event.Goal().Provider, nil, false, nil, nil, nil, "", false, "", nil, nil, "", nil, nil),
 					})
 					registers++
 				default:

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -1080,7 +1080,7 @@ func (s *RefreshStep) Apply() (resource.Status, StepCompleteFunc, error) {
 			s.old.Parent, s.old.Protect, s.old.External, s.old.Dependencies, initErrors, s.old.Provider,
 			s.old.PropertyDependencies, s.old.PendingReplacement, s.old.AdditionalSecretOutputs, s.old.Aliases,
 			&s.old.CustomTimeouts, s.old.ImportID, s.old.RetainOnDelete, s.old.DeletedWith, s.old.Created, s.old.Modified,
-			s.old.SourcePosition, s.old.IgnoreChanges,
+			s.old.SourcePosition, s.old.IgnoreChanges, s.old.ReplaceOnChanges,
 		)
 		var inputsChange, outputsChange bool
 		if s.old != nil {
@@ -1341,7 +1341,7 @@ func (s *ImportStep) Apply() (resource.Status, StepCompleteFunc, error) {
 	s.old = resource.NewState(s.new.Type, s.new.URN, s.new.Custom, false, s.new.ID, inputs, outputs,
 		s.new.Parent, s.new.Protect, false, s.new.Dependencies, s.new.InitErrors, s.new.Provider,
 		s.new.PropertyDependencies, false, nil, nil, &s.new.CustomTimeouts, s.new.ImportID, s.new.RetainOnDelete,
-		s.new.DeletedWith, nil, nil, s.new.SourcePosition, s.new.IgnoreChanges)
+		s.new.DeletedWith, nil, nil, s.new.SourcePosition, s.new.IgnoreChanges, s.new.ReplaceOnChanges)
 
 	// Import takes a resource that Pulumi did not create and imports it into pulumi state.
 	now := time.Now().UTC()

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -162,6 +162,6 @@ func CreateRootStackResource(stackName tokens.QName, projectName tokens.PackageN
 	typ, name := resource.RootStackType, fmt.Sprintf("%s-%s", projectName, stackName)
 	urn := resource.NewURN(stackName, projectName, "", typ, name)
 	state := resource.NewState(typ, urn, false, false, "", resource.PropertyMap{}, nil, "", false, false, nil, nil, "",
-		nil, false, nil, nil, nil, "", false, "", nil, nil, "", nil)
+		nil, false, nil, nil, nil, "", false, "", nil, nil, "", nil, nil)
 	return state
 }

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -522,6 +522,7 @@ func DeserializeResource(res apitype.ResourceV3, dec config.Decrypter) (*resourc
 		inputs, outputs, res.Parent, res.Protect, res.External, res.Dependencies, res.InitErrors, res.Provider,
 		res.PropertyDependencies, res.PendingReplacement, res.AdditionalSecretOutputs, res.Aliases, res.CustomTimeouts,
 		res.ImportID, res.RetainOnDelete, res.DeletedWith, res.Created, res.Modified, res.SourcePosition, res.IgnoreChanges,
+		res.ReplaceOnChanges,
 	), nil
 }
 

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -107,6 +107,7 @@ func TestDeploymentSerialization(t *testing.T) {
 		nil,
 		"",
 		nil,
+		nil,
 	)
 
 	dep, err := SerializeResource(context.Background(), res, config.NopEncrypter, false /* showSecrets */)

--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -355,6 +355,8 @@ type ResourceV3 struct {
 	SourcePosition string `json:"sourcePosition,omitempty" yaml:"sourcePosition,omitempty"`
 	// IgnoreChanges is a list of properties to ignore changes for.
 	IgnoreChanges []string `json:"ignoreChanges,omitempty" yaml:"ignoreChanges,omitempty"`
+	// ReplaceOnChanges is a list of properties that if changed trigger a replace.
+	ReplaceOnChanges []string `json:"replaceOnChanges,omitempty" yaml:"replaceOnChanges,omitempty"`
 }
 
 // ManifestV1 captures meta-information about this checkpoint file, such as versions of binaries, etc.

--- a/sdk/go/common/resource/resource_state.go
+++ b/sdk/go/common/resource/resource_state.go
@@ -58,6 +58,7 @@ type State struct {
 	Modified                *time.Time            // If set, the time when the state was last modified in the state file.
 	SourcePosition          string                // If set, the source location of the resource registration
 	IgnoreChanges           []string              // If set, the list of properties to ignore changes for.
+	ReplaceOnChanges        []string              // If set, the list of properties that if changed trigger a replace.
 }
 
 // Copy creates a deep copy of the resource state, except without copying the lock.
@@ -88,6 +89,7 @@ func (s *State) Copy() *State {
 		Modified:                s.Modified,
 		SourcePosition:          s.SourcePosition,
 		IgnoreChanges:           s.IgnoreChanges,
+		ReplaceOnChanges:        s.ReplaceOnChanges,
 	}
 }
 
@@ -110,7 +112,7 @@ func NewState(t tokens.Type, urn URN, custom bool, del bool, id ID,
 	propertyDependencies map[PropertyKey][]URN, pendingReplacement bool,
 	additionalSecretOutputs []PropertyKey, aliases []URN, timeouts *CustomTimeouts,
 	importID ID, retainOnDelete bool, deletedWith URN, created *time.Time, modified *time.Time,
-	sourcePosition string, ignoreChanges []string,
+	sourcePosition string, ignoreChanges []string, replaceOnChanges []string,
 ) *State {
 	contract.Assertf(t != "", "type was empty")
 	contract.Assertf(custom || id == "", "is custom or had empty ID")
@@ -140,6 +142,7 @@ func NewState(t tokens.Type, urn URN, custom bool, del bool, id ID,
 		Modified:                modified,
 		SourcePosition:          sourcePosition,
 		IgnoreChanges:           ignoreChanges,
+		ReplaceOnChanges:        replaceOnChanges,
 	}
 
 	if timeouts != nil {


### PR DESCRIPTION
Fixes #19056

This fixes two bugs with DBR logic. Firstly that ReplaceOnChanges would never trigger a replace as part of DBR even if the field was being changed, secondly that IgnoreChanges wouldn't prevent a replace if a field changed (but shouldn't have because of ignore changes).

Doing this requires that ReplaceOnChanges is saved to state with IgnoreChanges so that we have access to it at the point DBR is checking dependencies from state to see if they need replacing. 