### PR TITLE
Integration test explicit pulumi binary

### DIFF
--- a/docs/architecture/testing/integration.md
+++ b/docs/architecture/testing/integration.md
@@ -10,9 +10,16 @@ Integration tests use the built binaries for the CLI and language runtimes. We h
 
 :::{attention}
 
-By default the integration tests use the binaries for the CLI and the language runtime plugins from `$PATH`.  You can set `PULUMI_INTEGRATION_REBUILD_BINARIES=true` in your environment to automatically re-build the binaries locally to your repository and have the integration tests use them automatically.
+Integration tests should use have a TestMain which calls the `testutils.SetupPulumiBinary()` method to set an explicit path to the binaries under test to avoid reliance on the `$PATH` which can cause the wrong binary to be used in tests, resulting in incorrect test results.
 
-Alternatively you can build the binaries yourself and make sure they aren in the `$PATH` as follows:
+:::
+
+You can set `PULUMI_INTEGRATION_REBUILD_BINARIES=true` in your environment to automatically re-build the binaries locally to your repository and have the integration tests use them automatically.
+
+To test an alternative `pulumi` binary, set the environment variable `PULUMI_INTEGRATION_BINARY_PATH` to the absolute path of the binary you want to test.
+
+#### Build the required binaries
+
 ```bash
 # from the repostiory root, build and install `pulumi`
 make build install
@@ -20,7 +27,6 @@ make build install
 cd sdk/python
 make build install
 ```
-:::
 
 To run a single integration test, run the following command from the repository root.
 

--- a/docs/architecture/testing/integration.md
+++ b/docs/architecture/testing/integration.md
@@ -10,7 +10,7 @@ Integration tests use the built binaries for the CLI and language runtimes. We h
 
 :::{attention}
 
-Integration tests should use have a TestMain which calls the `testutils.SetupPulumiBinary()` method to set an explicit path to the binaries under test to avoid reliance on the `$PATH` which can cause the wrong binary to be used in tests, resulting in incorrect test results.
+Integration tests should have a TestMain which calls the `testutils.SetupPulumiBinary()` method to set an explicit path to the binaries under test to avoid reliance on the `$PATH` which can cause the wrong binary to be used in tests, resulting in incorrect test results.
 
 :::
 

--- a/sdk/go/common/lazy/lazy.go
+++ b/sdk/go/common/lazy/lazy.go
@@ -43,32 +43,3 @@ func (l *lazy[T]) Value() T {
 	})
 	return l.result
 }
-
-// Lazy2 is a type that represents two values that are computed only once on first access
-// and then cached for subsequent calls. This is thread-safe.
-type Lazy2[T any, U any] interface {
-	Value() (T, U)
-}
-
-type lazy2[T any, U any] struct {
-	once    sync.Once
-	result1 T
-	result2 U
-	f       func() (T, U)
-}
-
-// New2 creates a new Lazy2[T, U] with the given function to compute the values.
-func New2[T any, U any](f func() (T, U)) Lazy2[T, U] {
-	return &lazy2[T, U]{
-		f:    f,
-		once: sync.Once{},
-	}
-}
-
-// Value returns the computed values, computing them on the first access.
-func (l *lazy2[T, U]) Value() (T, U) {
-	l.once.Do(func() {
-		l.result1, l.result2 = l.f()
-	})
-	return l.result1, l.result2
-}

--- a/sdk/go/common/lazy/lazy.go
+++ b/sdk/go/common/lazy/lazy.go
@@ -43,3 +43,32 @@ func (l *lazy[T]) Value() T {
 	})
 	return l.result
 }
+
+// Lazy2 is a type that represents two values that are computed only once on first access
+// and then cached for subsequent calls. This is thread-safe.
+type Lazy2[T any, U any] interface {
+	Value() (T, U)
+}
+
+type lazy2[T any, U any] struct {
+	once    sync.Once
+	result1 T
+	result2 U
+	f       func() (T, U)
+}
+
+// New2 creates a new Lazy2[T, U] with the given function to compute the values.
+func New2[T any, U any](f func() (T, U)) Lazy2[T, U] {
+	return &lazy2[T, U]{
+		f:    f,
+		once: sync.Once{},
+	}
+}
+
+// Value returns the computed values, computing them on the first access.
+func (l *lazy2[T, U]) Value() (T, U) {
+	l.once.Do(func() {
+		l.result1, l.result2 = l.f()
+	})
+	return l.result1, l.result2
+}

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	testutil.SetupBinaryRebuilding()
+	testutil.SetupPulumiBinary()
 
 	code := m.Run()
 	os.Exit(code)

--- a/tests/stack/main_test.go
+++ b/tests/stack/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2024, Pulumi Corporation.
+// Copyright 2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,26 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tests
+package stack
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/tests/testutil"
 )
 
 func TestMain(m *testing.M) {
-	// Disable stack backups for tests to avoid filling up ~/.pulumi/backups with unnecessary
-	// backups of test stacks.
-	disableCheckpointBackups := env.DIYBackendDisableCheckpointBackups.Var().Name()
-	if err := os.Setenv(disableCheckpointBackups, "1"); err != nil {
-		fmt.Printf("error setting env var '%s': %v\n", disableCheckpointBackups, err)
-		os.Exit(1)
-	}
-
 	testutil.SetupPulumiBinary()
 
 	code := m.Run()

--- a/tests/stack/stack_test.go
+++ b/tests/stack/stack_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tests
+package stack
 
 import (
 	"context"

--- a/tests/testutil/test_main_util.go
+++ b/tests/testutil/test_main_util.go
@@ -43,11 +43,14 @@ func SetupPulumiBinary() {
 			os.Exit(1)
 		}
 	}
-	os.Setenv("PATH", fmt.Sprintf("%s:%s", filepath.Join(repoRoot, "bin"), os.Getenv("PATH")))
+	repoBin := filepath.Join(repoRoot, "bin")
+	os.Setenv("PATH", fmt.Sprintf("%s:%s", repoBin, os.Getenv("PATH")))
 	if os.Getenv("PULUMI_INTEGRATION_BINARY_PATH") == "" {
-		if _, err := os.Stat(filepath.Join(repoRoot, "bin", "pulumi")); os.IsNotExist(err) {
-			fmt.Printf("WARNING: pulumi binary not found in %s/bin. Run `make build_local` or set `PULUMI_INTEGRATION_REBUILD_BINARIES=true`.\n", repoRoot)
+		pulumiBinPath := filepath.Join(repoBin, "pulumi")
+		if _, err := os.Stat(pulumiBinPath); os.IsNotExist(err) {
+			fmt.Printf("WARNING: pulumi binary not found at %s."+
+				" Run `make build_local` or set `PULUMI_INTEGRATION_REBUILD_BINARIES=true`.\n", pulumiBinPath)
 		}
-		os.Setenv("PULUMI_INTEGRATION_BINARY_PATH", filepath.Join(repoRoot, "bin", "pulumi"))
+		os.Setenv("PULUMI_INTEGRATION_BINARY_PATH", pulumiBinPath)
 	}
 }

--- a/tests/testutil/test_main_util.go
+++ b/tests/testutil/test_main_util.go
@@ -47,10 +47,13 @@ func SetupPulumiBinary() {
 	os.Setenv("PATH", fmt.Sprintf("%s:%s", repoBin, os.Getenv("PATH")))
 	if os.Getenv("PULUMI_INTEGRATION_BINARY_PATH") == "" {
 		pulumiBinPath := filepath.Join(repoBin, "pulumi")
-		if _, err := os.Stat(pulumiBinPath); os.IsNotExist(err) {
-			fmt.Printf("WARNING: pulumi binary not found at %s. "+
-				"Falling back to searching the $PATH. "+
-				"Run `make build_local` or set `PULUMI_INTEGRATION_REBUILD_BINARIES=true`.\n", pulumiBinPath)
+		// Disable in CI to avoid breaking the matrix calculation which uses the output from `go test`
+		if _, isCI := os.LookupEnv("CI"); !isCI {
+			if _, err := os.Stat(pulumiBinPath); os.IsNotExist(err) {
+				fmt.Printf("WARNING: pulumi binary not found at %s. "+
+					"Falling back to searching the $PATH. "+
+					"Run `make build_local` or set `PULUMI_INTEGRATION_REBUILD_BINARIES=true`.\n", pulumiBinPath)
+			}
 		}
 		os.Setenv("PULUMI_INTEGRATION_BINARY_PATH", pulumiBinPath)
 	}

--- a/tests/testutil/test_main_util.go
+++ b/tests/testutil/test_main_util.go
@@ -44,5 +44,7 @@ func SetupPulumiBinary() {
 		}
 	}
 	os.Setenv("PATH", fmt.Sprintf("%s:%s", filepath.Join(repoRoot, "bin"), os.Getenv("PATH")))
-	os.Setenv("PULUMI_INTEGRATION_BINARY_PATH", filepath.Join(repoRoot, "bin", "pulumi"))
+	if os.Getenv("PULUMI_INTEGRATION_BINARY_PATH") == "" {
+		os.Setenv("PULUMI_INTEGRATION_BINARY_PATH", filepath.Join(repoRoot, "bin", "pulumi"))
+	}
 }

--- a/tests/testutil/test_main_util.go
+++ b/tests/testutil/test_main_util.go
@@ -45,6 +45,9 @@ func SetupPulumiBinary() {
 	}
 	os.Setenv("PATH", fmt.Sprintf("%s:%s", filepath.Join(repoRoot, "bin"), os.Getenv("PATH")))
 	if os.Getenv("PULUMI_INTEGRATION_BINARY_PATH") == "" {
+		if _, err := os.Stat(filepath.Join(repoRoot, "bin", "pulumi")); os.IsNotExist(err) {
+			fmt.Printf("WARNING: pulumi binary not found in %s/bin. Run `make build_local` or set `PULUMI_INTEGRATION_REBUILD_BINARIES=true`.\n", repoRoot)
+		}
 		os.Setenv("PULUMI_INTEGRATION_BINARY_PATH", filepath.Join(repoRoot, "bin", "pulumi"))
 	}
 }

--- a/tests/testutil/test_main_util.go
+++ b/tests/testutil/test_main_util.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -25,10 +26,7 @@ import (
 // Pulumi CLI and the language runtime plugins into the `bin` directory of the repository root. It will then set up the
 // $PATH environment variable to include this directory, so that when the tests run we will use the newly built binaries
 // without polluting the global $PATH, where the integration tests usually expect to find the binaries.
-func SetupBinaryRebuilding() {
-	if os.Getenv("PULUMI_INTEGRATION_REBUILD_BINARIES") != "true" {
-		return
-	}
+func SetupPulumiBinary() {
 	// Find the root of the repository
 	stdout, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
 	if err != nil {
@@ -36,12 +34,15 @@ func SetupBinaryRebuilding() {
 		os.Exit(1)
 	}
 	repoRoot := strings.TrimSpace(string(stdout))
-	cmd := exec.Command("make", "build_local")
-	cmd.Dir = repoRoot
-	stdout, err = cmd.CombinedOutput()
-	if err != nil {
-		fmt.Printf("error building plugin: %v.  Output: %v\n", err, string(stdout))
-		os.Exit(1)
+	if os.Getenv("PULUMI_INTEGRATION_REBUILD_BINARIES") == "true" {
+		cmd := exec.Command("make", "build_local")
+		cmd.Dir = repoRoot
+		stdout, err = cmd.CombinedOutput()
+		if err != nil {
+			fmt.Printf("error building plugin: %v.  Output: %v\n", err, string(stdout))
+			os.Exit(1)
+		}
 	}
-	os.Setenv("PATH", fmt.Sprintf("%s:%s", repoRoot+"/bin", os.Getenv("PATH")))
+	os.Setenv("PATH", fmt.Sprintf("%s:%s", filepath.Join(repoRoot, "bin"), os.Getenv("PATH")))
+	os.Setenv("PULUMI_INTEGRATION_BINARY_PATH", filepath.Join(repoRoot, "bin", "pulumi"))
 }

--- a/tests/testutil/test_main_util.go
+++ b/tests/testutil/test_main_util.go
@@ -48,8 +48,9 @@ func SetupPulumiBinary() {
 	if os.Getenv("PULUMI_INTEGRATION_BINARY_PATH") == "" {
 		pulumiBinPath := filepath.Join(repoBin, "pulumi")
 		if _, err := os.Stat(pulumiBinPath); os.IsNotExist(err) {
-			fmt.Printf("WARNING: pulumi binary not found at %s."+
-				" Run `make build_local` or set `PULUMI_INTEGRATION_REBUILD_BINARIES=true`.\n", pulumiBinPath)
+			fmt.Printf("WARNING: pulumi binary not found at %s. "+
+				"Falling back to searching the $PATH. "+
+				"Run `make build_local` or set `PULUMI_INTEGRATION_REBUILD_BINARIES=true`.\n", pulumiBinPath)
 		}
 		os.Setenv("PULUMI_INTEGRATION_BINARY_PATH", pulumiBinPath)
 	}


### PR DESCRIPTION
Stop resolving the pulumi binary from the `$PATH` for integration tests because this has unexpected failures modes where other installations might be used accidentally if the local project hasn't been built correctly.

Follow-on to #19461

- If `PULUMI_INTEGRATION_BINARY_PATH`, then require that to be used for `pulumi ...` commands
- Use the existing TestMain functions in integration tests to set `PULUMI_INTEGRATION_BINARY_PATH`
- Fail the test if the pulumi binary does not exist in `$REPO/bin` - do not fall back to using the $PATH.
- An alternative binary can be explicitly set by the user by specifying the environment variable `PULUMI_INTEGRATION_BINARY_PATH`.
- Remove the unused UseLocalPulumiBuild option.