### PR TITLE
Add `context.Context` to `NewPluginSpec`

### DIFF
--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -294,7 +294,7 @@ func runConvert(
 			return nil
 		}
 
-		pluginSpec, err := workspace.NewPluginSpec(pluginName, apitype.ResourcePlugin, nil, "", nil)
+		pluginSpec, err := workspace.NewPluginSpec(ctx, pluginName, apitype.ResourcePlugin, nil, "", nil)
 		if err != nil {
 			pCtx.Diag.Errorf(diag.Message("", "failed to create plugin spec for %q: %v"), pluginName, err)
 			return nil

--- a/pkg/cmd/pulumi/convert/io.go
+++ b/pkg/cmd/pulumi/convert/io.go
@@ -33,7 +33,7 @@ func LoadConverterPlugin(
 	name string,
 	log func(sev diag.Severity, msg string),
 ) (plugin.Converter, error) {
-	pluginSpec, err := workspace.NewPluginSpec(name, apitype.ConverterPlugin, nil, "", nil)
+	pluginSpec, err := workspace.NewPluginSpec(ctx.Request(), name, apitype.ConverterPlugin, nil, "", nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not load converter plugin: %w", err)
 	}

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -710,7 +710,7 @@ func NewImportCmd() *cobra.Command {
 						pCtx.Diag.Logf(sev, diag.RawMessage("", msg))
 					}
 
-					pluginSpec, err := workspace.NewPluginSpec(pluginName, apitype.ResourcePlugin, nil, "", nil)
+					pluginSpec, err := workspace.NewPluginSpec(ctx, pluginName, apitype.ResourcePlugin, nil, "", nil)
 					if err != nil {
 						pCtx.Diag.Warningf(diag.Message("", "failed to create plugin spec for provider %q: %v"), pluginName, err)
 						return nil

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -152,7 +152,7 @@ func (cmd *packagePublishCmd) Run(
 
 	// If no readme path is provided, check if there's a readme in the package source or plugin directory we can slurp up.
 	if args.readmePath == "" {
-		readmePath, err := cmd.findReadme(packageSrc)
+		readmePath, err := cmd.findReadme(ctx, packageSrc)
 		if err != nil {
 			return fmt.Errorf("failed to find readme: %w", err)
 		}
@@ -270,7 +270,7 @@ func login(ctx context.Context, project *workspace.Project) (backend.Backend, er
 // 1. The package source if it is a directory
 // 2. The installed plugin directory
 // If no readme is found, an empty string is returned.
-func (cmd *packagePublishCmd) findReadme(packageSrc string) (string, error) {
+func (cmd *packagePublishCmd) findReadme(ctx context.Context, packageSrc string) (string, error) {
 	findReadmeInDir := func(dir string) string {
 		info, err := os.Stat(dir)
 		if err != nil && errors.Is(err, os.ErrNotExist) {
@@ -305,7 +305,7 @@ func (cmd *packagePublishCmd) findReadme(packageSrc string) (string, error) {
 	}
 
 	// Otherwise, try to retrieve the readme from the installed plugin.
-	pluginSpec, err := workspace.NewPluginSpec(packageSrc, apitype.ResourcePlugin, nil, "", nil)
+	pluginSpec, err := workspace.NewPluginSpec(ctx, packageSrc, apitype.ResourcePlugin, nil, "", nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to create plugin spec: %w", err)
 	}

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -637,6 +637,7 @@ func unmarshalSchema(schemaBytes []byte) (*schema.PackageSpec, error) {
 func TestFindReadme(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
+	ctx := context.Background()
 
 	cmd := packagePublishCmd{
 		pluginDir: tmpDir,
@@ -645,7 +646,7 @@ func TestFindReadme(t *testing.T) {
 	t.Run("NonExistentDirectory", func(t *testing.T) {
 		t.Parallel()
 		nonExistentDir := filepath.Join(tmpDir, "does-not-exist")
-		readme, err := cmd.findReadme(nonExistentDir)
+		readme, err := cmd.findReadme(ctx, nonExistentDir)
 		assert.Empty(t, readme)
 		assert.NoError(t, err, "Should not return error for non-existent directory")
 	})
@@ -656,7 +657,7 @@ func TestFindReadme(t *testing.T) {
 		err := os.WriteFile(filePath, []byte("not a readme"), 0o600)
 		require.NoError(t, err)
 
-		readme, err := cmd.findReadme(filePath)
+		readme, err := cmd.findReadme(ctx, filePath)
 		assert.Empty(t, readme)
 		assert.NoError(t, err, "Should not return error when source is a file")
 	})
@@ -667,7 +668,7 @@ func TestFindReadme(t *testing.T) {
 		err := os.WriteFile(schemaPath, []byte("{}"), 0o600)
 		require.NoError(t, err)
 
-		readme, err := cmd.findReadme(schemaPath)
+		readme, err := cmd.findReadme(ctx, schemaPath)
 		assert.Empty(t, readme)
 		assert.NoError(t, err, "Should not return error when source is a schema file")
 	})
@@ -677,7 +678,7 @@ func TestFindReadme(t *testing.T) {
 		dirPath := filepath.Join(tmpDir, "no-readme-dir")
 		require.NoError(t, os.Mkdir(dirPath, 0o755))
 
-		readme, err := cmd.findReadme(dirPath)
+		readme, err := cmd.findReadme(ctx, dirPath)
 		assert.Empty(t, readme)
 		assert.NoError(t, err, "Should not return error when directory has no readme")
 	})
@@ -689,7 +690,7 @@ func TestFindReadme(t *testing.T) {
 		readmePath := filepath.Join(dirPath, "README.md")
 		require.NoError(t, os.WriteFile(readmePath, []byte("# Test Readme"), 0o600))
 
-		found, err := cmd.findReadme(dirPath)
+		found, err := cmd.findReadme(ctx, dirPath)
 		assert.Equal(t, readmePath, found)
 		assert.NoError(t, err)
 	})
@@ -698,7 +699,7 @@ func TestFindReadme(t *testing.T) {
 		t.Parallel()
 		// An invalid plugin spec string should return an error
 		invalidPlugin := "my-cool-plugin@not-a-valid-version"
-		readme, err := cmd.findReadme(invalidPlugin)
+		readme, err := cmd.findReadme(ctx, invalidPlugin)
 		assert.Empty(t, readme)
 		assert.Error(t, err, "Should return error for invalid plugin spec")
 		assert.Contains(t, err.Error(), "failed to create plugin spec")
@@ -708,7 +709,7 @@ func TestFindReadme(t *testing.T) {
 		t.Parallel()
 		// Use a valid-looking plugin name but with no readme
 		validPlugin := "my-cool-plugin"
-		readme, err := cmd.findReadme(validPlugin)
+		readme, err := cmd.findReadme(ctx, validPlugin)
 		assert.Empty(t, readme)
 		assert.NoError(t, err, "Should not return error when no readme is found")
 	})
@@ -716,7 +717,7 @@ func TestFindReadme(t *testing.T) {
 	t.Run("Git Plugin Download URL", func(t *testing.T) {
 		t.Parallel()
 		pluginDownloadURL := "git://github.com/pulumi/pulumi-example@v1.2.3"
-		pluginSpec, err := workspace.NewPluginSpec(pluginDownloadURL, apitype.ResourcePlugin, nil, "", nil)
+		pluginSpec, err := workspace.NewPluginSpec(ctx, pluginDownloadURL, apitype.ResourcePlugin, nil, "", nil)
 		require.NoError(t, err)
 		pluginSpec.PluginDir = cmd.pluginDir
 
@@ -725,7 +726,7 @@ func TestFindReadme(t *testing.T) {
 		readmePath := filepath.Join(dirPath, "README.md")
 		require.NoError(t, os.WriteFile(readmePath, []byte("# Test Readme"), 0o600))
 
-		readme, err := cmd.findReadme(pluginDownloadURL)
+		readme, err := cmd.findReadme(ctx, pluginDownloadURL)
 		assert.Equal(t, readmePath, readme)
 		assert.NoError(t, err)
 	})
@@ -733,7 +734,7 @@ func TestFindReadme(t *testing.T) {
 	t.Run("Git Plugin Download URL with subdirectory", func(t *testing.T) {
 		t.Parallel()
 		pluginDownloadURL := "git://github.com/pulumi/pulumi-subdir-example/path@v1.2.3"
-		pluginSpec, err := workspace.NewPluginSpec(pluginDownloadURL, apitype.ResourcePlugin, nil, "", nil)
+		pluginSpec, err := workspace.NewPluginSpec(ctx, pluginDownloadURL, apitype.ResourcePlugin, nil, "", nil)
 		require.NoError(t, err)
 		pluginSpec.PluginDir = cmd.pluginDir
 
@@ -746,7 +747,7 @@ func TestFindReadme(t *testing.T) {
 		subdirReadmePath := filepath.Join(subdirPath, "README.md")
 		require.NoError(t, os.WriteFile(subdirReadmePath, []byte("# Subdir Readme"), 0o600))
 
-		readme, err := cmd.findReadme(pluginDownloadURL)
+		readme, err := cmd.findReadme(ctx, pluginDownloadURL)
 		assert.Equal(t, subdirReadmePath, readme)
 		assert.NoError(t, err)
 	})

--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -691,7 +691,7 @@ func SchemaFromSchemaSource(pctx *plugin.Context, packageSource string, args []s
 	if err != nil {
 		return nil, err
 	}
-	pluginSpec, err := workspace.NewPluginSpec(packageSource, apitype.ResourcePlugin, nil, "", nil)
+	pluginSpec, err := workspace.NewPluginSpec(pctx.Request(), packageSource, apitype.ResourcePlugin, nil, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -757,7 +757,7 @@ func SchemaFromSchemaSourceValueArgs(
 //
 // PLUGIN[@VERSION] | PATH_TO_PLUGIN
 func ProviderFromSource(pctx *plugin.Context, packageSource string) (plugin.Provider, error) {
-	pluginSpec, err := workspace.NewPluginSpec(packageSource, apitype.ResourcePlugin, nil, "", nil)
+	pluginSpec, err := workspace.NewPluginSpec(pctx.Request(), packageSource, apitype.ResourcePlugin, nil, "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/plugin/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install.go
@@ -137,7 +137,8 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 			}
 		}
 
-		pluginSpec, err := workspace.NewPluginSpec(args[1], apitype.PluginKind(args[0]), version, cmd.serverURL, checksums)
+		pluginSpec, err := workspace.NewPluginSpec(ctx,
+			args[1], apitype.PluginKind(args[0]), version, cmd.serverURL, checksums)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -52,7 +52,7 @@ func newPluginRunCmd() *cobra.Command {
 			kind := apitype.PluginKind(kind)
 
 			// TODO: Add support for --server and --checksums.
-			pluginSpec, err := workspace.NewPluginSpec(args[0], kind, nil, "", nil)
+			pluginSpec, err := workspace.NewPluginSpec(ctx, args[0], kind, nil, "", nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/codegen/convert/base_plugin_mapper.go
+++ b/pkg/codegen/convert/base_plugin_mapper.go
@@ -236,7 +236,7 @@ func (m *basePluginMapper) GetMapping(
 
 	// Try the list of plugins we have and see if any of them produce a mapping we can return.
 	for _, mapperSpec := range m.pluginSpecs {
-		pluginSpec, err := workspace.NewPluginSpec(mapperSpec.name, apitype.ResourcePlugin, nil, "", nil)
+		pluginSpec, err := workspace.NewPluginSpec(ctx, mapperSpec.name, apitype.ResourcePlugin, nil, "", nil)
 		if err != nil {
 			return nil, fmt.Errorf("could not create plugin spec for plugin %s: %w", pluginSpec.Name, err)
 		}

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -15,6 +15,7 @@
 package plugin
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -108,7 +109,7 @@ func IsLocalPluginPath(source string) bool {
 
 	// For other cases, we need to be careful about how we interpret the source, so let's parse the spec
 	// and check if it has a download URL.
-	pluginSpec, err := workspace.NewPluginSpec(source, apitype.ResourcePlugin, nil, "", nil)
+	pluginSpec, err := workspace.NewPluginSpec(context.Background(), source, apitype.ResourcePlugin, nil, "", nil)
 	var pluginErr workspace.PluginVersionNotFoundError
 	if err != nil && !errors.As(err, &pluginErr) {
 		// If we can't parse it as a plugin spec, assume it's a local path

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1919,7 +1919,7 @@ func TestNewPluginSpec(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
-			spec, err := NewPluginSpec(c.source, c.kind, c.version, c.pluginDownloadURL, nil)
+			spec, err := NewPluginSpec(context.Background(), c.source, c.kind, c.version, c.pluginDownloadURL, nil)
 			if c.Error != nil {
 				require.EqualError(t, err, c.Error.Error())
 				return


### PR DESCRIPTION
Since `NewPluginSpec` makes a network call, it should be given a `context.Context` to control cancelation. This change threads that through.