### PR TITLE
Temporary changes to unblock v3.168.0 release

### DIFF
--- a/.github/workflows/on-release-manual-dispatch.yml
+++ b/.github/workflows/on-release-manual-dispatch.yml
@@ -1,0 +1,49 @@
+name: Release Dispatch
+
+permissions:
+  # To create the follow-up PR.
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        required: true
+        description: "Git Tag"
+        type: string
+      release_notes:
+        required: true
+        description: "Release Notes"
+        type: string
+
+concurrency: release
+
+jobs:
+  info:
+    name: gather
+    runs-on: ubuntu-22.04
+    outputs:
+      version: "${{ fromJSON(steps.version.outputs.version) }}"
+    steps:
+      - uses: actions/checkout@v4
+        # Uses release ref (tag)
+      - name: Info
+        id: version
+        run: |
+          TAG="${{ inputs.tag_name }}"
+          PULUMI_VERSION="${TAG#v}" # remove prefix
+
+          ./.github/scripts/set-output version "${PULUMI_VERSION}"
+
+  release:
+    name: release
+    needs: [info]
+    uses: ./.github/workflows/release.yml
+    with:
+      ref: ${{ inputs.tag_name }}
+      version: ${{ needs.info.outputs.version }}
+      release-notes: ${{ inputs.release_notes }}
+      queue-merge: true
+      run-dispatch-commands: true
+    secrets: inherit

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -66,7 +66,7 @@ jobs:
             cd pkg
             go get -u "github.com/pulumi/pulumi/sdk/v3@v${PULUMI_VERSION}"
           )
-          make tidy
+          make tidy_fix
           git add -A
           git commit -m "chore: post-release go.mod updates"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,77 +61,9 @@ env:
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 
 jobs:
-  sdks:
-    name: ${{ matrix.language }}
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        language: ["nodejs", "python", "go"]
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
-      - name: Set up uv
-        if: ${{ matrix.language == 'python' }}
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          cache-dependency-glob: sdk/python/uv.lock
-      - name: Set up Python ${{ fromJson(inputs.version-set).python }}
-        if: ${{ matrix.language == 'python' }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ fromJson(inputs.version-set).python }}
-      - name: Set up Node ${{ fromJson(inputs.version-set).nodejs }}
-        if: ${{ matrix.language == 'nodejs' }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ fromJson(inputs.version-set).nodejs }}
-          registry-url: https://registry.npmjs.org
-          always-auth: true
-      - name: Download release artifacts
-        if: ${{ matrix.language != 'go' }}
-        run: |
-          mkdir -p artifacts
-          gh release download "v${PULUMI_VERSION}" --dir ./artifacts --pattern 'sdk-${{ matrix.language }}-*'
-          find artifacts
-      - name: Publish Packages
-        run: |
-          make -C sdk/${{ matrix.language}} publish
-
-  s3-blobs:
-    name: s3 blobs
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: us-east-2
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 3600
-          role-external-id: upload-pulumi-release
-          role-session-name: pulumi@githubActions
-          role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-      - name: Download release artifacts
-        run: |
-          mkdir -p artifacts
-          gh release download "v${PULUMI_VERSION}" --dir ./artifacts --pattern 'pulumi-*'
-          find artifacts
-      - name: Publish Blobs
-        run: |
-          aws s3 sync artifacts s3://get.pulumi.com/releases/sdk --acl public-read
-
   pr:
     # Relies on the Go SDK being published to update pkg
     name: PR
-    needs: [sdks]
     uses: ./.github/workflows/release-pr.yml
     permissions:
       contents: write


### PR DESCRIPTION
Two commits:

## [1. Use the new `make tidy_fix` target](https://github.com/pulumi/pulumi/commit/867b2448eb115f8342d960489eadd899b43e0a68)

We changed `make tidy` to only check tidiness in #19421, and added a new `make tidy_fix` target to actually do the tidy. This fixes up the workflow to call the new `make tidy_fix` target.

## [2. Temporary changes to unblock v3.168.0 release](https://github.com/pulumi/pulumi/commit/d0eb77e7715acf6f4bcce3062f431c4a06b9711d)

This commit contains two changes:

1. Temporarily comment out jobs that have already successfully run in the `release.yml` workflow. See
https://github.com/pulumi/pulumi/actions/runs/14886609176/job/41807855803

2. Add a way to manually dispatch a release via `on-release-manual-dispatch.yml` workflow. The new file is a copy of `on-release.yml`, but setup to allow manual trigger with input variables, rather than being triggered by a release.

This change will be reverted after v3.168.0 is fully released.