### PR TITLE
Add `--exclude` and `--exclude-dependents` to the Python automation API

### DIFF
--- a/changelog/pending/20250424--auto-python--add-exclude-and-exclude-dependents-to-the-automation-api.yaml
+++ b/changelog/pending/20250424--auto-python--add-exclude-and-exclude-dependents-to-the-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/python
+  description: Add `--exclude` and `--exclude-dependents` to the Automation API

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -268,11 +268,13 @@ class Stack:
         parallel: Optional[int] = None,
         message: Optional[str] = None,
         target: Optional[List[str]] = None,
+        exclude: Optional[List[str]] = None,
         policy_packs: Optional[List[str]] = None,
         policy_pack_configs: Optional[List[str]] = None,
         expect_no_changes: Optional[bool] = None,
         diff: Optional[bool] = None,
         target_dependents: Optional[bool] = None,
+        exclude_dependents: Optional[bool] = None,
         replace: Optional[List[str]] = None,
         color: Optional[str] = None,
         on_output: Optional[OnOutput] = None,
@@ -299,11 +301,13 @@ class Stack:
                          (1 for no parallelism). Defaults to unbounded (2147483647).
         :param message: Message (optional) to associate with the update operation.
         :param target: Specify an exclusive list of resource URNs to destroy.
+        :param exclude: Specify an exclusive list of resource URNs to ignore.
         :param expect_no_changes: Return an error if any changes occur during this update.
         :param policy_packs: Run one or more policy packs as part of this update.
         :param policy_pack_configs: Path to JSON file containing the config for the policy pack of the corresponding "--policy-pack" flag.
         :param diff: Display operation as a rich diff showing the overall change.
         :param target_dependents: Allows updating of dependent targets discovered but not specified in the Target list.
+        :param exclude_dependents: Allows ignoring of dependent targets discovered but not specified in the Exclude list.
         :param replace: Specify resources to replace.
         :param on_output: A function to process the stdout stream.
         :param on_event: A function to process structured events from the Pulumi event stream.
@@ -392,11 +396,13 @@ class Stack:
         parallel: Optional[int] = None,
         message: Optional[str] = None,
         target: Optional[List[str]] = None,
+        exclude: Optional[List[str]] = None,
         policy_packs: Optional[List[str]] = None,
         policy_pack_configs: Optional[List[str]] = None,
         expect_no_changes: Optional[bool] = None,
         diff: Optional[bool] = None,
         target_dependents: Optional[bool] = None,
+        exclude_dependents: Optional[bool] = None,
         replace: Optional[List[str]] = None,
         color: Optional[str] = None,
         on_output: Optional[OnOutput] = None,
@@ -422,11 +428,13 @@ class Stack:
                          (1 for no parallelism). Defaults to unbounded (2147483647).
         :param message: Message to associate with the preview operation.
         :param target: Specify an exclusive list of resource URNs to update.
+        :param exclude: Specify an exclusive list of resource URNs to ignore.
         :param policy_packs: Run one or more policy packs as part of this update.
         :param policy_pack_configs: Path to JSON file containing the config for the policy pack of the corresponding "--policy-pack" flag.
         :param expect_no_changes: Return an error if any changes occur during this update.
         :param diff: Display operation as a rich diff showing the overall change.
         :param target_dependents: Allows updating of dependent targets discovered but not specified in the Target list.
+        :param exclude_dependents: Allows ignoring of dependent targets discovered but not specified in the Exclude list.
         :param replace: Specify resources to replace.
         :param on_output: A function to process the stdout stream.
         :param on_event: A function to process structured events from the Pulumi event stream.
@@ -521,6 +529,9 @@ class Stack:
         message: Optional[str] = None,
         preview_only: Optional[bool] = None,
         target: Optional[List[str]] = None,
+        exclude: Optional[List[str]] = None,
+        target_dependents: Optional[bool] = None,
+        exclude_dependents: Optional[bool] = None,
         expect_no_changes: Optional[bool] = None,
         clear_pending_creates: Optional[bool] = None,
         color: Optional[str] = None,
@@ -545,6 +556,9 @@ class Stack:
         :param message: Message (optional) to associate with the refresh operation.
         :param preview_only: Only show a preview of the refresh, but don't perform the refresh itself.
         :param target: Specify an exclusive list of resource URNs to refresh.
+        :param exclude: Specify an exclusive list of resource URNs to ignore.
+        :param target_dependents: Allows updating of dependent targets discovered but not specified in the Target list.
+        :param exclude_dependents: Allows ignoring of dependent targets discovered but not specified in the Exclude list.
         :param expect_no_changes: Return an error if any changes occur during this update.
         :param clear_pending_creates: Clear all pending creates, dropping them from the state.
         :param on_output: A function to process the stdout stream.
@@ -1075,9 +1089,11 @@ def _parse_extra_args(**kwargs) -> List[str]:
     diff: Optional[bool] = kwargs.get("diff")
     replace: Optional[List[str]] = kwargs.get("replace")
     target: Optional[List[str]] = kwargs.get("target")
+    exclude: Optional[List[str]] = kwargs.get("exclude")
     policy_packs: Optional[List[str]] = kwargs.get("policy_packs")
     policy_pack_configs: Optional[List[str]] = kwargs.get("policy_pack_configs")
     target_dependents: Optional[bool] = kwargs.get("target_dependents")
+    exclude_dependents: Optional[bool] = kwargs.get("exclude_dependents")
     parallel: Optional[int] = kwargs.get("parallel")
     color: Optional[str] = kwargs.get("color")
     log_flow: Optional[bool] = kwargs.get("log_flow")
@@ -1106,6 +1122,9 @@ def _parse_extra_args(**kwargs) -> List[str]:
     if target:
         for t in target:
             extra_args.extend(["--target", t])
+    if exclude:
+        for e in exclude:
+            extra_args.extend(["--exclude", e])
     if policy_packs:
         for p in policy_packs:
             extra_args.extend(["--policy-pack", p])
@@ -1114,6 +1133,8 @@ def _parse_extra_args(**kwargs) -> List[str]:
             extra_args.extend(["--policy-pack-config", p])
     if target_dependents:
         extra_args.append("--target-dependents")
+    if exclude_dependents:
+        extra_args.append("--exclude-dependents")
     if parallel:
         extra_args.extend(["--parallel", str(parallel)])
     if color:


### PR DESCRIPTION
I added these to NodeJS as part of another ticket, but I'll add them to the other SDKs for completeness' sake.

* https://github.com/pulumi/pulumi/pull/19270