### PR TITLE
Add `on_error` callbacks to the Python Automation API operations

### DIFF
--- a/changelog/pending/20250502--auto-python--add-on_error-callback-for-capturing-incremental-stderr-output.yaml
+++ b/changelog/pending/20250502--auto-python--add-on_error-callback-for-capturing-incremental-stderr-output.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/python
+  description: Add `on_error` callback for capturing incremental stderr output

--- a/sdk/python/lib/pulumi/automation/_cmd.py
+++ b/sdk/python/lib/pulumi/automation/_cmd.py
@@ -234,9 +234,13 @@ class PulumiCommand:
 
                     if chunk:
                         if incoming is process.stdout:
+                            if on_output:
+                                on_output(chunk)
                             stdout_chunks.append(chunk)
                         elif incoming is process.stderr:
                             stderr_chunks.append(chunk)
+                            if on_error:
+                                on_error(chunk)
                     else:
                         if incoming is process.stdout:
                             streams.remove(process.stdout)

--- a/sdk/python/lib/pulumi/automation/_cmd.py
+++ b/sdk/python/lib/pulumi/automation/_cmd.py
@@ -240,9 +240,7 @@ class PulumiCommand:
             code = process.returncode
 
         result = CommandResult(
-            stderr="\n".join(stderr_chunks),
-            stdout="\n".join(stdout_chunks),
-            code=code
+            stderr="\n".join(stderr_chunks), stdout="\n".join(stdout_chunks), code=code
         )
         if code != 0:
             raise create_command_error(result)

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -636,13 +636,16 @@ class LocalWorkspace(Workspace):
         return "--remote-inherit-settings" in help_string
 
     def _run_pulumi_cmd_sync(
-        self, args: List[str], on_output: Optional[OnOutput] = None
+            self,
+            args: List[str],
+            on_output: Optional[OnOutput] = None,
+            on_error: Optional[OnOutput] = None,
     ) -> CommandResult:
         envs = {"PULUMI_HOME": self.pulumi_home} if self.pulumi_home else {}
         if self._remote:
             envs["PULUMI_EXPERIMENTAL"] = "true"
         envs = {**envs, **self.env_vars}
-        return self.pulumi_command.run(args, self.work_dir, envs, on_output)
+        return self.pulumi_command.run(args, self.work_dir, envs, on_output, on_error)
 
     def _remote_args(self) -> List[str]:
         args: List[str] = []

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -636,10 +636,10 @@ class LocalWorkspace(Workspace):
         return "--remote-inherit-settings" in help_string
 
     def _run_pulumi_cmd_sync(
-            self,
-            args: List[str],
-            on_output: Optional[OnOutput] = None,
-            on_error: Optional[OnOutput] = None,
+        self,
+        args: List[str],
+        on_output: Optional[OnOutput] = None,
+        on_error: Optional[OnOutput] = None,
     ) -> CommandResult:
         envs = {"PULUMI_HOME": self.pulumi_home} if self.pulumi_home else {}
         if self._remote:

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -1055,10 +1055,10 @@ class Stack:
         return self.workspace.import_stack(self.name, state)
 
     def _run_pulumi_cmd_sync(
-            self,
-            args: List[str],
-            on_output: Optional[OnOutput] = None,
-            on_error: Optional[OnOutput] = None
+        self,
+        args: List[str],
+        on_output: Optional[OnOutput] = None,
+        on_error: Optional[OnOutput] = None,
     ) -> CommandResult:
         envs = {"PULUMI_DEBUG_COMMANDS": "true"}
         if self._remote:

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -278,6 +278,7 @@ class Stack:
         replace: Optional[List[str]] = None,
         color: Optional[str] = None,
         on_output: Optional[OnOutput] = None,
+        on_error: Optional[OnOutput] = None,
         on_event: Optional[OnEvent] = None,
         program: Optional[PulumiFn] = None,
         plan: Optional[str] = None,
@@ -310,6 +311,7 @@ class Stack:
         :param exclude_dependents: Allows ignoring of dependent targets discovered but not specified in the Exclude list.
         :param replace: Specify resources to replace.
         :param on_output: A function to process the stdout stream.
+        :param on_error: A function to process the stderr stream.
         :param on_event: A function to process structured events from the Pulumi event stream.
         :param program: The inline program.
         :param color: Colorize output. Choices are: always, never, raw, auto (default "auto")
@@ -375,7 +377,7 @@ class Stack:
             log_watcher_thread.start()
 
         try:
-            up_result = self._run_pulumi_cmd_sync(args, on_output)
+            up_result = self._run_pulumi_cmd_sync(args, on_output, on_error)
             outputs = self.outputs()
             # If it's a remote workspace, explicitly set show_secrets to False to prevent attempting to
             # load the project file.
@@ -406,6 +408,7 @@ class Stack:
         replace: Optional[List[str]] = None,
         color: Optional[str] = None,
         on_output: Optional[OnOutput] = None,
+        on_error: Optional[OnOutput] = None,
         on_event: Optional[OnEvent] = None,
         program: Optional[PulumiFn] = None,
         plan: Optional[str] = None,
@@ -437,6 +440,7 @@ class Stack:
         :param exclude_dependents: Allows ignoring of dependent targets discovered but not specified in the Exclude list.
         :param replace: Specify resources to replace.
         :param on_output: A function to process the stdout stream.
+        :param on_error: A function to process the stderr stream.
         :param on_event: A function to process structured events from the Pulumi event stream.
         :param program: The inline program.
         :param color: Colorize output. Choices are: always, never, raw, auto (default "auto")
@@ -510,7 +514,7 @@ class Stack:
         log_watcher_thread.start()
 
         try:
-            preview_result = self._run_pulumi_cmd_sync(args, on_output)
+            preview_result = self._run_pulumi_cmd_sync(args, on_output, on_error)
         finally:
             _cleanup(temp_dir, log_watcher_thread, on_exit)
 
@@ -536,6 +540,7 @@ class Stack:
         clear_pending_creates: Optional[bool] = None,
         color: Optional[str] = None,
         on_output: Optional[OnOutput] = None,
+        on_error: Optional[OnOutput] = None,
         on_event: Optional[OnEvent] = None,
         show_secrets: bool = True,
         log_flow: Optional[bool] = None,
@@ -562,6 +567,7 @@ class Stack:
         :param expect_no_changes: Return an error if any changes occur during this update.
         :param clear_pending_creates: Clear all pending creates, dropping them from the state.
         :param on_output: A function to process the stdout stream.
+        :param on_error: A function to process the stderr stream.
         :param on_event: A function to process structured events from the Pulumi event stream.
         :param color: Colorize output. Choices are: always, never, raw, auto (default "auto")
         :param show_secrets: Include config secrets in the RefreshResult summary.
@@ -607,7 +613,7 @@ class Stack:
             log_watcher_thread.start()
 
         try:
-            refresh_result = self._run_pulumi_cmd_sync(args, on_output)
+            refresh_result = self._run_pulumi_cmd_sync(args, on_output, on_error)
         finally:
             _cleanup(temp_dir, log_watcher_thread)
 
@@ -623,6 +629,7 @@ class Stack:
         self,
         stack_name: str,
         on_output: Optional[OnOutput] = None,
+        on_error: Optional[OnOutput] = None,
         show_secrets: bool = False,
     ) -> RenameResult:
         """
@@ -630,6 +637,7 @@ class Stack:
 
         :param stack_name: The new name for the stack.
         :param on_output: A function to process the stdout stream.
+        :param on_error: A function to process the stderr stream.
         :param show_secrets: Include config secrets in the RefreshResult summary.
         :returns: RenameResult
         """
@@ -638,7 +646,7 @@ class Stack:
         args.extend(extra_args)
 
         args.extend(self._remote_args())
-        rename_result = self._run_pulumi_cmd_sync(args, on_output)
+        rename_result = self._run_pulumi_cmd_sync(args, on_output, on_error)
 
         if self._remote and show_secrets:
             raise RuntimeError("can't enable `showSecrets` for remote workspaces")
@@ -657,6 +665,7 @@ class Stack:
         target_dependents: Optional[bool] = None,
         color: Optional[str] = None,
         on_output: Optional[OnOutput] = None,
+        on_error: Optional[OnOutput] = None,
         on_event: Optional[OnEvent] = None,
         show_secrets: bool = True,
         log_flow: Optional[bool] = None,
@@ -682,6 +691,7 @@ class Stack:
         :param target: Specify an exclusive list of resource URNs to destroy.
         :param target_dependents: Allows updating of dependent targets discovered but not specified in the Target list.
         :param on_output: A function to process the stdout stream.
+        :param on_error: A function to process the stderr stream.
         :param on_event: A function to process structured events from the Pulumi event stream.
         :param color: Colorize output. Choices are: always, never, raw, auto (default "auto")
         :param show_secrets: Include config secrets in the DestroyResult summary.
@@ -731,7 +741,7 @@ class Stack:
             log_watcher_thread.start()
 
         try:
-            destroy_result = self._run_pulumi_cmd_sync(args, on_output)
+            destroy_result = self._run_pulumi_cmd_sync(args, on_output, on_error)
         finally:
             _cleanup(temp_dir, log_watcher_thread)
 
@@ -761,6 +771,7 @@ class Stack:
         converter: Optional[str] = None,
         converter_args: Optional[List[str]] = None,
         on_output: Optional[OnOutput] = None,
+        on_error: Optional[OnOutput] = None,
         show_secrets: bool = True,
     ) -> ImportResult:
         """
@@ -779,6 +790,7 @@ class Stack:
         :param converter: The converter plugin to use for the import operation
         :param converter_args: Additional arguments to pass to the converter plugin
         :param on_output: A function to process the stdout stream.
+        :param on_error: A function to process the stderr stream.
         :param show_secrets: Include config secrets in the ImportResult summary.
         """
         args = ["import", "--yes", "--skip-preview"]
@@ -809,7 +821,7 @@ class Stack:
                     args.append("--")
                     args.extend(converter_args)
 
-            import_result = self._run_pulumi_cmd_sync(args, on_output)
+            import_result = self._run_pulumi_cmd_sync(args, on_output, on_error)
             summary = self.info(show_secrets and not self._remote)
             generated_code = ""
             if generate_code is not False:
@@ -1043,7 +1055,10 @@ class Stack:
         return self.workspace.import_stack(self.name, state)
 
     def _run_pulumi_cmd_sync(
-        self, args: List[str], on_output: Optional[OnOutput] = None
+            self,
+            args: List[str],
+            on_output: Optional[OnOutput] = None,
+            on_error: Optional[OnOutput] = None
     ) -> CommandResult:
         envs = {"PULUMI_DEBUG_COMMANDS": "true"}
         if self._remote:
@@ -1056,7 +1071,7 @@ class Stack:
         args.extend(additional_args)
         args.extend(["--stack", self.name])
         result = self.workspace.pulumi_command.run(
-            args, self.workspace.work_dir, envs, on_output
+            args, self.workspace.work_dir, envs, on_output, on_error
         )
         self.workspace.post_command_callback(self.name)
         return result

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -818,7 +818,7 @@ class TestLocalWorkspace(unittest.TestCase):
                 error += e
 
             try:
-                stack.up(plan = "halloumi", on_error = logger)
+                stack.up(plan="halloumi", on_error=logger)
             except:
                 self.assertNotEqual(error, "")
 
@@ -831,7 +831,7 @@ class TestLocalWorkspace(unittest.TestCase):
 
             # pulumi preview
             try:
-                stack.preview(parallel = -1, on_error = logger)
+                stack.preview(parallel=-1, on_error=logger)
             except:
                 self.assertNotEqual(error, "")
 
@@ -840,7 +840,7 @@ class TestLocalWorkspace(unittest.TestCase):
 
             # pulumi refresh
             try:
-                stack.refresh(parallel = -1, on_error = logger)
+                stack.refresh(parallel=-1, on_error=logger)
             except:
                 self.assertNotEqual(error, "")
 
@@ -853,7 +853,7 @@ class TestLocalWorkspace(unittest.TestCase):
 
             # pulumi destroy
             try:
-                stack.refresh(parallel = -1, on_error = logger)
+                stack.refresh(parallel=-1, on_error=logger)
             except:
                 self.assertNotEqual(error, "")
 

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -818,7 +818,7 @@ class TestLocalWorkspace(unittest.TestCase):
                 error += e
 
             try:
-                stack.up(plan="halloumi", on_error=logger)
+                stack.up(color="vibrant grey", on_error=logger)
             except:
                 self.assertNotEqual(error, "")
 

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -831,7 +831,7 @@ class TestLocalWorkspace(unittest.TestCase):
 
             # pulumi preview
             try:
-                stack.preview(parallel=-1, on_error=logger)
+                stack.preview(color="plum yellow", on_error=logger)
             except:
                 self.assertNotEqual(error, "")
 
@@ -840,7 +840,7 @@ class TestLocalWorkspace(unittest.TestCase):
 
             # pulumi refresh
             try:
-                stack.refresh(parallel=-1, on_error=logger)
+                stack.refresh(color="inquisitive heliotrope", on_error=logger)
             except:
                 self.assertNotEqual(error, "")
 
@@ -853,7 +853,7 @@ class TestLocalWorkspace(unittest.TestCase):
 
             # pulumi destroy
             try:
-                stack.refresh(parallel=-1, on_error=logger)
+                stack.refresh(color="violent orange", on_error=logger)
             except:
                 self.assertNotEqual(error, "")
 

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -803,6 +803,69 @@ class TestLocalWorkspace(unittest.TestCase):
         finally:
             stack.workspace.remove_stack(stack_name)
 
+    def test_on_error(self):
+        project_name = "inline_python"
+        stack_name = stack_namer(project_name)
+        stack = create_stack(
+            stack_name, program=pulumi_program, project_name=project_name
+        )
+
+        try:
+            error = ""
+
+            def logger(e):
+                nonlocal error
+                error += e
+
+            try:
+                stack.up(plan = "halloumi", on_error = logger)
+            except:
+                self.assertNotEqual(error, "")
+
+            self.assertIn(error, "error: open halloumi")
+            error = ""
+
+            up_res = stack.up()
+            self.assertEqual(up_res.summary.kind, "update")
+            self.assertEqual(up_res.summary.result, "succeeded")
+
+            # pulumi preview
+            try:
+                stack.preview(parallel = -1, on_error = logger)
+            except:
+                self.assertNotEqual(error, "")
+
+            self.assertIn(error, "error: invalid argument")
+            error = ""
+
+            # pulumi refresh
+            try:
+                stack.refresh(parallel = -1, on_error = logger)
+            except:
+                self.assertNotEqual(error, "")
+
+            self.assertIn(error, "error: invalid argument")
+            error = ""
+
+            refresh_res = stack.refresh()
+            self.assertEqual(refresh_res.summary.kind, "refresh")
+            self.assertEqual(refresh_res.summary.result, "succeeded")
+
+            # pulumi destroy
+            try:
+                stack.refresh(parallel = -1, on_error = logger)
+            except:
+                self.assertNotEqual(error, "")
+
+            self.assertIn(error, "error: invalid argument")
+            error = ""
+
+            destroy_res = stack.destroy()
+            self.assertEqual(destroy_res.summary.kind, "destroy")
+            self.assertEqual(destroy_res.summary.result, "succeeded")
+        finally:
+            stack.workspace.remove_stack(stack_name)
+
     def test_preview_refresh(self):
         project_name = "inline_python"
         stack_name = stack_namer(project_name)

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -822,7 +822,7 @@ class TestLocalWorkspace(unittest.TestCase):
             except:
                 self.assertNotEqual(error, "")
 
-            self.assertIn(error, "error: open halloumi")
+            self.assertIn("error: open halloumi", error)
             error = ""
 
             up_res = stack.up()
@@ -835,7 +835,7 @@ class TestLocalWorkspace(unittest.TestCase):
             except:
                 self.assertNotEqual(error, "")
 
-            self.assertIn(error, "error: invalid argument")
+            self.assertIn("error: invalid argument", error)
             error = ""
 
             # pulumi refresh
@@ -844,7 +844,7 @@ class TestLocalWorkspace(unittest.TestCase):
             except:
                 self.assertNotEqual(error, "")
 
-            self.assertIn(error, "error: invalid argument")
+            self.assertIn("error: invalid argument", error)
             error = ""
 
             refresh_res = stack.refresh()
@@ -857,7 +857,7 @@ class TestLocalWorkspace(unittest.TestCase):
             except:
                 self.assertNotEqual(error, "")
 
-            self.assertIn(error, "error: invalid argument")
+            self.assertIn("error: invalid argument", error)
             error = ""
 
             destroy_res = stack.destroy()

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -822,7 +822,7 @@ class TestLocalWorkspace(unittest.TestCase):
             except:
                 self.assertNotEqual(error, "")
 
-            self.assertIn("error: open halloumi", error)
+            self.assertIn(error, "error: open halloumi")
             error = ""
 
             up_res = stack.up()
@@ -835,7 +835,7 @@ class TestLocalWorkspace(unittest.TestCase):
             except:
                 self.assertNotEqual(error, "")
 
-            self.assertIn("error: invalid argument", error)
+            self.assertIn(error, "error: invalid argument")
             error = ""
 
             # pulumi refresh
@@ -844,7 +844,7 @@ class TestLocalWorkspace(unittest.TestCase):
             except:
                 self.assertNotEqual(error, "")
 
-            self.assertIn("error: invalid argument", error)
+            self.assertIn(error, "error: invalid argument")
             error = ""
 
             refresh_res = stack.refresh()
@@ -857,7 +857,7 @@ class TestLocalWorkspace(unittest.TestCase):
             except:
                 self.assertNotEqual(error, "")
 
-            self.assertIn("error: invalid argument", error)
+            self.assertIn(error, "error: invalid argument")
             error = ""
 
             destroy_res = stack.destroy()

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -835,7 +835,7 @@ class TestLocalWorkspace(unittest.TestCase):
             except:
                 self.assertNotEqual(error, "")
 
-            self.assertIn("error: invalid argument", error)
+            self.assertIn("error: unsupported color", error)
             error = ""
 
             # pulumi refresh
@@ -844,7 +844,7 @@ class TestLocalWorkspace(unittest.TestCase):
             except:
                 self.assertNotEqual(error, "")
 
-            self.assertIn("error: invalid argument", error)
+            self.assertIn("error: unsupported color", error)
             error = ""
 
             refresh_res = stack.refresh()
@@ -857,7 +857,7 @@ class TestLocalWorkspace(unittest.TestCase):
             except:
                 self.assertNotEqual(error, "")
 
-            self.assertIn("error: invalid argument", error)
+            self.assertIn("error: unsupported color", error)
             error = ""
 
             destroy_res = stack.destroy()

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -822,7 +822,7 @@ class TestLocalWorkspace(unittest.TestCase):
             except:
                 self.assertNotEqual(error, "")
 
-            self.assertIn("error: open halloumi", error)
+            self.assertIn("error: unsupported color", error)
             error = ""
 
             up_res = stack.up()


### PR DESCRIPTION
This PR replicates the `on_output` callback for stderr in the Python Automation API so that error information can be collected incrementally.

* #19372
* #6511

Fixes #6511.