### PR TITLE
Handle local plugin paths with a version number

### DIFF
--- a/changelog/pending/20250418--cli-install--handle-local-plugin-paths-with-a-version-number.yaml
+++ b/changelog/pending/20250418--cli-install--handle-local-plugin-paths-with-a-version-number.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/install
+  description: Handle local plugin paths with a version number

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -170,7 +170,7 @@ func installPackagesFromProject(pctx *plugin.Context, proj *workspace.Project, r
 		fmt.Printf("Installing package '%s'...\n", name)
 
 		installSource := packageSpec.Source
-		if packageSpec.Version != "" {
+		if !plugin.IsLocalPluginPath(installSource) && packageSpec.Version != "" {
 			installSource = fmt.Sprintf("%s@%s", installSource, packageSpec.Version)
 		}
 

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2472,6 +2472,24 @@ func TestPackagesInstall(t *testing.T) {
 	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview")
 }
 
+func TestInstallLocalPlugin(t *testing.T) {
+	t.Parallel()
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+
+	e.ImportDirectory("packages-install-local")
+	installNodejsProviderDependencies(t, filepath.Join(e.RootPath, "provider"))
+	e.CWD = filepath.Join(e.RootPath, "example")
+
+	// This command should generate the SDK for the local plugin
+	e.RunCommand("pulumi", "install")
+
+	require.True(t, e.PathExists(filepath.Join("sdks/provider/package.json")))
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.RunCommand("pulumi", "stack", "select", "organization/install-local-plugin", "--create")
+	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview")
+}
+
 func TestPackageAddProviderFromRemoteSourceNoVersion(t *testing.T) {
 	t.Parallel()
 	e := ptesting.NewEnvironment(t)

--- a/tests/integration/packages-install-local/example/.gitignore
+++ b/tests/integration/packages-install-local/example/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/tests/integration/packages-install-local/example/Pulumi.yaml
+++ b/tests/integration/packages-install-local/example/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: package-install-local
+description: Install
+packages:
+  # The test validates that we can deal with the version number here
+  provider: ../provider@0.0.0
+runtime: nodejs

--- a/tests/integration/packages-install-local/example/index.ts
+++ b/tests/integration/packages-install-local/example/index.ts
@@ -1,0 +1,4 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as provider from "@pulumi/provider";
+
+export const comp = new provider.MyComponent("test")

--- a/tests/integration/packages-install-local/example/package.json
+++ b/tests/integration/packages-install-local/example/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "package-add-with-publisher-python",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.113.0"
+    }
+}

--- a/tests/integration/packages-install-local/example/tsconfig.json
+++ b/tests/integration/packages-install-local/example/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/integration/packages-install-local/provider/PulumiPlugin.yaml
+++ b/tests/integration/packages-install-local/provider/PulumiPlugin.yaml
@@ -1,0 +1,1 @@
+runtime: nodejs

--- a/tests/integration/packages-install-local/provider/index.ts
+++ b/tests/integration/packages-install-local/provider/index.ts
@@ -1,0 +1,11 @@
+// Copyright 2025 Pulumi Corporation.
+
+import * as pulumi from "@pulumi/pulumi"
+
+export interface MyComponentArgs { }
+
+export class MyComponent extends pulumi.ComponentResource {
+    constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("provider:index:MyComponent", name, args, opts);
+    }
+}

--- a/tests/integration/packages-install-local/provider/package.json
+++ b/tests/integration/packages-install-local/provider/package.json
@@ -1,6 +1,4 @@
 {
     "name": "provider",
-    "dependencies": {
-        "@pulumi/pulumi": "^3.163.0"
-    }
+    "dependencies": {}
 }

--- a/tests/integration/packages-install-local/provider/package.json
+++ b/tests/integration/packages-install-local/provider/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "provider",
+    "dependencies": {
+        "@pulumi/pulumi": "^3.163.0"
+    }
+}


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/18940 we extended `pulumi install` to generate the SDKs for packages referenced in `Pulumi.yaml`, however depending on how the provider is referenced in `Pulumi.yaml`, this does not work for local providers.

When a provider is added via `pulumi package add /some/path`, we create an entry in `Pulumi.yaml` with the version:

```
packages:
  greeter: /some/path@0.0.0
```

This causes `pulumi install` to fail, as it does not properly detect the path due to the version number.

Fixes https://github.com/pulumi/pulumi/issues/19253
