### PR TITLE
Simplify `schema.Language` by removing fields we don't use

### DIFF
--- a/pkg/codegen/dotnet/doc.go
+++ b/pkg/codegen/dotnet/doc.go
@@ -148,7 +148,7 @@ func (d DocLanguageHelper) GetPropertyName(p *schema.Property) (string, error) {
 	propLangName := strings.Title(p.Name)
 
 	if raw, ok := p.Language["csharp"].(json.RawMessage); ok {
-		val, err := Importer.ImportPropertySpec(p, raw)
+		val, err := Importer.ImportPropertySpec(raw)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/codegen/dotnet/importer.go
+++ b/pkg/codegen/dotnet/importer.go
@@ -61,12 +61,12 @@ var Importer schema.Language = importer(0)
 type importer int
 
 // ImportDefaultSpec decodes language-specific metadata associated with a DefaultValue.
-func (importer) ImportDefaultSpec(def *schema.DefaultValue, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportDefaultSpec(raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }
 
 // ImportPropertySpec decodes language-specific metadata associated with a Property.
-func (importer) ImportPropertySpec(property *schema.Property, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportPropertySpec(raw json.RawMessage) (interface{}, error) {
 	var info CSharpPropertyInfo
 	if err := json.Unmarshal([]byte(raw), &info); err != nil {
 		return nil, err
@@ -75,12 +75,12 @@ func (importer) ImportPropertySpec(property *schema.Property, raw json.RawMessag
 }
 
 // ImportObjectTypeSpec decodes language-specific metadata associated with a ObjectType.
-func (importer) ImportObjectTypeSpec(object *schema.ObjectType, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportObjectTypeSpec(raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }
 
 // ImportResourceSpec decodes language-specific metadata associated with a Resource.
-func (importer) ImportResourceSpec(resource *schema.Resource, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportResourceSpec(raw json.RawMessage) (interface{}, error) {
 	var info CSharpResourceInfo
 	if err := json.Unmarshal([]byte(raw), &info); err != nil {
 		return nil, err
@@ -89,12 +89,12 @@ func (importer) ImportResourceSpec(resource *schema.Resource, raw json.RawMessag
 }
 
 // ImportFunctionSpec decodes language-specific metadata associated with a Function.
-func (importer) ImportFunctionSpec(function *schema.Function, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportFunctionSpec(raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }
 
 // ImportPackageSpec decodes language-specific metadata associated with a Package.
-func (importer) ImportPackageSpec(pkg *schema.Package, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportPackageSpec(raw json.RawMessage) (interface{}, error) {
 	var info CSharpPackageInfo
 	if err := json.Unmarshal([]byte(raw), &info); err != nil {
 		return nil, err

--- a/pkg/codegen/go/importer.go
+++ b/pkg/codegen/go/importer.go
@@ -112,32 +112,32 @@ var Importer schema.Language = importer(0)
 type importer int
 
 // ImportDefaultSpec decodes language-specific metadata associated with a DefaultValue.
-func (importer) ImportDefaultSpec(def *schema.DefaultValue, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportDefaultSpec(raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }
 
 // ImportPropertySpec decodes language-specific metadata associated with a Property.
-func (importer) ImportPropertySpec(property *schema.Property, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportPropertySpec(raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }
 
 // ImportObjectTypeSpec decodes language-specific metadata associated with a ObjectType.
-func (importer) ImportObjectTypeSpec(object *schema.ObjectType, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportObjectTypeSpec(raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }
 
 // ImportResourceSpec decodes language-specific metadata associated with a Resource.
-func (importer) ImportResourceSpec(resource *schema.Resource, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportResourceSpec(raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }
 
 // ImportFunctionSpec decodes language-specific metadata associated with a Function.
-func (importer) ImportFunctionSpec(function *schema.Function, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportFunctionSpec(raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }
 
 // ImportPackageSpec decodes language-specific metadata associated with a Package.
-func (importer) ImportPackageSpec(pkg *schema.Package, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportPackageSpec(raw json.RawMessage) (interface{}, error) {
 	var info GoPackageInfo
 	if err := json.Unmarshal(raw, &info); err != nil {
 		return nil, err

--- a/pkg/codegen/nodejs/importer.go
+++ b/pkg/codegen/nodejs/importer.go
@@ -91,17 +91,17 @@ var Importer schema.Language = importer(0)
 type importer int
 
 // ImportDefaultSpec decodes language-specific metadata associated with a DefaultValue.
-func (importer) ImportDefaultSpec(def *schema.DefaultValue, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportDefaultSpec(raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }
 
 // ImportPropertySpec decodes language-specific metadata associated with a Property.
-func (importer) ImportPropertySpec(property *schema.Property, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportPropertySpec(raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }
 
 // ImportObjectTypeSpec decodes language-specific metadata associated with a ObjectType.
-func (importer) ImportObjectTypeSpec(object *schema.ObjectType, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportObjectTypeSpec(raw json.RawMessage) (interface{}, error) {
 	var info NodeObjectInfo
 	if err := json.Unmarshal([]byte(raw), &info); err != nil {
 		return nil, err
@@ -110,17 +110,17 @@ func (importer) ImportObjectTypeSpec(object *schema.ObjectType, raw json.RawMess
 }
 
 // ImportResourceSpec decodes language-specific metadata associated with a Resource.
-func (importer) ImportResourceSpec(resource *schema.Resource, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportResourceSpec(raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }
 
 // ImportFunctionSpec decodes language-specific metadata associated with a Function.
-func (importer) ImportFunctionSpec(function *schema.Function, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportFunctionSpec(raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }
 
 // ImportPackageSpec decodes language-specific metadata associated with a Package.
-func (importer) ImportPackageSpec(pkg *schema.Package, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportPackageSpec(raw json.RawMessage) (interface{}, error) {
 	var info NodePackageInfo
 	if err := json.Unmarshal([]byte(raw), &info); err != nil {
 		return nil, err

--- a/pkg/codegen/python/importer.go
+++ b/pkg/codegen/python/importer.go
@@ -73,12 +73,12 @@ var Importer schema.Language = importer(0)
 type importer int
 
 // ImportDefaultSpec decodes language-specific metadata associated with a DefaultValue.
-func (importer) ImportDefaultSpec(def *schema.DefaultValue, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportDefaultSpec(raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }
 
 // ImportPropertySpec decodes language-specific metadata associated with a Property.
-func (importer) ImportPropertySpec(property *schema.Property, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportPropertySpec(raw json.RawMessage) (interface{}, error) {
 	var info PropertyInfo
 	if err := json.Unmarshal([]byte(raw), &info); err != nil {
 		return nil, err
@@ -87,22 +87,22 @@ func (importer) ImportPropertySpec(property *schema.Property, raw json.RawMessag
 }
 
 // ImportObjectTypeSpec decodes language-specific metadata associated with a ObjectType.
-func (importer) ImportObjectTypeSpec(object *schema.ObjectType, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportObjectTypeSpec(raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }
 
 // ImportResourceSpec decodes language-specific metadata associated with a Resource.
-func (importer) ImportResourceSpec(resource *schema.Resource, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportResourceSpec(raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }
 
 // ImportFunctionSpec decodes language-specific metadata associated with a Function.
-func (importer) ImportFunctionSpec(function *schema.Function, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportFunctionSpec(raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }
 
 // ImportPackageSpec decodes language-specific metadata associated with a Package.
-func (importer) ImportPackageSpec(pkg *schema.Package, raw json.RawMessage) (interface{}, error) {
+func (importer) ImportPackageSpec(raw json.RawMessage) (interface{}, error) {
 	var info PackageInfo
 	if err := json.Unmarshal([]byte(raw), &info); err != nil {
 		return nil, err

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -663,17 +663,17 @@ type Package struct {
 // Language provides hooks for importing language-specific metadata in a package.
 type Language interface {
 	// ImportDefaultSpec decodes language-specific metadata associated with a DefaultValue.
-	ImportDefaultSpec(def *DefaultValue, bytes json.RawMessage) (interface{}, error)
+	ImportDefaultSpec(bytes json.RawMessage) (any, error)
 	// ImportPropertySpec decodes language-specific metadata associated with a Property.
-	ImportPropertySpec(property *Property, bytes json.RawMessage) (interface{}, error)
+	ImportPropertySpec(bytes json.RawMessage) (interface{}, error)
 	// ImportObjectTypeSpec decodes language-specific metadata associated with a ObjectType.
-	ImportObjectTypeSpec(object *ObjectType, bytes json.RawMessage) (interface{}, error)
+	ImportObjectTypeSpec(bytes json.RawMessage) (interface{}, error)
 	// ImportResourceSpec decodes language-specific metadata associated with a Resource.
-	ImportResourceSpec(resource *Resource, bytes json.RawMessage) (interface{}, error)
+	ImportResourceSpec(bytes json.RawMessage) (interface{}, error)
 	// ImportFunctionSpec decodes language-specific metadata associated with a Function.
-	ImportFunctionSpec(function *Function, bytes json.RawMessage) (interface{}, error)
+	ImportFunctionSpec(bytes json.RawMessage) (interface{}, error)
 	// ImportPackageSpec decodes language-specific metadata associated with a Package.
-	ImportPackageSpec(pkg *Package, bytes json.RawMessage) (interface{}, error)
+	ImportPackageSpec(bytes json.RawMessage) (interface{}, error)
 }
 
 func sortedLanguageNames(metadata map[string]interface{}) []string {
@@ -690,7 +690,7 @@ func importDefaultLanguages(def *DefaultValue, languages map[string]Language) er
 		val := def.Language[name]
 		if raw, ok := val.(json.RawMessage); ok {
 			if lang, ok := languages[name]; ok {
-				val, err := lang.ImportDefaultSpec(def, raw)
+				val, err := lang.ImportDefaultSpec(raw)
 				if err != nil {
 					return fmt.Errorf("importing %v metadata: %w", name, err)
 				}
@@ -712,7 +712,7 @@ func importPropertyLanguages(property *Property, languages map[string]Language) 
 		val := property.Language[name]
 		if raw, ok := val.(json.RawMessage); ok {
 			if lang, ok := languages[name]; ok {
-				val, err := lang.ImportPropertySpec(property, raw)
+				val, err := lang.ImportPropertySpec(raw)
 				if err != nil {
 					return fmt.Errorf("importing %v metadata: %w", name, err)
 				}
@@ -734,7 +734,7 @@ func importObjectTypeLanguages(object *ObjectType, languages map[string]Language
 		val := object.Language[name]
 		if raw, ok := val.(json.RawMessage); ok {
 			if lang, ok := languages[name]; ok {
-				val, err := lang.ImportObjectTypeSpec(object, raw)
+				val, err := lang.ImportObjectTypeSpec(raw)
 				if err != nil {
 					return fmt.Errorf("importing %v metadata: %w", name, err)
 				}
@@ -770,7 +770,7 @@ func importResourceLanguages(resource *Resource, languages map[string]Language) 
 		val := resource.Language[name]
 		if raw, ok := val.(json.RawMessage); ok {
 			if lang, ok := languages[name]; ok {
-				val, err := lang.ImportResourceSpec(resource, raw)
+				val, err := lang.ImportResourceSpec(raw)
 				if err != nil {
 					return fmt.Errorf("importing %v metadata: %w", name, err)
 				}
@@ -799,7 +799,7 @@ func importFunctionLanguages(function *Function, languages map[string]Language) 
 		val := function.Language[name]
 		if raw, ok := val.(json.RawMessage); ok {
 			if lang, ok := languages[name]; ok {
-				val, err := lang.ImportFunctionSpec(function, raw)
+				val, err := lang.ImportFunctionSpec(raw)
 				if err != nil {
 					return fmt.Errorf("importing %v metadata: %w", name, err)
 				}
@@ -862,7 +862,7 @@ func (pkg *Package) ImportLanguages(languages map[string]Language) error {
 		val := pkg.Language[name]
 		if raw, ok := val.(json.RawMessage); ok {
 			if lang, ok := languages[name]; ok {
-				val, err := lang.ImportPackageSpec(pkg, raw)
+				val, err := lang.ImportPackageSpec(raw)
 				if err != nil {
 					return fmt.Errorf("importing %v metadata: %w", name, err)
 				}

--- a/pkg/codegen/testing/test/type_driver.go
+++ b/pkg/codegen/testing/test/type_driver.go
@@ -32,11 +32,11 @@ type typeTestCase struct {
 
 type typeTestImporter int
 
-func (typeTestImporter) ImportDefaultSpec(def *schema.DefaultValue, bytes json.RawMessage) (interface{}, error) {
+func (typeTestImporter) ImportDefaultSpec(bytes json.RawMessage) (interface{}, error) {
 	return bytes, nil
 }
 
-func (typeTestImporter) ImportPropertySpec(property *schema.Property, bytes json.RawMessage) (interface{}, error) {
+func (typeTestImporter) ImportPropertySpec(bytes json.RawMessage) (interface{}, error) {
 	var test typeTestCase
 	if err := json.Unmarshal([]byte(bytes), &test); err != nil {
 		return nil, err
@@ -44,19 +44,19 @@ func (typeTestImporter) ImportPropertySpec(property *schema.Property, bytes json
 	return &test, nil
 }
 
-func (typeTestImporter) ImportObjectTypeSpec(object *schema.ObjectType, bytes json.RawMessage) (interface{}, error) {
+func (typeTestImporter) ImportObjectTypeSpec(bytes json.RawMessage) (interface{}, error) {
 	return bytes, nil
 }
 
-func (typeTestImporter) ImportResourceSpec(resource *schema.Resource, bytes json.RawMessage) (interface{}, error) {
+func (typeTestImporter) ImportResourceSpec(bytes json.RawMessage) (interface{}, error) {
 	return bytes, nil
 }
 
-func (typeTestImporter) ImportFunctionSpec(function *schema.Function, bytes json.RawMessage) (interface{}, error) {
+func (typeTestImporter) ImportFunctionSpec(bytes json.RawMessage) (interface{}, error) {
 	return bytes, nil
 }
 
-func (typeTestImporter) ImportPackageSpec(pkg *schema.Package, bytes json.RawMessage) (interface{}, error) {
+func (typeTestImporter) ImportPackageSpec(bytes json.RawMessage) (interface{}, error) {
 	return bytes, nil
 }
 


### PR DESCRIPTION
The `schema` package defines a language interface to allow language specific changes. The current interface is overbuilt:

Each function takes the form `ImportT(*T, json.RawMessage) (interface{}, error)`. No implementer of `Language` ever actually accesses `*T`.

We can validate that this functionality is never used via GitHub search:

| Function                | Link                                                                      |
|-------------------------|---------------------------------------------------------------------------|
| `ImportDefaultSpec`     | <https://github.com/search?q=org%3Apulumi%20ImportDefaultSpec&type=code>  |
| `ImportPropertySpec`    | <https://github.com/search?q=org%3Apulumi+ImportPropertySpec&type=code>   |
| `ImportObjectTypeSpec`: | <https://github.com/search?q=org%3Apulumi+ImportObjectTypeSpec&type=code> |
| `ImportResourceSpec`    | <https://github.com/search?q=org%3Apulumi+ImportResourceSpec&type=code>   |
| `ImportFunctionSpec`    | <https://github.com/search?q=org%3Apulumi+ImportFunctionSpec&type=code>   |
| `ImportPackageSpec`     | <https://github.com/search?q=org%3Apulumi+ImportPackageSpec&type=code>    |

