### PR TITLE
feat: loosening github.com hostname requirement to support GitHub Ent

### DIFF
--- a/changelog/pending/20250430--sdk-go--loosening-github-com-hostname-requirement-to-support-github-enterprise.yaml
+++ b/changelog/pending/20250430--sdk-go--loosening-github-com-hostname-requirement-to-support-github-enterprise.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Support private GitHub and GitLab instances, when installing plugins directly from a repository

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -346,12 +346,12 @@ func getAuthForURL(url string) (string, transport.AuthMethod, error) {
 	}
 	// If we have no auth, try to get it from the environment.
 	if auth == nil {
-		if strings.Contains(endpoint, GitHubHostName) && os.Getenv("GITHUB_TOKEN") != "" {
+		if strings.Contains(endpoint, "github") && os.Getenv("GITHUB_TOKEN") != "" {
 			auth = &http.BasicAuth{
 				Username: "x-access-token",
 				Password: os.Getenv("GITHUB_TOKEN"),
 			}
-		} else if strings.Contains(endpoint, GitLabHostName) && os.Getenv("GITLAB_TOKEN") != "" {
+		} else if strings.Contains(endpoint, "gitlab") && os.Getenv("GITLAB_TOKEN") != "" {
 			auth = &http.BasicAuth{
 				Username: "oauth2",
 				Password: os.Getenv("GITLAB_TOKEN"),

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -378,6 +378,22 @@ func TestTryGetVCSInfoFromSSHRemote(t *testing.T) {
 		{"svn:something.com/owner/repo", nil},
 		{"https://bitbucket.org/foo.git", nil},
 		{"git@github.foo.acme.bad-tld:owner-name/repo-name.git", nil},
+		{
+			"git@github.com:owner-name/repo-name.git",
+			&VCSInfo{Owner: "owner-name", Repo: "repo-name", Kind: GitHubHostName},
+		},
+		{
+			"git@github.enterprise.example.com:owner-name/repo-name.git",
+			&VCSInfo{Owner: "owner-name", Repo: "repo-name", Kind: "github.enterprise.example.com"},
+		},
+		{
+			"https://github.com/owner-name/repo-name.git",
+			&VCSInfo{Owner: "owner-name", Repo: "repo-name", Kind: GitHubHostName},
+		},
+		{
+			"https://github.enterprise.example.com/owner-name/repo-name.git",
+			&VCSInfo{Owner: "owner-name", Repo: "repo-name", Kind: "github.enterprise.example.com"},
+		},
 	}
 
 	for _, test := range gitTests {
@@ -460,6 +476,10 @@ func TestParseAuthURL(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, &http.BasicAuth{Username: "x-access-token", Password: "token-1"}, auth)
 
+		_, auth, err = getAuthForURL("http://github.enterprise.example.com/pulumi/templates")
+		assert.NoError(t, err)
+		assert.Equal(t, &http.BasicAuth{Username: "x-access-token", Password: "token-1"}, auth)
+
 		_, auth, err = getAuthForURL("http://gitlab.com/pulumi/templates")
 		assert.NoError(t, err)
 		assert.Nil(t, auth)
@@ -469,6 +489,10 @@ func TestParseAuthURL(t *testing.T) {
 		t.Setenv("GITLAB_TOKEN", "token-1")
 		t.Setenv("GITHUB_TOKEN", "")
 		_, auth, err := getAuthForURL("http://gitlab.com/pulumi/templates")
+		assert.NoError(t, err)
+		assert.Equal(t, &http.BasicAuth{Username: "oauth2", Password: "token-1"}, auth)
+
+		_, auth, err = getAuthForURL("http://gitlab.enterprise.example.com/pulumi/templates")
 		assert.NoError(t, err)
 		assert.Equal(t, &http.BasicAuth{Username: "oauth2", Password: "token-1"}, auth)
 


### PR DESCRIPTION
feat: loosening github.com hostname requirement to support GitHub Ent)erprise
This pull request introduces changes to loosen the strict `github.com` hostname requirement, enabling support for GitHub Enterprise. The updates include modifications to the SDK and documentation to reflect this change.

### Feature Updates:

* [`changelog/pending/20250430--sdk-go--loosening-github-com-hostname-requirement-to-support-github-enterprise.yaml`](diffhunk://#diff-4d6ebc748f8b968493b2e8bf8ae16fe7943d7f6402942897f94a6a145a28dbcdR1-R4): Added a changelog entry describing the new feature that loosens the `github.com` hostname requirement to support GitHub Enterprise.

### Code Adjustments:

* [`sdk/go/common/util/gitutil/git.go`](diffhunk://#diff-32b4aaf1466287dbb878a57a8a1368d8f7741468444e8ff92c4a41b7e9aab370L57-R58): Updated the `GitHubHostName` constant to use a more generic value (`"github"`) instead of the full hostname (`"github.com"`), allowing compatibility with GitHub Enterprise.