### PR TITLE
Introduce wrapper around GetDefaultOrgs to include a fallback API call

### DIFF
--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -44,6 +44,7 @@ type MockBackend struct {
 	NameF                  func() string
 	URLF                   func() string
 	SetCurrentProjectF     func(proj *workspace.Project)
+	GetDefaultOrgF         func(ctx context.Context) (string, error)
 	GetPolicyPackF         func(ctx context.Context, policyPack string, d diag.Sink) (PolicyPack, error)
 	SupportsTagsF          func() bool
 	SupportsOrganizationsF func() bool
@@ -176,6 +177,9 @@ func (be *MockBackend) SupportsDeployments() bool {
 }
 
 func (be *MockBackend) GetDefaultOrg(ctx context.Context) (string, error) {
+	if be.GetDefaultOrgF != nil {
+		return be.GetDefaultOrgF(ctx)
+	}
 	return "", nil
 }
 

--- a/pkg/backend/organizations.go
+++ b/pkg/backend/organizations.go
@@ -1,0 +1,45 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"context"
+
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// GetDefaultOrg returns a user's default organization, if configured.
+// It will prefer the organization that the user has configured locally, falling back to making an API
+// call to the backend for the backend opinion on default organization if not manually set by the user.
+// Returns an empty string if the user does not have a default org explicitly configured and if the backend
+// does not have an opinion on user organizations.
+func GetDefaultOrg(ctx context.Context, b Backend, currentProject *workspace.Project) (string, error) {
+	return getDefaultOrg(ctx, b, currentProject, pkgWorkspace.GetBackendConfigDefaultOrg)
+}
+
+func getDefaultOrg(
+	ctx context.Context,
+	b Backend,
+	currentProject *workspace.Project,
+	getBackendConfigDefaultOrgF func(*workspace.Project) (string, error),
+) (string, error) {
+	userConfiguredDefaultOrg, err := getBackendConfigDefaultOrgF(currentProject)
+	if err != nil || userConfiguredDefaultOrg != "" {
+		return userConfiguredDefaultOrg, err
+	}
+	// if unset, defer to the backend's opinion of what the default org should be
+	return b.GetDefaultOrg(ctx)
+}

--- a/pkg/backend/organizations_test.go
+++ b/pkg/backend/organizations_test.go
@@ -1,0 +1,82 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDefaultOrg(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	userConfiguredOrg := "user-configured-default-org"
+	backendConfiguredOrg := "backend-configured-org"
+
+	t.Run("prefers user-configured default org", func(t *testing.T) {
+		t.Parallel()
+
+		defaultOrgConfigLookupFunc := func(*workspace.Project) (string, error) {
+			return userConfiguredOrg, nil
+		}
+
+		testBackend := &MockBackend{
+			GetDefaultOrgF: func(ctx context.Context) (string, error) {
+				assert.Fail(t, "should not make api call for get default org")
+				return "", nil
+			},
+		}
+
+		org, err := getDefaultOrg(ctx, testBackend, nil, defaultOrgConfigLookupFunc)
+
+		assert.NoError(t, err)
+		assert.Equal(t, userConfiguredOrg, org)
+	})
+
+	t.Run("falls back to making a call for user org", func(t *testing.T) {
+		t.Parallel()
+		defaultOrgConfigLookupFunc := func(*workspace.Project) (string, error) {
+			return "", nil
+		}
+
+		testBackend := &MockBackend{
+			GetDefaultOrgF: func(ctx context.Context) (string, error) {
+				return backendConfiguredOrg, nil
+			},
+		}
+
+		org, err := getDefaultOrg(ctx, testBackend, nil, defaultOrgConfigLookupFunc)
+
+		assert.NoError(t, err)
+		assert.Equal(t, backendConfiguredOrg, org)
+	})
+
+	// This maintains existing behavior with `GetBackendConfigDefaultOrg`.
+	t.Run("returns empty string if nothing is configured", func(t *testing.T) {
+		t.Parallel()
+		defaultOrgConfigLookupFunc := func(*workspace.Project) (string, error) {
+			return "", nil
+		}
+		testBackend := &MockBackend{}
+
+		org, err := getDefaultOrg(ctx, testBackend, nil, defaultOrgConfigLookupFunc)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "", org)
+	})
+}


### PR DESCRIPTION
Part of https://github.com/pulumi/pulumi-service/issues/26424

Introduces a wrapper `backend.GetDefaultOrg` that includes a fallback lookup to the backend for default org. If the backend does not support the GetDefaultOrg API, or if it has no opinion, `backend.GetDefaultOrg` will preserve existing behavior by returning an empty string for call sites to evaluate appropriately.

Notably we elected not to have this logic in `pkgWorkspace` as that would force a import cycle.

Follow-up PR's will migrate all call sites to using this function. For a preview of where this is headed, see: https://github.com/pulumi/pulumi/pull/19249