### PR TITLE
Test and fix importID in GenerateHCL2Definition

### DIFF
--- a/changelog/pending/20250417--programgen--fix-generation-of-importid-when-building-programs-from-state.yaml
+++ b/changelog/pending/20250417--programgen--fix-generation-of-importid-when-building-programs-from-state.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Fix generation of ImportID when building programs from state

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -303,12 +303,9 @@ func makeResourceOptions(state *resource.State, names NameTable, addedRefs map[s
 		ignoreChanges := make([]model.Expression, len(state.IgnoreChanges))
 		for i, prop := range state.IgnoreChanges {
 			v := cty.StringVal(prop)
-			ignoreChanges[i] = &model.TemplateExpression{
-				Parts: []model.Expression{
-					&model.LiteralValueExpression{
-						Value: v,
-					},
-				},
+			ignoreChanges[i] = &model.LiteralValueExpression{
+				Tokens: syntax.NewLiteralValueTokens(v),
+				Value:  v,
 			}
 		}
 		resourceOptions = appendResourceOption(resourceOptions, "ignoreChanges", &model.TupleConsExpression{

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -303,9 +303,12 @@ func makeResourceOptions(state *resource.State, names NameTable, addedRefs map[s
 		ignoreChanges := make([]model.Expression, len(state.IgnoreChanges))
 		for i, prop := range state.IgnoreChanges {
 			v := cty.StringVal(prop)
-			ignoreChanges[i] = &model.LiteralValueExpression{
-				Tokens: syntax.NewLiteralValueTokens(v),
-				Value:  v,
+			ignoreChanges[i] = &model.TemplateExpression{
+				Parts: []model.Expression{
+					&model.LiteralValueExpression{
+						Value: v,
+					},
+				},
 			}
 		}
 		resourceOptions = appendResourceOption(resourceOptions, "ignoreChanges", &model.TupleConsExpression{
@@ -327,9 +330,12 @@ func makeResourceOptions(state *resource.State, names NameTable, addedRefs map[s
 		resourceOptions = appendResourceOption(
 			resourceOptions,
 			"import",
-			&model.LiteralValueExpression{
-				Value:  v,
-				Tokens: syntax.NewLiteralValueTokens(v),
+			&model.TemplateExpression{
+				Parts: []model.Expression{
+					&model.LiteralValueExpression{
+						Value: v,
+					},
+				},
 			},
 		)
 	}

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -186,6 +186,7 @@ func renderResource(t *testing.T, r *pcl.Resource) *resource.State {
 	protect := false
 	var parent resource.URN
 	var providerRef string
+	var importID resource.ID
 	if r.Options != nil {
 		if r.Options.Protect != nil {
 			v, diags := r.Options.Protect.Evaluate(&hcl.EvalContext{})
@@ -205,6 +206,12 @@ func renderResource(t *testing.T, r *pcl.Resource) *resource.State {
 				providerRef = v.StringValue() + "::id"
 			}
 		}
+		if r.Options.ImportID != nil {
+			v := renderExpr(t, r.Options.ImportID)
+			if assert.True(t, v.IsString()) {
+				importID = resource.ID(v.StringValue())
+			}
+		}
 	}
 
 	// Pull the raw token from the resource.
@@ -222,6 +229,7 @@ func renderResource(t *testing.T, r *pcl.Resource) *resource.State {
 		Parent:   parent,
 		Provider: providerRef,
 		Protect:  protect,
+		ImportID: importID,
 	}
 }
 

--- a/pkg/importer/testdata/cases.json
+++ b/pkg/importer/testdata/cases.json
@@ -1664,6 +1664,16 @@
 			"inputs": {
 				"byteLength": 42
 			}
+		},
+		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:random::default_123::123",
+			"urn": "urn:pulumi:stack::project::random:index/randomId:RandomId::ignored",
+			"custom": true,
+			"type": "random:index/randomId:RandomId",
+			"ignoreChanges": ["byteLength"],
+			"inputs": {
+				"byteLength": 42
+			}
 		}
     ]
 }

--- a/pkg/importer/testdata/cases.json
+++ b/pkg/importer/testdata/cases.json
@@ -1654,6 +1654,16 @@
 			"inputs": {
 				"byteLength": 42
 			}
+		},
+		{
+			"provider": "urn:pulumi:stack::project::pulumi:providers:random::default_123::123",
+			"urn": "urn:pulumi:stack::project::random:index/randomId:RandomId::imported resource",
+			"custom": true,
+			"type": "random:index/randomId:RandomId",
+			"importId": "random-id",
+			"inputs": {
+				"byteLength": 42
+			}
 		}
     ]
 }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/19235

`import` and `ignoreChanges` are both options of strings, but the old code for `makeResourceOptions` recorded these as `LiteralValueExpressions`. A quoted string has to be wrapped in a `TemplateExpression` first so that it writes out correctly as a quoted string.
