### PR TITLE
Update `package add` docs

### DIFF
--- a/changelog/pending/20250512--cli--update-package-add-help-to-mention-pulumi-yaml.yaml
+++ b/changelog/pending/20250512--cli--update-package-add-help-to-mention-pulumi-yaml.yaml
@@ -1,4 +1,0 @@
-kind: improvement
-area: cli
-component: "cli/package"
-summary: "Update help text for `pulumi package add` to mention that it adds packages to Pulumi.yaml"

--- a/changelog/pending/20250512--cli--update-package-add-help-to-mention-pulumi-yaml.yaml
+++ b/changelog/pending/20250512--cli--update-package-add-help-to-mention-pulumi-yaml.yaml
@@ -1,0 +1,4 @@
+kind: improvement
+area: cli
+component: "cli/package"
+summary: "Update help text for `pulumi package add` to mention that it adds packages to Pulumi.yaml"

--- a/docs/architecture/providers/parameterized.md
+++ b/docs/architecture/providers/parameterized.md
@@ -4,7 +4,8 @@
 *Parameterized providers* are a Pulumi feature that allows a user to change a
 provider's behaviour at runtime. The user generates an SDK by running
 `pulumi package add` or `pulumi package gen-sdk` with additional command-line
-arguments (`args`). The provider is passed the arguments and generates an SDK
+arguments (`args`). When using `pulumi package add`, the package is also added to
+the project configuration file (Pulumi.yaml). The provider is passed the arguments and generates an SDK
 for the user, which also includes custom provider metadata. When the SDK is used
 from a Pulumi program, the provider is "parameterized" with the metadata from
 within the generated SDK so it's ready to use.

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -104,9 +104,10 @@ func newPackageAddCmd() *cobra.Command {
 		Short: "Add a package to your Pulumi project",
 		Long: `Add a package to your Pulumi project.
 
-This command locally generates an SDK in the currently selected Pulumi language
-and prints instructions on how to link it into your project. The SDK is based on
-a Pulumi package schema extracted from a given resource plugin or provided
+This command locally generates an SDK in the currently selected Pulumi language,
+adds the package to your project configuration file (Pulumi.yaml), and prints
+instructions on how to link it into your project. The SDK is based on a Pulumi
+package schema extracted from a given resource plugin or provided
 directly.
 
 The <provider> argument can be specified in one of the following ways:


### PR DESCRIPTION
Update the docs for `pulumi package add` to indicate that the package is also added to `Pulumi.yaml`.