### PR TITLE
Update type to start exposing the program id

### DIFF
--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -436,6 +436,7 @@ const (
 
 // Stack describes a Stack running on a Pulumi Cloud.
 type Stack struct {
+	ID          string       `json:"id"`
 	OrgName     string       `json:"orgName"`
 	ProjectName string       `json:"projectName"`
 	StackName   tokens.QName `json:"stackName"`

--- a/sdk/go/common/apitype/stacks.go
+++ b/sdk/go/common/apitype/stacks.go
@@ -16,6 +16,8 @@ package apitype
 
 // StackSummary describes the state of a stack, without including its specific resources, etc.
 type StackSummary struct {
+	// ID is the the stack's ProgramID.
+	ID string `json:"id"`
 	// OrgName is the organization name the stack is found in.
 	OrgName string `json:"orgName"`
 	// ProjectName is the name of the project the stack is associated with.


### PR DESCRIPTION
We are starting to expose the ProgramID as the stack's ID on the cloud's APIs. 