### PR TITLE
Add static pulumi_type property to resource classes

### DIFF
--- a/changelog/pending/20250415--sdk-python--add-static-pulumi_type-property-to-resource-classes.yaml
+++ b/changelog/pending/20250415--sdk-python--add-static-pulumi_type-property-to-resource-classes.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Add static pulumi_type property to resource classes

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1377,6 +1377,10 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 		fmt.Fprintf(w, "    warnings.warn(\"\"\"%s\"\"\", DeprecationWarning)\n\n", escaped)
 	}
 
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "    pulumi_type = \"%s\"\n", res.Token)
+	fmt.Fprintln(w)
+
 	// Determine if all inputs are optional.
 	allOptionalInputs := true
 	for _, prop := range res.InputProperties {

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/provider.py
@@ -22,6 +22,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:alpha"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/resource.py
@@ -32,6 +32,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "alpha:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/any-type-function-15.0.0/pulumi_any_type_function/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/any-type-function-15.0.0/pulumi_any_type_function/provider.py
@@ -22,6 +22,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:any-type-function"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/archive_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/archive_resource.py
@@ -32,6 +32,9 @@ class ArchiveResourceArgs:
 
 
 class ArchiveResource(pulumi.CustomResource):
+
+    pulumi_type = "asset-archive:index:ArchiveResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/asset_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/asset_resource.py
@@ -32,6 +32,9 @@ class AssetResourceArgs:
 
 
 class AssetResource(pulumi.CustomResource):
+
+    pulumi_type = "asset-archive:index:AssetResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/provider.py
@@ -22,6 +22,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:asset-archive"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/call-15.7.9/pulumi_call/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/call-15.7.9/pulumi_call/custom.py
@@ -32,6 +32,9 @@ class CustomArgs:
 
 
 class Custom(pulumi.CustomResource):
+
+    pulumi_type = "call:index:Custom"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/call-15.7.9/pulumi_call/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/call-15.7.9/pulumi_call/provider.py
@@ -32,6 +32,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:call"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/component_callable.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/component_callable.py
@@ -32,6 +32,9 @@ class ComponentCallableArgs:
 
 
 class ComponentCallable(pulumi.ComponentResource):
+
+    pulumi_type = "component:index:ComponentCallable"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
@@ -33,6 +33,9 @@ class ComponentCustomRefInputOutputArgs:
 
 
 class ComponentCustomRefInputOutput(pulumi.ComponentResource):
+
+    pulumi_type = "component:index:ComponentCustomRefInputOutput"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
@@ -33,6 +33,9 @@ class ComponentCustomRefOutputArgs:
 
 
 class ComponentCustomRefOutput(pulumi.ComponentResource):
+
+    pulumi_type = "component:index:ComponentCustomRefOutput"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/custom.py
@@ -32,6 +32,9 @@ class CustomArgs:
 
 
 class Custom(pulumi.CustomResource):
+
+    pulumi_type = "component:index:Custom"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/provider.py
@@ -22,6 +22,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:component"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
@@ -55,6 +55,9 @@ class ComponentArgs:
 
 
 class Component(pulumi.ComponentResource):
+
+    pulumi_type = "component-property-deps:index:Component"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
@@ -32,6 +32,9 @@ class CustomArgs:
 
 
 class Custom(pulumi.CustomResource):
+
+    pulumi_type = "component-property-deps:index:Custom"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/provider.py
@@ -22,6 +22,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:component-property-deps"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/provider.py
@@ -44,6 +44,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:config"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/resource.py
@@ -32,6 +32,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "config:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/config_fetcher.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/config_fetcher.py
@@ -22,6 +22,9 @@ class ConfigFetcherArgs:
 
 
 class ConfigFetcher(pulumi.CustomResource):
+
+    pulumi_type = "config-grpc:index:ConfigFetcher"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/provider.py
@@ -1174,6 +1174,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:config-grpc"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/provider.py
@@ -22,6 +22,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:fail_on_create"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/resource.py
@@ -32,6 +32,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "fail_on_create:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye.py
@@ -22,6 +22,9 @@ class GoodbyeArgs:
 
 
 class Goodbye(pulumi.CustomResource):
+
+    pulumi_type = "goodbye:index:Goodbye"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye_component.py
@@ -22,6 +22,9 @@ class GoodbyeComponentArgs:
 
 
 class GoodbyeComponent(pulumi.ComponentResource):
+
+    pulumi_type = "goodbye:index:GoodbyeComponent"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/provider.py
@@ -33,6 +33,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:goodbye"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/pulumi_large/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/pulumi_large/provider.py
@@ -22,6 +22,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:large"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/pulumi_large/string.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/pulumi_large/string.py
@@ -32,6 +32,9 @@ class StringArgs:
 
 
 class String(pulumi.CustomResource):
+
+    pulumi_type = "large:index:String"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/namespaced-16.0.0/a_namespace_namespaced/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/namespaced-16.0.0/a_namespace_namespaced/provider.py
@@ -22,6 +22,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:namespaced"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/namespaced-16.0.0/a_namespace_namespaced/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/namespaced-16.0.0/a_namespace_namespaced/resource.py
@@ -32,6 +32,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "namespaced:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/pulumi_plain/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/pulumi_plain/provider.py
@@ -22,6 +22,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:plain"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/pulumi_plain/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/pulumi_plain/resource.py
@@ -50,6 +50,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "plain:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/pulumi_primitive/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/pulumi_primitive/provider.py
@@ -22,6 +22,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:primitive"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/pulumi_primitive/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/pulumi_primitive/resource.py
@@ -87,6 +87,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "primitive:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/provider.py
@@ -22,6 +22,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:primitive-ref"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/resource.py
@@ -34,6 +34,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "primitive-ref:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/provider.py
@@ -22,6 +22,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:ref-ref"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/resource.py
@@ -34,6 +34,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "ref-ref:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/pulumi_secret/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/pulumi_secret/provider.py
@@ -22,6 +22,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:secret"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/pulumi_secret/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/pulumi_secret/resource.py
@@ -67,6 +67,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "secret:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/pulumi_simple/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/pulumi_simple/provider.py
@@ -22,6 +22,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:simple"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/pulumi_simple/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/pulumi_simple/resource.py
@@ -32,6 +32,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "simple:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/provider.py
@@ -22,6 +22,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:simple-invoke"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/string_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/string_resource.py
@@ -32,6 +32,9 @@ class StringResourceArgs:
 
 
 class StringResource(pulumi.CustomResource):
+
+    pulumi_type = "simple-invoke:index:StringResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world.py
@@ -22,6 +22,9 @@ class HelloWorldArgs:
 
 
 class HelloWorld(pulumi.CustomResource):
+
+    pulumi_type = "subpackage:index:HelloWorld"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world_component.py
@@ -22,6 +22,9 @@ class HelloWorldComponentArgs:
 
 
 class HelloWorldComponent(pulumi.ComponentResource):
+
+    pulumi_type = "subpackage:index:HelloWorldComponent"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/provider.py
@@ -33,6 +33,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:subpackage"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:alpha"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/resource.py
@@ -37,6 +37,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "alpha:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/any-type-function-15.0.0/pulumi_any_type_function/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/any-type-function-15.0.0/pulumi_any_type_function/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:any-type-function"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/archive_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/archive_resource.py
@@ -37,6 +37,9 @@ class ArchiveResourceArgs:
 
 
 class ArchiveResource(pulumi.CustomResource):
+
+    pulumi_type = "asset-archive:index:ArchiveResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/asset_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/asset_resource.py
@@ -37,6 +37,9 @@ class AssetResourceArgs:
 
 
 class AssetResource(pulumi.CustomResource):
+
+    pulumi_type = "asset-archive:index:AssetResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:asset-archive"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/call-15.7.9/pulumi_call/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/call-15.7.9/pulumi_call/custom.py
@@ -37,6 +37,9 @@ class CustomArgs:
 
 
 class Custom(pulumi.CustomResource):
+
+    pulumi_type = "call:index:Custom"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/call-15.7.9/pulumi_call/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/call-15.7.9/pulumi_call/provider.py
@@ -37,6 +37,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:call"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/component_callable.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/component_callable.py
@@ -37,6 +37,9 @@ class ComponentCallableArgs:
 
 
 class ComponentCallable(pulumi.ComponentResource):
+
+    pulumi_type = "component:index:ComponentCallable"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
@@ -38,6 +38,9 @@ class ComponentCustomRefInputOutputArgs:
 
 
 class ComponentCustomRefInputOutput(pulumi.ComponentResource):
+
+    pulumi_type = "component:index:ComponentCustomRefInputOutput"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
@@ -38,6 +38,9 @@ class ComponentCustomRefOutputArgs:
 
 
 class ComponentCustomRefOutput(pulumi.ComponentResource):
+
+    pulumi_type = "component:index:ComponentCustomRefOutput"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/custom.py
@@ -37,6 +37,9 @@ class CustomArgs:
 
 
 class Custom(pulumi.CustomResource):
+
+    pulumi_type = "component:index:Custom"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:component"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
@@ -60,6 +60,9 @@ class ComponentArgs:
 
 
 class Component(pulumi.ComponentResource):
+
+    pulumi_type = "component-property-deps:index:Component"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
@@ -37,6 +37,9 @@ class CustomArgs:
 
 
 class Custom(pulumi.CustomResource):
+
+    pulumi_type = "component-property-deps:index:Custom"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:component-property-deps"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/provider.py
@@ -49,6 +49,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:config"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/resource.py
@@ -37,6 +37,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "config:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/config_fetcher.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/config_fetcher.py
@@ -27,6 +27,9 @@ class ConfigFetcherArgs:
 
 
 class ConfigFetcher(pulumi.CustomResource):
+
+    pulumi_type = "config-grpc:index:ConfigFetcher"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/provider.py
@@ -1179,6 +1179,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:config-grpc"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:fail_on_create"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/resource.py
@@ -37,6 +37,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "fail_on_create:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye.py
@@ -27,6 +27,9 @@ class GoodbyeArgs:
 
 
 class Goodbye(pulumi.CustomResource):
+
+    pulumi_type = "goodbye:index:Goodbye"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye_component.py
@@ -27,6 +27,9 @@ class GoodbyeComponentArgs:
 
 
 class GoodbyeComponent(pulumi.ComponentResource):
+
+    pulumi_type = "goodbye:index:GoodbyeComponent"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/provider.py
@@ -38,6 +38,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:goodbye"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/pulumi_large/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/pulumi_large/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:large"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/pulumi_large/string.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/pulumi_large/string.py
@@ -37,6 +37,9 @@ class StringArgs:
 
 
 class String(pulumi.CustomResource):
+
+    pulumi_type = "large:index:String"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/namespaced-16.0.0/a_namespace_namespaced/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/namespaced-16.0.0/a_namespace_namespaced/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:namespaced"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/namespaced-16.0.0/a_namespace_namespaced/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/namespaced-16.0.0/a_namespace_namespaced/resource.py
@@ -37,6 +37,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "namespaced:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/pulumi_plain/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/pulumi_plain/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:plain"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/pulumi_plain/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/pulumi_plain/resource.py
@@ -55,6 +55,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "plain:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/pulumi_primitive/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/pulumi_primitive/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:primitive"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/pulumi_primitive/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/pulumi_primitive/resource.py
@@ -92,6 +92,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "primitive:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:primitive-ref"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/resource.py
@@ -39,6 +39,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "primitive-ref:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:ref-ref"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/resource.py
@@ -39,6 +39,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "ref-ref:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/pulumi_secret/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/pulumi_secret/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:secret"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/pulumi_secret/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/pulumi_secret/resource.py
@@ -72,6 +72,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "secret:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/pulumi_simple/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/pulumi_simple/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:simple"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/pulumi_simple/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/pulumi_simple/resource.py
@@ -37,6 +37,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "simple:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:simple-invoke"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/string_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/string_resource.py
@@ -37,6 +37,9 @@ class StringResourceArgs:
 
 
 class StringResource(pulumi.CustomResource):
+
+    pulumi_type = "simple-invoke:index:StringResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world.py
@@ -27,6 +27,9 @@ class HelloWorldArgs:
 
 
 class HelloWorld(pulumi.CustomResource):
+
+    pulumi_type = "subpackage:index:HelloWorld"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world_component.py
@@ -27,6 +27,9 @@ class HelloWorldComponentArgs:
 
 
 class HelloWorldComponent(pulumi.ComponentResource):
+
+    pulumi_type = "subpackage:index:HelloWorldComponent"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/provider.py
@@ -38,6 +38,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:subpackage"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:alpha"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/resource.py
@@ -37,6 +37,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "alpha:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/any-type-function-15.0.0/pulumi_any_type_function/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/any-type-function-15.0.0/pulumi_any_type_function/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:any-type-function"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/archive_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/archive_resource.py
@@ -37,6 +37,9 @@ class ArchiveResourceArgs:
 
 
 class ArchiveResource(pulumi.CustomResource):
+
+    pulumi_type = "asset-archive:index:ArchiveResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/asset_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/asset_resource.py
@@ -37,6 +37,9 @@ class AssetResourceArgs:
 
 
 class AssetResource(pulumi.CustomResource):
+
+    pulumi_type = "asset-archive:index:AssetResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:asset-archive"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/call-15.7.9/pulumi_call/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/call-15.7.9/pulumi_call/custom.py
@@ -37,6 +37,9 @@ class CustomArgs:
 
 
 class Custom(pulumi.CustomResource):
+
+    pulumi_type = "call:index:Custom"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/call-15.7.9/pulumi_call/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/call-15.7.9/pulumi_call/provider.py
@@ -37,6 +37,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:call"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/component_callable.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/component_callable.py
@@ -37,6 +37,9 @@ class ComponentCallableArgs:
 
 
 class ComponentCallable(pulumi.ComponentResource):
+
+    pulumi_type = "component:index:ComponentCallable"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
@@ -38,6 +38,9 @@ class ComponentCustomRefInputOutputArgs:
 
 
 class ComponentCustomRefInputOutput(pulumi.ComponentResource):
+
+    pulumi_type = "component:index:ComponentCustomRefInputOutput"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
@@ -38,6 +38,9 @@ class ComponentCustomRefOutputArgs:
 
 
 class ComponentCustomRefOutput(pulumi.ComponentResource):
+
+    pulumi_type = "component:index:ComponentCustomRefOutput"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/custom.py
@@ -37,6 +37,9 @@ class CustomArgs:
 
 
 class Custom(pulumi.CustomResource):
+
+    pulumi_type = "component:index:Custom"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:component"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
@@ -60,6 +60,9 @@ class ComponentArgs:
 
 
 class Component(pulumi.ComponentResource):
+
+    pulumi_type = "component-property-deps:index:Component"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
@@ -37,6 +37,9 @@ class CustomArgs:
 
 
 class Custom(pulumi.CustomResource):
+
+    pulumi_type = "component-property-deps:index:Custom"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:component-property-deps"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/provider.py
@@ -49,6 +49,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:config"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/resource.py
@@ -37,6 +37,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "config:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/config_fetcher.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/config_fetcher.py
@@ -27,6 +27,9 @@ class ConfigFetcherArgs:
 
 
 class ConfigFetcher(pulumi.CustomResource):
+
+    pulumi_type = "config-grpc:index:ConfigFetcher"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/provider.py
@@ -1179,6 +1179,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:config-grpc"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:fail_on_create"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/resource.py
@@ -37,6 +37,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "fail_on_create:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye.py
@@ -27,6 +27,9 @@ class GoodbyeArgs:
 
 
 class Goodbye(pulumi.CustomResource):
+
+    pulumi_type = "goodbye:index:Goodbye"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye_component.py
@@ -27,6 +27,9 @@ class GoodbyeComponentArgs:
 
 
 class GoodbyeComponent(pulumi.ComponentResource):
+
+    pulumi_type = "goodbye:index:GoodbyeComponent"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/provider.py
@@ -38,6 +38,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:goodbye"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pulumi_large/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pulumi_large/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:large"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pulumi_large/string.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pulumi_large/string.py
@@ -37,6 +37,9 @@ class StringArgs:
 
 
 class String(pulumi.CustomResource):
+
+    pulumi_type = "large:index:String"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/namespaced-16.0.0/a_namespace_namespaced/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/namespaced-16.0.0/a_namespace_namespaced/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:namespaced"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/namespaced-16.0.0/a_namespace_namespaced/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/namespaced-16.0.0/a_namespace_namespaced/resource.py
@@ -37,6 +37,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "namespaced:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pulumi_plain/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pulumi_plain/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:plain"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pulumi_plain/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pulumi_plain/resource.py
@@ -55,6 +55,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "plain:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pulumi_primitive/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pulumi_primitive/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:primitive"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pulumi_primitive/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pulumi_primitive/resource.py
@@ -92,6 +92,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "primitive:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:primitive-ref"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/resource.py
@@ -39,6 +39,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "primitive-ref:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:ref-ref"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/resource.py
@@ -39,6 +39,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "ref-ref:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pulumi_secret/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pulumi_secret/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:secret"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pulumi_secret/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pulumi_secret/resource.py
@@ -72,6 +72,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "secret:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pulumi_simple/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pulumi_simple/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:simple"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pulumi_simple/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pulumi_simple/resource.py
@@ -37,6 +37,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "simple:index:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:simple-invoke"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/string_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/string_resource.py
@@ -37,6 +37,9 @@ class StringResourceArgs:
 
 
 class StringResource(pulumi.CustomResource):
+
+    pulumi_type = "simple-invoke:index:StringResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world.py
@@ -27,6 +27,9 @@ class HelloWorldArgs:
 
 
 class HelloWorld(pulumi.CustomResource):
+
+    pulumi_type = "subpackage:index:HelloWorld"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world_component.py
@@ -27,6 +27,9 @@ class HelloWorldComponentArgs:
 
 
 class HelloWorldComponent(pulumi.ComponentResource):
+
+    pulumi_type = "subpackage:index:HelloWorldComponent"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/provider.py
@@ -38,6 +38,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:subpackage"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/assets-and-archives/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/assets-and-archives/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/assets-and-archives/python/pulumi_example/resource_with_assets.py
+++ b/tests/testdata/codegen/assets-and-archives/python/pulumi_example/resource_with_assets.py
@@ -63,6 +63,9 @@ class ResourceWithAssetsArgs:
 
 
 class ResourceWithAssets(pulumi.CustomResource):
+
+    pulumi_type = "example:index:ResourceWithAssets"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/documentdb/sql_resource_sql_container.py
+++ b/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/documentdb/sql_resource_sql_container.py
@@ -28,6 +28,9 @@ class SqlResourceSqlContainerArgs:
 
 
 class SqlResourceSqlContainer(pulumi.CustomResource):
+
+    pulumi_type = "azure-native:documentdb:SqlResourceSqlContainer"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/provider.py
+++ b/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:azure-native"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/config-variables/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/config-variables/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/cyclic-types/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/cyclic-types/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/provider.py
+++ b/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:foo-bar"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/submodule1/foo_encrypted_bar_class.py
+++ b/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/submodule1/foo_encrypted_bar_class.py
@@ -27,6 +27,9 @@ class FOOEncryptedBarClassArgs:
 
 
 class FOOEncryptedBarClass(pulumi.CustomResource):
+
+    pulumi_type = "foo-bar:submodule1:FOOEncryptedBarClass"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/submodule1/module_resource.py
+++ b/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/submodule1/module_resource.py
@@ -40,6 +40,9 @@ class ModuleResourceArgs:
 
 
 class ModuleResource(pulumi.CustomResource):
+
+    pulumi_type = "foo-bar:submodule1:ModuleResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/provider.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:plant"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/tree/v1/nursery.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/tree/v1/nursery.py
@@ -58,6 +58,9 @@ class NurseryArgs:
 
 
 class Nursery(pulumi.CustomResource):
+
+    pulumi_type = "plant:tree/v1:Nursery"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -118,6 +118,9 @@ class _RubberTreeState:
 
 
 class RubberTree(pulumi.CustomResource):
+
+    pulumi_type = "plant:tree/v1:RubberTree"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/different-enum/python/pulumi_plant/provider.py
+++ b/tests/testdata/codegen/different-enum/python/pulumi_plant/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:plant"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/different-enum/python/pulumi_plant/tree/v1/nursery.py
+++ b/tests/testdata/codegen/different-enum/python/pulumi_plant/tree/v1/nursery.py
@@ -58,6 +58,9 @@ class NurseryArgs:
 
 
 class Nursery(pulumi.CustomResource):
+
+    pulumi_type = "plant:tree/v1:Nursery"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/different-enum/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/tests/testdata/codegen/different-enum/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -118,6 +118,9 @@ class _RubberTreeState:
 
 
 class RubberTree(pulumi.CustomResource):
+
+    pulumi_type = "plant:tree/v1:RubberTree"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/component.py
+++ b/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/component.py
@@ -52,6 +52,9 @@ class ComponentArgs:
 
 
 class Component(pulumi.ComponentResource):
+
+    pulumi_type = "foo:index:Component"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/provider.py
+++ b/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:foo"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/enum-reference-python/python/pulumi_example/mymodule/iam_resource.py
+++ b/tests/testdata/codegen/enum-reference-python/python/pulumi_example/mymodule/iam_resource.py
@@ -39,6 +39,9 @@ class IamResourceArgs:
 
 
 class IamResource(pulumi.ComponentResource):
+
+    pulumi_type = "example:myModule:IamResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/enum-reference-python/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/enum-reference-python/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/enum-reference-python/python/pulumi_example/replicated_bucket.py
+++ b/tests/testdata/codegen/enum-reference-python/python/pulumi_example/replicated_bucket.py
@@ -43,6 +43,9 @@ class ReplicatedBucketArgs:
 
 
 class ReplicatedBucket(pulumi.ComponentResource):
+
+    pulumi_type = "example:index:ReplicatedBucket"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/enum-reference/python/pulumi_example/mymodule/iam_resource.py
+++ b/tests/testdata/codegen/enum-reference/python/pulumi_example/mymodule/iam_resource.py
@@ -39,6 +39,9 @@ class IamResourceArgs:
 
 
 class IamResource(pulumi.ComponentResource):
+
+    pulumi_type = "example:myModule:IamResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/enum-reference/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/enum-reference/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/external-enum/python/pulumi_example/component.py
+++ b/tests/testdata/codegen/external-enum/python/pulumi_example/component.py
@@ -52,6 +52,9 @@ class ComponentArgs:
 
 
 class Component(pulumi.CustomResource):
+
+    pulumi_type = "example:index:Component"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/external-enum/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/external-enum/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/cloudtrail/trail.py
+++ b/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/cloudtrail/trail.py
@@ -51,6 +51,9 @@ class TrailArgs:
 
 
 class Trail(pulumi.ComponentResource):
+
+    pulumi_type = "example:cloudtrail:Trail"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/external-resource-schema/python/pulumi_example/cat.py
+++ b/tests/testdata/codegen/external-resource-schema/python/pulumi_example/cat.py
@@ -52,6 +52,9 @@ class CatArgs:
 
 
 class Cat(pulumi.CustomResource):
+
+    pulumi_type = "example::Cat"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/external-resource-schema/python/pulumi_example/component.py
+++ b/tests/testdata/codegen/external-resource-schema/python/pulumi_example/component.py
@@ -97,6 +97,9 @@ class ComponentArgs:
 
 
 class Component(pulumi.CustomResource):
+
+    pulumi_type = "example::Component"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/external-resource-schema/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/external-resource-schema/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/external-resource-schema/python/pulumi_example/workload.py
+++ b/tests/testdata/codegen/external-resource-schema/python/pulumi_example/workload.py
@@ -28,6 +28,9 @@ class WorkloadArgs:
 
 
 class Workload(pulumi.CustomResource):
+
+    pulumi_type = "example::Workload"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/functions-secrets/python/pulumi_mypkg/provider.py
+++ b/tests/testdata/codegen/functions-secrets/python/pulumi_mypkg/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:mypkg"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/provider.py
+++ b/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:registrygeoreplication"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/registry_geo_replication.py
+++ b/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/registry_geo_replication.py
@@ -42,6 +42,9 @@ class RegistryGeoReplicationArgs:
 
 
 class RegistryGeoReplication(pulumi.ComponentResource):
+
+    pulumi_type = "registrygeoreplication:index:RegistryGeoReplication"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/foo.py
+++ b/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/foo.py
@@ -28,6 +28,9 @@ class FooArgs:
 
 
 class Foo(pulumi.CustomResource):
+
+    pulumi_type = "repro:index:Foo"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/provider.py
+++ b/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:repro"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/ConfigMap.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/ConfigMap.py
@@ -123,6 +123,9 @@ class ConfigMapInitArgs:
 
 
 class ConfigMap(pulumi.CustomResource):
+
+    pulumi_type = "kubernetes:core/v1:ConfigMap"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/ConfigMapList.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/ConfigMapList.py
@@ -92,6 +92,9 @@ class ConfigMapListArgs:
 
 
 class ConfigMapList(pulumi.CustomResource):
+
+    pulumi_type = "kubernetes:core/v1:ConfigMapList"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/helm/v3/Release.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/helm/v3/Release.py
@@ -73,6 +73,9 @@ class ReleaseArgs:
 
 
 class Release(pulumi.CustomResource):
+
+    pulumi_type = "kubernetes:helm.sh/v3:Release"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/provider.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/provider.py
@@ -87,6 +87,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:kubernetes"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/yaml/v2/ConfigGroup.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/yaml/v2/ConfigGroup.py
@@ -90,6 +90,9 @@ class ConfigGroupArgs:
 
 
 class ConfigGroup(pulumi.ComponentResource):
+
+    pulumi_type = "kubernetes:yaml/v2:ConfigGroup"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/example_resource.py
+++ b/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/example_resource.py
@@ -52,6 +52,9 @@ class Example_resourceArgs:
 
 
 class Example_resource(pulumi.CustomResource):
+
+    pulumi_type = "legacy_names:index:example_resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/provider.py
+++ b/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:legacy_names"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/configurer.py
+++ b/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/configurer.py
@@ -39,6 +39,9 @@ class ConfigurerArgs:
 
 
 class Configurer(pulumi.ComponentResource):
+
+    pulumi_type = "metaprovider:index:Configurer"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/provider.py
+++ b/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:metaprovider"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/main_component.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/main_component.py
@@ -27,6 +27,9 @@ class MainComponentArgs:
 
 
 class MainComponent(pulumi.CustomResource):
+
+    pulumi_type = "example::MainComponent"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/mod/component.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/mod/component.py
@@ -52,6 +52,9 @@ class ComponentArgs:
 
 
 class Component(pulumi.CustomResource):
+
+    pulumi_type = "example:mod:Component"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/mod/component2.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/mod/component2.py
@@ -27,6 +27,9 @@ class Component2Args:
 
 
 class Component2(pulumi.CustomResource):
+
+    pulumi_type = "example:mod:Component2"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/resource.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/resource.py
@@ -27,6 +27,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "example::Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/resource_input.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/resource_input.py
@@ -27,6 +27,9 @@ class ResourceInputArgs:
 
 
 class ResourceInput(pulumi.CustomResource):
+
+    pulumi_type = "example::ResourceInput"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/deeply/nested/module/resource.py
+++ b/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/deeply/nested/module/resource.py
@@ -38,6 +38,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "foo-bar:deeply/nested/module:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/provider.py
+++ b/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:foo-bar"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/nested-module/python/pulumi_foo/nested/module/resource.py
+++ b/tests/testdata/codegen/nested-module/python/pulumi_foo/nested/module/resource.py
@@ -38,6 +38,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "foo:nested/module:Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/nested-module/python/pulumi_foo/provider.py
+++ b/tests/testdata/codegen/nested-module/python/pulumi_foo/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:foo"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/provider.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:myedgeorder"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/provider.py
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:mypkg"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/provider.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:mypkg"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/module_resource.py
+++ b/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/module_resource.py
@@ -257,6 +257,9 @@ class ModuleResourceArgs:
 
 
 class ModuleResource(pulumi.CustomResource):
+
+    pulumi_type = "foobar::ModuleResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/provider.py
+++ b/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:foobar"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/foo.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/foo.py
@@ -87,6 +87,9 @@ class FooArgs:
 
 
 class Foo(pulumi.CustomResource):
+
+    pulumi_type = "example:index:Foo"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/module_test.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/module_test.py
@@ -53,6 +53,9 @@ class ModuleTestArgs:
 
 
 class ModuleTest(pulumi.CustomResource):
+
+    pulumi_type = "example:index:moduleTest"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/provider.py
@@ -43,6 +43,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/foo.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/foo.py
@@ -87,6 +87,9 @@ class FooArgs:
 
 
 class Foo(pulumi.CustomResource):
+
+    pulumi_type = "example:index:Foo"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/module_test.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/module_test.py
@@ -53,6 +53,9 @@ class ModuleTestArgs:
 
 
 class ModuleTest(pulumi.CustomResource):
+
+    pulumi_type = "example:index:moduleTest"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/provider.py
@@ -43,6 +43,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/provider.py
+++ b/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:xyz"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/static_page.py
+++ b/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/static_page.py
@@ -55,6 +55,9 @@ class StaticPageArgs:
 
 
 class StaticPage(pulumi.ComponentResource):
+
+    pulumi_type = "xyz:index:StaticPage"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/provider.py
+++ b/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/provider.py
@@ -62,6 +62,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:configstation"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/provider.py
+++ b/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:providerType"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/submod/provider.py
+++ b/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/submod/provider.py
@@ -38,6 +38,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.CustomResource):
+
+    pulumi_type = "providerType:submod:provider"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/component.py
+++ b/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/component.py
@@ -35,6 +35,9 @@ class ComponentArgs:
 
 
 class Component(pulumi.ComponentResource):
+
+    pulumi_type = "typedDictDisabledExample:index:Component"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/provider.py
+++ b/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/provider.py
@@ -22,6 +22,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:typedDictDisabledExample"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/component.py
+++ b/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/component.py
@@ -40,6 +40,9 @@ class ComponentArgs:
 
 
 class Component(pulumi.ComponentResource):
+
+    pulumi_type = "typedDictExample:index:Component"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/provider.py
+++ b/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:typedDictExample"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/component.py
+++ b/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/component.py
@@ -40,6 +40,9 @@ class ComponentArgs:
 
 
 class Component(pulumi.ComponentResource):
+
+    pulumi_type = "typedDictExample:index:Component"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/provider.py
+++ b/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:typedDictExample"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-8403/python/pulumi_mongodbatlas/provider.py
+++ b/tests/testdata/codegen/regress-8403/python/pulumi_mongodbatlas/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:mongodbatlas"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-node-8110/python/pulumi_my8110/provider.py
+++ b/tests/testdata/codegen/regress-node-8110/python/pulumi_my8110/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:my8110"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/provider.py
+++ b/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:plant"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -134,6 +134,9 @@ class _RubberTreeState:
 
 
 class RubberTree(pulumi.CustomResource):
+
+    pulumi_type = "plant:tree/v1:RubberTree"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childa/member_a1.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childa/member_a1.py
@@ -27,6 +27,9 @@ class MemberA1Args:
 
 
 class MemberA1(pulumi.ComponentResource):
+
+    pulumi_type = "myPkg:myMod/childA:MemberA1"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childb/member_b1.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childb/member_b1.py
@@ -27,6 +27,9 @@ class MemberB1Args:
 
 
 class MemberB1(pulumi.ComponentResource):
+
+    pulumi_type = "myPkg:myMod/childB:MemberB1"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childb/member_b2.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childb/member_b2.py
@@ -32,6 +32,9 @@ class MemberB2Args:
 
 
 class MemberB2(pulumi.ComponentResource):
+
+    pulumi_type = "myPkg:myMod/childB:MemberB2"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/provider.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:myPkg"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-14012/python/pulumi_foo/provider.py
+++ b/tests/testdata/codegen/regress-py-14012/python/pulumi_foo/provider.py
@@ -39,6 +39,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:foo"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/compute/instance/instance.py
+++ b/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/compute/instance/instance.py
@@ -70,6 +70,9 @@ class _InstanceState:
 
 
 class Instance(pulumi.CustomResource):
+
+    pulumi_type = "gcp:compute/instance:Instance"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/provider.py
+++ b/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:gcp"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/config.py
+++ b/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/config.py
@@ -76,6 +76,9 @@ class ConfigArgs:
 
 
 class Config(pulumi.CustomResource):
+
+    pulumi_type = "cloudinit:index/config:Config"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/provider.py
+++ b/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:cloudinit"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/provider.py
+++ b/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:aws"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/cat.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/cat.py
@@ -29,6 +29,9 @@ class CatArgs:
 
 
 class Cat(pulumi.CustomResource):
+
+    pulumi_type = "example::Cat"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/dog.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/dog.py
@@ -27,6 +27,9 @@ class DogArgs:
 
 
 class Dog(pulumi.CustomResource):
+
+    pulumi_type = "example::Dog"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/god.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/god.py
@@ -28,6 +28,9 @@ class GodArgs:
 
 
 class God(pulumi.CustomResource):
+
+    pulumi_type = "example::God"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/no_recursive.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/no_recursive.py
@@ -28,6 +28,9 @@ class NoRecursiveArgs:
 
 
 class NoRecursive(pulumi.CustomResource):
+
+    pulumi_type = "example::NoRecursive"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/toy_store.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/toy_store.py
@@ -30,6 +30,9 @@ class ToyStoreArgs:
 
 
 class ToyStore(pulumi.CustomResource):
+
+    pulumi_type = "example::ToyStore"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/person.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/person.py
@@ -52,6 +52,9 @@ class PersonArgs:
 
 
 class Person(pulumi.CustomResource):
+
+    pulumi_type = "example::Person"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/pet.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/pet.py
@@ -38,6 +38,9 @@ class PetInitArgs:
 
 
 class Pet(pulumi.CustomResource):
+
+    pulumi_type = "example::Pet"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/resource-args-python/python/pulumi_example/person.py
+++ b/tests/testdata/codegen/resource-args-python/python/pulumi_example/person.py
@@ -52,6 +52,9 @@ class PersonArgs:
 
 
 class Person(pulumi.CustomResource):
+
+    pulumi_type = "example::Person"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/resource-args-python/python/pulumi_example/pet.py
+++ b/tests/testdata/codegen/resource-args-python/python/pulumi_example/pet.py
@@ -38,6 +38,9 @@ class PetInitArgs:
 
 
 class Pet(pulumi.CustomResource):
+
+    pulumi_type = "example::Pet"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/resource-args-python/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/resource-args-python/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/rec.py
+++ b/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/rec.py
@@ -27,6 +27,9 @@ class RecArgs:
 
 
 class Rec(pulumi.CustomResource):
+
+    pulumi_type = "example::Rec"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/secrets/python/pulumi_mypkg/provider.py
+++ b/tests/testdata/codegen/secrets/python/pulumi_mypkg/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:mypkg"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/secrets/python/pulumi_mypkg/resource.py
+++ b/tests/testdata/codegen/secrets/python/pulumi_mypkg/resource.py
@@ -94,6 +94,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "mypkg::Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/provider.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:plant"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
@@ -58,6 +58,9 @@ class NurseryArgs:
 
 
 class Nursery(pulumi.CustomResource):
+
+    pulumi_type = "plant:tree/v1:Nursery"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -118,6 +118,9 @@ class _RubberTreeState:
 
 
 class RubberTree(pulumi.CustomResource):
+
+    pulumi_type = "plant:tree/v1:RubberTree"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/foo.py
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/foo.py
@@ -27,6 +27,9 @@ class FooArgs:
 
 
 class Foo(pulumi.ComponentResource):
+
+    pulumi_type = "example::Foo"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/foo.py
+++ b/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/foo.py
@@ -29,6 +29,9 @@ class FooArgs:
 
 
 class Foo(pulumi.ComponentResource):
+
+    pulumi_type = "example::Foo"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/component.py
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/component.py
@@ -133,6 +133,9 @@ class ComponentArgs:
 
 
 class Component(pulumi.ComponentResource):
+
+    pulumi_type = "example::Component"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/component.py
+++ b/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/component.py
@@ -145,6 +145,9 @@ class ComponentArgs:
 
 
 class Component(pulumi.ComponentResource):
+
+    pulumi_type = "example::Component"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/other_resource.py
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/other_resource.py
@@ -39,6 +39,9 @@ class OtherResourceArgs:
 
 
 class OtherResource(pulumi.ComponentResource):
+
+    pulumi_type = "example::OtherResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/provider.py
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/resource.py
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/resource.py
@@ -38,6 +38,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "example::Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/bar_resource.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/bar_resource.py
@@ -39,6 +39,9 @@ class BarResourceArgs:
 
 
 class BarResource(pulumi.ComponentResource):
+
+    pulumi_type = "bar::BarResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/foo_resource.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/foo_resource.py
@@ -39,6 +39,9 @@ class FooResourceArgs:
 
 
 class FooResource(pulumi.ComponentResource):
+
+    pulumi_type = "foo::FooResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/other_resource.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/other_resource.py
@@ -39,6 +39,9 @@ class OtherResourceArgs:
 
 
 class OtherResource(pulumi.ComponentResource):
+
+    pulumi_type = "example::OtherResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/resource.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/resource.py
@@ -38,6 +38,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "example::Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/type_uses.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/type_uses.py
@@ -65,6 +65,9 @@ class TypeUsesArgs:
 
 
 class TypeUses(pulumi.CustomResource):
+
+    pulumi_type = "example::TypeUses"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/basic_resource.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/basic_resource.py
@@ -37,6 +37,9 @@ class BasicResourceArgs:
 
 
 class BasicResource(pulumi.CustomResource):
+
+    pulumi_type = "example:index:BasicResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/basic_resource_v2.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/basic_resource_v2.py
@@ -37,6 +37,9 @@ class BasicResourceV2Args:
 
 
 class BasicResourceV2(pulumi.CustomResource):
+
+    pulumi_type = "example:index:BasicResourceV2"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/basic_resource_v3.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/basic_resource_v3.py
@@ -37,6 +37,9 @@ class BasicResourceV3Args:
 
 
 class BasicResourceV3(pulumi.CustomResource):
+
+    pulumi_type = "example:index:BasicResourceV3"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-schema-pyproject/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-schema-pyproject/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/other_resource.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/other_resource.py
@@ -51,6 +51,9 @@ class OtherResourceArgs:
 
 
 class OtherResource(pulumi.ComponentResource):
+
+    pulumi_type = "example::OtherResource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/resource.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/resource.py
@@ -38,6 +38,9 @@ class ResourceArgs:
 
 
 class Resource(pulumi.CustomResource):
+
+    pulumi_type = "example::Resource"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/type_uses.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/type_uses.py
@@ -78,6 +78,9 @@ class TypeUsesArgs:
 
 
 class TypeUses(pulumi.CustomResource):
+
+    pulumi_type = "example::TypeUses"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/unions-inline/python/pulumi_example/example_server.py
+++ b/tests/testdata/codegen/unions-inline/python/pulumi_example/example_server.py
@@ -39,6 +39,9 @@ class ExampleServerArgs:
 
 
 class ExampleServer(pulumi.CustomResource):
+
+    pulumi_type = "example:index:ExampleServer"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/unions-inline/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/unions-inline/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/example_server.py
+++ b/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/example_server.py
@@ -39,6 +39,9 @@ class ExampleServerArgs:
 
 
 class ExampleServer(pulumi.CustomResource):
+
+    pulumi_type = "example:index:ExampleServer"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:example"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/provider.py
+++ b/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/provider.py
@@ -27,6 +27,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:urnid"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/res.py
+++ b/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/res.py
@@ -51,6 +51,9 @@ class ResArgs:
 
 
 class Res(pulumi.CustomResource):
+
+    pulumi_type = "urnid:index:Res"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/provider.py
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/provider.py
@@ -87,6 +87,9 @@ class ProviderArgs:
 
 
 class Provider(pulumi.ProviderResource):
+
+    pulumi_type = "pulumi:providers:credentials"
+
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/user.py
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/user.py
@@ -38,6 +38,9 @@ class UserArgs:
 
 
 class User(pulumi.CustomResource):
+
+    pulumi_type = "credentials:index:User"
+
     @overload
     def __init__(__self__,
                  resource_name: str,


### PR DESCRIPTION
To support resource references in the component type analysers, we need to retrieve the Pulumi type token for resources. This PR adds a static `pulumi_type` to Python resources.

For Node.js we previously used the private `__pulumiType` https://github.com/pulumi/pulumi/pull/18885

Ref https://github.com/pulumi/pulumi/issues/18484