### PR TITLE
Implement `fmt.GoStringer` for `property.{Value,Map,Array}`

### DIFF
--- a/sdk/go/property/fmt.go
+++ b/sdk/go/property/fmt.go
@@ -1,0 +1,103 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// [fmt.GoStringer] lets a type define the go syntax needed to define it.
+//
+// If this is implemented well, then you can copy a printed value into your code, which
+// makes debugging a lot easier. With that goal in mind, we have chosen to print package
+// level constructs prefixed by "property.", since most people debugging with property
+// values will not be authors of the property package.
+var (
+	_ fmt.GoStringer = Value{}
+	_ fmt.GoStringer = Map{}
+	_ fmt.GoStringer = Array{}
+	_ fmt.GoStringer = Null
+	_ fmt.GoStringer = Computed
+)
+
+func (v Value) GoString() string {
+	value := func(s string) string {
+		var withSecret, withDependencies string
+		if v.isSecret {
+			withSecret = ".WithSecret(true)"
+		}
+		if len(v.dependencies) > 0 {
+			withDependencies = fmt.Sprintf(".WithDependencies(%#v)", v.dependencies)
+		}
+		return fmt.Sprintf("property.New(%s)%s%s", s, withSecret, withDependencies)
+	}
+	valuef := func(a any) string { return value(fmt.Sprintf("%#v", a)) }
+	switch {
+	case v.IsBool(), v.IsString(), v.IsComputed(),
+		v.IsAsset(), v.IsArchive(), v.IsResourceReference():
+		return valuef(v.v)
+
+	// Go doesn't allow New(1), since 1 is a int literal, not a float64 literal.
+	//
+	// We want to make sure that we always print a valid float64 literal.
+	case v.IsNumber():
+		n := v.AsNumber()
+		s := strconv.FormatFloat(n, 'f', -1, 64)
+		if float64(int(n)) == n {
+			return value(s + ".0")
+		}
+		return value(s)
+
+	// Null is normalized to nil, so that Value{} is the same as New(Null).
+	case v.IsNull():
+		return valuef(Null)
+
+	// [New] accepts both an [Array] or a []Value,
+
+	case v.IsArray():
+		a := v.AsArray()
+		if len(a.arr) == 0 {
+			return valuef(a)
+		}
+		return valuef(a.arr)
+	case v.IsMap():
+		m := v.AsMap()
+		if len(m.m) == 0 {
+			return valuef(m)
+		}
+		return valuef(v.AsMap().m)
+	default:
+		panic(fmt.Sprintf("impossible - unknown type %T within a value", v.v))
+	}
+}
+
+func (a Array) GoString() string {
+	if len(a.arr) == 0 {
+		return "property.Array{}"
+	}
+	return fmt.Sprintf("property.NewArray(%#v)", a.arr)
+}
+
+func (a Map) GoString() string {
+	if len(a.m) == 0 {
+		return "property.Map{}"
+	}
+	return fmt.Sprintf("property.NewMap(%#v)", a.m)
+}
+
+func (null) GoString() string { return "property.Null" }
+
+func (computed) GoString() string { return "property.Computed" }

--- a/sdk/go/property/fmt_test.go
+++ b/sdk/go/property/fmt_test.go
@@ -1,0 +1,119 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGoStringValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		value    Value
+		expected string
+	}{
+		{
+			value:    New(true),
+			expected: `property.New(true)`,
+		},
+		{
+			value:    New(123.0),
+			expected: `property.New(123.0)`,
+		},
+		{
+			value:    New(0.0),
+			expected: `property.New(0.0)`,
+		},
+		{
+			value:    New(Null),
+			expected: `property.New(property.Null)`,
+		},
+		{
+			value:    New(Computed),
+			expected: `property.New(property.Computed)`,
+		},
+		{
+			value:    New([]Value{}),
+			expected: `property.New(property.Array{})`,
+		},
+		{
+			value:    New([]Value{New(true), New(1.23)}),
+			expected: `property.New([]property.Value{property.New(true), property.New(1.23)})`,
+		},
+		{
+			value:    New(map[string]Value{}),
+			expected: `property.New(property.Map{})`,
+		},
+		{
+			value:    New(map[string]Value{"key": New(false)}),
+			expected: `property.New(map[string]property.Value{"key":property.New(false)})`,
+		},
+		{
+			value:    New(true).WithSecret(true),
+			expected: `property.New(true).WithSecret(true)`,
+		},
+		{
+			value:    New("s").WithDependencies([]urn.URN{"urn1", "urn2"}),
+			expected: `property.New("s").WithDependencies([]urn.URN{"urn1", "urn2"})`,
+		},
+		{
+			value:    New("s").WithDependencies([]urn.URN{"urn1"}).WithSecret(true),
+			expected: `property.New("s").WithSecret(true).WithDependencies([]urn.URN{"urn1"})`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, tt.value.GoString())
+		})
+	}
+}
+
+func TestGoStringArray(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, `property.Array{}`, (Array{}).GoString())
+	})
+
+	t.Run("not empty", func(t *testing.T) {
+		t.Parallel()
+
+		const expt = `property.NewArray([]property.Value{property.New(true), property.New(false)})`
+		assert.Equal(t, expt, NewArray([]Value{New(true), New(false)}).GoString())
+	})
+}
+
+func TestGoStringMap(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, `property.Map{}`, (Map{}).GoString())
+	})
+
+	t.Run("not empty", func(t *testing.T) {
+		t.Parallel()
+
+		const expt = `property.NewMap(map[string]property.Value{"k1":property.New(true), "k2":property.New(false)})`
+		assert.Equal(t, expt, NewMap(map[string]Value{"k1": New(true), "k2": New(false)}).GoString())
+	})
+}


### PR DESCRIPTION
Stacked on #19258.

This PR implements `fmt.GoStringer` for `property` types. This enables programmers to paste the value from `fmt.Printf("Properties: %#v", myPropertyMap)` into a unit test and have it compile. This is a quality of life feature for Go programmers using the library. It should not effect the runtime behavior of `property`.