### PR TITLE
Allow creating analyzer plugins without config

### DIFF
--- a/changelog/pending/20250501--cli-plugin--allow-creating-analyzer-plugins-without-config.yaml
+++ b/changelog/pending/20250501--cli-plugin--allow-creating-analyzer-plugins-without-config.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/plugin
+  description: Allow creating analyzer plugins without config

--- a/sdk/go/common/resource/plugin/analyzer_plugin_test.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin_test.go
@@ -69,3 +69,23 @@ func TestAnalyzerSpawn(t *testing.T) {
 	err = analyzer.Close()
 	require.NoError(t, err)
 }
+
+func TestAnalyzerSpawnNoConfig(t *testing.T) {
+	d := diagtest.LogSink(t)
+	ctx, err := NewContext(d, d, nil, nil, "", nil, false, nil)
+	require.NoError(t, err)
+
+	pluginPath, err := filepath.Abs("./testdata/analyzer-no-config")
+	require.NoError(t, err)
+
+	path := os.Getenv("PATH")
+	t.Setenv("PATH", pluginPath+string(os.PathListSeparator)+path)
+
+	// Pass `nil` for the config, this is used for example in `pulumi policy
+	// publish`, which does not run in the context of a stack.
+	analyzer, err := NewPolicyAnalyzer(ctx.Host, ctx, "policypack", "./testdata/policypack", nil)
+	require.NoError(t, err)
+
+	err = analyzer.Close()
+	require.NoError(t, err)
+}

--- a/sdk/go/common/resource/plugin/testdata/analyzer-no-config/main.go
+++ b/sdk/go/common/resource/plugin/testdata/analyzer-no-config/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"google.golang.org/grpc"
+)
+
+type analyzer struct {
+	pulumirpc.UnimplementedAnalyzerServer
+}
+
+func (a *analyzer) Handshake(ctx context.Context, req *pulumirpc.AnalyzerHandshakeRequest) (*pulumirpc.AnalyzerHandshakeResponse, error) {
+	if req.Stack != "" {
+		return nil, fmt.Errorf("expected stack not to be set, got %s", req.Stack)
+	}
+	if req.Project != "" {
+		return nil, fmt.Errorf("expected project not to be set, got %s", req.Project)
+	}
+	if req.Organization != "" {
+		return nil, fmt.Errorf("expected organization not to be set, got %s", req.Organization)
+	}
+	if req.DryRun {
+		return nil, fmt.Errorf("expected dry run to be false, got true")
+	}
+
+	if req.Config != nil {
+		return nil, fmt.Errorf("expected config not to be set, got %s", req.Config)
+	}
+
+	return &pulumirpc.AnalyzerHandshakeResponse{}, nil
+}
+
+func main() {
+	// Bootup a policy plugin but first assert that no config was passed
+
+	config := os.Getenv("PULUMI_CONFIG")
+	if config != "" {
+		fmt.Printf("fatal: expected no config, got %v\n", config)
+		os.Exit(1)
+	}
+
+	var cancelChannel chan bool
+	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+		Cancel: cancelChannel,
+		Init: func(srv *grpc.Server) error {
+			pulumirpc.RegisterAnalyzerServer(srv, &analyzer{})
+			return nil
+		},
+		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+	})
+	if err != nil {
+		fmt.Printf("fatal: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("%d\n", handle.Port)
+
+	if err := <-handle.Done; err != nil {
+		fmt.Printf("fatal: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/sdk/go/common/resource/plugin/testdata/analyzer-no-config/pulumi-analyzer-policy-test
+++ b/sdk/go/common/resource/plugin/testdata/analyzer-no-config/pulumi-analyzer-policy-test
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Absolute path to this script, e.g. /home/user/bin/foo.sh
+SCRIPT=$(readlink -f "$0")
+# Absolute path this script is in, thus /home/user/bin
+SCRIPTPATH=$(dirname "$SCRIPT")
+
+go run $SCRIPTPATH

--- a/sdk/go/common/resource/plugin/testdata/analyzer-no-config/pulumi-analyzer-policy-test.cmd
+++ b/sdk/go/common/resource/plugin/testdata/analyzer-no-config/pulumi-analyzer-policy-test.cmd
@@ -1,0 +1,7 @@
+@echo off
+
+REM Get the absolute path to this script
+for %%I in ("%~f0") do set SCRIPT=%%~dpI
+
+REM Run the Go program in the script's directory
+go run "%SCRIPT%"


### PR DESCRIPTION
When running `pulumi policy publish` we are not running in the context of a project stack, but we have to be able to spawn an Analyzer to call `GetAnalyzerInfo`.

Fixes https://github.com/pulumi/pulumi/issues/19383
