### PR TITLE
Add python sdk support for method calls that return scalars

### DIFF
--- a/changelog/pending/20250508--programgen-python--add-sdk-support-for-scalar-call-returns-from-providers.yaml
+++ b/changelog/pending/20250508--programgen-python--add-sdk-support-for-scalar-call-returns-from-providers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/python
+  description: Add sdk support for scalar call returns from providers

--- a/sdk/python/lib/pulumi/runtime/__init__.py
+++ b/sdk/python/lib/pulumi/runtime/__init__.py
@@ -56,6 +56,7 @@ from .invoke import (
     invoke_async,
     invoke_output,
     call,
+    call_single,
 )
 
 from ._json import (
@@ -102,6 +103,7 @@ __all__ = [
     "invoke_async",
     "invoke_output",
     "call",
+    "call_single",
     # _json
     "to_json",
     # rpc

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -532,3 +532,29 @@ def call(
     asyncio.ensure_future(_get_rpc_manager().do_rpc("call", do_call)())
 
     return out
+
+
+def call_single(
+    tok: str,
+    props: "Inputs",
+    res: Optional["Resource"] = None,
+    typ: Optional[type] = None,
+    package_ref: Optional[Awaitable[Optional[str]]] = None,
+) -> "Output[Any]":
+    """
+    Similar to `call`, but extracts a singular value from the result (eg { "foo": "bar" } => "bar").
+    """
+
+    return call(tok, props, res, typ, package_ref).apply(_extract_single_value)
+
+
+def _extract_single_value(out: Any) -> Any:
+    """
+    Extracts the first value from a result object.
+    Does not check (throws) if the result is None or an empty.
+    """
+
+    if not isinstance(out, dict):
+        return out
+
+    return out[list(out.keys())[0]]

--- a/sdk/python/lib/test/runtime/test_invoke.py
+++ b/sdk/python/lib/test/runtime/test_invoke.py
@@ -1,0 +1,34 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pulumi.runtime.invoke import _extract_single_value
+import pytest
+
+
+def test_extract_single_value():
+    d = {"foo": "bar"}
+    v = _extract_single_value(d)
+    assert v == "bar"
+
+
+def test_nondicts_return_identity():
+    x = 123
+    y = _extract_single_value(x)
+    assert x is y
+
+
+def test_empty_dicts_throw():
+    with pytest.raises(IndexError):
+        _extract_single_value({})


### PR DESCRIPTION
Much like #19387, this enables python scalar return values from method calls,
but now in python.

In order to keep things consistent, this change adds the equivalent functions call_single, call_single_plain.

Since python has automatic apply lifting there is no need to differentiate
between sync/async in these functions.

Codegen changes are in #19464

Part of #7345 