### PR TITLE
treat private plugins as Git Plugins still

### DIFF
--- a/changelog/pending/20250425--engine--fix-error-message-when-trying-to-load-plugins-in-private-repositories-with-no-authentication.yaml
+++ b/changelog/pending/20250425--engine--fix-error-message-when-trying-to-load-plugins-in-private-repositories-with-no-authentication.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix error message when trying to load plugins in private repositories with no authentication

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -109,7 +109,8 @@ func IsLocalPluginPath(source string) bool {
 	// For other cases, we need to be careful about how we interpret the source, so let's parse the spec
 	// and check if it has a download URL.
 	pluginSpec, err := workspace.NewPluginSpec(source, apitype.ResourcePlugin, nil, "", nil)
-	if err != nil {
+	var pluginErr workspace.PluginVersionNotFoundError
+	if err != nil && !errors.As(err, &pluginErr) {
 		// If we can't parse it as a plugin spec, assume it's a local path
 		return true
 	}

--- a/sdk/go/common/resource/plugin/host_test.go
+++ b/sdk/go/common/resource/plugin/host_test.go
@@ -124,6 +124,11 @@ func TestIsLocalPluginPath(t *testing.T) {
 			path:     "", // Can't be a valid plugin name
 			expected: true,
 		},
+		{
+			name:     "private github URL",
+			path:     "github.com/pulumi/home",
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/sdk/go/common/resource/plugin/host_test.go
+++ b/sdk/go/common/resource/plugin/host_test.go
@@ -129,6 +129,11 @@ func TestIsLocalPluginPath(t *testing.T) {
 			path:     "github.com/pulumi/home",
 			expected: false,
 		},
+		{
+			name:     "non-existent repo URL",
+			path:     "example.com/no-repo-exists/here",
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1003,6 +1003,8 @@ type PluginSpec struct {
 	Checksums map[string][]byte
 }
 
+type PluginVersionNotFoundError error
+
 func NewPluginSpec(
 	source string,
 	kind apitype.PluginKind,
@@ -1052,7 +1054,13 @@ func NewPluginSpec(
 				var err error
 				version, err = gitutil.GetLatestTagOrHash(context.Background(), url)
 				if err != nil {
-					return PluginSpec{}, err
+					return PluginSpec{
+						Name:              name,
+						Kind:              kind,
+						Version:           version,
+						PluginDownloadURL: pluginDownloadURL,
+						Checksums:         checksums,
+					}, PluginVersionNotFoundError(err)
 				}
 			}
 		}


### PR DESCRIPTION
In IsLocalPluginPath, we check if a plugin is a remote plugin. To do that, we parse the PluginSpec first, and then check based on that.

However, when the plugin is in a private Git repo, we get an error here, because we fail to fetch the latest tag of the Git repo. Instead, return a special error for that, and look for it specifically here, so we can correctly determine that it's a local plugin, or remote, and thus give a good error message to the user down the line.

Fixes https://github.com/pulumi/pulumi/issues/19325