### PR TITLE
Add Remote Executor Image configuration to the Python automation API.

### DIFF
--- a/changelog/pending/20250424--auto-python--add-the-ability-to-configure-a-remote-executor-image.yaml
+++ b/changelog/pending/20250424--auto-python--add-the-ability-to-configure-a-remote-executor-image.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/python
+  description: Add the ability to configure a remote executor image

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
 
 _setting_extensions = [".yaml", ".yml", ".json"]
 
+
 class DockerImageCredentials:
     """
     Credentials for the remote execution Docker image.
@@ -59,6 +60,7 @@ class DockerImageCredentials:
         self.username = username
         self.password = password
 
+
 class ExecutorImage:
     """
     Information about the remote execution image.
@@ -67,7 +69,11 @@ class ExecutorImage:
     image: Optional[str]
     credentials: Optional[DockerImageCredentials]
 
-    def __init__(self, image: Optional[str] = None, credentials: Optional[DockerImageCredentials] = None):
+    def __init__(
+        self,
+        image: Optional[str] = None,
+        credentials: Optional[DockerImageCredentials] = None,
+    ):
         self.image = image
         self.credentials = credentials
 
@@ -76,6 +82,7 @@ class Secret(str):
     """
     Represents a secret value.
     """
+
 
 class LocalWorkspaceOptions:
     work_dir: Optional[str] = None
@@ -694,11 +701,19 @@ class LocalWorkspace(Workspace):
 
         if self._remote_executor_image:
             if self._remote_executor_image.image:
-                args.append("--remote-executor-image=" + self._remote_executor_image.image)
+                args.append(
+                    "--remote-executor-image=" + self._remote_executor_image.image
+                )
 
             if self._remote_executor_image.credentials:
-                args.append("--remote-executor-image-username=" + self._remote_executor_image.credentials.username)
-                args.append("--remote-executor-image-password=" + self._remote_executor_image.credentials.password)
+                args.append(
+                    "--remote-executor-image-username="
+                    + self._remote_executor_image.credentials.username
+                )
+                args.append(
+                    "--remote-executor-image-password="
+                    + self._remote_executor_image.credentials.password
+                )
 
         if self._remote_inherit_settings:
             args.append("--remote-inherit-settings")

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -41,12 +41,35 @@ from ._workspace import (
     Workspace,
 )
 from .errors import InvalidVersionError
-from pulumi.automation._remote_workspace import ExecutorImage
 
 if TYPE_CHECKING:
     from pulumi.automation._remote_workspace import RemoteGitAuth
 
 _setting_extensions = [".yaml", ".yml", ".json"]
+
+class DockerImageCredentials:
+    """
+    Credentials for the remote execution Docker image.
+    """
+
+    username: str
+    password: str
+
+    def __init__(self, username: str, password: str):
+        self.username = username
+        self.password = password
+
+class ExecutorImage:
+    """
+    Information about the remote execution image.
+    """
+
+    image: Optional[str]
+    credentials: Optional[DockerImageCredentials]
+
+    def __init__(self, image: Optional[str] = None, credentials: Optional[DockerImageCredentials] = None):
+        self.image = image
+        self.credentials = credentials
 
 
 class Secret(str):
@@ -58,7 +81,6 @@ class LocalWorkspaceOptions:
     work_dir: Optional[str] = None
     pulumi_home: Optional[str] = None
     program: Optional[PulumiFn] = None
-    remote_executor_image: Optional[ExecutorImage] = None
     env_vars: Optional[Mapping[str, str]] = None
     secrets_provider: Optional[str] = None
     project_settings: Optional[ProjectSettings] = None
@@ -70,7 +92,6 @@ class LocalWorkspaceOptions:
         work_dir: Optional[str] = None,
         pulumi_home: Optional[str] = None,
         program: Optional[PulumiFn] = None,
-        remote_executor_image: Optional[ExecutorImage] = None,
         env_vars: Optional[Mapping[str, str]] = None,
         secrets_provider: Optional[str] = None,
         project_settings: Optional[ProjectSettings] = None,
@@ -79,7 +100,6 @@ class LocalWorkspaceOptions:
     ):
         self.work_dir = work_dir
         self.pulumi_home = pulumi_home
-        self.remote_executor_image = remote_executor_image
         self.program = program
         self.env_vars = env_vars
         self.secrets_provider = secrets_provider

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -41,6 +41,7 @@ from ._workspace import (
     Workspace,
 )
 from .errors import InvalidVersionError
+from pulumi.automation._remote_workspace import ExecutorImage
 
 if TYPE_CHECKING:
     from pulumi.automation._remote_workspace import RemoteGitAuth
@@ -53,11 +54,11 @@ class Secret(str):
     Represents a secret value.
     """
 
-
 class LocalWorkspaceOptions:
     work_dir: Optional[str] = None
     pulumi_home: Optional[str] = None
     program: Optional[PulumiFn] = None
+    remote_executor_image: Optional[ExecutorImage] = None
     env_vars: Optional[Mapping[str, str]] = None
     secrets_provider: Optional[str] = None
     project_settings: Optional[ProjectSettings] = None
@@ -69,6 +70,7 @@ class LocalWorkspaceOptions:
         work_dir: Optional[str] = None,
         pulumi_home: Optional[str] = None,
         program: Optional[PulumiFn] = None,
+        remote_executor_image: Optional[ExecutorImage] = None,
         env_vars: Optional[Mapping[str, str]] = None,
         secrets_provider: Optional[str] = None,
         project_settings: Optional[ProjectSettings] = None,
@@ -77,6 +79,7 @@ class LocalWorkspaceOptions:
     ):
         self.work_dir = work_dir
         self.pulumi_home = pulumi_home
+        self.remote_executor_image = remote_executor_image
         self.program = program
         self.env_vars = env_vars
         self.secrets_provider = secrets_provider
@@ -102,6 +105,7 @@ class LocalWorkspace(Workspace):
     _remote_env_vars: Optional[Mapping[str, Union[str, Secret]]]
     _remote_pre_run_commands: Optional[List[str]]
     _remote_skip_install_dependencies: Optional[bool]
+    _remote_executor_image: Optional[ExecutorImage]
     _remote_inherit_settings: Optional[bool]
     _remote_git_url: Optional[str]
     _remote_git_project_path: Optional[str]
@@ -667,6 +671,14 @@ class LocalWorkspace(Workspace):
 
         if self._remote_skip_install_dependencies:
             args.append("--remote-skip-install-dependencies")
+
+        if self._remote_executor_image:
+            if self._remote_executor_image.image:
+                args.append("--remote-executor-image=" + self._remote_executor_image.image)
+
+            if self._remote_executor_image.credentials:
+                args.append("--remote-executor-image-username=" + self._remote_executor_image.credentials.username)
+                args.append("--remote-executor-image-password=" + self._remote_executor_image.credentials.password)
 
         if self._remote_inherit_settings:
             args.append("--remote-inherit-settings")

--- a/sdk/python/lib/pulumi/automation/_remote_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_remote_workspace.py
@@ -18,6 +18,7 @@ from pulumi.automation._local_workspace import ExecutorImage, LocalWorkspace, Se
 from pulumi.automation._remote_stack import RemoteStack
 from pulumi.automation._stack import Stack
 
+
 class RemoteWorkspaceOptions:
     """
     Extensibility options to configure a RemoteWorkspace.
@@ -43,6 +44,7 @@ class RemoteWorkspaceOptions:
         self.skip_install_dependencies = skip_install_dependencies
         self.executor_image = executor_image
         self.inherit_settings = inherit_settings
+
 
 class RemoteGitAuth:
     """

--- a/sdk/python/lib/pulumi/automation/_remote_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_remote_workspace.py
@@ -14,26 +14,9 @@
 
 from typing import List, Mapping, Optional, Union
 
-from pulumi.automation._local_workspace import LocalWorkspace, Secret
+from pulumi.automation._local_workspace import ExecutorImage, LocalWorkspace, Secret
 from pulumi.automation._remote_stack import RemoteStack
 from pulumi.automation._stack import Stack
-
-class DockerImageCredentials:
-    """
-    Credentials for the remote execution Docker image.
-    """
-
-    username: str
-    password: str
-
-
-class ExecutorImage:
-    """
-    Information about the remote execution image.
-    """
-
-    image: Optional[None]
-    credentials: Optional[DockerImageCredentials]
 
 class RemoteWorkspaceOptions:
     """

--- a/sdk/python/lib/pulumi/automation/_remote_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_remote_workspace.py
@@ -18,6 +18,22 @@ from pulumi.automation._local_workspace import LocalWorkspace, Secret
 from pulumi.automation._remote_stack import RemoteStack
 from pulumi.automation._stack import Stack
 
+class DockerImageCredentials:
+    """
+    Credentials for the remote execution Docker image.
+    """
+
+    username: str
+    password: str
+
+
+class ExecutorImage:
+    """
+    Information about the remote execution image.
+    """
+
+    image: Optional[None]
+    credentials: Optional[DockerImageCredentials]
 
 class RemoteWorkspaceOptions:
     """
@@ -27,6 +43,7 @@ class RemoteWorkspaceOptions:
     env_vars: Optional[Mapping[str, Union[str, Secret]]]
     pre_run_commands: Optional[List[str]]
     skip_install_dependencies: Optional[bool]
+    executor_image: Optional[ExecutorImage]
     inherit_settings: Optional[bool]
 
     def __init__(
@@ -35,13 +52,14 @@ class RemoteWorkspaceOptions:
         env_vars: Optional[Mapping[str, Union[str, Secret]]] = None,
         pre_run_commands: Optional[List[str]] = None,
         skip_install_dependencies: Optional[bool] = None,
+        executor_image: Optional[ExecutorImage] = None,
         inherit_settings: Optional[bool] = None,
     ):
         self.env_vars = env_vars
         self.pre_run_commands = pre_run_commands
         self.skip_install_dependencies = skip_install_dependencies
+        self.executor_image = executor_image
         self.inherit_settings = inherit_settings
-
 
 class RemoteGitAuth:
     """
@@ -193,11 +211,13 @@ def _create_local_workspace(
     env_vars = None
     pre_run_commands = None
     skip_install_dependencies = None
+    remote_executor_image = None
     inherit_settings = None
     if opts is not None:
         env_vars = opts.env_vars
         pre_run_commands = opts.pre_run_commands
         skip_install_dependencies = opts.skip_install_dependencies
+        remote_executor_image = opts.executor_image
         inherit_settings = opts.inherit_settings
 
     if not url and not inherit_settings:
@@ -217,6 +237,7 @@ def _create_local_workspace(
     ws._remote_env_vars = env_vars
     ws._remote_pre_run_commands = pre_run_commands
     ws._remote_skip_install_dependencies = skip_install_dependencies
+    ws._remote_executor_image = remote_executor_image
     ws._remote_inherit_settings = inherit_settings
     ws._remote_git_url = url
     ws._remote_git_project_path = project_path

--- a/sdk/python/lib/test/automation/test_remote_workspace.py
+++ b/sdk/python/lib/test/automation/test_remote_workspace.py
@@ -17,6 +17,7 @@ from typing import Optional
 import pytest
 
 from pulumi.automation._remote_workspace import _is_fully_qualified_stack_name
+from pulumi.automation._local_workspace import DockerImageCredentials, ExecutorImage
 
 from pulumi.automation import (
     LocalWorkspace,


### PR DESCRIPTION
The Python portion of https://github.com/pulumi/pulumi/issues/15693.

* https://github.com/pulumi/pulumi/pull/19286
* https://github.com/pulumi/pulumi/pull/15697

There unfortunately aren't tests for checking command output in Python, but a manual dump of the arguments looks good:

```
... --remote-executor-image=test --remote-executor-image-username=foo --remote-executor-image-password=bar ...
```