### PR TITLE
Respect customized Node package names in Node program generator

### DIFF
--- a/changelog/pending/20250506--programgen-nodejs--fix-generating-imports-for-functions-in-3-rd-party-packages-such-as-atpulumiverse-scaleway.yaml
+++ b/changelog/pending/20250506--programgen-nodejs--fix-generating-imports-for-functions-in-3-rd-party-packages-such-as-atpulumiverse-scaleway.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/nodejs
+  description: Fix generating imports for functions in 3-rd party packages such as @pulumiverse/scaleway 

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -325,14 +325,21 @@ var functionImports = map[string][]string{
 	"sha1":               {"crypto"},
 }
 
-func (g *generator) getFunctionImports(x *model.FunctionCallExpression) []string {
+func (g *generator) visitFunctionImports(
+	x *model.FunctionCallExpression,
+	visitNodeImport func(nodeImportString string),
+	visitPackageImport func(pkg string),
+) {
 	if x.Name != pcl.Invoke {
-		return functionImports[x.Name]
+		for _, i := range functionImports[x.Name] {
+			visitNodeImport(i)
+		}
+		return
 	}
 
 	pkg, _, _, diags := functionName(x.Args[0])
 	contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
-	return []string{"@pulumi/" + pkg}
+	visitPackageImport(pkg)
 }
 
 func enumName(enum *model.EnumType) (string, error) {


### PR DESCRIPTION
Packages may override Node imports to be @pulumiverse/scaleway instead of @pulumi/scaleway. Before the change the code respected this for resources but not for invokes, and if invokes were used generated invalid Node programs. This is fixed by reusing the code that handled resources to cover invokes as well.

Fixes https://github.com/pulumi/pulumi/issues/19409