### PR TITLE
rename DebugEventEmitter to DebugContext

### DIFF
--- a/pkg/engine/debugging.go
+++ b/pkg/engine/debugging.go
@@ -18,19 +18,19 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 )
 
-func newDebuggingEventEmitter(events eventEmitter) plugin.DebugEventEmitter {
-	return &debuggingEventEmitter{
+func newDebugContext(events eventEmitter) plugin.DebugContext {
+	return &debugContext{
 		events: events,
 	}
 }
 
-type debuggingEventEmitter struct {
+type debugContext struct {
 	events eventEmitter // the channel to emit events into.
 }
 
-var _ plugin.DebugEventEmitter = (*debuggingEventEmitter)(nil)
+var _ plugin.DebugContext = (*debugContext)(nil)
 
-func (s *debuggingEventEmitter) StartDebugging(info plugin.DebuggingInfo) error {
+func (s *debugContext) StartDebugging(info plugin.DebuggingInfo) error {
 	s.events.startDebugging(info)
 	return nil
 }

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -42,7 +42,7 @@ const clientRuntimeName = "client"
 
 // ProjectInfoContext returns information about the current project, including its pwd, main, and plugin context.
 func ProjectInfoContext(projinfo *Projinfo, host plugin.Host,
-	diag, statusDiag diag.Sink, debugging plugin.DebugEventEmitter, disableProviderPreview bool,
+	diag, statusDiag diag.Sink, debugging plugin.DebugContext, disableProviderPreview bool,
 	tracingSpan opentracing.Span, config map[config.Key]string,
 ) (string, string, *plugin.Context, error) {
 	contract.Requiref(projinfo != nil, "projinfo", "must not be nil")
@@ -189,9 +189,9 @@ func newDeployment(
 	}
 
 	// Create a context for plugins.
-	debuggingEventEmitter := newDebuggingEventEmitter(opts.Events)
+	debugContext := newDebugContext(opts.Events)
 	pwd, main, plugctx, err := ProjectInfoContext(projinfo, opts.Host,
-		opts.Diag, opts.StatusDiag, debuggingEventEmitter, opts.DisableProviderPreview, info.TracingSpan, config)
+		opts.Diag, opts.StatusDiag, debugContext, opts.DisableProviderPreview, info.TracingSpan, config)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/common/resource/plugin/context.go
+++ b/sdk/go/common/resource/plugin/context.go
@@ -84,7 +84,7 @@ func NewContext(d, statusD diag.Sink, host Host, _ ConfigSource,
 func NewContextWithRoot(d, statusD diag.Sink, host Host,
 	pwd, root string, runtimeOptions map[string]interface{}, disableProviderPreview bool,
 	parentSpan opentracing.Span, plugins *workspace.Plugins, packages map[string]workspace.PackageSpec,
-	config map[config.Key]string, debugging DebugEventEmitter,
+	config map[config.Key]string, debugging DebugContext,
 ) (*Context, error) {
 	return NewContextWithContext(
 		context.Background(), d, statusD, host, pwd, root,
@@ -97,7 +97,7 @@ func NewContextWithContext(
 	d, statusD diag.Sink, host Host,
 	pwd, root string, runtimeOptions map[string]interface{}, disableProviderPreview bool,
 	parentSpan opentracing.Span, plugins *workspace.Plugins, packages map[string]workspace.PackageSpec,
-	config map[config.Key]string, debugging DebugEventEmitter,
+	config map[config.Key]string, debugging DebugContext,
 ) (*Context, error) {
 	if d == nil {
 		d = diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})

--- a/sdk/go/common/resource/plugin/debugging.go
+++ b/sdk/go/common/resource/plugin/debugging.go
@@ -14,7 +14,7 @@
 
 package plugin
 
-type DebugEventEmitter interface {
+type DebugContext interface {
 	// StartDebugging asks the host to start a debug session for the given configuration.
 	StartDebugging(info DebuggingInfo) error
 }

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -128,7 +128,7 @@ func IsLocalPluginPath(source string) bool {
 // NewDefaultHost implements the standard plugin logic, using the standard installation root to find them.
 func NewDefaultHost(ctx *Context, runtimeOptions map[string]interface{},
 	disableProviderPreview bool, plugins *workspace.Plugins, packages map[string]workspace.PackageSpec,
-	config map[config.Key]string, debugging DebugEventEmitter, projectName tokens.PackageName,
+	config map[config.Key]string, debugging DebugContext, projectName tokens.PackageName,
 ) (Host, error) {
 	// Create plugin info from providers
 	projectPlugins := make([]workspace.ProjectPlugin, 0)
@@ -303,7 +303,7 @@ type defaultHost struct {
 	disableProviderPreview  bool                             // true if provider plugins should disable provider preview
 	config                  map[config.Key]string            // the configuration map for the stack, if any.
 	projectName             tokens.PackageName               // name of the project
-	debugging               DebugEventEmitter
+	debugging               DebugContext
 
 	// Used to synchronize shutdown with in-progress plugin loads.
 	pluginLock sync.RWMutex


### PR DESCRIPTION
This will be used for more information in subsequent PRs.  Rename it in preparation for further PRs.

/xref https://github.com/pulumi/home/issues/4061