### PR TITLE
Support named providers in GenerateHCL2Definition

### DIFF
--- a/changelog/pending/20250411--programgen--support-provider-resources-in-generatehcl2definition.yaml
+++ b/changelog/pending/20250411--programgen--support-provider-resources-in-generatehcl2definition.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen
+  description: Support provider resources in generatehcl2definition

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -102,7 +102,7 @@ func GenerateHCL2Definition(
 
 	packageName := state.Type.Package()
 	if providers.IsProviderType(state.Type) {
-		// When the provider type is a provider type, the type triple is in the form
+		// When the type is a provider type, the type triple is in the form
 		// pulumi:providers:pkg instead of pkg:mod:type, so use the token "name"
 		// position as the package instead.
 		packageName = tokens.Package(state.Type.Name())

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -101,6 +101,12 @@ func GenerateHCL2Definition(
 	}
 
 	packageName := state.Type.Package()
+	if providers.IsProviderType(state.Type) {
+		// When the provider type is a provider type, the type triple is in the form
+		// pulumi:providers:pkg instead of pkg:mod:type, so use the token "name"
+		// position as the package instead.
+		packageName = tokens.Package(state.Type.Name())
+	}
 	pluginName, err := providers.GetProviderName(packageName, provider.Inputs)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get provider name: %w", err)
@@ -150,7 +156,14 @@ func GenerateHCL2Definition(
 
 	// With the package loaded, we can get the full resource schema and use that to generate an appropriate HCL2
 	// definition.
-	r, ok, err := pkg.Resources().Get(string(state.Type))
+	var r *schema.Resource
+	ok := true
+	if providers.IsProviderType(state.Type) {
+		r, err = pkg.Provider()
+	} else {
+		r, ok, err = pkg.Resources().Get(string(state.Type))
+	}
+
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading resource '%v': %w", state.Type, err)
 	}


### PR DESCRIPTION
Adds the ability to generate HCL during import, but after attempting to
write a smoke test I saw that we don't actually support importing
providers in the internal registry provider:

See pkg/resource/deploy/providers/registry.go:

```
func (r *Registry) Read(context.Context, plugin.ReadRequest) (plugin.ReadResponse, error) {
	return plugin.ReadResponse{}, errors.New("provider resources may not be read")
}
```

Although now we can generate HCL2, importing a provider will not work
until this is implemented.

Related #19036
