### PR TITLE
cache intermediate results for type conversions

### DIFF
--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -890,7 +890,7 @@ func (g *generator) argumentTypeName(destType model.Type, isInput bool) (result 
 			}
 			return "interface{}"
 		default:
-			return string(destType.Val)
+			return string(*destType)
 		}
 	case *model.ObjectType:
 

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -890,7 +890,7 @@ func (g *generator) argumentTypeName(destType model.Type, isInput bool) (result 
 			}
 			return "interface{}"
 		default:
-			return string(*destType)
+			return string(destType.Val)
 		}
 	case *model.ObjectType:
 

--- a/pkg/codegen/hcl2/model/type_const.go
+++ b/pkg/codegen/hcl2/model/type_const.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/pretty"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/util/gsync"
 )
 
 // ConstType represents a type that is a single constant value.
@@ -32,12 +33,12 @@ type ConstType struct {
 	// Value is the constant value.
 	Value cty.Value
 
-	cache conversionCache
+	cache *gsync.Map[Type, cacheEntry]
 }
 
 // NewConstType creates a new constant type with the given type and value.
 func NewConstType(typ Type, value cty.Value) *ConstType {
-	return &ConstType{Type: typ, Value: value, cache: make(conversionCache)}
+	return &ConstType{Type: typ, Value: value, cache: &gsync.Map[Type, cacheEntry]{}}
 }
 
 func (t *ConstType) pretty(seenFormatters map[Type]pretty.Formatter) pretty.Formatter {
@@ -105,7 +106,7 @@ func (t *ConstType) ConversionFrom(src Type) ConversionKind {
 
 func (t *ConstType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
 	if t.cache == nil {
-		t.cache = make(conversionCache)
+		t.cache = &gsync.Map[Type, cacheEntry]{}
 	}
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		if t.Type.ConversionFrom(src) != NoConversion {

--- a/pkg/codegen/hcl2/model/type_enum.go
+++ b/pkg/codegen/hcl2/model/type_enum.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/pretty"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/util/gsync"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -55,7 +56,7 @@ type EnumType struct {
 
 	s atomic.Value // Value<string>
 
-	cache conversionCache
+	cache *gsync.Map[Type, cacheEntry]
 }
 
 func NewEnumType(token string, typ Type, elements []cty.Value, annotations ...interface{}) *EnumType {
@@ -152,7 +153,7 @@ func (t *EnumType) ConversionFrom(src Type) ConversionKind {
 
 func (t *EnumType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
 	if t.cache == nil {
-		t.cache = make(conversionCache)
+		t.cache = &gsync.Map[Type, cacheEntry]{}
 	}
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		// We have a constant, of the correct type, so we might have a safe

--- a/pkg/codegen/hcl2/model/type_list.go
+++ b/pkg/codegen/hcl2/model/type_list.go
@@ -28,6 +28,8 @@ import (
 type ListType struct {
 	// ElementType is the element type of the list.
 	ElementType Type
+
+	cache conversionCache
 }
 
 // NewListType creates a new list type with the given element type.
@@ -121,7 +123,10 @@ func (t *ListType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (t *ListType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, lazyDiagnostics) {
+	if t.cache == nil {
+		t.cache = make(conversionCache)
+	}
+	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *ListType:
 			return t.ElementType.conversionFrom(src.ElementType, unifying, seen)

--- a/pkg/codegen/hcl2/model/type_list.go
+++ b/pkg/codegen/hcl2/model/type_list.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/pretty"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/util/gsync"
 )
 
 // ListType represents lists of particular element types.
@@ -29,7 +30,7 @@ type ListType struct {
 	// ElementType is the element type of the list.
 	ElementType Type
 
-	cache conversionCache
+	cache *gsync.Map[Type, cacheEntry]
 }
 
 // NewListType creates a new list type with the given element type.
@@ -124,7 +125,7 @@ func (t *ListType) ConversionFrom(src Type) ConversionKind {
 
 func (t *ListType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
 	if t.cache == nil {
-		t.cache = make(conversionCache)
+		t.cache = &gsync.Map[Type, cacheEntry]{}
 	}
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {

--- a/pkg/codegen/hcl2/model/type_map.go
+++ b/pkg/codegen/hcl2/model/type_map.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/pretty"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/util/gsync"
 )
 
 // MapType represents maps from strings to particular element types.
@@ -29,7 +30,7 @@ type MapType struct {
 	// ElementType is the element type of the map.
 	ElementType Type
 
-	cache conversionCache
+	cache *gsync.Map[Type, cacheEntry]
 }
 
 // NewMapType creates a new map type with the given element type.
@@ -119,7 +120,7 @@ func (t *MapType) ConversionFrom(src Type) ConversionKind {
 
 func (t *MapType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
 	if t.cache == nil {
-		t.cache = make(conversionCache)
+		t.cache = &gsync.Map[Type, cacheEntry]{}
 	}
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {

--- a/pkg/codegen/hcl2/model/type_map.go
+++ b/pkg/codegen/hcl2/model/type_map.go
@@ -28,6 +28,8 @@ import (
 type MapType struct {
 	// ElementType is the element type of the map.
 	ElementType Type
+
+	cache conversionCache
 }
 
 // NewMapType creates a new map type with the given element type.
@@ -116,7 +118,10 @@ func (t *MapType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (t *MapType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, lazyDiagnostics) {
+	if t.cache == nil {
+		t.cache = make(conversionCache)
+	}
+	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *MapType:
 			return t.ElementType.conversionFrom(src.ElementType, unifying, seen)

--- a/pkg/codegen/hcl2/model/type_none.go
+++ b/pkg/codegen/hcl2/model/type_none.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/pretty"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/util/gsync"
 )
 
 type noneType int
@@ -60,7 +61,7 @@ func (noneType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (noneType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	return conversionFrom(NoneType, src, unifying, seen, nil, func() (ConversionKind, lazyDiagnostics) {
+	return conversionFrom(NoneType, src, unifying, seen, &gsync.Map[Type, cacheEntry]{}, func() (ConversionKind, lazyDiagnostics) {
 		return NoConversion, nil
 	})
 }

--- a/pkg/codegen/hcl2/model/type_none.go
+++ b/pkg/codegen/hcl2/model/type_none.go
@@ -61,9 +61,10 @@ func (noneType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (noneType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	return conversionFrom(NoneType, src, unifying, seen, &gsync.Map[Type, cacheEntry]{}, func() (ConversionKind, lazyDiagnostics) {
-		return NoConversion, nil
-	})
+	return conversionFrom(
+		NoneType, src, unifying, seen, &gsync.Map[Type, cacheEntry]{}, func() (ConversionKind, lazyDiagnostics) {
+			return NoConversion, nil
+		})
 }
 
 func (noneType) String() string {

--- a/pkg/codegen/hcl2/model/type_none.go
+++ b/pkg/codegen/hcl2/model/type_none.go
@@ -60,7 +60,7 @@ func (noneType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (noneType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	return conversionFrom(NoneType, src, unifying, seen, func() (ConversionKind, lazyDiagnostics) {
+	return conversionFrom(NoneType, src, unifying, seen, nil, func() (ConversionKind, lazyDiagnostics) {
 		return NoConversion, nil
 	})
 }

--- a/pkg/codegen/hcl2/model/type_object.go
+++ b/pkg/codegen/hcl2/model/type_object.go
@@ -40,6 +40,8 @@ type ObjectType struct {
 
 	propertyUnion Type
 	s             atomic.Value // Value<string>
+
+	cache conversionCache
 }
 
 // NewObjectType creates a new object type with the given properties and annotations.
@@ -254,7 +256,10 @@ func (t *ObjectType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (t *ObjectType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, lazyDiagnostics) {
+	if t.cache == nil {
+		t.cache = make(conversionCache)
+	}
+	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *ObjectType:
 			if seen != nil {

--- a/pkg/codegen/hcl2/model/type_opaque.go
+++ b/pkg/codegen/hcl2/model/type_opaque.go
@@ -66,7 +66,7 @@ func (t *OpaqueType) AssignableFrom(src Type) bool {
 func (t *OpaqueType) conversionFromImpl(
 	src Type, unifying, checkUnsafe bool, seen map[Type]struct{},
 ) (ConversionKind, lazyDiagnostics) {
-	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, lazyDiagnostics) {
+	return conversionFrom(t, src, unifying, seen, nil, func() (ConversionKind, lazyDiagnostics) {
 		if constType, ok := src.(*ConstType); ok {
 			return t.conversionFrom(constType.Type, unifying, seen)
 		}

--- a/pkg/codegen/hcl2/model/type_output.go
+++ b/pkg/codegen/hcl2/model/type_output.go
@@ -27,6 +27,8 @@ import (
 type OutputType struct {
 	// ElementType is the element type of the output.
 	ElementType Type
+
+	cache conversionCache
 }
 
 // NewOutputType creates a new output type with the given element type after replacing any output or promise types
@@ -103,7 +105,10 @@ func (t *OutputType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (t *OutputType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, lazyDiagnostics) {
+	if t.cache == nil {
+		t.cache = make(conversionCache)
+	}
+	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *OutputType:
 			return t.ElementType.conversionFrom(src.ElementType, unifying, seen)

--- a/pkg/codegen/hcl2/model/type_output.go
+++ b/pkg/codegen/hcl2/model/type_output.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/pretty"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/util/gsync"
 )
 
 // OutputType represents eventual values that carry additional application-specific information.
@@ -28,7 +29,7 @@ type OutputType struct {
 	// ElementType is the element type of the output.
 	ElementType Type
 
-	cache conversionCache
+	cache *gsync.Map[Type, cacheEntry]
 }
 
 // NewOutputType creates a new output type with the given element type after replacing any output or promise types
@@ -106,7 +107,7 @@ func (t *OutputType) ConversionFrom(src Type) ConversionKind {
 
 func (t *OutputType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
 	if t.cache == nil {
-		t.cache = make(conversionCache)
+		t.cache = &gsync.Map[Type, cacheEntry]{}
 	}
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {

--- a/pkg/codegen/hcl2/model/type_promise.go
+++ b/pkg/codegen/hcl2/model/type_promise.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/pretty"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/util/gsync"
 )
 
 // PromiseType represents eventual values that do not carry additional information.
@@ -29,7 +30,7 @@ type PromiseType struct {
 	// ElementType is the element type of the promise.
 	ElementType Type
 
-	cache conversionCache
+	cache *gsync.Map[Type, cacheEntry]
 }
 
 // NewPromiseType creates a new promise type with the given element type after replacing any promise types within
@@ -106,7 +107,7 @@ func (t *PromiseType) conversionFrom(
 	src Type, unifying bool, seen map[Type]struct{},
 ) (ConversionKind, lazyDiagnostics) {
 	if t.cache == nil {
-		t.cache = make(conversionCache)
+		t.cache = &gsync.Map[Type, cacheEntry]{}
 	}
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		if src, ok := src.(*PromiseType); ok {

--- a/pkg/codegen/hcl2/model/type_promise.go
+++ b/pkg/codegen/hcl2/model/type_promise.go
@@ -28,6 +28,8 @@ import (
 type PromiseType struct {
 	// ElementType is the element type of the promise.
 	ElementType Type
+
+	cache conversionCache
 }
 
 // NewPromiseType creates a new promise type with the given element type after replacing any promise types within
@@ -103,7 +105,10 @@ func (t *PromiseType) ConversionFrom(src Type) ConversionKind {
 func (t *PromiseType) conversionFrom(
 	src Type, unifying bool, seen map[Type]struct{},
 ) (ConversionKind, lazyDiagnostics) {
-	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, lazyDiagnostics) {
+	if t.cache == nil {
+		t.cache = make(conversionCache)
+	}
+	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		if src, ok := src.(*PromiseType); ok {
 			return t.ElementType.conversionFrom(src.ElementType, unifying, seen)
 		}

--- a/pkg/codegen/hcl2/model/type_set.go
+++ b/pkg/codegen/hcl2/model/type_set.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/pretty"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/util/gsync"
 )
 
 // SetType represents sets of particular element types.
@@ -28,7 +29,7 @@ type SetType struct {
 	// ElementType is the element type of the set.
 	ElementType Type
 
-	cache conversionCache
+	cache *gsync.Map[Type, cacheEntry]
 }
 
 // NewSetType creates a new set type with the given element type.
@@ -81,7 +82,7 @@ func (t *SetType) ConversionFrom(src Type) ConversionKind {
 
 func (t *SetType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
 	if t.cache == nil {
-		t.cache = make(conversionCache)
+		t.cache = &gsync.Map[Type, cacheEntry]{}
 	}
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {

--- a/pkg/codegen/hcl2/model/type_set.go
+++ b/pkg/codegen/hcl2/model/type_set.go
@@ -27,6 +27,8 @@ import (
 type SetType struct {
 	// ElementType is the element type of the set.
 	ElementType Type
+
+	cache conversionCache
 }
 
 // NewSetType creates a new set type with the given element type.
@@ -78,7 +80,10 @@ func (t *SetType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (t *SetType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, lazyDiagnostics) {
+	if t.cache == nil {
+		t.cache = make(conversionCache)
+	}
+	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *SetType:
 			return t.ElementType.conversionFrom(src.ElementType, unifying, seen)

--- a/pkg/codegen/hcl2/model/type_test.go
+++ b/pkg/codegen/hcl2/model/type_test.go
@@ -25,7 +25,11 @@ import (
 
 func testTraverse(t *testing.T, receiver Traversable, traverser hcl.Traverser, expected Traversable, expectDiags bool) {
 	actual, diags := receiver.Traverse(traverser)
-	assert.Equal(t, expected, actual)
+	if a, ok := actual.(Type); ok {
+		assert.True(t, a.Equals(expected.(Type)))
+	} else {
+		assert.Equal(t, expected, actual)
+	}
 	if expectDiags {
 		assert.Greater(t, len(diags), 0)
 	} else {
@@ -569,16 +573,16 @@ func TestInputType(t *testing.T) {
 
 func assertUnified(t *testing.T, expectedSafe, expectedUnsafe Type, types ...Type) {
 	actualSafe, actualUnsafe := UnifyTypes(types...)
-	assert.Equal(t, expectedSafe, actualSafe)
-	assert.Equal(t, expectedUnsafe, actualUnsafe)
+	assert.True(t, expectedSafe.Equals(actualSafe))
+	assert.True(t, expectedUnsafe.Equals(actualUnsafe))
 
 	// Reverse the types and ensure we get the same results.
 	for i, j := 0, len(types)-1; i < j; i, j = i+1, j-1 {
 		types[i], types[j] = types[j], types[i]
 	}
 	actualSafe2, actualUnsafe2 := UnifyTypes(types...)
-	assert.Equal(t, actualSafe, actualSafe2)
-	assert.Equal(t, actualUnsafe, actualUnsafe2)
+	assert.True(t, actualSafe.Equals(actualSafe2))
+	assert.True(t, actualUnsafe.Equals(actualUnsafe2))
 }
 
 func TestUnifyType(t *testing.T) {

--- a/pkg/codegen/hcl2/model/type_tuple.go
+++ b/pkg/codegen/hcl2/model/type_tuple.go
@@ -35,6 +35,8 @@ type TupleType struct {
 
 	elementUnion Type
 	s            atomic.Value // Value<string>
+
+	cache conversionCache
 }
 
 // NewTupleType creates a new tuple type with the given element types.
@@ -183,7 +185,10 @@ func (t *TupleType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (t *TupleType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, lazyDiagnostics) {
+	if t.cache == nil {
+		t.cache = make(conversionCache)
+	}
+	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *TupleType:
 			// When unifying, we will unify two tuples of different length to a new tuple, where elements with matching

--- a/pkg/codegen/hcl2/model/type_union.go
+++ b/pkg/codegen/hcl2/model/type_union.go
@@ -35,6 +35,8 @@ type UnionType struct {
 	Annotations []interface{}
 
 	s atomic.Value // Value<string>
+
+	cache conversionCache
 }
 
 // NewUnionTypeAnnotated creates a new union type with the given element types and annotations.
@@ -232,7 +234,10 @@ func (t *UnionType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (t *UnionType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, lazyDiagnostics) {
+	if t.cache == nil {
+		t.cache = make(conversionCache)
+	}
+	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		var conversionKind ConversionKind
 		var diags []lazyDiagnostics
 

--- a/pkg/codegen/hcl2/model/type_union.go
+++ b/pkg/codegen/hcl2/model/type_union.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/pretty"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/util/gsync"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
@@ -36,7 +37,7 @@ type UnionType struct {
 
 	s atomic.Value // Value<string>
 
-	cache conversionCache
+	cache *gsync.Map[Type, cacheEntry]
 }
 
 // NewUnionTypeAnnotated creates a new union type with the given element types and annotations.
@@ -235,7 +236,7 @@ func (t *UnionType) ConversionFrom(src Type) ConversionKind {
 
 func (t *UnionType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
 	if t.cache == nil {
-		t.cache = make(conversionCache)
+		t.cache = &gsync.Map[Type, cacheEntry]{}
 	}
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		var conversionKind ConversionKind

--- a/pkg/codegen/pcl/functions_test.go
+++ b/pkg/codegen/pcl/functions_test.go
@@ -126,7 +126,7 @@ func TestTryWithCorrectArguments(t *testing.T) {
 		return model.NewConstType(model.NumberType, cty.NumberVal(new(big.Float).SetInt64(int64(i)).SetPrec(512)))
 	}
 	expectedType := model.NewUnionType(num(1), num(2), num(3))
-	assert.Equal(t, expectedType, variableType, "the type is a plain union")
+	assert.True(t, expectedType.Equals(variableType), "the type is a plain union")
 }
 
 // Tests that the PCL `try` intrinsic function binds when correctly passed an output based argument.
@@ -152,7 +152,7 @@ func TestTryWithCorrectOutputArguments(t *testing.T) {
 		return model.NewConstType(model.NumberType, cty.NumberVal(new(big.Float).SetInt64(int64(i)).SetPrec(512)))
 	}
 	expectedType := model.NewOutputType(model.NewUnionType(num(1), num(2), num(3)))
-	assert.Equal(t, expectedType, variableType, "the type is an output union")
+	assert.True(t, expectedType.Equals(variableType), "the type is an output union")
 }
 
 // Tests that the PCL `try` intrinsic function binds when correctly passed a dynamically typed arguments.
@@ -327,7 +327,7 @@ func TestInvalidBindingPulumiResourceTypeName(t *testing.T) {
 			},
 			{
 				name: "wrong argument",
-				source: fmt.Sprintf(`res = { id = "foo", urn = "bar" }			
+				source: fmt.Sprintf(`res = { id = "foo", urn = "bar" }
 				type = %s(res)`, function),
 				expected: function + " argument must be a single resource",
 			},


### PR DESCRIPTION
Type conversions are mutually recursive and can exhibit bad runtime behaviour (probably O(2^n) if I'm guessing right) in some cases.  With large schemas this means we essentially never finish the conversion.

To fix this we can use dynamic programming techniques, and cache the intermediate results, which helps cut down the runtime for this significantly.  Locally this brings the resourcedocgen command from https://github.com/pulumi/pulumi-java/issues/1772, from never finishing (or at least not before my patience runs out after running it overnight) to completing in ~3 minutes, after including this change in the Java language runtime.