### PR TITLE
sdk/{nodejs,python}/Makefile: export GOBIN before using it

### DIFF
--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -125,6 +125,7 @@ TEST_GREP ?= .*
 test_watch::
 	PULUMI_TEST_ORG=$(PULUMI_TEST_ORG) yarn mocha "**/*.spec.ts" --timeout 300000 --bail -j 1 --watch --watch-files "**/*.ts" --grep "$(TEST_GREP)"
 
+dist:: GOBIN=$(or $(shell go env GOBIN),$(shell go env GOPATH)/bin)
 dist::
 	go install -C cmd/pulumi-language-nodejs \
 		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -69,6 +69,7 @@ test_all:: test_fast test_auto test_go
 
 PULUMI_TEST_ORG ?= $(shell pulumi whoami --json | jq ".organizations[0]")
 
+dist:: GOBIN=$(or $(shell go env GOBIN),$(shell go env GOPATH)/bin)
 dist::
 	go install -C cmd/pulumi-language-python \
 		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/19250 we stopped setting `GOBIN` for the `dist` target in the makefiles for `sdk/{nodejs,python}`.  This is fine for the `go install` part, but are also using the same env variable to drop more scripts into this directory.  Having it not set breaks this target.  Fix that by re-adding setting the `GOBIN` variable for the target.