### PR TITLE
Unify the error message for invalid semver

### DIFF
--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1141,7 +1141,7 @@ func parsePluginSpecFromName(
 	spec, err := inference.parseVersion(spec, func(versionStr string) error {
 		v, err := semver.ParseTolerant(versionStr)
 		if err != nil {
-			return fmt.Errorf("VERSION must be valid semver: %w", err)
+			return fmt.Errorf("VERSION must be valid semver: %s", versionStr)
 		}
 		version = &v
 		return nil

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1769,7 +1769,7 @@ func TestNewPluginSpec(t *testing.T) {
 			name:   "plugin with invalid semver",
 			source: "pulumi-example@v1.0.0.0",
 			kind:   apitype.ResourcePlugin,
-			Error:  errors.New("VERSION must be valid semver: Invalid character(s) found in patch number \"0.0\""),
+			Error:  errors.New("VERSION must be valid semver: v1.0.0.0"),
 		},
 		{
 			name:   "git plugin with version",


### PR DESCRIPTION
Unify the error message when a user submits an invalid semver version:

```patch
 URL:  "VERSION must be valid semver or git commit hash: v1.0.0.0"
-Name: "VERSION must be valid semver: Invalid character(s) found in patch number \"0.0\""
+Name: "VERSION must be valid semver: v1.0.0.0"
```