### PR TITLE
Use language host to install policy pack dependencies

### DIFF
--- a/changelog/pending/20250509--engine--the-engine-now-defers-policy-pack-installation-to-the-language-hosts.yaml
+++ b/changelog/pending/20250509--engine--the-engine-now-defers-policy-pack-installation-to-the-language-hosts.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: The engine now defers policy pack installation to the language hosts

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -29,14 +29,15 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	resourceanalyzer "github.com/pulumi/pulumi/pkg/v3/resource/analyzer"
+	pkgCmdUtil "github.com/pulumi/pulumi/pkg/v3/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/archive"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/nodejs/npm"
-	"github.com/pulumi/pulumi/sdk/v3/python/toolchain"
 )
 
 type cloudRequiredPolicy struct {
@@ -61,7 +62,7 @@ func (rp *cloudRequiredPolicy) Name() string    { return rp.RequiredPolicy.Name 
 func (rp *cloudRequiredPolicy) Version() string { return rp.VersionTag }
 func (rp *cloudRequiredPolicy) OrgName() string { return rp.orgName }
 
-func (rp *cloudRequiredPolicy) Install(ctx context.Context) (string, error) {
+func (rp *cloudRequiredPolicy) Install(ctx *plugin.Context) (string, error) {
 	policy := rp.RequiredPolicy
 
 	// If version tag is empty, we use the version tag. This is to support older version of
@@ -85,7 +86,7 @@ func (rp *cloudRequiredPolicy) Install(ctx context.Context) (string, error) {
 	// PolicyPack has not been downloaded and installed. Do this now.
 
 	logging.V(7).Infof("Downloading policy pack %s %s from %s", policy.Name, version, policy.PackLocation)
-	policyPackTarball, err := rp.client.DownloadPolicyPack(ctx, policy.PackLocation)
+	policyPackTarball, err := rp.client.DownloadPolicyPack(ctx.Request(), policy.PackLocation)
 	if err != nil {
 		return "", err
 	}
@@ -260,7 +261,7 @@ func (pack *cloudPolicyPack) Remove(ctx context.Context, op backend.PolicyPackOp
 
 const packageDir = "package"
 
-func installRequiredPolicy(ctx context.Context, finalDir string, tgz io.ReadCloser) error {
+func installRequiredPolicy(ctx *plugin.Context, finalDir string, tgz io.ReadCloser) error {
 	// If part of the directory tree is missing, os.MkdirTemp will return an error, so make sure
 	// the path we're going to create the temporary folder in actually exists.
 	if err := os.MkdirAll(filepath.Dir(finalDir), 0o700); err != nil {
@@ -304,54 +305,22 @@ func installRequiredPolicy(ctx context.Context, finalDir string, tgz io.ReadClos
 		return fmt.Errorf("failed to load policy project at %s: %w", finalDir, err)
 	}
 
-	// TODO[pulumi/pulumi#1334]: move to the language plugins so we don't have to hard code here.
-	if strings.EqualFold(proj.Runtime.Name(), "nodejs") {
-		if err := completeNodeJSInstall(ctx, finalDir); err != nil {
-			return err
-		}
-	} else if strings.EqualFold(proj.Runtime.Name(), "python") {
-		if err := completePythonInstall(ctx, finalDir, projPath, proj); err != nil {
-			return err
-		}
+	info := plugin.NewProgramInfo(finalDir, finalDir, ".", proj.Runtime.Options())
+	language, err := ctx.Host.LanguageRuntime(proj.Runtime.Name(), info)
+	if err != nil {
+		return fmt.Errorf("failed to load language plugin %s: %w", proj.Runtime.Name(), err)
+	}
+
+	err = pkgCmdUtil.InstallDependencies(language, plugin.InstallDependenciesRequest{
+		Info:                    info,
+		UseLanguageVersionTools: false,
+	})
+	if err != nil {
+		return fmt.Errorf("installing dependencies: %w", err)
 	}
 
 	fmt.Println("Finished installing policy pack\r")
 	fmt.Println()
-
-	return nil
-}
-
-func completeNodeJSInstall(ctx context.Context, finalDir string) error {
-	if bin, err := npm.Install(ctx, npm.AutoPackageManager, finalDir, false /*production*/, nil, os.Stderr); err != nil {
-		return fmt.Errorf("failed to install dependencies of policy pack; you may need to re-run `%s install` "+
-			"in %q before this policy pack works"+": %w", bin, finalDir, err)
-	}
-
-	return nil
-}
-
-func completePythonInstall(ctx context.Context, finalDir, projPath string, proj *workspace.PolicyPackProject) error {
-	const venvDir = "venv"
-	// TODO[pulumi/pulumi/issues/16286]: Allow using different toolchains for policy packs.
-	tc, err := toolchain.ResolveToolchain(toolchain.PythonOptions{
-		Toolchain:  toolchain.Pip,
-		Root:       finalDir,
-		Virtualenv: venvDir,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to get python toolchain: %w", err)
-	}
-
-	if err := tc.InstallDependencies(ctx, finalDir, false /* useLanguageVersionTools */, false, /*showOutput*/
-		os.Stdout, os.Stderr); err != nil {
-		return err
-	}
-
-	// Save project with venv info.
-	proj.Runtime.SetOption("virtualenv", venvDir)
-	if err := proj.Save(projPath); err != nil {
-		return fmt.Errorf("saving project at %s: %w", projPath, err)
-	}
 
 	return nil
 }

--- a/pkg/engine/lifecycletest/analyzer_test.go
+++ b/pkg/engine/lifecycletest/analyzer_test.go
@@ -15,7 +15,6 @@
 package lifecycletest
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -48,7 +47,7 @@ func (p *testRequiredPolicy) Version() string {
 	return p.version
 }
 
-func (p *testRequiredPolicy) Install(_ context.Context) (string, error) {
+func (p *testRequiredPolicy) Install(_ *plugin.Context) (string, error) {
 	return "", nil
 }
 

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -45,7 +45,7 @@ type RequiredPolicy interface {
 	// Version of the PolicyPack.
 	Version() string
 	// Install will install the PolicyPack locally, returning the path it was installed to.
-	Install(ctx context.Context) (string, error)
+	Install(ctx *plugin.Context) (string, error)
 	// Config returns the PolicyPack's configuration.
 	Config() map[string]*json.RawMessage
 }
@@ -307,7 +307,7 @@ func installPlugins(
 
 // installAndLoadPolicyPlugins loads and installs all requird policy plugins and packages as well as any
 // local policy packs. It returns fully populated metadata about those policy plugins.
-func installAndLoadPolicyPlugins(ctx context.Context, plugctx *plugin.Context,
+func installAndLoadPolicyPlugins(plugctx *plugin.Context,
 	deployOpts *deploymentOptions, analyzerOpts *plugin.PolicyAnalyzerOptions,
 ) error {
 	var allValidationErrors []string
@@ -324,7 +324,7 @@ func installAndLoadPolicyPlugins(ctx context.Context, plugctx *plugin.Context,
 	// Install and load required policy packs.
 	for _, policy := range deployOpts.RequiredPolicies {
 		deployOpts.Events.PolicyLoadEvent()
-		policyPath, err := policy.Install(ctx)
+		policyPath, err := policy.Install(plugctx)
 		if err != nil {
 			return err
 		}
@@ -499,7 +499,7 @@ func newUpdateSource(ctx context.Context,
 		Config:       pconfig,
 		DryRun:       opts.DryRun,
 	}
-	if err := installAndLoadPolicyPlugins(ctx, plugctx, opts, analyzerOpts); err != nil {
+	if err := installAndLoadPolicyPlugins(plugctx, opts, analyzerOpts); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This updates the engine to use the InstallDependencies method on language hosts to install policy pack dependencies.

Tested on the policy repo at https://github.com/pulumi/pulumi-policy/pull/377