### PR TITLE
Fix make format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,9 @@ lint_actions:
 	go run github.com/rhysd/actionlint/cmd/actionlint@v1.6.27 \
 	  -format '{{range $$err := .}}### Error at line {{$$err.Line}}, col {{$$err.Column}} of `{{$$err.Filepath}}`\n\n{{$$err.Message}}\n\n```\n{{$$err.Snippet}}\n```\n\n{{end}}'
 
+format:: ensure
+	cd sdk/nodejs && yarn biome format --write ../../pkg/codegen/schema/pulumi.json
+
 test_fast:: build get_schemas
 	@cd pkg && $(GO_TEST_FAST) ${PROJECT_PKGS} ${PKG_CODEGEN_NODE}
 

--- a/build/common.mk
+++ b/build/common.mk
@@ -249,7 +249,6 @@ format::
 		-path "./*/compilation_error/*" -or \
 		-path "./*/testdata/*" \
 	\) | xargs gofumpt -w
-	cd sdk/nodejs && yarn biome format --write ../../pkg/codegen/schema/pulumi.json
 
 .SECONDEXPANSION: # Needed by .make/ensure/% and .make/ensure/__%.
 


### PR DESCRIPTION
Running `make format` inside an sdk folder breaks, because we pull in the format target from `common.mk`, which tries to fromat `pulumi.json`. This was added in https://github.com/pulumi/pulumi/pull/19281

The formatting for `pulumi.json` should only happen as part of the top level makefile.
