### PR TITLE
Deduplicate dependencies for `property.Value`

### DIFF
--- a/sdk/go/property/values.go
+++ b/sdk/go/property/values.go
@@ -274,10 +274,13 @@ func (v Value) WithDependencies(dependencies []urn.URN) Value {
 	//
 	// We don't want exiting references to dependencies to be able to effect
 	// v.dependencies.
-	v.dependencies = copyArray(dependencies)
+	cp := copyArray(dependencies)
 	// Sort the dependencies on ingestion so that Equals doesn't care about
 	// dependency order.
-	slices.Sort(v.dependencies)
+	slices.Sort(cp)
+	// Finally, deduplicate the dependencies, since a Value can't depend on the same
+	// resource more then once.
+	v.dependencies = slices.Compact(cp)
 	return v
 }
 

--- a/sdk/go/property/values_test.go
+++ b/sdk/go/property/values_test.go
@@ -430,6 +430,13 @@ func TestWithDependencies(t *testing.T) {
 		assert.Equal(t, v1, v2, "This tests that we can safely use dependencies in reflect based equality tests")
 		assert.True(t, v1.Equals(v2))
 	})
+
+	t.Run("duplicate", func(t *testing.T) {
+		t.Parallel()
+
+		v1 := New("v").WithDependencies([]urn.URN{"1", "2", "1"})
+		assert.Equal(t, []urn.URN{"1", "2"}, v1.Dependencies())
+	})
 }
 
 func TestNotComparable(t *testing.T) {


### PR DESCRIPTION
A `property.Value` can't depend on the same resource more then once, so it doesn't make sense to allow `property.Value` to represent duplicate resource dependencies.