### PR TITLE
Add `--json` input support to `pulumi config set-all`

### DIFF
--- a/changelog/pending/20250505--cli-config--add-json-input-support-to-pulumi-config-set-all.yaml
+++ b/changelog/pending/20250505--cli-config--add-json-input-support-to-pulumi-config-set-all.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/config
+  description: Add `--json` input support to `pulumi config set-all`

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -853,19 +853,18 @@ func newConfigSetAllCmd(ws pkgWorkspace.Context, stack *string, lm cmdBackend.Lo
 			// loaded it.
 			var c config.Encrypter
 			encrypt := func(plaintext string) (string, error) {
+				var err error
 				if c == nil {
-					var cerr error
-
 					// We're always going to save, so can ignore the bool for if GetStackEncrypter changed the config data.
-					c, _, cerr = ssml.GetEncrypter(ctx, stack, ps)
-					if cerr != nil {
-						return "", cerr
+					c, _, err = ssml.GetEncrypter(ctx, stack, ps)
+					if err != nil {
+						return "", err
 					}
 				}
 
-				enc, eerr := c.EncryptValue(ctx, plaintext)
-				if eerr != nil {
-					return "", eerr
+				enc, err := c.EncryptValue(ctx, plaintext)
+				if err != nil {
+					return "", err
 				}
 
 				return enc, nil
@@ -877,9 +876,9 @@ func newConfigSetAllCmd(ws pkgWorkspace.Context, stack *string, lm cmdBackend.Lo
 					return err
 				}
 
-				enc, eerr := encrypt(value)
-				if eerr != nil {
-					return eerr
+				enc, err := encrypt(value)
+				if err != nil {
+					return err
 				}
 				v := config.NewSecureValue(enc)
 

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -50,7 +50,9 @@ import (
 
 // encrypterFactory provides encryption functionality for configuration values.
 type encrypterFactory interface {
-	GetEncrypter(ctx context.Context, stack backend.Stack, ps *workspace.ProjectStack) (config.Encrypter, cmdStack.SecretsManagerState, error)
+	GetEncrypter(
+		ctx context.Context, stack backend.Stack, ps *workspace.ProjectStack,
+	) (config.Encrypter, cmdStack.SecretsManagerState, error)
 }
 
 func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
@@ -778,7 +780,9 @@ func (c *configSetCmd) Run(
 	return cmdStack.SaveProjectStack(ctx, s, ps)
 }
 
-func newConfigSetAllCmd(ws pkgWorkspace.Context, stack *string, lm cmdBackend.LoginManager, ssml encrypterFactory) *cobra.Command {
+func newConfigSetAllCmd(
+	ws pkgWorkspace.Context, stack *string, lm cmdBackend.LoginManager, ssml encrypterFactory,
+) *cobra.Command {
 	var plaintextArgs []string
 	var secretArgs []string
 	var path bool

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -137,7 +137,7 @@ func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
 	cmd.AddCommand(newConfigRmCmd(ws, &stack))
 	cmd.AddCommand(newConfigRmAllCmd(ws, &stack))
 	cmd.AddCommand(newConfigSetCmd(ws, &stack))
-	cmd.AddCommand(newConfigSetAllCmd(ws, &stack))
+	cmd.AddCommand(newConfigSetAllCmd(ws, &stack, cmdBackend.DefaultLoginManager))
 	cmd.AddCommand(newConfigRefreshCmd(ws, &stack))
 	cmd.AddCommand(newConfigCopyCmd(ws, &stack))
 	cmd.AddCommand(newConfigEnvCmd(ws, &stack))
@@ -772,10 +772,11 @@ func (c *configSetCmd) Run(
 	return cmdStack.SaveProjectStack(ctx, s, ps)
 }
 
-func newConfigSetAllCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
+func newConfigSetAllCmd(ws pkgWorkspace.Context, stack *string, lm cmdBackend.LoginManager) *cobra.Command {
 	var plaintextArgs []string
 	var secretArgs []string
 	var path bool
+	var jsonArg string
 
 	setCmd := &cobra.Command{
 		Use:   "set-all --plaintext key1=value1 --plaintext key2=value2 --secret key3=value3",
@@ -790,10 +791,20 @@ func newConfigSetAllCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 			"  - `pulumi config set-all --path --plaintext parent.nested=value --plaintext parent.other=value2` \n" +
 			"    will set the value of `parent` to a map `{nested: value, other: value2}`.\n" +
 			"  - `pulumi config set-all --path --plaintext '[\"parent.name\"].[\"nested.name\"]'=value` will set the \n" +
-			"    value of `parent.name` to a map `nested.name: value`.",
+			"    value of `parent.name` to a map `nested.name: value`.\n\n" +
+			"The `--json` flag can be used to pass a JSON string from which values should be read.\n" +
+			"The JSON string should follow the same format as that produced by `pulumi config --json`. If the\n" +
+			"`--json` option is passed, the `--plaintext`, `--secret` and `--path` flags must not be used.",
 		Args: cmdutil.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+
+			// If the --json option is passed, the --plaintext, --secret and --path arguments are not allowed.
+			nonJSONArgs := len(plaintextArgs) > 0 || len(secretArgs) > 0 || path
+			if jsonArg != "" && nonJSONArgs {
+				return errors.New("the --json option cannot be used with the --plaintext, --secret or --path options")
+			}
+
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -808,7 +819,7 @@ func newConfigSetAllCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 				ctx,
 				cmdutil.Diag(),
 				ws,
-				cmdBackend.DefaultLoginManager,
+				lm,
 				*stack,
 				cmdStack.OfferNew,
 				opts,
@@ -837,18 +848,36 @@ func newConfigSetAllCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 
+			// We only want to fetch the stack encrypter once, and then only if we actually have one or more secrets to
+			// encrypt. We thus set up a little helper function to encrypt a value, caching the crypter once we've initially
+			// loaded it.
+			var c config.Encrypter
+			encrypt := func(plaintext string) (string, error) {
+				if c == nil {
+					var cerr error
+
+					// We're always going to save, so can ignore the bool for if GetStackEncrypter changed the config data.
+					c, _, cerr = ssml.GetEncrypter(ctx, stack, ps)
+					if cerr != nil {
+						return "", cerr
+					}
+				}
+
+				enc, eerr := c.EncryptValue(ctx, plaintext)
+				if eerr != nil {
+					return "", eerr
+				}
+
+				return enc, nil
+			}
+
 			for _, sArg := range secretArgs {
 				key, value, err := parseKeyValuePair(sArg, path)
 				if err != nil {
 					return err
 				}
-				// We're always going to save, so can ignore the bool for if getStackEncrypter changed the
-				// config data.
-				c, _, cerr := ssml.GetEncrypter(ctx, stack, ps)
-				if cerr != nil {
-					return cerr
-				}
-				enc, eerr := c.EncryptValue(ctx, value)
+
+				enc, eerr := encrypt(value)
 				if eerr != nil {
 					return eerr
 				}
@@ -857,6 +886,60 @@ func newConfigSetAllCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 				err = ps.Config.Set(key, v, path)
 				if err != nil {
 					return err
+				}
+			}
+
+			if jsonArg != "" {
+				jsonConfig := make(map[string]configValueJSON)
+				err := json.Unmarshal([]byte(jsonArg), &jsonConfig)
+				if err != nil {
+					return fmt.Errorf("could not parse --json argument: %w", err)
+				}
+
+				for jsonKey, jsonValue := range jsonConfig {
+					// Every key in the JSON must have a value. While `pulumi config --json` may produce empty values for secrets
+					// where --show-secrets is not passed, we don't allow setting those same (missing) values back into
+					// configuration.
+					if jsonValue.Value == nil {
+						return fmt.Errorf("value for --json object key %q is nil", jsonKey)
+					}
+
+					key, err := ParseConfigKey(ws, jsonKey, false /*path*/)
+					if err != nil {
+						return fmt.Errorf("invalid --json object key %q: %w", jsonKey, err)
+					}
+
+					var value config.Value
+					var path bool
+					if jsonValue.ObjectValue != nil {
+						// If we have an ObjectValue, Value will be the stringified version of the object. We'll thus operate on
+						// ObjectValue directly.
+						path = true
+						if jsonValue.Secret {
+							enc, err := encrypt(*jsonValue.Value)
+							if err != nil {
+								return err
+							}
+
+							value = config.NewSecureObjectValue(enc)
+						} else {
+							value = config.NewObjectValue(*jsonValue.Value)
+						}
+					} else if jsonValue.Secret {
+						enc, err := encrypt(*jsonValue.Value)
+						if err != nil {
+							return err
+						}
+
+						value = config.NewSecureValue(enc)
+					} else {
+						value = config.NewValue(*jsonValue.Value)
+					}
+
+					err = ps.Config.Set(key, value, path)
+					if err != nil {
+						return fmt.Errorf("could not set --json config for %q: %w", jsonKey, err)
+					}
 				}
 			}
 
@@ -873,6 +956,10 @@ func newConfigSetAllCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 	setCmd.PersistentFlags().StringArrayVar(
 		&secretArgs, "secret", []string{},
 		"Marks a value as secret to be encrypted")
+	setCmd.PersistentFlags().StringVar(
+		&jsonArg, "json", "",
+		"Read values from a JSON string in the format produced by 'pulumi config --json'",
+	)
 
 	return setCmd
 }

--- a/pkg/cmd/pulumi/config/config_test.go
+++ b/pkg/cmd/pulumi/config/config_test.go
@@ -267,7 +267,8 @@ func TestConfigSetAll(t *testing.T) {
 		{
 			name:       "secret values",
 			secretArgs: []string{"testProject:secretKey1=secret1", "testProject:secretKey2=secret2"},
-			expected:   "config:\n  testProject:secretKey1:\n    secure: c2VjcmV0MQ==\n  testProject:secretKey2:\n    secure: c2VjcmV0Mg==\n",
+			expected: "config:\n  testProject:secretKey1:\n    secure: c2VjcmV0MQ==\n" +
+				"  testProject:secretKey2:\n    secure: c2VjcmV0Mg==\n",
 		},
 		{
 			name:       "secret with path",
@@ -279,7 +280,8 @@ func TestConfigSetAll(t *testing.T) {
 			name:          "mixed plaintext and secret",
 			plaintextArgs: []string{"testProject:plainKey=plainValue"},
 			secretArgs:    []string{"testProject:secretKey=secretValue"},
-			expected:      "config:\n  testProject:plainKey: plainValue\n  testProject:secretKey:\n    secure: c2VjcmV0VmFsdWU=\n",
+			expected: "config:\n  testProject:plainKey: plainValue\n" +
+				"  testProject:secretKey:\n    secure: c2VjcmV0VmFsdWU=\n",
 		},
 		{
 			name:     "json plaintext values",
@@ -287,14 +289,18 @@ func TestConfigSetAll(t *testing.T) {
 			expected: "config:\n  testProject:key1: value1\n  testProject:key2: value2\n",
 		},
 		{
-			name:     "json secret values",
-			jsonArg:  `{"testProject:secretKey1": {"value": "secret1", "secret": true}, "testProject:secretKey2": {"value": "secret2", "secret": true}}`,
-			expected: "config:\n  testProject:secretKey1:\n    secure: c2VjcmV0MQ==\n  testProject:secretKey2:\n    secure: c2VjcmV0Mg==\n",
+			name: "json secret values",
+			jsonArg: `{"testProject:secretKey1": {"value": "secret1", "secret": true}, ` +
+				`"testProject:secretKey2": {"value": "secret2", "secret": true}}`,
+			expected: "config:\n  testProject:secretKey1:\n    secure: c2VjcmV0MQ==\n" +
+				"  testProject:secretKey2:\n    secure: c2VjcmV0Mg==\n",
 		},
 		{
-			name:     "json mixed plaintext and secret",
-			jsonArg:  `{"testProject:plainKey": {"value": "plainValue"}, "testProject:secretKey": {"value": "secretValue", "secret": true}}`,
-			expected: "config:\n  testProject:plainKey: plainValue\n  testProject:secretKey:\n    secure: c2VjcmV0VmFsdWU=\n",
+			name: "json mixed plaintext and secret",
+			jsonArg: `{"testProject:plainKey": {"value": "plainValue"}, ` +
+				`"testProject:secretKey": {"value": "secretValue", "secret": true}}`,
+			expected: "config:\n  testProject:plainKey: plainValue\n" +
+				"  testProject:secretKey:\n    secure: c2VjcmV0VmFsdWU=\n",
 		},
 		{
 			name:          "json with plaintext flag should error",
@@ -315,9 +321,11 @@ func TestConfigSetAll(t *testing.T) {
 			expectError: "the --json option cannot be used with the --plaintext, --secret or --path options",
 		},
 		{
-			name:        "json with invalid key",
-			jsonArg:     `{"testProject:key1:invalid": {"value": "value"}}`,
-			expectError: "invalid --json object key \"testProject:key1:invalid\": could not parse testProject:key1:invalid as a configuration key (configuration keys should be of the form `<namespace>:<name>`)",
+			name:    "json with invalid key",
+			jsonArg: `{"testProject:key1:invalid": {"value": "value"}}`,
+			expectError: "invalid --json object key \"testProject:key1:invalid\": " +
+				"could not parse testProject:key1:invalid as a configuration key " +
+				"(configuration keys should be of the form `<namespace>:<name>`)",
 		},
 		{
 			name:        "json with nil value",

--- a/pkg/cmd/pulumi/config/config_test.go
+++ b/pkg/cmd/pulumi/config/config_test.go
@@ -16,15 +16,20 @@ package config
 
 import (
 	"context"
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/require"
@@ -233,4 +238,227 @@ func TestConfigSetTypes(t *testing.T) {
 			require.Equal(t, c.expected, string(data))
 		})
 	}
+}
+
+//nolint:paralleltest // changes global ConfigFile variable
+func TestConfigSetAll(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name          string
+		plaintextArgs []string
+		secretArgs    []string
+		jsonArg       string
+		path          bool
+		expected      string
+		expectError   string
+	}{
+		{
+			name:          "plaintext values",
+			plaintextArgs: []string{"testProject:key1=value1", "testProject:key2=value2"},
+			expected:      "config:\n  testProject:key1: value1\n  testProject:key2: value2\n",
+		},
+		{
+			name:          "plaintext with path",
+			plaintextArgs: []string{"testProject:nested.key1=value1", "testProject:nested.key2=value2"},
+			path:          true,
+			expected:      "config:\n  testProject:nested:\n    key1: value1\n    key2: value2\n",
+		},
+		{
+			name:       "secret values",
+			secretArgs: []string{"testProject:secretKey1=secret1", "testProject:secretKey2=secret2"},
+			expected:   "config:\n  testProject:secretKey1:\n    secure: c2VjcmV0MQ==\n  testProject:secretKey2:\n    secure: c2VjcmV0Mg==\n",
+		},
+		{
+			name:       "secret with path",
+			secretArgs: []string{"testProject:nested.secret1=secret1"},
+			path:       true,
+			expected:   "config:\n  testProject:nested:\n    secret1:\n      secure: c2VjcmV0MQ==\n",
+		},
+		{
+			name:          "mixed plaintext and secret",
+			plaintextArgs: []string{"testProject:plainKey=plainValue"},
+			secretArgs:    []string{"testProject:secretKey=secretValue"},
+			expected:      "config:\n  testProject:plainKey: plainValue\n  testProject:secretKey:\n    secure: c2VjcmV0VmFsdWU=\n",
+		},
+		{
+			name:     "json plaintext values",
+			jsonArg:  `{"testProject:key1": {"value": "value1"}, "testProject:key2": {"value": "value2"}}`,
+			expected: "config:\n  testProject:key1: value1\n  testProject:key2: value2\n",
+		},
+		{
+			name:     "json secret values",
+			jsonArg:  `{"testProject:secretKey1": {"value": "secret1", "secret": true}, "testProject:secretKey2": {"value": "secret2", "secret": true}}`,
+			expected: "config:\n  testProject:secretKey1:\n    secure: c2VjcmV0MQ==\n  testProject:secretKey2:\n    secure: c2VjcmV0Mg==\n",
+		},
+		{
+			name:     "json mixed plaintext and secret",
+			jsonArg:  `{"testProject:plainKey": {"value": "plainValue"}, "testProject:secretKey": {"value": "secretValue", "secret": true}}`,
+			expected: "config:\n  testProject:plainKey: plainValue\n  testProject:secretKey:\n    secure: c2VjcmV0VmFsdWU=\n",
+		},
+		{
+			name:          "json with plaintext flag should error",
+			jsonArg:       `{"testProject:key": {"value": "val"}}`,
+			plaintextArgs: []string{"testProject:otherkey=value"},
+			expectError:   "the --json option cannot be used with the --plaintext, --secret or --path options",
+		},
+		{
+			name:        "json with secret flag should error",
+			jsonArg:     `{"testProject:key": {"value": "val"}}`,
+			secretArgs:  []string{"testProject:secretkey=secretvalue"},
+			expectError: "the --json option cannot be used with the --plaintext, --secret or --path options",
+		},
+		{
+			name:        "json with path flag should error",
+			jsonArg:     `{"testProject:key": {"value": "val"}}`,
+			path:        true,
+			expectError: "the --json option cannot be used with the --plaintext, --secret or --path options",
+		},
+		{
+			name:        "json with invalid key",
+			jsonArg:     `{"testProject:key1:invalid": {"value": "value"}}`,
+			expectError: "invalid --json object key \"testProject:key1:invalid\": could not parse testProject:key1:invalid as a configuration key (configuration keys should be of the form `<namespace>:<name>`)",
+		},
+		{
+			name:        "json with nil value",
+			jsonArg:     `{"testProject:key1": {"value": null}}`,
+			expected:    "config:\n  testProject:key1: null\n",
+			expectError: `value for --json object key "testProject:key1" is nil`,
+		},
+		{
+			name:        "json with malformed input",
+			jsonArg:     `{`, // missing closing braces
+			expectError: "could not parse --json argument: unexpected end of JSON input",
+		},
+		{
+			name:     "json with object value",
+			jsonArg:  `{"testProject:key1": {"value": "{\"inner\":\"value2\"}", "objectValue": {"inner": "value2"}}}`,
+			expected: "config:\n  testProject:key1:\n    inner: value2\n",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			s := backend.MockStack{
+				RefF: func() backend.StackReference {
+					return &backend.MockStackReference{
+						NameV: tokens.MustParseStackName("testStack"),
+					}
+				},
+				ConfigLocationF: func() backend.StackConfigLocation {
+					return backend.StackConfigLocation{}
+				},
+			}
+
+			tmpdir := t.TempDir()
+			stack.ConfigFile = filepath.Join(tmpdir, "Pulumi.stack.yaml")
+			defer func() {
+				stack.ConfigFile = ""
+			}()
+
+			ws := &pkgWorkspace.MockContext{
+				ReadProjectF: func() (*workspace.Project, string, error) {
+					return &workspace.Project{
+						Name: "testProject",
+					}, "", nil
+				},
+			}
+
+			// Create the command
+			stackName := "testStack"
+			lm := &cmdBackend.MockLoginManager{
+				CurrentF: func(
+					ctx context.Context,
+					ws pkgWorkspace.Context,
+					sink diag.Sink,
+					url string,
+					project *workspace.Project,
+					setCurrent bool,
+				) (backend.Backend, error) {
+					return &backend.MockBackend{
+						GetStackF: func(ctx context.Context, ref backend.StackReference) (backend.Stack, error) {
+							return &s, nil
+						},
+					}, nil
+				},
+				LoginF: func(
+					ctx context.Context,
+					ws pkgWorkspace.Context,
+					sink diag.Sink,
+					url string,
+					project *workspace.Project,
+					setCurrent bool,
+					color colors.Colorization,
+				) (backend.Backend, error) {
+					return &backend.MockBackend{
+						GetStackF: func(ctx context.Context, ref backend.StackReference) (backend.Stack, error) {
+							return &s, nil
+						},
+					}, nil
+				},
+			}
+
+			// Create mock encrypter factory
+			mockEncrypterFactory := &mockEncrypterFactory{
+				encrypter: &secrets.MockEncrypter{
+					EncryptValueF: func(plaintext string) string {
+						return base64.StdEncoding.EncodeToString([]byte(plaintext))
+					},
+				},
+			}
+
+			cmd := newConfigSetAllCmd(ws, &stackName, lm, mockEncrypterFactory)
+			cmd.SetContext(ctx)
+
+			// Set flags based on test case
+			if c.jsonArg != "" {
+				err := cmd.PersistentFlags().Set("json", c.jsonArg)
+				require.NoError(t, err)
+			}
+			for _, pt := range c.plaintextArgs {
+				err := cmd.PersistentFlags().Set("plaintext", pt)
+				require.NoError(t, err)
+			}
+
+			for _, sec := range c.secretArgs {
+				err := cmd.PersistentFlags().Set("secret", sec)
+				require.NoError(t, err)
+			}
+			if c.path {
+				err := cmd.PersistentFlags().Set("path", "true")
+				require.NoError(t, err)
+			}
+
+			// Execute the command
+			err := cmd.RunE(cmd, []string{})
+
+			// Check for expected error
+			if c.expectError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), c.expectError)
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Verify the config was set correctly
+			data, err := os.ReadFile(stack.ConfigFile)
+			require.NoError(t, err)
+
+			require.Equal(t, c.expected, string(data))
+		})
+	}
+}
+
+type mockEncrypterFactory struct {
+	encrypter config.Encrypter
+}
+
+func (m *mockEncrypterFactory) GetEncrypter(
+	_ context.Context,
+	_ backend.Stack,
+	_ *workspace.ProjectStack,
+) (config.Encrypter, stack.SecretsManagerState, error) {
+	return m.encrypter, stack.SecretsManagerUnchanged, nil
 }

--- a/pkg/cmd/pulumi/config/config_test.go
+++ b/pkg/cmd/pulumi/config/config_test.go
@@ -346,7 +346,6 @@ func TestConfigSetAll(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			s := backend.MockStack{
 				RefF: func() backend.StackReference {

--- a/pkg/cmd/pulumi/config/config_test.go
+++ b/pkg/cmd/pulumi/config/config_test.go
@@ -396,6 +396,7 @@ func TestConfigSetAll(t *testing.T) {
 					url string,
 					project *workspace.Project,
 					setCurrent bool,
+					insecure bool,
 					color colors.Colorization,
 				) (backend.Backend, error) {
 					return &backend.MockBackend{

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1114,7 +1114,7 @@ description: A Pulumi program testing config set-all --json.
 	assert.Equal(t, "[\"foo\"]", myList["value"])
 	myListObjectValue := myList["objectValue"].([]interface{})
 	assert.Contains(t, myListObjectValue, "foo")
-	assert.Len(t, myListObjectValue, 1)
+	require.Len(t, myListObjectValue, 1)
 
 	// Assert that myList[0], a scalar (--json input does _not_ set --path), has the correct value.
 	myList0, ok := config["pulumi-test:myList[0]"].(map[string]interface{})

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1087,7 +1087,7 @@ description: A Pulumi program testing config set-all --json.
 
 	// Retrieve configuration, including secrets, in JSON format and unmarshal it.
 	jsonOutputWithSecrets, _ := e.RunCommand("pulumi", configShow("--json", "--show-secrets")...)
-	var config map[string]interface{}
+	var config map[string]any
 	err := json.Unmarshal([]byte(jsonOutputWithSecrets), &config)
 	assert.Nil(t, err)
 	assert.Equal(t, jsonInput, jsonOutputWithSecrets)
@@ -1097,27 +1097,27 @@ description: A Pulumi program testing config set-all --json.
 
 	// Retrieve configuration, not including secrets, in JSON format and unmarshal it.
 	jsonOutputWithoutSecrets, _ := e.RunCommand("pulumi", configShow("--json")...)
-	var configWithoutSecrets map[string]interface{}
+	var configWithoutSecrets map[string]any
 	err = json.Unmarshal([]byte(jsonOutputWithoutSecrets), &configWithoutSecrets)
 	assert.Nil(t, err)
 
 	// Assert that key1, a scalar, has the correct value.
-	key1, ok := config["pulumi-test:key1"].(map[string]interface{})
+	key1, ok := config["pulumi-test:key1"].(map[string]any)
 	assert.Truef(t, ok, "key1 should be a JSON object")
 
 	assert.Equal(t, "value1", key1["value"])
 
 	// Assert that myList, a nested list, has the correct value.
-	myList, ok := config["pulumi-test:myList"].(map[string]interface{})
+	myList, ok := config["pulumi-test:myList"].(map[string]any)
 	assert.Truef(t, ok, "myList should be a JSON object")
 
 	assert.Equal(t, "[\"foo\"]", myList["value"])
-	myListObjectValue := myList["objectValue"].([]interface{})
+	myListObjectValue := myList["objectValue"].([]any)
 	assert.Contains(t, myListObjectValue, "foo")
 	require.Len(t, myListObjectValue, 1)
 
 	// Assert that myList[0], a scalar (--json input does _not_ set --path), has the correct value.
-	myList0, ok := config["pulumi-test:myList[0]"].(map[string]interface{})
+	myList0, ok := config["pulumi-test:myList[0]"].(map[string]any)
 	assert.Truef(t, ok, "myList[0] should be a JSON object")
 
 	assert.Equal(t, "foo", myList0["value"])
@@ -1125,7 +1125,7 @@ description: A Pulumi program testing config set-all --json.
 	assert.Falsef(t, ok, "myList[0] should not have an objectValue key")
 
 	// Assert that my_token, a scalar secret, has the correct value in the configuration we loaded with secrets.
-	myToken, ok := config["pulumi-test:my_token"].(map[string]interface{})
+	myToken, ok := config["pulumi-test:my_token"].(map[string]any)
 	assert.Truef(t, ok, "my_token should be a JSON object")
 
 	assert.Equal(t, "my_secret_token", myToken["value"])
@@ -1134,18 +1134,18 @@ description: A Pulumi program testing config set-all --json.
 	assert.Truef(t, ok && secret, "my_token should be a secret in the configuration with secrets")
 
 	// Assert that my_token, a scalar secret, does not have a value in the configuration we loaded without secrets.
-	_, ok = configWithoutSecrets["pulumi-test:my_token"].(map[string]interface{})["value"]
+	_, ok = configWithoutSecrets["pulumi-test:my_token"].(map[string]any)["value"]
 	assert.Falsef(t, ok, "my_token should not have a value in the configuration without secrets")
 
 	// Assert that outer, an object value, has the correct value.
-	outer, ok := config["pulumi-test:outer"].(map[string]interface{})
+	outer, ok := config["pulumi-test:outer"].(map[string]any)
 	assert.Truef(t, ok, "outer should be a JSON object")
 
-	outerObjectValue := outer["objectValue"].(map[string]interface{})
+	outerObjectValue := outer["objectValue"].(map[string]any)
 	assert.Equal(t, "value2", outerObjectValue["inner"])
 
 	// Assert that outer.inner, a scalar (--json input does _not_ set --path), has the correct value.
-	outerInner, ok := config["pulumi-test:outer.inner"].(map[string]interface{})
+	outerInner, ok := config["pulumi-test:outer.inner"].(map[string]any)
 	assert.Truef(t, ok, "outer.inner should be a JSON object")
 
 	assert.Equal(t, "value2", outerInner["value"])

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1018,6 +1018,141 @@ description: A Pulumi program testing config rm and config rm-all.
 	assert.Contains(t, stderr, "'baz' not found")
 }
 
+func TestConfigSetAllJSON(t *testing.T) {
+	t.Parallel()
+
+	e := ptesting.NewEnvironment(t)
+	e.Passphrase = "test-passphrase"
+	defer e.DeleteIfNotFailed()
+
+	pulumiProject := `
+name: config-set-all-json-test
+runtime: yaml
+description: A Pulumi program testing config set-all --json.
+`
+
+	integration.CreatePulumiRepo(e, pulumiProject)
+	e.SetBackend(e.LocalURL())
+	e.RunCommand("pulumi", "stack", "init", "config-set-all-json-test")
+
+	configCmd := func(cmd string) func(args ...string) []string {
+		return func(args ...string) []string {
+			if cmd != "" {
+				return append([]string{"config", cmd}, args...)
+			}
+
+			return append([]string{"config"}, args...)
+		}
+	}
+
+	configShow := configCmd("")
+	configSetAll := configCmd("set-all")
+
+	// Set configuration all at once using the --json flag.
+	jsonInput := `{
+  "pulumi-test:key1": {
+    "value": "value1",
+    "secret": false
+  },
+  "pulumi-test:myList": {
+    "value": "[\"foo\"]",
+    "objectValue": [
+      "foo"
+    ],
+    "secret": false
+  },
+  "pulumi-test:myList[0]": {
+    "value": "foo",
+    "secret": false
+  },
+  "pulumi-test:my_token": {
+    "value": "my_secret_token",
+    "secret": true
+  },
+  "pulumi-test:outer": {
+    "value": "{\"inner\":\"value2\"}",
+    "objectValue": {
+      "inner": "value2"
+    },
+    "secret": false
+  },
+  "pulumi-test:outer.inner": {
+    "value": "value2",
+    "secret": false
+  }
+}
+`
+
+	e.RunCommand("pulumi", configSetAll("--json", jsonInput)...)
+
+	// Retrieve configuration, including secrets, in JSON format and unmarshal it.
+	jsonOutputWithSecrets, _ := e.RunCommand("pulumi", configShow("--json", "--show-secrets")...)
+	var config map[string]interface{}
+	err := json.Unmarshal([]byte(jsonOutputWithSecrets), &config)
+	assert.Nil(t, err)
+	assert.Equal(t, jsonInput, jsonOutputWithSecrets)
+
+	// When secrets are included, the retrieved configuration should match that we sent in exactly.
+	assert.Equal(t, jsonInput, jsonOutputWithSecrets)
+
+	// Retrieve configuration, not including secrets, in JSON format and unmarshal it.
+	jsonOutputWithoutSecrets, _ := e.RunCommand("pulumi", configShow("--json")...)
+	var configWithoutSecrets map[string]interface{}
+	err = json.Unmarshal([]byte(jsonOutputWithoutSecrets), &configWithoutSecrets)
+	assert.Nil(t, err)
+
+	// Assert that key1, a scalar, has the correct value.
+	key1, ok := config["pulumi-test:key1"].(map[string]interface{})
+	assert.Truef(t, ok, "key1 should be a JSON object")
+
+	assert.Equal(t, "value1", key1["value"])
+
+	// Assert that myList, a nested list, has the correct value.
+	myList, ok := config["pulumi-test:myList"].(map[string]interface{})
+	assert.Truef(t, ok, "myList should be a JSON object")
+
+	assert.Equal(t, "[\"foo\"]", myList["value"])
+	myListObjectValue := myList["objectValue"].([]interface{})
+	assert.Contains(t, myListObjectValue, "foo")
+	assert.Len(t, myListObjectValue, 1)
+
+	// Assert that myList[0], a scalar (--json input does _not_ set --path), has the correct value.
+	myList0, ok := config["pulumi-test:myList[0]"].(map[string]interface{})
+	assert.Truef(t, ok, "myList[0] should be a JSON object")
+
+	assert.Equal(t, "foo", myList0["value"])
+	_, ok = myList0["objectValue"]
+	assert.Falsef(t, ok, "myList[0] should not have an objectValue key")
+
+	// Assert that my_token, a scalar secret, has the correct value in the configuration we loaded with secrets.
+	myToken, ok := config["pulumi-test:my_token"].(map[string]interface{})
+	assert.Truef(t, ok, "my_token should be a JSON object")
+
+	assert.Equal(t, "my_secret_token", myToken["value"])
+	secretValue := myToken["secret"]
+	secret, ok := secretValue.(bool)
+	assert.Truef(t, ok && secret, "my_token should be a secret in the configuration with secrets")
+
+	// Assert that my_token, a scalar secret, does not have a value in the configuration we loaded without secrets.
+	_, ok = configWithoutSecrets["pulumi-test:my_token"].(map[string]interface{})["value"]
+	assert.Falsef(t, ok, "my_token should not have a value in the configuration without secrets")
+
+	// Assert that outer, an object value, has the correct value.
+	outer, ok := config["pulumi-test:outer"].(map[string]interface{})
+	assert.Truef(t, ok, "outer should be a JSON object")
+
+	outerObjectValue := outer["objectValue"].(map[string]interface{})
+	assert.Equal(t, "value2", outerObjectValue["inner"])
+
+	// Assert that outer.inner, a scalar (--json input does _not_ set --path), has the correct value.
+	outerInner, ok := config["pulumi-test:outer.inner"].(map[string]interface{})
+	assert.Truef(t, ok, "outer.inner should be a JSON object")
+
+	assert.Equal(t, "value2", outerInner["value"])
+	_, ok = outerInner["objectValue"]
+	assert.Falsef(t, ok, "outer.inner should not have an objectValue key")
+}
+
 // Regression test for https://github.com/pulumi/pulumi/issues/12593.
 //
 // Verifies that a "provider" option passed to a remote component


### PR DESCRIPTION
This change brings the work done by @arthurgavazza (thanks, @arthurgavazza!) in #12558 up-to-date, rebasing it and addressing the comments left on the PR. In doing so, it adds the `--json` flag to the `pulumi config set-all` command, so that users can bulk set configuration using a JSON string in the same format as produced by `pulumi config --json`.

Note that the command takes a JSON _value_, not a JSON _file_.

Fixes #11872
Closes #12558