### PR TITLE
Always save fully qualified stack names to settings

### DIFF
--- a/changelog/pending/20250425--cli--always-save-fully-qualified-stack-names-to-the-settings-file.yaml
+++ b/changelog/pending/20250425--cli--always-save-fully-qualified-stack-names-to-the-settings-file.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Always save fully qualified stack names to the settings file

--- a/pkg/cmd/pulumi/newcmd/new.go
+++ b/pkg/cmd/pulumi/newcmd/new.go
@@ -441,7 +441,7 @@ func runNew(ctx context.Context, args newArgs) error {
 
 	// Ensure the stack is selected.
 	if !args.generateOnly && s != nil {
-		contract.IgnoreError(state.SetCurrentStack(s.Ref().String()))
+		contract.IgnoreError(state.SetCurrentStack(s.Ref().FullyQualifiedName().String()))
 	}
 
 	// Install dependencies.

--- a/pkg/cmd/pulumi/newcmd/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_acceptance_test.go
@@ -16,6 +16,7 @@ package newcmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -88,6 +89,8 @@ func TestCreatingStackWithArgsSpecifiedName(t *testing.T) {
 	tempdir := tempProjectDir(t)
 	chdir(t, tempdir)
 
+	fullStackName := fmt.Sprintf("%s/%s/%s", currentUser(t), filepath.Base(tempdir), stackName)
+
 	args := newArgs{
 		interactive:       false,
 		yes:               true,
@@ -101,7 +104,7 @@ func TestCreatingStackWithArgsSpecifiedName(t *testing.T) {
 	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
-	assert.Equal(t, stackName, loadStackName(t))
+	assert.Equal(t, fullStackName, loadStackName(t))
 	removeStack(t, tempdir, stackName)
 }
 
@@ -118,6 +121,7 @@ func TestCreatingStackWithNumericName(t *testing.T) {
 	// instead of a constant.
 	unixTsNanos := time.Now().UnixNano()
 	numericProjectName := strconv.Itoa(int(unixTsNanos))
+	fullStackName := fmt.Sprintf("%s/%s/%s", currentUser(t), numericProjectName, stackName)
 
 	args := newArgs{
 		interactive:       false,
@@ -137,7 +141,7 @@ func TestCreatingStackWithNumericName(t *testing.T) {
 
 	assert.Equal(t, p.Name.String(), numericProjectName)
 
-	assert.Equal(t, stackName, loadStackName(t))
+	assert.Equal(t, fullStackName, loadStackName(t))
 	removeStack(t, tempdir, stackName)
 }
 
@@ -149,6 +153,8 @@ func TestCreatingStackWithPromptedName(t *testing.T) {
 	chdir(t, tempdir)
 	uniqueProjectName := filepath.Base(tempdir)
 
+	fullStackName := fmt.Sprintf("%s/%s/%s", currentUser(t), filepath.Base(tempdir), stackName)
+
 	args := newArgs{
 		interactive:       true,
 		prompt:            promptMock(uniqueProjectName, stackName),
@@ -159,7 +165,7 @@ func TestCreatingStackWithPromptedName(t *testing.T) {
 	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
-	assert.Equal(t, stackName, loadStackName(t))
+	assert.Equal(t, fullStackName, loadStackName(t))
 	removeStack(t, tempdir, stackName)
 }
 

--- a/pkg/cmd/pulumi/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_test.go
@@ -94,6 +94,7 @@ func TestCreatingStackWithArgsSpecifiedOrgName(t *testing.T) {
 	chdir(t, tempdir)
 
 	orgStackName := fmt.Sprintf("%s/%s", currentUser(t), stackName)
+	fullStackName := fmt.Sprintf("%s/%s/%s", currentUser(t), filepath.Base(tempdir), stackName)
 
 	args := newArgs{
 		interactive:       false,
@@ -107,7 +108,7 @@ func TestCreatingStackWithArgsSpecifiedOrgName(t *testing.T) {
 	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
-	assert.Equal(t, stackName, loadStackName(t))
+	assert.Equal(t, fullStackName, loadStackName(t))
 	removeStack(t, tempdir, stackName)
 }
 
@@ -120,6 +121,7 @@ func TestCreatingStackWithPromptedOrgName(t *testing.T) {
 
 	uniqueProjectName := filepath.Base(tempdir)
 	orgStackName := fmt.Sprintf("%s/%s", currentUser(t), stackName)
+	fullStackName := fmt.Sprintf("%s/%s/%s", currentUser(t), filepath.Base(tempdir), stackName)
 
 	args := newArgs{
 		interactive:       true,
@@ -131,7 +133,7 @@ func TestCreatingStackWithPromptedOrgName(t *testing.T) {
 	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
-	assert.Equal(t, stackName, loadStackName(t))
+	assert.Equal(t, fullStackName, loadStackName(t))
 	removeStack(t, tempdir, stackName)
 }
 
@@ -158,7 +160,7 @@ func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
 	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
-	assert.Equal(t, stackName, loadStackName(t))
+	assert.Equal(t, fullStackName, loadStackName(t))
 	removeStack(t, tempdir, stackName)
 }
 

--- a/pkg/cmd/pulumi/stack/io.go
+++ b/pkg/cmd/pulumi/stack/io.go
@@ -307,7 +307,7 @@ func ChooseStack(ctx context.Context, ws pkgWorkspace.Context,
 
 	// If setCurrent is true, we'll persist this choice so it'll be used for future CLI operations.
 	if lopt.SetCurrent() {
-		if err = state.SetCurrentStack(stackRef.String()); err != nil {
+		if err = state.SetCurrentStack(stackRef.FullyQualifiedName().String()); err != nil {
 			return nil, err
 		}
 	}
@@ -388,7 +388,7 @@ func CreateStack(ctx context.Context, ws pkgWorkspace.Context,
 	}
 
 	if setCurrent {
-		if err = state.SetCurrentStack(stack.Ref().String()); err != nil {
+		if err = state.SetCurrentStack(stack.Ref().FullyQualifiedName().String()); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/cmd/pulumi/stack/stack_rename.go
+++ b/pkg/cmd/pulumi/stack/stack_rename.go
@@ -95,7 +95,7 @@ func newStackRenameCmd() *cobra.Command {
 			}
 
 			// Update the current workspace state to have selected the new stack.
-			if err := state.SetCurrentStack(newStackName); err != nil {
+			if err := state.SetCurrentStack(newStackRef.FullyQualifiedName().String()); err != nil {
 				return fmt.Errorf("setting current stack: %w", err)
 			}
 

--- a/pkg/cmd/pulumi/stack/stack_select.go
+++ b/pkg/cmd/pulumi/stack/stack_select.go
@@ -82,7 +82,7 @@ func newStackSelectCmd() *cobra.Command {
 				if stackErr != nil {
 					return stackErr
 				} else if s != nil {
-					return state.SetCurrentStack(stackRef.String())
+					return state.SetCurrentStack(stackRef.FullyQualifiedName().String())
 				}
 				// If create flag was passed and stack was not found, create it and select it.
 				if create && stack != "" {
@@ -90,7 +90,7 @@ func newStackSelectCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					return state.SetCurrentStack(s.Ref().String())
+					return state.SetCurrentStack(s.Ref().FullyQualifiedName().String())
 				}
 
 				return fmt.Errorf("no stack named '%s' found", stackRef)
@@ -109,7 +109,7 @@ func newStackSelectCmd() *cobra.Command {
 			}
 
 			contract.Assertf(stack != nil, "must select a stack")
-			return state.SetCurrentStack(stack.Ref().String())
+			return state.SetCurrentStack(stack.Ref().FullyQualifiedName().String())
 		},
 	}
 	cmd.PersistentFlags().StringVarP(


### PR DESCRIPTION
Noticed in https://github.com/pulumi/pulumi/pull/19324/files/aa1c465e08639c1578cc43e62fa7ea86879a8634#r2059990017

We need to save fully qualified stack names to the settings to prevent the following issue. 

Imagine the default org is currently "foo" and we create and save a stack "bar". Historically this would save the abbreviated name to the settings so just "bar".
If we then change the default org to "qux" and run `up` it will load the name from settings and reconstruct "bar" into "qux/bar" instead of "foo/bar" which is the stack that had actually been selected!

This fixes that to just always save the fully qualified name to stack settings. 