### PR TITLE
clean up API for {Un,}ProtectResource

### DIFF
--- a/pkg/cmd/pulumi/state/state_delete.go
+++ b/pkg/cmd/pulumi/state/state_delete.go
@@ -87,7 +87,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 				handleProtected = func(res *resource.State) error {
 					cmdutil.Diag().Warningf(diag.Message(res.URN,
 						"deleting protected resource %s due to presence of --force"), res.URN)
-					edit.UnprotectResource(res)
+					res.Protect = false
 					return nil
 				}
 			}

--- a/pkg/cmd/pulumi/state/state_protect.go
+++ b/pkg/cmd/pulumi/state/state_protect.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
-	"github.com/pulumi/pulumi/pkg/v3/resource/edit"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -107,7 +106,7 @@ func protectAllResources(ctx context.Context, ws pkgWorkspace.Context, stackName
 			}
 
 			for _, res := range snap.Resources {
-				edit.ProtectResource(res)
+				res.Protect = true
 			}
 
 			return nil
@@ -130,7 +129,7 @@ func protectResource(
 		showPrompt,
 		urn,
 		func(_ *deploy.Snapshot, res *resource.State) error {
-			edit.ProtectResource(res)
+			res.Protect = true
 			return nil
 		},
 		protectMessage,

--- a/pkg/cmd/pulumi/state/state_unprotect.go
+++ b/pkg/cmd/pulumi/state/state_unprotect.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
-	"github.com/pulumi/pulumi/pkg/v3/resource/edit"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -92,7 +91,7 @@ func unprotectAllResources(ctx context.Context, ws pkgWorkspace.Context, stackNa
 			}
 
 			for _, res := range snap.Resources {
-				edit.UnprotectResource(res)
+				res.Protect = false
 			}
 
 			return nil
@@ -109,7 +108,7 @@ func unprotectResource(
 ) error {
 	err := runStateEdit(ctx, ws, backend.DefaultLoginManager, stackName, showPrompt, urn,
 		func(_ *deploy.Snapshot, res *resource.State) error {
-			edit.UnprotectResource(res)
+			res.Protect = false
 			return nil
 		})
 	if err != nil {

--- a/pkg/resource/edit/operations.go
+++ b/pkg/resource/edit/operations.go
@@ -125,16 +125,6 @@ search:
 	return nil
 }
 
-// UnprotectResource unprotects a resource, allowing it to be deleted.
-func UnprotectResource(res *resource.State) {
-	res.Protect = false
-}
-
-// ProtectResource protects a resource, preventing it from being deleted.
-func ProtectResource(res *resource.State) {
-	res.Protect = true
-}
-
 // LocateResource returns all resources in the given snapshot that have the given URN.
 func LocateResource(snap *deploy.Snapshot, urn resource.URN) []*resource.State {
 	// If there is no snapshot then return no resources

--- a/pkg/resource/edit/operations_test.go
+++ b/pkg/resource/edit/operations_test.go
@@ -483,27 +483,6 @@ func TestFailedDeletionParentDependency(t *testing.T) {
 	assert.Equal(t, []*resource.State{pA, a, b, c}, snap.Resources)
 }
 
-func TestUnprotectResource(t *testing.T) {
-	t.Parallel()
-
-	pA := NewProviderResource("a", "p1", "0")
-	a := NewResource("a", pA)
-	a.Protect = true
-	b := NewResource("b", pA)
-	c := NewResource("c", pA)
-	snap := NewSnapshot([]*resource.State{
-		pA,
-		a,
-		b,
-		c,
-	})
-
-	UnprotectResource(a)
-	assert.Len(t, snap.Resources, 4)
-	assert.Equal(t, []*resource.State{pA, a, b, c}, snap.Resources)
-	assert.False(t, a.Protect)
-}
-
 func TestLocateResourceNotFound(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This API is confusing, because it takes a snapshot that isn't used at all, and returns an error, but actually doesn't really.  Clean it up, so it only takes the arguments it needs, and doesn't return anything.