### PR TITLE
fix: use the rpc result for error reports since it includes secret se…

### DIFF
--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -329,7 +329,8 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 		state := resource.NewState(typ, urn, true, false, "", inputs, nil, "", false, false, nil, nil, "", nil, false,
 			nil, nil, nil, "", false, "", nil, nil, "", nil, nil)
 		// TODO(seqnum) should default providers be created with 1? When do they ever get recreated/replaced?
-		if issueCheckErrors(i.deployment, state, urn, resp.Failures) {
+		// TODO - we need the state to work here
+		if issueCheckErrors(i.deployment, state.Type, urn, &resp) {
 			return nil, false, nil
 		}
 

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -1428,7 +1428,7 @@ func (s *ImportStep) Apply() (resource.Status, StepCompleteFunc, error) {
 				errorMessage)
 		}
 
-		issueCheckFailures(s.deployment.Diag().Warningf, s.new, s.new.URN, resp.Failures)
+		issueCheckFailures(s.deployment.Diag().Warningf, s.new.Type, s.new.URN, &resp,)
 
 		s.diffs, s.detailedDiff = []resource.PropertyKey{}, map[string]plugin.PropertyDiff{}
 
@@ -1455,7 +1455,7 @@ func (s *ImportStep) Apply() (resource.Status, StepCompleteFunc, error) {
 	if err != nil {
 		return rst, nil, err
 	}
-	if issueCheckErrors(s.deployment, s.new, s.new.URN, resp.Failures) {
+	if issueCheckErrors(s.deployment, s.new.Type, s.new.URN, &resp) {
 		return rst, nil, errors.New("one or more inputs failed to validate")
 	}
 	s.new.Inputs = resp.Properties

--- a/sdk/go/common/resource/plugin/rpc.go
+++ b/sdk/go/common/resource/plugin/rpc.go
@@ -201,10 +201,19 @@ func MarshalPropertyValue(key resource.PropertyKey, v resource.PropertyValue,
 			})
 			return MarshalPropertyValue(key, output, opts)
 		}
-		secret := resource.NewObjectProperty(resource.PropertyMap{
-			resource.SigKey: resource.NewStringProperty(resource.SecretSig),
-			"value":         v.SecretValue().Element,
-		})
+		var secret resource.PropertyValue
+		secretValue := v.SecretValue().Element
+		if (secretValue.IsString()) {
+			secret = resource.NewObjectProperty(resource.PropertyMap{
+				resource.SigKey: resource.NewStringProperty(resource.SecretSig),
+				"value":         resource.NewStringProperty("************"),
+			})
+		} else {
+			secret = resource.NewObjectProperty(resource.PropertyMap{
+				resource.SigKey: resource.NewStringProperty(resource.SecretSig),
+				"value":         v.SecretValue().Element,
+			})
+		}
 		return MarshalPropertyValue(key, secret, opts)
 	} else if v.IsResourceReference() {
 		ref := v.ResourceReferenceValue()


### PR DESCRIPTION
…mantics

# Summary

Per  [this issue](https://github.com/pulumi/pulumi/issues/19465), this is a demonstration of the spots in the pulumi CLI that are printing out raw values on a failure.

The first commit: 

Swaps any reporting to use the returned RPC encoded inputs since the provider should have encoded secret information into it

The second commit:

Changes the Marshal property function to obfuscate string values, since the `Element` still contains the raw value and that makes it back to the RPC caller.  This is more for demonstration since I'm not entirely sure of the contract on `MashallPropertyValue()` and other functions and I didn't want to add it to the other spots (like the result of `keepOutputValues` or if the value is an output) that didn't affect my use case in the issue first.

I'd love to help contribute, but I'm also aware that there are probably developers that are more acquainted with the expected API contract of this section of the pulumi packages.