### PR TITLE
Ensure we don’t introduce `toolchain` directives in the go.mod files

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -64,14 +64,7 @@ jobs:
           go-version: ${{ fromJson(inputs.version-set).go }}
           check-latest: true
       - name: Run go mod tidy
-        run: make tidy
-      - name: Fail if go mod not tidy
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "::error go.mod not tidy"
-            echo "::error Please run 'make tidy'"
-            exit 1
-          fi
+        run: make tidy_check
 
   gen:
     name: Generate Go SDK

--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,9 @@ gotestsum/%:
 tidy::
 	./scripts/tidy.sh
 
+tidy_check::
+	./scripts/tidy.sh --check
+
 validate_codecov_yaml::
 	curl --data-binary @codecov.yml https://codecov.io/validate
 

--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -1,11 +1,48 @@
 #!/usr/bin/env bash
 
+# This script manages Go module dependencies across the project using `go mod tidy`.
+# It can run in two modes:
+# 1. Normal mode: Executes `go mod tidy` on all go.mod files to clean up dependencies
+# 2. Check mode (--check flag): Validates go.mod files without modifying them
+#    - Checks if any files contain `toolchain` directives
+#    - Uses 'go mod tidy -diff' to verify if modules are properly tidied
+#    - Fails with non-zero exit code if any issues are found
+#
+# We don't want to include `toolchain` directives to ensure that CI always run
+# with the "current" Go toolchain. Our CI sets up a matrix of versions to use
+# and we don't want this to be overriden by the toolchain directive.
+
 set -euo pipefail
+
+# Parse command line arguments
+CHECK_MODE=false
+for arg in "$@"
+do
+    case $arg in
+        --check)
+        CHECK_MODE=true
+        shift
+        ;;
+    esac
+done
 
 # Excluding tests that have their dependencies code-generated but under .gitignore.
 EXCLUDE="-e tests/integration/construct_component_configure_provider/go/go.mod -e sdk/go/pulumi-language-go/testdata -e tests/testdata -e tests/smoke/testdata"
 
 for f in $(git ls-files '**go.mod' | grep -v $EXCLUDE)
 do
-    (cd "$(dirname "${f}")" && go mod tidy -compat=1.23)
+    if [ "$CHECK_MODE" = true ]; then
+        if grep -q 'toolchain go1.' "$f"; then
+            echo "$f contains 'toolchain' directive"
+            exit 1
+        fi
+
+        if ! (cd "$(dirname "${f}")" && go mod tidy -compat=1.23 -diff); then
+            echo "$f is not tidy"
+            echo "Please run 'make tidy'"
+            exit 1
+        fi
+    else
+        (cd "$(dirname "${f}")" && go mod tidy -compat=1.23)
+    fi
 done


### PR DESCRIPTION
CI runs a matrix of Go versions, and we want to ensure we’re always building and testing with that version. If we have `toolchain` directives in the `go.mod` files, we’d use those versions instead, defeating the purpose of the matrix.

See https://github.com/pulumi/pulumi/pull/19118#discussion_r2071491860
