### PR TITLE
Add some NodeJS request types

### DIFF
--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -300,8 +300,8 @@ class Server implements grpc.UntypedServiceImplementation {
             const req: provproto.UpdateRequest = call.request;
             const resp = new provproto.UpdateResponse();
 
-            const olds = req.getOlds().toJavaScript();
-            const news = req.getNews().toJavaScript();
+            const olds = req.getOlds()!.toJavaScript();
+            const news = req.getNews()!.toJavaScript();
 
             let result: any = {};
             if (this.provider.update) {
@@ -320,7 +320,7 @@ class Server implements grpc.UntypedServiceImplementation {
     public async delete(call: any, callback: any): Promise<void> {
         try {
             const req: provproto.DeleteRequest = call.request;
-            const props: any = req.getProperties().toJavaScript();
+            const props: any = req.getProperties()!.toJavaScript();
             if (this.provider.delete) {
                 await this.provider.delete(req.getId(), req.getUrn(), props);
             }

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -85,7 +85,7 @@ class Server implements grpc.UntypedServiceImplementation {
     }
 
     public getSchema(call: any, callback: any): void {
-        const req: any = call.request;
+        const req: provproto.GetSchemaRequest = call.request;
         if (req.getVersion() !== 0) {
             callback(new Error(`unsupported schema version ${req.getVersion()}`), undefined);
             return;
@@ -173,11 +173,11 @@ class Server implements grpc.UntypedServiceImplementation {
 
     public async check(call: any, callback: any): Promise<void> {
         try {
-            const req: any = call.request;
+            const req: provproto.CheckRequest = call.request;
             const resp = new provproto.CheckResponse();
 
-            const olds = req.getOlds().toJavaScript();
-            const news = req.getNews().toJavaScript();
+            const olds = req.getOlds()!.toJavaScript();
+            const news = req.getNews()!.toJavaScript();
 
             let inputs: any = news;
             let failures: any[] = [];
@@ -216,11 +216,11 @@ class Server implements grpc.UntypedServiceImplementation {
 
     public async diff(call: any, callback: any): Promise<void> {
         try {
-            const req: any = call.request;
+            const req: provproto.DiffRequest = call.request;
             const resp = new provproto.DiffResponse();
 
-            const olds = req.getOlds().toJavaScript();
-            const news = req.getNews().toJavaScript();
+            const olds = req.getOlds()!.toJavaScript();
+            const news = req.getNews()!.toJavaScript();
             if (this.provider.diff) {
                 const result: any = await this.provider.diff(req.getId(), req.getUrn(), olds, news);
 
@@ -249,14 +249,14 @@ class Server implements grpc.UntypedServiceImplementation {
 
     public async create(call: any, callback: any): Promise<void> {
         try {
-            const req: any = call.request;
+            const req: provproto.CreateRequest = call.request;
             if (!this.provider.create) {
                 callback(new Error(`unknown resource type ${req.getUrn()}`), undefined);
                 return;
             }
 
             const resp = new provproto.CreateResponse();
-            const props = req.getProperties().toJavaScript();
+            const props = req.getProperties()!.toJavaScript();
             const result = await this.provider.create(req.getUrn(), props);
             resp.setId(result.id);
             resp.setProperties(structproto.Struct.fromJavaScript(result.outs));
@@ -270,11 +270,11 @@ class Server implements grpc.UntypedServiceImplementation {
 
     public async read(call: any, callback: any): Promise<void> {
         try {
-            const req: any = call.request;
+            const req: provproto.ReadRequest = call.request;
             const resp = new provproto.ReadResponse();
 
             const id = req.getId();
-            const props = req.getProperties().toJavaScript();
+            const props = req.getProperties()!.toJavaScript();
             if (this.provider.read) {
                 const result: any = await this.provider.read(id, req.getUrn(), props);
                 resp.setId(result.id);
@@ -297,7 +297,7 @@ class Server implements grpc.UntypedServiceImplementation {
 
     public async update(call: any, callback: any): Promise<void> {
         try {
-            const req: any = call.request;
+            const req: provproto.UpdateRequest = call.request;
             const resp = new provproto.UpdateResponse();
 
             const olds = req.getOlds().toJavaScript();
@@ -319,7 +319,7 @@ class Server implements grpc.UntypedServiceImplementation {
 
     public async delete(call: any, callback: any): Promise<void> {
         try {
-            const req: any = call.request;
+            const req: provproto.DeleteRequest = call.request;
             const props: any = req.getProperties().toJavaScript();
             if (this.provider.delete) {
                 await this.provider.delete(req.getId(), req.getUrn(), props);
@@ -369,7 +369,7 @@ class Server implements grpc.UntypedServiceImplementation {
             const callbackId = Symbol("id");
             this._callbacks.set(callbackId, callback);
             try {
-                const req: any = call.request;
+                const req: provproto.ConstructRequest = call.request;
                 const type = req.getType();
                 const name = req.getName();
 
@@ -380,7 +380,7 @@ class Server implements grpc.UntypedServiceImplementation {
 
                 await configureRuntime(req, this.engineAddr);
 
-                const inputs = await deserializeInputs(req.getInputs(), req.getInputdependenciesMap());
+                const inputs = await deserializeInputs(req.getInputs()!, req.getInputdependenciesMap());
 
                 // Rebuild the resource options.
                 const dependsOn: resource.Resource[] = [];
@@ -451,7 +451,7 @@ class Server implements grpc.UntypedServiceImplementation {
             const callbackId = Symbol("id");
             this._callbacks.set(callbackId, callback);
             try {
-                const req: any = call.request;
+                const req: provproto.CallRequest = call.request;
                 if (!this.provider.call) {
                     callback(new Error(`unknown function ${req.getTok()}`), undefined);
                     return;
@@ -459,7 +459,7 @@ class Server implements grpc.UntypedServiceImplementation {
 
                 await configureRuntime(req, this.engineAddr);
 
-                const args = await deserializeInputs(req.getArgs(), req.getArgdependenciesMap());
+                const args = await deserializeInputs(req.getArgs()!, req.getArgdependenciesMap());
 
                 const result = await this.provider.call(req.getTok(), args);
 
@@ -516,13 +516,13 @@ class Server implements grpc.UntypedServiceImplementation {
 
     public async invoke(call: any, callback: any): Promise<void> {
         try {
-            const req: any = call.request;
+            const req: provproto.InvokeRequest = call.request;
             if (!this.provider.invoke) {
                 callback(new Error(`unknown function ${req.getTok()}`), undefined);
                 return;
             }
 
-            const args: any = req.getArgs().toJavaScript();
+            const args: any = req.getArgs()!.toJavaScript();
             const result = await this.provider.invoke(req.getTok(), args);
 
             const resp = new provproto.InvokeResponse();


### PR DESCRIPTION
I _think_ this should be an absolute no-op, as these types don't seem to escape these functions.

We actually have types for the things we expect these to be, and if we're wrong, everything will still fail in exactly the same way as before this PR. This change should just mean that the LSP is a bit more useful.