### PR TITLE
Fix `refresh --preview-only` in the Automation API

### DIFF
--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -456,12 +456,12 @@ Event: ${line}\n${e.toString()}`);
      *  Options to customize the behavior of the refresh.
      */
     async refresh(opts?: RefreshOptions): Promise<RefreshResult> {
-        const args = ["refresh", "--yes"];
+        const args = ["refresh"];
 
         if (opts?.previewOnly) {
-          args.push("--skip-preview", "--yes");
-        } else {
           args.push("--preview-only");
+        } else {
+          args.push("--skip-preview", "--yes");
         }
 
         args.push(...this.remoteArgs());

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -458,7 +458,12 @@ Event: ${line}\n${e.toString()}`);
     async refresh(opts?: RefreshOptions): Promise<RefreshResult> {
         const args = ["refresh", "--yes"];
 
-        args.push(opts?.previewOnly ? "--preview-only" : "--skip-preview");
+        if (opts?.previewOnly) {
+          args.push("--skip-preview", "--yes");
+        } else {
+          args.push("--preview-only");
+        }
+
         args.push(...this.remoteArgs());
 
         if (opts) {

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -605,6 +605,26 @@ describe("LocalWorkspace", () => {
 
         await stack.workspace.removeStack(stackName);
     });
+    it(`previews a refresh without executing it`, async () => {
+        const projectName = "inline_node";
+        const stackName = fullyQualifiedStackName(getTestOrg(), projectName, `int_test${getTestSuffix()}`);
+        const stack = await LocalWorkspace.createStack(
+            { stackName, projectName, program: async () => {} },
+            withTestBackend({}, "inline_node"),
+        );
+
+        // pulumi up
+        const upRes = await stack.up({ userAgent });
+        assert.strictEqual(upRes.summary.kind, "update");
+        assert.strictEqual(upRes.summary.result, "succeeded");
+
+        // pulumi refresh
+        const refRes = await stack.refresh({ userAgent, previewOnly: true });
+        assert.strictEqual(refRes.summary.kind, "refresh");
+        assert.strictEqual(refRes.summary.result, "succeeded");
+
+        await stack.workspace.removeStack(stackName);
+    });
     it(`previews a destroy without executing it`, async () => {
         const stackName = fullyQualifiedStackName(getTestOrg(), "testproj_dotnet", `int_test${getTestSuffix()}`);
         const workDir = upath.joinSafe(__dirname, "data", "testproj_dotnet");

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -620,7 +620,7 @@ describe("LocalWorkspace", () => {
 
         // pulumi refresh
         const refRes = await stack.refresh({ userAgent, previewOnly: true });
-        assert.strictEqual(refRes.summary.kind, "refresh");
+        assert.strictEqual(refRes.summary.kind, "update");
         assert.strictEqual(refRes.summary.result, "succeeded");
 
         await stack.workspace.removeStack(stackName);


### PR DESCRIPTION
In #19354, it was reported that doing a `previewOnly: true` `refresh` in the NodeJS Automation API failed because the `--yes` flag wasn't removed under these circumstances. This PR fixes this, and adds a little test to be sure.