### PR TITLE
Add a benchmark for `GetPropertyNames`

### DIFF
--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/pkg/v3
 
-go 1.22
+go 1.24
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../sdk
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,8 @@
 module github.com/pulumi/pulumi/tests
 
-go 1.22
+go 1.24
+
+toolchain go1.24.1
 
 replace (
 	github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.5.0

--- a/tests/integration/construct_component_configure_provider/testcomponent-go/go.mod
+++ b/tests/integration/construct_component_configure_provider/testcomponent-go/go.mod
@@ -1,6 +1,8 @@
 module github.com/pulumi/pulumi/tests/integration/construct_component_configure_provider/testcomponent-go
 
-go 1.22
+go 1.24
+
+toolchain go1.24.1
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
This requires go1.24 in `pkg`. I have no idea if this is an attractive change in core. PTAL and let me know if we want to do this.