### PR TITLE
Fix typo in journal code

### DIFF
--- a/pkg/engine/journal.go
+++ b/pkg/engine/journal.go
@@ -118,7 +118,6 @@ func (entries JournalEntries) Snap(base *deploy.Snapshot) (*deploy.Snapshot, err
 				dones[e.Step.Old()] = true
 			case deploy.OpImport, deploy.OpImportReplacement:
 				resources = append(resources, e.Step.New())
-				dones[e.Step.New()] = true
 			case deploy.OpRefresh:
 				step, ok := e.Step.(*deploy.RefreshStep)
 				contract.Assertf(ok, "expected *deploy.RefreshStep, got %T", e.Step)


### PR DESCRIPTION
Imports are like creates and should not mark the state (if any) as done. This worked because it happened to pass `New()` rather than `Old()` which was probably a typo, but meant that this value was never matched on in the list filtering later.