### PR TITLE
fix(sdk/nodejs): improve error message for unsupported NodeJS versions

### DIFF
--- a/changelog/pending/20250509--sdk-nodejs--improve-error-message-for-unsupported-nodejs-versions.yaml
+++ b/changelog/pending/20250509--sdk-nodejs--improve-error-message-for-unsupported-nodejs-versions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: improve error message for unsupported NodeJS versions

--- a/sdk/nodejs/runtime/closure/v8Hooks.ts
+++ b/sdk/nodejs/runtime/closure/v8Hooks.ts
@@ -15,7 +15,7 @@
 // Module that hooks into v8 and provides information about it to interested parties. Because this
 // hooks into v8 events it is critical that this module is loaded early when the process starts.
 // Otherwise, information may not be known when needed.  This module is only intended for use on
-// Node v11 and higher.
+// Node v18 and higher.
 
 import * as v8 from "v8";
 v8.setFlagsFromString("--allow-natives-syntax");
@@ -55,12 +55,23 @@ async function createInspectorSessionAsync(): Promise<import("inspector").Sessio
 
 /**
  * Returns the inspector session that can be used to query the state of this
- * running Node instance. Must only be called on Node11 and above. On Node10 and
+ * running Node instance. Must only be called on Node18 and above. On Node17 and
  * below, this will throw.
  *
  * @internal
  */
 export async function getSessionAsync() {
+    // Check Node.js version first and provide a helpful error message
+    const nodeVersion = process.versions.node;
+    const majorVersion = parseInt(nodeVersion.split('.')[0], 10);
+
+    if (majorVersion < 18) {
+        throw new Error(
+            `NodeJS version ${nodeVersion} is not supported. Pulumi requires NodeJS >= 18. ` +
+            `Please upgrade NodeJS: https://nodejs.org/en/download/package-manager/`
+        );
+    }
+
     return getSession();
 }
 
@@ -71,6 +82,17 @@ export async function getSessionAsync() {
  * @internal
  */
 export async function isInitializedAsync() {
+    // Check Node.js version first
+    const nodeVersion = process.versions.node;
+    const majorVersion = parseInt(nodeVersion.split('.')[0], 10);
+
+    if (majorVersion < 18) {
+        throw new Error(
+            `NodeJS version ${nodeVersion} is not supported. Pulumi requires NodeJS >= 18. ` +
+            `Please upgrade NodeJS: https://nodejs.org/en/download/package-manager/`
+        );
+    }
+
     await getSession();
 }
 


### PR DESCRIPTION
Update v8Hooks.ts to provide a clearer error message when using unsupported NodeJS versions (< 18). The error now includes:
- The detected NodeJS version
- The minimum required version (18)
- A URL to installation instructions for upgrading

This addresses issue #9521 where Ubuntu 20.04 LTS ships with NodeJS 10, resulting in a cryptic error message when trying to run Pulumi.

This commit message follows the conventional commit format with:
1. Type: fix (since we're fixing a usability issue)
2. Scope: sdk/nodejs (the area of the codebase affected)
3. Subject: A concise description of the change
4. Body: Details about what was changed and why
5. Reference to the issue being fixed (#9521)