### PR TITLE
Support Resource References

### DIFF
--- a/changelog/pending/20250423--sdk-python--support-resource-references.yaml
+++ b/changelog/pending/20250423--sdk-python--support-resource-references.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Support Resource References

--- a/sdk/python/lib/pulumi/provider/experimental/analyzer.py
+++ b/sdk/python/lib/pulumi/provider/experimental/analyzer.py
@@ -17,7 +17,9 @@ import builtins
 import collections
 from dataclasses import dataclass
 from enum import Enum
+import importlib.resources
 import inspect
+import json
 import sys
 import types
 import typing
@@ -113,6 +115,24 @@ class ComponentDefinition:
     description: Optional[str] = None
 
 
+@dataclass
+class Parameterization:
+    name: str
+    version: str
+    # The value is a represented as base64 encoded string in JSON. Since all we
+    # do is return it again in the schema, we don't decode it to bytes, and keep
+    # it in base64.
+    value: str
+
+
+@dataclass
+class Dependency:
+    name: str
+    version: Optional[str] = None
+    downloadURL: Optional[str] = None
+    parameterization: Optional[Parameterization] = None
+
+
 class TypeNotFoundError(Exception):
     def __init__(self, name: str):
         self.name = name
@@ -204,6 +224,7 @@ class Analyzer:
 
     def __init__(self, name: str):
         self.name = name
+        self.dependencies: list[Dependency] = []
         self.type_definitions: dict[str, TypeDefinition] = {}
         # For unresolved types, we need to keep track of whether we saw them in a
         # component output or an input.
@@ -219,7 +240,9 @@ class Analyzer:
     def analyze(
         self,
         components: list[type[ComponentResource]],
-    ) -> tuple[dict[str, ComponentDefinition], dict[str, TypeDefinition]]:
+    ) -> tuple[
+        dict[str, ComponentDefinition], dict[str, TypeDefinition], list[Dependency]
+    ]:
         """
         Analyze walks the directory at `path` and searches for
         ComponentResources in Python files.
@@ -270,7 +293,7 @@ class Analyzer:
         if len(components) == 0:
             raise Exception("No components found")
 
-        return (component_defs, self.type_definitions)
+        return (component_defs, self.type_definitions, self.dependencies)
 
     def get_annotations(self, o: Any) -> dict[str, Any]:
         if sys.version_info >= (3, 10):
@@ -520,10 +543,51 @@ class Analyzer:
                 description=self.get_docstring(typ, name),
             )
         elif is_resource(arg):
-            # TODO: https://github.com/pulumi/pulumi/issues/18484
-            raise Exception(
-                f"Resource references are not supported yet: found type '{arg.__name__}' for '{typ.__name__}.{name}'"
-            )
+            type_string = getattr(arg, "pulumi_type", None)
+            if not type_string:
+                mod = arg.__module__.split(".")[0]
+                raise Exception(
+                    f"Can not determine resource reference for type '{arg.__name__}' used in '{typ.__name__}.{name}': "
+                    + f"'{arg.__name__}.pulumi_type' is not defined. This may be due to an outdated version of '{mod}'."
+                )
+            parts = type_string.split(":")
+            if len(parts) != 3:
+                raise Exception(
+                    f"invalid type string '{type_string}' for type '{arg}' used in '{typ.__name__}.{name}'"
+                )
+            package_name = parts[0]
+            try:
+                root_mod = arg.__module__.split(".")[0]
+                pluginJSON = (
+                    importlib.resources.files(root_mod)
+                    .joinpath("pulumi-plugin.json")
+                    .open("r")
+                    .read()
+                )
+                plugin = json.loads(pluginJSON)
+                dep = Dependency(plugin["name"], plugin["version"])
+                if "server" in plugin:
+                    dep.downloadURL = plugin["server"]
+                if "parameterization" in plugin:
+                    p = plugin["parameterization"]
+                    dep.parameterization = Parameterization(
+                        p["name"], p["version"], p["value"]
+                    )
+                self.dependencies.append(dep)
+                return PropertyDefinition(
+                    ref=f"/{dep.name}/v{dep.version}/schema.json#/resources/{type_string.replace('/', '%2F')}",
+                    optional=optional,
+                    description=self.get_docstring(typ, name),
+                )
+            except FileNotFoundError as e:
+                raise Exception(
+                    f"Could not load pulumi-plugin.json for package '{package_name}'"
+                ) from e
+            except json.JSONDecodeError as e:
+                raise Exception(
+                    f"Could not parse pulumi-plugin.json for package '{package_name}'"
+                ) from e
+
         elif is_union(arg):
             raise Exception(
                 f"Union types are not supported: found type '{arg}' for '{typ.__name__}.{name}'"

--- a/sdk/python/lib/pulumi/provider/experimental/analyzer.py
+++ b/sdk/python/lib/pulumi/provider/experimental/analyzer.py
@@ -32,6 +32,7 @@ from typing import (  # type: ignore
     ForwardRef,
     Literal,
     Optional,
+    TypedDict,
     Union,
     _GenericAlias,  # type: ignore
     _SpecialGenericAlias,  # type: ignore
@@ -181,6 +182,12 @@ class InvalidListTypeError(Exception):
         )
 
 
+class AnalyzeResult(TypedDict):
+    component_definitions: dict[str, ComponentDefinition]
+    type_definitions: dict[str, TypeDefinition]
+    dependencies: list[Dependency]
+
+
 class Analyzer:
     """
     Analyzer infers component and type definitions for a set of
@@ -240,9 +247,7 @@ class Analyzer:
     def analyze(
         self,
         components: list[type[ComponentResource]],
-    ) -> tuple[
-        dict[str, ComponentDefinition], dict[str, TypeDefinition], list[Dependency]
-    ]:
+    ) -> AnalyzeResult:
         """
         Analyze walks the directory at `path` and searches for
         ComponentResources in Python files.
@@ -293,7 +298,11 @@ class Analyzer:
         if len(components) == 0:
             raise Exception("No components found")
 
-        return (component_defs, self.type_definitions, self.dependencies)
+        return {
+            "component_definitions": component_defs,
+            "type_definitions": self.type_definitions,
+            "dependencies": self.dependencies,
+        }
 
     def get_annotations(self, o: Any) -> dict[str, Any]:
         if sys.version_info >= (3, 10):

--- a/sdk/python/lib/pulumi/provider/experimental/analyzer.py
+++ b/sdk/python/lib/pulumi/provider/experimental/analyzer.py
@@ -249,8 +249,8 @@ class Analyzer:
         components: list[type[ComponentResource]],
     ) -> AnalyzeResult:
         """
-        Analyze walks the directory at `path` and searches for
-        ComponentResources in Python files.
+        Analyze builds a Pulumi schema for a provider that handles the passed
+        list of components.
         """
         component_defs: dict[str, ComponentDefinition] = {}
         for component in components:
@@ -305,6 +305,9 @@ class Analyzer:
         }
 
     def get_annotations(self, o: Any) -> dict[str, Any]:
+        """
+        Get the type annotations for `o` in a backwards compatible way.
+        """
         if sys.version_info >= (3, 10):
             # Only available in 3.10 and later
             return inspect.get_annotations(o)
@@ -321,6 +324,11 @@ class Analyzer:
     def analyze_component(
         self, component: type[ComponentResource]
     ) -> ComponentDefinition:
+        """
+        Analyze a single component, building up a `ComponentDefinition` that
+        holds all the information necessary to create a resource in a Pulumi
+        provider schema.
+        """
         ann = self.get_annotations(component.__init__)
         args = ann.get("args", None)
         if not args:

--- a/sdk/python/lib/pulumi/provider/experimental/component.py
+++ b/sdk/python/lib/pulumi/provider/experimental/component.py
@@ -56,13 +56,11 @@ class ComponentProvider(Provider):
     ) -> None:
         self._name = name
         self.analyzer = Analyzer(name)
-        (components_defs, type_definitions, dependencies) = self.analyzer.analyze(
-            components
-        )
+        result = self.analyzer.analyze(components)
         self._components = {component.__name__: component for component in components}
-        self._component_defs = components_defs
-        self._type_defs = type_definitions
-        self._dependencies = dependencies
+        self._component_defs = result["component_definitions"]
+        self._type_defs = result["type_definitions"]
+        self._dependencies = result["dependencies"]
         schema = generate_schema(
             name,
             version,

--- a/sdk/python/lib/pulumi/provider/experimental/component.py
+++ b/sdk/python/lib/pulumi/provider/experimental/component.py
@@ -22,7 +22,13 @@ from ...errors import InputPropertyError
 from ...output import Input, Inputs, Output
 from ...resource import ComponentResource, ResourceOptions
 from ..provider import ConstructResult, Provider
-from .analyzer import Analyzer, ComponentDefinition, PropertyDefinition, TypeDefinition
+from .analyzer import (
+    Analyzer,
+    ComponentDefinition,
+    Dependency,
+    PropertyDefinition,
+    TypeDefinition,
+)
 from .schema import generate_schema
 
 
@@ -38,6 +44,7 @@ class ComponentProvider(Provider):
     _type_defs: dict[str, TypeDefinition]
     _component_defs: dict[str, ComponentDefinition]
     _components: dict[str, type[ComponentResource]]
+    _dependencies: list[Dependency]
     _name: str
 
     def __init__(
@@ -49,16 +56,20 @@ class ComponentProvider(Provider):
     ) -> None:
         self._name = name
         self.analyzer = Analyzer(name)
-        (components_defs, type_definitions) = self.analyzer.analyze(components)
+        (components_defs, type_definitions, dependencies) = self.analyzer.analyze(
+            components
+        )
         self._components = {component.__name__: component for component in components}
         self._component_defs = components_defs
         self._type_defs = type_definitions
+        self._dependencies = dependencies
         schema = generate_schema(
             name,
             version,
             namespace,
             self._component_defs,
             self._type_defs,
+            self._dependencies,
         )
         super().__init__(version, json.dumps(schema.to_json()))
 
@@ -95,9 +106,10 @@ class ComponentProvider(Provider):
         if not prop.ref:
             raise ValueError(f"property {prop} is not a complex type")
 
-        # Handle built-in types that don't have a colon in their reference
-        # This includes types like Any, Asset, Archive, etc. (e.g. pulumi.json#/Asset)
-        if ":" not in prop.ref:
+        # Handle external resource references (start with a "/") or built-in
+        # types that don't have a colon in their reference, such as Any, Asset,
+        # Archive, etc. (e.g. pulumi.json#/Asset)
+        if prop.ref.startswith("/") or ":" not in prop.ref:
             return None
 
         name = prop.ref.split(":")[-1]

--- a/sdk/python/lib/pulumi/provider/experimental/component.py
+++ b/sdk/python/lib/pulumi/provider/experimental/component.py
@@ -264,6 +264,12 @@ class ComponentProvider(Provider):
     def get_state(
         self, instance: ComponentResource, component_def: ComponentDefinition
     ) -> dict[str, Any]:
+        """
+        Retrieve the state for a ComponentResource instance.
+
+        This takes care of remapping Python snake_case names to Pulumi schema
+        camelCase names. It also handles mapping enum members to their values.
+        """
         state: dict[str, Any] = {}
         for k, prop in component_def.outputs.items():
             py_name = component_def.outputs_mapping[k]
@@ -315,6 +321,10 @@ class ComponentProvider(Provider):
 
     @staticmethod
     def validate_resource_type(pkg_name: str, resource_type: str) -> None:
+        """
+        Ensure that a resource type has the correct format and matches the
+        package.
+        """
         parts = resource_type.split(":")
         if len(parts) != 3:
             raise ValueError(f"invalid resource type: {resource_type}")

--- a/sdk/python/lib/pulumi/provider/experimental/schema.py
+++ b/sdk/python/lib/pulumi/provider/experimental/schema.py
@@ -282,6 +282,9 @@ def generate_schema(
     type_definitions: dict[str, TypeDefinition],
     dependencies: list[Dependency],
 ) -> PackageSpec:
+    """
+    Build a serializable `PackageSpec` that represents a complete Pulumi schema.
+    """
     pkg = PackageSpec(
         name=name,
         version=version,

--- a/sdk/python/lib/pulumi/provider/experimental/schema.py
+++ b/sdk/python/lib/pulumi/provider/experimental/schema.py
@@ -17,7 +17,9 @@ from typing import Any, Optional, Union
 
 from .analyzer import (
     ComponentDefinition,
+    Dependency,
     EnumValueDefinition,
+    Parameterization,
     PropertyDefinition,
     PropertyType,
     TypeDefinition,
@@ -188,6 +190,63 @@ class Resource(ObjectType):
 
 
 @dataclass
+class ParameterizationDescriptor:
+    name: str
+    version: str
+    value: str  # base64 encoded string
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "version": self.version,
+            "value": self.value,
+        }
+
+    @staticmethod
+    def from_definition(
+        parameterization: Parameterization,
+    ) -> "ParameterizationDescriptor":
+        return ParameterizationDescriptor(
+            name=parameterization.name,
+            version=parameterization.version,
+            value=parameterization.value,
+        )
+
+
+@dataclass
+class PackageDescriptor:
+    name: str
+    version: Optional[str] = None
+    downloadURL: Optional[str] = None
+    parameterization: Optional[ParameterizationDescriptor] = None
+
+    def to_json(self) -> dict[str, Any]:
+        return remove_none(
+            {
+                "name": self.name,
+                "version": self.version,
+                "downloadURL": self.downloadURL,
+                "parameterization": self.parameterization.to_json()
+                if self.parameterization
+                else None,
+            }
+        )
+
+    @staticmethod
+    def from_definition(dep: Dependency) -> "PackageDescriptor":
+        return PackageDescriptor(
+            name=dep.name,
+            version=dep.version,
+            downloadURL=dep.downloadURL,
+            parameterization=ParameterizationDescriptor.from_definition(
+                dep.parameterization
+            )
+            if dep.parameterization
+            else None,
+        )
+
+
+@dataclass
 class PackageSpec:
     """https://www.pulumi.com/docs/iac/using-pulumi/pulumi-packages/schema/#package"""
 
@@ -198,6 +257,7 @@ class PackageSpec:
     resources: dict[str, Resource]
     types: dict[str, ComplexType]
     language: dict[str, dict[str, Any]]
+    dependencies: Optional[list[PackageDescriptor]]
 
     def to_json(self) -> dict[str, Any]:
         return remove_none(
@@ -209,6 +269,7 @@ class PackageSpec:
                 "resources": {k: v.to_json() for k, v in self.resources.items()},
                 "types": {k: v.to_json() for k, v in self.types.items()},
                 "language": self.language,
+                "dependencies": [dep.to_json() for dep in self.dependencies or []],
             }
         )
 
@@ -219,6 +280,7 @@ def generate_schema(
     namespace: Optional[str],
     components: dict[str, ComponentDefinition],
     type_definitions: dict[str, TypeDefinition],
+    dependencies: list[Dependency],
 ) -> PackageSpec:
     pkg = PackageSpec(
         name=name,
@@ -244,6 +306,7 @@ def generate_schema(
                 "respectSchemaVersion": True,
             },
         },
+        dependencies=[PackageDescriptor.from_definition(dep) for dep in dependencies],
     )
     for component_name, component in components.items():
         pkg.resources[f"{name}:index:{component_name}"] = Resource.from_definition(

--- a/sdk/python/lib/test/provider/experimental/test_analyzer.py
+++ b/sdk/python/lib/test/provider/experimental/test_analyzer.py
@@ -792,10 +792,11 @@ def test_analyze_any():
 
 def test_analyze_descriptions():
     analyzer = Analyzer("descriptions")
-    (components, type_definitions, _) = analyzer.analyze(
-        components=load_components(Path("testdata", "docstrings")),
+    result = analyzer.analyze(
+        components=load_components(Path("testdata", "docstrings"))
     )
-    assert components == {
+
+    assert result["component_definitions"] == {
         "Component": ComponentDefinition(
             description="Component doc string",
             name="Component",
@@ -827,7 +828,7 @@ def test_analyze_descriptions():
             outputs_mapping={"complexOutput": "complex_output"},
         )
     }
-    assert type_definitions == {
+    assert result["type_definitions"] == {
         "ComplexType": TypeDefinition(
             description="ComplexType doc string",
             name="ComplexType",
@@ -895,10 +896,10 @@ def test_analyze_descriptions():
 def test_analyze_resource_ref():
     analyzer = Analyzer("resource-ref")
 
-    (component_defs, _, dependencies) = analyzer.analyze(
+    result = analyzer.analyze(
         components=load_components(Path("testdata", "resource-ref")),
     )
-    assert component_defs == {
+    assert result["component_definitions"] == {
         "Component": ComponentDefinition(
             name="Component",
             module="resource_ref",
@@ -918,7 +919,7 @@ def test_analyze_resource_ref():
             outputs_mapping={},
         )
     }
-    assert sorted(dependencies, key=lambda d: d.name) == [
+    assert sorted(result["dependencies"], key=lambda d: d.name) == [
         Dependency(
             name="mock_package",
             version="1.2.3",
@@ -1045,8 +1046,8 @@ def test_analyze_enum_type():
         def __init__(self, args: Args): ...
 
     analyzer = Analyzer("enum")
-    (component_defs, type_defs, _) = analyzer.analyze(components=[Component])
-    assert component_defs == {
+    result = analyzer.analyze(components=[Component])
+    assert result["component_definitions"] == {
         "Component": ComponentDefinition(
             name="Component",
             module="test_analyzer",
@@ -1078,7 +1079,7 @@ def test_analyze_enum_type():
             outputs_mapping={},
         )
     }
-    assert type_defs == {
+    assert result["type_definitions"] == {
         "MyEnumStr": TypeDefinition(
             name="MyEnumStr",
             description="string enum",
@@ -1264,10 +1265,10 @@ def test_analyze_component_self_recursive_complex_type():
 def test_analyze_component_mutually_recursive_complex_types_file():
     analyzer = Analyzer("mutually-recursive")
 
-    (components, type_definitions, _) = analyzer.analyze(
+    result = analyzer.analyze(
         components=load_components(Path("testdata", "mutually-recursive")),
     )
-    assert type_definitions == {
+    assert result["type_definitions"] == {
         "RecursiveTypeA": TypeDefinition(
             name="RecursiveTypeA",
             module="mutually_recursive",
@@ -1299,7 +1300,7 @@ def test_analyze_component_mutually_recursive_complex_types_file():
             ),
         ),
     }
-    assert components == {
+    assert result["component_definitions"] == {
         "Component": ComponentDefinition(
             name="Component",
             module="mutually_recursive",

--- a/sdk/python/lib/test/provider/experimental/testdata/resource-ref/component.py
+++ b/sdk/python/lib/test/provider/experimental/testdata/resource-ref/component.py
@@ -12,16 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pulumi.provider.experimental.schema import generate_schema
+import sys
+import os
+from typing import TypedDict
+
+import pulumi
 
 
-def test_generate_schema_with_namespace():
-    schema = generate_schema("name", "1.2.3", "namespace", {}, {}, [])
-    assert schema.name == "name"
-    assert schema.namespace == "namespace"
+# Make the mock packages available
+sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+import mock_package
+import mock_package_para
 
 
-def test_generate_schema_no_namespace():
-    schema = generate_schema("name", "1.2.3", None, {}, {}, [])
-    assert schema.name == "name"
-    assert schema.namespace is None
+class Args(TypedDict):
+    res: pulumi.Input[mock_package.MyResource]
+    res_para: pulumi.Input[mock_package_para.MyResource]
+
+
+class Component(pulumi.ComponentResource):
+    def __init__(self, args: Args): ...

--- a/sdk/python/lib/test/provider/experimental/testdata/resource-ref/mock_package/__init__.py
+++ b/sdk/python/lib/test/provider/experimental/testdata/resource-ref/mock_package/__init__.py
@@ -12,16 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pulumi.provider.experimental.schema import generate_schema
+from .mock_module import MyResource
 
 
-def test_generate_schema_with_namespace():
-    schema = generate_schema("name", "1.2.3", "namespace", {}, {}, [])
-    assert schema.name == "name"
-    assert schema.namespace == "namespace"
-
-
-def test_generate_schema_no_namespace():
-    schema = generate_schema("name", "1.2.3", None, {}, {}, [])
-    assert schema.name == "name"
-    assert schema.namespace is None
+__all__ = ["MyResource"]

--- a/sdk/python/lib/test/provider/experimental/testdata/resource-ref/mock_package/mock_module.py
+++ b/sdk/python/lib/test/provider/experimental/testdata/resource-ref/mock_package/mock_module.py
@@ -12,16 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pulumi.provider.experimental.schema import generate_schema
+import pulumi
 
 
-def test_generate_schema_with_namespace():
-    schema = generate_schema("name", "1.2.3", "namespace", {}, {}, [])
-    assert schema.name == "name"
-    assert schema.namespace == "namespace"
-
-
-def test_generate_schema_no_namespace():
-    schema = generate_schema("name", "1.2.3", None, {}, {}, [])
-    assert schema.name == "name"
-    assert schema.namespace is None
+class MyResource(pulumi.CustomResource):
+    pulumi_type = "mock_package:index:MyResource"

--- a/sdk/python/lib/test/provider/experimental/testdata/resource-ref/mock_package/pulumi-plugin.json
+++ b/sdk/python/lib/test/provider/experimental/testdata/resource-ref/mock_package/pulumi-plugin.json
@@ -1,0 +1,6 @@
+{
+    "resource": true,
+    "name": "mock_package",
+    "version": "1.2.3",
+    "server": "example.com/download"
+}

--- a/sdk/python/lib/test/provider/experimental/testdata/resource-ref/mock_package_para/__init__.py
+++ b/sdk/python/lib/test/provider/experimental/testdata/resource-ref/mock_package_para/__init__.py
@@ -12,16 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pulumi.provider.experimental.schema import generate_schema
+from .mock_module import MyResource
 
 
-def test_generate_schema_with_namespace():
-    schema = generate_schema("name", "1.2.3", "namespace", {}, {}, [])
-    assert schema.name == "name"
-    assert schema.namespace == "namespace"
-
-
-def test_generate_schema_no_namespace():
-    schema = generate_schema("name", "1.2.3", None, {}, {}, [])
-    assert schema.name == "name"
-    assert schema.namespace is None
+__all__ = ["MyResource"]

--- a/sdk/python/lib/test/provider/experimental/testdata/resource-ref/mock_package_para/mock_module.py
+++ b/sdk/python/lib/test/provider/experimental/testdata/resource-ref/mock_package_para/mock_module.py
@@ -12,16 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pulumi.provider.experimental.schema import generate_schema
+import pulumi
 
 
-def test_generate_schema_with_namespace():
-    schema = generate_schema("name", "1.2.3", "namespace", {}, {}, [])
-    assert schema.name == "name"
-    assert schema.namespace == "namespace"
-
-
-def test_generate_schema_no_namespace():
-    schema = generate_schema("name", "1.2.3", None, {}, {}, [])
-    assert schema.name == "name"
-    assert schema.namespace is None
+class MyResource(pulumi.CustomResource):
+    pulumi_type = "parameterized:index:MyResource"

--- a/sdk/python/lib/test/provider/experimental/testdata/resource-ref/mock_package_para/pulumi-plugin.json
+++ b/sdk/python/lib/test/provider/experimental/testdata/resource-ref/mock_package_para/pulumi-plugin.json
@@ -1,0 +1,10 @@
+{
+    "resource": true,
+    "name": "terraform-provider",
+    "version": "0.10.0",
+    "parameterization": {
+        "name": "parameterized",
+        "version": "0.2.2",
+        "value": "eyJyZW1vdGUiOnsidXJsIjoicmVnaXN0cnkub3BlbnRvZnUub3JnL25ldGxpZnkvbmV0bGlmeSIsInZlcnNpb24iOiIwLjIuMiJ9fQ=="
+    }
+}

--- a/tests/integration/component_provider/python/resource-ref/provider/PulumiPlugin.yaml
+++ b/tests/integration/component_provider/python/resource-ref/provider/PulumiPlugin.yaml
@@ -1,0 +1,1 @@
+runtime: python

--- a/tests/integration/component_provider/python/resource-ref/provider/__main__.py
+++ b/tests/integration/component_provider/python/resource-ref/provider/__main__.py
@@ -12,16 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pulumi.provider.experimental.schema import generate_schema
 
+from pulumi.provider.experimental import component_provider_host
+from component import EchoCommand
 
-def test_generate_schema_with_namespace():
-    schema = generate_schema("name", "1.2.3", "namespace", {}, {}, [])
-    assert schema.name == "name"
-    assert schema.namespace == "namespace"
-
-
-def test_generate_schema_no_namespace():
-    schema = generate_schema("name", "1.2.3", None, {}, {}, [])
-    assert schema.name == "name"
-    assert schema.namespace is None
+if __name__ == "__main__":
+    component_provider_host([EchoCommand], "provider")

--- a/tests/integration/component_provider/python/resource-ref/provider/component.py
+++ b/tests/integration/component_provider/python/resource-ref/provider/component.py
@@ -1,0 +1,54 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import TypedDict
+
+import pulumi
+import pulumi_command.local as command_local
+
+
+class Args(TypedDict):
+    name: str
+    command_in: command_local.Command
+
+
+class EchoCommand(pulumi.ComponentResource):
+    """
+    EchoCommand has an output that is a resource. Schema inference should detect
+    this and properly handle the resource output.
+
+    This component also takes a command as an input. We should be able to use
+    that resource inside the component.
+    """
+
+    command_out: pulumi.Output[command_local.Command]
+    command_in_stdout: pulumi.Output[str]
+
+    def __init__(self, name: str, args: Args, opts: pulumi.ResourceOptions):
+        super().__init__("provider:index:EchoCommand", name, {}, opts)
+        self.command_out = command_local.Command(
+            "echo",
+            create="echo Hello, ${USER_NAME}",
+            environment={
+                "USER_NAME": args["name"],
+            },
+        )
+        self.command_in_stdout = args["command_in"].stdout
+        self.register_outputs(
+            {
+                "command_out": self.command_out,
+                "command_in_stdout": self.command_in_stdout,
+            }
+        )

--- a/tests/integration/component_provider/python/resource-ref/provider/requirements.txt
+++ b/tests/integration/component_provider/python/resource-ref/provider/requirements.txt
@@ -1,0 +1,1 @@
+pulumi-command==1.1.0a1745259160

--- a/tests/integration/component_provider/python/resource-ref/provider/requirements.txt
+++ b/tests/integration/component_provider/python/resource-ref/provider/requirements.txt
@@ -1,1 +1,1 @@
-pulumi-command==1.1.0a1745259160
+pulumi-command==1.0.3

--- a/tests/integration/component_provider/python/resource-ref/yaml/Pulumi.yaml
+++ b/tests/integration/component_provider/python/resource-ref/yaml/Pulumi.yaml
@@ -1,0 +1,21 @@
+name: python-component-provider
+description: Using a component provider written in Python
+runtime: yaml
+packages:
+  provider: ../provider
+resources:
+  commandIn:
+    type: command:local:Command
+    properties:
+      create: echo "Hey there $${NAME}!"
+      environment:
+        NAME: Fridolin
+  echo:
+    type: provider:index:EchoCommand
+    properties:
+      name: Bonnie
+      commandIn: ${commandIn}
+outputs:
+  urn: ${echo.commandOut.urn}
+  commandOutStdout: ${echo.commandOut.stdout}
+  commandInStdout: ${echo.commandInStdout}

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -2192,6 +2192,44 @@ func TestPythonComponentProviderException(t *testing.T) {
 	})
 }
 
+// Test that resource references work
+//
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestPythonComponentProviderResourceReference(t *testing.T) {
+	// Manually set pulumi home so we can pass it to `plugin install`.
+	pulumiHome := t.TempDir()
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		PulumiHomeDir:   pulumiHome,
+		Dir:             filepath.Join("component_provider", "python", "resource-ref"),
+		RelativeWorkDir: "yaml",
+		PrepareProject: func(info *engine.Projinfo) error {
+			cmd := exec.Command("pulumi", "plugin", "install", "resource", "command", "1.0.3")
+			cmd.Env = append(cmd.Environ(), "PULUMI_HOME="+pulumiHome)
+			out, err := cmd.CombinedOutput()
+			require.NoError(t, err, "%s failed with: %s", cmd.String(), string(out))
+			providerPath := filepath.Join(info.Root, "..", "provider")
+			installPythonProviderDependencies(t, providerPath)
+			cmd = exec.Command("pulumi", "package", "add", providerPath)
+			cmd.Dir = info.Root
+			cmd.Env = append(cmd.Environ(), "PULUMI_HOME="+pulumiHome)
+			out, err = cmd.CombinedOutput()
+			require.NoError(t, err, "%s failed with: %s", cmd.String(), string(out))
+			return nil
+		},
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			urn, err := resource.ParseURN(stack.Outputs["urn"].(string))
+			require.NoError(t, err)
+			t.Logf("outputs = %+v\n", stack.Outputs)
+			require.Equal(t, tokens.Type("command:local:Command"), urn.Type())
+			require.Equal(t, "echo", urn.Name())
+			commandInOutput := stack.Outputs["commandInStdout"]
+			require.Equal(t, "Hey there Fridolin!", commandInOutput)
+			commandOutStdout := stack.Outputs["commandOutStdout"]
+			require.Equal(t, "Hello, Bonnie", commandOutStdout)
+		},
+	})
+}
+
 func installPythonProviderDependencies(t *testing.T, dir string) {
 	t.Helper()
 


### PR DESCRIPTION
Similar to the Node.js implementation in https://github.com/pulumi/pulumi/pull/18885

When we encounter an input or output that is a subclass of `Resource`, we look up its type token. This is available under the `pulumi_type` properties for SDKs built with https://github.com/pulumi/pulumi/pull/19221. To retrieve the version, download URL and parameterization for a Pulumi package, we load the `pulumi-plugin.json` file. These packages are tracked as dependencies and returned in the schema so that codegen can generate the correct language specific dependencies.