### PR TITLE
Add pulumi.type_token decorator

### DIFF
--- a/changelog/pending/20250424--sdk-python--add-pulumi_type-decorator.yaml
+++ b/changelog/pending/20250424--sdk-python--add-pulumi_type-decorator.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Add pulumi_type decorator

--- a/changelog/pending/20250424--sdk-python--add-pulumi_type-decorator.yaml
+++ b/changelog/pending/20250424--sdk-python--add-pulumi_type-decorator.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: sdk/python
-  description: Add pulumi_type decorator
+  description: Add pulumi.type_token decorator

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -102,6 +102,8 @@ from .stack_reference import (
     StackReferenceOutputDetails,
 )
 
+from .type_token import get_pulumi_type, pulumi_type
+
 from ._types import (
     MISSING,
     input_type,
@@ -178,6 +180,9 @@ __all__ = [
     # stack_reference
     "StackReference",
     "StackReferenceOutputDetails",
+    # type_token
+    "get_pulumi_type",
+    "pulumi_type",
     # _types
     "MISSING",
     "input_type",

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -102,7 +102,7 @@ from .stack_reference import (
     StackReferenceOutputDetails,
 )
 
-from .type_token import get_pulumi_type, pulumi_type
+from .type_token import get_type_token, type_token
 
 from ._types import (
     MISSING,
@@ -181,8 +181,8 @@ __all__ = [
     "StackReference",
     "StackReferenceOutputDetails",
     # type_token
-    "get_pulumi_type",
-    "pulumi_type",
+    "get_type_token",
+    "type_token",
     # _types
     "MISSING",
     "input_type",

--- a/sdk/python/lib/pulumi/type_token.py
+++ b/sdk/python/lib/pulumi/type_token.py
@@ -19,13 +19,13 @@ T = TypeVar("T", bound=type)
 _PULUMI_TYPE = "pulumi_type"
 
 
-def pulumi_type(type_token: str) -> Callable[[T], T]:
+def type_token(type_token: str) -> Callable[[T], T]:
     """
     Decorate a class representing a Pulumi type like a resource, but also enums,
     with its type token.
 
     Example:
-        @pulumi_type("aws:s3/bucket:Bucket")
+        @pulumi.type_token("aws:s3/bucket:Bucket")
         class Bucket(Resource): ...
     """
 
@@ -36,6 +36,6 @@ def pulumi_type(type_token: str) -> Callable[[T], T]:
     return decorator
 
 
-def get_pulumi_type(klass: type) -> Optional[str]:
+def get_type_token(klass: type) -> Optional[str]:
     """Retrieve the type token from a Pulumi type."""
     return getattr(klass, _PULUMI_TYPE, None)

--- a/sdk/python/lib/pulumi/type_token.py
+++ b/sdk/python/lib/pulumi/type_token.py
@@ -1,0 +1,41 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TypeVar, Callable, Optional
+
+T = TypeVar("T", bound=type)
+
+_PULUMI_TYPE = "pulumi_type"
+
+
+def pulumi_type(type_token: str) -> Callable[[T], T]:
+    """
+    Decorate a class representing a Pulumi type like a resource, but also enums,
+    with its type token.
+
+    Example:
+        @pulumi_type("aws:s3/bucket:Bucket")
+        class Bucket(Resource): ...
+    """
+
+    def decorator(klass: T) -> T:
+        setattr(klass, _PULUMI_TYPE, type_token)
+        return klass
+
+    return decorator
+
+
+def get_pulumi_type(klass: type) -> Optional[str]:
+    """Retrieve the type token from a Pulumi type."""
+    return getattr(klass, _PULUMI_TYPE, None)

--- a/sdk/python/lib/test/test_type_token.py
+++ b/sdk/python/lib/test/test_type_token.py
@@ -1,0 +1,37 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+from pulumi.resource import Resource
+from pulumi.type_token import get_pulumi_type, pulumi_type
+
+
+def test_pulumi_type():
+    class MyResourceWithoutToken(Resource): ...
+
+    assert get_pulumi_type(MyResourceWithoutToken) is None
+
+    @pulumi_type("package:module:resource")
+    class MyResource(Resource): ...
+
+    assert get_pulumi_type(MyResource) == "package:module:resource"
+
+    class MyEnumWithoutToken(Enum): ...
+
+    assert get_pulumi_type(MyEnumWithoutToken) is None
+
+    @pulumi_type("package:module:enum")
+    class MyEnum(Enum): ...
+
+    assert get_pulumi_type(MyEnum) == "package:module:enum"

--- a/sdk/python/lib/test/test_type_token.py
+++ b/sdk/python/lib/test/test_type_token.py
@@ -17,7 +17,7 @@ from pulumi.resource import Resource
 from pulumi.type_token import get_type_token, type_token
 
 
-def test_pulumi_type():
+def test_type_token():
     class MyResourceWithoutToken(Resource): ...
 
     assert get_type_token(MyResourceWithoutToken) is None

--- a/sdk/python/lib/test/test_type_token.py
+++ b/sdk/python/lib/test/test_type_token.py
@@ -14,24 +14,24 @@
 
 from enum import Enum
 from pulumi.resource import Resource
-from pulumi.type_token import get_pulumi_type, pulumi_type
+from pulumi.type_token import get_type_token, type_token
 
 
 def test_pulumi_type():
     class MyResourceWithoutToken(Resource): ...
 
-    assert get_pulumi_type(MyResourceWithoutToken) is None
+    assert get_type_token(MyResourceWithoutToken) is None
 
-    @pulumi_type("package:module:resource")
+    @type_token("package:module:resource")
     class MyResource(Resource): ...
 
-    assert get_pulumi_type(MyResource) == "package:module:resource"
+    assert get_type_token(MyResource) == "package:module:resource"
 
     class MyEnumWithoutToken(Enum): ...
 
-    assert get_pulumi_type(MyEnumWithoutToken) is None
+    assert get_type_token(MyEnumWithoutToken) is None
 
-    @pulumi_type("package:module:enum")
+    @type_token("package:module:enum")
     class MyEnum(Enum): ...
 
-    assert get_pulumi_type(MyEnum) == "package:module:enum"
+    assert get_type_token(MyEnum) == "package:module:enum"


### PR DESCRIPTION
Add a `pulumi_type` decorator to annotate Pulumi types such as resources and enums with their type token. This also provides a `get_pulumi_type` helper to retrieve the token.

Once this is released, we can update codegen to use this decorator to annotate resources and enums. We will also update the codegen change introduced in https://github.com/pulumi/pulumi/pull/19221 to use the decorator instead.

Ref https://github.com/pulumi/pulumi/issues/19297 & https://github.com/pulumi/pulumi/issues/18484