### PR TITLE
Remove `dotnet.DocLanguageHelper.Namespaces`

### DIFF
--- a/pkg/codegen/dotnet/doc.go
+++ b/pkg/codegen/dotnet/doc.go
@@ -25,12 +25,7 @@ import (
 )
 
 // DocLanguageHelper is the DotNet-specific implementation of the DocLanguageHelper.
-type DocLanguageHelper struct {
-	// Namespaces is a map of Pulumi schema module names to their
-	// C# equivalent names, to be used when creating fully-qualified
-	// property type strings.
-	Namespaces map[string]string
-}
+type DocLanguageHelper struct{}
 
 var _ codegen.DocLanguageHelper = DocLanguageHelper{}
 
@@ -56,7 +51,8 @@ func (d DocLanguageHelper) GetDocLinkForResourceType(pkg *schema.Package, _, typ
 	if pkg == nil {
 		packageNamespace = ""
 	} else if pkg.Name != "" {
-		packageNamespace = "." + namespaceName(d.Namespaces, pkg.Name)
+		info, _ := pkg.Language["csharp"].(CSharpPackageInfo)
+		packageNamespace = "." + namespaceName(info.Namespaces, pkg.Name)
 	}
 	return fmt.Sprintf("/docs/reference/pkg/dotnet/Pulumi%s/%s.html", packageNamespace, typeName)
 }
@@ -106,34 +102,32 @@ func (d DocLanguageHelper) GetMethodName(m *schema.Method) string {
 func (d DocLanguageHelper) GetMethodResultName(pkg *schema.Package, modName string, r *schema.Resource,
 	m *schema.Method,
 ) string {
+	info, _ := pkg.Language["csharp"].(CSharpPackageInfo)
 	var returnType *schema.ObjectType
 	if m.Function.ReturnType != nil {
 		if objectType, ok := m.Function.ReturnType.(*schema.ObjectType); ok {
 			returnType = objectType
 		} else {
-			typeDetails := map[*schema.ObjectType]*typeDetails{}
 			mod := &modContext{
-				pkg:         pkg.Reference(),
-				mod:         modName,
-				typeDetails: typeDetails,
-				namespaces:  d.Namespaces,
+				pkg:           pkg.Reference(),
+				mod:           modName,
+				typeDetails:   map[*schema.ObjectType]*typeDetails{},
+				namespaces:    info.Namespaces,
+				rootNamespace: info.GetRootNamespace(),
 			}
 			return mod.typeString(m.Function.ReturnType, "", false, false, false)
 		}
 	}
 
-	if info, ok := pkg.Language["csharp"].(CSharpPackageInfo); ok {
-		if info.LiftSingleValueMethodReturns && returnType != nil && len(returnType.Properties) == 1 {
-			typeDetails := map[*schema.ObjectType]*typeDetails{}
-			mod := &modContext{
-				pkg:           pkg.Reference(),
-				mod:           modName,
-				typeDetails:   typeDetails,
-				namespaces:    d.Namespaces,
-				rootNamespace: info.GetRootNamespace(),
-			}
-			return mod.typeString(returnType.Properties[0].Type, "", false, false, false)
+	if info.LiftSingleValueMethodReturns && returnType != nil && len(returnType.Properties) == 1 {
+		mod := &modContext{
+			pkg:           pkg.Reference(),
+			mod:           modName,
+			typeDetails:   map[*schema.ObjectType]*typeDetails{},
+			namespaces:    info.Namespaces,
+			rootNamespace: info.GetRootNamespace(),
 		}
+		return mod.typeString(returnType.Properties[0].Type, "", false, false, false)
 	}
 	return fmt.Sprintf("%s.%sResult", resourceName(r), d.GetMethodName(m))
 }

--- a/pkg/codegen/dotnet/doc_test.go
+++ b/pkg/codegen/dotnet/doc_test.go
@@ -82,8 +82,8 @@ func TestGetDocLinkForResourceInputOrOutputType(t *testing.T) {
 	t.Parallel()
 
 	pkg := getTestPackage(t)
-
-	d := DocLanguageHelper{
+	var d DocLanguageHelper
+	pkg.Language["csharp"] = CSharpPackageInfo{
 		Namespaces: map[string]string{
 			"s3": "S3",
 		},


### PR DESCRIPTION
This field is never written to, and so is always `nil`. We should remove it in favor of
the actual namespace value associated with the package we are operating on.