### PR TITLE
Add a more ergonomic system and safe code generation for function call

### DIFF
--- a/cmd/pulumi-test-language/providers/simple_invoke_with_scalar_return_provider.go
+++ b/cmd/pulumi-test-language/providers/simple_invoke_with_scalar_return_provider.go
@@ -164,12 +164,8 @@ func (p *SimpleInvokeWithScalarReturnProvider) Invoke(
 			}, nil
 		}
 
-		// Single value returns work because SDKs automatically extract single value returns in their
-		// invoke implementations.
 		return plugin.InvokeResponse{
-			Properties: resource.PropertyMap{
-				"result": resource.NewBoolProperty(true),
-			},
+			ScalarReturn: resource.NewBoolProperty(true),
 		}, nil
 	}
 

--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -303,9 +303,14 @@ type InvokeRequest struct {
 	Args resource.PropertyMap
 }
 
+const ScalarInvokeResponsePropertyName = "result__"
+
 type InvokeResponse struct {
+	// The return values if the result is of type schema.ObjectTypeSpec.
 	Properties resource.PropertyMap
-	Failures   []CheckFailure
+	// The return values if the result is a scalar of type schema.TypeSpec
+	ScalarReturn resource.PropertyValue
+	Failures     []CheckFailure
 }
 
 type CallRequest struct {

--- a/sdk/go/common/resource/plugin/provider_server.go
+++ b/sdk/go/common/resource/plugin/provider_server.go
@@ -836,6 +836,17 @@ func (p *providerServer) Invoke(ctx context.Context, req *pulumirpc.InvokeReques
 		return nil, err
 	}
 
+	if resp.ScalarReturn.V != nil && len(resp.Properties) > 0 {
+		return nil, status.Error(codes.Internal, "cannot set both scalar and object return values")
+	}
+
+	if resp.ScalarReturn.V != nil {
+		// If the resp is a scalar, we need to marshal it as a single property.
+		resp.Properties = resource.PropertyMap{
+			ScalarInvokeResponsePropertyName: resp.ScalarReturn,
+		}
+	}
+
 	rpcResult, err := MarshalProperties(resp.Properties, p.marshalOptions("result"))
 	if err != nil {
 		return nil, err

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/simple-invoke-with-scalar-return-17.0.0/myInvokeScalar.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/simple-invoke-with-scalar-return-17.0.0/myInvokeScalar.ts
@@ -6,21 +6,35 @@ import * as utilities from "./utilities";
 
 export function myInvokeScalar(args: MyInvokeScalarArgs, opts?: pulumi.InvokeOptions): Promise<boolean> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
-    return pulumi.runtime.invokeSingle("simple-invoke-with-scalar-return:index:myInvokeScalar", {
+    const result = pulumi.runtime.invoke("simple-invoke-with-scalar-return:index:myInvokeScalar", {
         "value": args.value,
     }, opts);
+    // @ts-ignore
+    return result.then((r) => r.result__);
 }
 
 export interface MyInvokeScalarArgs {
     value: string;
 }
+
+interface MyInvokeScalarResultPlain {
+    result__: boolean;
+};
+
 export function myInvokeScalarOutput(args: MyInvokeScalarOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<boolean> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
-    return pulumi.runtime.invokeSingleOutput("simple-invoke-with-scalar-return:index:myInvokeScalar", {
+    const result = pulumi.runtime.invokeOutput("simple-invoke-with-scalar-return:index:myInvokeScalar", {
         "value": args.value,
     }, opts);
+    // @ts-ignore
+    return result.apply((r) => r.result__);
 }
 
 export interface MyInvokeScalarOutputArgs {
     value: pulumi.Input<string>;
 }
+
+interface MyInvokeScalarResult {
+    result__: boolean;
+};
+

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/simple-invoke-with-scalar-return-17.0.0/myInvokeScalar.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/simple-invoke-with-scalar-return-17.0.0/myInvokeScalar.ts
@@ -6,21 +6,35 @@ import * as utilities from "./utilities";
 
 export function myInvokeScalar(args: MyInvokeScalarArgs, opts?: pulumi.InvokeOptions): Promise<boolean> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
-    return pulumi.runtime.invokeSingle("simple-invoke-with-scalar-return:index:myInvokeScalar", {
+    const result = pulumi.runtime.invoke("simple-invoke-with-scalar-return:index:myInvokeScalar", {
         "value": args.value,
     }, opts);
+    // @ts-ignore
+    return result.then((r) => r.result__);
 }
 
 export interface MyInvokeScalarArgs {
     value: string;
 }
+
+interface MyInvokeScalarResultPlain {
+    result__: boolean;
+};
+
 export function myInvokeScalarOutput(args: MyInvokeScalarOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<boolean> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
-    return pulumi.runtime.invokeSingleOutput("simple-invoke-with-scalar-return:index:myInvokeScalar", {
+    const result = pulumi.runtime.invokeOutput("simple-invoke-with-scalar-return:index:myInvokeScalar", {
         "value": args.value,
     }, opts);
+    // @ts-ignore
+    return result.apply((r) => r.result__);
 }
 
 export interface MyInvokeScalarOutputArgs {
     value: pulumi.Input<string>;
 }
+
+interface MyInvokeScalarResult {
+    result__: boolean;
+};
+

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -132,6 +132,9 @@ function extractSingleValue(result: Inputs | undefined): any {
  * Dynamically invokes the function `tok`, which is offered by a
  * provider plugin. Similar to `invoke`, but returns a single value instead of
  * an object with a single key.
+ *
+ * This was previously by codegen for returning scalars from invoke calls, but a new methodology
+ * and codegen practice that is type safe supersedes it.
  */
 export function invokeSingle(
     tok: string,
@@ -149,6 +152,9 @@ export function invokeSingle(
 /**
  * Similar to the plain `invokeSingle` but returns the response as an output, maintaining
  * secrets of the response, if any.
+ *
+ * This was previously by codegen for returning scalars from invoke calls, but a new methodology
+ * and codegen practice that is type safe supersedes it.
  */
 export function invokeSingleOutput<T>(
     tok: string,


### PR DESCRIPTION
Replace function invoke generation to utilize a more ergonomic scalar return

Inspired by #19387, this change simplifies returning scalar values from
providers' invoke calls by setting a known named key and extracting it
on return from invoke and invokeOutput.

Instead of using Object.keys, we access this known key, but since our
type has "any" we need to add a @ts-ignore to make tsc happy, but we
actually access by name instead of any singular map value.