### PR TITLE
remove "Debug branch name" step

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -398,19 +398,6 @@ jobs:
           path: |
             coverage/*
             !coverage/.gitkeep
-      - name: Debug branch name
-        env:
-          REF: ${{ github.ref }}
-          REF_NAME: ${{ github.ref_name }}
-          HEAD_REF: ${{ github.head_ref }}
-          EVENT_NAME: ${{ github.event_name }}
-          BRANCH_NAME: ${{ github.event_name == 'merge_group' && 'master' || github.head_ref }}
-        run: |
-          echo REF="${REF}"
-          echo REF_NAME="${REF_NAME}"
-          echo HEAD_REF="${HEAD_REF}"
-          echo EVENT_NAME="${EVENT_NAME}"
-          echo BRANCH_NAME="${BRANCH_NAME}"
       - name: Upload codecov test results
         uses: codecov/test-results-action@v1
         with:


### PR DESCRIPTION
This shouldn't be needed anymore (I think we introduced this temporarily, to debug selectively upload test results to codecov). Somehow this failed in https://github.com/pulumi/pulumi/actions/runs/14643049132/job/41090458864?pr=19305.

It really doesn't make sense to me that it failed (Windows behaves weirdly sometimes I guess), but at the same time we don't need this step, so let's get rid of it.