### PR TITLE
Fixes rendering `--copilot` error summary on auth errors

### DIFF
--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -427,12 +427,14 @@ func (r *CaptureProgressEvents) Output() string {
 }
 
 func (r *CaptureProgressEvents) OutputIncludesFailure() bool {
-	// If its an actual update we can use the failed flag
-	if !r.display.isPreview {
-		return r.display.failed
+	// Display layer has detected a ResourceOperationFailed event.
+	// Only happens in non-preview updates.
+	if r.display.failed {
+		return true
 	}
 
-	// If its a preview we need to check the resource rows for any failures
+	// Diagnostic events have an error.
+	// This can include things like Auth errors which are not ResourceOperationFailed events.
 	for _, row := range r.display.resourceRows {
 		diagInfo := row.DiagInfo()
 		if diagInfo != nil && diagInfo.ErrorCount > 0 {

--- a/pkg/backend/display/progress_test.go
+++ b/pkg/backend/display/progress_test.go
@@ -208,7 +208,7 @@ func TestCaptureProgressEventsCapturesOutput(t *testing.T) {
 	assert.Contains(t, captureRenderer.Output(), "Hello, world!")
 }
 
-func TestCaptureProgressEventsDetectsAndCapturesFailure(t *testing.T) {
+func TestCaptureProgressEventsDetectsResourceOperationFailed(t *testing.T) {
 	t.Parallel()
 
 	// If we see a ResourceOperationFailed event, the update is marked as failed.
@@ -218,12 +218,7 @@ func TestCaptureProgressEventsDetectsAndCapturesFailure(t *testing.T) {
 			Op:  deploy.OpUpdate,
 		},
 	})
-	// Some diagnostics which is what we're usually interested in.
-	diagEvent := engine.NewEvent(engine.DiagEventPayload{
-		URN:     "urn:pulumi:dev::eks::pulumi:pulumi:Stack::eks-dev",
-		Message: "Failed to update",
-	})
-	failureEvents := []engine.Event{resourceOperationFailedEvent, diagEvent}
+	failureEvents := []engine.Event{resourceOperationFailedEvent}
 	eventsChannel := sliceToBufferedChan(failureEvents)
 
 	captureRenderer := NewCaptureProgressEvents(
@@ -231,10 +226,9 @@ func TestCaptureProgressEventsDetectsAndCapturesFailure(t *testing.T) {
 	captureRenderer.ProcessEvents(eventsChannel, make(chan<- bool))
 
 	assert.True(t, captureRenderer.OutputIncludesFailure())
-	assert.Contains(t, captureRenderer.Output(), "Failed to update")
 }
 
-func TestCaptureProgressEventsDetectsAndCapturesFailurePreview(t *testing.T) {
+func TestCaptureProgressEventsDetectsDiagnosticsWithErrors(t *testing.T) {
 	t.Parallel()
 
 	diagEventWithErrors := engine.NewEvent(engine.DiagEventPayload{

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1323,9 +1323,8 @@ func (b *cloudBackend) PromptAI(
 
 func (b *cloudBackend) renderAndSummarizeOutput(
 	ctx context.Context, kind apitype.UpdateKind, stack backend.Stack, op backend.UpdateOperation,
-	events []engine.Event, update client.UpdateIdentifier, updateMeta updateMetadata,
+	events []engine.Event, update client.UpdateIdentifier, updateMeta updateMetadata, dryRun bool,
 ) {
-	dryRun := kind == apitype.PreviewUpdate
 	renderer := display.NewCaptureProgressEvents(
 		stack.Ref().Name(),
 		op.Proj.Name,
@@ -1526,7 +1525,7 @@ func (b *cloudBackend) apply(
 		defer func() {
 			close(eventsChannel)
 			<-done
-			b.renderAndSummarizeOutput(ctx, kind, stack, op, renderEvents, update, updateMeta)
+			b.renderAndSummarizeOutput(ctx, kind, stack, op, renderEvents, update, updateMeta, opts.DryRun)
 		}()
 	}
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi.ai/issues/1858

Two bugs here:

1. We were mis-identifying previews as updates. (and now correctly read `backend.UpdateOperation.isDryRun`), this is nice for completely accurate rendering of output. There are subtle differences between update and preview ("create" vs "created" and probably others).
2. We were using `isPreview` for some error condition checking (influenced by the above incorrect check). Additionally Auth errors are not ResourceOperationFailures so we weren't catching those in some cases at all. We simplify that logic to check both ResourceOperationFailed and then diagnostics too (auth errors) regardless of whether its a preview or update.

_Note: this affects the unreleased `--copilot` feature_