### PR TITLE
Python codegen shouldn't fail when we are missing `PackageInfo`

### DIFF
--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -125,7 +125,7 @@ func (d DocLanguageHelper) GetMethodResultName(pkg schema.PackageReference, modN
 
 	var info PackageInfo
 	if i, err := pkg.Language("python"); err == nil {
-		info = i.(PackageInfo)
+		info, _ = i.(PackageInfo)
 	}
 
 	if info.LiftSingleValueMethodReturns && returnType != nil && len(returnType.Properties) == 1 {


### PR DESCRIPTION
This was detected when attempting to upgrade the registry to latest pu/pu. The zero value is fine here.