### PR TITLE
Update Dependencies in the JSON schema

### DIFF
--- a/changelog/pending/20250423--pkg--update-dependencies-in-the-json-schema.yaml
+++ b/changelog/pending/20250423--pkg--update-dependencies-in-the-json-schema.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pkg
+  description: Update Dependencies in the JSON schema

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -35,19 +35,27 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+// ParameterizationDescriptor is the serializable description of a dependency's parameterization.
 type ParameterizationDescriptor struct {
-	Name    string         // the name of the package.
-	Version semver.Version // the version of the package.
-	Value   []byte         // the parameter value of the package.
+	// Name is the name of the package.
+	Name string `json:"name" yaml:"name"`
+	// Version is the version of the package.
+	Version semver.Version `json:"version" yaml:"version"`
+	// Value is the parameter value of the package.
+	Value []byte `json:"value" yaml:"value"`
 }
 
 // PackageDescriptor is a descriptor for a package, this is similar to a plugin spec but also contains parameterization
 // info.
 type PackageDescriptor struct {
-	Name             string                      // the simple name of the plugin.
-	Version          *semver.Version             // the plugin's semantic version, if present.
-	DownloadURL      string                      // an optional server to use when downloading this plugin.
-	Parameterization *ParameterizationDescriptor // the optional parameterization of the package.
+	// Name is the simple name of the plugin.
+	Name string `json:"name" yaml:"name"`
+	// Version is the optional version of the package.
+	Version *semver.Version `json:"version,omitempty" yaml:"version,omitempty"`
+	// DownloadURL is the optional URL to use when downloading the provider plugin binary.
+	DownloadURL string `json:"downloadURL,omitempty" yaml:"downloadURL,omitempty"`
+	// Parameterization is the optional parameterization of the package.
+	Parameterization *ParameterizationDescriptor `json:"parameterization,omitempty" yaml:"parameterization,omitempty"`
 }
 
 // PackageName returns the name of the package.

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -50,7 +50,7 @@ type ParameterizationDescriptor struct {
 type PackageDescriptor struct {
 	// Name is the simple name of the plugin.
 	Name string `json:"name" yaml:"name"`
-	// Version is the optional version of the package.
+	// Version is the optional version of the plugin.
 	Version *semver.Version `json:"version,omitempty" yaml:"version,omitempty"`
 	// DownloadURL is the optional URL to use when downloading the provider plugin binary.
 	DownloadURL string `json:"downloadURL,omitempty" yaml:"downloadURL,omitempty"`

--- a/pkg/codegen/schema/pulumi.json
+++ b/pkg/codegen/schema/pulumi.json
@@ -122,23 +122,38 @@
                         "pattern": "^[a-zA-Z][-a-zA-Z0-9_]*$"
                     },
                     "version": {
-                        "description": "The version of the package. The version must be valid semver.",
+                        "description": "The version of the package. The version must be valid semver if present.",
                         "type": "string",
                         "pattern": "^v?(?<major>0|[1-9]\\d*)\\.(?<minor>0|[1-9]\\d*)\\.(?<patch>0|[1-9]\\d*)(?:-(?<prerelease>(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
                     },
                     "pluginDownloadURL": {
-                        "description": "The URL to use when downloading the provider plugin binary.",
+                        "description": "The optional URL to use when downloading the provider plugin binary.",
                         "type": "string"
                     },
                     "parameterization": {
                         "type": "object",
-                        "allOf": [
-                            {
-                                "$ref": "#/$defs/parameterization"
+                        "description": "An optional object to define parameterization for the package.",
+                        "properties": {
+                            "name": {
+                                "description": "The unqualified name of the package (e.g. \"aws\", \"azure\", \"gcp\", \"kubernetes\", \"random\")",
+                                "type": "string",
+                                "pattern": "^[a-zA-Z][-a-zA-Z0-9_]*$"
+                            },
+                            "version": {
+                                "description": "The version of the package. The version must be valid semver.",
+                                "type": "string",
+                                "pattern": "^v?(?<major>0|[1-9]\\d*)\\.(?<minor>0|[1-9]\\d*)\\.(?<patch>0|[1-9]\\d*)(?:-(?<prerelease>(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+                            },
+                            "parameter": {
+                                "description": "The parameter for the provider.",
+                                "type": "string",
+                                "contentEncoding": "base64"
                             }
-                        ]
+                        },
+                        "required": ["name", "version", "parameter"]
                     }
-                }
+                },
+                "required": ["name"]
             }
         },
         "provider": {

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2579,8 +2579,8 @@ func TestNodejsComponentProviderGetSchema(t *testing.T) {
 	// Check the dependencies
 	dependencies := schema["dependencies"].([]any)
 	dep := dependencies[0].(map[string]any)
-	require.Equal(t, "random", dep["Name"].(string))
-	require.Equal(t, "4.18.0", dep["Version"].(string))
+	require.Equal(t, "random", dep["name"].(string))
+	require.Equal(t, "4.18.0", dep["version"].(string))
 
 	// Check the component schema
 	expectedJSON := `{


### PR DESCRIPTION
We added the dependencies field to the Pulumi schema in https://github.com/pulumi/pulumi/pull/19071, but after some refactoring we ended up with the wrong definition in `pulumi.json`. Update this to match the reality.