### PR TITLE
Allow for hyphens in function names

### DIFF
--- a/changelog/pending/20250425--pkg--allow-for-hyphens-in-function-names.yaml
+++ b/changelog/pending/20250425--pkg--allow-for-hyphens-in-function-names.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: pkg
+  description: Allow for hyphens in function names

--- a/pkg/codegen/schema/pulumi.json
+++ b/pkg/codegen/schema/pulumi.json
@@ -213,7 +213,7 @@
         "functionToken": {
             "title": "Function Token",
             "type": "string",
-            "$comment": "Some functions, such as provider methods, may have hyphens, for example in the case of a hyphenated provider name, which becomes part of the function name. This regex is the same as for Token but allows for a hyphen.",
+            "$comment": "Some functions, such as provider methods, may have hyphens, for example in the case of a hyphenated provider name. This becomes part of the function name and so this regex is the same as for Token but allows for hyphens.",
             "pattern": "^[a-zA-Z][-a-zA-Z0-9_]*:([^0-9][a-zA-Z0-9._/-]*)?:[^0-9][a-zA-Z0-9._/-]*$"
         },
         "schemaStringMap": {

--- a/pkg/codegen/schema/pulumi.json
+++ b/pkg/codegen/schema/pulumi.json
@@ -177,7 +177,7 @@
                 "$ref": "#/$defs/functionSpec"
             },
             "propertyNames": {
-                "$ref": "#/$defs/token"
+                "$ref": "#/$defs/functionToken"
             }
         },
         "language": {
@@ -209,6 +209,12 @@
             "type": "string",
             "$comment": "In the regex below, the 'module' portion of the token is optional. However, a missing module component creates a '::', which breaks URNs ('::' is the URN delimiter). We have many test schemas that use an empty module component successfully, as they never create URNs; while these are _probably_ the only places that need updating, it might be possible that there are module-less type tokens in the wild elsewhere and we may need to remain compatible with those tokens.",
             "pattern": "^[a-zA-Z][-a-zA-Z0-9_]*:([^0-9][a-zA-Z0-9._/-]*)?:[^0-9][a-zA-Z0-9._/]*$"
+        },
+        "functionToken": {
+            "title": "Function Token",
+            "type": "string",
+            "$comment": "Some functions, such as provider methods, may have hyphens, for example in the case of a hyphenated provider name, which becomes part of the function name. This regex is the same as for Token but allows for a hyphen.",
+            "pattern": "^[a-zA-Z][-a-zA-Z0-9_]*:([^0-9][a-zA-Z0-9._/-]*)?:[^0-9][a-zA-Z0-9._/-]*$"
         },
         "schemaStringMap": {
             "type": "object",

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -2039,3 +2039,110 @@ func TestRoundtripAliasesYAML(t *testing.T) {
 
 	assert.YAMLEq(t, string(schemaBytes), string(yamlData))
 }
+
+func TestFunctionToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		token    string
+		expected hcl.Diagnostics
+	}{
+		{
+			name:     "valid_token_for_provider_method",
+			token:    "pulumi:providers:terraform-provider/providerMethod",
+			expected: hcl.Diagnostics(nil),
+		},
+		{
+			name:     "valid_token_without_hyphens",
+			token:    "test:index:getFunction",
+			expected: hcl.Diagnostics(nil),
+		},
+		{
+			name:     "valid_token_with_hyphens",
+			token:    "test:index:get-function-data",
+			expected: hcl.Diagnostics(nil),
+		},
+		{
+			name:     "valid_token_with_leading_hyphen",
+			token:    "test:index:-getFunction",
+			expected: hcl.Diagnostics(nil),
+		},
+		{
+			name:     "valid_token_with_consecutive_hyphens",
+			token:    "test:index:get--function",
+			expected: hcl.Diagnostics(nil),
+		},
+		{
+			name:  "invalid_token_with_invalid_package",
+			token: "123:index:getFunction",
+			expected: hcl.Diagnostics{
+				{
+					Severity: hcl.DiagError,
+					Summary:  "#/functions/123:index:getFunction: doesn't validate with '/$defs/functionToken'",
+					Detail:   "",
+				},
+				{
+					Severity: hcl.DiagError,
+					Summary:  "#/functions/123:index:getFunction: does not match pattern '^[a-zA-Z][-a-zA-Z0-9_]*:([^0-9][a-zA-Z0-9._/-]*)?:[^0-9][a-zA-Z0-9._/-]*$'",
+					Detail:   "",
+				},
+				{
+					Severity: hcl.DiagError,
+					Summary:  "#/functions/123:index:getFunction: invalid token '123:index:getFunction' (must have package name 'test')",
+					Detail:   "",
+				},
+			},
+		},
+		{
+			name:  "invalid_token_with_invalid_module",
+			token: "test:123:getFunction",
+			expected: hcl.Diagnostics{
+				{
+					Severity: hcl.DiagError,
+					Summary:  "#/functions/test:123:getFunction: doesn't validate with '/$defs/functionToken'",
+					Detail:   "",
+				},
+				{
+					Severity: hcl.DiagError,
+					Summary:  "#/functions/test:123:getFunction: does not match pattern '^[a-zA-Z][-a-zA-Z0-9_]*:([^0-9][a-zA-Z0-9._/-]*)?:[^0-9][a-zA-Z0-9._/-]*$'",
+					Detail:   "",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			// Create a minimal package spec with the function token
+			spec := PackageSpec{
+				Name: "test",
+				Functions: map[string]FunctionSpec{
+					tt.token: {
+						Description: "Test function",
+					},
+				},
+			}
+
+			// Try to bind the spec
+			pkg, diags, err := BindSpec(spec, nil)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, diags)
+
+			//Test marshaling
+			newSpec, err := pkg.MarshalSpec()
+			require.NoError(t, err)
+			require.NotNil(t, newSpec)
+
+			// Try and bind again
+			_, diags, err = BindSpec(*newSpec, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, diags)
+
+			// Verify the function token is preserved
+			_, exists := newSpec.Functions[tt.token]
+			assert.True(t, exists)
+		})
+	}
+
+}

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -2112,7 +2112,6 @@ func TestFunctionToken(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			// Create a minimal package spec with the function token
 			spec := PackageSpec{
 				Name: "test",
@@ -2129,7 +2128,7 @@ func TestFunctionToken(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, diags)
 
-			//Test marshaling
+			// Test marshaling
 			newSpec, err := pkg.MarshalSpec()
 			require.NoError(t, err)
 			require.NotNil(t, newSpec)
@@ -2144,5 +2143,4 @@ func TestFunctionToken(t *testing.T) {
 			assert.True(t, exists)
 		})
 	}
-
 }

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -2112,6 +2112,7 @@ func TestFunctionToken(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			// Create a minimal package spec with the function token
 			spec := PackageSpec{
 				Name: "test",

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -2041,6 +2041,7 @@ func TestRoundtripAliasesYAML(t *testing.T) {
 }
 
 func TestFunctionToken(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		token    string


### PR DESCRIPTION
This pull request introduces a new schema definition for function types.

Currently, function tokens may not have any hyphens in their final part. For most existing functions, this is fine, since we habitually do not create functions that have hyphens in them.

However, for provider-level Methods, which are of the token format `pulumi:providers/packageName/functionName`, sometimes the provider has a hyphen. Famous example: `terraform-provider` - the base name for our provider parameterization.

Rather than widening the regex scope for all tokens, this pull request adds a new `functionToken` to the metaschema with an additional allowed `-` in the regex pattern.

Adds tests to confirm this is permissible for all function tokens, as well as the special provider methods.

Fixes https://github.com/pulumi/pulumi/issues/19274.