### PR TITLE
Fix --run-program hanging on non-trivial programs

### DIFF
--- a/changelog/pending/20250507--engine--fix-refresh-run-program-hanging-on-non-trivial-programs.yaml
+++ b/changelog/pending/20250507--engine--fix-refresh-run-program-hanging-on-non-trivial-programs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix `refresh --run-program` hanging on non-trivial programs

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -1910,11 +1910,12 @@ func TestRefreshWithBigProgram(t *testing.T) {
 	}
 
 	programExecutions := 0
+	parallel := int32(4)
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		programExecutions++
 
-		for i := int64(0); i < 5; i++ {
-			resp, err := monitor.RegisterResource("pkgA:m:typA", "resA"+strconv.FormatInt(i, 10), true, deploytest.ResourceOptions{
+		for i := int32(0); i < parallel+1; i++ {
+			resp, err := monitor.RegisterResource("pkgA:m:typA", "resA"+strconv.FormatInt(int64(i), 10), true, deploytest.ResourceOptions{
 				Inputs: programInputs,
 			})
 			assert.NoError(t, err)
@@ -1937,7 +1938,7 @@ func TestRefreshWithBigProgram(t *testing.T) {
 			HostF:            hostF,
 			SkipDisplayTests: true,
 			UpdateOptions: engine.UpdateOptions{
-				Parallel: 4,
+				Parallel: parallel,
 			},
 		},
 	}

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -1915,9 +1915,11 @@ func TestRefreshWithBigProgram(t *testing.T) {
 		programExecutions++
 
 		for i := int32(0); i < parallel+1; i++ {
-			resp, err := monitor.RegisterResource("pkgA:m:typA", "resA"+strconv.FormatInt(int64(i), 10), true, deploytest.ResourceOptions{
-				Inputs: programInputs,
-			})
+			resp, err := monitor.RegisterResource(
+				"pkgA:m:typA", "resA"+strconv.FormatInt(int64(i), 10), true,
+				deploytest.ResourceOptions{
+					Inputs: programInputs,
+				})
 			assert.NoError(t, err)
 
 			// First time we should see the create outputs, second time the read outputs

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -573,7 +573,7 @@ func (se *stepExecutor) worker(workerID int, launchAsync bool) {
 			)
 
 			if request.CompletionChan == nil {
-				se.log(workerID, "worker received nil chain, exiting")
+				se.log(workerID, "worker received nil completion channel, exiting")
 				return
 			}
 

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -568,7 +568,11 @@ func (se *stepExecutor) worker(workerID int, launchAsync bool) {
 		se.log(workerID, "worker waiting for incoming chains")
 		select {
 		case request := <-se.incomingChains:
-			if request.Chain == nil {
+			contract.Assertf(request.CompletionChan != nil || request.Chain == nil,
+				"worker received a non-nil chain with a nil completion channel: %v", request.Chain,
+			)
+
+			if request.CompletionChan == nil {
 				se.log(workerID, "worker received nil chain, exiting")
 				return
 			}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/19406

We were hitting an issue where the step generator would return no steps after a refresh but we'd still pass these off to the step executor to execute. This then hit the logic in step workers to shutdown if they get a `nil` chain, so after N refreshes you'd have no step workers left.

This makes two changes.
Firstly we don't bother sending things to the step executor if there's no steps.
Secondly I've changed the worker exit check to look at the completion channel (which `ExecuteSerial` always sets) rather than the `Chain` (which is set by the API user) to prevent us hitting this footgun that `nil` doesn't behave the same as just an empty slice again.