### PR TITLE
Remove the 'deletes' field, just use 'dones'

### DIFF
--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -638,7 +638,8 @@ func (sm *SnapshotManager) snap() *deploy.Snapshot {
 	// Start with a copy of the resources produced during the evaluation of the current plan.
 	resources := make([]*resource.State, 0, len(sm.resources))
 
-	// if any resources have been deleted we need to filter them out here
+	// If any resources are "done", we need to filter them out here. These could be resources that have been later
+	// deleted, or had some other operation performed on them such as an import then an update.
 	for _, res := range sm.resources {
 		if !sm.dones[res] {
 			resources = append(resources, res)

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -63,22 +63,22 @@ type SnapshotPersister interface {
 // This is subtle and a little confusing. The reason for this is that the engine directly mutates resource objects
 // that it creates and expects those mutations to be persisted directly to the snapshot.
 type SnapshotManager struct {
-	persister        SnapshotPersister        // The persister responsible for invalidating and persisting the snapshot
-	baseSnapshot     *deploy.Snapshot         // The base snapshot for this plan
-	secretsManager   secrets.Manager          // The default secrets manager to use
-	resources        []*resource.State        // The list of resources operated upon by this plan
-	operations       []resource.Operation     // The set of operations known to be outstanding in this plan
-	dones            map[*resource.State]bool // The set of resources that have been operated upon already by this plan
+	persister      SnapshotPersister    // The persister responsible for invalidating and persisting the snapshot
+	baseSnapshot   *deploy.Snapshot     // The base snapshot for this plan
+	secretsManager secrets.Manager      // The default secrets manager to use
+	resources      []*resource.State    // The list of resources operated upon by this plan
+	operations     []resource.Operation // The set of operations known to be outstanding in this plan
+
+	// The set of resources that have been operated upon already by this plan. These resources could also have
+	// been added to `resources` by other operations but need to be filtered out before writing the snapshot.
+	dones map[*resource.State]bool
+
 	completeOps      map[*resource.State]bool // The set of resources that have completed their operation
 	mutationRequests chan<- mutationRequest   // The queue of mutation requests, to be retired serially by the manager
 	cancel           chan bool                // A channel used to request cancellation of any new mutation requests.
 	done             <-chan error             // A channel that sends a single result when the manager has shut down.
 
 	refreshDeletes map[resource.URN]bool // The set of resources that have been deleted by a refresh in this plan.
-
-	// The set of resources that have been deleted. These resources could also have been added to `resources`
-	// by other operations but need to be filtered out before writing the snapshot.
-	deletes map[*resource.State]bool
 }
 
 var _ engine.SnapshotManager = (*SnapshotManager)(nil)
@@ -444,19 +444,6 @@ func (dsm *deleteSnapshotMutation) End(step deploy.Step, successful bool) error 
 				step.Old().Protect, step.Op())
 
 			if !step.Old().PendingReplacement {
-				// If this is a delete-replace operation, we don't want to mark the resource as deleted
-				// because we want to keep the new resource. If this is a normal delete/discard operation we
-				// need to add the resource to the "deletes" set so that we can filter it out when writing the
-				// snapshot.
-				op := step.Op()
-				contract.Assertf(
-					op == deploy.OpDiscardReplaced || op == deploy.OpReadDiscard ||
-						op == deploy.OpDeleteReplaced || op == deploy.OpDelete,
-					"unexpected step.Op(): %q", op)
-
-				if op == deploy.OpDelete || op == deploy.OpReadDiscard {
-					dsm.manager.deletes[step.Old()] = true
-				}
 				dsm.manager.markDone(step.Old())
 			}
 		}
@@ -653,7 +640,7 @@ func (sm *SnapshotManager) snap() *deploy.Snapshot {
 
 	// if any resources have been deleted we need to filter them out here
 	for _, res := range sm.resources {
-		if !sm.deletes[res] {
+		if !sm.dones[res] {
 			resources = append(resources, res)
 		}
 	}
@@ -826,7 +813,6 @@ func NewSnapshotManager(
 		mutationRequests: mutationRequests,
 		cancel:           cancel,
 		done:             done,
-		deletes:          make(map[*resource.State]bool),
 		refreshDeletes:   make(map[resource.URN]bool),
 	}
 

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -1095,7 +1095,7 @@ func TestRecordingSameFailure(t *testing.T) {
 		resourceA,
 	})
 	manager, sp := MockSetup(t, snap)
-	step := deploy.NewSameStep(nil, nil, resourceA, resourceA)
+	step := deploy.NewSameStep(nil, nil, resourceA, resourceA.Copy())
 	mutation, err := manager.BeginMutation(step)
 	require.NoError(t, err)
 

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -1064,7 +1064,7 @@ func TestRegisterOutputs(t *testing.T) {
 	require.Empty(t, sp.SavedSnapshots)
 
 	// The step here is not important.
-	step := deploy.NewSameStep(nil, nil, resourceA, resourceA)
+	step := deploy.NewSameStep(nil, nil, resourceA, resourceA.Copy())
 	err := manager.RegisterResourceOutputs(step)
 	require.NoError(t, err)
 

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -89,6 +89,8 @@ type SameStep struct {
 var _ Step = (*SameStep)(nil)
 
 func NewSameStep(deployment *Deployment, reg RegisterResourceEvent, old, new *resource.State) Step {
+	contract.Requiref(old != new, "old and new", "must not be the same")
+
 	contract.Requiref(old != nil, "old", "must not be nil")
 	contract.Requiref(old.URN != "", "old", "must have a URN")
 	contract.Requiref(old.ID != "" || !old.Custom, "old", "must have an ID if it is custom")
@@ -98,7 +100,7 @@ func NewSameStep(deployment *Deployment, reg RegisterResourceEvent, old, new *re
 
 	contract.Requiref(new != nil, "new", "must not be nil")
 	contract.Requiref(new.URN != "", "new", "must have a URN")
-	contract.Requiref(new == old || new.ID == "", "new", "must not have an ID")
+	contract.Requiref(new.ID == "", "new", "must not have an ID")
 	contract.Requiref(!new.Custom || new.Provider != "" || providers.IsProviderType(new.Type),
 		"new", "must have or be a provider if it is a custom resource")
 	contract.Requiref(!new.Delete, "new", "must not be marked for deletion")

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1326,7 +1326,9 @@ func (sg *stepGenerator) continueStepsFromRefresh(event ContinueResourceRefreshE
 					}
 				}
 
-				rootStep := NewSameStep(sg.deployment, event, old, old)
+				new := old.Copy()
+				new.ID = ""
+				rootStep := NewSameStep(sg.deployment, event, old, new)
 				steps = append(steps, rootStep)
 				return steps, nil
 			}


### PR DESCRIPTION
Rather than tracking deletes as a special case we can just treat them the same as things being "done" generally. This is really useful when we start allowing multiple operations per-resource (e.g. import then update) as the done semantics just work.

There were comments about "If this is a delete-replace operation, we don't want to mark the resource as deleted because we want to keep the new resource." but I can't recall the reasoning for those comments and removing them hasn't broken any tests. If anyone can come up with a test case that depended on these things share, but otherwise I think this is safe.

The only other change needed was when we make `SameSteps` the two state pointers have to be different objects. This requires a copy in `getDependencySteps`. I've also added an assert to the same step constructor to ensure we don't break that.