### PR TITLE
Require uv  0.6.16

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -19,7 +19,7 @@ node = "20"
 "npm:typescript-language-server" = "latest"
 "npm:yarn" = "latest"
 python = '3.11'
-uv = "latest"
+uv = "0.6.16"
 "go:github.com/mitranim/gow" = "latest"
 
 [plugins]


### PR DESCRIPTION
The lock file format has some extra information now. Require this version so `uv sync` doesn’t churn the file.
