### PR TITLE
Support optional types using union syntax

### DIFF
--- a/changelog/pending/20250414--sdk-python--support-optional-types-using-3-10-union-syntax.yaml
+++ b/changelog/pending/20250414--sdk-python--support-optional-types-using-3-10-union-syntax.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Support optional types using 3.10 union syntax

--- a/sdk/python/lib/pulumi/provider/experimental/analyzer.py
+++ b/sdk/python/lib/pulumi/provider/experimental/analyzer.py
@@ -17,6 +17,7 @@ import collections
 from enum import Enum
 import inspect
 import sys
+import types
 import typing
 from collections import abc
 from collections.abc import Awaitable
@@ -634,7 +635,13 @@ def py_type_to_property_type(typ: type) -> PropertyType:
 
 
 def is_union(typ: type):
-    return get_origin(typ) == Union
+    # Check for `Union[a, b]`
+    if get_origin(typ) == Union:
+        return True
+    if sys.version_info >= (3, 10):
+        # Check for `a | b`
+        return get_origin(typ) == types.UnionType
+    return False
 
 
 def is_enum(typ: type):

--- a/sdk/python/lib/test/provider/experimental/testdata/analyzer-errors/union-type-3-10-syntax/component.py
+++ b/sdk/python/lib/test/provider/experimental/testdata/analyzer-errors/union-type-3-10-syntax/component.py
@@ -1,0 +1,11 @@
+from typing import TypedDict, Union
+
+import pulumi
+
+
+class Args(TypedDict):
+    uni: str | int  # Unions are not supported
+
+
+class Component(pulumi.ComponentResource):
+    def __init__(self, args: Args): ...


### PR DESCRIPTION
Starting with Python 3.10, unions can be written using `|`. This also means that optional types can be typed as `some_type | None` in addition to `Optional[some_type]`.

Fixes https://github.com/pulumi/home/issues/4049
