### PR TITLE
Add `additionalSecretOutputs` to NodeJS `ComponentResourceOptions`

### DIFF
--- a/changelog/pending/20250506--sdk-nodejs--pass-additionalsecretoutputs-list-to-a-provider-constructor.yaml
+++ b/changelog/pending/20250506--sdk-nodejs--pass-additionalsecretoutputs-list-to-a-provider-constructor.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Pass `additionalSecretOutputs` list to a Provider constructor

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -396,6 +396,7 @@ class Server implements grpc.UntypedServiceImplementation {
                 }
                 const opts: resource.ComponentResourceOptions = {
                     aliases: req.getAliasesList(),
+                    additionalSecretOutputs: req.getAdditionalsecretoutputsList(),
                     dependsOn: dependsOn,
                     protect: req.getProtect(),
                     providers: providers,

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -757,6 +757,11 @@ export interface ResourceOptions {
     aliases?: Input<URN | Alias>[];
 
     /**
+     * A list of output properties to mark as secret.
+     */
+    additionalSecretOutputs?: string[];
+
+    /**
      * An optional provider to use for this resource's CRUD operations. If no provider is supplied,
      * the default provider for the resource's package will be used. The default provider is pulled
      * from the parent's provider bag (see also ComponentResourceOptions.providers).


### PR DESCRIPTION
The first of the extra custom resource options. This PR, and those that follow, pass extra custom resource options to the provider's constructor.

* #12154