### PR TITLE
schema check and reserve pulumi keyword

### DIFF
--- a/changelog/pending/20250425--programgen-python--add-pulumi-as-reserved-keyword-in-binder-to-fix-python-codegen-issues.yaml
+++ b/changelog/pending/20250425--programgen-python--add-pulumi-as-reserved-keyword-in-binder-to-fix-python-codegen-issues.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/python
+  description: Add pulumi as reserved keyword in binder to fix python codegen issues

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -1516,7 +1516,7 @@ func bindConfig(spec ConfigSpec, types *types, options ValidationOptions) ([]*Pr
 		"#/config/defaults", spec.Required, false, options)
 
 	for _, property := range properties {
-		if isReservedPropertyName(property.Name) {
+		if isReservedConfigKey(property.Name) {
 			path := "#/config/variables/" + property.Name
 			diags = diags.Append(errorf(path, property.Name+" is a reserved configuration key"))
 		}
@@ -1673,7 +1673,7 @@ func (t *types) bindProvider(decl *Resource, options ValidationOptions) (hcl.Dia
 
 	// If any input property is called "version" or "pulumi" error that it's reserved.
 	for _, property := range decl.InputProperties {
-		if isReservedPropertyName(property.Name) {
+		if isReservedTopLevelPropertyName(property.Name) {
 			path := "#/provider/properties/" + property.Name
 			diags = diags.Append(errorf(path, property.Name+" is a reserved property name"))
 		}

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -1508,6 +1508,8 @@ func bindConfig(spec ConfigSpec, types *types, options ValidationOptions) ([]*Pr
 	for _, property := range properties {
 		if property.Name == "version" {
 			diags = diags.Append(errorf("#/config/variables/version", "version is a reserved configuration key"))
+		} else if property.Name == "pulumi" {
+			diags = diags.Append(errorf("#/config/variables/pulumi", "pulumi is a reserved configuration key"))
 		}
 	}
 
@@ -1571,6 +1573,9 @@ func (t *types) bindResourceDetails(
 	for _, property := range properties {
 		if property.Name == "urn" {
 			diags = diags.Append(warningf(path+"/properties/urn", "urn is a reserved property name"))
+		} else if property.Name == "pulumi" {
+			// pulumi is a reserved name
+			diags = diags.Append(warningf(path+"/properties/pulumi", "pulumi is a reserved property name"))
 		}
 
 		if !spec.IsComponent && property.Name == "id" {
@@ -1648,10 +1653,12 @@ func (t *types) bindProvider(decl *Resource, options ValidationOptions) (hcl.Dia
 	}
 	decl.IsProvider = true
 
-	// If any input property is called "version" error that it's reserved.
+	// If any input property is called "version" or "pulumi" error that it's reserved.
 	for _, property := range decl.InputProperties {
 		if property.Name == "version" {
 			diags = diags.Append(errorf("#/provider/properties/version", "version is a reserved property name"))
+		} else if property.Name == "pulumi" {
+			diags = diags.Append(errorf("#/provider/properties/pulumi", "pulumi is a reserved property name"))
 		}
 	}
 

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -757,7 +757,7 @@ func (t *types) bindTypeDef(token string, options ValidationOptions) (Type, hcl.
 	if len(parts) == 3 {
 		name := parts[2]
 		if isReservedKeyword(name) {
-			diags = append(diags, errorf(path, name+" is a reserved name, cannot be used for type name"))
+			diags = append(diags, errorf(path, name+" is a reserved name, cannot name type"))
 			return nil, diags, errors.New("type name " + name + " is reserved")
 		}
 	}

--- a/pkg/codegen/schema/reserved_keywords.go
+++ b/pkg/codegen/schema/reserved_keywords.go
@@ -20,7 +20,7 @@ var (
 	// These property names are reserved
 	reservedKeywords = []string{"pulumi"}
 
-	reservedPropertyNames = []string{"version"}
+	reservedTopLevelPropertyNames = []string{"version"}
 	// urn is a reserved property name for all resources
 	// id is a reserved property name for resources which are not components
 	reservedResourcePropertyKeys = []string{"urn"}
@@ -32,8 +32,8 @@ func isReservedKeyword(name string) bool {
 	return slices.Contains(reservedKeywords, name)
 }
 
-func isReservedPropertyName(name string) bool {
-	return slices.Contains(reservedPropertyNames, name) || isReservedKeyword(name)
+func isReservedTopLevelPropertyName(name string) bool {
+	return slices.Contains(reservedTopLevelPropertyNames, name) || isReservedKeyword(name)
 }
 
 func isReservedResourcePropertyKey(name string) bool {
@@ -42,4 +42,8 @@ func isReservedResourcePropertyKey(name string) bool {
 
 func isReservedNonComponentPropertyKey(name string) bool {
 	return slices.Contains(reservedNonComponentPropertyKeys, name)
+}
+
+func isReservedConfigKey(name string) bool {
+	return isReservedKeyword(name)
 }

--- a/pkg/codegen/schema/reserved_keywords.go
+++ b/pkg/codegen/schema/reserved_keywords.go
@@ -32,18 +32,14 @@ func isReservedKeyword(name string) bool {
 	return slices.Contains(reservedKeywords, name)
 }
 
-func isReservedTopLevelPropertyName(name string) bool {
+func isReservedProviderPropertyName(name string) bool {
 	return slices.Contains(reservedTopLevelPropertyNames, name) || isReservedKeyword(name)
 }
 
-func isReservedResourcePropertyKey(name string) bool {
+func isReservedComponentResourcePropertyKey(name string) bool {
 	return slices.Contains(reservedResourcePropertyKeys, name) || isReservedKeyword(name)
 }
 
-func isReservedNonComponentPropertyKey(name string) bool {
+func isReservedCustomResourcePropertyKey(name string) bool {
 	return slices.Contains(reservedNonComponentPropertyKeys, name)
-}
-
-func isReservedConfigKey(name string) bool {
-	return isReservedKeyword(name)
 }

--- a/pkg/codegen/schema/reserved_keywords.go
+++ b/pkg/codegen/schema/reserved_keywords.go
@@ -1,0 +1,45 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import "slices"
+
+var (
+	// These property names are reserved
+	reservedKeywords = []string{"pulumi"}
+
+	reservedPropertyNames = []string{"version"}
+	// urn is a reserved property name for all resources
+	// id is a reserved property name for resources which are not components
+	reservedResourcePropertyKeys = []string{"urn"}
+	// These are only reserved for non-component resources
+	reservedNonComponentPropertyKeys = []string{"id"}
+)
+
+func isReservedKeyword(name string) bool {
+	return slices.Contains(reservedKeywords, name)
+}
+
+func isReservedPropertyName(name string) bool {
+	return slices.Contains(reservedPropertyNames, name) || isReservedKeyword(name)
+}
+
+func isReservedResourcePropertyKey(name string) bool {
+	return slices.Contains(reservedResourcePropertyKeys, name) || isReservedKeyword(name)
+}
+
+func isReservedNonComponentPropertyKey(name string) bool {
+	return slices.Contains(reservedNonComponentPropertyKeys, name)
+}

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -897,6 +897,49 @@ func TestUsingReservedWordInResourcePropertiesEmitsWarning(t *testing.T) {
 	assert.NotNil(t, pkg)
 }
 
+func TestUsingVersionKeywordInResourcePropertiesIsOk(t *testing.T) {
+	t.Parallel()
+	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	pkgSpec := PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Resources: map[string]ResourceSpec{
+			"test:index:TestResource": {
+				ObjectTypeSpec: ObjectTypeSpec{
+					Properties: map[string]PropertySpec{
+						"version": {
+							TypeSpec: TypeSpec{
+								Type: "string",
+							},
+						},
+					},
+				},
+			},
+			"test:index:TestComponent": {
+				IsComponent: true,
+				ObjectTypeSpec: ObjectTypeSpec{
+					Properties: map[string]PropertySpec{
+						"version": {
+							TypeSpec: TypeSpec{
+								Type: "string",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pkg, diags, err := BindSpec(pkgSpec, loader, ValidationOptions{
+		AllowDanglingReferences: true,
+	})
+	// No error as binding should work fine even with warnings
+	assert.NoError(t, err)
+	// assert that there are 2 warnings in the diagnostics because of using URN as a property
+	assert.Len(t, diags, 0)
+	assert.NotNil(t, pkg)
+}
+
 func TestUsingReservedWordInFunctionsEmitsError(t *testing.T) {
 	t.Parallel()
 	loader := NewPluginLoader(utils.NewHost(testdataPath))
@@ -931,6 +974,40 @@ func TestUsingReservedWordInFunctionsEmitsError(t *testing.T) {
 		)
 	}
 	assert.Nil(t, pkg)
+}
+
+func TestUsingReservedWordInFunctionParamsIsOk(t *testing.T) {
+	t.Parallel()
+	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	pkgSpec := PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Functions: map[string]FunctionSpec{
+			"test:index:fake": {
+				Inputs: &ObjectTypeSpec{
+					Properties: map[string]PropertySpec{
+						"pulumi": {
+							TypeSpec: TypeSpec{
+								Type: "string",
+							},
+						},
+						"version": {
+							TypeSpec: TypeSpec{
+								Type: "string",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pkg, diags, err := BindSpec(pkgSpec, loader, ValidationOptions{
+		AllowDanglingReferences: true,
+	})
+	assert.NoError(t, err)
+	assert.Len(t, diags, 0)
+	assert.NotNil(t, pkg)
 }
 
 func TestUsingReservedWordInTypesEmitsError(t *testing.T) {
@@ -968,6 +1045,41 @@ func TestUsingReservedWordInTypesEmitsError(t *testing.T) {
 		)
 	}
 	assert.Nil(t, pkg)
+}
+
+func TestUsingReservedWordInTypeIsOk(t *testing.T) {
+	t.Parallel()
+	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	pkgSpec := PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Types: map[string]ComplexTypeSpec{
+			"test:index:fake": {
+				ObjectTypeSpec: ObjectTypeSpec{
+					Type: "object",
+					Properties: map[string]PropertySpec{
+						"pulumi": {
+							TypeSpec: TypeSpec{
+								Type: "string",
+							},
+						},
+						"version": {
+							TypeSpec: TypeSpec{
+								Type: "string",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pkg, diags, err := BindSpec(pkgSpec, loader, ValidationOptions{
+		AllowDanglingReferences: true,
+	})
+	assert.NoError(t, err)
+	assert.Len(t, diags, 0)
+	assert.NotNil(t, pkg)
 }
 
 func TestUsingIdInResourcePropertiesEmitsWarning(t *testing.T) {
@@ -2117,7 +2229,7 @@ func TestProviderReservedKeywordsIsAnError(t *testing.T) {
 	assert.Equal(t, diags[0].Summary, "#/provider/properties/pulumi: pulumi is a reserved property name")
 	assert.Equal(t, diags[1].Summary, "#/provider/properties/version: version is a reserved property name")
 
-	// Test that reserved are allowed as an output property on the provider object.
+	// Test that reserved words are allowed as an output property on the provider object.
 	// Most providers probably won't add this, but it's there if they want to expose it.
 	pkgSpec = PackageSpec{
 		Name:    "xyz",

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -2015,7 +2015,6 @@ func TestProviderReservedKeywordsIsAnError(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, diags.HasErrors())
 	assert.Equal(t, diags[0].Summary, "#/config/variables/pulumi: pulumi is a reserved configuration key")
-	assert.Equal(t, diags[1].Summary, "#/config/variables/version: version is a reserved configuration key")
 
 	// Test that certain words aren't allowed as an input property on the provider object.
 	pkgSpec = PackageSpec{

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -1055,7 +1055,7 @@ func TestUsingReservedWordInTypesEmitsError(t *testing.T) {
 		assert.Equal(t, diag.Severity, hcl.DiagError)
 		assert.True(
 			t,
-			strings.Contains(diag.Summary, "pulumi is a reserved name, cannot be used for type name"),
+			strings.Contains(diag.Summary, "pulumi is a reserved name, cannot name type"),
 		)
 	}
 	assert.Nil(t, pkg)
@@ -2396,9 +2396,10 @@ func TestResourceWithKeynameOverlapType(t *testing.T) {
 		},
 	}
 
-	_, diags, _ := BindSpec(pkgSpec, loader, ValidationOptions{})
+	_, diags, err := BindSpec(pkgSpec, loader, ValidationOptions{})
+	assert.Error(t, err)
 	assert.Len(t, diags, 1)
-	assert.Contains(t, diags[0].Summary, "pulumi is a reserved name, cannot be used for type name")
+	assert.Contains(t, diags[0].Summary, "pulumi is a reserved name, cannot name type")
 }
 
 func TestRoundtripAliasesJSON(t *testing.T) {

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -2076,6 +2076,70 @@ func TestProviderReservedKeywordsIsAnError(t *testing.T) {
 	assert.NotNil(t, pkg)
 }
 
+func TestResourceWithKeynameOverlapFunction(t *testing.T) {
+	t.Parallel()
+
+	loader := NewPluginLoader(utils.NewHost(testdataPath))
+
+	pkgSpec := PackageSpec{
+		Name:    "xyz",
+		Version: "0.0.1",
+		Provider: ResourceSpec{
+			ObjectTypeSpec: ObjectTypeSpec{},
+		},
+		Functions: map[string]FunctionSpec{
+			"xyz:index:pulumi": {},
+		},
+	}
+
+	_, diags, err := BindSpec(pkgSpec, loader)
+	require.ErrorContains(t, err, "function name pulumi is reserved")
+	assert.Len(t, diags, 1)
+}
+
+func TestResourceWithKeynameOverlapResource(t *testing.T) {
+	t.Parallel()
+
+	loader := NewPluginLoader(utils.NewHost(testdataPath))
+
+	pkgSpec := PackageSpec{
+		Name:    "xyz",
+		Version: "0.0.1",
+		Provider: ResourceSpec{
+			ObjectTypeSpec: ObjectTypeSpec{},
+		},
+		Resources: map[string]ResourceSpec{
+			"xyz:index:pulumi": {},
+		},
+	}
+
+	_, diags, _ := BindSpec(pkgSpec, loader)
+	assert.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Summary, "is a reserved name")
+}
+
+func TestResourceWithKeynameOverlapType(t *testing.T) {
+	t.Parallel()
+
+	loader := NewPluginLoader(utils.NewHost(testdataPath))
+
+	pkgSpec := PackageSpec{
+		Name:    "xyz",
+		Version: "0.0.1",
+		Provider: ResourceSpec{
+			ObjectTypeSpec: ObjectTypeSpec{},
+		},
+		Types: map[string]ComplexTypeSpec{
+			"xyz:index:pulumi": {},
+		},
+	}
+
+	_, diags, _ := BindSpec(pkgSpec, loader)
+	assert.Len(t, diags, 2)
+	assert.Contains(t, diags[0].Summary, "is a reserved name")
+	assert.Contains(t, diags[1].Summary, "unknown primitive type")
+}
+
 func TestRoundtripAliasesJSON(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -2299,7 +2299,7 @@ func TestResourceWithKeynameOverlapResource(t *testing.T) {
 
 	_, diags, _ := BindSpec(pkgSpec, loader, ValidationOptions{})
 	assert.Len(t, diags, 1)
-	assert.Contains(t, diags[0].Summary, "is a reserved name")
+	assert.Contains(t, diags[0].Summary, "is a reserved name, cannot name resource")
 }
 
 func TestResourceWithKeynameOverlapType(t *testing.T) {
@@ -2314,14 +2314,24 @@ func TestResourceWithKeynameOverlapType(t *testing.T) {
 			ObjectTypeSpec: ObjectTypeSpec{},
 		},
 		Types: map[string]ComplexTypeSpec{
-			"xyz:index:pulumi": {},
+			"xyz:index:pulumi": {
+				ObjectTypeSpec: ObjectTypeSpec{
+					Type: "object",
+					Properties: map[string]PropertySpec{
+						"abc": {
+							TypeSpec: TypeSpec{
+								Type: "string",
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 
 	_, diags, _ := BindSpec(pkgSpec, loader, ValidationOptions{})
-	assert.Len(t, diags, 2)
-	assert.Contains(t, diags[0].Summary, "is a reserved name")
-	assert.Contains(t, diags[1].Summary, "unknown primitive type")
+	assert.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Summary, "pulumi is a reserved name, cannot be used for type name")
 }
 
 func TestRoundtripAliasesJSON(t *testing.T) {


### PR DESCRIPTION
Python codegen breaks due to the pulumi key name being reserved.  This change is a first pass at adding various checks to the schema to fail instead of generating the failing program.

Also added some diags that were not returned due to error.  Error should be checked but diags might be useful (as they are in these tests) so I moved some things around a bit to return them

Fixes #18994
