### PR TITLE
Add `onError` callbacks to the NodeJS Automation API operations

### DIFF
--- a/changelog/pending/20250430--auto-nodejs--add-onerror-callback-for-capturing-incremental-stderr-output.yaml
+++ b/changelog/pending/20250430--auto-nodejs--add-onerror-callback-for-capturing-incremental-stderr-output.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/nodejs
+  description: Add `onError` callback for capturing incremental stderr output

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -277,7 +277,7 @@ Event: ${line}\n${e.toString()}`);
 
         let upResult: CommandResult;
         try {
-            upResult = await this.runPulumiCmd(args, opts?.onOutput, opts?.signal);
+            upResult = await this.runPulumiCmd(args, opts?.onOutput, opts?.onError, opts?.signal);
         } catch (e) {
             didError = true;
             throw e;
@@ -425,7 +425,7 @@ Event: ${line}\n${e.toString()}`);
 
         let previewResult: CommandResult;
         try {
-            previewResult = await this.runPulumiCmd(args, opts?.onOutput, opts?.signal);
+            previewResult = await this.runPulumiCmd(args, opts?.onOutput, opts?.onError, opts?.signal);
         } catch (e) {
             didError = true;
             throw e;
@@ -521,7 +521,7 @@ Event: ${line}\n${e.toString()}`);
 
         let refResult: CommandResult;
         try {
-            refResult = await this.runPulumiCmd(args, opts?.onOutput, opts?.signal);
+            refResult = await this.runPulumiCmd(args, opts?.onOutput, opts?.onError, opts?.signal);
         } finally {
             await cleanUp(logFile, await logPromise);
         }
@@ -618,7 +618,7 @@ Event: ${line}\n${e.toString()}`);
 
         let desResult: CommandResult;
         try {
-            desResult = await this.runPulumiCmd(args, opts?.onOutput, opts?.signal);
+            desResult = await this.runPulumiCmd(args, opts?.onOutput, opts?.onError, opts?.signal);
         } finally {
             await cleanUp(logFile, await logPromise);
         }
@@ -651,7 +651,7 @@ Event: ${line}\n${e.toString()}`);
 
         applyGlobalOpts(options, args);
 
-        const renameResult = await this.runPulumiCmd(args, options?.onOutput, options?.signal);
+        const renameResult = await this.runPulumiCmd(args, options?.onOutput, options?.onError, options?.signal);
 
         if (this.isRemote && options?.showSecrets) {
             throw new Error("can't enable `showSecrets` for remote workspaces");
@@ -975,6 +975,7 @@ Event: ${line}\n${e.toString()}`);
     private async runPulumiCmd(
         args: string[],
         onOutput?: (out: string) => void,
+        onError?: (err: string) => void,
         signal?: AbortSignal,
     ): Promise<CommandResult> {
         let envs: { [key: string]: string } = {
@@ -990,7 +991,7 @@ Event: ${line}\n${e.toString()}`);
         envs = { ...envs, ...this.workspace.envVars };
         const additionalArgs = await this.workspace.serializeArgsForOp(this.name);
         args = [...args, "--stack", this.name, ...additionalArgs];
-        const result = await this.workspace.pulumiCommand.run(args, this.workspace.workDir, envs, onOutput, signal);
+        const result = await this.workspace.pulumiCommand.run(args, this.workspace.workDir, envs, onOutput, onError, signal);
         await this.workspace.postCommandCallback(this.name);
         return result;
     }
@@ -1419,7 +1420,12 @@ export interface UpOptions extends GlobalOpts {
     userAgent?: string;
 
     /**
-     * A callback to be executed when the operation produces output.
+     * A callback to be executed when the operation produces stderr output.
+     */
+    onError?: (err: string) => void;
+
+    /**
+     * A callback to be executed when the operation produces stdout output.
      */
     onOutput?: (out: string) => void;
 
@@ -1534,9 +1540,14 @@ export interface PreviewOptions extends GlobalOpts {
     program?: PulumiFn;
 
     /**
-     * A callback to be executed when the operation produces output.
+     * A callback to be executed when the operation produces stderr output.
      */
     onOutput?: (out: string) => void;
+
+    /**
+     * A callback to be executed when the operation produces stdout output.
+     */
+    onError?: (err: string) => void;
 
     /**
      * A callback to be executed when the operation yields an event.
@@ -1614,7 +1625,12 @@ export interface RefreshOptions extends GlobalOpts {
     userAgent?: string;
 
     /**
-     * A callback to be executed when the operation produces output.
+     * A callback to be executed when the operation produces stderr output.
+     */
+    onError?: (err: string) => void;
+
+    /**
+     * A callback to be executed when the operation produces stdout output.
      */
     onOutput?: (out: string) => void;
 
@@ -1683,7 +1699,12 @@ export interface DestroyOptions extends GlobalOpts {
     userAgent?: string;
 
     /**
-     * A callback to be executed when the operation produces output.
+     * A callback to be executed when the operation produces stderr output.
+     */
+    onError?: (err: string) => void;
+
+    /**
+     * A callback to be executed when the operation produces stdout output.
      */
     onOutput?: (out: string) => void;
 
@@ -1737,7 +1758,12 @@ export interface RenameOptions extends GlobalOpts {
     stackName: string;
 
     /**
-     * A callback to be executed when the operation produces output.
+     * A callback to be executed when the operation produces stderr output.
+     */
+    onError?: (err: string) => void;
+
+    /**
+     * A callback to be executed when the operation produces stdout output.
      */
     onOutput?: (out: string) => void;
 

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -991,7 +991,14 @@ Event: ${line}\n${e.toString()}`);
         envs = { ...envs, ...this.workspace.envVars };
         const additionalArgs = await this.workspace.serializeArgsForOp(this.name);
         args = [...args, "--stack", this.name, ...additionalArgs];
-        const result = await this.workspace.pulumiCommand.run(args, this.workspace.workDir, envs, onOutput, onError, signal);
+        const result = await this.workspace.pulumiCommand.run(
+            args,
+            this.workspace.workDir,
+            envs,
+            onOutput,
+            onError,
+            signal,
+        );
         await this.workspace.postCommandCallback(this.name);
         return result;
     }

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -711,7 +711,13 @@ describe("LocalWorkspace", () => {
         const projectName = "inline_node";
         const stackName = fullyQualifiedStackName(getTestOrg(), projectName, `int_test${getTestSuffix()}`);
         const stack = await LocalWorkspace.createStack(
-            { stackName, projectName, program: async () => {} },
+            {
+                stackName,
+                projectName,
+                program: async () => {
+                    return;
+                },
+            },
             withTestBackend({}, "inline_node"),
         );
 
@@ -719,15 +725,22 @@ describe("LocalWorkspace", () => {
         // produce error output. These are the least elaborate ideas I could
         // come up with.
 
-        let error = ""
+        let error = "";
 
         // pulumi up
         try {
-          await stack.up({ plan: "halloumi", onError: e => { error += e } });
-        } catch (e) {}
+            await stack.up({
+                plan: "halloumi",
+                onError: (e) => {
+                    error += e;
+                },
+            });
+        } catch (e) {
+            assert.notStrictEqual(error, "");
+        }
 
-        assert.strictEqual(error, "error: open halloumi: no such file or directory\n")
-        error = ""
+        assert.strictEqual(error, "error: open halloumi: no such file or directory\n");
+        error = "";
 
         const upRes = await stack.up();
         assert.strictEqual(upRes.summary.kind, "update");
@@ -735,22 +748,42 @@ describe("LocalWorkspace", () => {
 
         // pulumi preview
         try {
-          await stack.preview({ parallel: 1.1, onError: e => { error += e } });
-        } catch (e) {}
+            await stack.preview({
+                parallel: 1.1,
+                onError: (e) => {
+                    error += e;
+                },
+            });
+        } catch (e) {
+            assert.notStrictEqual(error, "");
+        }
 
-        assert.strictEqual(error, 'error: invalid argument "1.1" for "-p, --parallel" flag: strconv.ParseInt: parsing "1.1": invalid syntax\n')
-        error = ""
+        assert.strictEqual(
+            error,
+            'error: invalid argument "1.1" for "-p, --parallel" flag: strconv.ParseInt: parsing "1.1": invalid syntax\n',
+        );
+        error = "";
 
         const preRes = await stack.preview({ userAgent });
         assert.strictEqual(preRes.changeSummary.same, 1);
 
         // pulumi refresh
         try {
-          await stack.refresh({ parallel: 2.2, onError: e => { error += e } });
-        } catch (e) {}
+            await stack.refresh({
+                parallel: 2.2,
+                onError: (e) => {
+                    error += e;
+                },
+            });
+        } catch (e) {
+            assert.notStrictEqual(error, "");
+        }
 
-        assert.strictEqual(error, 'error: invalid argument "2.2" for "-p, --parallel" flag: strconv.ParseInt: parsing "2.2": invalid syntax\n')
-        error = ""
+        assert.strictEqual(
+            error,
+            'error: invalid argument "2.2" for "-p, --parallel" flag: strconv.ParseInt: parsing "2.2": invalid syntax\n',
+        );
+        error = "";
 
         const refRes = await stack.refresh({ userAgent });
         assert.strictEqual(refRes.summary.kind, "refresh");
@@ -758,11 +791,21 @@ describe("LocalWorkspace", () => {
 
         // pulumi destroy
         try {
-          await stack.destroy({ parallel: 3.3, onError: e => { error += e } });
-        } catch (e) {}
+            await stack.destroy({
+                parallel: 3.3,
+                onError: (e) => {
+                    error += e;
+                },
+            });
+        } catch (e) {
+            assert.notStrictEqual(error, "");
+        }
 
-        assert.strictEqual(error, 'error: invalid argument "3.3" for "-p, --parallel" flag: strconv.ParseInt: parsing "3.3": invalid syntax\n')
-        error = ""
+        assert.strictEqual(
+            error,
+            'error: invalid argument "3.3" for "-p, --parallel" flag: strconv.ParseInt: parsing "3.3": invalid syntax\n',
+        );
+        error = "";
 
         const destroyRes = await stack.destroy({ userAgent });
         assert.strictEqual(destroyRes.summary.kind, "destroy");

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -739,7 +739,7 @@ describe("LocalWorkspace", () => {
             assert.notStrictEqual(error, "");
         }
 
-        assert.strictEqual(error, /error: open halloumi/);
+        assert.match(error, /error: open halloumi/);
         error = "";
 
         const upRes = await stack.up();

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -715,6 +715,10 @@ describe("LocalWorkspace", () => {
             withTestBackend({}, "inline_node"),
         );
 
+        // We need to come up with some creative ways to make these commands
+        // produce error output. These are the least elaborate ideas I could
+        // come up with.
+
         let error = ""
 
         // pulumi up

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -739,7 +739,7 @@ describe("LocalWorkspace", () => {
             assert.notStrictEqual(error, "");
         }
 
-        assert.strictEqual(error, "error: open halloumi: no such file or directory\n");
+        assert.strictEqual(error, /error: open halloumi/);
         error = "";
 
         const upRes = await stack.up();
@@ -758,10 +758,7 @@ describe("LocalWorkspace", () => {
             assert.notStrictEqual(error, "");
         }
 
-        assert.strictEqual(
-            error,
-            'error: invalid argument "1.1" for "-p, --parallel" flag: strconv.ParseInt: parsing "1.1": invalid syntax\n',
-        );
+        assert.match(error, /error: invalid argument/);
         error = "";
 
         const preRes = await stack.preview({ userAgent });
@@ -779,10 +776,7 @@ describe("LocalWorkspace", () => {
             assert.notStrictEqual(error, "");
         }
 
-        assert.strictEqual(
-            error,
-            'error: invalid argument "2.2" for "-p, --parallel" flag: strconv.ParseInt: parsing "2.2": invalid syntax\n',
-        );
+        assert.match(error, /error: invalid argument/);
         error = "";
 
         const refRes = await stack.refresh({ userAgent });
@@ -801,10 +795,7 @@ describe("LocalWorkspace", () => {
             assert.notStrictEqual(error, "");
         }
 
-        assert.strictEqual(
-            error,
-            'error: invalid argument "3.3" for "-p, --parallel" flag: strconv.ParseInt: parsing "3.3": invalid syntax\n',
-        );
+        assert.match(error, /error: invalid argument/);
         error = "";
 
         const destroyRes = await stack.destroy({ userAgent });


### PR DESCRIPTION
This PR replicates the `onOutput` callback for stderr in the NodeJS Automation API so that error information can be collected incrementally. I also included a test (that was surprisingly difficult to come up with).

This is a part of #6511.