### PR TITLE
Remove unused `GetModuleDocLink` from `DocLanguageHelper`

### DIFF
--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -38,9 +38,6 @@ type DocLanguageHelper interface {
 
 	GetMethodName(m *schema.Method) string
 	GetMethodResultName(pkg *schema.Package, modName string, r *schema.Resource, m *schema.Method) string
-
-	// GetModuleDocLink returns the display name and the link for a module (including root modules) in a given package.
-	GetModuleDocLink(pkg *schema.Package, modName string) (string, string)
 }
 
 func filterExamples(source []byte, node ast.Node, lang string) {

--- a/pkg/codegen/dotnet/doc.go
+++ b/pkg/codegen/dotnet/doc.go
@@ -172,20 +172,3 @@ func (d DocLanguageHelper) GetEnumName(e *schema.Enum, typeName string) (string,
 	}
 	return makeSafeEnumName(name, typeName)
 }
-
-// GetModuleDocLink returns the display name and the link for a module.
-func (d DocLanguageHelper) GetModuleDocLink(pkg *schema.Package, modName string) (string, string) {
-	var displayName string
-	var link string
-	rootNamespace := "Pulumi"
-	if pkg.Namespace != "" {
-		rootNamespace = namespaceName(d.Namespaces, pkg.Namespace)
-	}
-	if modName == "" {
-		displayName = rootNamespace + "." + namespaceName(d.Namespaces, pkg.Name)
-	} else {
-		displayName = fmt.Sprintf("%s.%s.%s", rootNamespace, namespaceName(d.Namespaces, pkg.Name), modName)
-	}
-	link = d.GetDocLinkForResourceType(pkg, "", displayName)
-	return displayName, link
-}

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -166,16 +166,3 @@ func (d DocLanguageHelper) GetMethodResultName(pkg *schema.Package, modName stri
 	}
 	return fmt.Sprintf("%s%sResultOutput", rawResourceName(r), d.GetMethodName(m))
 }
-
-// GetModuleDocLink returns the display name and the link for a module.
-func (d DocLanguageHelper) GetModuleDocLink(pkg *schema.Package, modName string) (string, string) {
-	var displayName string
-	var link string
-	if modName == "" {
-		displayName = packageName(pkg)
-	} else {
-		displayName = fmt.Sprintf("%s/%s", packageName(pkg), modName)
-	}
-	link = d.GetDocLinkForResourceType(pkg, modName, "")
-	return displayName, link
-}

--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -145,20 +145,3 @@ func (d DocLanguageHelper) GetPropertyName(p *schema.Property) (string, error) {
 func (d DocLanguageHelper) GetEnumName(e *schema.Enum, typeName string) (string, error) {
 	return enumMemberName(typeName, e)
 }
-
-// GetModuleDocLink returns the display name and the link for a module.
-func (d DocLanguageHelper) GetModuleDocLink(pkg *schema.Package, modName string) (string, string) {
-	var displayName string
-	var link string
-	namespace := "@pulumi"
-	if pkg.Namespace != "" {
-		namespace = "@" + pkg.Namespace
-	}
-	if modName == "" {
-		displayName = fmt.Sprintf("%s/%s", namespace, pkg.Name)
-	} else {
-		displayName = fmt.Sprintf("%s/%s/%s", namespace, pkg.Name, strings.ToLower(modName))
-	}
-	link = d.GetDocLinkForResourceType(pkg, modName, "")
-	return displayName, link
-}

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -145,16 +145,3 @@ func (d DocLanguageHelper) GetEnumName(e *schema.Enum, typeName string) (string,
 	}
 	return makeSafeEnumName(name, typeName)
 }
-
-// GetModuleDocLink returns the display name and the link for a module.
-func (d DocLanguageHelper) GetModuleDocLink(pkg *schema.Package, modName string) (string, string) {
-	var displayName string
-	var link string
-	if modName == "" {
-		displayName = PyPack(pkg.Namespace, pkg.Name)
-	} else {
-		displayName = fmt.Sprintf("%s/%s", PyPack(pkg.Namespace, pkg.Name), strings.ToLower(modName))
-	}
-	link = "/docs/reference/pkg/python/" + displayName
-	return displayName, link
-}


### PR DESCRIPTION
This function is never called in Pulumi code:
https://github.com/search?q=org%3Apulumi%20GetModuleDocLink&type=code.