### PR TITLE
[convert] Copy assets emitted from converter plugins to target directory of the generated project

### DIFF
--- a/changelog/pending/20250509--programgen--copy-assets-emitted-from-converter-plugins-to-target-directory-of-the-generated-projects.yaml
+++ b/changelog/pending/20250509--programgen--copy-assets-emitted-from-converter-plugins-to-target-directory-of-the-generated-projects.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen
+  description: Copy assets emitted from converter plugins to target directory of the generated projects

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -153,9 +153,7 @@ func pclGenerateProject(
 ) (hcl.Diagnostics, error) {
 	_, diagnostics, bindErr := safePclBindDirectory(sourceDirectory, loader, strict)
 	// We always try to copy the source directory to the target directory even if binding failed
-	copyErr := aferoUtil.CopyDir(afero.NewOsFs(), sourceDirectory, targetDirectory, func(fi os.FileInfo) bool {
-		return true
-	})
+	copyErr := aferoUtil.CopyDir(afero.NewOsFs(), sourceDirectory, targetDirectory, nil)
 	// And then we return the combined diagnostics and errors
 	var err error
 	if bindErr != nil || copyErr != nil {

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -262,6 +262,21 @@ func runConvert(
 			// such that any assets are copied over, excluding the Pulumi.yaml project file
 			err = aferoUtil.CopyDir(afero.NewOsFs(), sourceDirectory, targetDirectory,
 				func(file os.FileInfo) bool {
+					if file.IsDir() {
+						sourceAbsPath, err := filepath.Abs(filepath.Join(sourceDirectory, file.Name()))
+						if err != nil {
+							return false
+						}
+
+						targetAbsPath, err := filepath.Abs(targetDirectory)
+						if err != nil {
+							return false
+						}
+						// if the target directory is a subdirectory of the source directory,
+						// skip copying it over
+						return sourceAbsPath != targetAbsPath
+					}
+
 					return file.Name() != "Pulumi.yaml" &&
 						path.Ext(file.Name()) != ".pp"
 				})

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -153,7 +153,9 @@ func pclGenerateProject(
 ) (hcl.Diagnostics, error) {
 	_, diagnostics, bindErr := safePclBindDirectory(sourceDirectory, loader, strict)
 	// We always try to copy the source directory to the target directory even if binding failed
-	copyErr := aferoUtil.CopyDir(afero.NewOsFs(), sourceDirectory, targetDirectory)
+	copyErr := aferoUtil.CopyDir(afero.NewOsFs(), sourceDirectory, targetDirectory, func(fi os.FileInfo) bool {
+		return true
+	})
 	// And then we return the combined diagnostics and errors
 	var err error
 	if bindErr != nil || copyErr != nil {
@@ -258,8 +260,8 @@ func runConvert(
 
 			// copy all non-PCL files from the source directory to the target directory
 			// such that any assets are copied over, excluding the Pulumi.yaml project file
-			err = aferoUtil.CopyDirWhen(afero.NewOsFs(), sourceDirectory, targetDirectory,
-				func(file afero.File) bool {
+			err = aferoUtil.CopyDir(afero.NewOsFs(), sourceDirectory, targetDirectory,
+				func(file os.FileInfo) bool {
 					return file.Name() != "Pulumi.yaml" &&
 						path.Ext(file.Name()) != ".pp"
 				})

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -253,6 +254,17 @@ func runConvert(
 			diags = append(diags, ds...)
 			if err != nil {
 				return nil, err
+			}
+
+			// copy all non-PCL files from the source directory to the target directory
+			// such that any assets are copied over, excluding the Pulumi.yaml project file
+			err = aferoUtil.CopyDirWhen(afero.NewOsFs(), sourceDirectory, targetDirectory,
+				func(file afero.File) bool {
+					return file.Name() != "Pulumi.yaml" &&
+						path.Ext(file.Name()) != ".pp"
+				})
+			if err != nil {
+				return nil, fmt.Errorf("copying files from source directory: %w", err)
 			}
 
 			packageBlockDescriptors, ds, err := getPackagesToGenerateSdks(sourceDirectory)

--- a/pkg/util/afero/afero.go
+++ b/pkg/util/afero/afero.go
@@ -36,14 +36,15 @@ func CopyDir(fs afero.Fs, src, dst string, filter func(os.FileInfo) bool) error 
 		sourcePath := filepath.Join(src, entry.Name())
 		destPath := filepath.Join(dst, entry.Name())
 
+		if filter != nil && !filter(entry) {
+			continue
+		}
+
 		if entry.IsDir() {
 			if err := CopyDir(fs, sourcePath, destPath, filter); err != nil {
 				return err
 			}
 		} else {
-			if filter != nil && !filter(entry) {
-				continue
-			}
 			if err := Copy(fs, sourcePath, destPath); err != nil {
 				return err
 			}

--- a/pkg/util/afero/afero_test.go
+++ b/pkg/util/afero/afero_test.go
@@ -1,0 +1,53 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package afero
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCopyFileWhenWorks(t *testing.T) {
+	content := []byte("hello world")
+	fs := afero.NewMemMapFs()
+	err := afero.WriteFile(fs, "/src/file.txt", content, 0o644)
+	assert.NoError(t, err)
+	// filter always returns false so nothing is copied
+	err = CopyWhen(fs, "/src/file.txt", "/dst/file.txt", func(f afero.File) bool {
+		return false
+	})
+
+	assert.NoError(t, err)
+	// assert that the file was not copied and thus should not exist
+	_, err = fs.Open("/dst/file.txt")
+	assert.True(t, os.IsNotExist(err))
+
+	// now copy the file with a filter that always returns true
+	err = CopyWhen(fs, "/src/file.txt", "/dst/file.txt", func(f afero.File) bool {
+		return true
+	})
+
+	assert.NoError(t, err)
+	// check that the file was copied
+	file, err := fs.Open("/dst/file.txt")
+	assert.NoError(t, err)
+	defer file.Close()
+	fileContent, err := afero.ReadAll(file)
+	assert.NoError(t, err)
+	assert.Equal(t, string(content), string(fileContent))
+}

--- a/pkg/util/afero/afero_test.go
+++ b/pkg/util/afero/afero_test.go
@@ -22,14 +22,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCopyFileWhenWorks(t *testing.T) {
+func TestCopyDirWorksWithFilters(t *testing.T) {
 	t.Parallel()
 	content := []byte("hello world")
 	fs := afero.NewMemMapFs()
 	err := afero.WriteFile(fs, "/src/file.txt", content, 0o644)
 	assert.NoError(t, err)
 	// filter always returns false so nothing is copied
-	err = CopyWhen(fs, "/src/file.txt", "/dst/file.txt", func(f afero.File) bool {
+	err = CopyDir(fs, "/src", "/dst", func(f os.FileInfo) bool {
 		return false
 	})
 
@@ -39,7 +39,7 @@ func TestCopyFileWhenWorks(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 
 	// now copy the file with a filter that always returns true
-	err = CopyWhen(fs, "/src/file.txt", "/dst/file.txt", func(f afero.File) bool {
+	err = CopyDir(fs, "/src", "/dst", func(f os.FileInfo) bool {
 		return true
 	})
 

--- a/pkg/util/afero/afero_test.go
+++ b/pkg/util/afero/afero_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestCopyFileWhenWorks(t *testing.T) {
+	t.Parallel()
 	content := []byte("hello world")
 	fs := afero.NewMemMapFs()
 	err := afero.WriteFile(fs, "/src/file.txt", content, 0o644)


### PR DESCRIPTION
### Description

When `pulumi convert` talks to converter plugins, it tells them where they should emit PCL files from which we bind a program and convert it. If the converters happen to emit non-PCL files such as assets of the program, we just ignore them. This PR addresses the issue by copying non-PCL files from the source program directory (where PCL files were emitted) into the target generated project directory so that the assets stay part of the project. 

This was implemented for conformance tests (specifically for the `l2-resource-asset-archive` test) but not for `pulumi convert` so here we implement it. 

This might be used to support using local TF modules via `pulumi-converter-terraform` where we could copy the contents of the modules into the target project directory. 

### Implementation

Extending `Copy` and `CopyDir` with a filter function `func(afero.File) bool` to become `CopyWhen` and `CopyDirWhen`, then 
 - implementing `Copy` in terms of `CopyWhen` with a filter that always passes
 - implementing `CopyDir` in terms of `CopyDirWhen` with a filter that always passes