### PR TITLE
Decorate resources and enums with their type token

### DIFF
--- a/changelog/pending/20250428--sdk-python--decorate-resources-and-enums-with-their-type-token.yaml
+++ b/changelog/pending/20250428--sdk-python--decorate-resources-and-enums-with-their-type-token.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Decorate resources and enums with their type token

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1372,15 +1372,12 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 	}
 
 	// Produce a class definition with optional """ comment.
+	fmt.Fprintf(w, "@pulumi.type_token(\"%s\")\n", res.Token)
 	fmt.Fprintf(w, "class %s(%s):\n", name, baseType)
 	if res.DeprecationMessage != "" && mod.compatibility != kubernetes20 {
 		escaped := strings.ReplaceAll(res.DeprecationMessage, `"`, `\"`)
 		fmt.Fprintf(w, "    warnings.warn(\"\"\"%s\"\"\", DeprecationWarning)\n\n", escaped)
 	}
-
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "    pulumi_type = \"%s\"\n", res.Token)
-	fmt.Fprintln(w)
 
 	// Determine if all inputs are optional.
 	allOptionalInputs := true
@@ -2130,8 +2127,8 @@ func (mod *modContext) genEnums(w io.Writer, enums []*schema.EnumType) error {
 	// Header
 	mod.genHeader(w, false /*needsSDK*/, nil)
 
+	fmt.Fprintf(w, "import pulumi\n")
 	// Enum import
-	fmt.Fprintf(w, "import builtins\n")
 	fmt.Fprintf(w, "from enum import Enum\n\n")
 
 	// Export only the symbols we want exported.
@@ -2159,6 +2156,7 @@ func (mod *modContext) genEnum(w io.Writer, enum *schema.EnumType) error {
 
 	switch enum.ElementType {
 	case schema.StringType, schema.IntType, schema.NumberType:
+		fmt.Fprintf(w, "@pulumi.type_token(\"%s\")\n", enum.Token)
 		fmt.Fprintf(w, "class %s(%s, Enum):\n", enumName, underlyingType)
 		printComment(w, enum.Comment, indent)
 		for _, e := range enum.Elements {
@@ -3432,7 +3430,7 @@ func setDependencies(schema *PyprojectSchema, pkg *schema.Package, dependencies 
 }
 
 // Require the SDK to fall within the same major version.
-var MinimumValidSDKVersion = ">=3.142.0,<4.0.0"
+var MinimumValidSDKVersion = ">=3.165.0,<4.0.0"
 
 // ensureValidPulumiVersion ensures that the Pulumi SDK has an entry.
 // It accepts a list of dependencies

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -320,7 +320,7 @@ func TestCalculateDeps(t *testing.T) {
 			// with semver and parver formatted differently from Pulumi.
 			// Pulumi should not have a version.
 			{"parver>=0.2.1", ""},
-			{"pulumi", ">=3.142.0,<4.0.0"},
+			{"pulumi", ">=3.165.0,<4.0.0"},
 			{"semver>=2.8.1"},
 		},
 	}, {
@@ -332,7 +332,7 @@ func TestCalculateDeps(t *testing.T) {
 		expected: [][2]string{
 			{"foobar", "7.10.8"},
 			{"parver>=0.2.1", ""},
-			{"pulumi", ">=3.142.0,<4.0.0"},
+			{"pulumi", ">=3.165.0,<4.0.0"},
 			{"semver>=2.8.1"},
 		},
 	}, {

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/provider.py
@@ -21,10 +21,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:alpha")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:alpha"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/resource.py
@@ -31,10 +31,8 @@ class ResourceArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("alpha:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "alpha:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_alpha',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/any-type-function-15.0.0/pulumi_any_type_function/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/any-type-function-15.0.0/pulumi_any_type_function/provider.py
@@ -21,10 +21,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:any-type-function")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:any-type-function"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/any-type-function-15.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/any-type-function-15.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_any_type_function',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/archive_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/archive_resource.py
@@ -31,10 +31,8 @@ class ArchiveResourceArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("asset-archive:index:ArchiveResource")
 class ArchiveResource(pulumi.CustomResource):
-
-    pulumi_type = "asset-archive:index:ArchiveResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/asset_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/asset_resource.py
@@ -31,10 +31,8 @@ class AssetResourceArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("asset-archive:index:AssetResource")
 class AssetResource(pulumi.CustomResource):
-
-    pulumi_type = "asset-archive:index:AssetResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/provider.py
@@ -21,10 +21,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:asset-archive")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:asset-archive"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_asset_archive',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/call-15.7.9/pulumi_call/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/call-15.7.9/pulumi_call/custom.py
@@ -31,10 +31,8 @@ class CustomArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("call:index:Custom")
 class Custom(pulumi.CustomResource):
-
-    pulumi_type = "call:index:Custom"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/call-15.7.9/pulumi_call/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/call-15.7.9/pulumi_call/provider.py
@@ -31,10 +31,8 @@ class ProviderArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("pulumi:providers:call")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:call"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/call-15.7.9/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/call-15.7.9/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_call',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/component_callable.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/component_callable.py
@@ -31,10 +31,8 @@ class ComponentCallableArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("component:index:ComponentCallable")
 class ComponentCallable(pulumi.ComponentResource):
-
-    pulumi_type = "component:index:ComponentCallable"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
@@ -32,10 +32,8 @@ class ComponentCustomRefInputOutputArgs:
         pulumi.set(self, "input_ref", value)
 
 
+@pulumi.type_token("component:index:ComponentCustomRefInputOutput")
 class ComponentCustomRefInputOutput(pulumi.ComponentResource):
-
-    pulumi_type = "component:index:ComponentCustomRefInputOutput"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
@@ -32,10 +32,8 @@ class ComponentCustomRefOutputArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("component:index:ComponentCustomRefOutput")
 class ComponentCustomRefOutput(pulumi.ComponentResource):
-
-    pulumi_type = "component:index:ComponentCustomRefOutput"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/custom.py
@@ -31,10 +31,8 @@ class CustomArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("component:index:Custom")
 class Custom(pulumi.CustomResource):
-
-    pulumi_type = "component:index:Custom"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/provider.py
@@ -21,10 +21,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:component")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:component"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_component',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
@@ -54,10 +54,8 @@ class ComponentArgs:
         pulumi.set(self, "resource_map", value)
 
 
+@pulumi.type_token("component-property-deps:index:Component")
 class Component(pulumi.ComponentResource):
-
-    pulumi_type = "component-property-deps:index:Component"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
@@ -31,10 +31,8 @@ class CustomArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("component-property-deps:index:Custom")
 class Custom(pulumi.CustomResource):
-
-    pulumi_type = "component-property-deps:index:Custom"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/provider.py
@@ -21,10 +21,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:component-property-deps")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:component-property-deps"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_component_property_deps',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/provider.py
@@ -43,10 +43,8 @@ class ProviderArgs:
         pulumi.set(self, "plugin_download_url", value)
 
 
+@pulumi.type_token("pulumi:providers:config")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:config"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/resource.py
@@ -31,10 +31,8 @@ class ResourceArgs:
         pulumi.set(self, "text", value)
 
 
+@pulumi.type_token("config:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "config:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_config',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/config_fetcher.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/config_fetcher.py
@@ -21,10 +21,8 @@ class ConfigFetcherArgs:
         pass
 
 
+@pulumi.type_token("config-grpc:index:ConfigFetcher")
 class ConfigFetcher(pulumi.CustomResource):
-
-    pulumi_type = "config-grpc:index:ConfigFetcher"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/provider.py
@@ -1173,10 +1173,8 @@ class ProviderArgs:
         pulumi.set(self, "string3", value)
 
 
+@pulumi.type_token("pulumi:providers:config-grpc")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:config-grpc"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_config_grpc',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/provider.py
@@ -21,10 +21,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:fail_on_create")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:fail_on_create"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/resource.py
@@ -31,10 +31,8 @@ class ResourceArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("fail_on_create:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "fail_on_create:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_fail_on_create',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye.py
@@ -21,10 +21,8 @@ class GoodbyeArgs:
         pass
 
 
+@pulumi.type_token("goodbye:index:Goodbye")
 class Goodbye(pulumi.CustomResource):
-
-    pulumi_type = "goodbye:index:Goodbye"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye_component.py
@@ -21,10 +21,8 @@ class GoodbyeComponentArgs:
         pass
 
 
+@pulumi.type_token("goodbye:index:GoodbyeComponent")
 class GoodbyeComponent(pulumi.ComponentResource):
-
-    pulumi_type = "goodbye:index:GoodbyeComponent"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/provider.py
@@ -32,10 +32,8 @@ class ProviderArgs:
         pulumi.set(self, "text", value)
 
 
+@pulumi.type_token("pulumi:providers:goodbye")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:goodbye"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_goodbye',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/pulumi_large/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/pulumi_large/provider.py
@@ -21,10 +21,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:large")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:large"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/pulumi_large/string.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/pulumi_large/string.py
@@ -31,10 +31,8 @@ class StringArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("large:index:String")
 class String(pulumi.CustomResource):
-
-    pulumi_type = "large:index:String"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_large',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/namespaced-16.0.0/a_namespace_namespaced/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/namespaced-16.0.0/a_namespace_namespaced/provider.py
@@ -21,10 +21,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:namespaced")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:namespaced"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/namespaced-16.0.0/a_namespace_namespaced/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/namespaced-16.0.0/a_namespace_namespaced/resource.py
@@ -44,10 +44,8 @@ class ResourceArgs:
         pulumi.set(self, "resource_ref", value)
 
 
+@pulumi.type_token("namespaced:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "namespaced:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/namespaced-16.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/namespaced-16.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='a_namespace_namespaced',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'pulumi_component>=13.3.7',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/pulumi_plain/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/pulumi_plain/provider.py
@@ -21,10 +21,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:plain")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:plain"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/pulumi_plain/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/pulumi_plain/resource.py
@@ -49,10 +49,8 @@ class ResourceArgs:
         pulumi.set(self, "non_plain_data", value)
 
 
+@pulumi.type_token("plain:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "plain:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_plain',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/pulumi_primitive/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/pulumi_primitive/provider.py
@@ -21,10 +21,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:primitive")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:primitive"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/pulumi_primitive/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/pulumi_primitive/resource.py
@@ -86,10 +86,8 @@ class ResourceArgs:
         pulumi.set(self, "string", value)
 
 
+@pulumi.type_token("primitive:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "primitive:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_primitive',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/provider.py
@@ -21,10 +21,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:primitive-ref")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:primitive-ref"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/resource.py
@@ -33,10 +33,8 @@ class ResourceArgs:
         pulumi.set(self, "data", value)
 
 
+@pulumi.type_token("primitive-ref:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "primitive-ref:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_primitive_ref',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/provider.py
@@ -21,10 +21,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:ref-ref")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:ref-ref"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/resource.py
@@ -33,10 +33,8 @@ class ResourceArgs:
         pulumi.set(self, "data", value)
 
 
+@pulumi.type_token("ref-ref:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "ref-ref:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_ref_ref',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/pulumi_secret/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/pulumi_secret/provider.py
@@ -21,10 +21,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:secret")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:secret"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/pulumi_secret/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/pulumi_secret/resource.py
@@ -66,10 +66,8 @@ class ResourceArgs:
         pulumi.set(self, "public_data", value)
 
 
+@pulumi.type_token("secret:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "secret:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_secret',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/pulumi_simple/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/pulumi_simple/provider.py
@@ -21,10 +21,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:simple")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:simple"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/pulumi_simple/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/pulumi_simple/resource.py
@@ -31,10 +31,8 @@ class ResourceArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("simple:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "simple:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_simple',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/provider.py
@@ -21,10 +21,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:simple-invoke")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:simple-invoke"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/string_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/string_resource.py
@@ -31,10 +31,8 @@ class StringResourceArgs:
         pulumi.set(self, "text", value)
 
 
+@pulumi.type_token("simple-invoke:index:StringResource")
 class StringResource(pulumi.CustomResource):
-
-    pulumi_type = "simple-invoke:index:StringResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_simple_invoke',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world.py
@@ -21,10 +21,8 @@ class HelloWorldArgs:
         pass
 
 
+@pulumi.type_token("subpackage:index:HelloWorld")
 class HelloWorld(pulumi.CustomResource):
-
-    pulumi_type = "subpackage:index:HelloWorld"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world_component.py
@@ -21,10 +21,8 @@ class HelloWorldComponentArgs:
         pass
 
 
+@pulumi.type_token("subpackage:index:HelloWorldComponent")
 class HelloWorldComponent(pulumi.ComponentResource):
-
-    pulumi_type = "subpackage:index:HelloWorldComponent"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/provider.py
@@ -32,10 +32,8 @@ class ProviderArgs:
         pulumi.set(self, "text", value)
 
 
+@pulumi.type_token("pulumi:providers:subpackage")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:subpackage"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_subpackage',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:alpha")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:alpha"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/resource.py
@@ -36,10 +36,8 @@ class ResourceArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("alpha:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "alpha:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_alpha',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/any-type-function-15.0.0/pulumi_any_type_function/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/any-type-function-15.0.0/pulumi_any_type_function/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:any-type-function")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:any-type-function"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/any-type-function-15.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/any-type-function-15.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_any_type_function',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/archive_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/archive_resource.py
@@ -36,10 +36,8 @@ class ArchiveResourceArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("asset-archive:index:ArchiveResource")
 class ArchiveResource(pulumi.CustomResource):
-
-    pulumi_type = "asset-archive:index:ArchiveResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/asset_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/asset_resource.py
@@ -36,10 +36,8 @@ class AssetResourceArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("asset-archive:index:AssetResource")
 class AssetResource(pulumi.CustomResource):
-
-    pulumi_type = "asset-archive:index:AssetResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:asset-archive")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:asset-archive"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_asset_archive',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/call-15.7.9/pulumi_call/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/call-15.7.9/pulumi_call/custom.py
@@ -36,10 +36,8 @@ class CustomArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("call:index:Custom")
 class Custom(pulumi.CustomResource):
-
-    pulumi_type = "call:index:Custom"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/call-15.7.9/pulumi_call/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/call-15.7.9/pulumi_call/provider.py
@@ -36,10 +36,8 @@ class ProviderArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("pulumi:providers:call")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:call"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/call-15.7.9/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/call-15.7.9/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_call',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/component_callable.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/component_callable.py
@@ -36,10 +36,8 @@ class ComponentCallableArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("component:index:ComponentCallable")
 class ComponentCallable(pulumi.ComponentResource):
-
-    pulumi_type = "component:index:ComponentCallable"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
@@ -37,10 +37,8 @@ class ComponentCustomRefInputOutputArgs:
         pulumi.set(self, "input_ref", value)
 
 
+@pulumi.type_token("component:index:ComponentCustomRefInputOutput")
 class ComponentCustomRefInputOutput(pulumi.ComponentResource):
-
-    pulumi_type = "component:index:ComponentCustomRefInputOutput"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
@@ -37,10 +37,8 @@ class ComponentCustomRefOutputArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("component:index:ComponentCustomRefOutput")
 class ComponentCustomRefOutput(pulumi.ComponentResource):
-
-    pulumi_type = "component:index:ComponentCustomRefOutput"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/custom.py
@@ -36,10 +36,8 @@ class CustomArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("component:index:Custom")
 class Custom(pulumi.CustomResource):
-
-    pulumi_type = "component:index:Custom"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:component")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:component"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_component',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
@@ -59,10 +59,8 @@ class ComponentArgs:
         pulumi.set(self, "resource_map", value)
 
 
+@pulumi.type_token("component-property-deps:index:Component")
 class Component(pulumi.ComponentResource):
-
-    pulumi_type = "component-property-deps:index:Component"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
@@ -36,10 +36,8 @@ class CustomArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("component-property-deps:index:Custom")
 class Custom(pulumi.CustomResource):
-
-    pulumi_type = "component-property-deps:index:Custom"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:component-property-deps")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:component-property-deps"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_component_property_deps',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/provider.py
@@ -48,10 +48,8 @@ class ProviderArgs:
         pulumi.set(self, "plugin_download_url", value)
 
 
+@pulumi.type_token("pulumi:providers:config")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:config"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/resource.py
@@ -36,10 +36,8 @@ class ResourceArgs:
         pulumi.set(self, "text", value)
 
 
+@pulumi.type_token("config:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "config:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_config',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/config_fetcher.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/config_fetcher.py
@@ -26,10 +26,8 @@ class ConfigFetcherArgs:
         pass
 
 
+@pulumi.type_token("config-grpc:index:ConfigFetcher")
 class ConfigFetcher(pulumi.CustomResource):
-
-    pulumi_type = "config-grpc:index:ConfigFetcher"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/provider.py
@@ -1178,10 +1178,8 @@ class ProviderArgs:
         pulumi.set(self, "string3", value)
 
 
+@pulumi.type_token("pulumi:providers:config-grpc")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:config-grpc"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_config_grpc',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:fail_on_create")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:fail_on_create"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/resource.py
@@ -36,10 +36,8 @@ class ResourceArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("fail_on_create:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "fail_on_create:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_fail_on_create',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye.py
@@ -26,10 +26,8 @@ class GoodbyeArgs:
         pass
 
 
+@pulumi.type_token("goodbye:index:Goodbye")
 class Goodbye(pulumi.CustomResource):
-
-    pulumi_type = "goodbye:index:Goodbye"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye_component.py
@@ -26,10 +26,8 @@ class GoodbyeComponentArgs:
         pass
 
 
+@pulumi.type_token("goodbye:index:GoodbyeComponent")
 class GoodbyeComponent(pulumi.ComponentResource):
-
-    pulumi_type = "goodbye:index:GoodbyeComponent"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/provider.py
@@ -37,10 +37,8 @@ class ProviderArgs:
         pulumi.set(self, "text", value)
 
 
+@pulumi.type_token("pulumi:providers:goodbye")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:goodbye"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_goodbye',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/pulumi_large/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/pulumi_large/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:large")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:large"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/pulumi_large/string.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/pulumi_large/string.py
@@ -36,10 +36,8 @@ class StringArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("large:index:String")
 class String(pulumi.CustomResource):
-
-    pulumi_type = "large:index:String"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_large',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/namespaced-16.0.0/a_namespace_namespaced/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/namespaced-16.0.0/a_namespace_namespaced/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:namespaced")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:namespaced"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/namespaced-16.0.0/a_namespace_namespaced/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/namespaced-16.0.0/a_namespace_namespaced/resource.py
@@ -49,10 +49,8 @@ class ResourceArgs:
         pulumi.set(self, "resource_ref", value)
 
 
+@pulumi.type_token("namespaced:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "namespaced:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/namespaced-16.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/namespaced-16.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='a_namespace_namespaced',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'pulumi_component>=13.3.7',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/pulumi_plain/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/pulumi_plain/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:plain")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:plain"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/pulumi_plain/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/pulumi_plain/resource.py
@@ -54,10 +54,8 @@ class ResourceArgs:
         pulumi.set(self, "non_plain_data", value)
 
 
+@pulumi.type_token("plain:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "plain:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_plain',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/pulumi_primitive/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/pulumi_primitive/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:primitive")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:primitive"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/pulumi_primitive/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/pulumi_primitive/resource.py
@@ -91,10 +91,8 @@ class ResourceArgs:
         pulumi.set(self, "string", value)
 
 
+@pulumi.type_token("primitive:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "primitive:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_primitive',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:primitive-ref")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:primitive-ref"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/resource.py
@@ -38,10 +38,8 @@ class ResourceArgs:
         pulumi.set(self, "data", value)
 
 
+@pulumi.type_token("primitive-ref:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "primitive-ref:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_primitive_ref',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:ref-ref")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:ref-ref"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/resource.py
@@ -38,10 +38,8 @@ class ResourceArgs:
         pulumi.set(self, "data", value)
 
 
+@pulumi.type_token("ref-ref:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "ref-ref:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_ref_ref',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/pulumi_secret/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/pulumi_secret/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:secret")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:secret"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/pulumi_secret/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/pulumi_secret/resource.py
@@ -71,10 +71,8 @@ class ResourceArgs:
         pulumi.set(self, "public_data", value)
 
 
+@pulumi.type_token("secret:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "secret:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_secret',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/pulumi_simple/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/pulumi_simple/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:simple")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:simple"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/pulumi_simple/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/pulumi_simple/resource.py
@@ -36,10 +36,8 @@ class ResourceArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("simple:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "simple:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_simple',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:simple-invoke")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:simple-invoke"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/string_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/string_resource.py
@@ -36,10 +36,8 @@ class StringResourceArgs:
         pulumi.set(self, "text", value)
 
 
+@pulumi.type_token("simple-invoke:index:StringResource")
 class StringResource(pulumi.CustomResource):
-
-    pulumi_type = "simple-invoke:index:StringResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_simple_invoke',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world.py
@@ -26,10 +26,8 @@ class HelloWorldArgs:
         pass
 
 
+@pulumi.type_token("subpackage:index:HelloWorld")
 class HelloWorld(pulumi.CustomResource):
-
-    pulumi_type = "subpackage:index:HelloWorld"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world_component.py
@@ -26,10 +26,8 @@ class HelloWorldComponentArgs:
         pass
 
 
+@pulumi.type_token("subpackage:index:HelloWorldComponent")
 class HelloWorldComponent(pulumi.ComponentResource):
-
-    pulumi_type = "subpackage:index:HelloWorldComponent"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/provider.py
@@ -37,10 +37,8 @@ class ProviderArgs:
         pulumi.set(self, "text", value)
 
 
+@pulumi.type_token("pulumi:providers:subpackage")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:subpackage"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_subpackage',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:alpha")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:alpha"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/resource.py
@@ -36,10 +36,8 @@ class ResourceArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("alpha:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "alpha:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_alpha"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "3.0.0a1+internal.exp.sha.12345678"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/any-type-function-15.0.0/pulumi_any_type_function/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/any-type-function-15.0.0/pulumi_any_type_function/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:any-type-function")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:any-type-function"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/any-type-function-15.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/any-type-function-15.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_any_type_function"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "15.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/archive_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/archive_resource.py
@@ -36,10 +36,8 @@ class ArchiveResourceArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("asset-archive:index:ArchiveResource")
 class ArchiveResource(pulumi.CustomResource):
-
-    pulumi_type = "asset-archive:index:ArchiveResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/asset_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/asset_resource.py
@@ -36,10 +36,8 @@ class AssetResourceArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("asset-archive:index:AssetResource")
 class AssetResource(pulumi.CustomResource):
-
-    pulumi_type = "asset-archive:index:AssetResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:asset-archive")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:asset-archive"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_asset_archive"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "5.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/call-15.7.9/pulumi_call/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/call-15.7.9/pulumi_call/custom.py
@@ -36,10 +36,8 @@ class CustomArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("call:index:Custom")
 class Custom(pulumi.CustomResource):
-
-    pulumi_type = "call:index:Custom"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/call-15.7.9/pulumi_call/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/call-15.7.9/pulumi_call/provider.py
@@ -36,10 +36,8 @@ class ProviderArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("pulumi:providers:call")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:call"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/call-15.7.9/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/call-15.7.9/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_call"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "15.7.9"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/component_callable.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/component_callable.py
@@ -36,10 +36,8 @@ class ComponentCallableArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("component:index:ComponentCallable")
 class ComponentCallable(pulumi.ComponentResource):
-
-    pulumi_type = "component:index:ComponentCallable"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
@@ -37,10 +37,8 @@ class ComponentCustomRefInputOutputArgs:
         pulumi.set(self, "input_ref", value)
 
 
+@pulumi.type_token("component:index:ComponentCustomRefInputOutput")
 class ComponentCustomRefInputOutput(pulumi.ComponentResource):
-
-    pulumi_type = "component:index:ComponentCustomRefInputOutput"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
@@ -37,10 +37,8 @@ class ComponentCustomRefOutputArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("component:index:ComponentCustomRefOutput")
 class ComponentCustomRefOutput(pulumi.ComponentResource):
-
-    pulumi_type = "component:index:ComponentCustomRefOutput"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/custom.py
@@ -36,10 +36,8 @@ class CustomArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("component:index:Custom")
 class Custom(pulumi.CustomResource):
-
-    pulumi_type = "component:index:Custom"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:component")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:component"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_component"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "13.3.7"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
@@ -59,10 +59,8 @@ class ComponentArgs:
         pulumi.set(self, "resource_map", value)
 
 
+@pulumi.type_token("component-property-deps:index:Component")
 class Component(pulumi.ComponentResource):
-
-    pulumi_type = "component-property-deps:index:Component"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
@@ -36,10 +36,8 @@ class CustomArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("component-property-deps:index:Custom")
 class Custom(pulumi.CustomResource):
-
-    pulumi_type = "component-property-deps:index:Custom"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:component-property-deps")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:component-property-deps"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_component_property_deps"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "1.33.7"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/provider.py
@@ -48,10 +48,8 @@ class ProviderArgs:
         pulumi.set(self, "plugin_download_url", value)
 
 
+@pulumi.type_token("pulumi:providers:config")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:config"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/resource.py
@@ -36,10 +36,8 @@ class ResourceArgs:
         pulumi.set(self, "text", value)
 
 
+@pulumi.type_token("config:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "config:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_config"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "9.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/config_fetcher.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/config_fetcher.py
@@ -26,10 +26,8 @@ class ConfigFetcherArgs:
         pass
 
 
+@pulumi.type_token("config-grpc:index:ConfigFetcher")
 class ConfigFetcher(pulumi.CustomResource):
-
-    pulumi_type = "config-grpc:index:ConfigFetcher"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/provider.py
@@ -1178,10 +1178,8 @@ class ProviderArgs:
         pulumi.set(self, "string3", value)
 
 
+@pulumi.type_token("pulumi:providers:config-grpc")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:config-grpc"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_config_grpc"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "1.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:fail_on_create")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:fail_on_create"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/resource.py
@@ -36,10 +36,8 @@ class ResourceArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("fail_on_create:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "fail_on_create:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_fail_on_create"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "4.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye.py
@@ -26,10 +26,8 @@ class GoodbyeArgs:
         pass
 
 
+@pulumi.type_token("goodbye:index:Goodbye")
 class Goodbye(pulumi.CustomResource):
-
-    pulumi_type = "goodbye:index:Goodbye"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye_component.py
@@ -26,10 +26,8 @@ class GoodbyeComponentArgs:
         pass
 
 
+@pulumi.type_token("goodbye:index:GoodbyeComponent")
 class GoodbyeComponent(pulumi.ComponentResource):
-
-    pulumi_type = "goodbye:index:GoodbyeComponent"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/provider.py
@@ -37,10 +37,8 @@ class ProviderArgs:
         pulumi.set(self, "text", value)
 
 
+@pulumi.type_token("pulumi:providers:goodbye")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:goodbye"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_goodbye"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pulumi_large/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pulumi_large/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:large")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:large"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pulumi_large/string.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pulumi_large/string.py
@@ -36,10 +36,8 @@ class StringArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("large:index:String")
 class String(pulumi.CustomResource):
-
-    pulumi_type = "large:index:String"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_large"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "4.3.2"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/namespaced-16.0.0/a_namespace_namespaced/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/namespaced-16.0.0/a_namespace_namespaced/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:namespaced")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:namespaced"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/namespaced-16.0.0/a_namespace_namespaced/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/namespaced-16.0.0/a_namespace_namespaced/resource.py
@@ -49,10 +49,8 @@ class ResourceArgs:
         pulumi.set(self, "resource_ref", value)
 
 
+@pulumi.type_token("namespaced:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "namespaced:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/namespaced-16.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/namespaced-16.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "a_namespace_namespaced"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "pulumi_component>=13.3.7", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "pulumi_component>=13.3.7", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "16.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pulumi_plain/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pulumi_plain/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:plain")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:plain"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pulumi_plain/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pulumi_plain/resource.py
@@ -54,10 +54,8 @@ class ResourceArgs:
         pulumi.set(self, "non_plain_data", value)
 
 
+@pulumi.type_token("plain:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "plain:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_plain"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "13.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pulumi_primitive/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pulumi_primitive/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:primitive")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:primitive"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pulumi_primitive/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pulumi_primitive/resource.py
@@ -91,10 +91,8 @@ class ResourceArgs:
         pulumi.set(self, "string", value)
 
 
+@pulumi.type_token("primitive:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "primitive:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_primitive"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "7.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:primitive-ref")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:primitive-ref"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/resource.py
@@ -38,10 +38,8 @@ class ResourceArgs:
         pulumi.set(self, "data", value)
 
 
+@pulumi.type_token("primitive-ref:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "primitive-ref:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_primitive_ref"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "11.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:ref-ref")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:ref-ref"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/resource.py
@@ -38,10 +38,8 @@ class ResourceArgs:
         pulumi.set(self, "data", value)
 
 
+@pulumi.type_token("ref-ref:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "ref-ref:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_ref_ref"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "12.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pulumi_secret/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pulumi_secret/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:secret")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:secret"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pulumi_secret/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pulumi_secret/resource.py
@@ -71,10 +71,8 @@ class ResourceArgs:
         pulumi.set(self, "public_data", value)
 
 
+@pulumi.type_token("secret:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "secret:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_secret"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "14.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pulumi_simple/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pulumi_simple/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:simple")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:simple"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pulumi_simple/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pulumi_simple/resource.py
@@ -36,10 +36,8 @@ class ResourceArgs:
         pulumi.set(self, "value", value)
 
 
+@pulumi.type_token("simple:index:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "simple:index:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_simple"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:simple-invoke")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:simple-invoke"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/string_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/string_resource.py
@@ -36,10 +36,8 @@ class StringResourceArgs:
         pulumi.set(self, "text", value)
 
 
+@pulumi.type_token("simple-invoke:index:StringResource")
 class StringResource(pulumi.CustomResource):
-
-    pulumi_type = "simple-invoke:index:StringResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_simple_invoke"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "10.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world.py
@@ -26,10 +26,8 @@ class HelloWorldArgs:
         pass
 
 
+@pulumi.type_token("subpackage:index:HelloWorld")
 class HelloWorld(pulumi.CustomResource):
-
-    pulumi_type = "subpackage:index:HelloWorld"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world_component.py
@@ -26,10 +26,8 @@ class HelloWorldComponentArgs:
         pass
 
 
+@pulumi.type_token("subpackage:index:HelloWorldComponent")
 class HelloWorldComponent(pulumi.ComponentResource):
-
-    pulumi_type = "subpackage:index:HelloWorldComponent"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/provider.py
@@ -37,10 +37,8 @@ class ProviderArgs:
         pulumi.set(self, "text", value)
 
 
+@pulumi.type_token("pulumi:providers:subpackage")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:subpackage"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_subpackage"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/tests/testdata/codegen/assets-and-archives/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/assets-and-archives/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/assets-and-archives/python/pulumi_example/resource_with_assets.py
+++ b/tests/testdata/codegen/assets-and-archives/python/pulumi_example/resource_with_assets.py
@@ -62,10 +62,8 @@ class ResourceWithAssetsArgs:
         pulumi.set(self, "nested", value)
 
 
+@pulumi.type_token("example:index:ResourceWithAssets")
 class ResourceWithAssets(pulumi.CustomResource):
-
-    pulumi_type = "example:index:ResourceWithAssets"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/assets-and-archives/python/setup.py
+++ b/tests/testdata/codegen/assets-and-archives/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/documentdb/sql_resource_sql_container.py
+++ b/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/documentdb/sql_resource_sql_container.py
@@ -27,10 +27,8 @@ class SqlResourceSqlContainerArgs:
         pass
 
 
+@pulumi.type_token("azure-native:documentdb:SqlResourceSqlContainer")
 class SqlResourceSqlContainer(pulumi.CustomResource):
-
-    pulumi_type = "azure-native:documentdb:SqlResourceSqlContainer"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/provider.py
+++ b/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:azure-native")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:azure-native"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/config-variables/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/config-variables/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/config-variables/python/setup.py
+++ b/tests/testdata/codegen/config-variables/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/cyclic-types/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/cyclic-types/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/cyclic-types/python/setup.py
+++ b/tests/testdata/codegen/cyclic-types/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/provider.py
+++ b/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:foo-bar")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:foo-bar"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/submodule1/foo_encrypted_bar_class.py
+++ b/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/submodule1/foo_encrypted_bar_class.py
@@ -26,10 +26,8 @@ class FOOEncryptedBarClassArgs:
         pass
 
 
+@pulumi.type_token("foo-bar:submodule1:FOOEncryptedBarClass")
 class FOOEncryptedBarClass(pulumi.CustomResource):
-
-    pulumi_type = "foo-bar:submodule1:FOOEncryptedBarClass"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/submodule1/module_resource.py
+++ b/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/submodule1/module_resource.py
@@ -39,10 +39,8 @@ class ModuleResourceArgs:
         pulumi.set(self, "thing", value)
 
 
+@pulumi.type_token("foo-bar:submodule1:ModuleResource")
 class ModuleResource(pulumi.CustomResource):
-
-    pulumi_type = "foo-bar:submodule1:ModuleResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/dash-named-schema/python/setup.py
+++ b/tests/testdata/codegen/dash-named-schema/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_foo_bar',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/_enums.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -14,6 +14,7 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("plant::CloudAuditOptionsLogName")
 class CloudAuditOptionsLogName(builtins.str, Enum):
     """
     The log_name to populate in the Cloud Audit Record. This is added to regress pulumi/pulumi issue #7913
@@ -36,11 +37,13 @@ class CloudAuditOptionsLogName(builtins.str, Enum):
     """
 
 
+@pulumi.type_token("plant::ContainerBrightness")
 class ContainerBrightness(builtins.float, Enum):
     ZERO_POINT_ONE = 0.1
     ONE = 1
 
 
+@pulumi.type_token("plant::ContainerColor")
 class ContainerColor(builtins.str, Enum):
     """
     plant container colors
@@ -50,6 +53,7 @@ class ContainerColor(builtins.str, Enum):
     YELLOW = "yellow"
 
 
+@pulumi.type_token("plant::ContainerSize")
 class ContainerSize(builtins.int, Enum):
     """
     plant container sizes

--- a/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/provider.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:plant")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:plant"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/tree/v1/_enums.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/tree/v1/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -14,16 +14,19 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("plant:tree/v1:Diameter")
 class Diameter(builtins.float, Enum):
     SIXINCH = 6
     TWELVEINCH = 12
 
 
+@pulumi.type_token("plant:tree/v1:Farm")
 class Farm(builtins.str, Enum):
     PULUMI_PLANTERS_INC_ = "Pulumi Planters Inc."
     PLANTS_R_US = "Plants'R'Us"
 
 
+@pulumi.type_token("plant:tree/v1:RubberTreeVariety")
 class RubberTreeVariety(builtins.str, Enum):
     """
     types of rubber trees
@@ -42,6 +45,7 @@ class RubberTreeVariety(builtins.str, Enum):
     """
 
 
+@pulumi.type_token("plant:tree/v1:TreeSize")
 class TreeSize(builtins.str, Enum):
     SMALL = "small"
     MEDIUM = "medium"

--- a/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/tree/v1/nursery.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/tree/v1/nursery.py
@@ -57,10 +57,8 @@ class NurseryArgs:
         pulumi.set(self, "sizes", value)
 
 
+@pulumi.type_token("plant:tree/v1:Nursery")
 class Nursery(pulumi.CustomResource):
-
-    pulumi_type = "plant:tree/v1:Nursery"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -117,10 +117,8 @@ class _RubberTreeState:
         pulumi.set(self, "farm", value)
 
 
+@pulumi.type_token("plant:tree/v1:RubberTree")
 class RubberTree(pulumi.CustomResource):
-
-    pulumi_type = "plant:tree/v1:RubberTree"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/dashed-import-schema/python/setup.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_plant',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/different-enum/python/pulumi_plant/_enums.py
+++ b/tests/testdata/codegen/different-enum/python/pulumi_plant/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -14,6 +14,7 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("plant::CloudAuditOptionsLogName")
 class CloudAuditOptionsLogName(builtins.str, Enum):
     """
     The log_name to populate in the Cloud Audit Record. This is added to regress pulumi/pulumi issue #7913
@@ -36,11 +37,13 @@ class CloudAuditOptionsLogName(builtins.str, Enum):
     """
 
 
+@pulumi.type_token("plant::ContainerBrightness")
 class ContainerBrightness(builtins.float, Enum):
     ZERO_POINT_ONE = 0.1
     ONE = 1
 
 
+@pulumi.type_token("plant::ContainerColor")
 class ContainerColor(builtins.str, Enum):
     """
     plant container colors
@@ -50,6 +53,7 @@ class ContainerColor(builtins.str, Enum):
     YELLOW = "yellow"
 
 
+@pulumi.type_token("plant::ContainerSize")
 class ContainerSize(builtins.int, Enum):
     """
     plant container sizes

--- a/tests/testdata/codegen/different-enum/python/pulumi_plant/provider.py
+++ b/tests/testdata/codegen/different-enum/python/pulumi_plant/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:plant")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:plant"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/different-enum/python/pulumi_plant/tree/v1/_enums.py
+++ b/tests/testdata/codegen/different-enum/python/pulumi_plant/tree/v1/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -14,16 +14,19 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("other:tree/v1:Diameter")
 class Diameter(builtins.float, Enum):
     SIXINCH = 6
     TWELVEINCH = 12
 
 
+@pulumi.type_token("plant:tree/v1:Farm")
 class Farm(builtins.str, Enum):
     PULUMI_PLANTERS_INC_ = "Pulumi Planters Inc."
     PLANTS_R_US = "Plants'R'Us"
 
 
+@pulumi.type_token("plant:tree/v1:RubberTreeVariety")
 class RubberTreeVariety(builtins.str, Enum):
     """
     types of rubber trees
@@ -42,6 +45,7 @@ class RubberTreeVariety(builtins.str, Enum):
     """
 
 
+@pulumi.type_token("plant:tree/v1:TreeSize")
 class TreeSize(builtins.str, Enum):
     SMALL = "small"
     MEDIUM = "medium"

--- a/tests/testdata/codegen/different-enum/python/pulumi_plant/tree/v1/nursery.py
+++ b/tests/testdata/codegen/different-enum/python/pulumi_plant/tree/v1/nursery.py
@@ -57,10 +57,8 @@ class NurseryArgs:
         pulumi.set(self, "sizes", value)
 
 
+@pulumi.type_token("plant:tree/v1:Nursery")
 class Nursery(pulumi.CustomResource):
-
-    pulumi_type = "plant:tree/v1:Nursery"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/different-enum/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/tests/testdata/codegen/different-enum/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -117,10 +117,8 @@ class _RubberTreeState:
         pulumi.set(self, "farm", value)
 
 
+@pulumi.type_token("plant:tree/v1:RubberTree")
 class RubberTree(pulumi.CustomResource):
-
-    pulumi_type = "plant:tree/v1:RubberTree"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/different-enum/python/setup.py
+++ b/tests/testdata/codegen/different-enum/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_plant',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/component.py
+++ b/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/component.py
@@ -51,10 +51,8 @@ class ComponentArgs:
         pulumi.set(self, "pod", value)
 
 
+@pulumi.type_token("foo:index:Component")
 class Component(pulumi.ComponentResource):
-
-    pulumi_type = "foo:index:Component"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/provider.py
+++ b/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:foo")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:foo"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/enum-reference-python/python/pulumi_example/mymodule/iam_resource.py
+++ b/tests/testdata/codegen/enum-reference-python/python/pulumi_example/mymodule/iam_resource.py
@@ -38,10 +38,8 @@ class IamResourceArgs:
         pulumi.set(self, "config", value)
 
 
+@pulumi.type_token("example:myModule:IamResource")
 class IamResource(pulumi.ComponentResource):
-
-    pulumi_type = "example:myModule:IamResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/enum-reference-python/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/enum-reference-python/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/enum-reference-python/python/pulumi_example/replicated_bucket.py
+++ b/tests/testdata/codegen/enum-reference-python/python/pulumi_example/replicated_bucket.py
@@ -42,10 +42,8 @@ class ReplicatedBucketArgs:
         pulumi.set(self, "destination_region", value)
 
 
+@pulumi.type_token("example:index:ReplicatedBucket")
 class ReplicatedBucket(pulumi.ComponentResource):
-
-    pulumi_type = "example:index:ReplicatedBucket"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/enum-reference/python/pulumi_example/mymodule/iam_resource.py
+++ b/tests/testdata/codegen/enum-reference/python/pulumi_example/mymodule/iam_resource.py
@@ -38,10 +38,8 @@ class IamResourceArgs:
         pulumi.set(self, "config", value)
 
 
+@pulumi.type_token("example:myModule:IamResource")
 class IamResource(pulumi.ComponentResource):
-
-    pulumi_type = "example:myModule:IamResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/enum-reference/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/enum-reference/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/external-enum/python/pulumi_example/component.py
+++ b/tests/testdata/codegen/external-enum/python/pulumi_example/component.py
@@ -51,10 +51,8 @@ class ComponentArgs:
         pulumi.set(self, "remote_enum", value)
 
 
+@pulumi.type_token("example:index:Component")
 class Component(pulumi.CustomResource):
-
-    pulumi_type = "example:index:Component"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/external-enum/python/pulumi_example/local/_enums.py
+++ b/tests/testdata/codegen/external-enum/python/pulumi_example/local/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -11,6 +11,7 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("example:local:MyEnum")
 class MyEnum(builtins.float, Enum):
     PI = 3.1415
     SMALL = 1e-07

--- a/tests/testdata/codegen/external-enum/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/external-enum/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/cloudtrail/trail.py
+++ b/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/cloudtrail/trail.py
@@ -50,10 +50,8 @@ class TrailArgs:
         pulumi.set(self, "trail", value)
 
 
+@pulumi.type_token("example:cloudtrail:Trail")
 class Trail(pulumi.ComponentResource):
-
-    pulumi_type = "example:cloudtrail:Trail"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/external-resource-schema/python/pulumi_example/cat.py
+++ b/tests/testdata/codegen/external-resource-schema/python/pulumi_example/cat.py
@@ -51,10 +51,8 @@ class CatArgs:
         pulumi.set(self, "pet", value)
 
 
+@pulumi.type_token("example::Cat")
 class Cat(pulumi.CustomResource):
-
-    pulumi_type = "example::Cat"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/external-resource-schema/python/pulumi_example/component.py
+++ b/tests/testdata/codegen/external-resource-schema/python/pulumi_example/component.py
@@ -96,10 +96,8 @@ class ComponentArgs:
         pulumi.set(self, "metadata_map", value)
 
 
+@pulumi.type_token("example::Component")
 class Component(pulumi.CustomResource):
-
-    pulumi_type = "example::Component"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/external-resource-schema/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/external-resource-schema/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/external-resource-schema/python/pulumi_example/workload.py
+++ b/tests/testdata/codegen/external-resource-schema/python/pulumi_example/workload.py
@@ -27,10 +27,8 @@ class WorkloadArgs:
         pass
 
 
+@pulumi.type_token("example::Workload")
 class Workload(pulumi.CustomResource):
-
-    pulumi_type = "example::Workload"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/external-resource-schema/python/setup.py
+++ b/tests/testdata/codegen/external-resource-schema/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/functions-secrets/python/pulumi_mypkg/provider.py
+++ b/tests/testdata/codegen/functions-secrets/python/pulumi_mypkg/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:mypkg")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:mypkg"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/functions-secrets/python/setup.py
+++ b/tests/testdata/codegen/functions-secrets/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_mypkg',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/provider.py
+++ b/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:registrygeoreplication")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:registrygeoreplication"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/registry_geo_replication.py
+++ b/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/registry_geo_replication.py
@@ -41,10 +41,8 @@ class RegistryGeoReplicationArgs:
         pulumi.set(self, "resource_group", value)
 
 
+@pulumi.type_token("registrygeoreplication:index:RegistryGeoReplication")
 class RegistryGeoReplication(pulumi.ComponentResource):
-
-    pulumi_type = "registrygeoreplication:index:RegistryGeoReplication"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/foo.py
+++ b/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/foo.py
@@ -27,10 +27,8 @@ class FooArgs:
         pass
 
 
+@pulumi.type_token("repro:index:Foo")
 class Foo(pulumi.CustomResource):
-
-    pulumi_type = "repro:index:Foo"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/provider.py
+++ b/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:repro")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:repro"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/hyphenated-symbols/python/setup.py
+++ b/tests/testdata/codegen/hyphenated-symbols/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_repro',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/ConfigMap.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/ConfigMap.py
@@ -122,10 +122,8 @@ class ConfigMapInitArgs:
         pulumi.set(self, "metadata", value)
 
 
+@pulumi.type_token("kubernetes:core/v1:ConfigMap")
 class ConfigMap(pulumi.CustomResource):
-
-    pulumi_type = "kubernetes:core/v1:ConfigMap"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/ConfigMapList.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/ConfigMapList.py
@@ -91,10 +91,8 @@ class ConfigMapListArgs:
         pulumi.set(self, "metadata", value)
 
 
+@pulumi.type_token("kubernetes:core/v1:ConfigMapList")
 class ConfigMapList(pulumi.CustomResource):
-
-    pulumi_type = "kubernetes:core/v1:ConfigMapList"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/helm/v3/Release.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/helm/v3/Release.py
@@ -72,10 +72,8 @@ class ReleaseArgs:
         pulumi.set(self, "values", value)
 
 
+@pulumi.type_token("kubernetes:helm.sh/v3:Release")
 class Release(pulumi.CustomResource):
-
-    pulumi_type = "kubernetes:helm.sh/v3:Release"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/provider.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/provider.py
@@ -86,10 +86,8 @@ class ProviderArgs:
         pulumi.set(self, "namespace", value)
 
 
+@pulumi.type_token("pulumi:providers:kubernetes")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:kubernetes"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/yaml/v2/ConfigGroup.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/yaml/v2/ConfigGroup.py
@@ -89,10 +89,8 @@ class ConfigGroupArgs:
         pulumi.set(self, "yaml", value)
 
 
+@pulumi.type_token("kubernetes:yaml/v2:ConfigGroup")
 class ConfigGroup(pulumi.ComponentResource):
-
-    pulumi_type = "kubernetes:yaml/v2:ConfigGroup"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/_enums.py
+++ b/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -11,6 +11,7 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("legacy_names:index:enum_XYZ")
 class Enum_XYZ(builtins.str, Enum):
     PLAIN = "A"
     SNAKE_CASE = "B"

--- a/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/example_resource.py
+++ b/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/example_resource.py
@@ -51,10 +51,8 @@ class Example_resourceArgs:
         pulumi.set(self, "request__http", value)
 
 
+@pulumi.type_token("legacy_names:index:example_resource")
 class Example_resource(pulumi.CustomResource):
-
-    pulumi_type = "legacy_names:index:example_resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/provider.py
+++ b/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:legacy_names")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:legacy_names"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/legacy-names/python/setup.py
+++ b/tests/testdata/codegen/legacy-names/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_legacy_names',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/configurer.py
+++ b/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/configurer.py
@@ -38,10 +38,8 @@ class ConfigurerArgs:
         pulumi.set(self, "tls_proxy", value)
 
 
+@pulumi.type_token("metaprovider:index:Configurer")
 class Configurer(pulumi.ComponentResource):
-
-    pulumi_type = "metaprovider:index:Configurer"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/provider.py
+++ b/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:metaprovider")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:metaprovider"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/methods-return-plain-resource/python/setup.py
+++ b/tests/testdata/codegen/methods-return-plain-resource/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_metaprovider',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/_enums.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -13,16 +13,19 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("example::ExampleEnum")
 class ExampleEnum(builtins.str, Enum):
     ONE = "one"
     TWO = "two"
 
 
+@pulumi.type_token("example::ExampleEnumInput")
 class ExampleEnumInput(builtins.str, Enum):
     ONE = "one"
     TWO = "two"
 
 
+@pulumi.type_token("example::ResourceType")
 class ResourceType(builtins.str, Enum):
     HAHA = "haha"
     BUSINESS = "business"

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/main_component.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/main_component.py
@@ -26,10 +26,8 @@ class MainComponentArgs:
         pass
 
 
+@pulumi.type_token("example::MainComponent")
 class MainComponent(pulumi.CustomResource):
-
-    pulumi_type = "example::MainComponent"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/mod/component.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/mod/component.py
@@ -51,10 +51,8 @@ class ComponentArgs:
         pulumi.set(self, "main", value)
 
 
+@pulumi.type_token("example:mod:Component")
 class Component(pulumi.CustomResource):
-
-    pulumi_type = "example:mod:Component"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/mod/component2.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/mod/component2.py
@@ -26,10 +26,8 @@ class Component2Args:
         pass
 
 
+@pulumi.type_token("example:mod:Component2")
 class Component2(pulumi.CustomResource):
-
-    pulumi_type = "example:mod:Component2"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/resource.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/resource.py
@@ -26,10 +26,8 @@ class ResourceArgs:
         pass
 
 
+@pulumi.type_token("example::Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "example::Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/resource_input.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/resource_input.py
@@ -26,10 +26,8 @@ class ResourceInputArgs:
         pass
 
 
+@pulumi.type_token("example::ResourceInput")
 class ResourceInput(pulumi.CustomResource):
-
-    pulumi_type = "example::ResourceInput"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/naming-collisions/python/setup.py
+++ b/tests/testdata/codegen/naming-collisions/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/deeply/nested/module/resource.py
+++ b/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/deeply/nested/module/resource.py
@@ -37,10 +37,8 @@ class ResourceArgs:
         pulumi.set(self, "baz", value)
 
 
+@pulumi.type_token("foo-bar:deeply/nested/module:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "foo-bar:deeply/nested/module:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/provider.py
+++ b/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:foo-bar")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:foo-bar"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/nested-module/python/pulumi_foo/nested/module/resource.py
+++ b/tests/testdata/codegen/nested-module/python/pulumi_foo/nested/module/resource.py
@@ -37,10 +37,8 @@ class ResourceArgs:
         pulumi.set(self, "bar", value)
 
 
+@pulumi.type_token("foo:nested/module:Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "foo:nested/module:Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/nested-module/python/pulumi_foo/provider.py
+++ b/tests/testdata/codegen/nested-module/python/pulumi_foo/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:foo")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:foo"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/nested-module/python/setup.py
+++ b/tests/testdata/codegen/nested-module/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_foo',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/_enums.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -11,6 +11,7 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("myedgeorder::SupportedFilterTypes")
 class SupportedFilterTypes(builtins.str, Enum):
     """
     Type of product filter.

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/provider.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:myedgeorder")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:myedgeorder"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/setup.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_myedgeorder',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/provider.py
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:mypkg")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:mypkg"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/output-funcs-tfbridge20/python/setup.py
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_mypkg',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/provider.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:mypkg")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:mypkg"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/output-funcs/python/setup.py
+++ b/tests/testdata/codegen/output-funcs/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_mypkg',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/_enums.py
+++ b/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -11,6 +11,7 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("foobar::EnumThing")
 class EnumThing(builtins.int, Enum):
     FOUR = 4
     SIX = 6

--- a/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/module_resource.py
+++ b/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/module_resource.py
@@ -256,10 +256,8 @@ class ModuleResourceArgs:
         pulumi.set(self, "plain_optional_string", value)
 
 
+@pulumi.type_token("foobar::ModuleResource")
 class ModuleResource(pulumi.CustomResource):
-
-    pulumi_type = "foobar::ModuleResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/provider.py
+++ b/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:foobar")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:foobar"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-and-default/python/setup.py
+++ b/tests/testdata/codegen/plain-and-default/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_foobar',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/foo.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/foo.py
@@ -86,10 +86,8 @@ class FooArgs:
         pulumi.set(self, "settings", value)
 
 
+@pulumi.type_token("example:index:Foo")
 class Foo(pulumi.CustomResource):
-
-    pulumi_type = "example:index:Foo"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/module_test.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/module_test.py
@@ -52,10 +52,8 @@ class ModuleTestArgs:
         pulumi.set(self, "val", value)
 
 
+@pulumi.type_token("example:index:moduleTest")
 class ModuleTest(pulumi.CustomResource):
-
-    pulumi_type = "example:index:moduleTest"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/provider.py
@@ -42,10 +42,8 @@ class ProviderArgs:
         pulumi.set(self, "helm_release_settings", value)
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-object-defaults/python/setup.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/foo.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/foo.py
@@ -86,10 +86,8 @@ class FooArgs:
         pulumi.set(self, "settings", value)
 
 
+@pulumi.type_token("example:index:Foo")
 class Foo(pulumi.CustomResource):
-
-    pulumi_type = "example:index:Foo"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/module_test.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/module_test.py
@@ -52,10 +52,8 @@ class ModuleTestArgs:
         pulumi.set(self, "val", value)
 
 
+@pulumi.type_token("example:index:moduleTest")
 class ModuleTest(pulumi.CustomResource):
-
-    pulumi_type = "example:index:moduleTest"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/provider.py
@@ -42,10 +42,8 @@ class ProviderArgs:
         pulumi.set(self, "helm_release_settings", value)
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/setup.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/provider.py
+++ b/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:xyz")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:xyz"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/static_page.py
+++ b/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/static_page.py
@@ -54,10 +54,8 @@ class StaticPageArgs:
         pulumi.set(self, "foo", value)
 
 
+@pulumi.type_token("xyz:index:StaticPage")
 class StaticPage(pulumi.ComponentResource):
-
-    pulumi_type = "xyz:index:StaticPage"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/_enums.py
+++ b/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -11,6 +11,7 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("configstation:index:color")
 class Color(builtins.str, Enum):
     BLUE = "blue"
     RED = "red"

--- a/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/provider.py
+++ b/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/provider.py
@@ -61,10 +61,8 @@ class ProviderArgs:
         pulumi.set(self, "secret_sandwiches", value)
 
 
+@pulumi.type_token("pulumi:providers:configstation")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:configstation"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/provider-config-schema/python/setup.py
+++ b/tests/testdata/codegen/provider-config-schema/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_configstation',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/provider.py
+++ b/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:providerType")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:providerType"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/submod/provider.py
+++ b/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/submod/provider.py
@@ -37,10 +37,8 @@ class ProviderArgs:
         pulumi.set(self, "a", value)
 
 
+@pulumi.type_token("providerType:submod:provider")
 class Provider(pulumi.CustomResource):
-
-    pulumi_type = "providerType:submod:provider"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/provider-type-schema/python/setup.py
+++ b/tests/testdata/codegen/provider-type-schema/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_providerType',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/component.py
+++ b/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/component.py
@@ -34,10 +34,8 @@ class ComponentArgs:
         pulumi.set(self, "my_type", value)
 
 
+@pulumi.type_token("typedDictDisabledExample:index:Component")
 class Component(pulumi.ComponentResource):
-
-    pulumi_type = "typedDictDisabledExample:index:Component"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/provider.py
+++ b/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/provider.py
@@ -21,10 +21,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:typedDictDisabledExample")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:typedDictDisabledExample"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/component.py
+++ b/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/component.py
@@ -39,10 +39,8 @@ class ComponentArgs:
         pulumi.set(self, "my_type", value)
 
 
+@pulumi.type_token("typedDictExample:index:Component")
 class Component(pulumi.ComponentResource):
-
-    pulumi_type = "typedDictExample:index:Component"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/provider.py
+++ b/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:typedDictExample")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:typedDictExample"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/component.py
+++ b/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/component.py
@@ -39,10 +39,8 @@ class ComponentArgs:
         pulumi.set(self, "my_type", value)
 
 
+@pulumi.type_token("typedDictExample:index:Component")
 class Component(pulumi.ComponentResource):
-
-    pulumi_type = "typedDictExample:index:Component"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/provider.py
+++ b/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:typedDictExample")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:typedDictExample"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-8403/python/pulumi_mongodbatlas/provider.py
+++ b/tests/testdata/codegen/regress-8403/python/pulumi_mongodbatlas/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:mongodbatlas")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:mongodbatlas"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-8403/python/setup.py
+++ b/tests/testdata/codegen/regress-8403/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_mongodbatlas',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/regress-node-8110/python/pulumi_my8110/_enums.py
+++ b/tests/testdata/codegen/regress-node-8110/python/pulumi_my8110/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -11,6 +11,7 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("my8110::MyEnum")
 class MyEnum(builtins.str, Enum):
     ONE = "one"
     TWO = "two"

--- a/tests/testdata/codegen/regress-node-8110/python/pulumi_my8110/provider.py
+++ b/tests/testdata/codegen/regress-node-8110/python/pulumi_my8110/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:my8110")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:my8110"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-node-8110/python/setup.py
+++ b/tests/testdata/codegen/regress-node-8110/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_my8110',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/_enums.py
+++ b/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -14,6 +14,7 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("plant::CloudAuditOptionsLogName")
 class CloudAuditOptionsLogName(builtins.str, Enum):
     """
     The log_name to populate in the Cloud Audit Record. This is added to regress pulumi/pulumi issue #7913
@@ -36,11 +37,13 @@ class CloudAuditOptionsLogName(builtins.str, Enum):
     """
 
 
+@pulumi.type_token("plant::ContainerBrightness")
 class ContainerBrightness(builtins.float, Enum):
     ZERO_POINT_ONE = 0.1
     ONE = 1
 
 
+@pulumi.type_token("plant::ContainerColor")
 class ContainerColor(builtins.str, Enum):
     """
     plant container colors
@@ -50,6 +53,7 @@ class ContainerColor(builtins.str, Enum):
     YELLOW = "yellow"
 
 
+@pulumi.type_token("plant::ContainerSize")
 class ContainerSize(builtins.int, Enum):
     """
     plant container sizes

--- a/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/provider.py
+++ b/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:plant")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:plant"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/tree/v1/_enums.py
+++ b/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/tree/v1/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -14,16 +14,19 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("other:tree/v1:Diameter")
 class Diameter(builtins.float, Enum):
     SIXINCH = 6
     TWELVEINCH = 12
 
 
+@pulumi.type_token("plant:tree/v1:Farm")
 class Farm(builtins.str, Enum):
     PULUMI_PLANTERS_INC_ = "Pulumi Planters Inc."
     PLANTS_R_US = "Plants'R'Us"
 
 
+@pulumi.type_token("plant:tree/v1:RubberTreeVariety")
 class RubberTreeVariety(builtins.str, Enum):
     """
     types of rubber trees
@@ -42,6 +45,7 @@ class RubberTreeVariety(builtins.str, Enum):
     """
 
 
+@pulumi.type_token("plant:tree/v1:TreeSize")
 class TreeSize(builtins.str, Enum):
     SMALL = "small"
     MEDIUM = "medium"

--- a/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -133,10 +133,8 @@ class _RubberTreeState:
         pulumi.set(self, "farm", value)
 
 
+@pulumi.type_token("plant:tree/v1:RubberTree")
 class RubberTree(pulumi.CustomResource):
-
-    pulumi_type = "plant:tree/v1:RubberTree"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-12546/python/setup.py
+++ b/tests/testdata/codegen/regress-py-12546/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_plant',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childa/_enums.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childa/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -11,6 +11,7 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("myPkg:myMod/childA:EnumA")
 class EnumA(builtins.str, Enum):
     A1 = "a1"
     A2 = "a2"

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childa/member_a1.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childa/member_a1.py
@@ -26,10 +26,8 @@ class MemberA1Args:
         pass
 
 
+@pulumi.type_token("myPkg:myMod/childA:MemberA1")
 class MemberA1(pulumi.ComponentResource):
-
-    pulumi_type = "myPkg:myMod/childA:MemberA1"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childb/_enums.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childb/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -11,6 +11,7 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("myPkg:myMod/childB:EnumB")
 class EnumB(builtins.str, Enum):
     B1 = "b1"
     B2 = "b2"

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childb/member_b1.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childb/member_b1.py
@@ -26,10 +26,8 @@ class MemberB1Args:
         pass
 
 
+@pulumi.type_token("myPkg:myMod/childB:MemberB1")
 class MemberB1(pulumi.ComponentResource):
-
-    pulumi_type = "myPkg:myMod/childB:MemberB1"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childb/member_b2.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childb/member_b2.py
@@ -31,10 +31,8 @@ class MemberB2Args:
         pass
 
 
+@pulumi.type_token("myPkg:myMod/childB:MemberB2")
 class MemberB2(pulumi.ComponentResource):
-
-    pulumi_type = "myPkg:myMod/childB:MemberB2"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/provider.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:myPkg")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:myPkg"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-12980/python/setup.py
+++ b/tests/testdata/codegen/regress-py-12980/python/setup.py
@@ -33,7 +33,7 @@ setup(name='pulumi_myPkg',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/regress-py-14012/python/pulumi_foo/provider.py
+++ b/tests/testdata/codegen/regress-py-14012/python/pulumi_foo/provider.py
@@ -38,10 +38,8 @@ class ProviderArgs:
         pulumi.set(self, "certmanager", value)
 
 
+@pulumi.type_token("pulumi:providers:foo")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:foo"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-14012/python/setup.py
+++ b/tests/testdata/codegen/regress-py-14012/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_foo',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/compute/instance/instance.py
+++ b/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/compute/instance/instance.py
@@ -69,10 +69,8 @@ class _InstanceState:
         pulumi.set(self, "boot_disk", value)
 
 
+@pulumi.type_token("gcp:compute/instance:Instance")
 class Instance(pulumi.CustomResource):
-
-    pulumi_type = "gcp:compute/instance:Instance"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/provider.py
+++ b/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:gcp")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:gcp"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/config.py
+++ b/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/config.py
@@ -75,10 +75,8 @@ class ConfigArgs:
         pulumi.set(self, "parts", value)
 
 
+@pulumi.type_token("cloudinit:index/config:Config")
 class Config(pulumi.CustomResource):
-
-    pulumi_type = "cloudinit:index/config:Config"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/provider.py
+++ b/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:cloudinit")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:cloudinit"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/provider.py
+++ b/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:aws")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:aws"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/cat.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/cat.py
@@ -28,10 +28,8 @@ class CatArgs:
         pass
 
 
+@pulumi.type_token("example::Cat")
 class Cat(pulumi.CustomResource):
-
-    pulumi_type = "example::Cat"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/dog.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/dog.py
@@ -26,10 +26,8 @@ class DogArgs:
         pass
 
 
+@pulumi.type_token("example::Dog")
 class Dog(pulumi.CustomResource):
-
-    pulumi_type = "example::Dog"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/god.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/god.py
@@ -27,10 +27,8 @@ class GodArgs:
         pass
 
 
+@pulumi.type_token("example::God")
 class God(pulumi.CustomResource):
-
-    pulumi_type = "example::God"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/no_recursive.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/no_recursive.py
@@ -27,10 +27,8 @@ class NoRecursiveArgs:
         pass
 
 
+@pulumi.type_token("example::NoRecursive")
 class NoRecursive(pulumi.CustomResource):
-
-    pulumi_type = "example::NoRecursive"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/toy_store.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/toy_store.py
@@ -29,10 +29,8 @@ class ToyStoreArgs:
         pass
 
 
+@pulumi.type_token("example::ToyStore")
 class ToyStore(pulumi.CustomResource):
-
-    pulumi_type = "example::ToyStore"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/replace-on-change/python/setup.py
+++ b/tests/testdata/codegen/replace-on-change/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/person.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/person.py
@@ -51,10 +51,8 @@ class PersonArgs:
         pulumi.set(self, "pets", value)
 
 
+@pulumi.type_token("example::Person")
 class Person(pulumi.CustomResource):
-
-    pulumi_type = "example::Person"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/pet.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/pet.py
@@ -37,10 +37,8 @@ class PetInitArgs:
         pulumi.set(self, "name", value)
 
 
+@pulumi.type_token("example::Pet")
 class Pet(pulumi.CustomResource):
-
-    pulumi_type = "example::Pet"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/setup.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/resource-args-python/python/pulumi_example/person.py
+++ b/tests/testdata/codegen/resource-args-python/python/pulumi_example/person.py
@@ -51,10 +51,8 @@ class PersonArgs:
         pulumi.set(self, "pets", value)
 
 
+@pulumi.type_token("example::Person")
 class Person(pulumi.CustomResource):
-
-    pulumi_type = "example::Person"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/resource-args-python/python/pulumi_example/pet.py
+++ b/tests/testdata/codegen/resource-args-python/python/pulumi_example/pet.py
@@ -37,10 +37,8 @@ class PetInitArgs:
         pulumi.set(self, "name", value)
 
 
+@pulumi.type_token("example::Pet")
 class Pet(pulumi.CustomResource):
-
-    pulumi_type = "example::Pet"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/resource-args-python/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/resource-args-python/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/resource-args-python/python/setup.py
+++ b/tests/testdata/codegen/resource-args-python/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/rec.py
+++ b/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/rec.py
@@ -26,10 +26,8 @@ class RecArgs:
         pass
 
 
+@pulumi.type_token("example::Rec")
 class Rec(pulumi.CustomResource):
-
-    pulumi_type = "example::Rec"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/resource-property-overlap/python/setup.py
+++ b/tests/testdata/codegen/resource-property-overlap/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/secrets/python/pulumi_mypkg/provider.py
+++ b/tests/testdata/codegen/secrets/python/pulumi_mypkg/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:mypkg")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:mypkg"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/secrets/python/pulumi_mypkg/resource.py
+++ b/tests/testdata/codegen/secrets/python/pulumi_mypkg/resource.py
@@ -93,10 +93,8 @@ class ResourceArgs:
         pulumi.set(self, "foo_map", value)
 
 
+@pulumi.type_token("mypkg::Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "mypkg::Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/secrets/python/setup.py
+++ b/tests/testdata/codegen/secrets/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_mypkg',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/_enums.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -14,6 +14,7 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("plant::CloudAuditOptionsLogName")
 class CloudAuditOptionsLogName(builtins.str, Enum):
     """
     The log_name to populate in the Cloud Audit Record. This is added to regress pulumi/pulumi issue #7913
@@ -37,11 +38,13 @@ class CloudAuditOptionsLogName(builtins.str, Enum):
     CLOUD_AUDIT_OPTIONS_LOG_NAME_N_O_NAME = "_NO_NAME"
 
 
+@pulumi.type_token("plant::ContainerBrightness")
 class ContainerBrightness(builtins.float, Enum):
     ZERO_POINT_ONE = 0.1
     ONE = 1
 
 
+@pulumi.type_token("plant::ContainerColor")
 class ContainerColor(builtins.str, Enum):
     """
     plant container colors
@@ -51,6 +54,7 @@ class ContainerColor(builtins.str, Enum):
     YELLOW = "yellow"
 
 
+@pulumi.type_token("plant::ContainerSize")
 class ContainerSize(builtins.int, Enum):
     """
     plant container sizes

--- a/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/provider.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:plant")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:plant"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/tree/v1/_enums.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/tree/v1/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -14,16 +14,19 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("plant:tree/v1:Diameter")
 class Diameter(builtins.float, Enum):
     SIXINCH = 6
     TWELVEINCH = 12
 
 
+@pulumi.type_token("plant:tree/v1:Farm")
 class Farm(builtins.str, Enum):
     PULUMI_PLANTERS_INC_ = "Pulumi Planters Inc."
     PLANTS_R_US = "Plants'R'Us"
 
 
+@pulumi.type_token("plant:tree/v1:RubberTreeVariety")
 class RubberTreeVariety(builtins.str, Enum):
     """
     types of rubber trees
@@ -42,6 +45,7 @@ class RubberTreeVariety(builtins.str, Enum):
     """
 
 
+@pulumi.type_token("plant:tree/v1:TreeSize")
 class TreeSize(builtins.str, Enum):
     SMALL = "small"
     MEDIUM = "medium"

--- a/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
@@ -57,10 +57,8 @@ class NurseryArgs:
         pulumi.set(self, "sizes", value)
 
 
+@pulumi.type_token("plant:tree/v1:Nursery")
 class Nursery(pulumi.CustomResource):
-
-    pulumi_type = "plant:tree/v1:Nursery"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -117,10 +117,8 @@ class _RubberTreeState:
         pulumi.set(self, "farm", value)
 
 
+@pulumi.type_token("plant:tree/v1:RubberTree")
 class RubberTree(pulumi.CustomResource):
-
-    pulumi_type = "plant:tree/v1:RubberTree"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-enum-schema/python/setup.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_plant',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/foo.py
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/foo.py
@@ -26,10 +26,8 @@ class FooArgs:
         pass
 
 
+@pulumi.type_token("example::Foo")
 class Foo(pulumi.ComponentResource):
-
-    pulumi_type = "example::Foo"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/setup.py
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/foo.py
+++ b/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/foo.py
@@ -28,10 +28,8 @@ class FooArgs:
         pass
 
 
+@pulumi.type_token("example::Foo")
 class Foo(pulumi.ComponentResource):
-
-    pulumi_type = "example::Foo"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-methods-schema/python/setup.py
+++ b/tests/testdata/codegen/simple-methods-schema/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/component.py
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/component.py
@@ -132,10 +132,8 @@ class ComponentArgs:
         pulumi.set(self, "foo", value)
 
 
+@pulumi.type_token("example::Component")
 class Component(pulumi.ComponentResource):
-
-    pulumi_type = "example::Component"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/python/setup.py
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/component.py
+++ b/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/component.py
@@ -144,10 +144,8 @@ class ComponentArgs:
         pulumi.set(self, "foo", value)
 
 
+@pulumi.type_token("example::Component")
 class Component(pulumi.ComponentResource):
-
-    pulumi_type = "example::Component"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-plain-schema/python/setup.py
+++ b/tests/testdata/codegen/simple-plain-schema/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/other_resource.py
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/other_resource.py
@@ -38,10 +38,8 @@ class OtherResourceArgs:
         pulumi.set(self, "foo", value)
 
 
+@pulumi.type_token("example::OtherResource")
 class OtherResource(pulumi.ComponentResource):
-
-    pulumi_type = "example::OtherResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/provider.py
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/resource.py
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/resource.py
@@ -37,10 +37,8 @@ class ResourceArgs:
         pulumi.set(self, "bar", value)
 
 
+@pulumi.type_token("example::Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "example::Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/setup.py
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/setup.py
@@ -32,7 +32,7 @@ setup(name='custom_py_package',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/bar_resource.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/bar_resource.py
@@ -38,10 +38,8 @@ class BarResourceArgs:
         pulumi.set(self, "foo", value)
 
 
+@pulumi.type_token("bar::BarResource")
 class BarResource(pulumi.ComponentResource):
-
-    pulumi_type = "bar::BarResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/foo_resource.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/foo_resource.py
@@ -38,10 +38,8 @@ class FooResourceArgs:
         pulumi.set(self, "foo", value)
 
 
+@pulumi.type_token("foo::FooResource")
 class FooResource(pulumi.ComponentResource):
-
-    pulumi_type = "foo::FooResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/other_resource.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/other_resource.py
@@ -38,10 +38,8 @@ class OtherResourceArgs:
         pulumi.set(self, "foo", value)
 
 
+@pulumi.type_token("example::OtherResource")
 class OtherResource(pulumi.ComponentResource):
-
-    pulumi_type = "example::OtherResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/resource.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/resource.py
@@ -37,10 +37,8 @@ class ResourceArgs:
         pulumi.set(self, "bar", value)
 
 
+@pulumi.type_token("example::Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "example::Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/type_uses.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/type_uses.py
@@ -64,10 +64,8 @@ class TypeUsesArgs:
         pulumi.set(self, "foo", value)
 
 
+@pulumi.type_token("example::TypeUses")
 class TypeUses(pulumi.CustomResource):
-
-    pulumi_type = "example::TypeUses"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-schema/python/setup.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/basic_resource.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/basic_resource.py
@@ -36,10 +36,8 @@ class BasicResourceArgs:
         pulumi.set(self, "bar", value)
 
 
+@pulumi.type_token("example:index:BasicResource")
 class BasicResource(pulumi.CustomResource):
-
-    pulumi_type = "example:index:BasicResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/basic_resource_v2.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/basic_resource_v2.py
@@ -36,10 +36,8 @@ class BasicResourceV2Args:
         pulumi.set(self, "bar", value)
 
 
+@pulumi.type_token("example:index:BasicResourceV2")
 class BasicResourceV2(pulumi.CustomResource):
-
-    pulumi_type = "example:index:BasicResourceV2"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/basic_resource_v3.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/basic_resource_v3.py
@@ -36,10 +36,8 @@ class BasicResourceV3Args:
         pulumi.set(self, "bar", value)
 
 
+@pulumi.type_token("example:index:BasicResourceV3")
 class BasicResourceV3(pulumi.CustomResource):
-
-    pulumi_type = "example:index:BasicResourceV3"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/setup.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/simple-schema-pyproject/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-schema-pyproject/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-schema-pyproject/python/pyproject.toml
+++ b/tests/testdata/codegen/simple-schema-pyproject/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
   name = "pulumi_example"
   description = "This is a test package for pyproject.toml"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.142.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   keywords = ["Testing", "Pulumipus"]
   readme = "README.md"
   requires-python = ">=3.9"

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/_enums.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -12,11 +12,13 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("example::OutputOnlyEnumType")
 class OutputOnlyEnumType(builtins.str, Enum):
     FOO = "foo"
     BAR = "bar"
 
 
+@pulumi.type_token("example::RubberTreeVariety")
 class RubberTreeVariety(builtins.str, Enum):
     """
     types of rubber trees

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/other_resource.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/other_resource.py
@@ -50,10 +50,8 @@ class OtherResourceArgs:
         pulumi.set(self, "foo", value)
 
 
+@pulumi.type_token("example::OtherResource")
 class OtherResource(pulumi.ComponentResource):
-
-    pulumi_type = "example::OtherResource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/resource.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/resource.py
@@ -37,10 +37,8 @@ class ResourceArgs:
         pulumi.set(self, "bar", value)
 
 
+@pulumi.type_token("example::Resource")
 class Resource(pulumi.CustomResource):
-
-    pulumi_type = "example::Resource"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/type_uses.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/type_uses.py
@@ -77,10 +77,8 @@ class TypeUsesArgs:
         pulumi.set(self, "qux", value)
 
 
+@pulumi.type_token("example::TypeUses")
 class TypeUses(pulumi.CustomResource):
-
-    pulumi_type = "example::TypeUses"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/simple-yaml-schema/python/setup.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/unions-inline/python/pulumi_example/example_server.py
+++ b/tests/testdata/codegen/unions-inline/python/pulumi_example/example_server.py
@@ -38,10 +38,8 @@ class ExampleServerArgs:
         pulumi.set(self, "properties", value)
 
 
+@pulumi.type_token("example:index:ExampleServer")
 class ExampleServer(pulumi.CustomResource):
-
-    pulumi_type = "example:index:ExampleServer"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/unions-inline/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/unions-inline/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/unions-inline/python/setup.py
+++ b/tests/testdata/codegen/unions-inline/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/example_server.py
+++ b/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/example_server.py
@@ -38,10 +38,8 @@ class ExampleServerArgs:
         pulumi.set(self, "properties_collection", value)
 
 
+@pulumi.type_token("example:index:ExampleServer")
 class ExampleServer(pulumi.CustomResource):
-
-    pulumi_type = "example:index:ExampleServer"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:example")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:example"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/unions-inside-arrays/python/setup.py
+++ b/tests/testdata/codegen/unions-inside-arrays/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/provider.py
+++ b/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/provider.py
@@ -26,10 +26,8 @@ class ProviderArgs:
         pass
 
 
+@pulumi.type_token("pulumi:providers:urnid")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:urnid"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/res.py
+++ b/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/res.py
@@ -50,10 +50,8 @@ class ResArgs:
         pulumi.set(self, "urn", value)
 
 
+@pulumi.type_token("urnid:index:Res")
 class Res(pulumi.CustomResource):
-
-    pulumi_type = "urnid:index:Res"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/urn-id-properties/python/setup.py
+++ b/tests/testdata/codegen/urn-id-properties/python/setup.py
@@ -33,7 +33,7 @@ setup(name='pulumi_urnid',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/_enums.py
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/_enums.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins
-import builtins
+import pulumi
 from enum import Enum
 
 __all__ = [
@@ -11,6 +11,7 @@ __all__ = [
 ]
 
 
+@pulumi.type_token("credentials:index:HashKind")
 class HashKind(builtins.str, Enum):
     ADLER32 = "Adler32"
     """

--- a/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/provider.py
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/provider.py
@@ -86,10 +86,8 @@ class ProviderArgs:
         pulumi.set(self, "password", value)
 
 
+@pulumi.type_token("pulumi:providers:credentials")
 class Provider(pulumi.ProviderResource):
-
-    pulumi_type = "pulumi:providers:credentials"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/user.py
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/user.py
@@ -37,10 +37,8 @@ class UserArgs:
         pulumi.set(self, "shared", value)
 
 
+@pulumi.type_token("credentials:index:User")
 class User(pulumi.CustomResource):
-
-    pulumi_type = "credentials:index:User"
-
     @overload
     def __init__(__self__,
                  resource_name: str,

--- a/tests/testdata/codegen/using-shared-types-in-config/python/setup.py
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_credentials',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.142.0,<4.0.0',
+          'pulumi>=3.165.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],


### PR DESCRIPTION
Use the `type_token` decorator added in https://github.com/pulumi/pulumi/pull/19309 and released with [v3.165.0](https://github.com/pulumi/pulumi/releases/tag/v3.165.0).

This replaces the manual annotation for classes and also adds it to enums, which will help us implement https://github.com/pulumi/pulumi/issues/19297.

Code changes are in https://github.com/pulumi/pulumi/pull/19357/commits/4e433035f7a57ff69c138c5beabe7abb75e65afb

`_enums.py` had a double `import builtins` (since https://github.com/pulumi/pulumi/pull/19035), I fixed that while I was already updating all the test snapshots.

`tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/_enums.py` shows an example of the decorator on enums.