### PR TITLE
Update some import tests

### DIFF
--- a/pkg/engine/lifecycletest/continue_on_error_test.go
+++ b/pkg/engine/lifecycletest/continue_on_error_test.go
@@ -721,13 +721,8 @@ func TestContinueOnErrorImport(t *testing.T) {
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return &deploytest.Provider{
-				DiffF: func(context.Context, plugin.DiffRequest) (plugin.DiffResult, error) {
-					return plugin.DiffResult{
-						Changes: plugin.DiffSome,
-						DetailedDiff: map[string]plugin.PropertyDiff{
-							"foo": {Kind: plugin.DiffUpdate},
-						},
-					}, nil
+				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					return plugin.ReadResponse{}, errors.New("intentionally failed read")
 				},
 				CreateF: func(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
 					return plugin.CreateResponse{
@@ -765,7 +760,7 @@ func TestContinueOnErrorImport(t *testing.T) {
 
 	// Run an update to create the resource
 	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
-	require.ErrorContains(t, err, "inputs to import do not match the existing resource")
+	require.ErrorContains(t, err, "intentionally failed read")
 	require.NotNil(t, snap)
 	assert.Equal(t, 1, len(snap.Resources)) // 1 provider
 }

--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -76,6 +76,12 @@ func TestImportOption(t *testing.T) {
 						Status:     resource.StatusOK,
 					}, nil
 				},
+				UpdateF: func(_ context.Context, req plugin.UpdateRequest) (plugin.UpdateResponse, error) {
+					return plugin.UpdateResponse{
+						Properties: req.NewInputs,
+						Status:     resource.StatusOK,
+					}, nil
+				},
 				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
 					assert.Equal(t, expectedInputs, req.Inputs)
 					assert.Equal(t, expectedState, req.State)
@@ -94,6 +100,7 @@ func TestImportOption(t *testing.T) {
 	}
 
 	readID, importID, inputs := resource.ID(""), resource.ID("id"), resource.PropertyMap{}
+	var expectedOutputs resource.PropertyMap
 	expectedID := resource.ID("imported-id")
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		if readID != "" {
@@ -106,6 +113,7 @@ func TestImportOption(t *testing.T) {
 			})
 			assert.NoError(t, err)
 			assert.Equal(t, expectedID, resp.ID)
+			assert.Equal(t, expectedOutputs, resp.Outputs)
 		}
 		return nil
 	})
@@ -125,6 +133,7 @@ func TestImportOption(t *testing.T) {
 
 	// Run a second update after fixing the inputs. The import should succeed.
 	inputs["foo"] = resource.NewStringProperty("bar")
+	expectedOutputs = readOutputs
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, entries JournalEntries, _ []Event, err error) error {
 			for _, entry := range entries {
@@ -167,6 +176,7 @@ func TestImportOption(t *testing.T) {
 
 	// Change a property value and run a third update. The update should succeed.
 	inputs["foo"] = resource.NewStringProperty("rab")
+	expectedOutputs = inputs
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, entries JournalEntries, _ []Event, err error) error {
 			for _, entry := range entries {
@@ -256,6 +266,7 @@ func TestImportOption(t *testing.T) {
 	// a delete-replaced.
 	importID = "id"
 	expectedID = resource.ID("imported-id")
+	expectedOutputs = readOutputs
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, entries JournalEntries, _ []Event, err error) error {
 			for _, entry := range entries {


### PR DESCRIPTION
In preparation for the new import system this changes a few tests such that they are still valid today, but have extra checks that we want to assert on for the new system as well.

`TestContinueOnErrorImport` is changed to explicitly fail the read, rather than relying on the diff failure that is being removed in the new system.

`TestImportOption` adds some checks that the outputs we see in the program are what we expect to see.