### PR TITLE
Add default org lookup against the backend if not locally configured by user

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -945,7 +945,7 @@ func (b *cloudBackend) GetStack(ctx context.Context, stackRef backend.StackRefer
 		return nil, err
 	}
 
-	return newStack(stack, b)
+	return newStack(ctx, stack, b)
 }
 
 // Confirm the specified stack's project doesn't contradict the Pulumi.yaml of the current project.
@@ -1008,7 +1008,7 @@ func (b *cloudBackend) CreateStack(
 		return nil, err
 	}
 
-	stack, err := newStack(apistack, b)
+	stack, err := newStack(ctx, apistack, b)
 	if err != nil {
 		fmt.Printf("Created stack '%s'\n", stack.Ref())
 	}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -945,7 +945,7 @@ func (b *cloudBackend) GetStack(ctx context.Context, stackRef backend.StackRefer
 		return nil, err
 	}
 
-	return newStack(stack, b), nil
+	return newStack(stack, b)
 }
 
 // Confirm the specified stack's project doesn't contradict the Pulumi.yaml of the current project.
@@ -1008,10 +1008,12 @@ func (b *cloudBackend) CreateStack(
 		return nil, err
 	}
 
-	stack := newStack(apistack, b)
-	fmt.Printf("Created stack '%s'\n", stack.Ref())
+	stack, err := newStack(apistack, b)
+	if err != nil {
+		fmt.Printf("Created stack '%s'\n", stack.Ref())
+	}
 
-	return stack, nil
+	return stack, err
 }
 
 func (b *cloudBackend) ListStacks(

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -775,7 +775,7 @@ func (b *cloudBackend) ParseStackReference(s string) (backend.StackReference, er
 	if qualifiedName.Owner == "" {
 		// if the qualifiedName doesn't include an owner then let's check to see if there is a default org which *will*
 		// be the stack owner. If there is no defaultOrg, then we revert to checking the CurrentUser
-		defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(b.currentProject)
+		defaultOrg, err := backend.GetDefaultOrg(context.TODO(), b, b.currentProject)
 		if err != nil {
 			return nil, err
 		}
@@ -915,7 +915,7 @@ func (b *cloudBackend) DoesProjectExist(ctx context.Context, orgName string, pro
 	}
 
 	getDefaultOrg := func() (string, error) {
-		return pkgWorkspace.GetBackendConfigDefaultOrg(nil)
+		return backend.GetDefaultOrg(ctx, b, nil)
 	}
 	getUserOrg := func() (string, error) {
 		orgName, _, _, err := b.currentUser(ctx)
@@ -1038,12 +1038,30 @@ func (b *cloudBackend) ListStacks(
 		return nil, nil, err
 	}
 
+	// Look up the default organization and persist it across each stack summary, in order to reduce
+	// the number of lookups each stack summary would otherwise have to make to determine whether to
+	// elide the organization name.
+	// Since ListStacks is also a potentially long-running operation for power users with many stacks,
+	// this has the added benefit of ensuring that the default org is consistent for the duration of the
+	// operation, even if the user changes their default org mid-process.
+	defaultOrg, err := b.GetDefaultOrg(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if defaultOrg == "" {
+		defaultOrg, _, _, err = b.CurrentUser()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
 	// Convert []apitype.StackSummary into []backend.StackSummary.
 	backendSummaries := slice.Prealloc[backend.StackSummary](len(apiSummaries))
 	for _, apiSummary := range apiSummaries {
 		backendSummary := cloudStackSummary{
-			summary: apiSummary,
-			b:       b,
+			summary:    apiSummary,
+			b:          b,
+			defaultOrg: defaultOrg,
 		}
 		backendSummaries = append(backendSummaries, backendSummary)
 	}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -770,16 +770,16 @@ func (b *cloudBackend) ParseStackReference(s string) (backend.StackReference, er
 		return nil, err
 	}
 
+	defaultOrg, err := backend.GetDefaultOrg(context.TODO(), b, b.currentProject)
+	if err != nil {
+		return nil, err
+	}
+
 	// If the provided stack name didn't include the Owner or Project, infer them from the
 	// local environment.
 	if qualifiedName.Owner == "" {
 		// if the qualifiedName doesn't include an owner then let's check to see if there is a default org which *will*
 		// be the stack owner. If there is no defaultOrg, then we revert to checking the CurrentUser
-		defaultOrg, err := backend.GetDefaultOrg(context.TODO(), b, b.currentProject)
-		if err != nil {
-			return nil, err
-		}
-
 		if defaultOrg != "" {
 			qualifiedName.Owner = defaultOrg
 		} else {
@@ -805,10 +805,11 @@ func (b *cloudBackend) ParseStackReference(s string) (backend.StackReference, er
 	}
 
 	return cloudBackendReference{
-		owner:   qualifiedName.Owner,
-		project: tokens.Name(qualifiedName.Project),
-		name:    parsedName,
-		b:       b,
+		owner:      qualifiedName.Owner,
+		defaultOrg: defaultOrg,
+		project:    tokens.Name(qualifiedName.Project),
+		name:       parsedName,
+		b:          b,
 	}, nil
 }
 

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/service"
-	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -45,10 +44,11 @@ type Stack interface {
 }
 
 type cloudBackendReference struct {
-	name    tokens.StackName
-	project tokens.Name
-	owner   string
-	b       *cloudBackend
+	name       tokens.StackName
+	project    tokens.Name
+	defaultOrg string
+	owner      string
+	b          *cloudBackend
 }
 
 func (c cloudBackendReference) String() string {
@@ -64,7 +64,7 @@ func (c cloudBackendReference) String() string {
 	// If the project names match, we can elide them.
 	if currentProject != nil && c.project == tokens.Name(currentProject.Name) {
 		// Elide owner too, if it is the default owner.
-		defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(currentProject)
+		defaultOrg, err := c.getDefaultOrg()
 		if err == nil && defaultOrg != "" {
 			// The default owner is the org
 			if c.owner == defaultOrg {
@@ -96,6 +96,15 @@ func (c cloudBackendReference) Organization() (string, bool) {
 
 func (c cloudBackendReference) FullyQualifiedName() tokens.QName {
 	return tokens.IntoQName(fmt.Sprintf("%v/%v/%v", c.owner, c.project, c.name.String()))
+}
+
+// Returns configured default org, if configured..
+// If unset, will fallback to requesting default org from the backend, which may involve an additional API call.
+func (c cloudBackendReference) getDefaultOrg() (string, error) {
+	if c.defaultOrg != "" {
+		return c.defaultOrg, nil
+	}
+	return backend.GetDefaultOrg(context.TODO(), c.b, c.b.currentProject)
 }
 
 // cloudStack is a cloud stack descriptor.
@@ -226,8 +235,9 @@ func (s *cloudStack) DefaultSecretManager(info *workspace.ProjectStack) (secrets
 // cloudStackSummary implements the backend.StackSummary interface, by wrapping
 // an apitype.StackSummary struct.
 type cloudStackSummary struct {
-	summary apitype.StackSummary
-	b       *cloudBackend
+	summary    apitype.StackSummary
+	b          *cloudBackend
+	defaultOrg string
 }
 
 func (css cloudStackSummary) Name() backend.StackReference {
@@ -236,10 +246,11 @@ func (css cloudStackSummary) Name() backend.StackReference {
 	contract.AssertNoErrorf(err, "unexpected invalid stack name: %v", css.summary.StackName)
 
 	return cloudBackendReference{
-		owner:   css.summary.OrgName,
-		project: tokens.Name(css.summary.ProjectName),
-		name:    stackName,
-		b:       css.b,
+		owner:      css.summary.OrgName,
+		defaultOrg: css.defaultOrg,
+		project:    tokens.Name(css.summary.ProjectName),
+		name:       stackName,
+		b:          css.b,
 	}
 }
 

--- a/pkg/backend/httpstate/stack_test.go
+++ b/pkg/backend/httpstate/stack_test.go
@@ -1,0 +1,117 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpstate
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloudBackendReference(t *testing.T) {
+	t.Parallel()
+	t.Run("String()", func(t *testing.T) {
+		project := &workspace.Project{
+			Name: "cbr-project",
+		}
+		defaultOrg := "cbr-default-org"
+		stackName := tokens.MustParseStackName("cbr-test-stack")
+
+		t.Run("elides default org if owner match", func(t *testing.T) {
+			t.Parallel()
+			// By populating the defaultOrg, we should not make any calls to the underlying client,
+			// preferring what has already been configured.
+			stubClient := &client.Client{}
+			backend := &cloudBackend{
+				client:         stubClient,
+				currentProject: project,
+				d:              diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never}),
+			}
+
+			ref := cloudBackendReference{
+				name:       stackName,
+				project:    tokens.Name(project.Name.String()),
+				defaultOrg: defaultOrg,
+				owner:      defaultOrg,
+				b:          backend,
+			}
+
+			stack := ref.String()
+
+			assert.Equal(t, stackName.String(), stack)
+		})
+
+		t.Run("does not elide default org if does not match owner", func(t *testing.T) {
+			t.Parallel()
+			// By populating the defaultOrg, we should not make any calls to the underlying client,
+			// preferring what has already been configured.
+			stubClient := &client.Client{}
+			backend := &cloudBackend{
+				client:         stubClient,
+				currentProject: project,
+				d:              diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never}),
+			}
+
+			someOtherOrg := "some-other-org"
+
+			ref := cloudBackendReference{
+				name:       stackName,
+				project:    tokens.Name(project.Name.String()),
+				defaultOrg: defaultOrg,
+				owner:      someOtherOrg,
+				b:          backend,
+			}
+
+			stack := ref.String()
+
+			assert.Equal(t, fmt.Sprintf("%s/%s", someOtherOrg, stackName), stack)
+		})
+
+		t.Run("does not elide if projects do not match", func(t *testing.T) {
+			t.Parallel()
+			// By populating the defaultOrg, we should not make any calls to the underlying client,
+			// preferring what has already been configured.
+			stubClient := &client.Client{}
+			backend := &cloudBackend{
+				client:         stubClient,
+				currentProject: project,
+				d:              diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never}),
+			}
+
+			otherProject := &workspace.Project{
+				Name: "cbr-project-other",
+			}
+
+			ref := cloudBackendReference{
+				name:       stackName,
+				project:    tokens.Name(otherProject.Name.String()),
+				defaultOrg: defaultOrg,
+				owner:      defaultOrg,
+				b:          backend,
+			}
+
+			stack := ref.String()
+
+			assert.Equal(t, fmt.Sprintf("%s/%s/%s", defaultOrg, otherProject.Name, stackName), stack)
+		})
+	})
+}

--- a/pkg/backend/httpstate/stack_test.go
+++ b/pkg/backend/httpstate/stack_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2025, Pulumi Corporation.
+// Copyright 2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -44,6 +44,7 @@ type MockBackend struct {
 	NameF                  func() string
 	URLF                   func() string
 	SetCurrentProjectF     func(proj *workspace.Project)
+	GetDefaultOrgF         func(ctx context.Context) (string, error)
 	GetPolicyPackF         func(ctx context.Context, policyPack string, d diag.Sink) (PolicyPack, error)
 	SupportsTagsF          func() bool
 	SupportsOrganizationsF func() bool
@@ -176,6 +177,9 @@ func (be *MockBackend) SupportsDeployments() bool {
 }
 
 func (be *MockBackend) GetDefaultOrg(ctx context.Context) (string, error) {
+	if be.GetDefaultOrgF != nil {
+		return be.GetDefaultOrgF(ctx)
+	}
 	return "", nil
 }
 

--- a/pkg/backend/organizations.go
+++ b/pkg/backend/organizations.go
@@ -1,0 +1,45 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"context"
+
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// GetDefaultOrg returns a user's default organization, if configured.
+// It will prefer the organization that the user has configured locally, falling back to making an API
+// call to the backend for the backend opinion on default organization if not manually set by the user.
+// Returns an empty string if the user does not have a default org explicitly configured and if the backend
+// does not have an opinion on user organizations.
+func GetDefaultOrg(ctx context.Context, b Backend, currentProject *workspace.Project) (string, error) {
+	return getDefaultOrg(ctx, b, currentProject, pkgWorkspace.GetBackendConfigDefaultOrg)
+}
+
+func getDefaultOrg(
+	ctx context.Context,
+	b Backend,
+	currentProject *workspace.Project,
+	getBackendConfigDefaultOrgF func(*workspace.Project) (string, error),
+) (string, error) {
+	userConfiguredDefaultOrg, err := getBackendConfigDefaultOrgF(currentProject)
+	if err != nil || userConfiguredDefaultOrg != "" {
+		return userConfiguredDefaultOrg, err
+	}
+	// if unset, defer to the backend's opinion of what the default org should be
+	return b.GetDefaultOrg(ctx)
+}

--- a/pkg/backend/organizations.go
+++ b/pkg/backend/organizations.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2025, Pulumi Corporation.
+// Copyright 2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/backend/organizations_test.go
+++ b/pkg/backend/organizations_test.go
@@ -1,0 +1,82 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDefaultOrg(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	userConfiguredOrg := "user-configured-default-org"
+	backendConfiguredOrg := "backend-configured-org"
+
+	t.Run("prefers user-configured default org", func(t *testing.T) {
+		t.Parallel()
+
+		defaultOrgConfigLookupFunc := func(*workspace.Project) (string, error) {
+			return userConfiguredOrg, nil
+		}
+
+		testBackend := &MockBackend{
+			GetDefaultOrgF: func(ctx context.Context) (string, error) {
+				assert.Fail(t, "should not make api call for get default org")
+				return "", nil
+			},
+		}
+
+		org, err := getDefaultOrg(ctx, testBackend, nil, defaultOrgConfigLookupFunc)
+
+		assert.NoError(t, err)
+		assert.Equal(t, userConfiguredOrg, org)
+	})
+
+	t.Run("falls back to making a call for user org", func(t *testing.T) {
+		t.Parallel()
+		defaultOrgConfigLookupFunc := func(*workspace.Project) (string, error) {
+			return "", nil
+		}
+
+		testBackend := &MockBackend{
+			GetDefaultOrgF: func(ctx context.Context) (string, error) {
+				return backendConfiguredOrg, nil
+			},
+		}
+
+		org, err := getDefaultOrg(ctx, testBackend, nil, defaultOrgConfigLookupFunc)
+
+		assert.NoError(t, err)
+		assert.Equal(t, backendConfiguredOrg, org)
+	})
+
+	// This maintains existing behavior with `GetBackendConfigDefaultOrg`.
+	t.Run("returns empty string if nothing is configured", func(t *testing.T) {
+		t.Parallel()
+		defaultOrgConfigLookupFunc := func(*workspace.Project) (string, error) {
+			return "", nil
+		}
+		testBackend := &MockBackend{}
+
+		org, err := getDefaultOrg(ctx, testBackend, nil, defaultOrgConfigLookupFunc)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "", org)
+	})
+}

--- a/pkg/backend/organizations_test.go
+++ b/pkg/backend/organizations_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2025, Pulumi Corporation.
+// Copyright 2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cmd/pulumi/newcmd/new.go
+++ b/pkg/cmd/pulumi/newcmd/new.go
@@ -257,7 +257,7 @@ func runNew(ctx context.Context, args newArgs) error {
 		orgName = parts[0]
 		projectName := parts[1]
 
-		stackName, err := buildStackName(args.stack)
+		stackName, err := buildStackName(ctx, b, args.stack)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/newcmd/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_acceptance_test.go
@@ -90,6 +90,7 @@ func TestCreatingStackWithArgsSpecifiedName(t *testing.T) {
 	chdir(t, tempdir)
 
 	fullStackName := fmt.Sprintf("%s/%s/%s", currentUser(t), filepath.Base(tempdir), stackName)
+	orgStackName := fmt.Sprintf("%s/%s", currentUser(t), stackName)
 
 	args := newArgs{
 		interactive:       false,
@@ -97,7 +98,7 @@ func TestCreatingStackWithArgsSpecifiedName(t *testing.T) {
 		prompt:            ui.PromptForValue,
 		secretsProvider:   "default",
 		description:       "foo: bar", // Needs special escaping for YAML
-		stack:             stackName,
+		stack:             orgStackName,
 		templateNameOrURL: "typescript",
 	}
 
@@ -105,7 +106,7 @@ func TestCreatingStackWithArgsSpecifiedName(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, fullStackName, loadStackName(t))
-	removeStack(t, tempdir, stackName)
+	removeStack(t, tempdir, orgStackName)
 }
 
 //nolint:paralleltest // changes directory for process
@@ -122,6 +123,7 @@ func TestCreatingStackWithNumericName(t *testing.T) {
 	unixTsNanos := time.Now().UnixNano()
 	numericProjectName := strconv.Itoa(int(unixTsNanos))
 	fullStackName := fmt.Sprintf("%s/%s/%s", currentUser(t), numericProjectName, stackName)
+	orgStackName := fmt.Sprintf("%s/%s", currentUser(t), stackName)
 
 	args := newArgs{
 		interactive:       false,
@@ -129,7 +131,7 @@ func TestCreatingStackWithNumericName(t *testing.T) {
 		name:              numericProjectName, // Should be serialized as a string.
 		prompt:            ui.PromptForValue,
 		secretsProvider:   "default",
-		stack:             stackName,
+		stack:             orgStackName,
 		templateNameOrURL: "yaml",
 	}
 
@@ -142,7 +144,7 @@ func TestCreatingStackWithNumericName(t *testing.T) {
 	assert.Equal(t, p.Name.String(), numericProjectName)
 
 	assert.Equal(t, fullStackName, loadStackName(t))
-	removeStack(t, tempdir, stackName)
+	removeStack(t, tempdir, orgStackName)
 }
 
 //nolint:paralleltest // changes directory for process
@@ -154,10 +156,11 @@ func TestCreatingStackWithPromptedName(t *testing.T) {
 	uniqueProjectName := filepath.Base(tempdir)
 
 	fullStackName := fmt.Sprintf("%s/%s/%s", currentUser(t), filepath.Base(tempdir), stackName)
+	orgStackName := fmt.Sprintf("%s/%s", currentUser(t), stackName)
 
 	args := newArgs{
 		interactive:       true,
-		prompt:            promptMock(uniqueProjectName, stackName),
+		prompt:            promptMock(uniqueProjectName, orgStackName),
 		secretsProvider:   "default",
 		templateNameOrURL: "typescript",
 	}
@@ -166,7 +169,7 @@ func TestCreatingStackWithPromptedName(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, fullStackName, loadStackName(t))
-	removeStack(t, tempdir, stackName)
+	removeStack(t, tempdir, orgStackName)
 }
 
 //nolint:paralleltest // changes directory for process
@@ -250,6 +253,7 @@ func promptMock(name string, stackName string) promptForValueFunc {
 			err := isValidFn(name)
 			return name, err
 		}
+
 		if valueType == "Stack name" {
 			err := isValidFn(stackName)
 			return stackName, err

--- a/pkg/cmd/pulumi/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_test.go
@@ -146,8 +146,7 @@ func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
 
 	// the project name and the project name in the stack name must match
 	uniqueProjectName := filepath.Base(tempdir)
-	owner := currentUser(t)
-	fullStackName := fmt.Sprintf("%s/%s/%s", owner, uniqueProjectName, stackName)
+	fullStackName := fmt.Sprintf("%s/%s/%s", currentUser(t), uniqueProjectName, stackName)
 
 	args := newArgs{
 		interactive:       false,

--- a/pkg/cmd/pulumi/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_test.go
@@ -146,7 +146,8 @@ func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
 
 	// the project name and the project name in the stack name must match
 	uniqueProjectName := filepath.Base(tempdir)
-	fullStackName := fmt.Sprintf("%s/%s/%s", currentUser(t), uniqueProjectName, stackName)
+	owner := currentUser(t)
+	fullStackName := fmt.Sprintf("%s/%s/%s", owner, uniqueProjectName, stackName)
 
 	args := newArgs{
 		interactive:       false,

--- a/pkg/cmd/pulumi/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_test.go
@@ -109,7 +109,7 @@ func TestCreatingStackWithArgsSpecifiedOrgName(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, fullStackName, loadStackName(t))
-	removeStack(t, tempdir, stackName)
+	removeStack(t, tempdir, orgStackName)
 }
 
 //nolint:paralleltest // changes directory for process
@@ -134,7 +134,7 @@ func TestCreatingStackWithPromptedOrgName(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, fullStackName, loadStackName(t))
-	removeStack(t, tempdir, stackName)
+	removeStack(t, tempdir, orgStackName)
 }
 
 //nolint:paralleltest // changes directory for process
@@ -161,7 +161,7 @@ func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, fullStackName, loadStackName(t))
-	removeStack(t, tempdir, stackName)
+	removeStack(t, tempdir, fullStackName)
 }
 
 //nolint:paralleltest // changes directory for process

--- a/pkg/cmd/pulumi/newcmd/stack.go
+++ b/pkg/cmd/pulumi/newcmd/stack.go
@@ -65,7 +65,7 @@ func PromptAndCreateStack(ctx context.Context, ws pkgWorkspace.Context, b backen
 	contract.Requiref(root != "", "root", "must not be empty")
 
 	if stack != "" {
-		stackName, err := buildStackName(stack)
+		stackName, err := buildStackName(ctx, b, stack)
 		if err != nil {
 			return nil, err
 		}
@@ -87,7 +87,7 @@ func PromptAndCreateStack(ctx context.Context, ws pkgWorkspace.Context, b backen
 		if err != nil {
 			return nil, err
 		}
-		formattedStackName, err := buildStackName(stackName)
+		formattedStackName, err := buildStackName(ctx, b, stackName)
 		if err != nil {
 			return nil, err
 		}
@@ -104,7 +104,7 @@ func PromptAndCreateStack(ctx context.Context, ws pkgWorkspace.Context, b backen
 	}
 }
 
-func buildStackName(stackName string) (string, error) {
+func buildStackName(ctx context.Context, b backend.Backend, stackName string) (string, error) {
 	// If we already have a slash (e.g. org/stack, or org/proj/stack) don't add the default org.
 	if strings.Contains(stackName, "/") {
 		return stackName, nil
@@ -112,7 +112,7 @@ func buildStackName(stackName string) (string, error) {
 
 	// We never have a project at the point of calling buildStackName (only called from new), so we just pass
 	// nil for the project and only check the global settings.
-	defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(nil)
+	defaultOrg, err := backend.GetDefaultOrg(ctx, b, nil)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/pulumi/org/org.go
+++ b/pkg/cmd/pulumi/org/org.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	pkgBackend "github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -38,6 +39,11 @@ func NewOrgCmd() *cobra.Command {
 			"e.g. setting the default organization for a backend",
 		Args: cmdutil.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			displayOpts := display.Options{
+				Color: cmdutil.GetGlobalColorization(),
+			}
+
 			// Try to read the current project
 			ws := pkgWorkspace.Instance
 			project, _, err := ws.ReadProject()
@@ -50,7 +56,12 @@ func NewOrgCmd() *cobra.Command {
 				return err
 			}
 
-			defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(project)
+			currentBe, err := backend.CurrentBackend(ctx, ws, backend.DefaultLoginManager, project, displayOpts)
+			if err != nil {
+				return err
+			}
+
+			defaultOrg, err := pkgBackend.GetDefaultOrg(ctx, currentBe, project)
 			if err != nil {
 				return err
 			}
@@ -156,7 +167,7 @@ func newOrgGetDefaultCmd() *cobra.Command {
 					currentBe.Name())
 			}
 
-			defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(project)
+			defaultOrg, err := pkgBackend.GetDefaultOrg(ctx, currentBe, project)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/org/org_search.go
+++ b/pkg/cmd/pulumi/org/org_search.go
@@ -141,15 +141,15 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	backend, err := currentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, displayOpts)
+	currBackend, err := currentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, displayOpts)
 	if err != nil {
 		return err
 	}
-	cloudBackend, isCloud := backend.(httpstate.Backend)
+	cloudBackend, isCloud := currBackend.(httpstate.Backend)
 	if !isCloud {
 		return errors.New("Pulumi AI search is only supported for the Pulumi Cloud")
 	}
-	defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(project)
+	defaultOrg, err := backend.GetDefaultOrg(ctx, cloudBackend, project)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/org/org_search.go
+++ b/pkg/cmd/pulumi/org/org_search.go
@@ -141,11 +141,11 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	currBackend, err := currentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, displayOpts)
+	currentBe, err := currentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, displayOpts)
 	if err != nil {
 		return err
 	}
-	cloudBackend, isCloud := currBackend.(httpstate.Backend)
+	cloudBackend, isCloud := currentBe.(httpstate.Backend)
 	if !isCloud {
 		return errors.New("Pulumi AI search is only supported for the Pulumi Cloud")
 	}

--- a/pkg/cmd/pulumi/org/org_search_ai.go
+++ b/pkg/cmd/pulumi/org/org_search_ai.go
@@ -64,11 +64,11 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	currBackend, err := currentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, displayOpts)
+	currentBe, err := currentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, displayOpts)
 	if err != nil {
 		return err
 	}
-	cloudBackend, isCloud := currBackend.(httpstate.Backend)
+	cloudBackend, isCloud := currentBe.(httpstate.Backend)
 	if !isCloud {
 		return errors.New("Pulumi AI search is only supported for the Pulumi Cloud")
 	}

--- a/pkg/cmd/pulumi/org/org_search_ai.go
+++ b/pkg/cmd/pulumi/org/org_search_ai.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/pkg/browser"
+	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
@@ -63,15 +64,15 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	backend, err := currentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, displayOpts)
+	currBackend, err := currentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, displayOpts)
 	if err != nil {
 		return err
 	}
-	cloudBackend, isCloud := backend.(httpstate.Backend)
+	cloudBackend, isCloud := currBackend.(httpstate.Backend)
 	if !isCloud {
 		return errors.New("Pulumi AI search is only supported for the Pulumi Cloud")
 	}
-	defaultOrg, err := pkgWorkspace.GetBackendConfigDefaultOrg(project)
+	defaultOrg, err := backend.GetDefaultOrg(ctx, cloudBackend, project)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/org/org_search_test.go
+++ b/pkg/cmd/pulumi/org/org_search_test.go
@@ -149,6 +149,7 @@ type stubHTTPBackend struct {
 	) (*apitype.ResourceSearchResponse, error)
 	NaturalLanguageSearchF func(context.Context, string, string) (*apitype.ResourceSearchResponse, error)
 	CurrentUserF           func() (string, []string, *workspace.TokenInformation, error)
+	GetDefaultOrgF         func(ctx context.Context) (string, error)
 }
 
 var _ httpstate.Backend = (*stubHTTPBackend)(nil)
@@ -171,4 +172,11 @@ func (f *stubHTTPBackend) CurrentUser() (string, []string, *workspace.TokenInfor
 
 func (*stubHTTPBackend) Capabilities(context.Context) apitype.Capabilities {
 	return apitype.Capabilities{}
+}
+
+func (f *stubHTTPBackend) GetDefaultOrg(ctx context.Context) (string, error) {
+	if f.GetDefaultOrgF == nil {
+		return "", nil
+	}
+	return f.GetDefaultOrgF(ctx)
 }

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -55,7 +55,7 @@ type publishPackageArgs struct {
 }
 
 type packagePublishCmd struct {
-	defaultOrg    func(*workspace.Project) (string, error)
+	defaultOrg    func(context.Context, backend.Backend, *workspace.Project) (string, error)
 	extractSchema func(pctx *plugin.Context, packageSource string, args []string) (*schema.Package, error)
 	pluginDir     string
 }
@@ -88,7 +88,7 @@ func newPackagePublishCmd() *cobra.Command {
 		Hidden: !env.Experimental.Value(),
 		RunE: func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := cmd.Context()
-			pkgPublishCmd.defaultOrg = pkgWorkspace.GetBackendConfigDefaultOrg
+			pkgPublishCmd.defaultOrg = backend.GetDefaultOrg
 			pkgPublishCmd.extractSchema = SchemaFromSchemaSource
 			return pkgPublishCmd.Run(ctx, args, cliArgs[0], cliArgs[1:])
 		},
@@ -171,7 +171,7 @@ func (cmd *packagePublishCmd) Run(
 	} else if pkg.Publisher != "" { // Otherwise, fall back to the publisher set in the package schema.
 		publisher = pkg.Publisher
 	} else { // As a last resort, try to determine the publisher from the default organization or fail if none is found.
-		publisher, err = cmd.defaultOrg(project)
+		publisher, err = cmd.defaultOrg(ctx, b, project)
 		if err != nil {
 			return fmt.Errorf("failed to determine default organization: %w", err)
 		}

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -413,7 +413,7 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 			})
 
 			// Setup defaultOrg mock
-			defaultOrg := func(project *workspace.Project) (string, error) {
+			defaultOrg := func(context.Context, backend.Backend, *workspace.Project) (string, error) {
 				return tt.mockOrg, tt.mockOrgErr
 			}
 
@@ -512,7 +512,7 @@ func TestPackagePublishCmd_IOErrors(t *testing.T) {
 			})
 
 			cmd := &packagePublishCmd{
-				defaultOrg: func(project *workspace.Project) (string, error) {
+				defaultOrg: func(context.Context, backend.Backend, *workspace.Project) (string, error) {
 					return "default-org", nil
 				},
 				extractSchema: func(pctx *plugin.Context, packageSource string, args []string) (*schema.Package, error) {
@@ -567,7 +567,7 @@ func TestPackagePublishCmd_BackendErrors(t *testing.T) {
 			tt.setupBackend(t)
 
 			cmd := &packagePublishCmd{
-				defaultOrg: func(project *workspace.Project) (string, error) {
+				defaultOrg: func(context.Context, backend.Backend, *workspace.Project) (string, error) {
 					return "default-org", nil
 				},
 				extractSchema: func(pctx *plugin.Context, packageSource string, args []string) (*schema.Package, error) {
@@ -604,7 +604,7 @@ func (m *mockWorkspace) GetStoredCredentials() (workspace.Credentials, error) {
 //nolint:paralleltest // This test uses the global pkgWorkspace.Instance variable
 func TestPackagePublishCmd_Run_ReadProjectError(t *testing.T) {
 	cmd := packagePublishCmd{
-		defaultOrg: func(p *workspace.Project) (string, error) {
+		defaultOrg: func(context.Context, backend.Backend, *workspace.Project) (string, error) {
 			return "", nil
 		},
 		extractSchema: func(pctx *plugin.Context, packageSource string, args []string) (*schema.Package, error) {

--- a/pkg/cmd/pulumi/policy/policy_publish.go
+++ b/pkg/cmd/pulumi/policy/policy_publish.go
@@ -165,14 +165,13 @@ func loginToCloudBackend(
 	return lm.Login(ctx, ws, cmdutil.Diag(), cloudURL, project, true /* setCurrent*/, displayOptions.Color)
 }
 
+// requirePolicyPack attempts to log into the cloud backend and retrieves the requested policy
+// pack.
 func requirePolicyPack(
 	ctx context.Context,
 	policyPack string,
 	lm cmdBackend.LoginManager,
 ) (backend.PolicyPack, error) {
-	//
-	// Attempt to log into cloud backend.
-	//
 	b, err := loginToCloudBackend(ctx, lm)
 	if err != nil {
 		return nil, err
@@ -181,14 +180,12 @@ func requirePolicyPack(
 	return requirePolicyPackForBackend(ctx, policyPack, b)
 }
 
+// requirePolicyPackForBackend retrieves a requested policy pack against a provided backend.
 func requirePolicyPackForBackend(
 	ctx context.Context,
 	policyPack string,
 	b backend.Backend,
 ) (backend.PolicyPack, error) {
-	//
-	// Obtain PolicyPackReference.
-	//
 	policy, err := b.GetPolicyPack(ctx, policyPack, cmdutil.Diag())
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/pulumi/policy/policy_publish_test.go
+++ b/pkg/cmd/pulumi/policy/policy_publish_test.go
@@ -66,7 +66,7 @@ func TestPolicyPublishCmd_default(t *testing.T) {
 			}
 			return filepath.Join(cwd, "testdata"), nil
 		},
-		defaultOrg: func(*workspace.Project) (string, error) {
+		defaultOrg: func(context.Context, backend.Backend, *workspace.Project) (string, error) {
 			return "org1", nil
 		},
 	}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -523,7 +523,12 @@ func testDestroyStackRef(e *ptesting.Environment, organization string) {
 	stackName, err := resource.NewUniqueHex("rm-test-", 8, -1)
 	contract.AssertNoErrorf(err, "resource.NewUniqueHex should not fail with no maximum length is set")
 
-	e.RunCommand("pulumi", "stack", "init", stackName)
+	if organization != "" {
+		qualifiedStackName := fmt.Sprintf("%s/%s", organization, stackName)
+		e.RunCommand("pulumi", "stack", "init", qualifiedStackName)
+	} else {
+		e.RunCommand("pulumi", "stack", "init", stackName)
+	}
 
 	e.RunCommand("yarn", "link", "@pulumi/pulumi")
 	e.RunCommand("yarn", "install")
@@ -1054,7 +1059,12 @@ func testProjectRename(e *ptesting.Environment, organization string) {
 	stackName, err := resource.NewUniqueHex("rm-test-", 8, -1)
 	contract.AssertNoErrorf(err, "resource.NewUniqueHex should not fail with no maximum length is set")
 
-	e.RunCommand("pulumi", "stack", "init", stackName)
+	if organization != "" {
+		qualifiedStackName := fmt.Sprintf("%s/%s", organization, stackName)
+		e.RunCommand("pulumi", "stack", "init", qualifiedStackName)
+	} else {
+		e.RunCommand("pulumi", "stack", "init", stackName)
+	}
 
 	e.RunCommand("yarn", "link", "@pulumi/pulumi")
 	e.RunCommand("yarn", "install")
@@ -1161,17 +1171,18 @@ func testStackRmConfig(e *ptesting.Environment, organization string) {
 	stackName, err := resource.NewUniqueHex("rm-test-", 8, -1)
 	contract.AssertNoErrorf(err, "resource.NewUniqueHex should not fail with no maximum length is set")
 
+	qualifiedStackName := fmt.Sprintf("%s/%s", organization, stackName)
 	// Create a stack in the go project
 	e.CWD = goDir
 	e.ImportDirectory("large_resource/go")
-	e.RunCommand("pulumi", "stack", "init", stackName)
+	e.RunCommand("pulumi", "stack", "init", qualifiedStackName)
 	// Create a config value to ensure there's a Pulumi.<name>.yaml file.
 	e.RunCommand("pulumi", "config", "set", "key", "value")
 
 	// Now create the js project
 	e.CWD = jsDir
 	e.ImportDirectory("large_resource/nodejs")
-	e.RunCommand("pulumi", "stack", "init", stackName)
+	e.RunCommand("pulumi", "stack", "init", qualifiedStackName)
 	// Create a config value to ensure there's a Pulumi.<name>.yaml file.
 	e.RunCommand("pulumi", "config", "set", "key", "value")
 

--- a/tests/stack/stack_test.go
+++ b/tests/stack/stack_test.go
@@ -500,12 +500,6 @@ func TestStackRenameAfterCreateServiceBackend(t *testing.T) {
 	e.RunCommandExpectError("pulumi", "stack", "rename", "fakeorg/"+stackRenameBase)
 
 	// Next perform a legal rename. This should work.
-	e.RunCommand("pulumi", "stack", "rename", stackRenameBase)
-	stdoutXyz1, _ := e.RunCommand("pulumi", "config", "get", "xyz")
-	assert.Equal(t, "abc", strings.Trim(stdoutXyz1, "\r\n"))
-
-	// Now perform another legal rename, this time explicitly specifying the
-	// "organization" for the stack (which should match the default).
 	e.RunCommand("pulumi", "stack", "rename", orgName+"/"+stackRenameBase+"2")
 	stdoutXyz2, _ := e.RunCommand("pulumi", "config", "get", "xyz")
 	assert.Equal(t, "abc", strings.Trim(stdoutXyz2, "\r\n"))

--- a/tests/stack/stack_test.go
+++ b/tests/stack/stack_test.go
@@ -487,7 +487,7 @@ func TestStackRenameAfterCreateServiceBackend(t *testing.T) {
 	stackName := addRandomSuffix("stack-rename-svcbe")
 	stackRenameBase := addRandomSuffix("renamed-stack-svcbe")
 	integration.CreateBasicPulumiRepo(e)
-	e.RunCommand("pulumi", "stack", "init", stackName)
+	e.RunCommand("pulumi", "stack", "init", fmt.Sprintf("%s/%s", orgName, stackName))
 
 	// Create some configuration so that a per-project YAML file is generated.
 	e.RunCommand("pulumi", "config", "set", "xyz", "abc")


### PR DESCRIPTION
Essentially a copy of https://github.com/pulumi/pulumi/pull/19249 but with commits re-organized for readability. 
This work is part of Project Hockeystick (https://github.com/orgs/pulumi/projects/274)

This PR updates the call sites for workspace.GetBackendConfigDefaultOrg to a wrapper `backend.GetDefaultOrg` that includes a fallback lookup to the backend for default org. If the backend does not support the GetDefaultOrg API, or if it has no opinion, `backend.GetDefaultOrg` will preserve existing behavior by returning an empty string for call sites to evaluate appropriately.

It additionally introduces a new call site: cloudBackend.ListStacks` -- This upfront call will reduce the number of API calls made in `cloudBackendReference.String()` to check the workspace against the default organization when eliding stack route, reducing performance impact for large scale organizations.