### PR TITLE
Fix the return type of the PCL `call` intrinsic

### DIFF
--- a/pkg/codegen/pcl/call.go
+++ b/pkg/codegen/pcl/call.go
@@ -118,7 +118,7 @@ func (b *binder) bindCallSignature(args []model.Expression) (model.StaticFunctio
 				Type: sigArgsType,
 			},
 		},
-		ReturnType: b.schemaTypeToType(method.Function.ReturnType),
+		ReturnType: model.NewOutputType(b.schemaTypeToType(method.Function.ReturnType)),
 	}
 
 	if argsObject, isObjectExpression := args[1].(*model.ObjectConsExpression); isObjectExpression {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-component-call-simple/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-component-call-simple/index.ts
@@ -2,7 +2,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as component from "@pulumi/component";
 
 const component1 = new component.ComponentCallable("component1", {value: "bar"});
-export const from_identity = component1.identity().result;
+export const from_identity = component1.identity().apply(call => call.result);
 export const from_prefixed = component1.prefixed(({
     prefix: "foo-",
-})).result;
+})).apply(call => call.result);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-provider-call-explicit/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-provider-call-explicit/index.ts
@@ -5,8 +5,8 @@ const explicitProv = new call.Provider("explicitProv", {value: "explicitProvValu
 const explicitRes = new call.Custom("explicitRes", {value: "explicitValue"}, {
     provider: explicitProv,
 });
-export const explicitProviderValue = explicitRes.providerValue().result;
-export const explicitProvFromIdentity = explicitProv.identity().result;
+export const explicitProviderValue = explicitRes.providerValue().apply(call => call.result);
+export const explicitProvFromIdentity = explicitProv.identity().apply(call => call.result);
 export const explicitProvFromPrefixed = explicitProv.prefixed(({
     prefix: "call-prefix-",
-})).result;
+})).apply(call => call.result);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-provider-call/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-provider-call/index.ts
@@ -2,4 +2,4 @@ import * as pulumi from "@pulumi/pulumi";
 import * as call from "@pulumi/call";
 
 const defaultRes = new call.Custom("defaultRes", {value: "defaultValue"});
-export const defaultProviderValue = defaultRes.providerValue().result;
+export const defaultProviderValue = defaultRes.providerValue().apply(call => call.result);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-component-call-simple/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-component-call-simple/index.ts
@@ -2,7 +2,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as component from "@pulumi/component";
 
 const component1 = new component.ComponentCallable("component1", {value: "bar"});
-export const from_identity = component1.identity().result;
+export const from_identity = component1.identity().apply(call => call.result);
 export const from_prefixed = component1.prefixed(({
     prefix: "foo-",
-})).result;
+})).apply(call => call.result);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-provider-call-explicit/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-provider-call-explicit/index.ts
@@ -5,8 +5,8 @@ const explicitProv = new call.Provider("explicitProv", {value: "explicitProvValu
 const explicitRes = new call.Custom("explicitRes", {value: "explicitValue"}, {
     provider: explicitProv,
 });
-export const explicitProviderValue = explicitRes.providerValue().result;
-export const explicitProvFromIdentity = explicitProv.identity().result;
+export const explicitProviderValue = explicitRes.providerValue().apply(call => call.result);
+export const explicitProvFromIdentity = explicitProv.identity().apply(call => call.result);
 export const explicitProvFromPrefixed = explicitProv.prefixed(({
     prefix: "call-prefix-",
-})).result;
+})).apply(call => call.result);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-provider-call/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-provider-call/index.ts
@@ -2,4 +2,4 @@ import * as pulumi from "@pulumi/pulumi";
 import * as call from "@pulumi/call";
 
 const defaultRes = new call.Custom("defaultRes", {value: "defaultValue"});
-export const defaultProviderValue = defaultRes.providerValue().result;
+export const defaultProviderValue = defaultRes.providerValue().apply(call => call.result);

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-component-call-simple/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-component-call-simple/__main__.py
@@ -2,5 +2,5 @@ import pulumi
 import pulumi_component as component
 
 component1 = component.ComponentCallable("component1", value="bar")
-pulumi.export("from_identity", component1.identity().result)
-pulumi.export("from_prefixed", component1.prefixed(prefix="foo-").result)
+pulumi.export("from_identity", component1.identity().apply(lambda call: call.result))
+pulumi.export("from_prefixed", component1.prefixed(prefix="foo-").apply(lambda call: call.result))

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-provider-call-explicit/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-provider-call-explicit/__main__.py
@@ -4,6 +4,6 @@ import pulumi_call as call
 explicit_prov = call.Provider("explicitProv", value="explicitProvValue")
 explicit_res = call.Custom("explicitRes", value="explicitValue",
 opts = pulumi.ResourceOptions(provider=explicit_prov))
-pulumi.export("explicitProviderValue", explicit_res.provider_value().result)
-pulumi.export("explicitProvFromIdentity", explicit_prov.identity().result)
-pulumi.export("explicitProvFromPrefixed", explicit_prov.prefixed(prefix="call-prefix-").result)
+pulumi.export("explicitProviderValue", explicit_res.provider_value().apply(lambda call: call.result))
+pulumi.export("explicitProvFromIdentity", explicit_prov.identity().apply(lambda call: call.result))
+pulumi.export("explicitProvFromPrefixed", explicit_prov.prefixed(prefix="call-prefix-").apply(lambda call: call.result))

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-provider-call/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l2-provider-call/__main__.py
@@ -2,4 +2,4 @@ import pulumi
 import pulumi_call as call
 
 default_res = call.Custom("defaultRes", value="defaultValue")
-pulumi.export("defaultProviderValue", default_res.provider_value().result)
+pulumi.export("defaultProviderValue", default_res.provider_value().apply(lambda call: call.result))

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-component-call-simple/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-component-call-simple/__main__.py
@@ -2,5 +2,5 @@ import pulumi
 import pulumi_component as component
 
 component1 = component.ComponentCallable("component1", value="bar")
-pulumi.export("from_identity", component1.identity().result)
-pulumi.export("from_prefixed", component1.prefixed(prefix="foo-").result)
+pulumi.export("from_identity", component1.identity().apply(lambda call: call.result))
+pulumi.export("from_prefixed", component1.prefixed(prefix="foo-").apply(lambda call: call.result))

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-provider-call-explicit/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-provider-call-explicit/__main__.py
@@ -4,6 +4,6 @@ import pulumi_call as call
 explicit_prov = call.Provider("explicitProv", value="explicitProvValue")
 explicit_res = call.Custom("explicitRes", value="explicitValue",
 opts = pulumi.ResourceOptions(provider=explicit_prov))
-pulumi.export("explicitProviderValue", explicit_res.provider_value().result)
-pulumi.export("explicitProvFromIdentity", explicit_prov.identity().result)
-pulumi.export("explicitProvFromPrefixed", explicit_prov.prefixed(prefix="call-prefix-").result)
+pulumi.export("explicitProviderValue", explicit_res.provider_value().apply(lambda call: call.result))
+pulumi.export("explicitProvFromIdentity", explicit_prov.identity().apply(lambda call: call.result))
+pulumi.export("explicitProvFromPrefixed", explicit_prov.prefixed(prefix="call-prefix-").apply(lambda call: call.result))

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-provider-call/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-provider-call/__main__.py
@@ -2,4 +2,4 @@ import pulumi
 import pulumi_call as call
 
 default_res = call.Custom("defaultRes", value="defaultValue")
-pulumi.export("defaultProviderValue", default_res.provider_value().result)
+pulumi.export("defaultProviderValue", default_res.provider_value().apply(lambda call: call.result))

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-component-call-simple/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-component-call-simple/__main__.py
@@ -2,5 +2,5 @@ import pulumi
 import pulumi_component as component
 
 component1 = component.ComponentCallable("component1", value="bar")
-pulumi.export("from_identity", component1.identity().result)
-pulumi.export("from_prefixed", component1.prefixed(prefix="foo-").result)
+pulumi.export("from_identity", component1.identity().apply(lambda call: call.result))
+pulumi.export("from_prefixed", component1.prefixed(prefix="foo-").apply(lambda call: call.result))

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-provider-call-explicit/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-provider-call-explicit/__main__.py
@@ -4,6 +4,6 @@ import pulumi_call as call
 explicit_prov = call.Provider("explicitProv", value="explicitProvValue")
 explicit_res = call.Custom("explicitRes", value="explicitValue",
 opts = pulumi.ResourceOptions(provider=explicit_prov))
-pulumi.export("explicitProviderValue", explicit_res.provider_value().result)
-pulumi.export("explicitProvFromIdentity", explicit_prov.identity().result)
-pulumi.export("explicitProvFromPrefixed", explicit_prov.prefixed(prefix="call-prefix-").result)
+pulumi.export("explicitProviderValue", explicit_res.provider_value().apply(lambda call: call.result))
+pulumi.export("explicitProvFromIdentity", explicit_prov.identity().apply(lambda call: call.result))
+pulumi.export("explicitProvFromPrefixed", explicit_prov.prefixed(prefix="call-prefix-").apply(lambda call: call.result))

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-provider-call/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-provider-call/__main__.py
@@ -2,4 +2,4 @@ import pulumi
 import pulumi_call as call
 
 default_res = call.Custom("defaultRes", value="defaultValue")
-pulumi.export("defaultProviderValue", default_res.provider_value().result)
+pulumi.export("defaultProviderValue", default_res.provider_value().apply(lambda call: call.result))


### PR DESCRIPTION
Method calls (represented by the `Call` gRPC call on the provider interface and the `call` intrinsic in PCL) always return outputs -- we don't support "plain" (e.g. `Promise` in NodeJS, `Task` in Python) calls as we do for invokes. When the `call` PCL intrinsic was introduced, we incorrectly gave it a plain type, which happened to work for the NodeJS and Python conformance tests we introduced due to those languages' support for automatic lifting of output properties. For instance, in NodeJS, the below is fine, even though `component1.identity()` returns an `Output`:

```typescript
export const from_identity = component1.identity().result;
```

Under the hood, "lifting" means that this is desugared to an `apply`:

```typescript
export const from_identity = component1.identity().apply(call => call.result);
```

This doesn't fly in languages like Java and Go though, where we don't have lifting. This change fixes the type of the `call` intrinsic to correctly report that it returns an output. Doing so means that program code generation can proceed correctly in all languages.

Part of pulumi/pulumi-java#262