### PR TITLE
Ensure we always save ImportID

### DIFF
--- a/changelog/pending/20250424--engine--fix-importid-being-lost-from-state-during-update-operations.yaml
+++ b/changelog/pending/20250424--engine--fix-importid-being-lost-from-state-during-update-operations.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix ImportID being lost from state during update operations

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -730,7 +730,7 @@ func (sg *stepGenerator) continueStepsFromRefresh(event ContinueResourceRefreshE
 	}
 	new := resource.NewState(goal.Type, urn, goal.Custom, false, "", inputs, nil, goal.Parent, protectState, false,
 		goal.Dependencies, goal.InitErrors, goal.Provider, goal.PropertyDependencies, false,
-		goal.AdditionalSecretOutputs, aliasUrns, &goal.CustomTimeouts, "", retainOnDelete, goal.DeletedWith,
+		goal.AdditionalSecretOutputs, aliasUrns, &goal.CustomTimeouts, goal.ID, retainOnDelete, goal.DeletedWith,
 		createdAt, modifiedAt, goal.SourcePosition, goal.IgnoreChanges, goal.ReplaceOnChanges)
 
 	if providers.IsProviderType(goal.Type) {
@@ -872,9 +872,7 @@ func (sg *stepGenerator) continueStepsFromRefresh(event ContinueResourceRefreshE
 	if isImport {
 		// TODO(seqnum) Not sure how sequence numbers should interact with imports
 
-		// Write the ID of the resource to import into the new state and return an ImportStep or an
-		// ImportReplacementStep
-		new.ImportID = goal.ID
+		// Return an ImportStep or an ImportReplacementStep
 
 		// If we're generating plans create a plan, Imports have no diff, just a goal state
 		if sg.deployment.opts.GeneratePlan {


### PR DESCRIPTION
`ImportID` was only set when doing an import which meant it was lost from state if you did a normal update on the resource. This then broke the re-import logic on a later `up`.

This fixes it to always save it to state, and updates the test to check that actual import IDs and IDs are kept track of ok.