### PR TITLE
[codegen/nodejs] Do not import during docs generation

### DIFF
--- a/pkg/codegen/docs_integration_test.go
+++ b/pkg/codegen/docs_integration_test.go
@@ -266,21 +266,22 @@ func TestGetLanguageTypeString(t *testing.T) {
 		},
 	}
 
-	// Code generation is not safe to parallelize since import binding mutates the
-	// [schema.Package].
-	for _, tt := range tests { //nolint:paralleltest
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.NotEmpty(t, tt.expected, "Must test at least one language")
 			for lang, expected := range tt.expected {
 				testDocsGenHelper(t, lang, tt.schema, func(t *testing.T, helper codegen.DocLanguageHelper) {
 					if tt.input == nil || *tt.input {
-						t.Run("input", func(t *testing.T) { //nolint:paralleltest // golangci-lint v2 upgrade
+						t.Run("input", func(t *testing.T) {
+							t.Parallel()
 							actual := helper.GetTypeName(tt.schema, tt.typ, true, tt.module)
 							assert.Equal(t, expected, actual)
 						})
 					}
 					if tt.input == nil || !*tt.input {
-						t.Run("output", func(t *testing.T) { //nolint:paralleltest // golangci-lint v2 upgrade
+						t.Run("output", func(t *testing.T) {
+							t.Parallel()
 							actual := helper.GetTypeName(tt.schema, tt.typ, false, tt.module)
 							assert.Equal(t, expected, actual)
 						})
@@ -439,10 +440,9 @@ func TestGetMethodResultName(t *testing.T) {
 		},
 	}
 
-	// Code generation is not safe to parallelize since import binding mutates the
-	// [schema.Package].
-	for _, tt := range tests { //nolint:paralleltest
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.NotEmpty(t, tt.expected, "Must test at least one language")
 			for lang, expected := range tt.expected {
 				testDocsGenHelper(t, lang, tt.schema, func(t *testing.T, helper codegen.DocLanguageHelper) {
@@ -559,7 +559,8 @@ func testDocsGenHelper(
 		assert.Fail(t, "Unknown language %T", language)
 	}
 
-	t.Run(name, func(t *testing.T) { //nolint:paralleltest // golangci-lint v2 upgrade
+	t.Run(name, func(t *testing.T) {
+		t.Parallel()
 		f(t, helper())
 	})
 }

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -828,12 +828,8 @@ func resourceTypeName(r *pcl.Resource) (string, string, string, hcl.Diagnostics)
 func moduleName(module string, pkg schema.PackageReference) string {
 	// Normalize module.
 	if pkg != nil {
-		def, err := pkg.Definition()
-		contract.AssertNoErrorf(err, "error loading package definition for %q", pkg.Name())
-		err = def.ImportLanguages(map[string]schema.Language{"nodejs": Importer})
-		contract.AssertNoErrorf(err, "error importing nodejs language for %q", pkg.Name())
-		if lang, ok := def.Language["nodejs"]; ok {
-			pkgInfo := lang.(NodePackageInfo)
+		if a, err := pkg.Language("nodejs"); err == nil {
+			pkgInfo, _ := a.(NodePackageInfo)
 			if m, ok := pkgInfo.ModuleToPackage[module]; ok {
 				module = m
 			}

--- a/pkg/codegen/schema/package_reference.go
+++ b/pkg/codegen/schema/package_reference.go
@@ -523,6 +523,10 @@ func (p *PartialPackage) Language(language string) (any, error) {
 		}
 	}
 
+	if p.spec == nil {
+		return nil, nil
+	}
+
 	val, ok := p.spec.Language[language]
 	if !ok {
 		return nil, nil


### PR DESCRIPTION
This PR brings nodejs's `moduleName` inline with the rest of nodejs's codegen and codegen at large. Language specific blocks are managed by specifying an importer at bind time, not by codegen injecting their own language importer.

This allows us to test docs generation in parallel.

Follow-up on https://github.com/pulumi/pulumi/pull/19488.