### PR TITLE
clean up error message on premature provider exits

### DIFF
--- a/changelog/pending/20250424--sdk-go--improve-output-when-plugin-crashes.yaml
+++ b/changelog/pending/20250424--sdk-go--improve-output-when-plugin-crashes.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Improve output when plugin crashes

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -638,12 +638,11 @@ func (p *plugin) Close() error {
 		p.unstructuredOutput.outputLock.Lock()
 		defer p.unstructuredOutput.outputLock.Unlock()
 		d.Errorf(diag.StreamMessage("",
-			fmt.Sprintf("Detected that %s exited prematurely.", p.Bin), id))
-		d.Errorf(diag.StreamMessage("", "This is *always* a bug in the provider. "+
-			"Please report the issue to the provider author as appropriate.\n", id))
-		d.Errorf(diag.StreamMessage("",
-			"To assist with debugging we have dumped the STDOUT and STDERR streams of the plugin:\n"+
-				p.unstructuredOutput.output.String(), id))
+			fmt.Sprintf("Detected that %s exited prematurely. \n"+
+				"       This is *always* a bug in the provider. "+
+				"Please report the issue to the provider author as appropriate.\n"+
+				"       To assist with debugging we have dumped the STDOUT and STDERR streams of the plugin:%s\n",
+				p.Bin, p.unstructuredOutput.output.String()), id))
 	}
 
 	return result

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -639,9 +639,11 @@ func (p *plugin) Close() error {
 		defer p.unstructuredOutput.outputLock.Unlock()
 		d.Errorf(diag.StreamMessage("",
 			fmt.Sprintf("Detected that %s exited prematurely.", p.Bin), id))
-		d.Errorf(diag.StreamMessage("", fmt.Sprintf("This is *always* a bug in the provider. "+
-			"To assist with debugging we have dumped the STDOUT and STDERR streams of the plugin:\n%s",
-			p.unstructuredOutput.output.String()), id))
+		d.Errorf(diag.StreamMessage("", "This is *always* a bug in the provider. "+
+			"Please report the issue to the provider author as appropriate.\n", id))
+		d.Errorf(diag.StreamMessage("",
+			"To assist with debugging we have dumped the STDOUT and STDERR streams of the plugin:\n"+
+				p.unstructuredOutput.output.String(), id))
 	}
 
 	return result

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -635,15 +635,13 @@ func (p *plugin) Close() error {
 		//	To assist with debugging we have dumped the STDOUT and STDERR streams of the plugin:
 		//
 		//	<output>
-		d.Errorf(diag.StreamMessage("", fmt.Sprintf("\n\n         Detected that %s exited prematurely.\n", p.Bin), id))
-		d.Errorf(diag.StreamMessage("",
-			"         This is *always* a bug in the provider. "+
-				"Please report the issue to the provider author as appropriate.\n\n", id))
-		d.Errorf(diag.StreamMessage("",
-			"To assist with debugging we have dumped the STDOUT and STDERR streams of the plugin:\n\n", id))
 		p.unstructuredOutput.outputLock.Lock()
 		defer p.unstructuredOutput.outputLock.Unlock()
-		d.Errorf(diag.StreamMessage("", p.unstructuredOutput.output.String(), id))
+		d.Errorf(diag.StreamMessage("",
+			fmt.Sprintf("Detected that %s exited prematurely.", p.Bin), id))
+		d.Errorf(diag.StreamMessage("", fmt.Sprintf("This is *always* a bug in the provider. "+
+			"To assist with debugging we have dumped the STDOUT and STDERR streams of the plugin:\n%s",
+			p.unstructuredOutput.output.String()), id))
 	}
 
 	return result

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -138,11 +138,9 @@ func TestPanickingComponentConfigure(t *testing.T) {
 		ExtraRuntimeValidation: func(t *testing.T, _ integration.RuntimeValidationStackInfo) {
 			const needle = "panic: great sadness\n"
 			haystack := stderr.String()
-			// 2 instances of needle:
-			// - One instance is the returned error.
-			// - Another instance is in the stderr output.
-			assert.Equal(t, 2, strings.Count(haystack, needle),
-				"Expected only two instance of %q in:\n%s", needle, haystack)
+			// one instances of needle in the returned error:
+			assert.Equal(t, 1, strings.Count(haystack, needle),
+				"Expected only one instance of %q in:\n%s", needle, haystack)
 		},
 	})
 }


### PR DESCRIPTION
We added this message recently, but at least to my eyes it always looked a little off, and almost like the output code was in some way buggy itself.  Instead of trying to make this message very fancy, report it like any other error message.

Before:
![image](https://github.com/user-attachments/assets/bcbcbf6c-295c-4c06-ad4c-dbb6fe6253ee)
 After:
![image](https://github.com/user-attachments/assets/e7d568d6-f28f-4ee2-9df3-87aade644788)
