### PR TITLE
Update client to integrate against cloud GetDefaultOrg API

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -130,6 +130,10 @@ type Backend interface {
 	// SupportsDeployments tells whether it is possible to manage deployments in this backend.
 	SupportsDeployments() bool
 
+	// GetDefaultOrg returns the organization if the backend has an opinion on what user organization to default to,
+	// if not configured locally by the user.
+	GetDefaultOrg(ctx context.Context) (apitype.GetDefaultOrganizationResponse, error)
+
 	// ParseStackReference takes a string representation and parses it to a reference which may be used for other
 	// methods in this backend.
 	ParseStackReference(s string) (StackReference, error)

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -661,6 +661,10 @@ func (b *diyBackend) SupportsDeployments() bool {
 	return false
 }
 
+func (b *diyBackend) GetDefaultOrg(ctx context.Context) (apitype.GetDefaultOrganizationResponse, error) {
+	return apitype.GetDefaultOrganizationResponse{}, nil
+}
+
 func (b *diyBackend) ParseStackReference(stackRef string) (backend.StackReference, error) {
 	return b.parseStackReference(stackRef)
 }

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -2202,6 +2202,10 @@ func (b *cloudBackend) showDeploymentEvents(ctx context.Context, stackID client.
 	}
 }
 
+func (b *cloudBackend) GetDefaultOrg(ctx context.Context) (apitype.GetDefaultOrganizationResponse, error) {
+	return b.client.GetDefaultOrg(ctx)
+}
+
 type httpstateBackendClient struct {
 	backend deploy.BackendClient
 }

--- a/pkg/backend/httpstate/client/api_endpoints.go
+++ b/pkg/backend/httpstate/client/api_endpoints.go
@@ -81,6 +81,7 @@ func init() {
 
 	addEndpoint("GET", "/api/user", "getCurrentUser")
 	addEndpoint("GET", "/api/user/stacks", "listUserStacks")
+	addEndpoint("GET", "/api/user/organizations/default", "getDefaultOrg")
 	addEndpoint("GET", "/api/stacks/{orgName}", "listOrganizationStacks")
 	addEndpoint("POST", "/api/stacks/{orgName}", "createStack")
 	addEndpoint("DELETE", "/api/stacks/{orgName}/{projectName}/{stackName}", "deleteStack")

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -321,6 +321,21 @@ func (pc *Client) GetCLIVersionInfo(ctx context.Context) (semver.Version, semver
 	return latestSem, oldestSem, devSem, nil
 }
 
+// GetDefaultOrg lists the backend's opinion of which user organization to use, if default organization
+// is unset. This API should only be called if the backend supports DefaultOrg as a capability.
+func (pc *Client) GetDefaultOrg(ctx context.Context) (apitype.GetDefaultOrganizationResponse, error) {
+	var resp apitype.GetDefaultOrganizationResponse
+	if err := pc.restCall(ctx, "GET", "/api/user/organizations/default", nil, nil, &resp); err != nil {
+		if is404(err) {
+			// The client continues to support legacy backends. They do not support GetDefaultOrg; decision
+			// for default org is left for the CLI to determine.
+			return apitype.GetDefaultOrganizationResponse{}, nil
+		}
+		return apitype.GetDefaultOrganizationResponse{}, err
+	}
+	return resp, nil
+}
+
 // ListStacksFilter describes optional filters when listing stacks.
 type ListStacksFilter struct {
 	Project      *string

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -429,3 +429,23 @@ func TestListTemplates(t *testing.T) {
 		}, actual)
 	})
 }
+
+func TestGetDefaultOrg(t *testing.T) {
+	t.Parallel()
+	t.Run("legacy-service-404", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN
+		s := newMockServer(404, "NOT FOUND")
+		defer s.Close()
+
+		// WHEN
+		c := newMockClient(s)
+		resp, err := c.GetDefaultOrg(context.Background())
+
+		// THEN
+		// We should gracefully handle the 404
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Empty(t, resp.GitHubLogin)
+	})
+}

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -175,6 +175,10 @@ func (be *MockBackend) SupportsDeployments() bool {
 	panic("not implemented")
 }
 
+func (be *MockBackend) GetDefaultOrg(ctx context.Context) (apitype.GetDefaultOrganizationResponse, error) {
+	return apitype.GetDefaultOrganizationResponse{}, nil
+}
+
 func (be *MockBackend) ParseStackReference(s string) (StackReference, error) {
 	if be.ParseStackReferenceF != nil {
 		return be.ParseStackReferenceF(s)


### PR DESCRIPTION
Design doc: https://docs.google.com/document/d/1oy0XSEGk7fY2aayxRMsb7CAPrOYeFIxLXZjqDa3WjY0/edit?tab=t.0#heading=h.v16harzbxr17

As a part of Project Hockeystick, we are creating a trial org for users so that they will be able to explore premium Pulumi features without having to create an org. We would like to default new users to using this trial org, rather than their individual org, if they do not have a default org configured in their `~/.pulumi/config.json.` 

This change integrates the new cloud API into the backend client, which currently has no callers. A future PR will introduce an entry point via something like the following code sketch:

```golang
func GetDefaultOrg(ctx context.Context, b backend.Backend, currentProject *workspace.Project) (string, error) {
   userConfiguredDefaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(currentProject)
   if err != nil || userConfiguredDefaultOrg != "" {
		return userConfiguredDefaultOrg, err
    }
    // if unset, defer to the backend's opinion of what the default org should be
    backendOpinionDefaultOrg, err := b.GetDefaultOrg(ctx)
    return backendOpinionDefaultOrg.GitHubLogin, err
}
```

## Testing

Built locally and ran against my local pulumi API:

* Confirmed integration on success
* Confirmed no error on CLI side on 404

## Related Issues

* https://github.com/pulumi/pulumi-service/issues/26424