### PR TITLE
make host return the whole DebugContext

### DIFF
--- a/cmd/pulumi-test-language/test_host.go
+++ b/cmd/pulumi-test-language/test_host.go
@@ -214,7 +214,7 @@ func (h *testHost) Close() error {
 	return nil
 }
 
-func (h *testHost) StartDebugging(plugin.DebuggingInfo) error {
+func (h *testHost) DebugContext() plugin.DebugContext {
 	panic("not implemented")
 }
 

--- a/pkg/engine/debugging.go
+++ b/pkg/engine/debugging.go
@@ -18,19 +18,19 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 )
 
-func newDebuggingEventEmitter(events eventEmitter) plugin.DebugEventEmitter {
-	return &debuggingEventEmitter{
+func newDebugContext(events eventEmitter) plugin.DebugContext {
+	return &debugContext{
 		events: events,
 	}
 }
 
-type debuggingEventEmitter struct {
+type debugContext struct {
 	events eventEmitter // the channel to emit events into.
 }
 
-var _ plugin.DebugEventEmitter = (*debuggingEventEmitter)(nil)
+var _ plugin.DebugContext = (*debugContext)(nil)
 
-func (s *debuggingEventEmitter) StartDebugging(info plugin.DebuggingInfo) error {
+func (s *debugContext) StartDebugging(info plugin.DebuggingInfo) error {
 	s.events.startDebugging(info)
 	return nil
 }

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -42,7 +42,7 @@ const clientRuntimeName = "client"
 
 // ProjectInfoContext returns information about the current project, including its pwd, main, and plugin context.
 func ProjectInfoContext(projinfo *Projinfo, host plugin.Host,
-	diag, statusDiag diag.Sink, debugging plugin.DebugEventEmitter, disableProviderPreview bool,
+	diag, statusDiag diag.Sink, debugging plugin.DebugContext, disableProviderPreview bool,
 	tracingSpan opentracing.Span, config map[config.Key]string,
 ) (string, string, *plugin.Context, error) {
 	contract.Requiref(projinfo != nil, "projinfo", "must not be nil")
@@ -189,9 +189,9 @@ func newDeployment(
 	}
 
 	// Create a context for plugins.
-	debuggingEventEmitter := newDebuggingEventEmitter(opts.Events)
+	debugContext := newDebugContext(opts.Events)
 	pwd, main, plugctx, err := ProjectInfoContext(projinfo, opts.Host,
-		opts.Diag, opts.StatusDiag, debuggingEventEmitter, opts.DisableProviderPreview, info.TracingSpan, config)
+		opts.Diag, opts.StatusDiag, debugContext, opts.DisableProviderPreview, info.TracingSpan, config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -439,7 +439,7 @@ func (host *pluginHost) LogStatus(sev diag.Severity, urn resource.URN, msg strin
 	}
 }
 
-func (host *pluginHost) StartDebugging(plugin.DebuggingInfo) error {
+func (host *pluginHost) DebugContext() plugin.DebugContext {
 	return nil
 }
 

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -108,7 +108,7 @@ func (host *testPluginHost) GetRequiredPlugins(project string, info plugin.Progr
 	return nil, nil
 }
 
-func (host *testPluginHost) StartDebugging(plugin.DebuggingInfo) error {
+func (host *testPluginHost) DebugContext() plugin.DebugContext {
 	return nil
 }
 

--- a/sdk/go/common/resource/plugin/context.go
+++ b/sdk/go/common/resource/plugin/context.go
@@ -84,7 +84,7 @@ func NewContext(d, statusD diag.Sink, host Host, _ ConfigSource,
 func NewContextWithRoot(d, statusD diag.Sink, host Host,
 	pwd, root string, runtimeOptions map[string]interface{}, disableProviderPreview bool,
 	parentSpan opentracing.Span, plugins *workspace.Plugins, packages map[string]workspace.PackageSpec,
-	config map[config.Key]string, debugging DebugEventEmitter,
+	config map[config.Key]string, debugging DebugContext,
 ) (*Context, error) {
 	return NewContextWithContext(
 		context.Background(), d, statusD, host, pwd, root,
@@ -97,7 +97,7 @@ func NewContextWithContext(
 	d, statusD diag.Sink, host Host,
 	pwd, root string, runtimeOptions map[string]interface{}, disableProviderPreview bool,
 	parentSpan opentracing.Span, plugins *workspace.Plugins, packages map[string]workspace.PackageSpec,
-	config map[config.Key]string, debugging DebugEventEmitter,
+	config map[config.Key]string, debugging DebugContext,
 ) (*Context, error) {
 	if d == nil {
 		d = diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})

--- a/sdk/go/common/resource/plugin/debugging.go
+++ b/sdk/go/common/resource/plugin/debugging.go
@@ -14,7 +14,7 @@
 
 package plugin
 
-type DebugEventEmitter interface {
+type DebugContext interface {
 	// StartDebugging asks the host to start a debug session for the given configuration.
 	StartDebugging(info DebuggingInfo) error
 }

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -128,7 +128,7 @@ func IsLocalPluginPath(source string) bool {
 // NewDefaultHost implements the standard plugin logic, using the standard installation root to find them.
 func NewDefaultHost(ctx *Context, runtimeOptions map[string]interface{},
 	disableProviderPreview bool, plugins *workspace.Plugins, packages map[string]workspace.PackageSpec,
-	config map[config.Key]string, debugging DebugEventEmitter, projectName tokens.PackageName,
+	config map[config.Key]string, debugging DebugContext, projectName tokens.PackageName,
 ) (Host, error) {
 	// Create plugin info from providers
 	projectPlugins := make([]workspace.ProjectPlugin, 0)
@@ -303,7 +303,7 @@ type defaultHost struct {
 	disableProviderPreview  bool                             // true if provider plugins should disable provider preview
 	config                  map[config.Key]string            // the configuration map for the stack, if any.
 	projectName             tokens.PackageName               // name of the project
-	debugging               DebugEventEmitter
+	debugging               DebugContext
 
 	// Used to synchronize shutdown with in-progress plugin loads.
 	pluginLock sync.RWMutex

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -93,7 +93,7 @@ type Host interface {
 	SignalCancellation() error
 
 	// StartDebugging asks the host to start a debugging session with the given configuration.
-	StartDebugging(DebuggingInfo) error
+	DebugContext() DebugContext
 
 	// Close reclaims any resources associated with the host.
 	Close() error
@@ -189,7 +189,7 @@ func NewDefaultHost(ctx *Context, runtimeOptions map[string]interface{},
 		config:                  config,
 		closer:                  new(sync.Once),
 		projectPlugins:          projectPlugins,
-		debugging:               debugging,
+		debugContext:            debugging,
 		projectName:             projectName,
 	}
 
@@ -303,7 +303,7 @@ type defaultHost struct {
 	disableProviderPreview  bool                             // true if provider plugins should disable provider preview
 	config                  map[config.Key]string            // the configuration map for the stack, if any.
 	projectName             tokens.PackageName               // name of the project
-	debugging               DebugContext
+	debugContext            DebugContext
 
 	// Used to synchronize shutdown with in-progress plugin loads.
 	pluginLock sync.RWMutex
@@ -341,9 +341,8 @@ func (host *defaultHost) LogStatus(sev diag.Severity, urn resource.URN, msg stri
 	host.ctx.StatusDiag.Logf(sev, diag.StreamMessage(urn, msg, streamID))
 }
 
-func (host *defaultHost) StartDebugging(info DebuggingInfo) error {
-	contract.Assertf(host.debugging != nil, "expected host.debugging to be non-nil")
-	return host.debugging.StartDebugging(info)
+func (host *defaultHost) DebugContext() DebugContext {
+	return host.debugContext
 }
 
 // loadPlugin sends an appropriate load request to the plugin loader and returns the loaded plugin (if any) and error.

--- a/sdk/go/common/resource/plugin/host_server.go
+++ b/sdk/go/common/resource/plugin/host_server.go
@@ -141,7 +141,7 @@ func (eng *hostServer) StartDebugging(ctx context.Context,
 		diag.Info, resource.URN(""),
 		fmt.Sprintf("Waiting for debugger to attach (%v)...", req.GetMessage()), 0)
 
-	err := eng.host.StartDebugging(info)
+	err := eng.host.DebugContext().StartDebugging(info)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/common/resource/plugin/mock.go
+++ b/sdk/go/common/resource/plugin/mock.go
@@ -39,7 +39,7 @@ type MockHost struct {
 	GetProjectPluginsF  func() []workspace.ProjectPlugin
 	SignalCancellationF func() error
 	CloseF              func() error
-	StartDebuggingF     func(DebuggingInfo) error
+	DebugContextF       func() DebugContext
 }
 
 var _ Host = (*MockHost)(nil)
@@ -142,9 +142,9 @@ func (m *MockHost) Close() error {
 	return nil
 }
 
-func (m *MockHost) StartDebugging(info DebuggingInfo) error {
-	if m.StartDebuggingF != nil {
-		return m.StartDebuggingF(info)
+func (m *MockHost) DebugContext() DebugContext {
+	if m.DebugContextF != nil {
+		return m.DebugContextF()
 	}
 	return nil
 }


### PR DESCRIPTION
Instead of exposing all methods of the DebugContext separately, expose the DebugContext as a whole.  This will be useful in subsequent PRs, where we're going to add more methods to this.

Based on top of https://github.com/pulumi/pulumi/pull/19511
/xref https://github.com/pulumi/home/issues/4061