### PR TITLE
Remove unused testfiles

### DIFF
--- a/sdk/python/lib/test/provider/experimental/testdata/complex-args/PulumiPlugin.yaml
+++ b/sdk/python/lib/test/provider/experimental/testdata/complex-args/PulumiPlugin.yaml
@@ -1,2 +1,0 @@
-runtime: python
-name: complex-args

--- a/sdk/python/lib/test/provider/experimental/testdata/missing-input/PulumiPlugin.yaml
+++ b/sdk/python/lib/test/provider/experimental/testdata/missing-input/PulumiPlugin.yaml
@@ -1,2 +1,0 @@
-runtime: python
-name: missing-input


### PR DESCRIPTION
I think these were leftover from a rebase when the python analyzer was changed to take a list of components.
