### PR TITLE
Use ImportID not ID for import strings

### DIFF
--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -427,8 +427,8 @@ func (i *importer) importResources(ctx context.Context) error {
 
 		// Create the new desired state. Note that the resource is protected. Provider might be "" at this point.
 		new := resource.NewState(
-			urn.Type(), urn, !imp.Component, false, imp.ID, resource.PropertyMap{}, nil, parent, imp.Protect,
-			false, nil, nil, provider, nil, false, nil, nil, nil, "", false, "", nil, nil, "", nil, nil)
+			urn.Type(), urn, !imp.Component, false, "", resource.PropertyMap{}, nil, parent, imp.Protect,
+			false, nil, nil, provider, nil, false, nil, nil, nil, imp.ID, false, "", nil, nil, "", nil, nil)
 		// Set a dummy goal so the resource is tracked as managed.
 		i.deployment.goals.Store(urn, &resource.Goal{})
 

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -874,7 +874,6 @@ func (sg *stepGenerator) continueStepsFromRefresh(event ContinueResourceRefreshE
 
 		// Write the ID of the resource to import into the new state and return an ImportStep or an
 		// ImportReplacementStep
-		new.ID = goal.ID
 		new.ImportID = goal.ID
 
 		// If we're generating plans create a plan, Imports have no diff, just a goal state

--- a/pkg/resource/deploy/step_test.go
+++ b/pkg/resource/deploy/step_test.go
@@ -1001,9 +1001,9 @@ func TestImportStep(t *testing.T) {
 						news: &gsync.Map[urn.URN, *resource.State]{},
 					},
 					new: &resource.State{
-						URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
-						ID:     "some-id",
-						Custom: true,
+						URN:      "urn:pulumi:stack::project::foo:bar:Bar::name",
+						ImportID: "some-id",
+						Custom:   true,
 					},
 					provider: &deploytest.Provider{
 						ReadF: func(context.Context, plugin.ReadRequest) (plugin.ReadResponse, error) {
@@ -1026,9 +1026,9 @@ func TestImportStep(t *testing.T) {
 						news: &gsync.Map[urn.URN, *resource.State]{},
 					},
 					new: &resource.State{
-						URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
-						ID:     "some-id",
-						Custom: true,
+						URN:      "urn:pulumi:stack::project::foo:bar:Bar::name",
+						ImportID: "some-id",
+						Custom:   true,
 					},
 					provider: &deploytest.Provider{
 						ReadF: func(context.Context, plugin.ReadRequest) (plugin.ReadResponse, error) {
@@ -1056,9 +1056,9 @@ func TestImportStep(t *testing.T) {
 						news: &gsync.Map[urn.URN, *resource.State]{},
 					},
 					new: &resource.State{
-						URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
-						ID:     "some-id",
-						Custom: true,
+						URN:      "urn:pulumi:stack::project::foo:bar:Bar::name",
+						ImportID: "some-id",
+						Custom:   true,
 					},
 					provider: &deploytest.Provider{
 						ReadF: func(context.Context, plugin.ReadRequest) (plugin.ReadResponse, error) {
@@ -1081,9 +1081,9 @@ func TestImportStep(t *testing.T) {
 						news: &gsync.Map[urn.URN, *resource.State]{},
 					},
 					new: &resource.State{
-						URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
-						ID:     "some-id",
-						Custom: true,
+						URN:      "urn:pulumi:stack::project::foo:bar:Bar::name",
+						ImportID: "some-id",
+						Custom:   true,
 					},
 					provider: &deploytest.Provider{
 						ReadF: func(context.Context, plugin.ReadRequest) (plugin.ReadResponse, error) {
@@ -1117,10 +1117,10 @@ func TestImportStep(t *testing.T) {
 						news: &gsync.Map[urn.URN, *resource.State]{},
 					},
 					new: &resource.State{
-						URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
-						ID:     "some-id",
-						Type:   "foo:bar:Bar",
-						Custom: true,
+						URN:      "urn:pulumi:stack::project::foo:bar:Bar::name",
+						ImportID: "some-id",
+						Type:     "foo:bar:Bar",
+						Custom:   true,
 					},
 					randomSeed: []byte{},
 					provider: &deploytest.Provider{
@@ -1162,7 +1162,7 @@ func TestImportStep(t *testing.T) {
 					},
 					new: &resource.State{
 						URN:      "urn:pulumi:stack::project::foo:bar:Bar::name",
-						ID:       "some-id",
+						ImportID: "some-id",
 						Type:     "foo:bar:Bar",
 						Custom:   true,
 						Parent:   "urn:pulumi:stack::project::pulumi:pulumi:Stack::name",
@@ -1224,10 +1224,10 @@ func TestImportStep(t *testing.T) {
 					ctx:  ctx,
 				},
 				new: &resource.State{
-					URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
-					ID:     "some-id",
-					Type:   "foo:bar:Bar",
-					Custom: true,
+					URN:      "urn:pulumi:stack::project::foo:bar:Bar::name",
+					ImportID: "some-id",
+					Type:     "foo:bar:Bar",
+					Custom:   true,
 				},
 				randomSeed: []byte{},
 				provider: &deploytest.Provider{
@@ -1271,10 +1271,10 @@ func TestImportStep(t *testing.T) {
 					ctx:  ctx,
 				},
 				new: &resource.State{
-					URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
-					ID:     "some-id",
-					Type:   "foo:bar:Bar",
-					Custom: true,
+					URN:      "urn:pulumi:stack::project::foo:bar:Bar::name",
+					ImportID: "some-id",
+					Type:     "foo:bar:Bar",
+					Custom:   true,
 				},
 				randomSeed: []byte{},
 				provider:   &deploytest.Provider{},
@@ -1307,10 +1307,10 @@ func TestImportStep(t *testing.T) {
 					ctx:  ctx,
 				},
 				new: &resource.State{
-					URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
-					ID:     "some-id",
-					Type:   "foo:bar:Bar",
-					Custom: true,
+					URN:      "urn:pulumi:stack::project::foo:bar:Bar::name",
+					ImportID: "some-id",
+					Type:     "foo:bar:Bar",
+					Custom:   true,
 				},
 				randomSeed: []byte{},
 				provider: &deploytest.Provider{
@@ -1355,10 +1355,10 @@ func TestImportStep(t *testing.T) {
 					ctx:  ctx,
 				},
 				new: &resource.State{
-					URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
-					ID:     "some-id",
-					Type:   "foo:bar:Bar",
-					Custom: true,
+					URN:      "urn:pulumi:stack::project::foo:bar:Bar::name",
+					ImportID: "some-id",
+					Type:     "foo:bar:Bar",
+					Custom:   true,
 				},
 				randomSeed: []byte{},
 				provider:   &deploytest.Provider{},


### PR DESCRIPTION
Just trying to be a bit more consistent that import strings aren't IDs really. This uses the actual ImportID field for them instead, and sets ID once the import step has run.