### PR TITLE
Fixes link in `--copilot` error summary appearing.

### DIFF
--- a/pkg/backend/display/ai.go
+++ b/pkg/backend/display/ai.go
@@ -75,9 +75,7 @@ func RenderCopilotErrorSummary(summary *CopilotErrorSummaryMetadata, err error, 
 
 	fmt.Fprintln(out)
 
-	if opts.ShowLinkToCopilot {
-		PrintCopilotLink(out, opts, permalink)
-	}
+	PrintCopilotLink(out, opts, permalink)
 }
 
 func PrintCopilotLink(out io.Writer, opts Options, permalink string) {

--- a/pkg/backend/display/ai_test.go
+++ b/pkg/backend/display/ai_test.go
@@ -50,27 +50,6 @@ func TestRenderCopilotErrorSummary(t *testing.T) {
 	assert.Equal(t, expectedCopilotSummary, buf.String())
 }
 
-func TestRenderCopilotErrorSummaryNoLink(t *testing.T) {
-	t.Parallel()
-
-	buf := new(bytes.Buffer)
-	opts := Options{
-		Stdout:            buf,
-		Color:             colors.Never,
-		ShowLinkToCopilot: false,
-	}
-
-	RenderCopilotErrorSummary(&CopilotErrorSummaryMetadata{
-		Summary: "This is a test summary",
-	}, nil, opts, "http://foo.bar/baz")
-
-	expectedCopilotSummary := fmt.Sprintf(`Copilot Diagnostics%s
-  This is a test summary
-
-`, copilotDelimiterEmoji())
-	assert.Equal(t, expectedCopilotSummary, buf.String())
-}
-
 func TestRenderCopilotErrorSummaryError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Part of https://github.com/pulumi/pulumi.ai/issues/1858

Decouple `SUPPRESS_COPILOT_LINK` and `--copilot`

Previous behavior: 

- `up --copilot` is the only command that showed the link after the copilot error summary.
  - `up` was the only command that originally had the _old_ link and actually set `ShowCopilotLink = !SUPPRESS_COPILOT_LINK` in `up.go`
- `preview --copilot`, `refresh --copilot`, `destroy --copilot` did not show the link after the copilot error summary as we were respecting this older flag in the newer code.

New behaviour:

- `--copilot` shows the link after the copilot error summary on all 4 commands.


Notes:
- SUPPRESS_COPILOT_LINK is part of an older feature that is only honored by `pulumi up`.
- As `--copilot` is available on up, preview, destroy, refresh this make reconciling logic and expected UX a bit hairy. I think the simplest approach here is to ignore SUPPRESS_COPILOT_LINK if `--copilot` is provided.
- `--copilot` could potentially respect SUPPRESS_COPILOT_LINK in the future too, just to respect this old flag, but I'm not sure if its something we really want UX wise anyway.