### PR TITLE
Add bootstrap-less mode for Python component providers

### DIFF
--- a/changelog/pending/20250411--sdk-python--add-bootstrap-less-mode-for-python-component-providers.yaml
+++ b/changelog/pending/20250411--sdk-python--add-bootstrap-less-mode-for-python-component-providers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Add bootstrap-less mode for Python component providers

--- a/sdk/go/common/workspace/plugins_install_python_test.go
+++ b/sdk/go/common/workspace/plugins_install_python_test.go
@@ -25,5 +25,21 @@ func TestPythonInstall(t *testing.T) {
 	testPluginInstall(t, "venv", map[string][]byte{
 		"PulumiPlugin.yaml": []byte("runtime: python\n"),
 		"package.json":      []byte("pulumi==2.0.0\n"),
+		"__main__.py":       []byte("print('hello')\n"),
+	})
+}
+
+func TestPythonInstallPackage(t *testing.T) {
+	t.Parallel()
+	testPluginInstall(t, "venv", map[string][]byte{
+		"PulumiPlugin.yaml": []byte("runtime: python\n"),
+		"pyproject.toml": []byte(`[project]
+								name = "plugin-package"
+								version = "0.1.0"
+								dependencies = []
+								[build-system]
+								requires = ["setuptools"]
+								build-backend = "setuptools.build_meta"`),
+		"src/plugin_package/__main__.py": []byte("print('hello')\n"),
 	})
 }

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -1375,10 +1375,14 @@ func (host *pythonLanguageHost) RunPlugin(
 
 	var cmd *exec.Cmd
 
-	hasMainPy := false
+	hasMainPy := true
 	mainPy := filepath.Join(opts.Root, "__main__.py")
-	if _, err = os.Stat(mainPy); err == nil {
-		hasMainPy = true
+	if _, err = os.Stat(mainPy); err != nil {
+		if os.IsNotExist(err) {
+			hasMainPy = false
+		} else {
+			return fmt.Errorf("looking for __main__.py: %w", err)
+		}
 	}
 
 	// Check if the `pulumi.run.plugin` module exists in the plugin's

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -1396,7 +1396,7 @@ func (host *pythonLanguageHost) RunPlugin(
 	}
 
 	if hasPluginRunModule && !hasMainPy {
-		// Run `python -m pulumi.run <project name> req.Args...
+		// Run `python -m pulumi.run.plugin <project name> req.Args...
 		buildable, err := toolchain.IsBuildablePackage(opts.Root)
 		if err != nil {
 			return fmt.Errorf("checking if plugin is a buildable package: %w", err)

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -1378,9 +1378,7 @@ func (host *pythonLanguageHost) RunPlugin(
 	hasMainPy := false
 	mainPy := filepath.Join(opts.Root, "__main__.py")
 	if _, err = os.Stat(mainPy); err == nil {
-		if os.IsNotExist(err) {
-			hasMainPy = true
-		}
+		hasMainPy = true
 	}
 
 	// Check if the `pulumi.run.plugin` module exists in the plugin's

--- a/sdk/python/lib/pulumi/provider/experimental/host.py
+++ b/sdk/python/lib/pulumi/provider/experimental/host.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from inspect import isclass
 import sys
+from types import ModuleType
 from typing import Optional
 
 from ...resource import ComponentResource
@@ -52,3 +54,11 @@ def component_provider_host(
     # confused without a version.
     version = "0.0.0"
     main(ComponentProvider(components, name, namespace, version), args)
+
+
+def components_from_module(mod: ModuleType) -> list[type[ComponentResource]]:
+    components: list[type[ComponentResource]] = []
+    for _, v in mod.__dict__.items():
+        if isclass(v) and issubclass(v, ComponentResource):
+            components.append(v)
+    return components

--- a/sdk/python/lib/pulumi/run/plugin/__main__.py
+++ b/sdk/python/lib/pulumi/run/plugin/__main__.py
@@ -36,7 +36,7 @@ def main():
 
     # Get the distribution name (aka package name) from the args and remove it.
     distribution_name = sys.argv.pop(1)
-    module__name = distribution_name.replace("-", "_")
+    module_name = distribution_name.replace("-", "_")
     # We could provide an override here in the future, where a user can specify
     # a list of modules or components in pyproject.toml, for example
     #
@@ -45,19 +45,20 @@ def main():
     #
     # For now we always host all the components exported from the module with the same name
     # as the distribution.
-    mod = importlib.import_module(module__name)
+    mod = importlib.import_module(module_name)
     components = components_from_module(mod)
     if len(components) > 0:
         component_provider_host(name=distribution_name, components=components)
     else:
         # The module has no components, assume that the module is runnable.
         try:
-            runpy.run_module(module__name)
+            runpy.run_module(module_name, run_name="__main__")
         except ImportError as e:
             print(
-                f"{module__name} can not be executed: {e.msg}\n\n"
+                f"{module_name} can not be executed: {e.msg}\n\n"
                 + "Please ensure that your module includes a `__main__.py` file that can be run with `python -m <module>`",
                 file=sys.stderr,
+                flush=True,
             )
             sys.exit(1)
 

--- a/sdk/python/lib/pulumi/run/plugin/__main__.py
+++ b/sdk/python/lib/pulumi/run/plugin/__main__.py
@@ -1,0 +1,66 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import runpy
+import sys
+
+from pulumi.provider.experimental.host import (
+    component_provider_host,
+    components_from_module,
+)
+
+
+def main():
+    """
+    Run the Python package based plugin specified by sys.argv[1].
+
+    We expect the package to have a module matching the package name (with `-`
+    replaced by `_`). If the module exports any components, we run
+    `component_provider_host` with those components. If the package does not
+    export any components, we attempt to run the module's `__main__.py` file.
+    """
+    if len(sys.argv) < 2:
+        raise Exception("Missing package name argument")
+
+    # Get the distribution name (aka package name) from the args and remove it.
+    distribution_name = sys.argv.pop(1)
+    module__name = distribution_name.replace("-", "_")
+    # We could provide an override here in the future, where a user can specify
+    # a list of modules or components in pyproject.toml, for example
+    #
+    # [tool.pulumi]
+    # components = ["some.module.here", "another.module:MyComponent"]
+    #
+    # For now we always host all the components exported from the module with the same name
+    # as the distribution.
+    mod = importlib.import_module(module__name)
+    components = components_from_module(mod)
+    if len(components) > 0:
+        component_provider_host(name=distribution_name, components=components)
+    else:
+        # The module has no components, assume that the module is runnable.
+        try:
+            runpy.run_module(module__name)
+        except ImportError as e:
+            print(
+                f"{module__name} can not be executed: {e.msg}\n\n"
+                + "Please ensure that your module includes a `__main__.py` file that can be run with `python -m <module>`",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/python/toolchain/poetry.go
+++ b/sdk/python/toolchain/poetry.go
@@ -292,16 +292,6 @@ func (p *poetry) convertRequirementsTxt(requirementsTxt, pyprojectToml string, s
 }
 
 func (p *poetry) generatePyProjectTOML(dependencies map[string]string) (string, error) {
-	type BuildSystem struct {
-		Requires     []string `toml:"requires,omitempty" json:"requires,omitempty"`
-		BuildBackend string   `toml:"build-backend,omitempty" json:"build-backend,omitempty"`
-	}
-
-	type Pyproject struct {
-		BuildSystem *BuildSystem           `toml:"build-system,omitempty" json:"build-system,omitempty"`
-		Tool        map[string]interface{} `toml:"tool,omitempty" json:"tool,omitempty"`
-	}
-
 	pp := Pyproject{
 		BuildSystem: &BuildSystem{
 			Requires:     []string{"poetry-core"},

--- a/sdk/python/toolchain/pyproject.go
+++ b/sdk/python/toolchain/pyproject.go
@@ -1,0 +1,70 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolchain
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+type BuildSystem struct {
+	Requires     []string `toml:"requires,omitempty" json:"requires,omitempty"`
+	BuildBackend string   `toml:"build-backend,omitempty" json:"build-backend,omitempty"`
+}
+
+type Project struct {
+	Name string
+}
+
+type Pyproject struct {
+	Project     Project        `toml:"project" json:"project"`
+	BuildSystem *BuildSystem   `toml:"build-system,omitempty" json:"build-system,omitempty"`
+	Tool        map[string]any `toml:"tool,omitempty" json:"tool,omitempty"`
+}
+
+// IsBuildablePackage checks if a directory is a buildable Python package. A
+// directory is considered a buildable package if it contains a pyproject.toml
+// file with a build-system section.
+func IsBuildablePackage(dir string) (bool, error) {
+	pyproject, err := LoadPyproject(dir)
+	if err != nil {
+		return false, fmt.Errorf("parsing pyproject.toml: %w", err)
+	}
+	return pyproject.BuildSystem != nil && pyproject.BuildSystem.BuildBackend != "", nil
+}
+
+func LoadPyproject(dir string) (Pyproject, error) {
+	pyprojectToml := filepath.Join(dir, "pyproject.toml")
+	_, err := os.Stat(pyprojectToml)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Pyproject{}, nil
+		}
+		return Pyproject{}, fmt.Errorf("checking pyproject.toml: %w", err)
+	}
+
+	b, err := os.ReadFile(pyprojectToml)
+	if err != nil {
+		return Pyproject{}, fmt.Errorf("reading %s: %w", pyprojectToml, err)
+	}
+	var pyproject Pyproject
+	if err := toml.Unmarshal(b, &pyproject); err != nil {
+		return Pyproject{}, fmt.Errorf("unmarshaling pyproject.toml: %w", err)
+	}
+	return pyproject, nil
+}

--- a/sdk/python/toolchain/pyproject.go
+++ b/sdk/python/toolchain/pyproject.go
@@ -28,11 +28,11 @@ type BuildSystem struct {
 }
 
 type Project struct {
-	Name string
+	Name string `toml:"name" json:"name"`
 }
 
 type Pyproject struct {
-	Project     Project        `toml:"project" json:"project"`
+	Project     *Project       `toml:"project" json:"project"`
 	BuildSystem *BuildSystem   `toml:"build-system,omitempty" json:"build-system,omitempty"`
 	Tool        map[string]any `toml:"tool,omitempty" json:"tool,omitempty"`
 }
@@ -45,7 +45,8 @@ func IsBuildablePackage(dir string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("parsing pyproject.toml: %w", err)
 	}
-	return pyproject.BuildSystem != nil && pyproject.BuildSystem.BuildBackend != "", nil
+	return pyproject.Project != nil && pyproject.Project.Name != "" &&
+		pyproject.BuildSystem != nil && pyproject.BuildSystem.BuildBackend != "", nil
 }
 
 func LoadPyproject(dir string) (Pyproject, error) {

--- a/sdk/python/toolchain/pyproject_test.go
+++ b/sdk/python/toolchain/pyproject_test.go
@@ -1,0 +1,109 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolchain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildablePackage(t *testing.T) {
+	tests := []struct {
+		name               string
+		content            string
+		setupFunc          func(dir string) error
+		isBuildablePackage bool
+		errContains        string
+	}{
+		{
+			name: "valid buildable package",
+			content: `
+				[project]
+				name = "bananas"
+				[build-system]
+				requires = ["setuptools", "wheel"]
+				build-backend = "setuptools.build_meta"`,
+			isBuildablePackage: true,
+		},
+		{
+			name: "non-buildable package",
+			content: `
+				[project]
+				name = "bananas"`,
+			isBuildablePackage: false,
+		},
+		{
+			name: "no build-backend",
+			content: `
+				[project]
+				name = "bananas"
+				[build-system]
+				requires = ["hatchling"]`,
+			isBuildablePackage: false,
+		},
+		{
+			name:               "missing pyproject.toml",
+			isBuildablePackage: false,
+		},
+		{
+			name: "invalid TOML syntax",
+			content: `
+				[project
+				name = "invalid"`,
+			isBuildablePackage: false,
+			errContains:        "unmarshaling pyproject.toml",
+		},
+		{
+			name:    "permission denied",
+			content: "something",
+			setupFunc: func(dir string) error {
+				// Make the file unreadable
+				return os.Chmod(filepath.Join(dir, "pyproject.toml"), 0000)
+			},
+			isBuildablePackage: false,
+			errContains:        "permission denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			pyprojectToml := filepath.Join(dir, "pyproject.toml")
+
+			if tt.content != "" {
+				err := os.WriteFile(pyprojectToml, []byte(tt.content), 0644)
+				require.NoError(t, err)
+			}
+
+			if tt.setupFunc != nil {
+				err := tt.setupFunc(dir)
+				require.NoError(t, err)
+			}
+
+			is, err := IsBuildablePackage(dir)
+
+			if tt.errContains != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.isBuildablePackage, is)
+			}
+		})
+	}
+}

--- a/sdk/python/toolchain/pyproject_test.go
+++ b/sdk/python/toolchain/pyproject_test.go
@@ -57,6 +57,15 @@ func TestBuildablePackage(t *testing.T) {
 			isBuildablePackage: false,
 		},
 		{
+			name: "no name",
+			content: `
+				[project]
+				[build-system]
+				requires = ["setuptools"]
+				build-backend = "setuptools.build_meta"`,
+			isBuildablePackage: false,
+		},
+		{
 			name:               "missing pyproject.toml",
 			isBuildablePackage: false,
 		},

--- a/sdk/python/toolchain/pyproject_test.go
+++ b/sdk/python/toolchain/pyproject_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestBuildablePackage(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name               string
 		content            string
@@ -82,7 +83,7 @@ func TestBuildablePackage(t *testing.T) {
 			content: "something",
 			setupFunc: func(dir string) error {
 				// Make the file unreadable
-				return os.Chmod(filepath.Join(dir, "pyproject.toml"), 0000)
+				return os.Chmod(filepath.Join(dir, "pyproject.toml"), 0o000) // gosec
 			},
 			isBuildablePackage: false,
 			errContains:        "permission denied",
@@ -91,11 +92,12 @@ func TestBuildablePackage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			dir := t.TempDir()
 			pyprojectToml := filepath.Join(dir, "pyproject.toml")
 
 			if tt.content != "" {
-				err := os.WriteFile(pyprojectToml, []byte(tt.content), 0644)
+				err := os.WriteFile(pyprojectToml, []byte(tt.content), 0o600)
 				require.NoError(t, err)
 			}
 

--- a/tests/integration/component_provider/python/bootstrap-less/provider/.gitignore
+++ b/tests/integration/component_provider/python/bootstrap-less/provider/.gitignore
@@ -1,0 +1,2 @@
+build
+provider.egg-info

--- a/tests/integration/component_provider/python/bootstrap-less/provider/PulumiPlugin.yaml
+++ b/tests/integration/component_provider/python/bootstrap-less/provider/PulumiPlugin.yaml
@@ -1,0 +1,1 @@
+runtime: python

--- a/tests/integration/component_provider/python/bootstrap-less/provider/pyproject.toml
+++ b/tests/integration/component_provider/python/bootstrap-less/provider/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "provider"
+version = "0.1.0"
+dependencies = ["pulumi"]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/tests/integration/component_provider/python/bootstrap-less/provider/src/provider/__init__.py
+++ b/tests/integration/component_provider/python/bootstrap-less/provider/src/provider/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .component import MyComponent
+
+__all__ = ["MyComponent"]

--- a/tests/integration/component_provider/python/bootstrap-less/provider/src/provider/component.py
+++ b/tests/integration/component_provider/python/bootstrap-less/provider/src/provider/component.py
@@ -1,0 +1,26 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TypedDict
+
+import pulumi
+
+
+class Args(TypedDict):
+    str_input: pulumi.Input[str]
+
+
+class MyComponent(pulumi.ComponentResource):
+    def __init__(self, name: str, args: Args, opts: pulumi.ResourceOptions):
+        super().__init__("provider:index:MyComponent", name, {}, opts)

--- a/tests/integration/component_provider/python/bootstrap-less/yaml/Pulumi.yaml
+++ b/tests/integration/component_provider/python/bootstrap-less/yaml/Pulumi.yaml
@@ -1,0 +1,14 @@
+name: python-component-provider-yaml
+description: Using a component provider written in Python bootstrap-less mode from YAML
+runtime: yaml
+plugins:
+  providers:
+    - name: provider
+      path: ../provider
+resources:
+  comp:
+    type: provider:index:MyComponent
+    properties:
+      strInput: hello
+outputs:
+  urn: ${comp.urn}

--- a/tests/integration/component_provider/python/bootstrap-less/yaml/Pulumi.yaml
+++ b/tests/integration/component_provider/python/bootstrap-less/yaml/Pulumi.yaml
@@ -1,10 +1,8 @@
 name: python-component-provider-yaml
 description: Using a component provider written in Python bootstrap-less mode from YAML
 runtime: yaml
-plugins:
-  providers:
-    - name: provider
-      path: ../provider
+packages:
+  provider: ../provider
 resources:
   comp:
     type: provider:index:MyComponent

--- a/tests/integration/component_provider/python/package/provider/.gitignore
+++ b/tests/integration/component_provider/python/package/provider/.gitignore
@@ -1,0 +1,2 @@
+build
+provider.egg-info

--- a/tests/integration/component_provider/python/package/provider/PulumiPlugin.yaml
+++ b/tests/integration/component_provider/python/package/provider/PulumiPlugin.yaml
@@ -1,0 +1,1 @@
+runtime: python

--- a/tests/integration/component_provider/python/package/provider/pyproject.toml
+++ b/tests/integration/component_provider/python/package/provider/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "provider"
+version = "0.1.0"
+dependencies = ["pulumi"]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/tests/integration/component_provider/python/package/provider/src/provider/__init__.py
+++ b/tests/integration/component_provider/python/package/provider/src/provider/__init__.py
@@ -1,17 +1,1 @@
-# Copyright 2025, Pulumi Corporation.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
-from .component import MyComponent
-
-__all__ = ["MyComponent"]

--- a/tests/integration/component_provider/python/package/provider/src/provider/__init__.py
+++ b/tests/integration/component_provider/python/package/provider/src/provider/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .component import MyComponent
+
+__all__ = ["MyComponent"]

--- a/tests/integration/component_provider/python/package/provider/src/provider/__main__.py
+++ b/tests/integration/component_provider/python/package/provider/src/provider/__main__.py
@@ -1,0 +1,20 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pulumi.provider.experimental import component_provider_host
+from .component import MyComponent
+
+if __name__ == "__main__":
+    component_provider_host([MyComponent], "provider")

--- a/tests/integration/component_provider/python/package/provider/src/provider/component.py
+++ b/tests/integration/component_provider/python/package/provider/src/provider/component.py
@@ -1,0 +1,26 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TypedDict
+
+import pulumi
+
+
+class Args(TypedDict):
+    str_input: pulumi.Input[str]
+
+
+class MyComponent(pulumi.ComponentResource):
+    def __init__(self, name: str, args: Args, opts: pulumi.ResourceOptions):
+        super().__init__("provider:index:MyComponent", name, {}, opts)

--- a/tests/integration/component_provider/python/package/yaml/Pulumi.yaml
+++ b/tests/integration/component_provider/python/package/yaml/Pulumi.yaml
@@ -1,8 +1,10 @@
 name: python-component-provider-yaml
 description: Using a component provider written as a Python package from YAML
 runtime: yaml
-packages:
-  provider: ../provider
+plugins:
+  providers:
+    - name: provider
+      path: ../provider
 resources:
   comp:
     type: provider:index:MyComponent

--- a/tests/integration/component_provider/python/package/yaml/Pulumi.yaml
+++ b/tests/integration/component_provider/python/package/yaml/Pulumi.yaml
@@ -1,10 +1,8 @@
 name: python-component-provider-yaml
 description: Using a component provider written as a Python package from YAML
 runtime: yaml
-plugins:
-  providers:
-    - name: provider
-      path: ../provider
+packages:
+  provider: ../provider
 resources:
   comp:
     type: provider:index:MyComponent

--- a/tests/integration/component_provider/python/package/yaml/Pulumi.yaml
+++ b/tests/integration/component_provider/python/package/yaml/Pulumi.yaml
@@ -1,0 +1,14 @@
+name: python-component-provider-yaml
+description: Using a component provider written as a Python package from YAML
+runtime: yaml
+plugins:
+  providers:
+    - name: provider
+      path: ../provider
+resources:
+  comp:
+    type: provider:index:MyComponent
+    properties:
+      strInput: hello
+outputs:
+  urn: ${comp.urn}

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1926,6 +1926,44 @@ func TestPythonComponentProviderRun(t *testing.T) {
 	}
 }
 
+// Tests that we can run a Python component provider using bootstrap-less mode.
+//
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestPythonComponentProviderBootstraplessRun(t *testing.T) {
+	testData, err := filepath.Abs(filepath.Join("component_provider", "python", "bootstrap-less"))
+	require.NoError(t, err)
+	providerDir := filepath.Join(testData, "provider")
+	installPythonProviderDependencies(t, providerDir)
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir: filepath.Join(testData, "yaml"),
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			urn, err := resource.ParseURN(stack.Outputs["urn"].(string))
+			require.NoError(t, err)
+			require.Equal(t, tokens.Type("provider:index:MyComponent"), urn.Type())
+		},
+	})
+}
+
+// Tests that we can run a Python component provider that's a Python package
+//
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestPythonComponentProviderPackageRun(t *testing.T) {
+	testData, err := filepath.Abs(filepath.Join("component_provider", "python", "package"))
+	require.NoError(t, err)
+	providerDir := filepath.Join(testData, "provider")
+	installPythonProviderDependencies(t, providerDir)
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir: filepath.Join(testData, "yaml"),
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			urn, err := resource.ParseURN(stack.Outputs["urn"].(string))
+			require.NoError(t, err)
+			require.Equal(t, tokens.Type("provider:index:MyComponent"), urn.Type())
+		},
+	})
+}
+
 func checkAssetText(t *testing.T, runtime, expected, actual string) {
 	t.Helper()
 	switch runtime {
@@ -2173,11 +2211,25 @@ func installPythonProviderDependencies(t *testing.T, dir string) {
 		Toolchain:  toolchain.Pip,
 	})
 	require.NoError(t, err)
+
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	err = tc.InstallDependencies(context.Background(), dir, false, false, stdout, stderr)
-	require.NoError(t, err, "stdout: %s, stderr: %s", stdout, stderr)
-	// Install the core SDK
+	if _, err := os.Stat(filepath.Join(dir, "pyproject.toml")); err == nil {
+		t.Logf("Found bootstrap-less Python plugin in %s", dir)
+		// Create a venv and install the package into it
+		err = tc.EnsureVenv(context.Background(), dir, false, false, stdout, stderr)
+		require.NoError(t, err)
+		cmd, err := tc.ModuleCommand(context.Background(), "pip", "install", dir)
+		require.NoError(t, err)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "output: %s", out)
+	} else {
+		// Install dependencies from requirements.txt
+		err = tc.InstallDependencies(context.Background(), dir, false, false, stdout, stderr)
+		require.NoError(t, err, "stdout: %s, stderr: %s", stdout, stderr)
+	}
+
+	// Install the core SDK so we have the current version
 	coreSDK, err := filepath.Abs(filepath.Join("..", "..", "sdk", "python"))
 	require.NoError(t, err)
 	cmd, err := tc.ModuleCommand(context.Background(), "pip", "install", coreSDK)

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1928,7 +1928,7 @@ func TestPythonComponentProviderRun(t *testing.T) {
 
 // Tests that we can run a Python component provider using bootstrap-less mode.
 //
-//nolint:paralleltest // ProgramTest calls t.Parallel()
+//nolint:paralleltest // We're installing dependencies in the test data dir
 func TestPythonComponentProviderBootstraplessRun(t *testing.T) {
 	testData, err := filepath.Abs(filepath.Join("component_provider", "python", "bootstrap-less"))
 	require.NoError(t, err)
@@ -1947,7 +1947,7 @@ func TestPythonComponentProviderBootstraplessRun(t *testing.T) {
 
 // Tests that we can run a Python component provider that's a Python package
 //
-//nolint:paralleltest // ProgramTest calls t.Parallel()
+//nolint:paralleltest // We're installing dependencies in the test data dir
 func TestPythonComponentProviderPackageRun(t *testing.T) {
 	testData, err := filepath.Abs(filepath.Join("component_provider", "python", "package"))
 	require.NoError(t, err)

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1928,15 +1928,15 @@ func TestPythonComponentProviderRun(t *testing.T) {
 
 // Tests that we can run a Python component provider using bootstrap-less mode.
 //
-//nolint:paralleltest // We're installing dependencies in the test data dir
+//nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestPythonComponentProviderBootstraplessRun(t *testing.T) {
-	testData, err := filepath.Abs(filepath.Join("component_provider", "python", "bootstrap-less"))
-	require.NoError(t, err)
-	providerDir := filepath.Join(testData, "provider")
-	installPythonProviderDependencies(t, providerDir)
-
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		Dir: filepath.Join(testData, "yaml"),
+		Dir:             filepath.Join("component_provider", "python", "bootstrap-less"),
+		RelativeWorkDir: "yaml",
+		PrepareProject: func(info *engine.Projinfo) error {
+			installPythonProviderDependencies(t, filepath.Join(info.Root, "..", "provider"))
+			return nil
+		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			urn, err := resource.ParseURN(stack.Outputs["urn"].(string))
 			require.NoError(t, err)
@@ -1947,15 +1947,15 @@ func TestPythonComponentProviderBootstraplessRun(t *testing.T) {
 
 // Tests that we can run a Python component provider that's a Python package
 //
-//nolint:paralleltest // We're installing dependencies in the test data dir
+//nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestPythonComponentProviderPackageRun(t *testing.T) {
-	testData, err := filepath.Abs(filepath.Join("component_provider", "python", "package"))
-	require.NoError(t, err)
-	providerDir := filepath.Join(testData, "provider")
-	installPythonProviderDependencies(t, providerDir)
-
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		Dir: filepath.Join(testData, "yaml"),
+		Dir:             filepath.Join("component_provider", "python", "package"),
+		RelativeWorkDir: "yaml",
+		PrepareProject: func(info *engine.Projinfo) error {
+			installPythonProviderDependencies(t, filepath.Join(info.Root, "..", "provider"))
+			return nil
+		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			urn, err := resource.ParseURN(stack.Outputs["urn"].(string))
 			require.NoError(t, err)


### PR DESCRIPTION
We now support two ways of running Python based plugins: bare
directories (the existing implementation) and now additionally as
buildable packages.

If the plugin directory is a bare directory (that is not a Python
package) with a `__main__.py`, we run the plugin's `__main__.py`
directly. Dependencies for these plugins are specified via
`requirements.txt`.

Otherwise, we check if the plugin directory is a buildable Python
package. In that case we run the plugin via `pulumu.run.plugin`.
Dependencies are installed from the `dependencies` section of the
`pyproject.toml`.

This enables bootstrap-less mode, where when running in package
mode, and the package exports ComponentResources, we
automatically host a provider for them.

Fixes https://github.com/pulumi/home/issues/4044
Fixes https://github.com/pulumi/home/issues/4045