### PR TITLE
Add run-program to automation api

### DIFF
--- a/changelog/pending/20250415--auto-go-nodejs-python--add-run-program-to-automation-api-for-destroy-and-refresh.yaml
+++ b/changelog/pending/20250415--auto-go-nodejs-python--add-run-program-to-automation-api-for-destroy-and-refresh.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go,nodejs,python
+  description: Add --run-program to automation api for destroy and refresh

--- a/sdk/go/auto/optdestroy/optdestroy.go
+++ b/sdk/go/auto/optdestroy/optdestroy.go
@@ -144,6 +144,13 @@ func ConfigFile(path string) Option {
 	})
 }
 
+// RunProgram runs the program in the workspace to perform the destroy.
+func RunProgram(f bool) Option {
+	return optionFunc(func(opts *Options) {
+		opts.RunProgram = &f
+	})
+}
+
 // Option is a parameter to be applied to a Stack.Destroy() operation
 type Option interface {
 	ApplyOption(*Options)
@@ -189,6 +196,8 @@ type Options struct {
 	Remove bool
 	// Run using the configuration values in the specified file rather than detecting the file name
 	ConfigFile string
+	// When set to true, run the program in the workspace to perform the destroy.
+	RunProgram *bool
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/optrefresh/optrefresh.go
+++ b/sdk/go/auto/optrefresh/optrefresh.go
@@ -136,6 +136,13 @@ func ConfigFile(path string) Option {
 	})
 }
 
+// RunProgram runs the program in the workspace to perform the refresh.
+func RunProgram(f bool) Option {
+	return optionFunc(func(opts *Options) {
+		opts.RunProgram = &f
+	})
+}
+
 // Option is a parameter to be applied to a Stack.Refresh() operation
 type Option interface {
 	ApplyOption(*Options)
@@ -178,6 +185,8 @@ type Options struct {
 	ConfigFile string
 	// When set, display operation as a rich diff showing the overall change
 	Diff bool
+	// When set to true, run the program in the workspace to perform the refresh.
+	RunProgram *bool
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -776,6 +776,13 @@ func refreshOptsToCmd(o *optrefresh.Options, s *Stack, isPreview bool) []string 
 	if o.Diff {
 		args = append(args, "--diff")
 	}
+	if o.RunProgram != nil {
+		if *o.RunProgram {
+			args = append(args, "--run-program=true")
+		} else {
+			args = append(args, "--run-program=false")
+		}
+	}
 
 	// Apply the remote args, if needed.
 	args = append(args, s.remoteArgs()...)
@@ -1021,6 +1028,13 @@ func destroyOptsToCmd(destroyOpts *optdestroy.Options, s *Stack) []string {
 	}
 	if destroyOpts.ConfigFile != "" {
 		args = append(args, "--config-file="+destroyOpts.ConfigFile)
+	}
+	if destroyOpts.RunProgram != nil {
+		if *destroyOpts.RunProgram {
+			args = append(args, "--run-program=true")
+		} else {
+			args = append(args, "--run-program=false")
+		}
 	}
 
 	execKind := constant.ExecKindAutoLocal

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -466,6 +466,13 @@ Event: ${line}\n${e.toString()}`);
             if (opts.userAgent) {
                 args.push("--exec-agent", opts.userAgent);
             }
+            if (opts.runProgram !== undefined) {
+                if (opts.runProgram) {
+                    args.push("--run-program=true");
+                } else {
+                    args.push("--run-program=false");
+                }
+            }
             applyGlobalOpts(opts, args);
         }
 
@@ -547,6 +554,13 @@ Event: ${line}\n${e.toString()}`);
             }
             if (opts.refresh) {
                 args.push("--refresh");
+            }
+            if (opts.runProgram !== undefined) {
+                if (opts.runProgram) {
+                    args.push("--run-program=true");
+                } else {
+                    args.push("--run-program=false");
+                }
             }
             applyGlobalOpts(opts, args);
         }
@@ -1547,6 +1561,11 @@ export interface RefreshOptions extends GlobalOpts {
      * A signal to abort an ongoing operation.
      */
     signal?: AbortSignal;
+
+    /**
+     * Run the program in the workspace to perform the refresh.
+     */
+    runProgram?: boolean;
 }
 
 /**
@@ -1621,6 +1640,11 @@ export interface DestroyOptions extends GlobalOpts {
      * A signal to abort an ongoing operation.
      */
     signal?: AbortSignal;
+
+    /**
+     * Run the program in the workspace to perform the destroy.
+     */
+    runProgram?: boolean;
 }
 
 /**

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -534,6 +534,7 @@ class Stack:
         debug: Optional[bool] = None,
         suppress_outputs: Optional[bool] = None,
         suppress_progress: Optional[bool] = None,
+        run_program: Optional[bool] = None,
     ) -> RefreshResult:
         """
         Compares the current stack’s resource state with the state known to exist in the actual
@@ -557,6 +558,7 @@ class Stack:
         :param debug: Print detailed debugging output during resource operations
         :param suppress_outputs: Suppress display of stack outputs (in case they contain sensitive values)
         :param suppress_progress: Suppress display of periodic progress dots
+        :param run_program: Run the program in the workspace to refresh the stack
         :returns: RefreshResult
         """
         extra_args = _parse_extra_args(**locals())
@@ -566,6 +568,12 @@ class Stack:
             args.append("--preview-only")
         else:
             args.append("--skip-preview")
+
+        if run_program is not None:
+            if run_program:
+                args.append("--run-program=true")
+            else:
+                args.append("--run-program=false")
 
         args.extend(extra_args)
         args.extend(self._remote_args())
@@ -648,6 +656,7 @@ class Stack:
         remove: Optional[bool] = None,
         refresh: Optional[bool] = None,
         preview_only: Optional[bool] = None,
+        run_program: Optional[bool] = None,
     ) -> DestroyResult:
         """
         Destroy deletes all resources in a stack, leaving all history and configuration intact.
@@ -673,6 +682,7 @@ class Stack:
         :param remove: Remove the stack and its configuration after all resources in the stack have been deleted.
         :param refresh: Refresh the state of the stack's resources against the cloud provider before running destroy.
         :param preview_only: Only show a preview of the destroy, but don't perform the destroy itself
+        :param run_program: Run the program in the workspace to destroy the stack
         :returns: DestroyResult
         """
         extra_args = _parse_extra_args(**locals())
@@ -682,6 +692,12 @@ class Stack:
             args.append("--preview-only")
         else:
             args.extend(["--skip-preview", "--yes"])
+
+        if run_program is not None:
+            if run_program:
+                args.append("--run-program=true")
+            else:
+                args.append("--run-program=false")
 
         args.extend(extra_args)
         args.extend(self._remote_args())


### PR DESCRIPTION
Adds --run-program support to nodejs, python, and go.

I've added this explicitly (that is we explicitly pass `=true` or `=false`) so that if we change the default behaviour of the flag in the future anyone who explicitly set `false` will continue to get the same behaviour they expect.  As opposed to passing `--run-program` for true and nothing for false, where if we then changed the default behaviour anyone who had explicitly set false would suddenly be having their program run.