### PR TITLE
[Python] Propagate more ComponentResourceOptions to provider constructors

### DIFF
--- a/changelog/pending/20250509--sdk-nodejs--pass-ignorechanges-replaceonchanges-customtimeouts-retainondelete-and-deletedwith-to-the-provider-constructor.yaml
+++ b/changelog/pending/20250509--sdk-nodejs--pass-ignorechanges-replaceonchanges-customtimeouts-retainondelete-and-deletedwith-to-the-provider-constructor.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Pass `ignoreChanges`, `replaceOnChanges`, `customTimeouts`, `retainOnDelete`, and `deletedWith` to the provider constructor

--- a/sdk/python/lib/pulumi/provider/server.py
+++ b/sdk/python/lib/pulumi/provider/server.py
@@ -250,6 +250,15 @@ class ProviderServicer(ResourceProviderServicer):
                 for pkg, ref in request.providers.items()
             },
             parent=parent,
+            custom_timeouts=pulumi.resource.CustomTimeouts(
+                request.customTimeouts.create,
+                request.customTimeouts.update,
+                request.customTimeouts.delete,
+            ),
+            ignore_changes=list(request.ignoreChanges),
+            replace_on_changes=list(request.replaceOnChanges),
+            retain_on_delete=request.retainOnDelete,
+            deleted_with=_create_provider_resource(request.deletedWith),
         )
 
     async def _construct_response(

--- a/sdk/python/lib/pulumi/provider/server.py
+++ b/sdk/python/lib/pulumi/provider/server.py
@@ -246,6 +246,14 @@ class ProviderServicer(ResourceProviderServicer):
         if request.deletedWith != "":
             deleted_with = _create_provider_resource(request.deletedWith)
 
+        custom_timeouts = None
+        if request.customTimeouts:
+            pulumi.resource.CustomTimeouts(
+                request.customTimeouts.create,
+                request.customTimeouts.update,
+                request.customTimeouts.delete,
+            )
+
         return pulumi.ResourceOptions(
             aliases=list(request.aliases),
             depends_on=[DependencyResource(urn) for urn in request.dependencies],
@@ -255,11 +263,7 @@ class ProviderServicer(ResourceProviderServicer):
                 for pkg, ref in request.providers.items()
             },
             parent=parent,
-            custom_timeouts=pulumi.resource.CustomTimeouts(
-                request.customTimeouts.create,
-                request.customTimeouts.update,
-                request.customTimeouts.delete,
-            ),
+            custom_timeouts=custom_timeouts,
             ignore_changes=list(request.ignoreChanges),
             replace_on_changes=list(request.replaceOnChanges),
             retain_on_delete=request.retainOnDelete,

--- a/sdk/python/lib/pulumi/provider/server.py
+++ b/sdk/python/lib/pulumi/provider/server.py
@@ -241,6 +241,11 @@ class ProviderServicer(ResourceProviderServicer):
         parent = None
         if not _empty_as_none(request.parent):
             parent = DependencyResource(request.parent)
+
+        deleted_with = None
+        if request.deletedWith != "":
+            deleted_with = _create_provider_resource(request.deletedWith)
+
         return pulumi.ResourceOptions(
             aliases=list(request.aliases),
             depends_on=[DependencyResource(urn) for urn in request.dependencies],
@@ -258,7 +263,7 @@ class ProviderServicer(ResourceProviderServicer):
             ignore_changes=list(request.ignoreChanges),
             replace_on_changes=list(request.replaceOnChanges),
             retain_on_delete=request.retainOnDelete,
-            deleted_with=_create_provider_resource(request.deletedWith),
+            deleted_with=deleted_with,
         )
 
     async def _construct_response(


### PR DESCRIPTION
This PR passes more resource options to the provider constructor. This is the equivalent code for the NodeJS and Go.

* https://github.com/pulumi/pulumi/pull/19494
* https://github.com/pulumi/pulumi/pull/12701