### PR TITLE
Set the version at runtime if it wasn't embedded at compile time

### DIFF
--- a/sdk/go/common/version/version.go
+++ b/sdk/go/common/version/version.go
@@ -14,5 +14,18 @@
 
 package version
 
+import "runtime/debug"
+
 // Version is initialized by the Go linker to contain the semver of this build.
 var Version string
+
+func init() {
+	if Version != "" {
+		return
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	Version = info.Main.Version
+}


### PR DESCRIPTION
This enables binaries built with `go build github.com/pulumi/pulumi/pkg/v3/cmd/pulumi` to have an accurate `pulumi version`. If `version.Version` is set during link time, then this commit has no effect.