### PR TITLE
codegen/python: don't use builtins.* prefix for docs (part 2)

### DIFF
--- a/pkg/codegen/docs_integration_test.go
+++ b/pkg/codegen/docs_integration_test.go
@@ -421,7 +421,7 @@ func TestGetMethodResultName(t *testing.T) {
 			expected: map[language]string{
 				golang: "pulumi.StringOutput",
 				nodejs: "string",
-				python: "builtins.str", // TODO[https://github.com/pulumi/pulumi/issues/19272]
+				python: "str",
 				dotnet: "string",
 			},
 		},

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -135,7 +135,9 @@ func (d DocLanguageHelper) GetMethodResultName(pkg schema.PackageReference, modN
 			mod:         modName,
 			typeDetails: typeDetails,
 		}
-		return mod.typeString(returnType.Properties[0].Type, typeStringOpts{})
+		return mod.typeString(returnType.Properties[0].Type, typeStringOpts{
+			forDocs: true,
+		})
 	}
 	return fmt.Sprintf("%s.%sResult", resourceName(r), title(d.GetMethodName(m)))
 }


### PR DESCRIPTION
In #19035 we started out writing the fully qualified types for python in codegen, e.g. `builtins.str` instead of just `str`.

However this is not desired for docs, as it might confuse people. Don't add the builtins prefix for docs generation.

This was partly fixed in https://github.com/pulumi/pulumi/pull/19359, but I missed a spot. Fix that now.

Fixes https://github.com/pulumi/pulumi/issues/19272