### PR TITLE
[sdk/nodejs] Target ES2020

### DIFF
--- a/changelog/pending/20250410--sdk-nodejs--target-es2020-instead-of-es2016.yaml
+++ b/changelog/pending/20250410--sdk-nodejs--target-es2020-instead-of-es2016.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/nodejs
+  description: Target ES2020 instead of ES2016

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/116-Do-not-capture-2/snapshot.txt
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/116-Do-not-capture-2/snapshot.txt
@@ -7,8 +7,8 @@ function __f0() {
     with({ message: "Function 'b' cannot be called at runtime. It can only be used at deployment time.\n\nFunction code:\n  () => console.log(\"the actual function\")\n", this: undefined, arguments: undefined }) {
 
 return () => {
-                throw new Error(message);
-            };
+            throw new Error(message);
+        };
 
     }
   }).apply(undefined, undefined).apply(this, arguments);

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,


### PR DESCRIPTION
This change bumps TypeScript's target ECMAScript version from ES2016 to ES2020, which:

-  Reduces the amount of downlevel support code that TypeScript emits in the .js files we ship as part of the `@pulumi/pulumi` npm package
- Allows native JavaScript language features (such as async/await) to be used directly by Node/V8 rather than those features being emulated using older language features

We've indicated in our `package.json` that Node 18+ is required ([over a year ago](https://github.com/pulumi/pulumi/pull/15816)). Node 18 [supports ES2022](https://node.green/#ES2022). However, we're still building the SDK with TypeScript 3.8, which [supports targeting ES2020](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#es2020-for-target-and-module). So it should be safe to target ES2020.

Highlights from ES2016 to ES2020:

- async/await
- object rest/spread
- nullish coalescing operator (??)
- optional chaining operator (?.)

I've created a temporary repository to show the diff between the built `@pulumi/pulumi` `bin` dir going from ES2016 to ES2020: https://github.com/justinvp/pulumi-nodejs-sdk/commit/202b8539c964259394c9dd7773df5ed379235376?w=1

The largest changes are the removal of all the downlevel code to make async/await work on top of generators (`yield`); now async/await is emitted as-is.

# Example Diffs

## async/await

```diff
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
```

```diff
-    static create(name, workspace) {
-        return __awaiter(this, void 0, void 0, function* () {
-            const stack = new Stack(name, workspace, "create");
-            yield stack.ready;
-            return stack;
-        });
+    static async create(name, workspace) {
+        const stack = new Stack(name, workspace, "create");
+        await stack.ready;
+        return stack;
     }
```

## object rest/spread

```diff
-            this.remoteEnvVars = Object.assign({}, remoteEnvVars);
+            this.remoteEnvVars = { ...remoteEnvVars };
```

## nullish coalescing operator (??)

```diff
-        this.version = (_a = options.version) !== null && _a !== void 0 ? _a : "0.0.0";
+        this.version = options.version ?? "0.0.0";
```

## optional chaining operator (?.)

```diff
-        if (opts === null || opts === void 0 ? void 0 : opts.projectSettings) {
+        if (opts?.projectSettings) {
```