### PR TITLE
factor the option arguments to `mod.typeString`

### DIFF
--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -81,7 +81,7 @@ func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName
 		mod:         moduleName,
 		typeDetails: typeDetails,
 	}
-	typeName := mod.typeString(t, input, false /*acceptMapping*/, false /*forDict*/)
+	typeName := mod.typeString(t, typeStringOpts{input: input})
 
 	// Remove any package qualifiers from the type name.
 	if !input {
@@ -126,7 +126,7 @@ func (d DocLanguageHelper) GetMethodResultName(pkg *schema.Package, modName stri
 				mod:         modName,
 				typeDetails: typeDetails,
 			}
-			return mod.typeString(returnType.Properties[0].Type, false, false, false /*forDict*/)
+			return mod.typeString(returnType.Properties[0].Type, typeStringOpts{})
 		}
 	}
 	return fmt.Sprintf("%s.%sResult", resourceName(r), title(d.GetMethodName(m)))

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1239,7 +1239,7 @@ func (mod *modContext) genAwaitableType(w io.Writer, obj *schema.ObjectType) str
 	// Note that deprecation messages will be emitted on access to the property, rather than initialization.
 	// This avoids spamming end users with irrelevant deprecation messages.
 	mod.genProperties(w, obj.Properties, false /*setters*/, "", func(prop *schema.Property) string {
-		return mod.typeString(prop.Type, false /*input*/, false /*acceptMapping*/, false /*forDict*/)
+		return mod.typeString(prop.Type, typeStringOpts{})
 	})
 
 	// Produce an awaitable subclass.
@@ -1398,7 +1398,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 
 		// If there's an argument type, emit it.
 		for _, prop := range res.InputProperties {
-			ty := mod.typeString(codegen.OptionalType(prop), true, true /*acceptMapping*/, false /*forDict*/)
+			ty := mod.typeString(codegen.OptionalType(prop), typeStringOpts{input: true, acceptMapping: true})
 			fmt.Fprintf(w, ",\n                 %s: %s = None", InitParamName(prop.Name), ty)
 		}
 
@@ -1589,7 +1589,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 		if hasStateInputs {
 			for _, prop := range res.StateInputs.Properties {
 				pname := InitParamName(prop.Name)
-				ty := mod.typeString(codegen.OptionalType(prop), true, true /*acceptMapping*/, false /*forDict*/)
+				ty := mod.typeString(codegen.OptionalType(prop), typeStringOpts{input: true, acceptMapping: true})
 				fmt.Fprintf(w, ",\n            %s: %s = None", pname, ty)
 			}
 		}
@@ -1624,7 +1624,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 
 	// Write out Python property getters for each of the resource's properties.
 	mod.genProperties(w, res.Properties, false /*setters*/, "", func(prop *schema.Property) string {
-		ty := mod.typeString(prop.Type, false /*input*/, false /*acceptMapping*/, false /*forDict*/)
+		ty := mod.typeString(prop.Type, typeStringOpts{})
 		return fmt.Sprintf("pulumi.Output[%s]", ty)
 	})
 
@@ -1727,7 +1727,7 @@ func (mod *modContext) genMethodReturnType(w io.Writer, method *schema.Method) s
 	// Note that deprecation messages will be emitted on access to the property, rather than initialization.
 	// This avoids spamming end users with irrelevant deprecation messages.
 	mod.genProperties(w, properties, false /*setters*/, "    ", func(prop *schema.Property) string {
-		return mod.typeString(prop.Type, false /*input*/, false /*acceptMapping*/, false /*forDict*/)
+		return mod.typeString(prop.Type, typeStringOpts{})
 	})
 
 	return name
@@ -1795,7 +1795,7 @@ func (mod *modContext) genMethods(w io.Writer, res *schema.Resource) {
 		}
 		for _, arg := range args {
 			pname := PyName(arg.Name)
-			ty := mod.typeString(arg.Type, true, false /*acceptMapping*/, false /*forDict*/)
+			ty := mod.typeString(arg.Type, typeStringOpts{input: true})
 			var defaultValue string
 			if !arg.IsRequired() {
 				defaultValue = " = None"
@@ -2102,7 +2102,7 @@ func (mod *modContext) genFunDef(w io.Writer, name, retTypeName string, args []*
 			argType = codegen.OptionalType(arg)
 		}
 
-		ty := mod.typeString(argType, true /*input*/, true /*acceptMapping*/, false /*forDict*/)
+		ty := mod.typeString(argType, typeStringOpts{input: true, acceptMapping: true})
 		fmt.Fprintf(w, "%s%s: %s = None,\n", ind, pname, ty)
 	}
 	if plain {
@@ -2155,7 +2155,7 @@ func (mod *modContext) genEnums(w io.Writer, enums []*schema.EnumType) error {
 func (mod *modContext) genEnum(w io.Writer, enum *schema.EnumType) error {
 	indent := "    "
 	enumName := tokenToName(enum.Token)
-	underlyingType := mod.typeString(enum.ElementType, false, false, false /*forDict*/)
+	underlyingType := mod.typeString(enum.ElementType, typeStringOpts{})
 
 	switch enum.ElementType {
 	case schema.StringType, schema.IntType, schema.NumberType:
@@ -2505,7 +2505,7 @@ func (mod *modContext) genPropDocstring(w io.Writer, name string, prop *schema.P
 		return
 	}
 
-	ty := mod.typeString(codegen.RequiredType(prop), true, acceptMapping, false /*forDict*/)
+	ty := mod.typeString(codegen.RequiredType(prop), typeStringOpts{input: true, acceptMapping: acceptMapping})
 
 	// If this property has some documentation associated with it, we need to split it so that it is indented
 	// in a way that Sphinx can understand.
@@ -2524,16 +2524,25 @@ func (mod *modContext) genPropDocstring(w io.Writer, name string, prop *schema.P
 	}
 }
 
-func (mod *modContext) typeString(t schema.Type, input, acceptMapping bool, forDict bool) string {
+type typeStringOpts struct {
+	// Whether the type is an input
+	input bool
+	// Whether we should try to use the UnionType directy and avoid the InputType wrapper if possible
+	acceptMapping bool
+	// Whether the object is a dict or not
+	forDict bool
+}
+
+func (mod *modContext) typeString(t schema.Type, opts typeStringOpts) string {
 	switch t := t.(type) {
 	case *schema.OptionalType:
-		typ := mod.typeString(t.ElementType, input, acceptMapping, forDict)
-		if forDict {
+		typ := mod.typeString(t.ElementType, opts)
+		if opts.forDict {
 			return fmt.Sprintf("NotRequired[%s]", typ)
 		}
 		return fmt.Sprintf("Optional[%s]", typ)
 	case *schema.InputType:
-		typ := mod.typeString(codegen.SimplifyInputUnion(t.ElementType), input, acceptMapping, forDict)
+		typ := mod.typeString(codegen.SimplifyInputUnion(t.ElementType), opts)
 		if typ == "Any" {
 			return typ
 		}
@@ -2541,15 +2550,15 @@ func (mod *modContext) typeString(t schema.Type, input, acceptMapping bool, forD
 	case *schema.EnumType:
 		return mod.enumType(t)
 	case *schema.ArrayType:
-		return fmt.Sprintf("Sequence[%s]", mod.typeString(t.ElementType, input, acceptMapping, forDict))
+		return fmt.Sprintf("Sequence[%s]", mod.typeString(t.ElementType, opts))
 	case *schema.MapType:
-		return fmt.Sprintf("Mapping[str, %s]", mod.typeString(t.ElementType, input, acceptMapping, forDict))
+		return fmt.Sprintf("Mapping[str, %s]", mod.typeString(t.ElementType, opts))
 	case *schema.ObjectType:
-		if forDict {
-			return mod.objectType(t, input, true /*dictType*/)
+		if opts.forDict {
+			return mod.objectType(t, opts.input, true /*dictType*/)
 		}
-		typ := mod.objectType(t, input, false /*dictType*/)
-		if !acceptMapping {
+		typ := mod.objectType(t, opts.input, false /*dictType*/)
+		if !opts.acceptMapping {
 			return typ
 		}
 		// If the type is an input and the TypedDict generation is enabled for the type's package, we
@@ -2563,8 +2572,8 @@ func (mod *modContext) typeString(t schema.Type, input, acceptMapping bool, forD
 		// Remove samePackage condition to enable TypedDicts for external packages by default.
 		samePackage := codegen.PkgEquals(t.PackageReference, mod.pkg)
 		typedDicts := ok && typedDictEnabled(info.InputTypes) && samePackage
-		if typedDicts && input {
-			return fmt.Sprintf("Union[%s, %s]", typ, mod.objectType(t, input, true /*dictType*/))
+		if typedDicts && opts.input {
+			return fmt.Sprintf("Union[%s, %s]", typ, mod.objectType(t, opts.input, true /*dictType*/))
 		}
 		return fmt.Sprintf("pulumi.InputType[%s]", typ)
 	case *schema.ResourceType:
@@ -2572,20 +2581,20 @@ func (mod *modContext) typeString(t schema.Type, input, acceptMapping bool, forD
 	case *schema.TokenType:
 		// Use the underlying type for now.
 		if t.UnderlyingType != nil {
-			return mod.typeString(t.UnderlyingType, input, acceptMapping, forDict)
+			return mod.typeString(t.UnderlyingType, opts)
 		}
 		return "Any"
 	case *schema.UnionType:
-		if !input {
+		if !opts.input {
 			for _, e := range t.ElementTypes {
 				// If this is an output and a "relaxed" enum, emit the type as the underlying primitive type rather than the union.
 				// Eg. Output[str] rather than Output[Any]
 				if typ, ok := e.(*schema.EnumType); ok {
-					return mod.typeString(typ.ElementType, input, acceptMapping, forDict)
+					return mod.typeString(typ.ElementType, opts)
 				}
 			}
 			if t.DefaultType != nil {
-				return mod.typeString(t.DefaultType, input, acceptMapping, forDict)
+				return mod.typeString(t.DefaultType, opts)
 			}
 			return "Any"
 		}
@@ -2593,7 +2602,7 @@ func (mod *modContext) typeString(t schema.Type, input, acceptMapping bool, forD
 		elementTypeSet := codegen.NewStringSet()
 		elements := slice.Prealloc[string](len(t.ElementTypes))
 		for _, e := range t.ElementTypes {
-			et := mod.typeString(e, input, acceptMapping, forDict)
+			et := mod.typeString(e, opts)
 			if !elementTypeSet.Has(et) {
 				elementTypeSet.Add(et)
 				elements = append(elements, et)
@@ -2629,7 +2638,7 @@ func (mod *modContext) typeString(t schema.Type, input, acceptMapping bool, forD
 }
 
 // pyType returns the expected runtime type for the given variable.  Of course, being a dynamic language, this
-// check is not exhaustive, but it should be good enough to catch 80% of the cases early on.
+// check is not exhaustive, but it should be good eonugh to catch 80% of the cases early on.
 func (mod *modContext) pyType(typ schema.Type) string {
 	switch typ := typ.(type) {
 	case *schema.OptionalType:
@@ -2793,9 +2802,9 @@ func (mod *modContext) genType(w io.Writer, name, comment string, properties []*
 	}
 	for _, prop := range props {
 		pname := PyName(prop.Name)
-		ty := mod.typeString(prop.Type, input, false /*acceptMapping*/, false /*forDict*/)
+		ty := mod.typeString(prop.Type, typeStringOpts{input: input})
 		if prop.DefaultValue != nil {
-			ty = mod.typeString(codegen.OptionalType(prop), input, false /*acceptMapping*/, false /*forDict*/)
+			ty = mod.typeString(codegen.OptionalType(prop), typeStringOpts{input: input})
 		}
 
 		var defaultValue string
@@ -2854,7 +2863,7 @@ func (mod *modContext) genType(w io.Writer, name, comment string, properties []*
 
 	// Generate properties. Input types have getters and setters, output types only have getters.
 	mod.genProperties(w, props, input /*setters*/, "", func(prop *schema.Property) string {
-		return mod.typeString(prop.Type, input, false /*acceptMapping*/, false /*forDict*/)
+		return mod.typeString(prop.Type, typeStringOpts{input: input})
 	})
 
 	fmt.Fprintf(w, "\n")
@@ -2895,7 +2904,7 @@ func (mod *modContext) genDictType(w io.Writer, name, comment string, properties
 
 	for _, prop := range props {
 		pname := PyName(prop.Name)
-		ty := mod.typeString(prop.Type, true /*input*/, false /*acceptMapping*/, true /*forDict*/)
+		ty := mod.typeString(prop.Type, typeStringOpts{input: true, forDict: true})
 		fmt.Fprintf(w, "%s%s: %s\n", indent, pname, ty)
 		if prop.Comment != "" {
 			printComment(w, prop.Comment, indent)

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -269,7 +269,7 @@ func TestGenerateTypeNames(t *testing.T) {
 		require.True(t, ok)
 
 		return func(t schema.Type) string {
-			return root.typeString(t, false, false, false)
+			return root.typeString(t, typeStringOpts{})
 		}
 	})
 }


### PR DESCRIPTION
We pass a few different bools into this function. Let's make that a struct instead for the options, which is easier to expand in the future (I'm planning to add another option for https://github.com/pulumi/pulumi/issues/19272), and has the additonal benefit that it's more self documenting, rather than needing comments for every argument.