### PR TITLE
pin @pulumi/random in test

### DIFF
--- a/tests/integration/component_provider/nodejs/component-provider-host/provider/package.json
+++ b/tests/integration/component_provider/nodejs/component-provider-host/provider/package.json
@@ -2,6 +2,6 @@
     "name": "nodejs-component-provider",
     "description": "Node.js Sample Components",
     "dependencies": {
-        "@pulumi/random": "^4.18.0"
+        "@pulumi/random": "4.18.0"
     }
 }


### PR DESCRIPTION
We rely on this dependency being the exact version for the test to run, otherwise we infer the latest version that matches ^4.18.0, which currently is 4.18.1, breaking the test.

Noticed in https://github.com/pulumi/pulumi/actions/runs/14621588029/job/41023355115