### PR TITLE
Replace `GetLanguageTypeString` with `GetTypeName`

### DIFF
--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -25,20 +25,56 @@ import (
 type DocLanguageHelper interface {
 	GetPropertyName(p *schema.Property) (string, error)
 	GetEnumName(e *schema.Enum, typeName string) (string, error)
-	GetDocLinkForResourceType(pkg *schema.Package, moduleName, typeName string) string
-	GetDocLinkForPulumiType(pkg *schema.Package, typeName string) string
-	GetDocLinkForResourceInputOrOutputType(pkg *schema.Package, moduleName, typeName string, input bool) string
-	GetDocLinkForFunctionInputOrOutputType(pkg *schema.Package, moduleName, typeName string, input bool) string
-	GetLanguageTypeString(pkg *schema.Package, moduleName string, t schema.Type, input bool) string
-
+	// GetTypeName gets the name of a type in the language of the DocLanguageHelper.
+	//
+	// relativeToModule describes the module that is consuming the type
+	// name. Typically, GetTypeName will output an unqualified name if typ is native
+	// to relativeToModule. Otherwise GetTypeName may return a qualified name.
+	// relativeToModule should always be a module returned from pkg.TokenToModule. It
+	// should not be language specialized.
+	//
+	// For example, lets get the name of a hypothetical python property type:
+	//
+	//	var pkg *schema.Package = getOurPackage(/* Schema{
+	//		Name: "pkg",
+	//		Resource: []{
+	//			{
+	//				Token: "pkg:myModule:Resource",
+	//				Properties: []{
+	//					{
+	//						Type: Object{Name: "pkg:myModule:TheType"},
+	//						Name: "theType",
+	//					},
+	//				},
+	//			},
+	//		},
+	//	} */)
+	//	var res *schema.Resource = pkg.Resources[i]
+	//	var prop *schema.Property := res.Properties[j]
+	//
+	//	var python python_codegen.DocLanguageHelper
+	//
+	//	unqualifiedName := python.GetTypeName(pkg, prop.Type, false, pkg.TokenToModule(res.Token))
+	//	fmt.Println(unqualifiedName) // Prints "TheType".
+	//
+	//	qualifiedName := python.GetTypeName(pkg, prop.Type, false, "")
+	//	fmt.Println(qualifiedName) // Prints "my_module.TheType"
+	GetTypeName(pkg *schema.Package, typ schema.Type, input bool, relativeToModule string) string
 	GetFunctionName(f *schema.Function) string
 
 	// GetResourceFunctionResultName returns the name of the result type when a static resource function is used to lookup
 	// an existing resource.
 	GetResourceFunctionResultName(modName string, f *schema.Function) string
 
+	// Methods
 	GetMethodName(m *schema.Method) string
 	GetMethodResultName(pkg *schema.Package, modName string, r *schema.Resource, m *schema.Method) string
+
+	// Doc links
+	GetDocLinkForResourceType(pkg *schema.Package, moduleName, typeName string) string
+	GetDocLinkForPulumiType(pkg *schema.Package, typeName string) string
+	GetDocLinkForResourceInputOrOutputType(pkg *schema.Package, moduleName, typeName string, input bool) string
+	GetDocLinkForFunctionInputOrOutputType(pkg *schema.Package, moduleName, typeName string, input bool) string
 }
 
 func filterExamples(source []byte, node ast.Node, lang string) {

--- a/pkg/codegen/docs_integration_test.go
+++ b/pkg/codegen/docs_integration_test.go
@@ -19,6 +19,7 @@
 package codegen_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
@@ -65,6 +66,39 @@ func TestGetLanguageTypeString(t *testing.T) {
 					Value: "value1",
 				}},
 			},
+		},
+	})
+
+	schemaWithOverrides := bind(t, schema.PackageSpec{
+		Name: "pkg",
+		Types: map[string]schema.ComplexTypeSpec{
+			"pkg:shouldoverride:simpleType": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Type: "object",
+				},
+			},
+		},
+		Language: map[string]schema.RawMessage{
+			"go": marshalIntoRaw(t, golang_codegen.GoPackageInfo{
+				ModuleToPackage: map[string]string{
+					"shouldoverride": "overridden",
+				},
+			}),
+			"csharp": marshalIntoRaw(t, dotnet_codegen.CSharpPackageInfo{
+				Namespaces: map[string]string{
+					"shouldoverride": "Overridden",
+				},
+			}),
+			"nodejs": marshalIntoRaw(t, nodejs_codegen.NodePackageInfo{
+				ModuleToPackage: map[string]string{
+					"shouldoverride": "overridden",
+				},
+			}),
+			"python": marshalIntoRaw(t, python_codegen.PackageInfo{
+				ModuleNameOverrides: map[string]string{
+					"shouldoverride": "overridden",
+				},
+			}),
 		},
 	})
 
@@ -194,52 +228,89 @@ func TestGetLanguageTypeString(t *testing.T) {
 				dotnet: "Pulumi.Pkg.Module.AnEnum",
 			},
 		},
+		{
+			name:   "overridden-names-in-module",
+			schema: schemaWithOverrides,
+			typ:    mustToken(t, schemaWithOverrides.Types().Get, "pkg:shouldoverride:simpleType"),
+			module: schemaWithOverrides.TokenToModule("pkg:shouldoverride:simpleType"),
+			input:  ptr(true),
+			expected: map[language]string{
+				golang: "SimpleType",
+				nodejs: "overridden.SimpleType",
+				python: "SimpleType",
+				dotnet: "Pulumi.Pkg.Overridden.Inputs.SimpleType",
+			},
+		},
+		{
+			name:   "overridden-names",
+			schema: schemaWithOverrides,
+			typ:    mustToken(t, schemaWithOverrides.Types().Get, "pkg:shouldoverride:simpleType"),
+			input:  ptr(false),
+			expected: map[language]string{
+				golang: "overridden.SimpleType",
+				nodejs: "overridden.SimpleType",
+				python: "_overridden.SimpleType",
+				dotnet: "Pulumi.Pkg.Overridden.Outputs.SimpleType",
+			},
+		},
+		{
+			name:   "optionals",
+			schema: schema.DefaultPulumiPackage.Reference(),
+			typ:    &schema.OptionalType{ElementType: schema.StringType},
+			expected: map[language]string{
+				golang: "*string",
+				nodejs: "string",
+				python: "Optional[str]",
+				dotnet: "string?",
+			},
+		},
 	}
 
-	for _, tt := range tests {
+	// Code generation is not safe to parallelize since import binding mutates the
+	// [schema.Package].
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			def, err := tt.schema.Definition()
 			require.NoError(t, err)
 			require.NotEmpty(t, tt.expected, "Must test at least one language")
 			for lang, expected := range tt.expected {
 				var name string
-				var helper codegen.DocLanguageHelper
+				var helper func() codegen.DocLanguageHelper
 				switch lang {
 				case nodejs:
-					helper = nodejs_codegen.DocLanguageHelper{}
+					helper = mkHelper[nodejs_codegen.DocLanguageHelper]
 					name = "nodejs"
 				case python:
-					helper = python_codegen.DocLanguageHelper{}
+					helper = mkHelper[python_codegen.DocLanguageHelper]
 					name = "python"
 				case golang:
-					h := golang_codegen.DocLanguageHelper{}
-					var info golang_codegen.GoPackageInfo
-					if i, ok := def.Language["go"].(golang_codegen.GoPackageInfo); ok {
-						info = i
+					helper = func() codegen.DocLanguageHelper {
+						h := golang_codegen.DocLanguageHelper{}
+						var info golang_codegen.GoPackageInfo
+						if i, ok := def.Language["go"].(golang_codegen.GoPackageInfo); ok {
+							info = i
+						}
+						h.GeneratePackagesMap(def, "test", info)
+						return h
 					}
-					h.GeneratePackagesMap(def, "test", info)
-					helper = h
 					name = "go"
 				case dotnet:
-					helper = dotnet_codegen.DocLanguageHelper{}
+					helper = mkHelper[dotnet_codegen.DocLanguageHelper]
 					name = "dotnet"
 				default:
 					assert.Fail(t, "Unknown language %T", lang)
 				}
 
 				t.Run(name, func(t *testing.T) {
-					t.Parallel()
-
 					if tt.input == nil || *tt.input {
 						t.Run("input", func(t *testing.T) {
-							actual := helper.GetLanguageTypeString(def, tt.module, tt.typ, true)
+							actual := helper().GetTypeName(def, tt.typ, true, tt.module)
 							assert.Equal(t, expected, actual)
 						})
 					}
 					if tt.input == nil || !*tt.input {
 						t.Run("output", func(t *testing.T) {
-							actual := helper.GetLanguageTypeString(def, tt.module, tt.typ, false)
+							actual := helper().GetTypeName(def, tt.typ, false, tt.module)
 							assert.Equal(t, expected, actual)
 						})
 					}
@@ -254,7 +325,7 @@ func bind(t *testing.T, spec schema.PackageSpec) schema.PackageReference {
 		"go":     golang_codegen.Importer,
 		"nodejs": nodejs_codegen.Importer,
 		"python": python_codegen.Importer,
-		"dotnet": dotnet_codegen.Importer,
+		"csharp": dotnet_codegen.Importer,
 	})
 	require.NoError(t, err)
 	return pkg.Reference()
@@ -268,3 +339,11 @@ func mustToken[T any](t *testing.T, get func(string) (T, bool, error), token str
 }
 
 func ptr[T any](v T) *T { return &v }
+
+func marshalIntoRaw(t *testing.T, v any) schema.RawMessage {
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return schema.RawMessage(b)
+}
+
+func mkHelper[T codegen.DocLanguageHelper]() codegen.DocLanguageHelper { var v T; return v }

--- a/pkg/codegen/dotnet/doc.go
+++ b/pkg/codegen/dotnet/doc.go
@@ -72,17 +72,13 @@ func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(pkg *schema.Pa
 }
 
 // GetLanguageTypeString returns the DotNet-specific type given a Pulumi schema type.
-func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName string, t schema.Type, input bool) string {
-	info, ok := pkg.Language["csharp"].(CSharpPackageInfo)
-	if !ok {
-		info = CSharpPackageInfo{}
-	}
-	typeDetails := map[*schema.ObjectType]*typeDetails{}
+func (d DocLanguageHelper) GetTypeName(pkg *schema.Package, t schema.Type, input bool, relativeToModule string) string {
+	info, _ := pkg.Language["csharp"].(CSharpPackageInfo)
 	mod := &modContext{
 		pkg:           pkg.Reference(),
-		mod:           moduleName,
-		typeDetails:   typeDetails,
-		namespaces:    d.Namespaces,
+		mod:           relativeToModule,
+		typeDetails:   map[*schema.ObjectType]*typeDetails{},
+		namespaces:    info.Namespaces,
 		rootNamespace: info.GetRootNamespace(),
 	}
 	qualifier := "Inputs"

--- a/pkg/codegen/dotnet/doc_test.go
+++ b/pkg/codegen/dotnet/doc_test.go
@@ -83,16 +83,15 @@ func TestGetDocLinkForResourceInputOrOutputType(t *testing.T) {
 
 	pkg := getTestPackage(t)
 
-	namespaces := map[string]string{
-		"s3": "S3",
-	}
 	d := DocLanguageHelper{
-		Namespaces: namespaces,
+		Namespaces: map[string]string{
+			"s3": "S3",
+		},
 	}
-	expected := "/docs/reference/pkg/dotnet/Pulumi.Aws/Pulumi.Aws.S3.Inputs.BucketCorsRuleArgs.html"
+
 	// Generate the type string for the property type and use that to generate the doc link.
 	propertyType := codegen.UnwrapType(pkg.Resources[0].InputProperties[0].Type)
-	typeString := d.GetLanguageTypeString(pkg, "S3", propertyType, true)
+	typeString := d.GetTypeName(pkg, propertyType, true, pkg.TokenToModule("aws:s3/BucketCorsRule:BucketCorsRule"))
 	link := d.GetDocLinkForResourceInputOrOutputType(pkg, "doesNotMatter", typeString, true)
-	assert.Equal(t, expected, link)
+	assert.Equal(t, "/docs/reference/pkg/dotnet/Pulumi.Aws/Pulumi.Aws.S3.Inputs.BucketCorsRuleArgs.html", link)
 }

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -20,7 +20,6 @@ package gen
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/golang/glog"
@@ -90,11 +89,12 @@ func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(pkg *schema.Pa
 }
 
 // GetLanguageTypeString returns the Go-specific type given a Pulumi schema type.
-func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName string, t schema.Type, input bool) string {
-	modPkg, ok := d.packages[moduleName]
+func (d DocLanguageHelper) GetTypeName(pkg *schema.Package, t schema.Type, input bool, relativeToModule string) string {
+	goPkg := moduleToPackage(d.goPkgInfo.ModuleToPackage, relativeToModule)
+	modPkg, ok := d.packages[goPkg]
 	if !ok {
-		glog.Errorf("cannot calculate type string for type %q. could not find a package for module %q", t.String(), moduleName)
-		os.Exit(1)
+		glog.Fatalf("cannot calculate type string for type %q. could not find a package for module %q",
+			t.String(), goPkg)
 	}
 	return modPkg.typeString(t)
 }
@@ -164,9 +164,8 @@ func (d DocLanguageHelper) GetMethodResultName(pkg *schema.Package, modName stri
 			t := objectReturnType.Properties[0].Type
 			modPkg, ok := d.packages[modName]
 			if !ok {
-				glog.Errorf("cannot calculate type string for type %q. could not find a package for module %q",
+				glog.Fatalf("cannot calculate type string for type %q. could not find a package for module %q",
 					t.String(), modName)
-				os.Exit(1)
 			}
 			return modPkg.outputType(t)
 		}

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -116,8 +116,19 @@ func Title(s string) string {
 	return s
 }
 
+// tokenToPackage accepts a *Pulumi token* and returns name of the *Go package* that it
+// should be generated into.
+//
+// For example, it converts: "pkg:someModule:Resource" to "somemodule".
 func tokenToPackage(pkg schema.PackageReference, overrides map[string]string, tok string) string {
-	mod := pkg.TokenToModule(tok)
+	return moduleToPackage(overrides, pkg.TokenToModule(tok))
+}
+
+// moduleToPackage accepts a *Pulumi module* and returns name of the *Go package* that it
+// should be generated into.
+//
+// For example, it converts: "someModule" to "somemodule".
+func moduleToPackage(overrides map[string]string, mod string) string {
 	if override, ok := overrides[mod]; ok {
 		mod = override
 	}

--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -69,16 +69,22 @@ func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(pkg *schema.Pa
 }
 
 // GetLanguageTypeString returns the language-specific type given a Pulumi schema type.
-func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName string, t schema.Type, input bool) string {
+func (d DocLanguageHelper) GetTypeName(pkg *schema.Package, t schema.Type, input bool, relativeToModule string) string {
 	// Remove the union with `undefined` for optional types,
 	// since we will show that information separately anyway.
 	if optional, ok := t.(*schema.OptionalType); ok {
 		t = optional.ElementType
 	}
 
+	var info NodePackageInfo
+	if i, ok := pkg.Language["nodejs"].(NodePackageInfo); ok {
+		info = i
+	}
+
 	modCtx := &modContext{
-		pkg: pkg.Reference(),
-		mod: moduleName,
+		pkg:      pkg.Reference(),
+		modToPkg: info.ModuleToPackage,
+		mod:      moduleName(relativeToModule, pkg.Reference()),
 	}
 	typeName := modCtx.typeString(t, input, nil)
 

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -74,12 +74,14 @@ func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(pkg *schema.Pa
 }
 
 // GetLanguageTypeString returns the Python-specific type given a Pulumi schema type.
-func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName string, t schema.Type, input bool) string {
-	typeDetails := map[*schema.ObjectType]*typeDetails{}
+func (d DocLanguageHelper) GetTypeName(pkg *schema.Package, t schema.Type, input bool, relativeToModule string) string {
+	info, _ := pkg.Language["python"].(PackageInfo)
+
 	mod := &modContext{
-		pkg:         pkg.Reference(),
-		mod:         moduleName,
-		typeDetails: typeDetails,
+		pkg:              pkg.Reference(),
+		mod:              moduleToPythonModule(relativeToModule, info.ModuleNameOverrides),
+		modNameOverrides: info.ModuleNameOverrides,
+		typeDetails:      map[*schema.ObjectType]*typeDetails{},
 	}
 	typeName := mod.typeString(t, typeStringOpts{input: input, forDocs: true})
 

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -360,6 +360,10 @@ func tokenToName(tok string) string {
 	return title(components[2])
 }
 
+// tokenToPackage accepts a *Pulumi token* and returns name of the *Python module* that it
+// should be generated into.
+//
+// For example, it converts: "pkg:someModule:Resource" to "somemodule".
 func tokenToModule(tok string, pkg schema.PackageReference, moduleNameOverrides map[string]string) string {
 	// See if there's a manually-overridden module name.
 	if pkg == nil {
@@ -367,6 +371,14 @@ func tokenToModule(tok string, pkg schema.PackageReference, moduleNameOverrides 
 		pkg = (&schema.Package{}).Reference()
 	}
 	canonicalModName := pkg.TokenToModule(tok)
+	return moduleToPythonModule(canonicalModName, moduleNameOverrides)
+}
+
+// tokenToPackage accepts a *Pulumi module* and returns name of the *Python module* that it
+// should be generated into.
+//
+// For example, it converts: "someModule" to "somemodule".
+func moduleToPythonModule(canonicalModName string, moduleNameOverrides map[string]string) string {
 	if override, ok := moduleNameOverrides[canonicalModName]; ok {
 		return override
 	}

--- a/pkg/codegen/python/python_test.go
+++ b/pkg/codegen/python/python_test.go
@@ -78,3 +78,10 @@ func TestPyNameLegacy(t *testing.T) {
 		})
 	}
 }
+
+func TestTokenToModule(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "module", tokenToModule("pkg:module:Type", nil, nil))
+	assert.Equal(t, "mymodule", tokenToModule("pkg:myModule:Type", nil, nil))
+}


### PR DESCRIPTION
```patch
 type DocLanguageHelper interface {
-	GetLanguageTypeString(pkg *schema.Package, moduleName string, t schema.Type, input bool) string
+ 	// GetTypeName gets the name of a type in the language of the DocLanguageHelper.
+	//
+	// relativeToModule should always be a module returned from pkg.TokenToModule. It
+	// should not be language specialized.
+	GetTypeName(pkg *schema.Package, t schema.Type, input bool, relativeToModule string) string
 ...
 }
```

This change (similar to https://github.com/pulumi/pulumi/pull/19268) reduces the book-keeping necessary to use `DocLanguageHelper`. The name change brings the method more inline with other `DocLanguageHelper` methods like `GetPropertyName`, `GetEnumName` and `GetFunctionName`. 

More important is the change in what is expected from the "relative to module" field. `module` (from `GetLanguageTypeString`) expected a language specialized module name (like `some_module`), requiring each call to `DocLanguageHelper.GetLanguageTypeString` to know what language it's calling into. `relativeToModule` (from `GetTypeName`) accepts a Pulumi module (like `someModule`). Pulumi modules are not language specific.