### PR TITLE
Add optional cache duration to CLIVersionResponse apitype

### DIFF
--- a/changelog/pending/20250513--sdk--add-cliversionresponsewithcache-apitype.yaml
+++ b/changelog/pending/20250513--sdk--add-cliversionresponsewithcache-apitype.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk
+  description: Add optional cache duration to CLIVersionResponse apitype

--- a/sdk/go/common/apitype/cli.go
+++ b/sdk/go/common/apitype/cli.go
@@ -19,4 +19,5 @@ type CLIVersionResponse struct {
 	LatestVersion        string `json:"latestVersion"`
 	OldestWithoutWarning string `json:"oldestWithoutWarning"`
 	LatestDevVersion     string `json:"latestDevVersion"`
+	CacheMS              int    `json:"cacheMS,omitempty"`
 }


### PR DESCRIPTION
The upcoming work in pulumi-service to use OpenAPI codegen requires all returns to be defined in `apitype`. While this new field is transitional as we roll out changes to the version checking endpoint, we still need to add it to the struct to not block the OpenAPI work.

Ref https://github.com/pulumi/pulumi-service/pull/27857