### PR TITLE
Add `--exclude` and `--exclude-dependents` to the Go Automation API

### DIFF
--- a/changelog/pending/20250425--auto-go--add-exclude-and-exclude-dependents-to-the-automation-api.yaml
+++ b/changelog/pending/20250425--auto-go--add-exclude-and-exclude-dependents-to-the-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Add `--exclude` and `--exclude-dependents` to the Automation API

--- a/sdk/go/auto/optdestroy/optdestroy.go
+++ b/sdk/go/auto/optdestroy/optdestroy.go
@@ -52,6 +52,20 @@ func TargetDependents() Option {
 	})
 }
 
+// Exclude specifies an exclusive list of resource URNs to ignore
+func Exclude(urns []string) Option {
+	return optionFunc(func(opts *Options) {
+		opts.Exclude = urns
+	})
+}
+
+// ExcludeDependents allows ignoring of dependent targets discovered but not specified in the Exclude list
+func ExcludeDependents() Option {
+	return optionFunc(func(opts *Options) {
+		opts.ExcludeDependents = true
+	})
+}
+
 // ProgressStreams allows specifying one or more io.Writers to redirect incremental destroy stdout
 func ProgressStreams(writers ...io.Writer) Option {
 	return optionFunc(func(opts *Options) {
@@ -169,6 +183,10 @@ type Options struct {
 	Target []string
 	// Allows updating of dependent targets discovered but not specified in the Target list
 	TargetDependents bool
+	// Specify an exclusive list of resource URNs to ignore
+	Exclude []string
+	// Allows ignoring of dependent targets discovered but not specified in the Exclude list
+	ExcludeDependents bool
 	// ProgressStreams allows specifying one or more io.Writers to redirect incremental destroy stdout
 	ProgressStreams []io.Writer
 	// ProgressStreams allows specifying one or more io.Writers to redirect incremental destroy stderr

--- a/sdk/go/auto/optpreview/optpreview.go
+++ b/sdk/go/auto/optpreview/optpreview.go
@@ -73,6 +73,20 @@ func TargetDependents() Option {
 	})
 }
 
+// Exclude specifies an exclusive list of resource URNs to ignore
+func Exclude(urns []string) Option {
+	return optionFunc(func(opts *Options) {
+		opts.Exclude = urns
+	})
+}
+
+// ExcludeDependents allows ignoring of dependent targets discovered but not specified in the Exclude list
+func ExcludeDependents() Option {
+	return optionFunc(func(opts *Options) {
+		opts.ExcludeDependents = true
+	})
+}
+
 // DebugLogging provides options for verbose logging to standard error, and enabling plugin logs.
 func DebugLogging(debugOpts debug.LoggingOptions) Option {
 	return optionFunc(func(opts *Options) {
@@ -188,6 +202,10 @@ type Options struct {
 	Target []string
 	// Allows updating of dependent targets discovered but not specified in the Target list
 	TargetDependents bool
+	// Specify an exclusive list of resource URNs to ignore
+	Exclude []string
+	// Allows ignoring of dependent targets discovered but not specified in the Exclude list
+	ExcludeDependents bool
 	// DebugLogOpts specifies additional settings for debug logging
 	DebugLogOpts debug.LoggingOptions
 	// ProgressStreams allows specifying one or more io.Writers to redirect incremental preview stdout

--- a/sdk/go/auto/optrefresh/optrefresh.go
+++ b/sdk/go/auto/optrefresh/optrefresh.go
@@ -59,6 +59,27 @@ func Target(urns []string) Option {
 	})
 }
 
+// TargetDependents allows updating of dependent targets discovered but not specified in the Target list
+func TargetDependents() Option {
+	return optionFunc(func(opts *Options) {
+		opts.TargetDependents = true
+	})
+}
+
+// Exclude specifies an exclusive list of resource URNs to ignore
+func Exclude(urns []string) Option {
+	return optionFunc(func(opts *Options) {
+		opts.Exclude = urns
+	})
+}
+
+// ExcludeDependents allows ignoring of dependent targets discovered but not specified in the Exclude list
+func ExcludeDependents() Option {
+	return optionFunc(func(opts *Options) {
+		opts.ExcludeDependents = true
+	})
+}
+
 // ProgressStreams allows specifying one or more io.Writers to redirect incremental refresh stdout
 func ProgressStreams(writers ...io.Writer) Option {
 	return optionFunc(func(opts *Options) {
@@ -163,6 +184,12 @@ type Options struct {
 	ClearPendingCreates bool
 	// Specify an exclusive of resource URNs to refresh
 	Target []string
+	// Allows updating of dependent targets discovered but not specified in the Target list
+	TargetDependents bool
+	// Specify an exclusive of resource URNs to ignore
+	Exclude []string
+	// Allows ignoring of dependent targets discovered but not specified in the Exclude list
+	ExcludeDependents bool
 	// ProgressStreams allows specifying one or more io.Writers to redirect incremental refresh stdout
 	ProgressStreams []io.Writer
 	// ErrorProgressStreams allows specifying one or more io.Writers to redirect incremental refresh stderr

--- a/sdk/go/auto/optup/optup.go
+++ b/sdk/go/auto/optup/optup.go
@@ -73,6 +73,20 @@ func TargetDependents() Option {
 	})
 }
 
+// Exclude specifies an exclusive list of resource URNs to ignore
+func Exclude(urns []string) Option {
+	return optionFunc(func(opts *Options) {
+		opts.Exclude = urns
+	})
+}
+
+// ExcludeDependents allows ignoring of dependent targets discovered but not specified in the Exclude list
+func ExcludeDependents() Option {
+	return optionFunc(func(opts *Options) {
+		opts.ExcludeDependents = true
+	})
+}
+
 // ProgressStreams allows specifying one or more io.Writers to redirect incremental update stdout
 func ProgressStreams(writers ...io.Writer) Option {
 	return optionFunc(func(opts *Options) {
@@ -195,6 +209,10 @@ type Options struct {
 	Target []string
 	// Allows updating of dependent targets discovered but not specified in the Target list
 	TargetDependents bool
+	// Specify an exclusive of resource URNs to ignore
+	Exclude []string
+	// Allows ignoring of dependent targets discovered but not specified in the Exclude list
+	ExcludeDependents bool
 	// DebugLogOpts specifies additional settings for debug logging
 	DebugLogOpts debug.LoggingOptions
 	// ProgressStreams allows specifying one or more io.Writers to redirect incremental update stdout

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -247,6 +247,9 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 	for _, tURN := range preOpts.Target {
 		sharedArgs = append(sharedArgs, "--target="+tURN)
 	}
+	for _, eURN := range preOpts.Exclude {
+		sharedArgs = append(sharedArgs, "--exclude="+eURN)
+	}
 	for _, pack := range preOpts.PolicyPacks {
 		sharedArgs = append(sharedArgs, "--policy-pack="+pack)
 	}
@@ -255,6 +258,9 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 	}
 	if preOpts.TargetDependents {
 		sharedArgs = append(sharedArgs, "--target-dependents")
+	}
+	if preOpts.ExcludeDependents {
+		sharedArgs = append(sharedArgs, "--exclude-dependents")
 	}
 	if preOpts.Parallel > 0 {
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--parallel=%d", preOpts.Parallel))
@@ -386,6 +392,9 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 	for _, tURN := range upOpts.Target {
 		sharedArgs = append(sharedArgs, "--target="+tURN)
 	}
+	for _, eURN := range upOpts.Exclude {
+		sharedArgs = append(sharedArgs, "--exclude="+eURN)
+	}
 	for _, pack := range upOpts.PolicyPacks {
 		sharedArgs = append(sharedArgs, "--policy-pack="+pack)
 	}
@@ -394,6 +403,9 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 	}
 	if upOpts.TargetDependents {
 		sharedArgs = append(sharedArgs, "--target-dependents")
+	}
+	if upOpts.ExcludeDependents {
+		sharedArgs = append(sharedArgs, "--exclude-dependents")
 	}
 	if upOpts.Parallel > 0 {
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--parallel=%d", upOpts.Parallel))
@@ -755,6 +767,15 @@ func refreshOptsToCmd(o *optrefresh.Options, s *Stack, isPreview bool) []string 
 	for _, tURN := range o.Target {
 		args = append(args, "--target="+tURN)
 	}
+	for _, eURN := range o.Exclude {
+		args = append(args, "--exclude="+eURN)
+	}
+	if o.TargetDependents {
+		args = append(args, "--target-dependents")
+	}
+	if o.ExcludeDependents {
+		args = append(args, "--exclude-dependents")
+	}
 	if o.Parallel > 0 {
 		args = append(args, fmt.Sprintf("--parallel=%d", o.Parallel))
 	}
@@ -1002,8 +1023,14 @@ func destroyOptsToCmd(destroyOpts *optdestroy.Options, s *Stack) []string {
 	for _, tURN := range destroyOpts.Target {
 		args = append(args, "--target="+tURN)
 	}
+	for _, eURN := range destroyOpts.Exclude {
+		args = append(args, "--exclude="+eURN)
+	}
 	if destroyOpts.TargetDependents {
 		args = append(args, "--target-dependents")
+	}
+	if destroyOpts.ExcludeDependents {
+		args = append(args, "--exclude-dependents")
 	}
 	if destroyOpts.Parallel > 0 {
 		args = append(args, fmt.Sprintf("--parallel=%d", destroyOpts.Parallel))


### PR DESCRIPTION
The next in a series. This PR adds `--exclude` and `--exclude-dependents` options for the stack commands in the Go Automation API.

- #19270 
- #19310