### PR TITLE
Views: Adopt on `plugin.Provider`

### DIFF
--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -235,14 +235,16 @@ type DiffRequest struct {
 type DiffResponse = DiffResult
 
 type CreateRequest struct {
-	URN                   resource.URN
-	Name                  string
-	Type                  tokens.Type
-	Properties            resource.PropertyMap
-	Timeout               float64
-	Preview               bool
+	URN        resource.URN
+	Name       string
+	Type       tokens.Type
+	Properties resource.PropertyMap
+	Timeout    float64
+	Preview    bool
+	// The gRPC address of the ResourceStatus service which can be used to create view resources.
 	ResourceStatusAddress string
-	ResourceStatusToken   string
+	// The ResourceStatus service token to pass when calling methods on the service.
+	ResourceStatusToken string
 }
 
 type CreateResponse struct {
@@ -252,23 +254,18 @@ type CreateResponse struct {
 }
 
 type ReadRequest struct {
-	URN                   resource.URN
-	Name                  string
-	Type                  tokens.Type
-	ID                    resource.ID
-	Inputs, State         resource.PropertyMap
+	URN           resource.URN
+	Name          string
+	Type          tokens.Type
+	ID            resource.ID
+	Inputs, State resource.PropertyMap
+	// The gRPC address of the ResourceStatus service which can be used to read view resources.
 	ResourceStatusAddress string
-	ResourceStatusToken   string
-	OldViews              []View
-}
-
-type View struct {
-	Type       tokens.Type
-	Name       string
-	ParentType tokens.Type
-	ParentName string
-	Inputs     resource.PropertyMap
-	Outputs    resource.PropertyMap
+	// The ResourceStatus service token to pass when calling methods on the service.
+	ResourceStatusToken string
+	// The old views for the resource being read. These will only be populated when the Read call is being made as part
+	// of a refresh operation.
+	OldViews []View
 }
 
 type ReadResponse struct {
@@ -285,9 +282,12 @@ type UpdateRequest struct {
 	Timeout                          float64
 	IgnoreChanges                    []string
 	Preview                          bool
-	ResourceStatusAddress            string
-	ResourceStatusToken              string
-	OldViews                         []View
+	// The gRPC address of the ResourceStatus service which can be used to update view resources.
+	ResourceStatusAddress string
+	// The ResourceStatus service token to pass when calling methods on the service.
+	ResourceStatusToken string
+	// The old views for the resource being updated.
+	OldViews []View
 }
 
 type UpdateResponse struct {
@@ -296,15 +296,18 @@ type UpdateResponse struct {
 }
 
 type DeleteRequest struct {
-	URN                   resource.URN
-	Name                  string
-	Type                  tokens.Type
-	ID                    resource.ID
-	Inputs, Outputs       resource.PropertyMap
-	Timeout               float64
+	URN             resource.URN
+	Name            string
+	Type            tokens.Type
+	ID              resource.ID
+	Inputs, Outputs resource.PropertyMap
+	Timeout         float64
+	// The gRPC address of the ResourceStatus service which can be used to delete view resources.
 	ResourceStatusAddress string
-	ResourceStatusToken   string
-	OldViews              []View
+	// The ResourceStatus service token to pass when calling methods on the service.
+	ResourceStatusToken string
+	// The old views of the resource being deleted.
+	OldViews []View
 }
 
 type DeleteResponse struct {
@@ -835,4 +838,25 @@ type CallResult struct {
 	ReturnDependencies map[resource.PropertyKey][]resource.URN
 	// The failures if any arguments didn't pass verification.
 	Failures []CheckFailure
+}
+
+// View represents the state of a view resource.
+type View struct {
+	// The type of the view resource.
+	Type tokens.Type
+
+	// The name of the view resource.
+	Name string
+
+	// An optional type of the parent view resource.
+	ParentType tokens.Type
+
+	// An optional name of the parent view resource.
+	ParentName string
+
+	// The view resource's inputs.
+	Inputs resource.PropertyMap
+
+	// The view resource's outputs.
+	Outputs resource.PropertyMap
 }

--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -55,6 +55,10 @@ type ProviderHandshakeRequest struct {
 
 	// If true the engine will send URN, Name, Type and ID to the provider as part of the configuration.
 	ConfigureWithUrn bool
+
+	// If true the engine supports views and can send an address of the resource status service that
+	// can be used to create or update view resources.
+	SupportsViews bool
 }
 
 // The type of responses sent as part of a Handshake call.
@@ -231,12 +235,14 @@ type DiffRequest struct {
 type DiffResponse = DiffResult
 
 type CreateRequest struct {
-	URN        resource.URN
-	Name       string
-	Type       tokens.Type
-	Properties resource.PropertyMap
-	Timeout    float64
-	Preview    bool
+	URN                   resource.URN
+	Name                  string
+	Type                  tokens.Type
+	Properties            resource.PropertyMap
+	Timeout               float64
+	Preview               bool
+	ResourceStatusAddress string
+	ResourceStatusToken   string
 }
 
 type CreateResponse struct {
@@ -246,11 +252,23 @@ type CreateResponse struct {
 }
 
 type ReadRequest struct {
-	URN           resource.URN
-	Name          string
-	Type          tokens.Type
-	ID            resource.ID
-	Inputs, State resource.PropertyMap
+	URN                   resource.URN
+	Name                  string
+	Type                  tokens.Type
+	ID                    resource.ID
+	Inputs, State         resource.PropertyMap
+	ResourceStatusAddress string
+	ResourceStatusToken   string
+	OldViews              []View
+}
+
+type View struct {
+	Type       tokens.Type
+	Name       string
+	ParentType tokens.Type
+	ParentName string
+	Inputs     resource.PropertyMap
+	Outputs    resource.PropertyMap
 }
 
 type ReadResponse struct {
@@ -267,6 +285,9 @@ type UpdateRequest struct {
 	Timeout                          float64
 	IgnoreChanges                    []string
 	Preview                          bool
+	ResourceStatusAddress            string
+	ResourceStatusToken              string
+	OldViews                         []View
 }
 
 type UpdateResponse struct {
@@ -275,12 +296,15 @@ type UpdateResponse struct {
 }
 
 type DeleteRequest struct {
-	URN             resource.URN
-	Name            string
-	Type            tokens.Type
-	ID              resource.ID
-	Inputs, Outputs resource.PropertyMap
-	Timeout         float64
+	URN                   resource.URN
+	Name                  string
+	Type                  tokens.Type
+	ID                    resource.ID
+	Inputs, Outputs       resource.PropertyMap
+	Timeout               float64
+	ResourceStatusAddress string
+	ResourceStatusToken   string
+	OldViews              []View
 }
 
 type DeleteResponse struct {

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -2313,6 +2313,7 @@ func (p *provider) GetMappings(ctx context.Context, req GetMappingsRequest) (Get
 	return GetMappingsResponse{resp.Providers}, nil
 }
 
+// marshalViews is a helper that marshals a slice of views into the gRPC equivalent.
 func marshalViews(views []View, opts MarshalOptions) ([]*pulumirpc.View, error) {
 	if len(views) == 0 {
 		return nil, nil
@@ -2329,6 +2330,7 @@ func marshalViews(views []View, opts MarshalOptions) ([]*pulumirpc.View, error) 
 	return result, nil
 }
 
+// marshalView is a helper that marshals a view into the gRPC equivalent.
 func marshalView(v View, opts MarshalOptions) (*pulumirpc.View, error) {
 	var err error
 

--- a/sdk/go/common/resource/plugin/provider_plugin_test.go
+++ b/sdk/go/common/resource/plugin/provider_plugin_test.go
@@ -748,13 +748,13 @@ func TestProvider_ConfigureDeleteRace(t *testing.T) {
 
 		close(deleting)
 		_, err := p.Delete(context.Background(), DeleteRequest{
-			resource.NewURN("org/proj/dev", "foo", "", "bar:baz", "qux"),
-			"qux",
-			"bar:baz",
-			"whatever",
-			props,
-			props,
-			1000,
+			URN:     resource.NewURN("org/proj/dev", "foo", "", "bar:baz", "qux"),
+			Name:    "qux",
+			Type:    "bar:baz",
+			ID:      "whatever",
+			Inputs:  props,
+			Outputs: props,
+			Timeout: 1000,
 		})
 		assert.NoError(t, err, "Delete failed")
 	}()

--- a/sdk/go/common/resource/plugin/provider_server.go
+++ b/sdk/go/common/resource/plugin/provider_server.go
@@ -978,6 +978,7 @@ func (p *providerServer) GetMappings(ctx context.Context,
 	return &pulumirpc.GetMappingsResponse{Providers: providers.Keys}, nil
 }
 
+// unmarshalViews is a helper that unmarshals a slice of views from gRPC into a slice of View structs.
 func unmarshalViews(views []*pulumirpc.View, opts MarshalOptions) ([]View, error) {
 	if len(views) == 0 {
 		return nil, nil
@@ -994,6 +995,7 @@ func unmarshalViews(views []*pulumirpc.View, opts MarshalOptions) ([]View, error
 	return result, nil
 }
 
+// unmarshalView is a helper that unmarshals a single view from gRPC into a View struct.
 func unmarshalView(v *pulumirpc.View, opts MarshalOptions) (View, error) {
 	var err error
 


### PR DESCRIPTION
This change adopts the protobuf changes for views on `plugin.Provider`. This isn't functional yet. Just updating the interfaces.

Part of https://github.com/pulumi/pulumi/issues/19240