### PR TITLE
Enable AI-generated update summary by default

### DIFF
--- a/changelog/pending/20250414--cli-display--add-copilot-summaries-of-errors-in-pulumi-up-previews-and-updates.yaml
+++ b/changelog/pending/20250414--cli-display--add-copilot-summaries-of-errors-in-pulumi-up-previews-and-updates.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/display
+  description: Add Copilot summaries of errors in `pulumi up` previews and updates

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -99,7 +99,7 @@ var BackendURL = env.String("BACKEND_URL",
 var SuppressCopilotLink = env.Bool("SUPPRESS_COPILOT_LINK",
 	"Suppress showing the 'explainFailure' link to Copilot in the CLI output.")
 
-var CopilotSummary = env.Bool("COPILOT_SUMMARY",
+var SuppressCopilotSummary = env.Bool("SUPPRESS_COPILOT_SUMMARY",
 	"Enable showing the Copilot summary in the CLI output.")
 
 // TODO: This is a soft-release feature and will be removed after the feature flag is launched


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi.ai/issues/1711

This PR releases and "unhides" the work done to provide Copilot summaries in `pulumi up` when either the preview or update fails[0]. It was initially hidden to support internal dogfooding.

The summary will be automatically printed out to the user given:

1. The stack is hosted on app.pulumi.com
2. The org that stack belongs to has Copilot enabled for members or admins (and the user is also an admin in the latter case).

This PR change the flags from opt-in to opt-out and renames them for a better UX:
- flag changes: `--copilot-summary` is replaced with `--suppress-copilot-summary`
- env var changes: `PULUMI_COPILOT_SUMMARY` is replaced with `PULUMI_SUPPRESS_COPILOT_SUMMARY`

[0] References:
1. #17956 
2. #19070 