### PR TITLE
Add `RemoteExecutorImage` configuration to the NodeJS Automation API

### DIFF
--- a/changelog/pending/20250423--auto-nodejs--add-the-ability-to-configure-a-remote-executor-image.yaml
+++ b/changelog/pending/20250423--auto-nodejs--add-the-ability-to-configure-a-remote-executor-image.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/nodejs
+  description: Add the ability to configure a remote executor image

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -20,9 +20,8 @@ import * as upath from "upath";
 
 import { CommandResult, PulumiCommand } from "./cmd";
 import { ConfigMap, ConfigValue } from "./config";
-import { minimumVersion } from "./minimumVersion";
 import { ProjectSettings } from "./projectSettings";
-import { RemoteGitProgramArgs } from "./remoteWorkspace";
+import { ExecutorImage, RemoteGitProgramArgs } from "./remoteWorkspace";
 import { OutputMap, Stack } from "./stack";
 import { StackSettings, stackSettingsSerDeKeys } from "./stackSettings";
 import { TagMap } from "./tag";
@@ -78,6 +77,11 @@ export class LocalWorkspace implements Workspace {
         }
         return this._pulumiCommand;
     }
+
+    /**
+     * The image to use for the remote Pulumi operation.
+     */
+    remoteExecutorImage?: ExecutorImage;
 
     /**
      * The inline program {@link PulumiFn} to be used for preview/update
@@ -333,6 +337,7 @@ export class LocalWorkspace implements Workspace {
                 workDir,
                 pulumiHome,
                 program,
+                remoteExecutorImage,
                 envVars,
                 secretsProvider,
                 remote,
@@ -350,6 +355,7 @@ export class LocalWorkspace implements Workspace {
                 dir = workDir;
             }
             this.pulumiHome = pulumiHome;
+            this.remoteExecutorImage = remoteExecutorImage;
             this.program = program;
             this.secretsProvider = secretsProvider;
             this.remote = remote;
@@ -1154,6 +1160,15 @@ export class LocalWorkspace implements Workspace {
             args.push("--remote-skip-install-dependencies");
         }
 
+        if (this.remoteExecutorImage) {
+          args.push("--remote-executor-image=" + this.remoteExecutorImage.image)
+
+          if (this.remoteExecutorImage.credentials) {
+            args.push("--remote-executor-image-username=" + this.remoteExecutorImage.credentials.username)
+            args.push("--remote-executor-image-password=" + this.remoteExecutorImage.credentials.password)
+          }
+        }
+
         if (this.remoteInheritSettings) {
             args.push("--remote-inherit-settings");
         }
@@ -1224,6 +1239,11 @@ export interface LocalWorkspaceOptions {
      * {@link ProjectSettings} for this information.
      */
     program?: PulumiFn;
+
+    /**
+     * The image to use for the remote Pulumi operation.
+     */
+    remoteExecutorImage?: ExecutorImage;
 
     /**
      * Environment values scoped to the current workspace. These will be supplied to every Pulumi command.

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -1161,12 +1161,12 @@ export class LocalWorkspace implements Workspace {
         }
 
         if (this.remoteExecutorImage) {
-          args.push("--remote-executor-image=" + this.remoteExecutorImage.image)
+            args.push("--remote-executor-image=" + this.remoteExecutorImage.image);
 
-          if (this.remoteExecutorImage.credentials) {
-            args.push("--remote-executor-image-username=" + this.remoteExecutorImage.credentials.username)
-            args.push("--remote-executor-image-password=" + this.remoteExecutorImage.credentials.password)
-          }
+            if (this.remoteExecutorImage.credentials) {
+                args.push("--remote-executor-image-username=" + this.remoteExecutorImage.credentials.username);
+                args.push("--remote-executor-image-password=" + this.remoteExecutorImage.credentials.password);
+            }
         }
 
         if (this.remoteInheritSettings) {

--- a/sdk/nodejs/automation/remoteWorkspace.ts
+++ b/sdk/nodejs/automation/remoteWorkspace.ts
@@ -186,16 +186,16 @@ export interface RemoteWorkspaceOptions {
  * Information about the remote execution image.
  */
 export interface ExecutorImage {
-  image: string;
-  credentials?: DockerImageCredentials;
+    image: string;
+    credentials?: DockerImageCredentials;
 }
 
 /**
  * Credentials for the remote execution Docker image.
  */
 export interface DockerImageCredentials {
-  username: string;
-  password: string;
+    username: string;
+    password: string;
 }
 
 async function createLocalWorkspace(

--- a/sdk/nodejs/automation/remoteWorkspace.ts
+++ b/sdk/nodejs/automation/remoteWorkspace.ts
@@ -175,6 +175,27 @@ export interface RemoteWorkspaceOptions {
      * false.
      */
     inheritSettings?: boolean;
+
+    /**
+     * The image to use for the remote executor.
+     */
+    executorImage?: ExecutorImage;
+}
+
+/**
+ * Information about the remote execution image.
+ */
+export interface ExecutorImage {
+  image: string;
+  credentials?: DockerImageCredentials;
+}
+
+/**
+ * Credentials for the remote execution Docker image.
+ */
+export interface DockerImageCredentials {
+  username: string;
+  password: string;
 }
 
 async function createLocalWorkspace(
@@ -207,6 +228,7 @@ async function createLocalWorkspace(
         remotePreRunCommands: opts?.preRunCommands,
         remoteSkipInstallDependencies: opts?.skipInstallDependencies,
         remoteInheritSettings: opts?.inheritSettings,
+        remoteExecutorImage: opts?.executorImage,
     };
     return await LocalWorkspace.create(localOpts);
 }

--- a/sdk/nodejs/tests/automation/remoteWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/remoteWorkspace.spec.ts
@@ -227,7 +227,7 @@ describe("RemoteWorkspace", () => {
                 opts: {
                     remote: true,
                     remoteExecutorImage: {
-                        image: "test-image"
+                        image: "test-image",
                     },
                 },
                 expected: ["--remote", "--remote-executor-image=test-image"],
@@ -239,16 +239,16 @@ describe("RemoteWorkspace", () => {
                     remoteExecutorImage: {
                         image: "test-image",
                         credentials: {
-                          username: "foo",
-                          password: "bar",
+                            username: "foo",
+                            password: "bar",
                         },
                     },
                 },
                 expected: [
-                  "--remote",
-                  "--remote-executor-image=test-image",
-                  "--remote-executor-image-username=foo",
-                  "--remote-executor-image-password=bar"
+                    "--remote",
+                    "--remote-executor-image=test-image",
+                    "--remote-executor-image-username=foo",
+                    "--remote-executor-image-password=bar",
                 ],
             },
         ];

--- a/sdk/nodejs/tests/automation/remoteWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/remoteWorkspace.spec.ts
@@ -222,6 +222,35 @@ describe("RemoteWorkspace", () => {
                 },
                 expected: ["--remote", "--remote-inherit-settings"],
             },
+            {
+                name: "remote image",
+                opts: {
+                    remote: true,
+                    remoteExecutorImage: {
+                        image: "test-image"
+                    },
+                },
+                expected: ["--remote", "--remote-executor-image=test-image"],
+            },
+            {
+                name: "remote image credentials",
+                opts: {
+                    remote: true,
+                    remoteExecutorImage: {
+                        image: "test-image",
+                        credentials: {
+                          username: "foo",
+                          password: "bar",
+                        },
+                    },
+                },
+                expected: [
+                  "--remote",
+                  "--remote-executor-image=test-image",
+                  "--remote-executor-image-username=foo",
+                  "--remote-executor-image-password=bar"
+                ],
+            },
         ];
         tests.forEach((test) => {
             it(`${test.name}`, async () => {


### PR DESCRIPTION
This PR is the NodeJS part of the automation API work to add `RemoteExecutorImage` configuration to all the various languages.

* https://github.com/pulumi/pulumi/issues/15693
* https://github.com/pulumi/pulumi/pull/15697