### PR TITLE
Fix race condition when rendering progress events

### DIFF
--- a/changelog/pending/20250506--cli-display--fix-race-condition-when-rendering-progress-events.yaml
+++ b/changelog/pending/20250506--cli-display--fix-race-condition-when-rendering-progress-events.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Fix race condition when rendering progress events


### PR DESCRIPTION
When we are installing plugins as part of a Pulumi operation (e.g. `pulumi up`), we'll render a series of progress bars to show the user what is going on. Under the hood, the CLI manages this by responding to progress events, tracking them in a map and rendering them as system messages. Concurrent access to this map is guarded by a mutex.

Recently, #17594 was re-opened due to users experiencing hangs/locking behaviour when installing plugins as part of an update. While we don't have a solid reproduction, we do have some data from occurrences which suggests that the system is idle, and thus most likely deadlocked. If so, given that we did not see these issues prior to the introduction of progress events, we can reason that the mutex guarding the progress events map is the cause of this deadlock.

Digging in, we find one possible culprit. The `handleProgressEvent` method uses a `defer` statement to unlock the mutex after completing its operation. However, prior to return, it calls `renderer.progress`, which _can_ in some circumstances call back into methods requiring the same lock (`generateTreeNodes`). This could cause a nested-lock deadlock, in which the same Goroutine attempts to call `Lock()` twice, deadlocking.

Assuming this is indeed the cause (one can hope, at least), this change fixes it, moving the `Unlock` call above the call to `renderer.progress`. This should still be data-race-safe -- the events map is still protected -- but tightens the bound of the critical section to one in which deadlocks can no longer occur.

Fixes #17594