### PR TITLE
fix: detect readme in subdir for package publishing

### DIFF
--- a/changelog/pending/20250424--cli-package--detect-readme-in-subdir-for-package-publishing.yaml
+++ b/changelog/pending/20250424--cli-package--detect-readme-in-subdir-for-package-publishing.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/package
+  description: Detect readme in subdir for package publishing

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -305,10 +305,12 @@ func (cmd *packagePublishCmd) findReadme(packageSrc string) (string, error) {
 	}
 	pluginSpec.PluginDir = cmd.pluginDir
 
-	dir, err := pluginSpec.DirPath()
+	pluginDir, err := pluginSpec.DirPath()
 	if err != nil {
 		return "", fmt.Errorf("failed to get plugin directory: %w", err)
 	}
+	_, path := pluginSpec.LocalName()
+	dir := filepath.Join(pluginDir, path)
 
 	if readmeFromPlugin := findReadmeInDir(dir); readmeFromPlugin != "" {
 		return readmeFromPlugin, nil

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -309,7 +309,7 @@ func (cmd *packagePublishCmd) findReadme(packageSrc string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get plugin directory: %w", err)
 	}
-	_, path := pluginSpec.LocalName()
+	path := pluginSpec.SubDir()
 	dir := filepath.Join(pluginDir, path)
 
 	if readmeFromPlugin := findReadmeInDir(dir); readmeFromPlugin != "" {


### PR DESCRIPTION
When publishing a VCS based component - via `pulumi package publish` - it picked the README in the root of the repository instead of the one located in the subdirectory where the component is located.

For example, running `GITHUB_TOKEN="$(gh auth token)" pulumi package publish https://github.com/pulumi/pulumiup-2025-keynote-demo/components/container-app --source private` should use this readme: https://github.com/pulumi/pulumiup-2025-keynote-demo/blob/main/components/container-app/README.md

But it ends up picking this one: https://github.com/pulumi/pulumiup-2025-keynote-demo/blob/main/README.md

The missing piece was taking the packages `LocalName` into account as well.

Fixes https://github.com/pulumi/pulumi-service/issues/27663