### PR TITLE
Implement stack creation with cloud config

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -405,7 +405,10 @@ func (c *backendClient) GetStackResourceOutputs(
 
 // ErrTeamsNotSupported is returned by backends
 // which do not support the teams feature.
-var ErrTeamsNotSupported = errors.New("teams are not supported")
+var (
+	ErrTeamsNotSupported  = errors.New("teams are not supported")
+	ErrConfigNotSupported = errors.New("remote config is not supported")
+)
 
 // CreateStackOptions provides options for stack creation.
 // At present, options only apply to the Service.
@@ -418,6 +421,10 @@ type CreateStackOptions struct {
 	// The backend may return ErrTeamsNotSupported
 	// if Teams is specified but not supported.
 	Teams []string
+
+	// Config is the optional cloud stack config to use instead of reading from a local file on disk.
+	// This is only used by the Service backend.
+	Config *apitype.StackConfig
 }
 
 // TarReaderCloser is a [tar.Reader] that owns it's backing memory.

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -732,6 +732,9 @@ func (b *diyBackend) CreateStack(
 	if opts != nil && len(opts.Teams) > 0 {
 		return nil, backend.ErrTeamsNotSupported
 	}
+	if opts != nil && opts.Config != nil {
+		return nil, backend.ErrConfigNotSupported
+	}
 
 	diyStackRef, err := b.getReference(stackRef)
 	if err != nil {

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -991,7 +991,7 @@ func (b *cloudBackend) CreateStack(
 		return nil, fmt.Errorf("getting stack tags: %w", err)
 	}
 
-	apistack, err := b.client.CreateStack(ctx, stackID, tags, opts.Teams, initialState)
+	apistack, err := b.client.CreateStack(ctx, stackID, tags, opts.Teams, initialState, opts.Config)
 	if err != nil {
 		// Wire through well-known error types.
 		if errResp, ok := err.(*apitype.ErrorResponse); ok && errResp.Code == http.StatusConflict {

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -477,6 +477,7 @@ func (pc *Client) CreateStack(
 	tags map[apitype.StackTagName]string,
 	teams []string,
 	state *apitype.UntypedDeployment,
+	config *apitype.StackConfig,
 ) (apitype.Stack, error) {
 	// Validate names and tags.
 	if err := validation.ValidateStackTags(tags); err != nil {
@@ -494,6 +495,7 @@ func (pc *Client) CreateStack(
 		Tags:      tags,
 		Teams:     teams,
 		State:     state,
+		Config:    config,
 	}
 
 	endpoint := fmt.Sprintf("/api/stacks/%s/%s", stackID.Owner, stackID.Project)

--- a/sdk/go/common/apitype/stacks.go
+++ b/sdk/go/common/apitype/stacks.go
@@ -66,6 +66,8 @@ type CreateStackRequest struct {
 
 	// An optional state to initialize the stack with.
 	State *UntypedDeployment `json:"state,omitempty"`
+
+	Config *StackConfig `json:"config,omitempty"`
 }
 
 // CreateStackResponse is the response from a create Stack request.


### PR DESCRIPTION
Follow-up to #19086

When creating a new stack, allow the option to enable storing the stack config remotely in the cloud.

The backend is not yet implemented, so integration tests will be added as part of #19166