### PR TITLE
Use PackageSpec.Dependencies for component provider dependencies

### DIFF
--- a/changelog/pending/20250417--sdk-nodejs--use-packagespec-dependencies-for-component-provider-dependencies.yaml
+++ b/changelog/pending/20250417--sdk-nodejs--use-packagespec-dependencies-for-component-provider-dependencies.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Use PackageSpec.Dependencies for component provider dependencies

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -3272,7 +3272,7 @@ func GeneratePackage(
 	}
 	// Add typing-extensions if we're using TypedDicts
 	if typedDictEnabled(info.InputTypes) {
-		requires["typing-extensions"] = ">=4.11; python_version < \"3.11\""
+		requires["typing-extensions"] = ">=4.11,<5; python_version < \"3.11\""
 	}
 
 	// Next, emit the package metadata (setup.py).

--- a/sdk/nodejs/provider/experimental/schema.ts
+++ b/sdk/nodejs/provider/experimental/schema.ts
@@ -139,7 +139,7 @@ export function generateSchema(
     }
 
     for (const [packageName, packageVersion] of Object.entries(packageReferences)) {
-        result.dependencies?.push({ name: packageName, version: packageVersion })
+        result.dependencies?.push({ name: packageName, version: packageVersion });
     }
 
     return result;

--- a/sdk/nodejs/tests/provider/experimental/schema.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/schema.spec.ts
@@ -17,7 +17,7 @@ import { generateSchema } from "../../../provider/experimental/schema";
 import { ComponentDefinition, TypeDefinition } from "../../../provider/experimental/analyzer";
 
 describe("Schema", function () {
-    it("should generate schema with correct language dependencies", function () {
+    it("should generate schema dependencies", function () {
         const components: Record<string, ComponentDefinition> = {};
         const typeDefinitions: Record<string, TypeDefinition> = {};
 
@@ -38,35 +38,11 @@ describe("Schema", function () {
             packageReferences,
         );
 
-        // Verify NodeJS dependencies
-        assert.deepStrictEqual(schema.language?.nodejs.dependencies, {
-            "@pulumi/aws": "5.0.0",
-            "@pulumi/azure-native": "4.0.0",
-            "@pulumi/kubernetes": "3.0.0",
-        });
-
-        // Verify Python dependencies
-        assert.deepStrictEqual(schema.language?.python.requires, {
-            "pulumi-aws": "==5.0.0",
-            "pulumi-azure-native": "==4.0.0",
-            "pulumi-kubernetes": "==3.0.0",
-        });
-
-        // Verify C# dependencies
-        assert.deepStrictEqual(schema.language?.csharp.packageReferences, {
-            "Pulumi.Aws": "5.0.0",
-            "Pulumi.AzureNative": "4.0.0",
-            "Pulumi.Kubernetes": "3.0.0",
-        });
-
-        // Verify Java dependencies
-        assert.deepStrictEqual(schema.language?.java.dependencies, {
-            "com.pulumi:aws": "5.0.0",
-            "com.pulumi:azure-native": "4.0.0",
-            "com.pulumi:kubernetes": "3.0.0",
-        });
-
-        assert.strictEqual(schema.description, "Test provider for Pulumi");
+        assert.deepStrictEqual(schema.dependencies, [
+            { name: "aws", version: "5.0.0" },
+            { name: "azure-native", version: "4.0.0" },
+            { name: "kubernetes", version: "3.0.0" },
+        ]);
     });
 
     it("should use the namespace if there is one", function () {

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/namespaced-16.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/namespaced-16.0.0/setup.py
@@ -33,6 +33,7 @@ setup(name='a_namespace_namespaced',
       install_requires=[
           'parver>=0.2.1',
           'pulumi>=3.142.0,<4.0.0',
+          'pulumi_component>=13.3.7',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/namespaced-16.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/namespaced-16.0.0/setup.py
@@ -33,6 +33,7 @@ setup(name='a_namespace_namespaced',
       install_requires=[
           'parver>=0.2.1',
           'pulumi>=3.142.0,<4.0.0',
+          'pulumi_component>=13.3.7',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_alpha"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "3.0.0a1+internal.exp.sha.12345678"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/any-type-function-15.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/any-type-function-15.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_any_type_function"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "15.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_asset_archive"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "5.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/call-15.7.9/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/call-15.7.9/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_call"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "15.7.9"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_component"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "13.3.7"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_component_property_deps"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "1.33.7"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_config"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "9.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_config_grpc"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "1.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_fail_on_create"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "4.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_goodbye"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_large"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "4.3.2"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/namespaced-16.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/namespaced-16.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "a_namespace_namespaced"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "pulumi_component>=13.3.7", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "pulumi_component>=13.3.7", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "16.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_plain"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "13.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_primitive"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "7.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_primitive_ref"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "11.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_ref_ref"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "12.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_secret"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "14.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_simple"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_simple_invoke"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "10.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_subpackage"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2560,6 +2560,12 @@ func TestNodejsComponentProviderGetSchema(t *testing.T) {
 	require.Equal(t, "0.0.0", schema["version"].(string))
 	require.Equal(t, "Node.js Sample Components", schema["description"].(string))
 
+	// Check the dependencies
+	dependencies := schema["dependencies"].([]any)
+	dep := dependencies[0].(map[string]any)
+	require.Equal(t, "random", dep["Name"].(string))
+	require.Equal(t, "4.18.0", dep["Version"].(string))
+
 	// Check the component schema
 	expectedJSON := `{
 		"isComponent": true,

--- a/tests/testdata/codegen/kubernetes20/python/pyproject.toml
+++ b/tests/testdata/codegen/kubernetes20/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
   name = "pulumi_kubernetes"
   description = "A Pulumi package for creating and managing Kubernetes resources."
-  dependencies = ["parver>=0.2.1", "pulumi>=3.25.0,<4.0.0", "requests>=2.21,<3.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.25.0,<4.0.0", "requests>=2.21,<3.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   keywords = ["pulumi", "kubernetes", "category/cloud", "kind/native"]
   readme = "README.md"
   requires-python = ">=3.9"

--- a/tests/testdata/codegen/python-typed-dict-pyproject/python/pyproject.toml
+++ b/tests/testdata/codegen/python-typed-dict-pyproject/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_typedDictExample"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "pulumi-kubernetes>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "pulumi-kubernetes>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "0.0.0"

--- a/tests/testdata/codegen/regress-py-14539/python/pyproject.toml
+++ b/tests/testdata/codegen/regress-py-14539/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_gcp"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "0.0.0"

--- a/tests/testdata/codegen/regress-py-17219/python/pyproject.toml
+++ b/tests/testdata/codegen/regress-py-17219/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_cloudinit"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "0.0.1"

--- a/tests/testdata/codegen/simple-schema-pyproject/python/pyproject.toml
+++ b/tests/testdata/codegen/simple-schema-pyproject/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
   name = "pulumi_example"
   description = "This is a test package for pyproject.toml"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   keywords = ["Testing", "Pulumipus"]
   readme = "README.md"
   requires-python = ">=3.9"


### PR DESCRIPTION
With https://github.com/pulumi/pulumi/pull/19071 we can pass `dependencies` to the schema and let codegen handle language specific details, instead of doing so inside the component provider host and abusing language specific deps.

This also fixes an issue where the dependencies from the schema were not being set when using `setup.py`, as well as an inconsistency on `typing-extensions`.