### PR TITLE
fix package_add panic when there's no version in the schema

### DIFF
--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -174,8 +174,14 @@ from the parameters, as in:
 			}
 
 			// Build and add the package spec to the project
-			source := strings.Split(plugin, "@")[0]
-			version := pkg.Version.String()
+			pluginSplit := strings.Split(plugin, "@")
+			source := pluginSplit[0]
+			version := ""
+			if pkg.Version != nil {
+				version = pkg.Version.String()
+			} else if len(pluginSplit) == 2 {
+				version = pluginSplit[1]
+			}
 			if pkg.Parameterization != nil {
 				source = pkg.Parameterization.BaseProvider.Name
 				version = pkg.Parameterization.BaseProvider.Version.String()

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2525,8 +2525,14 @@ func TestPackageAddWithPublisherSetNodeJS(t *testing.T) {
 	require.Contains(t, stdout,
 		"You can then import the SDK in your TypeScript code with:\n\n  import * as mypkg from \"@my-namespace/mypkg\"")
 
+	yamlContent, err := os.ReadFile(filepath.Join(e.CWD, "Pulumi.yaml"))
+	require.NoError(t, err)
+	yamlString := string(yamlContent)
+	require.Contains(t, yamlString, "packages:")
+	require.Contains(t, yamlString, "mypkg: ../provider")
+
 	// Make sure the SDK was generated in the expected directory
-	_, err := os.Stat(filepath.Join(e.CWD, "sdks", "my-namespace-mypkg", "index.ts"))
+	_, err = os.Stat(filepath.Join(e.CWD, "sdks", "my-namespace-mypkg", "index.ts"))
 	require.NoError(t, err)
 }
 

--- a/tests/integration/packageadd-namespace/provider/schema.json
+++ b/tests/integration/packageadd-namespace/provider/schema.json
@@ -1,6 +1,5 @@
 {
   "name": "mypkg",
-  "version": "1.0.0",
   "namespace": "my-namespace",
   "resources": {
     "mypkg::Resource": {


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/19157 we introduced saving details of the package added with `pulumi package add` into the Pulumi.yaml packages section.  For doing that we get the version from the installed package, which in turn gets it from the schema.

However the version is an optional field in the schema.  We set it automatically when using Git based plugins, but e.g. local plugins don't necessarily return a version at all.  This means `pkg.Version` can be `nil` and thus the CLI panics.  Add a check for that, and keep the version from what's passed in in the command line args if available.

No changelog necessary here since this wasn't released yet, so the bug was never customer facing.

Fixes https://github.com/pulumi/pulumi-yaml/issues/778