### PR TITLE
Migrate httpstate calls for GetDefaultOrg

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -775,7 +775,7 @@ func (b *cloudBackend) ParseStackReference(s string) (backend.StackReference, er
 	if qualifiedName.Owner == "" {
 		// if the qualifiedName doesn't include an owner then let's check to see if there is a default org which *will*
 		// be the stack owner. If there is no defaultOrg, then we revert to checking the CurrentUser
-		defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(b.currentProject)
+		defaultOrg, err := backend.GetDefaultOrg(context.TODO(), b, b.currentProject)
 		if err != nil {
 			return nil, err
 		}
@@ -915,7 +915,7 @@ func (b *cloudBackend) DoesProjectExist(ctx context.Context, orgName string, pro
 	}
 
 	getDefaultOrg := func() (string, error) {
-		return pkgWorkspace.GetBackendConfigDefaultOrg(nil)
+		return backend.GetDefaultOrg(ctx, b, nil)
 	}
 	getUserOrg := func() (string, error) {
 		orgName, _, _, err := b.currentUser(ctx)
@@ -1038,12 +1038,30 @@ func (b *cloudBackend) ListStacks(
 		return nil, nil, err
 	}
 
+	// Look up the default organization and persist it across each stack summary, in order to reduce
+	// the number of lookups each stack summary would otherwise have to make to determine whether to
+	// elide the organization name.
+	// Since ListStacks is also a potentially long-running operation for power users with many stacks,
+	// this has the added benefit of ensuring that the default org is consistent for the duration of the
+	// operation, even if the user changes their default org mid-process.
+	defaultOrg, err := b.GetDefaultOrg(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if defaultOrg == "" {
+		defaultOrg, _, _, err = b.CurrentUser()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
 	// Convert []apitype.StackSummary into []backend.StackSummary.
 	backendSummaries := slice.Prealloc[backend.StackSummary](len(apiSummaries))
 	for _, apiSummary := range apiSummaries {
 		backendSummary := cloudStackSummary{
-			summary: apiSummary,
-			b:       b,
+			summary:    apiSummary,
+			b:          b,
+			defaultOrg: defaultOrg,
 		}
 		backendSummaries = append(backendSummaries, backendSummary)
 	}

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/service"
-	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -45,10 +44,11 @@ type Stack interface {
 }
 
 type cloudBackendReference struct {
-	name    tokens.StackName
-	project tokens.Name
-	owner   string
-	b       *cloudBackend
+	name       tokens.StackName
+	project    tokens.Name
+	defaultOrg string
+	owner      string
+	b          *cloudBackend
 }
 
 func (c cloudBackendReference) String() string {
@@ -64,7 +64,7 @@ func (c cloudBackendReference) String() string {
 	// If the project names match, we can elide them.
 	if currentProject != nil && c.project == tokens.Name(currentProject.Name) {
 		// Elide owner too, if it is the default owner.
-		defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(currentProject)
+		defaultOrg, err := c.getDefaultOrg()
 		if err == nil && defaultOrg != "" {
 			// The default owner is the org
 			if c.owner == defaultOrg {
@@ -96,6 +96,15 @@ func (c cloudBackendReference) Organization() (string, bool) {
 
 func (c cloudBackendReference) FullyQualifiedName() tokens.QName {
 	return tokens.IntoQName(fmt.Sprintf("%v/%v/%v", c.owner, c.project, c.name.String()))
+}
+
+// Returns configured default org, if configured..
+// If unset, will fallback to requesting default org from the backend, which may involve an additional API call.
+func (c cloudBackendReference) getDefaultOrg() (string, error) {
+	if c.defaultOrg != "" {
+		return c.defaultOrg, nil
+	}
+	return backend.GetDefaultOrg(context.TODO(), c.b, c.b.currentProject)
 }
 
 // cloudStack is a cloud stack descriptor.
@@ -226,8 +235,9 @@ func (s *cloudStack) DefaultSecretManager(info *workspace.ProjectStack) (secrets
 // cloudStackSummary implements the backend.StackSummary interface, by wrapping
 // an apitype.StackSummary struct.
 type cloudStackSummary struct {
-	summary apitype.StackSummary
-	b       *cloudBackend
+	summary    apitype.StackSummary
+	b          *cloudBackend
+	defaultOrg string
 }
 
 func (css cloudStackSummary) Name() backend.StackReference {
@@ -236,10 +246,11 @@ func (css cloudStackSummary) Name() backend.StackReference {
 	contract.AssertNoErrorf(err, "unexpected invalid stack name: %v", css.summary.StackName)
 
 	return cloudBackendReference{
-		owner:   css.summary.OrgName,
-		project: tokens.Name(css.summary.ProjectName),
-		name:    stackName,
-		b:       css.b,
+		owner:      css.summary.OrgName,
+		defaultOrg: css.defaultOrg,
+		project:    tokens.Name(css.summary.ProjectName),
+		name:       stackName,
+		b:          css.b,
 	}
 }
 

--- a/pkg/backend/httpstate/stack_test.go
+++ b/pkg/backend/httpstate/stack_test.go
@@ -1,0 +1,117 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpstate
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloudBackendReference(t *testing.T) {
+	t.Parallel()
+	t.Run("String()", func(t *testing.T) {
+		project := &workspace.Project{
+			Name: "cbr-project",
+		}
+		defaultOrg := "cbr-default-org"
+		stackName := tokens.MustParseStackName("cbr-test-stack")
+
+		t.Run("elides default org if owner match", func(t *testing.T) {
+			t.Parallel()
+			// By populating the defaultOrg, we should not make any calls to the underlying client,
+			// preferring what has already been configured.
+			stubClient := &client.Client{}
+			backend := &cloudBackend{
+				client:         stubClient,
+				currentProject: project,
+				d:              diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never}),
+			}
+
+			ref := cloudBackendReference{
+				name:       stackName,
+				project:    tokens.Name(project.Name.String()),
+				defaultOrg: defaultOrg,
+				owner:      defaultOrg,
+				b:          backend,
+			}
+
+			stack := ref.String()
+
+			assert.Equal(t, stackName.String(), stack)
+		})
+
+		t.Run("does not elide default org if does not match owner", func(t *testing.T) {
+			t.Parallel()
+			// By populating the defaultOrg, we should not make any calls to the underlying client,
+			// preferring what has already been configured.
+			stubClient := &client.Client{}
+			backend := &cloudBackend{
+				client:         stubClient,
+				currentProject: project,
+				d:              diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never}),
+			}
+
+			someOtherOrg := "some-other-org"
+
+			ref := cloudBackendReference{
+				name:       stackName,
+				project:    tokens.Name(project.Name.String()),
+				defaultOrg: defaultOrg,
+				owner:      someOtherOrg,
+				b:          backend,
+			}
+
+			stack := ref.String()
+
+			assert.Equal(t, fmt.Sprintf("%s/%s", someOtherOrg, stackName), stack)
+		})
+
+		t.Run("does not elide if projects do not match", func(t *testing.T) {
+			t.Parallel()
+			// By populating the defaultOrg, we should not make any calls to the underlying client,
+			// preferring what has already been configured.
+			stubClient := &client.Client{}
+			backend := &cloudBackend{
+				client:         stubClient,
+				currentProject: project,
+				d:              diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never}),
+			}
+
+			otherProject := &workspace.Project{
+				Name: "cbr-project-other",
+			}
+
+			ref := cloudBackendReference{
+				name:       stackName,
+				project:    tokens.Name(otherProject.Name.String()),
+				defaultOrg: defaultOrg,
+				owner:      defaultOrg,
+				b:          backend,
+			}
+
+			stack := ref.String()
+
+			assert.Equal(t, fmt.Sprintf("%s/%s/%s", defaultOrg, otherProject.Name, stackName), stack)
+		})
+	})
+}

--- a/tests/stack/stack_test.go
+++ b/tests/stack/stack_test.go
@@ -487,7 +487,7 @@ func TestStackRenameAfterCreateServiceBackend(t *testing.T) {
 	stackName := addRandomSuffix("stack-rename-svcbe")
 	stackRenameBase := addRandomSuffix("renamed-stack-svcbe")
 	integration.CreateBasicPulumiRepo(e)
-	e.RunCommand("pulumi", "stack", "init", stackName)
+	e.RunCommand("pulumi", "stack", "init", fmt.Sprintf("%s/%s", orgName, stackName))
 
 	// Create some configuration so that a per-project YAML file is generated.
 	e.RunCommand("pulumi", "config", "set", "xyz", "abc")


### PR DESCRIPTION
Builds on changes introduced in https://github.com/pulumi/pulumi/pull/19321

Migrate calls from `httpstate/*` to use the new `GetDefaultOrgs` wrapper. Updates the following call sites:

1. `cloudBackend.ParseStackReference`
2. `cloudBackend.DoesProjectExist`

It additionally introduces a new call site:

3. `cloudBackend.ListStacks` -- This upfront call will reduce the number of API calls made in `cloudBackendReference.String()` to check the workspace against the default organization when eliding stack route, reducing performance impact for large scale organizations.

### Release Notes

For a preview of where this work is headed, see: https://github.com/pulumi/pulumi/pull/19249

This change should be merged with all other site migration changes; it is split out for code review readability. Once approved, this change should be merged into local branch `casey/default-orgs/staging` to stage approved changes to be merged into master together.