### PR TITLE
Reorder golangci-lint in mise.toml

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,17 +1,15 @@
 [env]
 PULUMI_ROOT = "{{config_root}}/.root"
 
-_.path = [
-  "{{env.PULUMI_ROOT}}/bin",
-]
+_.path = ["{{env.PULUMI_ROOT}}/bin"]
 
 [tools]
 github-cli = "latest"
 "go:github.com/go-delve/delve/cmd/dlv" = "latest"
 "go:golang.org/x/tools/gopls" = "latest"
+golangci-lint = "1.64.2"
 go = "1.24"
 gofumpt = "latest"
-golangci-lint = "1.64.2"
 jq = "latest"
 node = "20"
 "npm:pnpm" = "latest"


### PR DESCRIPTION
previously the ordering was (at least on my machine) causing the path to
be used by the go installation of golangci-lint.
