### PR TITLE
introduce `pulumi package info`

### DIFF
--- a/changelog/pending/20250423--cli-package--introduce-pulumi-package-info-to-show-information-about-a-package.yaml
+++ b/changelog/pending/20250423--cli-package--introduce-pulumi-package-info-to-show-information-about-a-package.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/package
+  description: Introduce `pulumi package info` to show information about a package

--- a/pkg/cmd/pulumi/packagecmd/package.go
+++ b/pkg/cmd/pulumi/packagecmd/package.go
@@ -36,6 +36,7 @@ Install and configure Pulumi packages and their plugins and SDKs.`,
 		newPackagePackSdkCmd(),
 		newPackageAddCmd(),
 		newPackagePublishCmd(),
+		newPackageInfoCmd(),
 	)
 	return cmd
 }

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -153,7 +153,7 @@ func showProviderInfo(spec *schema.PackageSpec, args []string, stdout io.Writer)
 }
 
 func summaryFromDescription(description string) string {
-	// The description of a resource is markdown formatted.  We only want to provide aa
+	// The description of a resource is markdown formatted.  We only want to provide a
 	// short summary of the description, so we will only show the first paragraph. Note
 	// that an empty newline denotes the end of the paragraph, but a regular newline might
 	// still be part of the first paragraph, and may be in the middle of a sentence.

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -180,6 +180,7 @@ func simplifyModuleName(resourceName string) (string, error) {
 
 func showModuleInfo(spec *schema.PackageSpec, moduleName string, stdout io.Writer) error {
 	fmt.Fprintf(stdout, bold("Name")+": %s\n", spec.Name)
+	fmt.Fprintf(stdout, bold("Module")+": %s\n", moduleName)
 	fmt.Fprintf(stdout, bold("Version")+": %s\n", spec.Version)
 	fmt.Fprintf(stdout, bold("Description")+": %s\n", summaryFromDescription(spec.Description))
 
@@ -189,11 +190,12 @@ func showModuleInfo(spec *schema.PackageSpec, moduleName string, stdout io.Write
 		if err != nil {
 			return err
 		}
+		fullModuleName := strings.Split(res, ":")[1]
 		split := strings.Split(simplifiedName, ":")
 		if len(split) < 3 {
 			return fmt.Errorf("invalid resource name %q", res)
 		}
-		if split[1] != moduleName {
+		if fullModuleName != moduleName && split[1] != moduleName {
 			continue
 		}
 		resources[split[2]] = spec

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -72,10 +72,8 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 				return showProviderInfo(spec, args, stdout)
 			} else if resource == "" {
 				return showModuleInfo(spec, module, stdout)
-			} else {
-				return showResourceInfo(spec, module, resource, stdout)
 			}
-			return nil
+			return showResourceInfo(spec, module, resource, stdout)
 		},
 	}
 

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -1,0 +1,283 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packagecmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/maputil"
+	"github.com/spf13/cobra"
+)
+
+func newPackageInfoCmd() *cobra.Command {
+	var module string
+	var resource string
+	cmd := &cobra.Command{
+		Use:   "info <provider|schema|path> [provider-parameter...]",
+		Args:  cmdutil.MinimumNArgs(1),
+		Short: "Show information about a package",
+		Long: `Show information about a package
+
+This command shows information about a package, its modules and detailed resource info.
+
+The <provider> argument can be specified in the same way as in 'pulumi package add'.
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			wd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			sink := cmdutil.Diag()
+			pctx, err := plugin.NewContext(sink, sink, nil, nil, wd, nil, false, nil)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				contract.IgnoreError(pctx.Close())
+			}()
+
+			pkg, err := SchemaFromSchemaSource(pctx, args[0], args[1:])
+			if err != nil {
+				return err
+			}
+			spec, err := pkg.MarshalSpec()
+			if err != nil {
+				return err
+			}
+
+			stdout := cmd.OutOrStdout()
+
+			if resource != "" && module == "" {
+				return fmt.Errorf("resource name %q specified without module", resource)
+			}
+
+			if module == "" {
+				showProviderInfo(spec, args, stdout)
+			} else if resource == "" {
+				return showModuleInfo(spec, module, stdout)
+			} else {
+				return showResourceInfo(spec, module, resource, stdout)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&module, "module", "m", "", "Module name")
+	cmd.Flags().StringVarP(&resource, "resource", "r", "", "Resource name")
+
+	return cmd
+}
+
+func showProviderInfo(spec *schema.PackageSpec, args []string, stdout io.Writer) {
+	fmt.Fprintf(stdout, "Provider: %s (%s)\n", spec.Name, spec.Version)
+	fmt.Fprintf(stdout, "  Description: %s\n", summaryFromDescription(spec.Description))
+	fmt.Fprintf(stdout, "Total resources: %d\n", len(spec.Resources))
+
+	modules := make(map[string]struct{})
+	for res := range spec.Resources {
+		split := strings.Split(res, ":")
+		if len(split) < 2 {
+			continue
+		}
+		moduleSplit := strings.Split(split[1], "/")
+		modules[moduleSplit[0]] = struct{}{}
+	}
+	fmt.Fprintf(stdout, "Total modules: %d\n", len(modules))
+
+	fmt.Fprintln(stdout)
+	fmt.Fprintf(
+		stdout,
+		"Use 'pulumi package info --module <module> %s' to list resources in a module\n",
+		strings.Join(args, " "))
+	fmt.Fprintf(
+		stdout,
+		"Use 'pulumi package info --module <module> --resource <resource> %s' for detailed resource info\n",
+		strings.Join(args, " "))
+}
+
+func summaryFromDescription(description string) string {
+	// The description of a resource is markdown formatted.  We only want to provide aa
+	// short summary of the description, so we will only show the first paragraph. Note
+	// that an empty newline denotes the end of the paragraph, but a regular newline might
+	// still be part of the first paragraph, and may be in the middle of a sentence.
+	// Therefore we split the description into lines, and join the first paragraph, replacing
+	// newlines with spaces.
+	summary := ""
+	for _, line := range strings.Split(description, "\n") {
+		if strings.TrimSpace(line) == "" {
+			break
+		}
+		summary += line + " "
+	}
+	return strings.TrimSpace(summary)
+}
+
+func simplifyModuleName(resourceName string) (string, error) {
+	split := strings.Split(resourceName, ":")
+	if len(split) < 3 {
+		return "", fmt.Errorf("invalid resource name %q", resourceName)
+	}
+	moduleSplit := strings.Split(split[1], "/")
+	return split[0] + ":" + moduleSplit[0] + ":" + split[2], nil
+}
+
+func showModuleInfo(spec *schema.PackageSpec, moduleName string, stdout io.Writer) error {
+	fmt.Fprintf(stdout, "Module: %s:%s\n", spec.Name, moduleName)
+
+	resources := make(map[string]schema.ResourceSpec)
+	for res, spec := range spec.Resources {
+		simplifiedName, err := simplifyModuleName(res)
+		if err != nil {
+			return err
+		}
+		split := strings.Split(simplifiedName, ":")
+		if len(split) < 3 {
+			return fmt.Errorf("invalid resource name %q", res)
+		}
+		if split[1] != moduleName {
+			continue
+		}
+		resources[split[2]] = spec
+	}
+
+	if len(resources) == 0 {
+		return fmt.Errorf("module %q not found", moduleName)
+	}
+	fmt.Fprintf(stdout, "Resources: %d\n", len(resources))
+
+	fmt.Fprintln(stdout)
+	for _, name := range maputil.SortedKeys(resources) {
+		fmt.Fprintf(stdout, " - %s: %s\n", name, summaryFromDescription(resources[name].Description))
+	}
+	return nil
+}
+
+func showResourceInfo(spec *schema.PackageSpec, moduleName, resourceName string, stdout io.Writer) error {
+	fullResourceName := fmt.Sprintf("%s:%s:%s", spec.Name, moduleName, resourceName)
+
+	fmt.Fprintf(stdout, "Resource: %s\n", fullResourceName)
+
+	res, ok := spec.Resources[fullResourceName]
+	if !ok {
+		for name, r := range spec.Resources {
+			simplifiedName, err := simplifyModuleName(name)
+			if err != nil {
+				return err
+			}
+			if fullResourceName == simplifiedName {
+				res = r
+				ok = true
+				break
+			}
+		}
+	}
+	if !ok {
+		return fmt.Errorf("resource %q not found", fullResourceName)
+	}
+
+	fmt.Fprintln(stdout)
+	fmt.Fprintln(stdout, "Input Properties:")
+	for _, name := range maputil.SortedKeys(res.InputProperties) {
+		prop := res.InputProperties[name]
+		optionalStr := ""
+		if !slices.Contains(res.RequiredInputs, name) {
+			optionalStr = " (optional)"
+		}
+		typ, err := getType(spec, prop.TypeSpec)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(stdout, " - %s (%s%s): %s\n",
+			name, typ, optionalStr, summaryFromDescription(prop.Description))
+	}
+
+	fmt.Fprintln(stdout)
+
+	fmt.Fprintln(stdout, "Output Properties:")
+	for _, name := range maputil.SortedKeys(res.Properties) {
+		prop := res.Properties[name]
+		presentStr := ""
+		if slices.Contains(res.Required, name) {
+			presentStr = " (always present)"
+		}
+		typ, err := getType(spec, prop.TypeSpec)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(stdout, " - %s (%s%s): %s\n",
+			name, typ, presentStr, summaryFromDescription(prop.Description))
+	}
+	return nil
+}
+
+func getType(spec *schema.PackageSpec, prop schema.TypeSpec) (string, error) {
+	typ := prop.Type
+	if typ != "" && typ != "object" && typ != "array" {
+		return typ, nil
+	}
+	if prop.Type == "array" {
+		if prop.Items == nil {
+			return "[]unknown", nil
+		}
+		typ, err := getType(spec, *prop.Items)
+		if err != nil {
+			return "", err
+		}
+		return "[]" + typ, nil
+	}
+	if prop.Ref != "" {
+		if strings.HasPrefix(prop.Ref, "#/types/") {
+			ref := strings.TrimPrefix(prop.Ref, "#/types/")
+			ref = strings.ReplaceAll(ref, "%2F", "/")
+			if typeSpec, ok := spec.Types[ref]; ok {
+				if len(typeSpec.Enum) > 0 {
+					return fmt.Sprintf("enum(%s){%s}",
+						typeSpec.Type, formatEnumValues(typeSpec.Enum)), nil
+				}
+				simplifiedName, err := simplifyModuleName(ref)
+				if err != nil {
+					return "", err
+				}
+				split := strings.Split(simplifiedName, ":")
+				return split[2], nil
+			}
+		}
+		return prop.Ref, nil
+	}
+	if prop.Ref != "" {
+		return prop.Ref, nil
+	}
+	return "unknown", nil
+}
+
+func formatEnumValues(enum []schema.EnumValueSpec) string {
+	var values []string
+	for _, v := range enum {
+		if v.Name != "" {
+			values = append(values, v.Name)
+		} else if v.Value != nil {
+			values = append(values, fmt.Sprintf("%v", v.Value))
+		}
+	}
+	return strings.Join(values, ", ")
+}

--- a/pkg/cmd/pulumi/packagecmd/package_info_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info_test.go
@@ -164,6 +164,7 @@ func TestModuleInfo(t *testing.T) {
 	err = cmd.Execute()
 	require.NoError(t, err)
 	require.Equal(t, `\x1b[1mName\x1b[0m: test
+\x1b[1mModule\x1b[0m: index
 \x1b[1mVersion\x1b[0m: 0.0.1
 \x1b[1mDescription\x1b[0m: test description markdown formatted
 \x1b[1mResources\x1b[0m: 2

--- a/pkg/cmd/pulumi/packagecmd/package_info_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info_test.go
@@ -1,0 +1,186 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packagecmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func generateSchema(t *testing.T) []byte {
+	spec := &schema.PackageSpec{
+		Name:    "test",
+		Version: "0.0.1",
+		Description: `test description
+markdown formatted
+
+another paragraph`,
+		Resources: map[string]schema.ResourceSpec{
+			"test:index:Test": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Description: "test\nresource\ndescription\n\nanother paragraph",
+					Properties: map[string]schema.PropertySpec{
+						"prop1": {
+							Description: "this is a string property",
+							TypeSpec: schema.TypeSpec{
+								Type: "string",
+							},
+						},
+						"arrayProp": {
+							Description: "this is an array property",
+							TypeSpec: schema.TypeSpec{
+								Type: "array",
+								Items: &schema.TypeSpec{
+									Ref: "#/types/test:index:TestType",
+								},
+							},
+						},
+						"enumProp": {
+							Description: "this is an enum property",
+							TypeSpec: schema.TypeSpec{
+								Ref: "#/types/test:index:EnumType",
+							},
+						},
+					},
+					Required: []string{"prop1"},
+				},
+				InputProperties: map[string]schema.PropertySpec{
+					"prop1": {
+						Description: "this is a string property",
+						TypeSpec: schema.TypeSpec{
+							Type: "string",
+						},
+					},
+				},
+			},
+			"test:index:Test2": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Description: "this is another test resource",
+				},
+			},
+			"test:another/Test:Test": {},
+		},
+		Types: map[string]schema.ComplexTypeSpec{
+			"test:index:TestType": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Description: "this is a test type",
+					Type:        "object",
+				},
+			},
+			"test:index:EnumType": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Description: "this is an enum type",
+					Type:        "string",
+				},
+				Enum: []schema.EnumValueSpec{
+					{
+						Name:  "EnumValue1",
+						Value: "value1",
+					},
+					{
+						Value: "value2",
+					},
+				},
+			},
+		},
+	}
+	marshalled, err := json.Marshal(spec)
+	require.NoError(t, err)
+	return marshalled
+}
+
+func TestPackageInfo(t *testing.T) {
+	t.Parallel()
+
+	schema := generateSchema(t)
+	tmpDir := t.TempDir()
+	schemaPath := filepath.Join(tmpDir, "schema.json")
+
+	err := os.WriteFile(schemaPath, schema, 0o600)
+	require.NoError(t, err)
+
+	cmd := newPackageInfoCmd()
+	cmd.SetArgs([]string{schemaPath})
+	var output bytes.Buffer
+	cmd.SetOutput(&output)
+	err = cmd.Execute()
+	require.NoError(t, err)
+	require.Equal(t, fmt.Sprintf(`Provider: test (0.0.1)
+  Description: test description markdown formatted
+Total resources: 3
+Total modules: 2
+
+Use 'pulumi package info --module <module> %[1]s' to list resources in a module
+Use 'pulumi package info --module <module> --resource <resource> %[1]s' for detailed resource info
+`, schemaPath), output.String())
+}
+
+func TestModuleInfo(t *testing.T) {
+	t.Parallel()
+
+	schema := generateSchema(t)
+	tmpDir := t.TempDir()
+	schemaPath := filepath.Join(tmpDir, "schema.json")
+
+	err := os.WriteFile(schemaPath, schema, 0o600)
+	require.NoError(t, err)
+
+	cmd := newPackageInfoCmd()
+	cmd.SetArgs([]string{"--module", "index", schemaPath})
+	var output bytes.Buffer
+	cmd.SetOutput(&output)
+	err = cmd.Execute()
+	require.NoError(t, err)
+	require.Equal(t, `Module: test:index
+Resources: 2
+
+ - Test: test resource description
+ - Test2: this is another test resource
+`, output.String())
+}
+
+func TestResourceInfo(t *testing.T) {
+	t.Parallel()
+
+	schema := generateSchema(t)
+	tmpDir := t.TempDir()
+	schemaPath := filepath.Join(tmpDir, "schema.json")
+
+	err := os.WriteFile(schemaPath, schema, 0o600)
+	require.NoError(t, err)
+	cmd := newPackageInfoCmd()
+	cmd.SetArgs([]string{"--module", "index", "--resource", "Test", schemaPath})
+	var output bytes.Buffer
+	cmd.SetOutput(&output)
+	err = cmd.Execute()
+	require.NoError(t, err)
+	require.Equal(t, `Resource: test:index:Test
+
+Input Properties:
+ - prop1 (string (optional)): this is a string property
+
+Output Properties:
+ - arrayProp ([]TestType): this is an array property
+ - enumProp (enum(string){EnumValue1, value2}): this is an enum property
+ - prop1 (string (always present)): this is a string property
+`, output.String())
+}

--- a/pkg/cmd/pulumi/packagecmd/package_info_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -124,14 +125,17 @@ func TestPackageInfo(t *testing.T) {
 	cmd.SetOutput(&output)
 	err = cmd.Execute()
 	require.NoError(t, err)
-	require.Equal(t, fmt.Sprintf(`Provider: test (0.0.1)
-  Description: test description markdown formatted
-Total resources: 3
-Total modules: 2
+	require.Equal(t, fmt.Sprintf(`\x1b[1mName\x1b[0m: test
+\x1b[1mVersion\x1b[0m: 0.0.1
+\x1b[1mDescription\x1b[0m: test description markdown formatted
+\x1b[1mTotal resources\x1b[0m 3
+\x1b[1mTotal modules\x1b[0m: 2
 
-Use 'pulumi package info --module <module> %[1]s' to list resources in a module
-Use 'pulumi package info --module <module> --resource <resource> %[1]s' for detailed resource info
-`, schemaPath), output.String())
+\x1b[1mModules\x1b[0m: another, index
+
+Use 'pulumi package info %[1]s --module <module>' to list resources in a module
+Use 'pulumi package info %[1]s --resource <resource>  --module <module>' for detailed resource info
+`, schemaPath), strings.ReplaceAll(output.String(), "\x1b", "\\x1b"))
 }
 
 func TestModuleInfo(t *testing.T) {
@@ -150,12 +154,14 @@ func TestModuleInfo(t *testing.T) {
 	cmd.SetOutput(&output)
 	err = cmd.Execute()
 	require.NoError(t, err)
-	require.Equal(t, `Module: test:index
-Resources: 2
+	require.Equal(t, `\x1b[1mName\x1b[0m: test
+\x1b[1mVersion\x1b[0m: 0.0.1
+\x1b[1mDescription\x1b[0m: test description markdown formatted
+\x1b[1mResources\x1b[0m: 2
 
- - Test: test resource description
- - Test2: this is another test resource
-`, output.String())
+ - \x1b[1mTest\x1b[0m: test resource description
+ - \x1b[1mTest2\x1b[0m: this is another test resource
+`, strings.ReplaceAll(output.String(), "\x1b", "\\x1b"))
 }
 
 func TestResourceInfo(t *testing.T) {
@@ -173,14 +179,16 @@ func TestResourceInfo(t *testing.T) {
 	cmd.SetOutput(&output)
 	err = cmd.Execute()
 	require.NoError(t, err)
-	require.Equal(t, `Resource: test:index:Test
+	require.Equal(t, `\x1b[1mResource\x1b[0m: test:index:Test
+\x1b[1mDescription\x1b[0m: test resource description
 
-Input Properties:
- - prop1 (string (optional)): this is a string property
+\x1b[1mInputs\x1b[0m:
+ - \x1b[1mprop1\x1b[0m (\x1b[4mstring\x1b[0m\x1b[4m*\x1b[0m): this is a string property
+Inputs marked with '*' are required
 
-Output Properties:
- - arrayProp ([]TestType): this is an array property
- - enumProp (enum(string){EnumValue1, value2}): this is an enum property
- - prop1 (string (always present)): this is a string property
-`, output.String())
+\x1b[1mOutputs\x1b[0m:
+(All input properties are implicitly available as output properties)
+ - \x1b[1marrayProp\x1b[0m (\x1b[4m[]TestType\x1b[0m\x1b[4m\x1b[0m): this is an array property
+ - \x1b[1menumProp\x1b[0m (\x1b[4menum(string){EnumValue1, value2}\x1b[0m\x1b[4m\x1b[0m): this is an enum property
+`, strings.ReplaceAll(output.String(), "\x1b", "\\x1b"))
 }

--- a/pkg/cmd/pulumi/packagecmd/package_info_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info_test.go
@@ -61,6 +61,15 @@ another paragraph`,
 								Ref: "#/types/test:index:EnumType",
 							},
 						},
+						"mapProp": {
+							Description: "this is a map property",
+							TypeSpec: schema.TypeSpec{
+								Type: "object",
+								AdditionalProperties: &schema.TypeSpec{
+									Type: "string",
+								},
+							},
+						},
 					},
 					Required: []string{"prop1"},
 				},
@@ -190,5 +199,6 @@ Inputs marked with '*' are required
 (All input properties are implicitly available as output properties)
  - \x1b[1marrayProp\x1b[0m (\x1b[4m[]TestType\x1b[0m\x1b[4m\x1b[0m): this is an array property
  - \x1b[1menumProp\x1b[0m (\x1b[4menum(string){EnumValue1, value2}\x1b[0m\x1b[4m\x1b[0m): this is an enum property
+ - \x1b[1mmapProp\x1b[0m (\x1b[4mmap[string]string\x1b[0m\x1b[4m\x1b[0m): this is a map property
 `, strings.ReplaceAll(output.String(), "\x1b", "\\x1b"))
 }


### PR DESCRIPTION
Introduce a new `pulumi package info` command that allows the user to get details of a package without having to read through the whole schema.  It filters out some details, and intentionally simplifies some of it to make it more accessible.

Examples:
```
$ pulumi package info aws
Provider: aws (6.75.0)
  Description: A Pulumi package for creating and managing Amazon Web Services (AWS) cloud resources.
Total resources: 1502
Total modules: 214

Use 'pulumi package info --module <module> aws' to list resources in a module
Use 'pulumi package info --module <module> --resource <resource> aws' for detailed resource info
```

```
$ pulumi package info aws --module s3
Module: aws:s3
Resources: 27

 - AccessPoint: Provides a resource to manage an S3 Access Point.
 - AccountPublicAccessBlock: Manages S3 account-level Public Access Block configuration. For more information about these settings, see the [AWS S3 Block Public Access documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html).
 - AnalyticsConfiguration: Provides a S3 bucket [analytics configuration](https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html) resource.
 - Bucket: Provides a S3 bucket resource.
 - BucketAccelerateConfigurationV2: Provides an S3 bucket accelerate configuration resource. See the [Requirements for using Transfer Acceleration](https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration.html#transfer-acceleration-requirements) for more details.
 - BucketAclV2: Provides an S3 bucket ACL resource.
 - BucketCorsConfigurationV2: Provides an S3 bucket CORS configuration resource. For more information about CORS, go to [Enabling Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/userguide/cors.html) in the Amazon S3 User Guide.
[....]
```

```
$ pulumi package info aws --module s3 --resource Bucket
Resource: aws:s3:Bucket

Input Properties:
 - accelerationStatus (string (optional)): Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
 - acl (string (optional)): The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
 - arn (string (optional)): The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
 - bucket (string (optional)): The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 - bucketPrefix (string (optional)): Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 - corsRules ([]BucketCorsRule (optional)): A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
[...]

Output Properties:
 - accelerationStatus (string (always present)): Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
 - acl (string): The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
 - arn (string (always present)): The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
 - bucket (string (always present)): The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
[...]
```
Fixes https://github.com/pulumi/pulumi/issues/19097