### PR TITLE
Use the new property.Value system for plugin config

### DIFF
--- a/pkg/engine/lifecycletest/analyzer_test.go
+++ b/pkg/engine/lifecycletest/analyzer_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -75,12 +76,12 @@ func TestSimpleAnalyzer(t *testing.T) {
 			assert.Equal(t, "test-proj", opts.Project)
 			assert.Equal(t, "test", opts.Stack)
 
-			assert.Equal(t, map[config.Key]string{
-				config.MustMakeKey(opts.Project, "bool"):   "true",
-				config.MustMakeKey(opts.Project, "float"):  "1.5",
-				config.MustMakeKey(opts.Project, "string"): "hello",
-				config.MustMakeKey(opts.Project, "obj"):    "{\"key\":\"value\"}",
-			}, opts.Config)
+			assert.Equal(t, property.NewMap(map[string]property.Value{
+				opts.Project + ":bool":   property.New(true),
+				opts.Project + ":float":  property.New(1.5),
+				opts.Project + ":string": property.New("hello"),
+				opts.Project + ":obj":    property.New(property.NewMap(map[string]property.Value{"key": property.New("value")})),
+			}), opts.Config)
 
 			return &deploytest.Analyzer{}, nil
 		}),

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -487,15 +487,16 @@ func newUpdateSource(ctx context.Context,
 	//
 
 	// Decrypt the configuration.
-	config, err := target.Config.Decrypt(target.Decrypter)
+	config, err := target.Config.AsDecryptedPropertyMap(ctx, target.Decrypter)
 	if err != nil {
 		return nil, err
 	}
+	pconfig := resource.FromResourcePropertyMap(config)
 	analyzerOpts := &plugin.PolicyAnalyzerOptions{
 		Organization: target.Organization.String(),
 		Project:      proj.Name.String(),
 		Stack:        target.Name.String(),
-		Config:       config,
+		Config:       pconfig,
 		DryRun:       opts.DryRun,
 	}
 	if err := installAndLoadPolicyPlugins(ctx, plugctx, opts, analyzerOpts); err != nil {

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -801,14 +801,12 @@ func constructEnv(opts *PolicyAnalyzerOptions, runtime string) ([]string, error)
 
 // constructConfig JSON-serializes the configuration data.
 func constructConfig(opts *PolicyAnalyzerOptions) (string, error) {
-	if opts == nil || opts.Config == nil {
+	if opts == nil || opts.Config.Len() == 0 {
 		return "", nil
 	}
 
-	config := make(map[string]string)
-	for k, v := range opts.Config {
-		config[k.String()] = v
-	}
+	// We get rich property values here, but the envvar interface just expects JSON-like strings.
+	config, _ := PropertyMapToConfig(opts.Config)
 
 	configJSON, err := json.Marshal(config)
 	if err != nil {

--- a/sdk/go/common/resource/plugin/analyzer_plugin_test.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin_test.go
@@ -15,11 +15,13 @@
 package plugin
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/stretchr/testify/require"
@@ -39,7 +41,7 @@ func TestAnalyzerSpawn(t *testing.T) {
 		config.MustMakeKey(proj, "obj"):    config.NewObjectValue("{\"key\": \"value\"}"),
 	}
 
-	configDecrypted, err := configMap.Decrypt(config.NopDecrypter)
+	configDecrypted, err := configMap.AsDecryptedPropertyMap(context.Background(), config.NopDecrypter)
 	require.NoError(t, err)
 
 	opts := PolicyAnalyzerOptions{
@@ -47,7 +49,7 @@ func TestAnalyzerSpawn(t *testing.T) {
 		Project:      proj,
 		Stack:        "test-stack",
 		DryRun:       true,
-		Config:       configDecrypted,
+		Config:       resource.FromResourcePropertyMap(configDecrypted),
 	}
 
 	pluginPath, err := filepath.Abs("./testdata/analyzer")

--- a/sdk/go/common/resource/plugin/config.go
+++ b/sdk/go/common/resource/plugin/config.go
@@ -1,0 +1,80 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"encoding/json"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+func toConfig(prop property.Value) interface{} {
+	if prop.IsNull() {
+		return nil
+	}
+	if prop.IsString() {
+		return prop.AsString()
+	}
+	if prop.IsBool() {
+		return prop.AsBool()
+	}
+	if prop.IsNumber() {
+		return prop.AsNumber()
+	}
+	if prop.IsArray() {
+		list := []interface{}{}
+		prop.AsArray().All(func(i int, v property.Value) bool {
+			list = append(list, toConfig(v))
+			return true
+		})
+		return list
+	}
+	if prop.IsMap() {
+		obj := map[string]interface{}{}
+		prop.AsMap().All(func(s string, v property.Value) bool {
+			obj[s] = toConfig(v)
+			return true
+		})
+		return obj
+	}
+	contract.Failf("unexpected property type %+v", prop)
+	return nil
+}
+
+// PropertyMapToConfig converts a map of property values to a map of strings that can be passed via envvar strings to a
+// plugin.
+func PropertyMapToConfig(props property.Map) (map[string]string, []string) {
+	config := map[string]string{}
+	secretKeys := []string{}
+	props.All(func(s string, v property.Value) bool {
+		if v.Secret() {
+			secretKeys = append(secretKeys, s)
+		}
+
+		// At the top level if it's a string return it as is
+		if v.IsString() {
+			config[s] = v.AsString()
+			return true
+		}
+		// Otherwise, convert it to a JSON style string
+		value := toConfig(v)
+		bytes, err := json.Marshal(value)
+		contract.AssertNoErrorf(err, "failed to marshal config value %v", value)
+		config[s] = string(bytes)
+		return true
+	})
+	return config, secretKeys
+}

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // A Host hosts provider plugins and makes them easily accessible by package name.
@@ -276,7 +277,7 @@ type PolicyAnalyzerOptions struct {
 	Organization string
 	Project      string
 	Stack        string
-	Config       map[config.Key]string
+	Config       property.Map
 	DryRun       bool
 }
 

--- a/sdk/go/common/resource/plugin/langruntime.go
+++ b/sdk/go/common/resource/plugin/langruntime.go
@@ -24,9 +24,8 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	structpb "google.golang.org/protobuf/types/known/structpb"
 )
@@ -193,21 +192,19 @@ type RunPluginInfo struct {
 
 // RunInfo contains all of the information required to perform a plan or deployment operation.
 type RunInfo struct {
-	Info              ProgramInfo           // the information about the program to run.
-	MonitorAddress    string                // the RPC address to the host resource monitor.
-	Project           string                // the project name housing the program being run.
-	Stack             string                // the stack name being evaluated.
-	Pwd               string                // the program's working directory.
-	Args              []string              // any arguments to pass to the program.
-	Config            map[config.Key]string // the configuration variables to apply before running.
-	ConfigSecretKeys  []config.Key          // the configuration keys that have secret values.
-	ConfigPropertyMap resource.PropertyMap  // the configuration as a property map.
-	DryRun            bool                  // true if we are performing a dry-run (preview).
-	QueryMode         bool                  // true if we're only doing a query.
-	Parallel          int32                 // the degree of parallelism for resource operations (<=1 for serial).
-	Organization      string                // the organization name housing the program being run (might be empty).
-	LoaderAddress     string                // the RPC address of the host's schema loader.
-	AttachDebugger    bool                  // true if we are starting the program under a debugger.
+	Info           ProgramInfo  // the information about the program to run.
+	MonitorAddress string       // the RPC address to the host resource monitor.
+	Project        string       // the project name housing the program being run.
+	Stack          string       // the stack name being evaluated.
+	Pwd            string       // the program's working directory.
+	Args           []string     // any arguments to pass to the program.
+	Config         property.Map // the configuration as a property map.
+	DryRun         bool         // true if we are performing a dry-run (preview).
+	QueryMode      bool         // true if we're only doing a query.
+	Parallel       int32        // the degree of parallelism for resource operations (<=1 for serial).
+	Organization   string       // the organization name housing the program being run (might be empty).
+	LoaderAddress  string       // the RPC address of the host's schema loader.
+	AttachDebugger bool         // true if we are starting the program under a debugger.
 }
 
 type RuntimeOptionType int

--- a/sdk/go/common/resource/plugin/testdata/analyzer/main.go
+++ b/sdk/go/common/resource/plugin/testdata/analyzer/main.go
@@ -23,7 +23,7 @@ func main() {
 		"test-project:bool":   "true",
 		"test-project:float":  "1.5",
 		"test-project:string": "hello",
-		"test-project:obj":    "{\"key\": \"value\"}",
+		"test-project:obj":    "{\"key\":\"value\"}",
 	}
 	if !reflect.DeepEqual(actual, expect) {
 		fmt.Printf("fatal: expected config to be %v, got %v\n", expect, actual)


### PR DESCRIPTION
This updates the language and analyser plugin interfaces to take `property.Map` from the engine layer, rather than `map[string]string`. 

We still have to translate to string maps internally for backwards compatibility, but we can push that lower and lower till we can eventually get rid of it.

There's a lot of follow ups that could be done after this to spread the new `property.Value/Map` system further, but that's not a rush. We can translate between the two at each boundary point for now.