### PR TITLE
Tidy up Node.js component provider tests

### DIFF
--- a/tests/integration/component_provider/nodejs/component-provider-host/python/Pulumi.yaml
+++ b/tests/integration/component_provider/nodejs/component-provider-host/python/Pulumi.yaml
@@ -5,7 +5,5 @@ runtime:
   options:
     toolchain: pip
     virtualenv: venv
-plugins:
-  providers:
-    - name: nodejs-component-provider
-      path: ../provider
+packages:
+  provider: ../provider

--- a/tests/integration/component_provider/nodejs/component-provider-host/yaml/Pulumi.yaml
+++ b/tests/integration/component_provider/nodejs/component-provider-host/yaml/Pulumi.yaml
@@ -1,10 +1,8 @@
 name: nodejs-component-provider-yaml
 description: Using a component provider written in Node.js from YAML
 runtime: yaml
-plugins:
-  providers:
-    - name: nodejs-component-provider
-      path: ../provider
+packages:
+  provider: ../provider
 resources:
   comp:
     type: nodejs-component-provider:index:MyComponent


### PR DESCRIPTION
Similar to https://github.com/pulumi/pulumi/pull/19210, use the `packages` section in `Pulumi.yaml` to hook up the local component provider.
