### PR TITLE
Fix test_analyze_syntax_error on Python 3.10

### DIFF
--- a/sdk/python/lib/test/provider/experimental/test_analyzer.py
+++ b/sdk/python/lib/test/provider/experimental/test_analyzer.py
@@ -1042,8 +1042,8 @@ def test_analyze_syntax_error():
         import traceback
 
         stack = traceback.extract_tb(e.__traceback__)[:]
-        print(stack)
-        assert str(e) == "invalid syntax (component.py, line 13)"
+        # The error message can be slightly different depending on the Python version.
+        assert "invalid syntax" in str(e) and "component.py, line 13)" in str(e)
 
 
 def test_analyze_duplicate_type():


### PR DESCRIPTION
On Python 3.10, we get a different error message than on the other
supported Python versions:

```
    - invalid syntax (component.py, line 13)
    + invalid syntax. Perhaps you forgot a comma? (component.py, line 13)
```

Adjust the test so this passes on all of our versions and we don't run
into a failure once we bump the minimum support to 3.10 in CI later this
year.
