### PR TITLE
Regenerate GOB data for config tests

### DIFF
--- a/sdk/go/common/resource/config/testdata/repr/1.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/1.expected.yaml
@@ -6,7 +6,7 @@ paths:
       nested: 12321123131
     string: '{"nested":12321123131}'
     redacted: '{"nested":12321123131}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAb/4IYAAEGbmVzdGVkBWludDY0BAcA+wW8ytZ2
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABv/gBgAAQZuZXN0ZWQFaW50NjQEBwD7BbzK1nY=
     secure: false
     isObject: true
   my:parent.nested:

--- a/sdk/go/common/resource/config/testdata/repr/10.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/10.expected.yaml
@@ -7,7 +7,7 @@ paths:
       port: 80
     string: '[{"host":"example","port":80}]'
     redacted: '[{"host":"example","port":80}]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAWP+EKAABF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAs/4IpAAIEaG9zdAZzdHJpbmcMCQAHZXhhbXBsZQRwb3J0BWludDY0BAMA/6A=
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAV/+CJwABF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAACz/gCkAAgRwb3J0BWludDY0BAMA/6AEaG9zdAZzdHJpbmcMCQAHZXhhbXBsZQ==
     secure: false
     isObject: true
   my:servers[0]:
@@ -16,7 +16,7 @@ paths:
       port: 80
     string: '{"host":"example","port":80}'
     redacted: '{"host":"example","port":80}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAs/4IpAAIEcG9ydAVpbnQ2NAQDAP+gBGhvc3QGc3RyaW5nDAkAB2V4YW1wbGU=
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAACz/gCkAAgRob3N0BnN0cmluZwwJAAdleGFtcGxlBHBvcnQFaW50NjQEAwD/oA==
     secure: false
     isObject: true
   my:servers[0].host:

--- a/sdk/go/common/resource/config/testdata/repr/11.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/11.expected.yaml
@@ -9,7 +9,7 @@ paths:
       - 3
     string: '{"nums":[1,2,3]}'
     redacted: '{"nums":[1,2,3]}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAABJ/4IiAAEEbnVtcw5bXWludGVyZmFjZSB7ff+DAgEC/4QAARAAACP/hCAAAwVpbnQ2NAQCAAIFaW50NjQEAgAEBWludDY0BAIABg==
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAEn/gCIAAQRudW1zDltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAI/+CIAADBWludDY0BAIAAgVpbnQ2NAQCAAQFaW50NjQEAgAG
     secure: false
     isObject: true
   my:mapKey.nums:
@@ -19,7 +19,7 @@ paths:
     - 3
     string: '[1,2,3]'
     redacted: '[1,2,3]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAI/+EIAADBWludDY0BAIAAgVpbnQ2NAQCAAQFaW50NjQEAgAG
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAI/+CIAADBWludDY0BAIAAgVpbnQ2NAQCAAQFaW50NjQEAgAG
     secure: false
     isObject: true
   my:mapKey.nums[0]:

--- a/sdk/go/common/resource/config/testdata/repr/12.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/12.expected.yaml
@@ -8,7 +8,7 @@ paths:
       c: d
     string: '{"a":{"secure":"securevalue"},"c":"d"}'
     redacted: '{"a":"[secret]","c":"d"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAABP/4JMAAIBYRdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+CHwABBnNlY3VyZQZzdHJpbmcMDQALc2VjdXJldmFsdWUBYwZzdHJpbmcMAwABZA==
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAE//gEwAAgFhF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4AfAAEGc2VjdXJlBnN0cmluZwwNAAtzZWN1cmV2YWx1ZQFjBnN0cmluZwwDAAFk
     secure: true
     isObject: true
     secureValues:

--- a/sdk/go/common/resource/config/testdata/repr/13.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/13.expected.yaml
@@ -9,7 +9,7 @@ paths:
         secure: securevalue
     string: '[{"host":"example","port":80,"token":{"secure":"securevalue"}}]'
     redacted: '[{"host":"example","port":80,"token":"[secret]"}]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAA/5j/hCgAARdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+BBAEC/4IAAQwBEAAAbP+CaQADBXRva2VuF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4IfAAEGc2VjdXJlBnN0cmluZwwNAAtzZWN1cmV2YWx1ZQRob3N0BnN0cmluZwwJAAdleGFtcGxlBHBvcnQFaW50NjQEAwD/oA==
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAA/5f/gicAARdtYXBbc3RyaW5nXWludGVyZmFjZSB7fX8EAQL/gAABDAEQAABs/4BpAAMEcG9ydAVpbnQ2NAQDAP+gBXRva2VuF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4AfAAEGc2VjdXJlBnN0cmluZwwNAAtzZWN1cmV2YWx1ZQRob3N0BnN0cmluZwwJAAdleGFtcGxl
     secure: true
     isObject: true
     secureValues:
@@ -22,7 +22,7 @@ paths:
         secure: securevalue
     string: '{"host":"example","port":80,"token":{"secure":"securevalue"}}'
     redacted: '{"host":"example","port":80,"token":"[secret]"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAABs/4JpAAMEaG9zdAZzdHJpbmcMCQAHZXhhbXBsZQRwb3J0BWludDY0BAMA/6AFdG9rZW4XbWFwW3N0cmluZ11pbnRlcmZhY2Uge33/gh8AAQZzZWN1cmUGc3RyaW5nDA0AC3NlY3VyZXZhbHVl
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAGz/gGkAAwRob3N0BnN0cmluZwwJAAdleGFtcGxlBHBvcnQFaW50NjQEAwD/oAV0b2tlbhdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+AHwABBnNlY3VyZQZzdHJpbmcMDQALc2VjdXJldmFsdWU=
     secure: true
     isObject: true
     secureValues:

--- a/sdk/go/common/resource/config/testdata/repr/14.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/14.expected.yaml
@@ -9,7 +9,7 @@ paths:
       c: d
     string: '{"a":{"bar":"blah","secure":"foo"},"c":"d"}'
     redacted: '{"a":{"bar":"blah","secure":"foo"},"c":"d"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAABa/4JXAAIBYRdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+CKgACA2JhcgZzdHJpbmcMBgAEYmxhaAZzZWN1cmUGc3RyaW5nDAUAA2ZvbwFjBnN0cmluZwwDAAFk
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAFr/gFcAAgFjBnN0cmluZwwDAAFkAWEXbWFwW3N0cmluZ11pbnRlcmZhY2Uge33/gCoAAgNiYXIGc3RyaW5nDAYABGJsYWgGc2VjdXJlBnN0cmluZwwFAANmb28=
     secure: false
     isObject: true
   my:mapKey.a:
@@ -18,7 +18,7 @@ paths:
       secure: foo
     string: '{"bar":"blah","secure":"foo"}'
     redacted: '{"bar":"blah","secure":"foo"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAt/4IqAAIDYmFyBnN0cmluZwwGAARibGFoBnNlY3VyZQZzdHJpbmcMBQADZm9v
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAC3/gCoAAgZzZWN1cmUGc3RyaW5nDAUAA2ZvbwNiYXIGc3RyaW5nDAYABGJsYWg=
     secure: false
     isObject: true
   my:mapKey.a.bar:

--- a/sdk/go/common/resource/config/testdata/repr/17.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/17.expected.yaml
@@ -6,7 +6,7 @@ paths:
       inner: value
     string: '{"inner":"value"}'
     redacted: '{"inner":"value"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAb/4IYAAEFaW5uZXIGc3RyaW5nDAcABXZhbHVl
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABv/gBgAAQVpbm5lcgZzdHJpbmcMBwAFdmFsdWU=
     secure: false
     isObject: true
   my:testKey.inner:

--- a/sdk/go/common/resource/config/testdata/repr/18.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/18.expected.yaml
@@ -7,7 +7,7 @@ paths:
         secure: securevalue
     string: '{"inner":{"secure":"securevalue"}}'
     redacted: '{"inner":"[secret]"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAABF/4JCAAEFaW5uZXIXbWFwW3N0cmluZ11pbnRlcmZhY2Uge33/gh8AAQZzZWN1cmUGc3RyaW5nDA0AC3NlY3VyZXZhbHVl
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAEX/gEIAAQVpbm5lchdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+AHwABBnNlY3VyZQZzdHJpbmcMDQALc2VjdXJldmFsdWU=
     secure: true
     isObject: true
     secureValues:

--- a/sdk/go/common/resource/config/testdata/repr/19.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/19.expected.yaml
@@ -8,7 +8,7 @@ paths:
     - secure: securevalue2
     string: '[{"inner":{"secure":"securevalue"}},{"secure":"securevalue2"}]'
     redacted: '[{"inner":"[secret]"},"[secret]"]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAA/63/hCgAAhdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+BBAEC/4IAAQwBEAAA/4D/gkIAAQVpbm5lchdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+CHwABBnNlY3VyZQZzdHJpbmcMDQALc2VjdXJldmFsdWUXbWFwW3N0cmluZ11pbnRlcmZhY2Uge33/giAAAQZzZWN1cmUGc3RyaW5nDA4ADHNlY3VyZXZhbHVlMg==
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAA/6z/gicAAhdtYXBbc3RyaW5nXWludGVyZmFjZSB7fX8EAQL/gAABDAEQAAD/gP+AQgABBWlubmVyF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4AfAAEGc2VjdXJlBnN0cmluZwwNAAtzZWN1cmV2YWx1ZRdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+AIAABBnNlY3VyZQZzdHJpbmcMDgAMc2VjdXJldmFsdWUy
     secure: true
     isObject: true
     secureValues:
@@ -20,7 +20,7 @@ paths:
         secure: securevalue
     string: '{"inner":{"secure":"securevalue"}}'
     redacted: '{"inner":"[secret]"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAABF/4JCAAEFaW5uZXIXbWFwW3N0cmluZ11pbnRlcmZhY2Uge33/gh8AAQZzZWN1cmUGc3RyaW5nDA0AC3NlY3VyZXZhbHVl
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAEX/gEIAAQVpbm5lchdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+AHwABBnNlY3VyZQZzdHJpbmcMDQALc2VjdXJldmFsdWU=
     secure: true
     isObject: true
     secureValues:

--- a/sdk/go/common/resource/config/testdata/repr/2.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/2.expected.yaml
@@ -7,7 +7,7 @@ paths:
       - 12321123131
     string: '{"nested":[12321123131]}'
     redacted: '{"nested":[12321123131]}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAA8/4IkAAEGbmVzdGVkDltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAFP+EEQABBWludDY0BAcA+wW8ytZ2
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAADz/gCQAAQZuZXN0ZWQOW11pbnRlcmZhY2Uge33/gQIBAv+CAAEQAAAU/4IRAAEFaW50NjQEBwD7BbzK1nY=
     secure: false
     isObject: true
   my:parent.nested:
@@ -15,7 +15,7 @@ paths:
     - 12321123131
     string: '[12321123131]'
     redacted: '[12321123131]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAFP+EEQABBWludDY0BAcA+wW8ytZ2
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAFP+CEQABBWludDY0BAcA+wW8ytZ2
     secure: false
     isObject: true
   my:parent.nested[0]:

--- a/sdk/go/common/resource/config/testdata/repr/23.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/23.expected.yaml
@@ -6,7 +6,7 @@ paths:
       inner: value
     string: '{"inner":"value"}'
     redacted: '{"inner":"value"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAb/4IYAAEFaW5uZXIGc3RyaW5nDAcABXZhbHVl
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABv/gBgAAQVpbm5lcgZzdHJpbmcMBwAFdmFsdWU=
     secure: false
     isObject: true
   my:outer.inner:

--- a/sdk/go/common/resource/config/testdata/repr/24.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/24.expected.yaml
@@ -7,7 +7,7 @@ paths:
         secure: securevalue
     string: '{"inner":{"secure":"securevalue"}}'
     redacted: '{"inner":"[secret]"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAABF/4JCAAEFaW5uZXIXbWFwW3N0cmluZ11pbnRlcmZhY2Uge33/gh8AAQZzZWN1cmUGc3RyaW5nDA0AC3NlY3VyZXZhbHVl
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAEX/gEIAAQVpbm5lchdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+AHwABBnNlY3VyZQZzdHJpbmcMDQALc2VjdXJldmFsdWU=
     secure: true
     isObject: true
     secureValues:

--- a/sdk/go/common/resource/config/testdata/repr/25.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/25.expected.yaml
@@ -6,7 +6,7 @@ paths:
       inner: true
     string: '{"inner":true}'
     redacted: '{"inner":true}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAU/4IRAAEFaW5uZXIEYm9vbAICAAE=
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABT/gBEAAQVpbm5lcgRib29sAgIAAQ==
     secure: false
     isObject: true
   my:outer.inner:

--- a/sdk/go/common/resource/config/testdata/repr/26.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/26.expected.yaml
@@ -6,7 +6,7 @@ paths:
       inner: false
     string: '{"inner":false}'
     redacted: '{"inner":false}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAU/4IRAAEFaW5uZXIEYm9vbAICAAA=
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABT/gBEAAQVpbm5lcgRib29sAgIAAA==
     secure: false
     isObject: true
   my:outer.inner:

--- a/sdk/go/common/resource/config/testdata/repr/27.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/27.expected.yaml
@@ -6,7 +6,7 @@ paths:
       inner: 100
     string: '{"inner":100}'
     redacted: '{"inner":100}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAW/4ITAAEFaW5uZXIFaW50NjQEAwD/yA==
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABb/gBMAAQVpbm5lcgVpbnQ2NAQDAP/I
     secure: false
     isObject: true
   my:outer.inner:

--- a/sdk/go/common/resource/config/testdata/repr/28.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/28.expected.yaml
@@ -6,7 +6,7 @@ paths:
       inner: -2
     string: '{"inner":-2}'
     redacted: '{"inner":-2}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAV/4ISAAEFaW5uZXIFaW50NjQEAgAD
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABX/gBIAAQVpbm5lcgVpbnQ2NAQCAAM=
     secure: false
     isObject: true
   my:outer.inner:

--- a/sdk/go/common/resource/config/testdata/repr/29.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/29.expected.yaml
@@ -7,7 +7,7 @@ paths:
         nested: foo
     string: '{"inner":{"nested":"foo"}}'
     redacted: '{"inner":{"nested":"foo"}}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAA9/4I6AAEFaW5uZXIXbWFwW3N0cmluZ11pbnRlcmZhY2Uge33/ghcAAQZuZXN0ZWQGc3RyaW5nDAUAA2Zvbw==
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAD3/gDoAAQVpbm5lchdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+AFwABBm5lc3RlZAZzdHJpbmcMBQADZm9v
     secure: false
     isObject: true
   my:outer.inner:
@@ -15,7 +15,7 @@ paths:
       nested: foo
     string: '{"nested":"foo"}'
     redacted: '{"nested":"foo"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAa/4IXAAEGbmVzdGVkBnN0cmluZwwFAANmb28=
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABr/gBcAAQZuZXN0ZWQGc3RyaW5nDAUAA2Zvbw==
     secure: false
     isObject: true
   my:outer.inner.nested:

--- a/sdk/go/common/resource/config/testdata/repr/3.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/3.expected.yaml
@@ -7,7 +7,7 @@ paths:
         foo: 12321123131
     string: '{"nested":{"foo":12321123131}}'
     redacted: '{"nested":{"foo":12321123131}}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAA8/4I5AAEGbmVzdGVkF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4IVAAEDZm9vBWludDY0BAcA+wW8ytZ2
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAADz/gDkAAQZuZXN0ZWQXbWFwW3N0cmluZ11pbnRlcmZhY2Uge33/gBUAAQNmb28FaW50NjQEBwD7BbzK1nY=
     secure: false
     isObject: true
   my:parent.nested:
@@ -15,7 +15,7 @@ paths:
       foo: 12321123131
     string: '{"foo":12321123131}'
     redacted: '{"foo":12321123131}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAY/4IVAAEDZm9vBWludDY0BAcA+wW8ytZ2
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABj/gBUAAQNmb28FaW50NjQEBwD7BbzK1nY=
     secure: false
     isObject: true
   my:parent.nested.foo:

--- a/sdk/go/common/resource/config/testdata/repr/30.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/30.expected.yaml
@@ -8,7 +8,7 @@ paths:
           secure: securevalue
     string: '{"inner":{"nested":{"secure":"securevalue"}}}'
     redacted: '{"inner":{"nested":"[secret]"}}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAABp/4JmAAEFaW5uZXIXbWFwW3N0cmluZ11pbnRlcmZhY2Uge33/gkMAAQZuZXN0ZWQXbWFwW3N0cmluZ11pbnRlcmZhY2Uge33/gh8AAQZzZWN1cmUGc3RyaW5nDA0AC3NlY3VyZXZhbHVl
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAGn/gGYAAQVpbm5lchdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+AQwABBm5lc3RlZBdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+AHwABBnNlY3VyZQZzdHJpbmcMDQALc2VjdXJldmFsdWU=
     secure: true
     isObject: true
     secureValues:
@@ -19,7 +19,7 @@ paths:
         secure: securevalue
     string: '{"nested":{"secure":"securevalue"}}'
     redacted: '{"nested":"[secret]"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAABG/4JDAAEGbmVzdGVkF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4IfAAEGc2VjdXJlBnN0cmluZwwNAAtzZWN1cmV2YWx1ZQ==
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAEb/gEMAAQZuZXN0ZWQXbWFwW3N0cmluZ11pbnRlcmZhY2Uge33/gB8AAQZzZWN1cmUGc3RyaW5nDA0AC3NlY3VyZXZhbHVl
     secure: true
     isObject: true
     secureValues:

--- a/sdk/go/common/resource/config/testdata/repr/31.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/31.expected.yaml
@@ -9,7 +9,7 @@ paths:
           secure: val
     string: '{"inner":{"nested":{"a":"b","secure":"val"}}}'
     redacted: '{"inner":{"nested":{"a":"b","secure":"val"}}}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAABv/4JsAAEFaW5uZXIXbWFwW3N0cmluZ11pbnRlcmZhY2Uge33/gkkAAQZuZXN0ZWQXbWFwW3N0cmluZ11pbnRlcmZhY2Uge33/giUAAgFhBnN0cmluZwwDAAFiBnNlY3VyZQZzdHJpbmcMBQADdmFs
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAG//gGwAAQVpbm5lchdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+ASQABBm5lc3RlZBdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+AJQACBnNlY3VyZQZzdHJpbmcMBQADdmFsAWEGc3RyaW5nDAMAAWI=
     secure: false
     isObject: true
   my:outer.inner:
@@ -19,7 +19,7 @@ paths:
         secure: val
     string: '{"nested":{"a":"b","secure":"val"}}'
     redacted: '{"nested":{"a":"b","secure":"val"}}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAABM/4JJAAEGbmVzdGVkF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4IlAAIBYQZzdHJpbmcMAwABYgZzZWN1cmUGc3RyaW5nDAUAA3ZhbA==
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAEz/gEkAAQZuZXN0ZWQXbWFwW3N0cmluZ11pbnRlcmZhY2Uge33/gCUAAgFhBnN0cmluZwwDAAFiBnNlY3VyZQZzdHJpbmcMBQADdmFs
     secure: false
     isObject: true
   my:outer.inner.nested:
@@ -28,7 +28,7 @@ paths:
       secure: val
     string: '{"a":"b","secure":"val"}'
     redacted: '{"a":"b","secure":"val"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAo/4IlAAIBYQZzdHJpbmcMAwABYgZzZWN1cmUGc3RyaW5nDAUAA3ZhbA==
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAACj/gCUAAgFhBnN0cmluZwwDAAFiBnNlY3VyZQZzdHJpbmcMBQADdmFs
     secure: false
     isObject: true
   my:outer.inner.nested.a:

--- a/sdk/go/common/resource/config/testdata/repr/32.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/32.expected.yaml
@@ -6,7 +6,7 @@ paths:
     - a
     string: '["a"]'
     redacted: '["a"]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAEf+EDgABBnN0cmluZwwDAAFh
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAEf+CDgABBnN0cmluZwwDAAFh
     secure: false
     isObject: true
   my:testKey[0]:

--- a/sdk/go/common/resource/config/testdata/repr/33.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/33.expected.yaml
@@ -8,7 +8,7 @@ paths:
     - c
     string: '["a","b","c"]'
     redacted: '["a","b","c"]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAKf+EJgADBnN0cmluZwwDAAFhBnN0cmluZwwDAAFiBnN0cmluZwwDAAFj
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAKf+CJgADBnN0cmluZwwDAAFhBnN0cmluZwwDAAFiBnN0cmluZwwDAAFj
     secure: false
     isObject: true
   my:names[0]:

--- a/sdk/go/common/resource/config/testdata/repr/34.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/34.expected.yaml
@@ -6,7 +6,7 @@ paths:
       inner: hi
     string: '{"inner":"hi"}'
     redacted: '{"inner":"hi"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAY/4IVAAEFaW5uZXIGc3RyaW5nDAQAAmhp
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABj/gBUAAQVpbm5lcgZzdHJpbmcMBAACaGk=
     secure: false
     isObject: true
   my:outer.inner:

--- a/sdk/go/common/resource/config/testdata/repr/37.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/37.expected.yaml
@@ -7,7 +7,7 @@ paths:
       secure: myvalue
     string: '{"bar":"baz","secure":"myvalue"}'
     redacted: '{"bar":"baz","secure":"myvalue"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAw/4ItAAIGc2VjdXJlBnN0cmluZwwJAAdteXZhbHVlA2JhcgZzdHJpbmcMBQADYmF6
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAADD/gC0AAgNiYXIGc3RyaW5nDAUAA2JhegZzZWN1cmUGc3RyaW5nDAkAB215dmFsdWU=
     secure: false
     isObject: true
   my:foo.bar:

--- a/sdk/go/common/resource/config/testdata/repr/39.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/39.expected.yaml
@@ -6,7 +6,7 @@ paths:
       test.Key: value
     string: '{"test.Key":"value"}'
     redacted: '{"test.Key":"value"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAe/4IbAAEIdGVzdC5LZXkGc3RyaW5nDAcABXZhbHVl
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAB7/gBsAAQh0ZXN0LktleQZzdHJpbmcMBwAFdmFsdWU=
     secure: false
     isObject: true
   my:nested["test.Key"]:

--- a/sdk/go/common/resource/config/testdata/repr/4.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/4.expected.yaml
@@ -6,7 +6,7 @@ paths:
       nested: 4.2
     string: '{"nested":4.2}'
     redacted: '{"nested":4.2}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAg/4IdAAEGbmVzdGVkB2Zsb2F0NjQICgD4zczMzMzMEEA=
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAACD/gB0AAQZuZXN0ZWQHZmxvYXQ2NAgKAPjNzMzMzMwQQA==
     secure: false
     isObject: true
   my:parent.nested:

--- a/sdk/go/common/resource/config/testdata/repr/40.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/40.expected.yaml
@@ -6,7 +6,7 @@ paths:
       inner: 10
     string: '{"inner":10}'
     redacted: '{"inner":10}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAV/4ISAAEFaW5uZXIFaW50NjQEAgAU
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABX/gBIAAQVpbm5lcgVpbnQ2NAQCABQ=
     secure: false
     isObject: true
   my:outer.inner:

--- a/sdk/go/common/resource/config/testdata/repr/41.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/41.expected.yaml
@@ -6,7 +6,7 @@ paths:
       inner: 0
     string: '{"inner":0}'
     redacted: '{"inner":0}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAV/4ISAAEFaW5uZXIFaW50NjQEAgAA
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABX/gBIAAQVpbm5lcgVpbnQ2NAQCAAA=
     secure: false
     isObject: true
   my:outer.inner:

--- a/sdk/go/common/resource/config/testdata/repr/42.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/42.expected.yaml
@@ -6,7 +6,7 @@ paths:
       inner: -1
     string: '{"inner":-1}'
     redacted: '{"inner":-1}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAV/4ISAAEFaW5uZXIFaW50NjQEAgAB
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABX/gBIAAQVpbm5lcgVpbnQ2NAQCAAE=
     secure: false
     isObject: true
   my:outer.inner:

--- a/sdk/go/common/resource/config/testdata/repr/43.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/43.expected.yaml
@@ -6,7 +6,7 @@ paths:
       inner: "00"
     string: '{"inner":"00"}'
     redacted: '{"inner":"00"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAY/4IVAAEFaW5uZXIGc3RyaW5nDAQAAjAw
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABj/gBUAAQVpbm5lcgZzdHJpbmcMBAACMDA=
     secure: false
     isObject: true
   my:outer.inner:

--- a/sdk/go/common/resource/config/testdata/repr/44.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/44.expected.yaml
@@ -6,7 +6,7 @@ paths:
       inner: "01"
     string: '{"inner":"01"}'
     redacted: '{"inner":"01"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAY/4IVAAEFaW5uZXIGc3RyaW5nDAQAAjAx
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABj/gBUAAQVpbm5lcgZzdHJpbmcMBAACMDE=
     secure: false
     isObject: true
   my:outer.inner:

--- a/sdk/go/common/resource/config/testdata/repr/45.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/45.expected.yaml
@@ -6,7 +6,7 @@ paths:
       inner: "0123456"
     string: '{"inner":"0123456"}'
     redacted: '{"inner":"0123456"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAd/4IaAAEFaW5uZXIGc3RyaW5nDAkABzAxMjM0NTY=
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAB3/gBoAAQVpbm5lcgZzdHJpbmcMCQAHMDEyMzQ1Ng==
     secure: false
     isObject: true
   my:outer.inner:

--- a/sdk/go/common/resource/config/testdata/repr/46.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/46.expected.yaml
@@ -6,7 +6,7 @@ paths:
     - value
     string: '["value"]'
     redacted: '["value"]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAFf+EEgABBnN0cmluZwwHAAV2YWx1ZQ==
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAFf+CEgABBnN0cmluZwwHAAV2YWx1ZQ==
     secure: false
     isObject: true
   my:array[0]:

--- a/sdk/go/common/resource/config/testdata/repr/47.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/47.expected.yaml
@@ -7,7 +7,7 @@ paths:
       inner: value
     string: '{"existing":"existingValue","inner":"value"}'
     redacted: '{"existing":"existingValue","inner":"value"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAA8/4I5AAIIZXhpc3RpbmcGc3RyaW5nDA8ADWV4aXN0aW5nVmFsdWUFaW5uZXIGc3RyaW5nDAcABXZhbHVl
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAADz/gDkAAgVpbm5lcgZzdHJpbmcMBwAFdmFsdWUIZXhpc3RpbmcGc3RyaW5nDA8ADWV4aXN0aW5nVmFsdWU=
     secure: false
     isObject: true
   my:outer.existing:

--- a/sdk/go/common/resource/config/testdata/repr/48.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/48.expected.yaml
@@ -7,7 +7,7 @@ paths:
         nested: value
     string: '{"inner":{"nested":"value"}}'
     redacted: '{"inner":{"nested":"value"}}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAA//4I8AAEFaW5uZXIXbWFwW3N0cmluZ11pbnRlcmZhY2Uge33/ghkAAQZuZXN0ZWQGc3RyaW5nDAcABXZhbHVl
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAD//gDwAAQVpbm5lchdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+AGQABBm5lc3RlZAZzdHJpbmcMBwAFdmFsdWU=
     secure: false
     isObject: true
   my:outer.inner:
@@ -15,7 +15,7 @@ paths:
       nested: value
     string: '{"nested":"value"}'
     redacted: '{"nested":"value"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAc/4IZAAEGbmVzdGVkBnN0cmluZwwHAAV2YWx1ZQ==
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABz/gBkAAQZuZXN0ZWQGc3RyaW5nDAcABXZhbHVl
     secure: false
     isObject: true
   my:outer.inner.nested:

--- a/sdk/go/common/resource/config/testdata/repr/49.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/49.expected.yaml
@@ -6,7 +6,7 @@ paths:
     - value
     string: '["value"]'
     redacted: '["value"]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAFf+EEgABBnN0cmluZwwHAAV2YWx1ZQ==
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAFf+CEgABBnN0cmluZwwHAAV2YWx1ZQ==
     secure: false
     isObject: true
   my:name[0]:

--- a/sdk/go/common/resource/config/testdata/repr/5.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/5.expected.yaml
@@ -7,7 +7,7 @@ paths:
       - 4.2
     string: '{"nested":[4.2]}'
     redacted: '{"nested":[4.2]}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAABB/4IkAAEGbmVzdGVkDltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAGf+EFgABB2Zsb2F0NjQICgD4zczMzMzMEEA=
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAEH/gCQAAQZuZXN0ZWQOW11pbnRlcmZhY2Uge33/gQIBAv+CAAEQAAAZ/4IWAAEHZmxvYXQ2NAgKAPjNzMzMzMwQQA==
     secure: false
     isObject: true
   my:parent.nested:
@@ -15,7 +15,7 @@ paths:
     - 4.2
     string: '[4.2]'
     redacted: '[4.2]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAGf+EFgABB2Zsb2F0NjQICgD4zczMzMzMEEA=
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAGf+CFgABB2Zsb2F0NjQICgD4zczMzMzMEEA=
     secure: false
     isObject: true
   my:parent.nested[0]:

--- a/sdk/go/common/resource/config/testdata/repr/50.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/50.expected.yaml
@@ -6,7 +6,7 @@ paths:
     - - value
     string: '[["value"]]'
     redacted: '[["value"]]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAKf+EJgABDltdaW50ZXJmYWNlIHt9/4QSAAEGc3RyaW5nDAcABXZhbHVl
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAKf+CJgABDltdaW50ZXJmYWNlIHt9/4ISAAEGc3RyaW5nDAcABXZhbHVl
     secure: false
     isObject: true
   my:name[0]:
@@ -14,7 +14,7 @@ paths:
     - value
     string: '["value"]'
     redacted: '["value"]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAFf+EEgABBnN0cmluZwwHAAV2YWx1ZQ==
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAFf+CEgABBnN0cmluZwwHAAV2YWx1ZQ==
     secure: false
     isObject: true
   my:name[0][0]:

--- a/sdk/go/common/resource/config/testdata/repr/51.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/51.expected.yaml
@@ -8,7 +8,7 @@ paths:
     - c
     string: '["value","b","c"]'
     redacted: '["value","b","c"]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAALf+EKgADBnN0cmluZwwHAAV2YWx1ZQZzdHJpbmcMAwABYgZzdHJpbmcMAwABYw==
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAALf+CKgADBnN0cmluZwwHAAV2YWx1ZQZzdHJpbmcMAwABYgZzdHJpbmcMAwABYw==
     secure: false
     isObject: true
   my:name[0]:

--- a/sdk/go/common/resource/config/testdata/repr/52.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/52.expected.yaml
@@ -8,7 +8,7 @@ paths:
     - c
     string: '["a","value","c"]'
     redacted: '["a","value","c"]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAALf+EKgADBnN0cmluZwwDAAFhBnN0cmluZwwHAAV2YWx1ZQZzdHJpbmcMAwABYw==
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAALf+CKgADBnN0cmluZwwDAAFhBnN0cmluZwwHAAV2YWx1ZQZzdHJpbmcMAwABYw==
     secure: false
     isObject: true
   my:name[0]:

--- a/sdk/go/common/resource/config/testdata/repr/53.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/53.expected.yaml
@@ -8,7 +8,7 @@ paths:
     - value
     string: '["a","b","value"]'
     redacted: '["a","b","value"]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAALf+EKgADBnN0cmluZwwDAAFhBnN0cmluZwwDAAFiBnN0cmluZwwHAAV2YWx1ZQ==
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAALf+CKgADBnN0cmluZwwDAAFhBnN0cmluZwwDAAFiBnN0cmluZwwHAAV2YWx1ZQ==
     secure: false
     isObject: true
   my:name[0]:

--- a/sdk/go/common/resource/config/testdata/repr/54.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/54.expected.yaml
@@ -9,7 +9,7 @@ paths:
     - value
     string: '["a","b","c","value"]'
     redacted: '["a","b","c","value"]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAOf+ENgAEBnN0cmluZwwDAAFhBnN0cmluZwwDAAFiBnN0cmluZwwDAAFjBnN0cmluZwwHAAV2YWx1ZQ==
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAOf+CNgAEBnN0cmluZwwDAAFhBnN0cmluZwwDAAFiBnN0cmluZwwDAAFjBnN0cmluZwwHAAV2YWx1ZQ==
     secure: false
     isObject: true
   my:name[0]:

--- a/sdk/go/common/resource/config/testdata/repr/55.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/55.expected.yaml
@@ -9,7 +9,7 @@ paths:
     - - value
     string: '["a","b","c",["value"]]'
     redacted: '["a","b","c",["value"]]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAATf+ESgAEBnN0cmluZwwDAAFhBnN0cmluZwwDAAFiBnN0cmluZwwDAAFjDltdaW50ZXJmYWNlIHt9/4QSAAEGc3RyaW5nDAcABXZhbHVl
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAATf+CSgAEBnN0cmluZwwDAAFhBnN0cmluZwwDAAFiBnN0cmluZwwDAAFjDltdaW50ZXJmYWNlIHt9/4ISAAEGc3RyaW5nDAcABXZhbHVl
     secure: false
     isObject: true
   my:name[0]:
@@ -38,7 +38,7 @@ paths:
     - value
     string: '["value"]'
     redacted: '["value"]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAFf+EEgABBnN0cmluZwwHAAV2YWx1ZQ==
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAFf+CEgABBnN0cmluZwwHAAV2YWx1ZQ==
     secure: false
     isObject: true
   my:name[3][0]:

--- a/sdk/go/common/resource/config/testdata/repr/56.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/56.expected.yaml
@@ -9,7 +9,7 @@ paths:
     - - nested: value
     string: '["a","b","c",[{"nested":"value"}]]'
     redacted: '["a","b","c",[{"nested":"value"}]]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAA/4D/hH0ABAZzdHJpbmcMAwABYQZzdHJpbmcMAwABYgZzdHJpbmcMAwABYw5bXWludGVyZmFjZSB7ff+EKAABF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAc/4IZAAEGbmVzdGVkBnN0cmluZwwHAAV2YWx1ZQ==
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAf/+CfAAEBnN0cmluZwwDAAFhBnN0cmluZwwDAAFiBnN0cmluZwwDAAFjDltdaW50ZXJmYWNlIHt9/4InAAEXbWFwW3N0cmluZ11pbnRlcmZhY2Uge31/BAEC/4AAAQwBEAAAHP+AGQABBm5lc3RlZAZzdHJpbmcMBwAFdmFsdWU=
     secure: false
     isObject: true
   my:name[0]:
@@ -38,7 +38,7 @@ paths:
     - nested: value
     string: '[{"nested":"value"}]'
     redacted: '[{"nested":"value"}]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAASP+EKAABF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAc/4IZAAEGbmVzdGVkBnN0cmluZwwHAAV2YWx1ZQ==
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAR/+CJwABF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABz/gBkAAQZuZXN0ZWQGc3RyaW5nDAcABXZhbHVl
     secure: false
     isObject: true
   my:name[3][0]:
@@ -46,7 +46,7 @@ paths:
       nested: value
     string: '{"nested":"value"}'
     redacted: '{"nested":"value"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAc/4IZAAEGbmVzdGVkBnN0cmluZwwHAAV2YWx1ZQ==
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABz/gBkAAQZuZXN0ZWQGc3RyaW5nDAcABXZhbHVl
     secure: false
     isObject: true
   my:name[3][0].nested:

--- a/sdk/go/common/resource/config/testdata/repr/57.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/57.expected.yaml
@@ -10,7 +10,7 @@ paths:
         bar: value
     string: '["a","b","c",{"foo":{"bar":"value"}}]'
     redacted: '["a","b","c",{"foo":{"bar":"value"}}]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAA/4r/hEwABAZzdHJpbmcMAwABYQZzdHJpbmcMAwABYgZzdHJpbmcMAwABYxdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+BBAEC/4IAAQwBEAAAOv+CNwABA2ZvbxdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+CFgABA2JhcgZzdHJpbmcMBwAFdmFsdWU=
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAA/4n/gksABAZzdHJpbmcMAwABYQZzdHJpbmcMAwABYgZzdHJpbmcMAwABYxdtYXBbc3RyaW5nXWludGVyZmFjZSB7fX8EAQL/gAABDAEQAAA6/4A3AAEDZm9vF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4AWAAEDYmFyBnN0cmluZwwHAAV2YWx1ZQ==
     secure: false
     isObject: true
   my:name[0]:
@@ -40,7 +40,7 @@ paths:
         bar: value
     string: '{"foo":{"bar":"value"}}'
     redacted: '{"foo":{"bar":"value"}}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAA6/4I3AAEDZm9vF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4IWAAEDYmFyBnN0cmluZwwHAAV2YWx1ZQ==
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAADr/gDcAAQNmb28XbWFwW3N0cmluZ11pbnRlcmZhY2Uge33/gBYAAQNiYXIGc3RyaW5nDAcABXZhbHVl
     secure: false
     isObject: true
   my:name[3].foo:
@@ -48,7 +48,7 @@ paths:
       bar: value
     string: '{"bar":"value"}'
     redacted: '{"bar":"value"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAZ/4IWAAEDYmFyBnN0cmluZwwHAAV2YWx1ZQ==
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABn/gBYAAQNiYXIGc3RyaW5nDAcABXZhbHVl
     secure: false
     isObject: true
   my:name[3].foo.bar:

--- a/sdk/go/common/resource/config/testdata/repr/58.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/58.expected.yaml
@@ -6,7 +6,7 @@ paths:
     - name: foo
     string: '[{"name":"foo"}]'
     redacted: '[{"name":"foo"}]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAARP+EKAABF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAY/4IVAAEEbmFtZQZzdHJpbmcMBQADZm9v
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAQ/+CJwABF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABj/gBUAAQRuYW1lBnN0cmluZwwFAANmb28=
     secure: false
     isObject: true
   my:servers[0]:
@@ -14,7 +14,7 @@ paths:
       name: foo
     string: '{"name":"foo"}'
     redacted: '{"name":"foo"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAY/4IVAAEEbmFtZQZzdHJpbmcMBQADZm9v
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABj/gBUAAQRuYW1lBnN0cmluZwwFAANmb28=
     secure: false
     isObject: true
   my:servers[0].name:

--- a/sdk/go/common/resource/config/testdata/repr/59.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/59.expected.yaml
@@ -7,7 +7,7 @@ paths:
       name: foo
     string: '[{"host":"example","name":"foo"}]'
     redacted: '[{"host":"example","name":"foo"}]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAW/+EKAABF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAv/4IsAAIEaG9zdAZzdHJpbmcMCQAHZXhhbXBsZQRuYW1lBnN0cmluZwwFAANmb28=
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAWv+CJwABF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAC//gCwAAgRuYW1lBnN0cmluZwwFAANmb28EaG9zdAZzdHJpbmcMCQAHZXhhbXBsZQ==
     secure: false
     isObject: true
   my:servers[0]:
@@ -16,7 +16,7 @@ paths:
       name: foo
     string: '{"host":"example","name":"foo"}'
     redacted: '{"host":"example","name":"foo"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAv/4IsAAIEbmFtZQZzdHJpbmcMBQADZm9vBGhvc3QGc3RyaW5nDAkAB2V4YW1wbGU=
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAC//gCwAAgRob3N0BnN0cmluZwwJAAdleGFtcGxlBG5hbWUGc3RyaW5nDAUAA2Zvbw==
     secure: false
     isObject: true
   my:servers[0].host:

--- a/sdk/go/common/resource/config/testdata/repr/6.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/6.expected.yaml
@@ -7,7 +7,7 @@ paths:
         foo: 4.2
     string: '{"nested":{"foo":4.2}}'
     redacted: '{"nested":{"foo":4.2}}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAABB/4I+AAEGbmVzdGVkF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4IaAAEDZm9vB2Zsb2F0NjQICgD4zczMzMzMEEA=
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAEH/gD4AAQZuZXN0ZWQXbWFwW3N0cmluZ11pbnRlcmZhY2Uge33/gBoAAQNmb28HZmxvYXQ2NAgKAPjNzMzMzMwQQA==
     secure: false
     isObject: true
   my:parent.nested:
@@ -15,7 +15,7 @@ paths:
       foo: 4.2
     string: '{"foo":4.2}'
     redacted: '{"foo":4.2}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAd/4IaAAEDZm9vB2Zsb2F0NjQICgD4zczMzMzMEEA=
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAB3/gBoAAQNmb28HZmxvYXQ2NAgKAPjNzMzMzMwQQA==
     secure: false
     isObject: true
   my:parent.nested.foo:

--- a/sdk/go/common/resource/config/testdata/repr/60.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/60.expected.yaml
@@ -8,7 +8,7 @@ paths:
     - c
     string: '[{"secure":"securevalue"},"b","c"]'
     redacted: '["[secret]","b","c"]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAZv+EKAADF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAA6/4IfAAEGc2VjdXJlBnN0cmluZwwNAAtzZWN1cmV2YWx1ZQZzdHJpbmcMAwABYgZzdHJpbmcMAwABYw==
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAZf+CJwADF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAADr/gB8AAQZzZWN1cmUGc3RyaW5nDA0AC3NlY3VyZXZhbHVlBnN0cmluZwwDAAFiBnN0cmluZwwDAAFj
     secure: true
     isObject: true
     secureValues:

--- a/sdk/go/common/resource/config/testdata/repr/65.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/65.expected.yaml
@@ -6,7 +6,7 @@ paths:
     - false
     string: '[false]'
     redacted: '[false]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAADv+ECwABBGJvb2wCAgAA
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAADv+CCwABBGJvb2wCAgAA
     secure: false
     isObject: true
   my:testKey[0]:

--- a/sdk/go/common/resource/config/testdata/repr/66.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/66.expected.yaml
@@ -6,7 +6,7 @@ paths:
     - true
     string: '[true]'
     redacted: '[true]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAADv+ECwABBGJvb2wCAgAB
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAADv+CCwABBGJvb2wCAgAB
     secure: false
     isObject: true
   my:testKey[0]:

--- a/sdk/go/common/resource/config/testdata/repr/67.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/67.expected.yaml
@@ -6,7 +6,7 @@ paths:
     - 10
     string: '[10]'
     redacted: '[10]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAD/+EDAABBWludDY0BAIAFA==
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAD/+CDAABBWludDY0BAIAFA==
     secure: false
     isObject: true
   my:testKey[0]:

--- a/sdk/go/common/resource/config/testdata/repr/68.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/68.expected.yaml
@@ -6,7 +6,7 @@ paths:
     - 0
     string: '[0]'
     redacted: '[0]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAD/+EDAABBWludDY0BAIAAA==
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAD/+CDAABBWludDY0BAIAAA==
     secure: false
     isObject: true
   my:testKey[0]:

--- a/sdk/go/common/resource/config/testdata/repr/69.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/69.expected.yaml
@@ -6,7 +6,7 @@ paths:
     - -1
     string: '[-1]'
     redacted: '[-1]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAD/+EDAABBWludDY0BAIAAQ==
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAD/+CDAABBWludDY0BAIAAQ==
     secure: false
     isObject: true
   my:testKey[0]:

--- a/sdk/go/common/resource/config/testdata/repr/70.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/70.expected.yaml
@@ -6,7 +6,7 @@ paths:
     - "00"
     string: '["00"]'
     redacted: '["00"]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAEv+EDwABBnN0cmluZwwEAAIwMA==
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAEv+CDwABBnN0cmluZwwEAAIwMA==
     secure: false
     isObject: true
   my:testKey[0]:

--- a/sdk/go/common/resource/config/testdata/repr/71.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/71.expected.yaml
@@ -6,7 +6,7 @@ paths:
     - "01"
     string: '["01"]'
     redacted: '["01"]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAEv+EDwABBnN0cmluZwwEAAIwMQ==
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAEv+CDwABBnN0cmluZwwEAAIwMQ==
     secure: false
     isObject: true
   my:testKey[0]:

--- a/sdk/go/common/resource/config/testdata/repr/72.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/72.expected.yaml
@@ -6,7 +6,7 @@ paths:
     - "0123456"
     string: '["0123456"]'
     redacted: '["0123456"]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAF/+EFAABBnN0cmluZwwJAAcwMTIzNDU2
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAF/+CFAABBnN0cmluZwwJAAcwMTIzNDU2
     secure: false
     isObject: true
   my:testKey[0]:

--- a/sdk/go/common/resource/config/testdata/repr/73.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/73.expected.yaml
@@ -7,7 +7,7 @@ paths:
       secure: value
     string: '{"bar":"baz","secure":"value"}'
     redacted: '{"bar":"baz","secure":"value"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAu/4IrAAIDYmFyBnN0cmluZwwFAANiYXoGc2VjdXJlBnN0cmluZwwHAAV2YWx1ZQ==
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAC7/gCsAAgNiYXIGc3RyaW5nDAUAA2JhegZzZWN1cmUGc3RyaW5nDAcABXZhbHVl
     secure: false
     isObject: true
   my:key.bar:

--- a/sdk/go/common/resource/config/testdata/repr/74.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/74.expected.yaml
@@ -10,7 +10,7 @@ paths:
       thing2: 2
     string: '{"object":{"fizz":"buzz","foo":"bar"},"thing1":1,"thing2":2}'
     redacted: '{"object":{"fizz":"buzz","foo":"bar"},"thing1":1,"thing2":2}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAABx/4JuAAMGdGhpbmcxBWludDY0BAIAAgZ0aGluZzIFaW50NjQEAgAEBm9iamVjdBdtYXBbc3RyaW5nXWludGVyZmFjZSB7ff+CKAACBGZpenoGc3RyaW5nDAYABGJ1enoDZm9vBnN0cmluZwwFAANiYXI=
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAAHH/gG4AAwZvYmplY3QXbWFwW3N0cmluZ11pbnRlcmZhY2Uge33/gCgAAgRmaXp6BnN0cmluZwwGAARidXp6A2ZvbwZzdHJpbmcMBQADYmFyBnRoaW5nMQVpbnQ2NAQCAAIGdGhpbmcyBWludDY0BAIABA==
     secure: false
     isObject: true
   my:special.object:
@@ -19,7 +19,7 @@ paths:
       foo: bar
     string: '{"fizz":"buzz","foo":"bar"}'
     redacted: '{"fizz":"buzz","foo":"bar"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAr/4IoAAIEZml6egZzdHJpbmcMBgAEYnV6egNmb28Gc3RyaW5nDAUAA2Jhcg==
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAACv/gCgAAgNmb28Gc3RyaW5nDAUAA2JhcgRmaXp6BnN0cmluZwwGAARidXp6
     secure: false
     isObject: true
   my:special.object.fizz:

--- a/sdk/go/common/resource/config/testdata/repr/75.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/75.expected.yaml
@@ -8,7 +8,7 @@ paths:
     - 3
     string: '[1,2,3]'
     redacted: '[1,2,3]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAI/+EIAADBWludDY0BAIAAgVpbnQ2NAQCAAQFaW50NjQEAgAG
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAI/+CIAADBWludDY0BAIAAgVpbnQ2NAQCAAQFaW50NjQEAgAG
     secure: false
     isObject: true
   my:outer[0]:

--- a/sdk/go/common/resource/config/testdata/repr/76.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/76.expected.yaml
@@ -6,7 +6,7 @@ paths:
       inner: value
     string: '{"inner":"value"}'
     redacted: '{"inner":"value"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAb/4IYAAEFaW5uZXIGc3RyaW5nDAcABXZhbHVl
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAABv/gBgAAQVpbm5lcgZzdHJpbmcMBwAFdmFsdWU=
     secure: false
     isObject: true
   my:array.inner:

--- a/sdk/go/common/resource/config/testdata/repr/8.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/8.expected.yaml
@@ -8,7 +8,7 @@ paths:
     - c
     string: '["a","b","c"]'
     redacted: '["a","b","c"]'
-    object: HRAADltdaW50ZXJmYWNlIHt9/4MCAQL/hAABEAAAKf+EJgADBnN0cmluZwwDAAFhBnN0cmluZwwDAAFiBnN0cmluZwwDAAFj
+    object: HRAADltdaW50ZXJmYWNlIHt9/4ECAQL/ggABEAAAKf+CJgADBnN0cmluZwwDAAFhBnN0cmluZwwDAAFiBnN0cmluZwwDAAFj
     secure: false
     isObject: true
   my:arrayKey[0]:

--- a/sdk/go/common/resource/config/testdata/repr/9.expected.yaml
+++ b/sdk/go/common/resource/config/testdata/repr/9.expected.yaml
@@ -7,7 +7,7 @@ paths:
       c: d
     string: '{"a":"b","c":"d"}'
     redacted: '{"a":"b","c":"d"}'
-    object: KBAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9/4EEAQL/ggABDAEQAAAh/4IeAAIBYQZzdHJpbmcMAwABYgFjBnN0cmluZwwDAAFk
+    object: JxAAF21hcFtzdHJpbmddaW50ZXJmYWNlIHt9fwQBAv+AAAEMARAAACH/gB4AAgFhBnN0cmluZwwDAAFiAWMGc3RyaW5nDAMAAWQ=
     secure: false
     isObject: true
   my:mapKey.a:


### PR DESCRIPTION
Looks like [GOB](https://pkg.go.dev/encoding/gob@go1.24.3) has changed over Go versions, so this data now writes differently. This bulk re-generates it to keep it up to date, making it easier to see if things change for real with other modifications to this code.