### PR TITLE
Mark package publish command as non-experimental

### DIFF
--- a/changelog/pending/20250428--cli-package--mark-package-publish-command-as-non-experimental.yaml
+++ b/changelog/pending/20250428--cli-package--mark-package-publish-command-as-non-experimental.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli/package
+  description: Mark package publish command as non-experimental

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -85,7 +85,6 @@ func newPackagePublishCmd() *cobra.Command {
 			"When <schema> is a path to a local file with a '.json', '.yml' or '.yaml' " +
 			"extension, Pulumi package schema is read from it directly:\n\n" +
 			"  pulumi package publish ./my/schema.json --readme ./README.md",
-		Hidden: !env.Experimental.Value(),
 		RunE: func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := cmd.Context()
 			pkgPublishCmd.defaultOrg = pkgWorkspace.GetBackendConfigDefaultOrg


### PR DESCRIPTION
We've started using this command for publishing public packages to the registry, as well as started dogfooding it for the private registry. Marking it as non-experimental now to make it easier to discover.