### PR TITLE
Format & lint pulumi.json

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -173,3 +173,27 @@ jobs:
           check-latest: true
       - run: |
           make lint_actions
+
+  pulumi-json:
+    name: Lint pulumi.json
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ fromJson(inputs.version-set).go }}
+          check-latest: true
+      - name: Set up Node ${{ fromJson(inputs.version-set).nodejs }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ fromJson(inputs.version-set).nodejs }}
+          cache: yarn
+          cache-dependency-path: sdk/nodejs/yarn.lock
+      - name: Ensure Node # We need to install Node.js deps so that biome is available
+        run: |
+          cd sdk/nodejs && make ensure
+      - run: |
+          make lint_pulumi_json

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,10 @@ lint_pulumi_json::
 	go run github.com/santhosh-tekuri/jsonschema/cmd/jv@v0.7.0 pkg/codegen/schema/pulumi.json
 	cd sdk/nodejs && yarn biome format ../../pkg/codegen/schema/pulumi.json
 
-lint_fix:: lint_golang_fix
+lint_pulumi_json_fix::
+	cd sdk/nodejs && yarn biome format --write ../../pkg/codegen/schema/pulumi.json
+
+lint_fix:: lint_golang_fix lint_pulumi_json_fix
 
 lint_golang:: lint_deps
 	$(eval GOLANGCI_LINT_CONFIG = $(shell pwd)/.golangci.yml)

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,8 @@ brew::
 lint:: .make/ensure/golangci-lint lint_golang lint_pulumi_json
 
 lint_pulumi_json::
+	# NOTE: github.com/santhosh-tekuri/jsonschema uses Go's regexp engine, but
+	# JSON schema says regexps should conform to ECMA 262.
 	go run github.com/santhosh-tekuri/jsonschema/cmd/jv@v0.7.0 pkg/codegen/schema/pulumi.json
 	cd sdk/nodejs && yarn biome format ../../pkg/codegen/schema/pulumi.json
 

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,11 @@ brew::
 	./scripts/brew.sh "${PROJECT}"
 
 .PHONY: lint_%
-lint:: .make/ensure/golangci-lint lint_golang
+lint:: .make/ensure/golangci-lint lint_golang lint_pulumi_json
+
+lint_pulumi_json::
+	go run github.com/santhosh-tekuri/jsonschema/cmd/jv@v0.7.0 pkg/codegen/schema/pulumi.json
+	cd sdk/nodejs && yarn biome format ../../pkg/codegen/schema/pulumi.json
 
 lint_fix:: lint_golang_fix
 

--- a/build/common.mk
+++ b/build/common.mk
@@ -249,6 +249,7 @@ format::
 		-path "./*/compilation_error/*" -or \
 		-path "./*/testdata/*" \
 	\) | xargs gofumpt -w
+	cd sdk/nodejs && yarn biome format --write ../../pkg/codegen/schema/pulumi.json
 
 .SECONDEXPANSION: # Needed by .make/ensure/% and .make/ensure/__%.
 

--- a/pkg/codegen/schema/pulumi.json
+++ b/pkg/codegen/schema/pulumi.json
@@ -110,35 +110,37 @@
                 "$ref": "#/$defs/token"
             }
         },
-	"dependencies": {
-	    "description": "A list of package descriptors that describes the set of dependencies for this package.",
-	    "type": "array",
-	    "items": {
-		"type": "object",
-		"properties": {
-		    "name": {
+        "dependencies": {
+            "description": "A list of package descriptors that describes the set of dependencies for this package.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
                         "description": "The unqualified name of the package (e.g. \"aws\", \"azure\", \"gcp\", \"kubernetes\", \"random\")",
                         "type": "string",
                         "pattern": "^[a-zA-Z][-a-zA-Z0-9_]*$"
-		    },
-		    "version": {
-			"description": "The version of the package. The version must be valid semver.",
-			"type": "string",
-			"pattern": "^v?(?<major>0|[1-9]\\d*)\\.(?<minor>0|[1-9]\\d*)\\.(?<patch>0|[1-9]\\d*)(?:-(?<prerelease>(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
-		    },
-		    "pluginDownloadURL": {
-			"description": "The URL to use when downloading the provider plugin binary.",
-			"type": "string"
-		    },
-		    "parameterization": {
-			"type": "object",
-			"allOf": [
-			    { "$ref": "#/$defs/parameterization" }
-			]
-		    }
-		}
-	    }
-	},
+                    },
+                    "version": {
+                        "description": "The version of the package. The version must be valid semver.",
+                        "type": "string",
+                        "pattern": "^v?(?<major>0|[1-9]\\d*)\\.(?<minor>0|[1-9]\\d*)\\.(?<patch>0|[1-9]\\d*)(?:-(?<prerelease>(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+                    },
+                    "pluginDownloadURL": {
+                        "description": "The URL to use when downloading the provider plugin binary.",
+                        "type": "string"
+                    },
+                    "parameterization": {
+                        "type": "object",
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/parameterization"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
         "provider": {
             "description": "The provider type for this package.",
             "$ref": "#/$defs/resourceSpec"
@@ -170,11 +172,11 @@
         "parameterization": {
             "description": "An optional object to define parameterization for the package.",
             "type": "object",
-	    "allOf": [
-		{
-		    "$ref": "#/$defs/parameterization"
-		}
-	    ]
+            "allOf": [
+                {
+                    "$ref": "#/$defs/parameterization"
+                }
+            ]
         },
         "allowedPackageNames": {
             "description": "A list of allowed package names in addition to the name property.",
@@ -185,9 +187,7 @@
         }
     },
     "additionalProperties": false,
-    "required": [
-        "name"
-    ],
+    "required": ["name"],
     "$defs": {
         "token": {
             "title": "Token",
@@ -201,32 +201,32 @@
                 "type": "string"
             }
         },
-	"parameterization": {
-	    "type": "object",
-	    "properties": {
-		"baseProvider": {
+        "parameterization": {
+            "type": "object",
+            "properties": {
+                "baseProvider": {
                     "type": "object",
                     "properties": {
-			"name": {
+                        "name": {
                             "description": "The unqualified name of the package (e.g. \"aws\", \"azure\", \"gcp\", \"kubernetes\", \"random\")",
                             "type": "string",
                             "pattern": "^[a-zA-Z][-a-zA-Z0-9_]*$"
-			},
-			"version": {
+                        },
+                        "version": {
                             "description": "The version of the package. The version must be valid semver.",
                             "type": "string",
                             "pattern": "^v?(?<major>0|[1-9]\\d*)\\.(?<minor>0|[1-9]\\d*)\\.(?<patch>0|[1-9]\\d*)(?:-(?<prerelease>(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
-			}
+                        }
                     },
                     "required": ["name", "version"],
                     "additionalProperties": false
-		},
-		"parameter": {
+                },
+                "parameter": {
                     "description": "The parameter for the provider.",
                     "type": "string",
                     "contentEncoding": "base64"
-		}
-	    }
+                }
+            }
         },
         "typeSpec": {
             "title": "Type Reference",
@@ -348,9 +348,7 @@
                                     }
                                 }
                             },
-                            "required": [
-                                "propertyName"
-                            ]
+                            "required": ["propertyName"]
                         },
                         "additionalProperties": false,
                         "items": false,
@@ -365,7 +363,9 @@
             "description": "Describes an object or resource property",
             "type": "object",
             "allOf": [
-                { "$ref": "#/$defs/typeSpec" }
+                {
+                    "$ref": "#/$defs/typeSpec"
+                }
             ],
             "properties": {
                 "description": {
@@ -443,7 +443,9 @@
                     "title": "Object Type Definition",
                     "type": "object",
                     "allOf": [
-                        { "$ref": "#/$defs/objectTypeSpec" }
+                        {
+                            "$ref": "#/$defs/objectTypeSpec"
+                        }
                     ],
                     "properties": {
                         "type": {
@@ -451,7 +453,9 @@
                         }
                     }
                 },
-                { "$ref": "#/$defs/enumTypeSpec" }
+                {
+                    "$ref": "#/$defs/enumTypeSpec"
+                }
             ]
         },
         "objectTypeSpec": {
@@ -503,7 +507,7 @@
             "title": "Enum Type Definition",
             "description": "Describes an enum type",
             "type": "object",
-            "properties" :{
+            "properties": {
                 "type": {
                     "description": "The underlying primitive type of the enum",
                     "type": "string",
@@ -544,7 +548,9 @@
             "description": "Describes a resource or component.",
             "type": "object",
             "allOf": [
-                { "$ref": "#/$defs/objectTypeSpec" }
+                {
+                    "$ref": "#/$defs/objectTypeSpec"
+                }
             ],
             "properties": {
                 "description": {
@@ -627,15 +633,23 @@
                 "outputs": {
                     "description": "Specifies the return type of the function definition.",
                     "anyOf": [
-                        { "$ref": "#/$defs/typeSpec" },
-                        { "$ref": "#/$defs/objectTypeSpec" }
+                        {
+                            "$ref": "#/$defs/typeSpec"
+                        },
+                        {
+                            "$ref": "#/$defs/objectTypeSpec"
+                        }
                     ]
                 },
                 "returnType": {
                     "description": "Specifies the return type of the function definition.",
                     "anyOf": [
-                        { "$ref": "#/$defs/typeSpec" },
-                        { "$ref": "#/$defs/objectTypeSpec" }
+                        {
+                            "$ref": "#/$defs/typeSpec"
+                        },
+                        {
+                            "$ref": "#/$defs/objectTypeSpec"
+                        }
                     ]
                 },
                 "deprecationMessage": {


### PR DESCRIPTION
Use biome to format `pulumi.json` and https://github.com/santhosh-tekuri/jsonschema to validate it.

I picked  `github.com/santhosh-tekuri/jsonschema` because we are already using this in `developer-docs/utils/jsonschema2md.go`.

I picked `biome` because that's the formatter we use for the Node.js SDK and it supports formatting JSON files.