### PR TITLE
`DocLanguageHelper`: `*schema.Package` -> `schema.PackageReference`

### DIFF
--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -59,7 +59,7 @@ type DocLanguageHelper interface {
 	//
 	//	qualifiedName := python.GetTypeName(pkg, prop.Type, false, "")
 	//	fmt.Println(qualifiedName) // Prints "my_module.TheType"
-	GetTypeName(pkg *schema.Package, typ schema.Type, input bool, relativeToModule string) string
+	GetTypeName(pkg schema.PackageReference, t schema.Type, input bool, relativeToModule string) string
 	GetFunctionName(f *schema.Function) string
 
 	// GetResourceFunctionResultName returns the name of the result type when a static resource function is used to lookup
@@ -68,7 +68,7 @@ type DocLanguageHelper interface {
 
 	// Methods
 	GetMethodName(m *schema.Method) string
-	GetMethodResultName(pkg *schema.Package, modName string, r *schema.Resource, m *schema.Method) string
+	GetMethodResultName(pkg schema.PackageReference, modName string, r *schema.Resource, m *schema.Method) string
 
 	// Doc links
 	GetDocLinkForResourceType(pkg *schema.Package, moduleName, typeName string) string

--- a/pkg/codegen/docs_integration_test.go
+++ b/pkg/codegen/docs_integration_test.go
@@ -270,8 +270,6 @@ func TestGetLanguageTypeString(t *testing.T) {
 	// [schema.Package].
 	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
-			def, err := tt.schema.Definition()
-			require.NoError(t, err)
 			require.NotEmpty(t, tt.expected, "Must test at least one language")
 			for lang, expected := range tt.expected {
 				var name string
@@ -287,10 +285,10 @@ func TestGetLanguageTypeString(t *testing.T) {
 					helper = func() codegen.DocLanguageHelper {
 						h := golang_codegen.DocLanguageHelper{}
 						var info golang_codegen.GoPackageInfo
-						if i, ok := def.Language["go"].(golang_codegen.GoPackageInfo); ok {
-							info = i
+						if i, err := tt.schema.Language("go"); err == nil && i != nil {
+							info = i.(golang_codegen.GoPackageInfo)
 						}
-						h.GeneratePackagesMap(def, "test", info)
+						h.GeneratePackagesMap(tt.schema, "test", info)
 						return h
 					}
 					name = "go"
@@ -304,13 +302,13 @@ func TestGetLanguageTypeString(t *testing.T) {
 				t.Run(name, func(t *testing.T) {
 					if tt.input == nil || *tt.input {
 						t.Run("input", func(t *testing.T) {
-							actual := helper().GetTypeName(def, tt.typ, true, tt.module)
+							actual := helper().GetTypeName(tt.schema, tt.typ, true, tt.module)
 							assert.Equal(t, expected, actual)
 						})
 					}
 					if tt.input == nil || !*tt.input {
 						t.Run("output", func(t *testing.T) {
-							actual := helper().GetTypeName(def, tt.typ, false, tt.module)
+							actual := helper().GetTypeName(tt.schema, tt.typ, false, tt.module)
 							assert.Equal(t, expected, actual)
 						})
 					}

--- a/pkg/codegen/dotnet/doc.go
+++ b/pkg/codegen/dotnet/doc.go
@@ -68,10 +68,13 @@ func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(pkg *schema.Pa
 }
 
 // GetLanguageTypeString returns the DotNet-specific type given a Pulumi schema type.
-func (d DocLanguageHelper) GetTypeName(pkg *schema.Package, t schema.Type, input bool, relativeToModule string) string {
-	info, _ := pkg.Language["csharp"].(CSharpPackageInfo)
+func (d DocLanguageHelper) GetTypeName(pkg schema.PackageReference, t schema.Type, input bool, relativeToModule string) string {
+	var info CSharpPackageInfo
+	if a, err := pkg.Language("csharp"); err == nil {
+		info, _ = a.(CSharpPackageInfo)
+	}
 	mod := &modContext{
-		pkg:           pkg.Reference(),
+		pkg:           pkg,
 		mod:           relativeToModule,
 		typeDetails:   map[*schema.ObjectType]*typeDetails{},
 		namespaces:    info.Namespaces,
@@ -99,17 +102,18 @@ func (d DocLanguageHelper) GetMethodName(m *schema.Method) string {
 	return Title(m.Name)
 }
 
-func (d DocLanguageHelper) GetMethodResultName(pkg *schema.Package, modName string, r *schema.Resource,
+func (d DocLanguageHelper) GetMethodResultName(pkg schema.PackageReference, modName string, r *schema.Resource,
 	m *schema.Method,
 ) string {
-	info, _ := pkg.Language["csharp"].(CSharpPackageInfo)
+	a, _ := pkg.Language("csharp")
+	info, _ := a.(CSharpPackageInfo)
 	var returnType *schema.ObjectType
 	if m.Function.ReturnType != nil {
 		if objectType, ok := m.Function.ReturnType.(*schema.ObjectType); ok {
 			returnType = objectType
 		} else {
 			mod := &modContext{
-				pkg:           pkg.Reference(),
+				pkg:           pkg,
 				mod:           modName,
 				typeDetails:   map[*schema.ObjectType]*typeDetails{},
 				namespaces:    info.Namespaces,
@@ -121,7 +125,7 @@ func (d DocLanguageHelper) GetMethodResultName(pkg *schema.Package, modName stri
 
 	if info.LiftSingleValueMethodReturns && returnType != nil && len(returnType.Properties) == 1 {
 		mod := &modContext{
-			pkg:           pkg.Reference(),
+			pkg:           pkg,
 			mod:           modName,
 			typeDetails:   map[*schema.ObjectType]*typeDetails{},
 			namespaces:    info.Namespaces,

--- a/pkg/codegen/dotnet/doc_test.go
+++ b/pkg/codegen/dotnet/doc_test.go
@@ -91,7 +91,7 @@ func TestGetDocLinkForResourceInputOrOutputType(t *testing.T) {
 
 	// Generate the type string for the property type and use that to generate the doc link.
 	propertyType := codegen.UnwrapType(pkg.Resources[0].InputProperties[0].Type)
-	typeString := d.GetTypeName(pkg, propertyType, true, pkg.TokenToModule("aws:s3/BucketCorsRule:BucketCorsRule"))
+	typeString := d.GetTypeName(pkg.Reference(), propertyType, true, pkg.TokenToModule("aws:s3/BucketCorsRule:BucketCorsRule"))
 	link := d.GetDocLinkForResourceInputOrOutputType(pkg, "doesNotMatter", typeString, true)
 	assert.Equal(t, "/docs/reference/pkg/dotnet/Pulumi.Aws/Pulumi.Aws.S3.Inputs.BucketCorsRuleArgs.html", link)
 }

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -89,7 +89,7 @@ func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(pkg *schema.Pa
 }
 
 // GetLanguageTypeString returns the Go-specific type given a Pulumi schema type.
-func (d DocLanguageHelper) GetTypeName(pkg *schema.Package, t schema.Type, input bool, relativeToModule string) string {
+func (d DocLanguageHelper) GetTypeName(pkg schema.PackageReference, t schema.Type, input bool, relativeToModule string) string {
 	goPkg := moduleToPackage(d.goPkgInfo.ModuleToPackage, relativeToModule)
 	modPkg, ok := d.packages[goPkg]
 	if !ok {
@@ -100,12 +100,12 @@ func (d DocLanguageHelper) GetTypeName(pkg *schema.Package, t schema.Type, input
 }
 
 // GeneratePackagesMap generates a map of Go packages for resources, functions and types.
-func (d *DocLanguageHelper) GeneratePackagesMap(pkg *schema.Package, tool string, goInfo GoPackageInfo) {
+func (d *DocLanguageHelper) GeneratePackagesMap(pkg schema.PackageReference, tool string, goInfo GoPackageInfo) {
 	var err error
-	d.packages, err = generatePackageContextMap(tool, pkg.Reference(), goInfo, nil)
+	d.packages, err = generatePackageContextMap(tool, pkg, goInfo, nil)
 	d.goPkgInfo = goInfo
-	d.topLevelPkg = pkg.Reference()
-	contract.AssertNoErrorf(err, "Could not generate package context map for %q", pkg.Name)
+	d.topLevelPkg = pkg
+	contract.AssertNoErrorf(err, "Could not generate package context map for %q", pkg.Name())
 }
 
 // GetPropertyName returns the property name specific to Go.
@@ -149,26 +149,28 @@ func (d DocLanguageHelper) GetMethodName(m *schema.Method) string {
 	return Title(m.Name)
 }
 
-func (d DocLanguageHelper) GetMethodResultName(pkg *schema.Package, modName string, r *schema.Resource,
+func (d DocLanguageHelper) GetMethodResultName(pkg schema.PackageReference, modName string, r *schema.Resource,
 	m *schema.Method,
 ) string {
-	if info, ok := pkg.Language["go"].(GoPackageInfo); ok {
-		var objectReturnType *schema.ObjectType
-		if m.Function.ReturnType != nil {
-			if objectType, ok := m.Function.ReturnType.(*schema.ObjectType); ok && objectType != nil {
-				objectReturnType = objectType
-			}
+	var info GoPackageInfo
+	if i, err := pkg.Language("go"); err == nil {
+		info, _ = i.(GoPackageInfo)
+	}
+	var objectReturnType *schema.ObjectType
+	if m.Function.ReturnType != nil {
+		if objectType, ok := m.Function.ReturnType.(*schema.ObjectType); ok && objectType != nil {
+			objectReturnType = objectType
 		}
+	}
 
-		if info.LiftSingleValueMethodReturns && objectReturnType != nil && len(objectReturnType.Properties) == 1 {
-			t := objectReturnType.Properties[0].Type
-			modPkg, ok := d.packages[modName]
-			if !ok {
-				glog.Fatalf("cannot calculate type string for type %q. could not find a package for module %q",
-					t.String(), modName)
-			}
-			return modPkg.outputType(t)
+	if info.LiftSingleValueMethodReturns && objectReturnType != nil && len(objectReturnType.Properties) == 1 {
+		t := objectReturnType.Properties[0].Type
+		modPkg, ok := d.packages[modName]
+		if !ok {
+			glog.Fatalf("cannot calculate type string for type %q. could not find a package for module %q",
+				t.String(), modName)
 		}
+		return modPkg.outputType(t)
 	}
 	return fmt.Sprintf("%s%sResultOutput", rawResourceName(r), d.GetMethodName(m))
 }

--- a/pkg/codegen/go/doc_test.go
+++ b/pkg/codegen/go/doc_test.go
@@ -133,7 +133,7 @@ func TestGetFunctionName(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 	d := DocLanguageHelper{}
-	d.GeneratePackagesMap(pkg, "test", GoPackageInfo{})
+	d.GeneratePackagesMap(pkg.Reference(), "test", GoPackageInfo{})
 
 	names := map[string]string{}
 	for _, f := range pkg.Functions {

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -74,11 +74,14 @@ func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(pkg *schema.Pa
 }
 
 // GetLanguageTypeString returns the Python-specific type given a Pulumi schema type.
-func (d DocLanguageHelper) GetTypeName(pkg *schema.Package, t schema.Type, input bool, relativeToModule string) string {
-	info, _ := pkg.Language["python"].(PackageInfo)
+func (d DocLanguageHelper) GetTypeName(pkg schema.PackageReference, t schema.Type, input bool, relativeToModule string) string {
+	var info PackageInfo
+	if a, err := pkg.Language("python"); err == nil {
+		info, _ = a.(PackageInfo)
+	}
 
 	mod := &modContext{
-		pkg:              pkg.Reference(),
+		pkg:              pkg,
 		mod:              moduleToPythonModule(relativeToModule, info.ModuleNameOverrides),
 		modNameOverrides: info.ModuleNameOverrides,
 		typeDetails:      map[*schema.ObjectType]*typeDetails{},
@@ -110,7 +113,7 @@ func (d DocLanguageHelper) GetMethodName(m *schema.Method) string {
 	return PyName(m.Name)
 }
 
-func (d DocLanguageHelper) GetMethodResultName(pkg *schema.Package, modName string, r *schema.Resource,
+func (d DocLanguageHelper) GetMethodResultName(pkg schema.PackageReference, modName string, r *schema.Resource,
 	m *schema.Method,
 ) string {
 	var returnType *schema.ObjectType
@@ -120,16 +123,19 @@ func (d DocLanguageHelper) GetMethodResultName(pkg *schema.Package, modName stri
 		}
 	}
 
-	if info, ok := pkg.Language["python"].(PackageInfo); ok {
-		if info.LiftSingleValueMethodReturns && returnType != nil && len(returnType.Properties) == 1 {
-			typeDetails := map[*schema.ObjectType]*typeDetails{}
-			mod := &modContext{
-				pkg:         pkg.Reference(),
-				mod:         modName,
-				typeDetails: typeDetails,
-			}
-			return mod.typeString(returnType.Properties[0].Type, typeStringOpts{})
+	var info PackageInfo
+	if i, err := pkg.Language("python"); err == nil {
+		info = i.(PackageInfo)
+	}
+
+	if info.LiftSingleValueMethodReturns && returnType != nil && len(returnType.Properties) == 1 {
+		typeDetails := map[*schema.ObjectType]*typeDetails{}
+		mod := &modContext{
+			pkg:         pkg,
+			mod:         modName,
+			typeDetails: typeDetails,
 		}
+		return mod.typeString(returnType.Properties[0].Type, typeStringOpts{})
 	}
 	return fmt.Sprintf("%s.%sResult", resourceName(r), title(d.GetMethodName(m)))
 }


### PR DESCRIPTION
Change the interface of `DocLanguageHelper.GetTypeName` and `GetMethodResultName` to accept `schema.PackageReference` instead of `*schema.Package`. Lazily bound schemas are much more efficient when producing docs for a single page (as we intend to do for a live registry).

The original logic for `schema.PackageReference` can be found here: https://github.com/pulumi/pulumi/pull/9620.