### PR TITLE
Migrate call sites for pulumi new command

### DIFF
--- a/pkg/cmd/pulumi/newcmd/new.go
+++ b/pkg/cmd/pulumi/newcmd/new.go
@@ -257,7 +257,7 @@ func runNew(ctx context.Context, args newArgs) error {
 		orgName = parts[0]
 		projectName := parts[1]
 
-		stackName, err := buildStackName(args.stack)
+		stackName, err := buildStackName(ctx, b, args.stack)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_test.go
@@ -107,8 +107,8 @@ func TestCreatingStackWithArgsSpecifiedOrgName(t *testing.T) {
 	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
-	assert.Equal(t, stackName, loadStackName(t))
-	removeStack(t, tempdir, stackName)
+	assert.Equal(t, orgStackName, loadStackName(t))
+	removeStack(t, tempdir, orgStackName)
 }
 
 //nolint:paralleltest // changes directory for process
@@ -131,8 +131,8 @@ func TestCreatingStackWithPromptedOrgName(t *testing.T) {
 	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
-	assert.Equal(t, stackName, loadStackName(t))
-	removeStack(t, tempdir, stackName)
+	assert.Equal(t, orgStackName, loadStackName(t))
+	removeStack(t, tempdir, orgStackName)
 }
 
 //nolint:paralleltest // changes directory for process
@@ -144,7 +144,8 @@ func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
 
 	// the project name and the project name in the stack name must match
 	uniqueProjectName := filepath.Base(tempdir)
-	fullStackName := fmt.Sprintf("%s/%s/%s", currentUser(t), uniqueProjectName, stackName)
+	owner := currentUser(t)
+	fullStackName := fmt.Sprintf("%s/%s/%s", owner, uniqueProjectName, stackName)
 
 	args := newArgs{
 		interactive:       false,
@@ -158,8 +159,9 @@ func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
 	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
-	assert.Equal(t, stackName, loadStackName(t))
-	removeStack(t, tempdir, stackName)
+	expectedStackName := fmt.Sprintf("%s/%s", owner, stackName)
+	assert.Equal(t, expectedStackName, loadStackName(t))
+	removeStack(t, tempdir, expectedStackName)
 }
 
 //nolint:paralleltest // changes directory for process

--- a/pkg/cmd/pulumi/newcmd/stack.go
+++ b/pkg/cmd/pulumi/newcmd/stack.go
@@ -65,7 +65,7 @@ func PromptAndCreateStack(ctx context.Context, ws pkgWorkspace.Context, b backen
 	contract.Requiref(root != "", "root", "must not be empty")
 
 	if stack != "" {
-		stackName, err := buildStackName(stack)
+		stackName, err := buildStackName(ctx, b, stack)
 		if err != nil {
 			return nil, err
 		}
@@ -87,7 +87,7 @@ func PromptAndCreateStack(ctx context.Context, ws pkgWorkspace.Context, b backen
 		if err != nil {
 			return nil, err
 		}
-		formattedStackName, err := buildStackName(stackName)
+		formattedStackName, err := buildStackName(ctx, b, stackName)
 		if err != nil {
 			return nil, err
 		}
@@ -104,7 +104,7 @@ func PromptAndCreateStack(ctx context.Context, ws pkgWorkspace.Context, b backen
 	}
 }
 
-func buildStackName(stackName string) (string, error) {
+func buildStackName(ctx context.Context, b backend.Backend, stackName string) (string, error) {
 	// If we already have a slash (e.g. org/stack, or org/proj/stack) don't add the default org.
 	if strings.Contains(stackName, "/") {
 		return stackName, nil
@@ -112,7 +112,7 @@ func buildStackName(stackName string) (string, error) {
 
 	// We never have a project at the point of calling buildStackName (only called from new), so we just pass
 	// nil for the project and only check the global settings.
-	defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(nil)
+	defaultOrg, err := backend.GetDefaultOrg(ctx, b, nil)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Builds on changes introduced in https://github.com/pulumi/pulumi/pull/19322

Migrate calls for `pulumi new` to use the new GetDefaultOrgs wrapper.

### Release Notes

For a preview of where this work is headed, see: https://github.com/pulumi/pulumi/pull/19249

This change should be merged with all other site migration changes; it is split out for code review readability. Once approved, this change should be merged into local branch casey/default-orgs/staging to stage approved changes to be merged into master together.