### PR TITLE
Add failure case to test pkg parser

### DIFF
--- a/pkg/codegen/schema/docs_test.go
+++ b/pkg/codegen/schema/docs_test.go
@@ -187,8 +187,8 @@ func TestParseAndRenderDocs(t *testing.T) {
 
 func pkgInfo(t *testing.T, filename string) (string, *semver.Version) {
 	filename = strings.TrimSuffix(filename, ".json")
-	idx := 0
-	for {
+
+	for idx := range len(filename) {
 		i := strings.IndexByte(filename[idx:], '-') + idx
 		require.Truef(t, i != -1, "Could not parse %q into (pkg, version)", filename)
 		name := filename[:i]
@@ -196,8 +196,10 @@ func pkgInfo(t *testing.T, filename string) (string, *semver.Version) {
 		if v, err := semver.Parse(version); err == nil {
 			return name, &v
 		}
-		idx = i + 1
 	}
+
+	require.Failf(t, "invalid filename", "%q is not suffixed with a semver version", filename)
+	return "", nil
 }
 
 func TestReferenceRenderer(t *testing.T) {


### PR DESCRIPTION
I called a file something like `example-failure.json` and it caused this particular function to get stuck in a loop. I didn't notice for a few days because of (A) flakes and (B) the output not mentioning what had gone wrong. This PR raises a specific error if an entire filename is consumed without successfully parsing a semver version.