### PR TITLE
Add MainWithContext to allow for provider cancellation

### DIFF
--- a/changelog/pending/20250506--pkg--add-mainctx-to-allow-for-provider-cancelation.yaml
+++ b/changelog/pending/20250506--pkg--add-mainctx-to-allow-for-provider-cancelation.yaml
@@ -1,0 +1,4 @@
+changes:
+  - type: feat
+    scope: pkg
+    description: Add MainWithContext to allow for provider cancelation

--- a/pkg/resource/provider/main.go
+++ b/pkg/resource/provider/main.go
@@ -36,6 +36,11 @@ var tracing string
 // Main is the typical entrypoint for a resource provider plugin.  Using it isn't required but can cut down
 // significantly on the amount of boilerplate necessary to fire up a new resource provider.
 func Main(name string, provMaker func(*HostClient) (pulumirpc.ResourceProviderServer, error)) error {
+	return MainWithContext(context.Background(), name, provMaker)
+}
+
+// MainWithContext is the same as Main but it accepts a context so it can be cancelled.
+func MainWithContext(ctx context.Context, name string, provMaker func(*HostClient) (pulumirpc.ResourceProviderServer, error)) error {
 	flag.StringVar(&tracing, "tracing", "", "Emit tracing to a Zipkin-compatible tracing endpoint")
 	flag.Parse()
 
@@ -57,7 +62,7 @@ func Main(name string, provMaker func(*HostClient) (pulumirpc.ResourceProviderSe
 		}
 
 		// If we have a host cancel our cancellation context if it fails the healthcheck
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(ctx)
 		// map the context Done channel to the rpcutil boolean cancel channel
 		cancelChannel = make(chan bool)
 		go func() {


### PR DESCRIPTION
`provider.Main` currently forces `context.Background()`, but this is better left up to the caller. For example if I want to run a test provider in-process for 1 second, I should be able to do that by passing a context with a timeout.

For backward compatibility we keep `Main` as-is and introduce `MainWithContext` alongside it.