### PR TITLE
Support readable forms of package parameterization blocks in PCL

### DIFF
--- a/changelog/pending/20250512--programgen--support-readable-forms-of-package-parameterization-blocks-in-pcl.yaml
+++ b/changelog/pending/20250512--programgen--support-readable-forms-of-package-parameterization-blocks-in-pcl.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen
+  description: Support readable forms of package parameterization blocks in PCL

--- a/cmd/pulumi-test-language/tests/testdata/l2-parameterized-resource/main.pp
+++ b/cmd/pulumi-test-language/tests/testdata/l2-parameterized-resource/main.pp
@@ -4,7 +4,7 @@ package "subpackage" {
     parameterization {
         name = "subpackage"
         version = "2.0.0"
-        value = "SGVsbG9Xb3JsZA==" // base64(utf8_bytes("HelloWorld"))
+        value = toBase64("HelloWorld")
     }
 }
 


### PR DESCRIPTION
### Description

In PCL `package` declarations accept a `parameterization` block that expects the parameter `value` to be a base64-encoded string which is then decoded in the parsing logic to byte[]. 

Although this is internal and not visible to users, it makes PCL files harder to edit and review when actually emitting them from converter plugins. 

This PR adds additional readable forms to the parsing logic such that the `value` of parameterization accepts:
 - a base-64 encoded string (current default) for example `"SGVsbG8="` which the string `"Hello"` but base64 encoded
 - an expression of the form `toBase64(<expr>)` for example `toBase64("Hello") which is a more readable version of the above
 - an expression of the form `toBase64(toJSON({<object-expression>))` 

Example with `toBase64(<litral-expression>)`
```hcl
package "random" {
    baseProviderName = "terraform-provider"
    baseProviderVersion = "0.1.0"
    baseProviderDownloadUrl = "https://example.com/terraform-provider.zip"
    parameterization {
        name = "random"
        version = "4.5.6"
        value = toBase64("Hello")
    }
}
```

Example with `toBase64(toJSON(<object-expression>))`

```hcl
package "vpc" {
    baseProviderName = "terraform-module"
    baseProviderVersion = "0.1.3"
    parameterization {
        name = "vpc"
        version = "5.18.1"
        value = toBase64(toJSON({
            module = "terraform-aws-modules/vpc/aws"
            version = "5.18.1"
            packageName = "vpc"
        }))
    }
}
```
The above is also how it will be used from the pulumi-converter-terraform repo