### PR TITLE
Round trip computed property.Value's through gRPC

### DIFF
--- a/sdk/go/common/resource/property_compatibility.go
+++ b/sdk/go/common/resource/property_compatibility.go
@@ -73,7 +73,7 @@ func ToResourcePropertyValue(v property.Value) PropertyValue {
 	case v.Secret():
 		r = MakeSecret(r)
 	case v.IsComputed():
-		r = MakeComputed(r)
+		r = MakeComputed(NewProperty(""))
 	}
 
 	return r


### PR DESCRIPTION
Stacked on top of #19256.

This PR changes the `resource.PropertyValue` representation of a computed `property.Value` so that it correctly roundtrips through gRPC.

Before this PR, `resource.ToResourcePropertyValue(property.New(property.Computed))` returns a `resource.PropertyValue{V: resource.Computed{}}`, which is semantically correct: a computed value with no additional information known. Unfortunately, this does not round trip through `plugin.(Un)Marshal` functions. Marshalling and unmarshaling turns `resource.PropertyValue{V: resource.Computed{}}` into `resource.PropertyValue{V: nil}`, which is not semantically equivalent. 

This PR solves the problem by changing the how `resource.ToResourcePropertyValue` translates computed values. `resource.ToResourcePropertyValue(property.New(property.Computed))` now returns a `resource.PropertyValue{V: resource.Computed{Element: resource.PropertyValue{V: ""}}}`, which does round trip correctly.