### PR TITLE
`plugin.NewContext(WithRoot)?` accept `context.Context`

### DIFF
--- a/changelog/pending/20250513--sdk-go--accept-context-context-wherever-new-plugin-context-s-are-created.yaml
+++ b/changelog/pending/20250513--sdk-go--accept-context-context-wherever-new-plugin-context-s-are-created.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/go
+  description: Accept `context.Context` wherever new `plugin.Context`s are created.

--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -352,7 +352,7 @@ func (eng *languageTestServer) PrepareLanguageTests(
 	})
 
 	// Start up a plugin context
-	pctx, err := plugin.NewContextWithContext(ctx, snk, snk, nil, "", "", nil, false, nil, nil, nil, nil, nil)
+	pctx, err := plugin.NewContextWithRoot(ctx, snk, snk, nil, "", "", nil, false, nil, nil, nil, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("setup plugin context: %w", err)
 	}
@@ -502,13 +502,13 @@ func (eng *languageTestServer) RunLanguageTest(
 	})
 
 	// Start up a plugin context
-	pctx, err := plugin.NewContextWithContext(
+	pctx, err := plugin.NewContextWithRoot(
 		ctx, snk, snk, nil, token.TemporaryDirectory, token.TemporaryDirectory, nil, false, nil, nil, nil, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("setup plugin context: %w", err)
 	}
 
-	// NewContextWithContext will make a default plugin host, but we want to make sure we never actually use that
+	// NewContextWithRoot will make a default plugin host, but we want to make sure we never actually use that
 	pctx.Host = nil
 
 	// Connect to the language host

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -670,7 +670,7 @@ func NewImportCmd() *cobra.Command {
 				return fmt.Errorf("get working directory: %w", err)
 			}
 			sink := cmdutil.Diag()
-			pCtx, err := plugin.NewContext(sink, sink, nil, nil, cwd, nil, true, nil)
+			pCtx, err := plugin.NewContext(ctx, sink, sink, nil, nil, cwd, nil, true, nil)
 			if err != nil {
 				return fmt.Errorf("create plugin context: %w", err)
 			}
@@ -883,7 +883,7 @@ func NewImportCmd() *cobra.Command {
 				}
 				sink := cmdutil.Diag()
 
-				ctx, err := plugin.NewContext(sink, sink, nil, nil, cwd, nil, true, nil)
+				ctx, err := plugin.NewContext(ctx, sink, sink, nil, nil, cwd, nil, true, nil)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -157,7 +157,7 @@ from the parameters, as in:
 				return err
 			}
 			sink := cmdutil.Diag()
-			pctx, err := plugin.NewContext(sink, sink, nil, nil, wd, nil, false, nil)
+			pctx, err := plugin.NewContext(cmd.Context(), sink, sink, nil, nil, wd, nil, false, nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
@@ -51,7 +51,7 @@ empty string.`,
 				return err
 			}
 			sink := cmdutil.Diag()
-			pctx, err := plugin.NewContext(sink, sink, nil, nil, wd, nil, false, nil)
+			pctx, err := plugin.NewContext(cmd.Context(), sink, sink, nil, nil, wd, nil, false, nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
@@ -43,7 +43,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 				return err
 			}
 			sink := cmdutil.Diag()
-			pctx, err := plugin.NewContext(sink, sink, nil, nil, wd, nil, false, nil)
+			pctx, err := plugin.NewContext(cmd.Context(), sink, sink, nil, nil, wd, nil, false, nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
@@ -51,7 +51,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 				return err
 			}
 			sink := cmdutil.Diag()
-			pctx, err := plugin.NewContext(sink, sink, nil, nil, wd, nil, false, nil)
+			pctx, err := plugin.NewContext(cmd.Context(), sink, sink, nil, nil, wd, nil, false, nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -49,7 +49,7 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 				return err
 			}
 			sink := cmdutil.Diag()
-			pctx, err := plugin.NewContext(sink, sink, nil, nil, wd, nil, false, nil)
+			pctx, err := plugin.NewContext(cmd.Context(), sink, sink, nil, nil, wd, nil, false, nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -139,7 +139,7 @@ func (cmd *packagePublishCmd) Run(
 		return err
 	}
 	sink := cmdutil.Diag()
-	pctx, err := plugin.NewContext(sink, sink, nil, nil, wd, nil, false, nil)
+	pctx, err := plugin.NewContext(ctx, sink, sink, nil, nil, wd, nil, false, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -597,7 +597,7 @@ func NewPluginContext(cwd string) (*plugin.Context, error) {
 	sink := diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{
 		Color: cmdutil.GetGlobalColorization(),
 	})
-	pluginCtx, err := plugin.NewContext(sink, sink, nil, nil, cwd, nil, true, nil)
+	pluginCtx, err := plugin.NewContext(context.TODO(), sink, sink, nil, nil, cwd, nil, true, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/policy/policy_publish.go
+++ b/pkg/cmd/pulumi/policy/policy_publish.go
@@ -124,7 +124,7 @@ func (cmd *policyPublishCmd) Run(ctx context.Context, lm cmdBackend.LoginManager
 		return err
 	}
 
-	plugctx, err := plugin.NewContextWithRoot(cmdutil.Diag(), cmdutil.Diag(), nil, pwd, projinfo.Root,
+	plugctx, err := plugin.NewContextWithRoot(ctx, cmdutil.Diag(), cmdutil.Diag(), nil, pwd, projinfo.Root,
 		projinfo.Proj.Runtime.Options(), false, nil, nil, nil, nil, nil)
 	if err != nil {
 		return err

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -15,6 +15,7 @@
 package pcl
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io/fs"
@@ -174,7 +175,7 @@ func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagno
 		if err != nil {
 			return nil, nil, err
 		}
-		ctx, err := plugin.NewContext(nil, nil, nil, nil, cwd, nil, false, nil)
+		ctx, err := plugin.NewContext(context.TODO(), nil, nil, nil, nil, cwd, nil, false, nil)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -16,6 +16,7 @@ package schema
 
 import (
 	"cmp"
+	"context"
 	_ "embed"
 	"fmt"
 	"io"
@@ -295,7 +296,7 @@ func newBinder(info PackageInfoSpec, spec specSource, loader Loader,
 		if err != nil {
 			return nil, nil, err
 		}
-		ctx, err := plugin.NewContext(nil, nil, nil, nil, cwd, nil, false, nil)
+		ctx, err := plugin.NewContext(context.TODO(), nil, nil, nil, nil, cwd, nil, false, nil)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/codegen/schema/loader_test.go
+++ b/pkg/codegen/schema/loader_test.go
@@ -33,7 +33,7 @@ func initLoader(b testing.TB, options pluginLoaderCacheOptions) ReferenceLoader 
 	cwd, err := os.Getwd()
 	require.NoError(b, err)
 	sink := diagtest.LogSink(b)
-	ctx, err := plugin.NewContext(sink, sink, nil, nil, cwd, nil, true, nil)
+	ctx, err := plugin.NewContext(context.Background(), sink, sink, nil, nil, cwd, nil, true, nil)
 	require.NoError(b, err)
 	loader := newPluginLoaderWithOptions(ctx.Host, options)
 

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -1967,7 +1967,7 @@ func debugProvidersHelperHost(t *testing.T) plugin.Host {
 	sink := diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{
 		Color: cmdutil.GetGlobalColorization(),
 	})
-	pluginCtx, err := plugin.NewContext(sink, sink, nil, nil, cwd, nil, true, nil)
+	pluginCtx, err := plugin.NewContext(context.Background(), sink, sink, nil, nil, cwd, nil, true, nil)
 	require.NoError(t, err)
 	return pluginCtx.Host
 }

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -54,7 +54,7 @@ func ProjectInfoContext(projinfo *Projinfo, host plugin.Host,
 	}
 
 	// Create a context for plugins.
-	ctx, err := plugin.NewContextWithRoot(diag, statusDiag, host, pwd, projinfo.Root,
+	ctx, err := plugin.NewContextWithRoot(context.TODO(), diag, statusDiag, host, pwd, projinfo.Root,
 		projinfo.Proj.Runtime.Options(), disableProviderPreview, tracingSpan, projinfo.Proj.Plugins,
 		projinfo.Proj.GetPackageSpecs(), config, debugging)
 	if err != nil {

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -194,7 +194,7 @@ func newTestPluginContext(t testing.TB, program deploytest.ProgramFunc) (*plugin
 	statusSink := diagtest.LogSink(t)
 	lang := deploytest.NewLanguageRuntime(program)
 	host := deploytest.NewPluginHost(sink, statusSink, lang)
-	return plugin.NewContext(sink, statusSink, host, nil, "", nil, false, nil)
+	return plugin.NewContext(context.Background(), sink, statusSink, host, nil, "", nil, false, nil)
 }
 
 type testProviderSource struct {
@@ -1960,7 +1960,7 @@ func TestInvoke(t *testing.T) {
 	t.Run("error in invoke", func(t *testing.T) {
 		t.Parallel()
 
-		plugctx, err := plugin.NewContext(
+		plugctx, err := plugin.NewContext(context.Background(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
 			deploytest.NewPluginHostF(nil, nil, nil)(),
 			nil, "", nil, false, nil)
@@ -2017,7 +2017,7 @@ func TestInvoke(t *testing.T) {
 	t.Run("error in invoke", func(t *testing.T) {
 		t.Parallel()
 
-		plugctx, err := plugin.NewContext(
+		plugctx, err := plugin.NewContext(context.Background(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
 			deploytest.NewPluginHostF(nil, nil, nil)(),
 			nil, "", nil, false, nil)
@@ -2095,7 +2095,7 @@ func TestCall(t *testing.T) {
 	t.Run("error in call", func(t *testing.T) {
 		t.Parallel()
 
-		plugctx, err := plugin.NewContext(
+		plugctx, err := plugin.NewContext(context.Background(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
 			deploytest.NewPluginHostF(nil, nil, nil)(),
 			nil, "", nil, false, nil)
@@ -2166,7 +2166,7 @@ func TestCall(t *testing.T) {
 	t.Run("handles args and arg dependencies", func(t *testing.T) {
 		t.Parallel()
 
-		plugctx, err := plugin.NewContext(
+		plugctx, err := plugin.NewContext(context.Background(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
 			deploytest.NewPluginHostF(nil, nil, nil)(),
 			nil, "", nil, false, nil)
@@ -2268,7 +2268,7 @@ func TestCall(t *testing.T) {
 	t.Run("catch invalid arg dependencies", func(t *testing.T) {
 		t.Parallel()
 
-		plugctx, err := plugin.NewContext(
+		plugctx, err := plugin.NewContext(context.Background(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
 			deploytest.NewPluginHostF(nil, nil, nil)(),
 			nil, "", nil, false, nil)
@@ -2333,7 +2333,7 @@ func TestCall(t *testing.T) {
 	t.Run("catch invalid arg dependencies", func(t *testing.T) {
 		t.Parallel()
 
-		plugctx, err := plugin.NewContext(
+		plugctx, err := plugin.NewContext(context.Background(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
 			deploytest.NewPluginHostF(nil, nil, nil)(),
 			nil, "", nil, false, nil)

--- a/pkg/resource/deploy/step_test.go
+++ b/pkg/resource/deploy/step_test.go
@@ -1204,7 +1204,7 @@ func TestImportStep(t *testing.T) {
 			t.Parallel()
 			var diffCalled bool
 			var stderrbuff, stdoutbuff bytes.Buffer
-			ctx, _ := plugin.NewContext(
+			ctx, _ := plugin.NewContext(context.Background(),
 				diagtest.MockSink(&stdoutbuff, &stderrbuff), // The diagnostics sink to use for messages.
 				diagtest.MockSink(&stdoutbuff, &stderrbuff), // The diagnostics sink to use for status messages.
 				nil,         // the host that can be used to fetch providers.
@@ -1251,7 +1251,7 @@ func TestImportStep(t *testing.T) {
 		t.Run("preview: no resource input diff found -> no error, no msg", func(t *testing.T) {
 			t.Parallel()
 			var stderrbuff, stdoutbuff bytes.Buffer
-			ctx, _ := plugin.NewContext(
+			ctx, _ := plugin.NewContext(context.Background(),
 				diagtest.MockSink(&stdoutbuff, &stderrbuff), // The diagnostics sink to use for messages.
 				diagtest.MockSink(&stdoutbuff, &stderrbuff), // The diagnostics sink to use for status messages.
 				nil,         // the host that can be used to fetch providers.
@@ -1287,7 +1287,7 @@ func TestImportStep(t *testing.T) {
 			t.Parallel()
 			var diffCalled bool
 			var stderrbuff, stdoutbuff bytes.Buffer
-			ctx, _ := plugin.NewContext(
+			ctx, _ := plugin.NewContext(context.Background(),
 				diagtest.MockSink(&stdoutbuff, &stderrbuff), // The diagnostics sink to use for messages.
 				diagtest.MockSink(&stdoutbuff, &stderrbuff), // The diagnostics sink to use for status messages.
 				nil,         // the host that can be used to fetch providers.
@@ -1335,7 +1335,7 @@ func TestImportStep(t *testing.T) {
 		t.Run("up: no resource input diff found", func(t *testing.T) {
 			t.Parallel()
 			var stderrbuff, stdoutbuff bytes.Buffer
-			ctx, _ := plugin.NewContext(
+			ctx, _ := plugin.NewContext(context.Background(),
 				diagtest.MockSink(&stdoutbuff, &stderrbuff), // The diagnostics sink to use for messages.
 				diagtest.MockSink(&stdoutbuff, &stderrbuff), // The diagnostics sink to use for status messages.
 				nil,         // the host that can be used to fetch providers.

--- a/sdk/go/common/resource/plugin/analyzer_plugin_test.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestAnalyzerSpawn(t *testing.T) {
 	d := diagtest.LogSink(t)
-	ctx, err := NewContext(d, d, nil, nil, "", nil, false, nil)
+	ctx, err := NewContext(context.Background(), d, d, nil, nil, "", nil, false, nil)
 	require.NoError(t, err)
 
 	// Sanity test that from config.Map to envvars we see what we expect to see
@@ -72,7 +72,7 @@ func TestAnalyzerSpawn(t *testing.T) {
 
 func TestAnalyzerSpawnNoConfig(t *testing.T) {
 	d := diagtest.LogSink(t)
-	ctx, err := NewContext(d, d, nil, nil, "", nil, false, nil)
+	ctx, err := NewContext(context.Background(), d, d, nil, nil, "", nil, false, nil)
 	require.NoError(t, err)
 
 	pluginPath, err := filepath.Abs("./testdata/analyzer-no-config")
@@ -92,7 +92,7 @@ func TestAnalyzerSpawnNoConfig(t *testing.T) {
 
 func TestAnalyzerSpawnViaLanguage(t *testing.T) {
 	d := diagtest.LogSink(t)
-	ctx, err := NewContext(d, d, nil, nil, "", nil, false, nil)
+	ctx, err := NewContext(context.Background(), d, d, nil, nil, "", nil, false, nil)
 	require.NoError(t, err)
 
 	// Sanity test that from config.Map to property values we see what we expect to see

--- a/sdk/go/common/resource/plugin/context.go
+++ b/sdk/go/common/resource/plugin/context.go
@@ -58,7 +58,7 @@ type Context struct {
 // that the host is "owned" by this context from here forwards, such
 // that when the context's resources are reclaimed, so too are the
 // host's.
-func NewContext(d, statusD diag.Sink, host Host, _ ConfigSource,
+func NewContext(ctx context.Context, d, statusD diag.Sink, host Host, _ ConfigSource,
 	pwd string, runtimeOptions map[string]interface{}, disableProviderPreview bool,
 	parentSpan opentracing.Span,
 ) (*Context, error) {
@@ -76,25 +76,12 @@ func NewContext(d, statusD diag.Sink, host Host, _ ConfigSource,
 		}
 	}
 
-	return NewContextWithRoot(d, statusD, host, pwd, pwd, runtimeOptions,
+	return NewContextWithRoot(ctx, d, statusD, host, pwd, pwd, runtimeOptions,
 		disableProviderPreview, parentSpan, plugins, packages, nil, nil)
 }
 
 // NewContextWithRoot is a variation of NewContext that also sets known project Root. Additionally accepts Plugins
-func NewContextWithRoot(d, statusD diag.Sink, host Host,
-	pwd, root string, runtimeOptions map[string]interface{}, disableProviderPreview bool,
-	parentSpan opentracing.Span, plugins *workspace.Plugins, packages map[string]workspace.PackageSpec,
-	config map[config.Key]string, debugging DebugContext,
-) (*Context, error) {
-	return NewContextWithContext(
-		context.Background(), d, statusD, host, pwd, root,
-		runtimeOptions, disableProviderPreview, parentSpan, plugins, packages, config, debugging)
-}
-
-// NewContextWithContext is a variation of NewContextWithRoot that also sets the base context.
-func NewContextWithContext(
-	ctx context.Context,
-	d, statusD diag.Sink, host Host,
+func NewContextWithRoot(ctx context.Context, d, statusD diag.Sink, host Host,
 	pwd, root string, runtimeOptions map[string]interface{}, disableProviderPreview bool,
 	parentSpan opentracing.Span, plugins *workspace.Plugins, packages map[string]workspace.PackageSpec,
 	config map[config.Key]string, debugging DebugContext,

--- a/sdk/go/common/resource/plugin/context_test.go
+++ b/sdk/go/common/resource/plugin/context_test.go
@@ -15,6 +15,7 @@
 package plugin
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -27,6 +28,7 @@ func TestContextRequest_race(t *testing.T) {
 	t.Parallel()
 
 	ctx, err := NewContext(
+		context.Background(),
 		diagtest.LogSink(t), // The diagnostics sink to use for messages.
 		diagtest.LogSink(t), // The diagnostics sink to use for status messages.
 		nil,                 // the host that can be used to fetch providers.

--- a/sdk/go/common/resource/plugin/host_test.go
+++ b/sdk/go/common/resource/plugin/host_test.go
@@ -15,6 +15,7 @@
 package plugin
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sync"
@@ -32,7 +33,7 @@ func TestClosePanic(t *testing.T) {
 	t.Parallel()
 
 	sink := diagtest.LogSink(t)
-	ctx, err := NewContext(sink, sink, nil, nil, "", nil, false, nil)
+	ctx, err := NewContext(context.Background(), sink, sink, nil, nil, "", nil, false, nil)
 	require.NoError(t, err)
 	host, ok := ctx.Host.(*defaultHost)
 	require.True(t, ok)

--- a/sdk/go/common/resource/plugin/langruntime_test.go
+++ b/sdk/go/common/resource/plugin/langruntime_test.go
@@ -152,7 +152,7 @@ func TestRunPluginPassesCorrectPwd(t *testing.T) {
 		},
 	}
 
-	pCtx, err := NewContext(nil, nil, nil, nil, "", nil, false, nil)
+	pCtx, err := NewContext(context.Background(), nil, nil, nil, nil, "", nil, false, nil)
 	require.NoError(t, err)
 	host := &langhost{
 		ctx:     pCtx,

--- a/sdk/go/common/resource/plugin/plugin_test.go
+++ b/sdk/go/common/resource/plugin/plugin_test.go
@@ -194,7 +194,7 @@ func TestHealthCheck(t *testing.T) {
 
 func TestStartupFailure(t *testing.T) {
 	d := diagtest.LogSink(t)
-	ctx, err := NewContext(d, d, nil, nil, "", nil, false, nil)
+	ctx, err := NewContext(context.Background(), d, d, nil, nil, "", nil, false, nil)
 	require.NoError(t, err)
 
 	pluginPath, err := filepath.Abs("./testdata/provider-language")

--- a/sdk/go/common/resource/plugin/provider_plugin_test.go
+++ b/sdk/go/common/resource/plugin/provider_plugin_test.go
@@ -782,6 +782,7 @@ func newTestContext(t testing.TB) *Context {
 
 	sink := diagtest.LogSink(t)
 	ctx, err := NewContext(
+		context.Background(),
 		sink, sink,
 		nil /* host */, nil /* source */, cwd, nil /* options */, false, nil /* span */)
 	require.NoError(t, err, "build context")

--- a/tests/integration/run_plugin/go/main.go
+++ b/tests/integration/run_plugin/go/main.go
@@ -63,7 +63,7 @@ func main() {
 		}
 
 		sink := cmdutil.Diag()
-		pCtx, err := plugin.NewContext(sink, sink, nil, nil, wd, nil, false, nil)
+		pCtx, err := plugin.NewContext(ctx.Context(), sink, sink, nil, nil, wd, nil, false, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This commit alters the signature of `plugin.NewContext` and `plugin.NewContextWithRoot` to accept a `context.Context`, instead of grabbing a new one from `context.Background`. It removes `plugin.NewContextWithContext`, since it is now redundant.

[GitHub Search](https://github.com/search?q=plugin.NewContextWithContext+-is%3Afork&type=code) shows that `plugin.NewContextWithContext` is only used in `pulumi/pulumi`.

[GitHub Search](https://github.com/search?q=plugin.NewContextWithRoot+-is%3Afork&type=code) shows that `plugin.NewContextWithRoot` is used in `pulumi/pulumi` and once in `pulumi/pulumi-yaml`.

[GitHub Search](https://github.com/search?q=org%3Apulumi+plugin.NewContext&type=code) shows that `plugin.NewContext` is used in `pulumi/pulumi`, once in `pulumi/pulumi-terraform-bridge`, once in `pulumi/pulumi-yaml` and a couple times in the service.

I believe that these breaking changes represent improvements in our code, and are worth taking. They are trivial to fix, by either supplying the ambient `ctx` or with `context.Background()`.

This is especially helpful for packages that inject ambient information via `context.Context` like `pulumi/pulumi`:

https://github.com/pulumi/pulumi/blob/4958a846115650578e8e3b97f6f4d908dba8b720/pkg/cmd/pulumi/pulumi.go#L243-L261