### PR TITLE
Don’t install python/nodejs runtimes during `make build`

### DIFF
--- a/changelog/pending/20250418--sdk-nodejs-python--dont-install-python-nodejs-runtimes-during-make-build.yaml
+++ b/changelog/pending/20250418--sdk-nodejs-python--dont-install-python-nodejs-runtimes-during-make-build.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/nodejs,python
+  description: Don’t install python/nodejs runtimes during make build

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -49,8 +49,10 @@ build_package:: ensure
 	find tests/runtime/langhost/cases/* -type d -exec cp -R {} bin/tests/runtime/langhost/cases/ \;
 
 build_plugin::
-	cd cmd/pulumi-language-nodejs && \
-	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
+	go build -C cmd/pulumi-language-nodejs \
+    	-o ../../../../bin/pulumi-language-nodejs \
+    	-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" \
+        ${LANGHOST_PKG}
 
 build:: build_package build_plugin
 
@@ -59,8 +61,8 @@ install_package:: build
 	cp dist/pulumi-analyzer-policy* "$(PULUMI_BIN)"
 
 install_plugin:: build
-	cd cmd/pulumi-language-nodejs && \
-	GOBIN=$(PULUMI_BIN) go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
+	GOBIN=$(PULUMI_BIN) go install -C cmd/pulumi-language-nodejs \
+	   -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
 
 install:: install_package install_plugin
 
@@ -123,14 +125,16 @@ TEST_GREP ?= .*
 test_watch::
 	PULUMI_TEST_ORG=$(PULUMI_TEST_ORG) yarn mocha "**/*.spec.ts" --timeout 300000 --bail -j 1 --watch --watch-files "**/*.ts" --grep "$(TEST_GREP)"
 
-dist:: build
-	cp dist/pulumi-resource-pulumi-nodejs "$$(go env GOPATH)"/bin/
-	cp dist/pulumi-analyzer-policy "$$(go env GOPATH)"/bin/
+dist::
+	GOBIN=${GOBIN} go install -C cmd/pulumi-language-nodejs \
+		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
+	cp dist/pulumi-resource-pulumi-nodejs "${GOBIN}"
+	cp dist/pulumi-analyzer-policy "${GOBIN}"
 
 brew:: BREW_VERSION := $(shell ../../scripts/get-version HEAD)
 brew::
-	cd cmd/pulumi-language-nodejs && \
-	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
+	go install -C cmd/pulumi-language-nodejs \
+	   -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
 	cp dist/pulumi-resource-pulumi-nodejs "$$(go env GOPATH)"/bin/
 	cp dist/pulumi-analyzer-policy "$$(go env GOPATH)"/bin/
 

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -126,7 +126,7 @@ test_watch::
 	PULUMI_TEST_ORG=$(PULUMI_TEST_ORG) yarn mocha "**/*.spec.ts" --timeout 300000 --bail -j 1 --watch --watch-files "**/*.ts" --grep "$(TEST_GREP)"
 
 dist::
-	GOBIN=${GOBIN} go install -C cmd/pulumi-language-nodejs \
+	go install -C cmd/pulumi-language-nodejs \
 		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
 	cp dist/pulumi-resource-pulumi-nodejs "${GOBIN}"
 	cp dist/pulumi-analyzer-policy "${GOBIN}"

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -24,8 +24,10 @@ build_package:: ensure
 	uv run -m build --outdir ./build --installer uv
 
 build_plugin::
-	go install -C cmd/pulumi-language-python \
-		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
+	go build -C cmd/pulumi-language-python \
+		-o ../../../../bin/pulumi-language-python \
+		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" \
+		${LANGHOST_PKG}
 
 build:: build_package build_plugin
 
@@ -67,7 +69,6 @@ test_all:: test_fast test_auto test_go
 
 PULUMI_TEST_ORG ?= $(shell pulumi whoami --json | jq ".organizations[0]")
 
-dist:: GOBIN=$(or $(shell go env GOBIN),$(shell go env GOPATH)/bin)
 dist::
 	GOBIN=${GOBIN} go install -C cmd/pulumi-language-python \
 		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -70,7 +70,7 @@ test_all:: test_fast test_auto test_go
 PULUMI_TEST_ORG ?= $(shell pulumi whoami --json | jq ".organizations[0]")
 
 dist::
-	GOBIN=${GOBIN} go install -C cmd/pulumi-language-python \
+	go install -C cmd/pulumi-language-python \
 		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
 	cp ./cmd/pulumi-language-python-exec "${GOBIN}"
 	cp ./dist/pulumi-resource-pulumi-python "${GOBIN}"


### PR DESCRIPTION
Similar to https://github.com/pulumi/pulumi/pull/19048 we should not install the binaries during `make build`.

This helps when using `mise`.  Previously `make build` would also install `pulumi-language-python` into `$GOBIN`, however not the `pulumi-language-python-exec` shim, causing problems when the shim is not found in the same directory as the runtime.
