### PR TITLE
Adds /api/capabilities checking for `--copilot`

### DIFF
--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -52,7 +52,7 @@ type Explainer interface {
 	Explain(ctx context.Context, stackRef StackReference, kind apitype.UpdateKind, op UpdateOperation,
 		events []engine.Event) (string, error)
 	// IsCopilotFeatureEnabled returns whether the explainer is enabled for the given project.
-	IsCopilotFeatureEnabled(opts display.Options) bool
+	IsCopilotFeatureEnabled(ctx context.Context, opts display.Options) bool
 }
 
 func ActionLabel(kind apitype.UpdateKind, dryRun bool) string {
@@ -195,7 +195,7 @@ func confirmBeforeUpdating(ctx context.Context, kind apitype.UpdateKind, stack S
 			choices = append(choices, string(details))
 
 			// If we have an explainer (pulumi-cloud) we can offer to explain the changes.
-			if explainer != nil && explainer.IsCopilotFeatureEnabled(opts.Display) {
+			if explainer != nil && explainer.IsCopilotFeatureEnabled(ctx, opts.Display) {
 				choices = append(choices, explainChoice)
 			}
 		}

--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -51,8 +51,8 @@ type Explainer interface {
 	// Explain returns a human-readable explanation of the changes that will be made to the stack.
 	Explain(ctx context.Context, stackRef StackReference, kind apitype.UpdateKind, op UpdateOperation,
 		events []engine.Event) (string, error)
-	// IsCopilotFeatureEnabled returns whether the explainer is enabled for the given project.
-	IsCopilotFeatureEnabled(ctx context.Context, opts display.Options) bool
+	// IsExplainPreviewEnabled returns whether the explainer is enabled for the given project.
+	IsExplainPreviewEnabled(ctx context.Context, opts display.Options) bool
 }
 
 func ActionLabel(kind apitype.UpdateKind, dryRun bool) string {
@@ -195,7 +195,7 @@ func confirmBeforeUpdating(ctx context.Context, kind apitype.UpdateKind, stack S
 			choices = append(choices, string(details))
 
 			// If we have an explainer (pulumi-cloud) we can offer to explain the changes.
-			if explainer != nil && explainer.IsCopilotFeatureEnabled(ctx, opts.Display) {
+			if explainer != nil && explainer.IsExplainPreviewEnabled(ctx, opts.Display) {
 				choices = append(choices, explainChoice)
 			}
 		}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1155,9 +1155,9 @@ func (b *cloudBackend) Update(ctx context.Context, stack backend.Stack,
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.UpdateUpdate, stack, op, b.apply, b)
 }
 
-// IsCopilotFeatureEnabled implements the "explainer" interface.
+// IsExplainPreviewEnabled implements the "explainer" interface.
 // Checks that the backend supports the CopilotExplainPreviewV1 capability.
-func (b *cloudBackend) IsCopilotFeatureEnabled(ctx context.Context, opts display.Options) bool {
+func (b *cloudBackend) IsExplainPreviewEnabled(ctx context.Context, opts display.Options) bool {
 	return b.copilotFeatureEnabled(ctx, opts, apitype.CopilotExplainPreviewV1)
 }
 

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1155,12 +1155,14 @@ func (b *cloudBackend) Update(ctx context.Context, stack backend.Stack,
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.UpdateUpdate, stack, op, b.apply, b)
 }
 
+// IsCopilotFeatureEnabled implements the "explainer" interface.
+// Checks that the backend supports the CopilotExplainPreviewV1 capability.
 func (b *cloudBackend) IsCopilotFeatureEnabled(ctx context.Context, opts display.Options) bool {
 	return b.copilotFeatureEnabled(ctx, opts, apitype.CopilotExplainPreviewV1)
 }
 
 func (b *cloudBackend) copilotFeatureEnabled(ctx context.Context, opts display.Options,
-	copilotCapabilities ...apitype.APICapability,
+	requiredCopilotCapability apitype.APICapability,
 ) bool {
 	// Have copilot features been requested by specifying the --copilot flag to the cli
 	if !opts.ShowCopilotFeatures {
@@ -1168,11 +1170,9 @@ func (b *cloudBackend) copilotFeatureEnabled(ctx context.Context, opts display.O
 	}
 
 	// Check that the backend supports the copilot capabilities requested
-	for _, capability := range copilotCapabilities {
-		if !b.Capabilities(ctx).Supports(capability) {
-			logging.V(7).Infof("Copilot feature %q is not supported by the backend", capability)
-			return false
-		}
+	if !b.Capabilities(ctx).Supports(requiredCopilotCapability) {
+		logging.V(7).Infof("Copilot feature %q is not supported by the backend", requiredCopilotCapability)
+		return false
 	}
 
 	// Is copilot enabled this project in Pulumi Cloud

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1156,22 +1156,24 @@ func (b *cloudBackend) Update(ctx context.Context, stack backend.Stack,
 }
 
 // IsExplainPreviewEnabled implements the "explainer" interface.
-// Checks that the backend supports the CopilotExplainPreviewV1 capability.
+// Checks that the backend supports the CopilotExplainPreview capability and that the user has enabled
+// the Copilot features.
 func (b *cloudBackend) IsExplainPreviewEnabled(ctx context.Context, opts display.Options) bool {
-	return b.copilotFeatureEnabled(ctx, opts, apitype.CopilotExplainPreviewV1)
-}
-
-func (b *cloudBackend) copilotFeatureEnabled(ctx context.Context, opts display.Options,
-	requiredCopilotCapability apitype.APICapability,
-) bool {
-	// Have copilot features been requested by specifying the --copilot flag to the cli
-	if !opts.ShowCopilotFeatures {
+	if !b.isCopilotFeaturesEnabled(opts) {
 		return false
 	}
 
-	// Check that the backend supports the copilot capabilities requested
-	if !b.Capabilities(ctx).Supports(requiredCopilotCapability) {
-		logging.V(7).Infof("Copilot feature %q is not supported by the backend", requiredCopilotCapability)
+	if !b.Capabilities(ctx).CopilotExplainPreviewV1 {
+		logging.V(7).Infof("CopilotExplainPreviewV1 is not supported by the backend")
+		return false
+	}
+
+	return true
+}
+
+func (b *cloudBackend) isCopilotFeaturesEnabled(opts display.Options) bool {
+	// Have copilot features been requested by specifying the --copilot flag to the cli
+	if !opts.ShowCopilotFeatures {
 		return false
 	}
 
@@ -1512,35 +1514,39 @@ func (b *cloudBackend) apply(
 		return nil, nil, err
 	}
 
-	if b.copilotFeatureEnabled(ctx, op.Opts.Display, apitype.CopilotSummarizeErrorV1) {
-		originalEvents := events
-		// New var as we need a bidirectional channel type to be able to read from it.
-		eventsChannel := make(chan engine.Event)
-		events = eventsChannel
+	if b.isCopilotFeaturesEnabled(op.Opts.Display) {
+		if !b.Capabilities(ctx).CopilotSummarizeErrorV1 {
+			logging.V(7).Infof("CopilotSummarizeErrorV1 is not supported by the backend")
+		} else {
+			originalEvents := events
+			// New var as we need a bidirectional channel type to be able to read from it.
+			eventsChannel := make(chan engine.Event)
+			events = eventsChannel
 
-		var renderEvents []engine.Event
-		done := make(chan bool)
-		go func() {
-			for e := range eventsChannel {
-				// Forward all events from the engine to the original channel.
-				// (e.g. PreviewThenPrompt also saves events to be able to generate a diff on request).
-				if originalEvents != nil {
-					originalEvents <- e
+			var renderEvents []engine.Event
+			done := make(chan bool)
+			go func() {
+				for e := range eventsChannel {
+					// Forward all events from the engine to the original channel.
+					// (e.g. PreviewThenPrompt also saves events to be able to generate a diff on request).
+					if originalEvents != nil {
+						originalEvents <- e
+					}
+					// Do not send internal events to the copilot summary as they are not displayed to the user either.
+					// We can skip Ephemeral events as well as we want to display the "final" output.
+					if e.Internal() || e.Ephemeral() {
+						continue
+					}
+					renderEvents = append(renderEvents, e)
 				}
-				// Do not send internal events to the copilot summary as they are not displayed to the user either.
-				// We can skip Ephemeral events as well as we want to display the "final" output.
-				if e.Internal() || e.Ephemeral() {
-					continue
-				}
-				renderEvents = append(renderEvents, e)
-			}
-			done <- true
-		}()
-		defer func() {
-			close(eventsChannel)
-			<-done
-			b.renderAndSummarizeOutput(ctx, kind, stack, op, renderEvents, update, updateMeta, opts.DryRun)
-		}()
+				done <- true
+			}()
+			defer func() {
+				close(eventsChannel)
+				<-done
+				b.renderAndSummarizeOutput(ctx, kind, stack, op, renderEvents, update, updateMeta, opts.DryRun)
+			}()
+		}
 	}
 
 	// Display messages from the backend if present.

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1512,7 +1512,7 @@ func (b *cloudBackend) apply(
 		return nil, nil, err
 	}
 
-	if b.copilotFeatureEnabled(ctx, op.Opts.Display, apitype.CopilotExplainPreviewV1) {
+	if b.copilotFeatureEnabled(ctx, op.Opts.Display, apitype.CopilotSummarizeErrorV1) {
 		originalEvents := events
 		// New var as we need a bidirectional channel type to be able to read from it.
 		eventsChannel := make(chan engine.Event)

--- a/pkg/backend/httpstate/client/ai.go
+++ b/pkg/backend/httpstate/client/ai.go
@@ -84,7 +84,7 @@ func createExplainPreviewRequest(
 				},
 			},
 		},
-		DirectSkillCall: apitype.CopilotExplainPreview{
+		DirectSkillCall: apitype.CopilotExplainPreviewSkill{
 			Skill: apitype.SkillExplainPreview,
 			Params: apitype.CopilotExplainPreviewParams{
 				PulumiPreviewOutput: content,

--- a/sdk/go/common/apitype/ai.go
+++ b/sdk/go/common/apitype/ai.go
@@ -66,10 +66,10 @@ type CopilotSummarizeUpdateParams struct {
 
 type CopilotExplainPreviewRequest struct {
 	CopilotRequest
-	DirectSkillCall CopilotExplainPreview `json:"directSkillCall"`
+	DirectSkillCall CopilotExplainPreviewSkill `json:"directSkillCall"`
 }
 
-type CopilotExplainPreview struct {
+type CopilotExplainPreviewSkill struct {
 	Skill  CopilotSkill                `json:"skill"` // Always "explainPreview"
 	Params CopilotExplainPreviewParams `json:"params"`
 }

--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -17,8 +17,6 @@ package apitype
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
 // An APICapability is the name of a capability or feature that a service backend
@@ -37,10 +35,10 @@ const (
 	BatchEncrypt APICapability = "batch-encrypt"
 
 	// Indicates whether the service supports summarizing errors via Copilot.
-	CopilotSummarizeErrorV1 APICapability = "copilot-summarize-error"
+	CopilotSummarizeError APICapability = "copilot-summarize-error"
 
 	// Indicates whether the service supports the Copilot explainer.
-	CopilotExplainPreviewV1 APICapability = "copilot-explain-preview"
+	CopilotExplainPreview APICapability = "copilot-explain-preview"
 )
 
 type DeltaCheckpointUploadsConfigV2 struct {
@@ -77,15 +75,11 @@ type Capabilities struct {
 
 	// Indicates whether the service supports the Copilot explainer.
 	CopilotExplainPreviewV1 bool
-
-	// Dynamic map for supported capabilities
-	supported map[APICapability]bool
 }
 
 // Parse decodes the CapabilitiesResponse into a Capabilities struct for ease of use.
 func (r CapabilitiesResponse) Parse() (Capabilities, error) {
 	var parsed Capabilities
-	parsed.supported = make(map[APICapability]bool)
 	for _, entry := range r.Capabilities {
 		switch entry.Capability {
 		case DeltaCheckpointUploads:
@@ -94,7 +88,6 @@ func (r CapabilitiesResponse) Parse() (Capabilities, error) {
 				return Capabilities{}, fmt.Errorf("decoding DeltaCheckpointUploadsConfig returned %w", err)
 			}
 			parsed.DeltaCheckpointUpdates = &upcfg
-			parsed.supported[DeltaCheckpointUploads] = true
 		case DeltaCheckpointUploadsV2:
 			if entry.Version == 2 {
 				var upcfg DeltaCheckpointUploadsConfigV2
@@ -102,33 +95,20 @@ func (r CapabilitiesResponse) Parse() (Capabilities, error) {
 					return Capabilities{}, fmt.Errorf("decoding DeltaCheckpointUploadsConfigV2 returned %w", err)
 				}
 				parsed.DeltaCheckpointUpdates = &upcfg
-				parsed.supported[DeltaCheckpointUploadsV2] = true
 			}
 		case BatchEncrypt:
 			parsed.BatchEncryption = true
-			parsed.supported[BatchEncrypt] = true
-		case CopilotSummarizeErrorV1:
+		case CopilotSummarizeError:
 			if entry.Version == 1 {
 				parsed.CopilotSummarizeErrorV1 = true
-				parsed.supported[CopilotSummarizeErrorV1] = true
 			}
-		case CopilotExplainPreviewV1:
+		case CopilotExplainPreview:
 			if entry.Version == 1 {
 				parsed.CopilotExplainPreviewV1 = true
-				parsed.supported[CopilotExplainPreviewV1] = true
 			}
 		default:
 			continue
 		}
 	}
 	return parsed, nil
-}
-
-// Supports returns true if the given capability is supported by this backend.
-func (c Capabilities) Supports(capability APICapability) bool {
-	if c.supported == nil {
-		logging.V(7).Infof("Capabilities not parsed, assuming %q is not supported", capability)
-		return false
-	}
-	return c.supported[capability]
 }

--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -17,6 +17,8 @@ package apitype
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
 // An APICapability is the name of a capability or feature that a service backend
@@ -116,7 +118,6 @@ func (r CapabilitiesResponse) Parse() (Capabilities, error) {
 				parsed.supported[CopilotExplainPreviewV1] = true
 			}
 		default:
-			parsed.supported[entry.Capability] = true
 			continue
 		}
 	}
@@ -125,5 +126,9 @@ func (r CapabilitiesResponse) Parse() (Capabilities, error) {
 
 // Supports returns true if the given capability is supported by this backend.
 func (c Capabilities) Supports(capability APICapability) bool {
+	if c.supported == nil {
+		logging.V(7).Infof("Capabilities not parsed, assuming %q is not supported", capability)
+		return false
+	}
 	return c.supported[capability]
 }

--- a/sdk/go/common/apitype/service_test.go
+++ b/sdk/go/common/apitype/service_test.go
@@ -27,9 +27,7 @@ func TestCapabilities(t *testing.T) {
 		t.Parallel()
 		actual, err := CapabilitiesResponse{}.Parse()
 		assert.NoError(t, err)
-		assert.Equal(t, Capabilities{
-			supported: map[APICapability]bool{},
-		}, actual)
+		assert.Equal(t, Capabilities{}, actual)
 	})
 	t.Run("parse delta v1", func(t *testing.T) {
 		t.Parallel()
@@ -45,9 +43,6 @@ func TestCapabilities(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, Capabilities{
 			DeltaCheckpointUpdates: &DeltaCheckpointUploadsConfigV2{},
-			supported: map[APICapability]bool{
-				DeltaCheckpointUploads: true,
-			},
 		}, actual)
 	})
 	t.Run("parse delta v1 with config", func(t *testing.T) {
@@ -66,9 +61,6 @@ func TestCapabilities(t *testing.T) {
 			DeltaCheckpointUpdates: &DeltaCheckpointUploadsConfigV2{
 				CheckpointCutoffSizeBytes: 1024,
 			},
-			supported: map[APICapability]bool{
-				DeltaCheckpointUploads: true,
-			},
 		}, actual)
 	})
 	t.Run("parse delta v2", func(t *testing.T) {
@@ -86,9 +78,6 @@ func TestCapabilities(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, Capabilities{
 			DeltaCheckpointUpdates: &DeltaCheckpointUploadsConfigV2{},
-			supported: map[APICapability]bool{
-				DeltaCheckpointUploadsV2: true,
-			},
 		}, actual)
 	})
 	t.Run("parse delta v2 with config", func(t *testing.T) {
@@ -108,9 +97,6 @@ func TestCapabilities(t *testing.T) {
 			DeltaCheckpointUpdates: &DeltaCheckpointUploadsConfigV2{
 				CheckpointCutoffSizeBytes: 1024,
 			},
-			supported: map[APICapability]bool{
-				DeltaCheckpointUploadsV2: true,
-			},
 		}, actual)
 	})
 	t.Run("parse batch encrypt", func(t *testing.T) {
@@ -124,9 +110,6 @@ func TestCapabilities(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, Capabilities{
 			BatchEncryption: true,
-			supported: map[APICapability]bool{
-				BatchEncrypt: true,
-			},
 		}, actual)
 	})
 
@@ -134,16 +117,13 @@ func TestCapabilities(t *testing.T) {
 		t.Parallel()
 		response := CapabilitiesResponse{
 			Capabilities: []APICapabilityConfig{
-				{Capability: CopilotSummarizeErrorV1, Version: 1},
+				{Capability: CopilotSummarizeError, Version: 1},
 			},
 		}
 		actual, err := response.Parse()
 		assert.NoError(t, err)
 		assert.Equal(t, Capabilities{
 			CopilotSummarizeErrorV1: true,
-			supported: map[APICapability]bool{
-				CopilotSummarizeErrorV1: true,
-			},
 		}, actual)
 	})
 
@@ -151,13 +131,11 @@ func TestCapabilities(t *testing.T) {
 		t.Parallel()
 		response := CapabilitiesResponse{
 			Capabilities: []APICapabilityConfig{
-				{Capability: CopilotSummarizeErrorV1, Version: 2},
+				{Capability: CopilotSummarizeError, Version: 2},
 			},
 		}
 		actual, err := response.Parse()
 		assert.NoError(t, err)
-		assert.Equal(t, Capabilities{
-			supported: map[APICapability]bool{},
-		}, actual)
+		assert.Equal(t, Capabilities{}, actual)
 	})
 }

--- a/sdk/go/common/apitype/service_test.go
+++ b/sdk/go/common/apitype/service_test.go
@@ -27,7 +27,9 @@ func TestCapabilities(t *testing.T) {
 		t.Parallel()
 		actual, err := CapabilitiesResponse{}.Parse()
 		assert.NoError(t, err)
-		assert.Equal(t, Capabilities{}, actual)
+		assert.Equal(t, Capabilities{
+			supported: map[APICapability]bool{},
+		}, actual)
 	})
 	t.Run("parse delta v1", func(t *testing.T) {
 		t.Parallel()
@@ -43,6 +45,9 @@ func TestCapabilities(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, Capabilities{
 			DeltaCheckpointUpdates: &DeltaCheckpointUploadsConfigV2{},
+			supported: map[APICapability]bool{
+				DeltaCheckpointUploads: true,
+			},
 		}, actual)
 	})
 	t.Run("parse delta v1 with config", func(t *testing.T) {
@@ -61,6 +66,9 @@ func TestCapabilities(t *testing.T) {
 			DeltaCheckpointUpdates: &DeltaCheckpointUploadsConfigV2{
 				CheckpointCutoffSizeBytes: 1024,
 			},
+			supported: map[APICapability]bool{
+				DeltaCheckpointUploads: true,
+			},
 		}, actual)
 	})
 	t.Run("parse delta v2", func(t *testing.T) {
@@ -78,6 +86,9 @@ func TestCapabilities(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, Capabilities{
 			DeltaCheckpointUpdates: &DeltaCheckpointUploadsConfigV2{},
+			supported: map[APICapability]bool{
+				DeltaCheckpointUploadsV2: true,
+			},
 		}, actual)
 	})
 	t.Run("parse delta v2 with config", func(t *testing.T) {
@@ -97,6 +108,9 @@ func TestCapabilities(t *testing.T) {
 			DeltaCheckpointUpdates: &DeltaCheckpointUploadsConfigV2{
 				CheckpointCutoffSizeBytes: 1024,
 			},
+			supported: map[APICapability]bool{
+				DeltaCheckpointUploadsV2: true,
+			},
 		}, actual)
 	})
 	t.Run("parse batch encrypt", func(t *testing.T) {
@@ -110,6 +124,40 @@ func TestCapabilities(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, Capabilities{
 			BatchEncryption: true,
+			supported: map[APICapability]bool{
+				BatchEncrypt: true,
+			},
+		}, actual)
+	})
+
+	t.Run("parse copilot summarize error v1", func(t *testing.T) {
+		t.Parallel()
+		response := CapabilitiesResponse{
+			Capabilities: []APICapabilityConfig{
+				{Capability: CopilotSummarizeErrorV1, Version: 1},
+			},
+		}
+		actual, err := response.Parse()
+		assert.NoError(t, err)
+		assert.Equal(t, Capabilities{
+			CopilotSummarizeErrorV1: true,
+			supported: map[APICapability]bool{
+				CopilotSummarizeErrorV1: true,
+			},
+		}, actual)
+	})
+
+	t.Run("parse copilot summarize error with newer version", func(t *testing.T) {
+		t.Parallel()
+		response := CapabilitiesResponse{
+			Capabilities: []APICapabilityConfig{
+				{Capability: CopilotSummarizeErrorV1, Version: 2},
+			},
+		}
+		actual, err := response.Parse()
+		assert.NoError(t, err)
+		assert.Equal(t, Capabilities{
+			supported: map[APICapability]bool{},
 		}, actual)
 	})
 }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi.ai/issues/1821

Provides a deprecation story for the APIs that power the two `--copilot` features:

1. `explain-preview` #19138 
2. `summarize-error` #17956 

We now check `/api/capabilities` to see if those features are supported on the backend before enabling either the above features.

Server side PR:
- https://github.com/pulumi/pulumi-service/pull/28203