### PR TITLE
fix component construct when package.json includes namespace

### DIFF
--- a/changelog/pending/20250417--components-nodejs--fix-component-construct-when-the-theres-a-namespace-in-the-name-field-in-package-json.yaml
+++ b/changelog/pending/20250417--components-nodejs--fix-component-construct-when-the-theres-a-namespace-in-the-name-field-in-package-json.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: components/nodejs
+  description: Fix component construct when the there's a namespace in the `name` field in `package.json

--- a/sdk/nodejs/provider/experimental/provider.ts
+++ b/sdk/nodejs/provider/experimental/provider.ts
@@ -187,7 +187,7 @@ export class ComponentProvider implements Provider {
         inputs: Inputs,
         options: ComponentResourceOptions,
     ): Promise<ConstructResult> {
-        ComponentProvider.validateResourceType(this.packageJSON.name, type);
+        ComponentProvider.validateResourceType(this.name, type);
         const componentName = type.split(":")[2];
         const constructor = this.componentConstructors[componentName];
         if (!constructor) {

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2737,3 +2737,19 @@ func TestNodeComponentNamespaceInference(t *testing.T) {
 	require.True(t, ok, fmt.Sprintf("missing expected input property in %v", res.InputProperties))
 	require.Equal(t, "#/types/namespaced-component:index:Nested", input.Ref)
 }
+
+func TestNodeCanConstructNamespacedComponent(t *testing.T) {
+	t.Parallel()
+
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+
+	e.ImportDirectory("namespaced_component")
+	installNodejsProviderDependencies(t, e.CWD)
+	e.CWD = filepath.Join(e.CWD, "example")
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.Env = append(e.Env, "PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=false")
+	e.RunCommand("pulumi", "stack", "select", "organization/namespaced_component", "--create")
+	e.RunCommand("pulumi", "install")
+	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview")
+}

--- a/tests/integration/namespaced_component/example/Pulumi.yaml
+++ b/tests/integration/namespaced_component/example/Pulumi.yaml
@@ -1,0 +1,10 @@
+name: test-program
+description: test
+runtime: yaml
+packages:
+  namespaced-component: ..
+resources:
+  myComponent:
+    type: namespaced-component:index:MyComponent
+    properties:
+      anInput:

--- a/tests/integration/namespaced_component/index.ts
+++ b/tests/integration/namespaced_component/index.ts
@@ -11,7 +11,7 @@ export interface MyComponentArgs {
 
 export class MyComponent extends pulumi.ComponentResource {
     constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
-	super("namespaced-component:component:MyComponent", name, args, opts);
+	super("namespaced-component:index:MyComponent", name, args, opts);
 
 	// Create a resource here
     }


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/19066, we fixed component schema generation to work correctly when the `name` field in the `package.json` file includes the namespace.  However we missed that we also need to fix up construct, so we can correctly construct a component.  Fix that now.

Fixes https://github.com/pulumi/pulumi/issues/19055