### PR TITLE
make namespaces we get from git repos always lowercase

### DIFF
--- a/changelog/pending/20250506--cli-package--make-sure-namespaces-from-git-plugins-are-always-lowercase.yaml
+++ b/changelog/pending/20250506--cli-package--make-sure-namespaces-from-git-plugins-are-always-lowercase.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/package
+  description: Make sure namespaces from Git Plugins are always lowercase

--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -609,7 +609,7 @@ func setSpecNamespace(spec *schema.PackageSpec, pluginSpec workspace.PluginSpec)
 		namespaceRegex := regexp.MustCompile(`git://[^/]+/([^/]+)/`)
 		matches := namespaceRegex.FindStringSubmatch(pluginSpec.PluginDownloadURL)
 		if len(matches) == 2 {
-			spec.Namespace = matches[1]
+			spec.Namespace = strings.ToLower(matches[1])
 		}
 	}
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1604,6 +1604,22 @@ func TestOverrideComponentNamespace(t *testing.T) {
 	require.Equal(t, "pulumi", packageSpec.Namespace)
 }
 
+func TestOverrideNamespaceLowercase(t *testing.T) {
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+
+	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
+	stdout, _ := e.RunCommand("pulumi", "package", "get-schema",
+		"github.com/Pulumi/component-test-providers/test-provider@b39e20e4e33600e33073ccb2df0ddb46388641dc")
+	var packageSpec schema.PackageSpec
+	err := json.Unmarshal([]byte(stdout), &packageSpec)
+	require.NoError(t, err)
+	// Without the override in the `package` command we'd expect the namespace to be empty here. Check that
+	// it is 'pulumi', which we get from `github.com/*Pulumi*/....; note that namespaces only allow lowercasee
+	// characters, so we lowercase it automatically.
+	require.Equal(t, "pulumi", packageSpec.Namespace)
+}
+
 func TestTaggedComponent(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Namespaces are only allowed to be lowercase.  For git repos we take them from the URL, which is allowed to have uppercase characters and is usually not case sensitive.  Automatically lowercase the namespace, so this always works and doesn't confuse users that use components from Git repos that don't have an explicit namespace set.

E.g. someone might use `pulumi package add github.com/Pulumi/xyz-component`, which should just use the lowercase `pulumi` (as that's what the URL is pointing to because of case insensitivity), instead of `Pulumi`.