### PR TITLE
Support Node.js 24

### DIFF
--- a/changelog/pending/20250506--sdk--support-node-js-24.yaml
+++ b/changelog/pending/20250506--sdk--support-node-js-24.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk
+  description: Support Node.js 24

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -139,7 +139,7 @@ ALL_PLATFORMS = ["ubuntu-22.04", "windows-latest", "macos-latest"]
 ALL_VERSION_SET = {
     "dotnet": ["8", "9"],
     "go": ["1.23.x", "1.24.x"],
-    "nodejs": ["18.x", "20.x", "22.x", "23.x"],
+    "nodejs": ["20.x", "22.x", "23.x", "24.x"],
     # When updating the minimum Python version here, also update `pyproject.toml`, including the
     # `mypy` and `ruff` sections.
     "python": ["3.9.x", "3.10.x", "3.11.x", "3.12.x", "3.13.x"],

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -247,6 +247,22 @@ func TestLanguage(t *testing.T) {
 						t.Skipf("Skipping known failure: %s", expected)
 					}
 
+					// Skip l2-large-string on Node.js 24 https://github.com/nodejs/node/issues/58197
+					// TODO: https://github.com/pulumi/pulumi/issues/19442
+					if tt == "l2-large-string" {
+						cmd := exec.Command("node", "-v")
+						output, err := cmd.Output()
+						require.NoError(t, err)
+
+						var major int
+						_, err = fmt.Sscanf(string(output), "v%d", &major)
+						require.NoError(t, err)
+
+						if major >= 24 {
+							t.Skip("Skipping test on Node.js 24+ due to known regression")
+						}
+					}
+
 					result, err := engine.RunLanguageTest(t.Context(), &testingrpc.RunLanguageTestRequest{
 						Token: prepare.Token,
 						Test:  tt,

--- a/sdk/nodejs/tests/runtime/closure-integration-tests.ts
+++ b/sdk/nodejs/tests/runtime/closure-integration-tests.ts
@@ -59,7 +59,7 @@ async function copyDir(src: string, dest: string) {
     );
 
     for (const entry of entries) {
-        const srcPath = path.join(entry.path, entry.name);
+        const srcPath = path.join(entry.parentPath ?? entry.path, entry.name);
         const destPath = srcPath.replace(src, dest);
         const destDir = path.dirname(destPath);
 


### PR DESCRIPTION
Node.js 18 is no longer supported. We don’t have any changes that break compatibility with this version, but we are no longer running tests for it.
