### PR TITLE
`workspace.GetPlugin{Path,Info}` accepts `context.Context`

### DIFF
--- a/changelog/pending/20250513--sdk-go--accept-context-context-in-workspace-getplugininfo-and-workspace-getpluginpath.yaml
+++ b/changelog/pending/20250513--sdk-go--accept-context-context-in-workspace-getplugininfo-and-workspace-getpluginpath.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/go
+  description: Accept `context.Context` in `workspace.GetPluginInfo` and `workspace.GetPluginPath`.

--- a/changelog/pending/20250513--sdk-go--accept-context-context-in-workspace-getplugininfo-and-workspace-getpluginpath.yaml
+++ b/changelog/pending/20250513--sdk-go--accept-context-context-in-workspace-getplugininfo-and-workspace-getpluginpath.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: chore
   scope: sdk/go
-  description: Accept `context.Context` in `workspace.GetPluginInfo` and `workspace.GetPluginPath`.
+  description: Accept `context.Context` in `workspace.GetPluginInfo` and `workspace.GetPluginPath`.

--- a/pkg/cmd/pulumi/plugin/plugin.go
+++ b/pkg/cmd/pulumi/plugin/plugin.go
@@ -102,7 +102,7 @@ func resolvePlugins(plugins []workspace.PluginSpec) ([]workspace.PluginInfo, err
 	// a plugin required by the project hasn't yet been installed, we will simply skip any errors we encounter.
 	var results []workspace.PluginInfo
 	for _, plugin := range plugins {
-		info, err := workspace.GetPluginInfo(d, plugin, ctx.Host.GetProjectPlugins())
+		info, err := workspace.GetPluginInfo(ctx.Base(), d, plugin, ctx.Host.GetProjectPlugins())
 		if err != nil {
 			contract.IgnoreError(err)
 		}

--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -68,7 +68,7 @@ func newPluginRunCmd() *cobra.Command {
 
 			d := diag.DefaultSink(os.Stdout, os.Stderr, diag.FormatOptions{Color: cmdutil.GetGlobalColorization()})
 
-			path, err := workspace.GetPluginPath(d, pluginSpec, nil)
+			path, err := workspace.GetPluginPath(ctx, d, pluginSpec, nil)
 			if err != nil {
 				// Try to install the plugin, unless auto plugin installs are turned off.
 				var me *workspace.MissingError
@@ -86,7 +86,7 @@ func newPluginRunCmd() *cobra.Command {
 					return err
 				}
 
-				path, err = workspace.GetPluginPath(d, pluginSpec, nil)
+				path, err = workspace.GetPluginPath(ctx, d, pluginSpec, nil)
 				if err != nil {
 					return fmt.Errorf("could not get plugin path: %w", err)
 				}

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -345,7 +345,7 @@ func EnsurePluginsAreInstalled(ctx context.Context, opts *deploymentOptions, d d
 			continue
 		}
 
-		path, err := workspace.GetPluginPath(d, plug, projectPlugins)
+		path, err := workspace.GetPluginPath(ctx, d, plug, projectPlugins)
 		if err == nil && path != "" {
 			logging.V(preparePluginLog).Infof(
 				"ensurePluginsAreInstalled(): plugin %s %s already installed", plug.Name, plug.Version)

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -62,6 +62,7 @@ var _ Analyzer = (*analyzer)(nil)
 func NewAnalyzer(host Host, ctx *Context, name tokens.QName) (Analyzer, error) {
 	// Load the plugin's path by using the standard workspace logic.
 	path, err := workspace.GetPluginPath(
+		ctx.baseContext,
 		ctx.Diag,
 		workspace.PluginSpec{
 			Name: strings.ReplaceAll(string(name), tokens.QNameDelimiter, "_"),
@@ -142,6 +143,7 @@ func NewPolicyAnalyzer(
 	// legacy behavior.
 	if proj.Runtime.Name() != "python" && proj.Runtime.Name() != "nodejs" {
 		path, err = workspace.GetPluginPath(
+			ctx.baseContext,
 			ctx.Diag,
 			workspace.PluginSpec{Name: proj.Runtime.Name(), Kind: apitype.LanguagePlugin},
 			host.GetProjectPlugins())
@@ -159,7 +161,8 @@ func NewPolicyAnalyzer(
 		// Load the policy-booting analyzer plugin (i.e., `pulumi-analyzer-${policyAnalyzerName}`).
 		var pluginPath string
 		pluginPath, err = workspace.GetPluginPath(
-			ctx.Diag, workspace.PluginSpec{Name: policyAnalyzerName, Kind: apitype.AnalyzerPlugin}, host.GetProjectPlugins())
+			ctx.baseContext, ctx.Diag,
+			workspace.PluginSpec{Name: policyAnalyzerName, Kind: apitype.AnalyzerPlugin}, host.GetProjectPlugins())
 
 		var e *workspace.MissingError
 		if errors.As(err, &e) {

--- a/sdk/go/common/resource/plugin/converter_plugin.go
+++ b/sdk/go/common/resource/plugin/converter_plugin.go
@@ -46,7 +46,7 @@ func NewConverter(ctx *Context, name string, version *semver.Version) (Converter
 
 	// Load the plugin's path by using the standard workspace logic.
 	path, err := workspace.GetPluginPath(
-		ctx.Diag,
+		ctx.baseContext, ctx.Diag,
 		workspace.PluginSpec{Name: name, Version: version, Kind: apitype.ConverterPlugin},
 		ctx.Host.GetProjectPlugins())
 	if err != nil {

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -582,7 +582,7 @@ func (host *defaultHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds Fla
 }
 
 func (host *defaultHost) ResolvePlugin(spec workspace.PluginSpec) (*workspace.PluginInfo, error) {
-	return workspace.GetPluginInfo(host.ctx.Diag, spec, host.GetProjectPlugins())
+	return workspace.GetPluginInfo(host.ctx.baseContext, host.ctx.Diag, spec, host.GetProjectPlugins())
 }
 
 func (host *defaultHost) GetProjectPlugins() []workspace.ProjectPlugin {

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -107,7 +107,7 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime, workingDirectory strin
 		client = pulumirpc.NewLanguageRuntimeClient(plug.Conn)
 	} else {
 		path, err := workspace.GetPluginPath(
-			ctx.Diag,
+			ctx.baseContext, ctx.Diag,
 			workspace.PluginSpec{
 				Name: strings.ReplaceAll(runtime, tokens.QNameDelimiter, "_"),
 				Kind: apitype.LanguagePlugin,

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -213,7 +213,7 @@ func NewProvider(host Host, ctx *Context, spec workspace.PluginSpec,
 		}
 	} else {
 		// Load the plugin's path by using the standard workspace logic.
-		path, err := workspace.GetPluginPath(ctx.Diag, spec, host.GetProjectPlugins())
+		path, err := workspace.GetPluginPath(ctx.baseContext, ctx.Diag, spec, host.GetProjectPlugins())
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -2228,9 +2228,9 @@ func IsPluginBundled(kind apitype.PluginKind, name string) bool {
 // is >= the version specified.  If no version is supplied, the latest plugin for that given kind/name pair is loaded,
 // using standard semver sorting rules.  A plugin may be overridden entirely by placing it on your $PATH, though it is
 // possible to opt out of this behavior by setting PULUMI_IGNORE_AMBIENT_PLUGINS to any non-empty value.
-func GetPluginPath(d diag.Sink, spec PluginSpec, projectPlugins []ProjectPlugin,
+func GetPluginPath(ctx context.Context, d diag.Sink, spec PluginSpec, projectPlugins []ProjectPlugin,
 ) (string, error) {
-	info, path, err := getPluginInfoAndPath(context.TODO(), d, spec, true /* skipMetadata */, projectPlugins)
+	info, path, err := getPluginInfoAndPath(ctx, d, spec, true /* skipMetadata */, projectPlugins)
 	if err != nil {
 		return "", err
 	}
@@ -2240,9 +2240,9 @@ func GetPluginPath(d diag.Sink, spec PluginSpec, projectPlugins []ProjectPlugin,
 	return path, err
 }
 
-func GetPluginInfo(d diag.Sink, spec PluginSpec, projectPlugins []ProjectPlugin,
+func GetPluginInfo(ctx context.Context, d diag.Sink, spec PluginSpec, projectPlugins []ProjectPlugin,
 ) (*PluginInfo, error) {
-	info, path, err := getPluginInfoAndPath(context.TODO(), d, spec, false, projectPlugins)
+	info, path, err := getPluginInfoAndPath(ctx, d, spec, false, projectPlugins)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1465,6 +1465,7 @@ func TestBundledPluginSearch(t *testing.T) {
 	// Get the path of this executable
 	exe, err := os.Executable()
 	require.NoError(t, err)
+	ctx := context.Background()
 
 	// Create a fake side-by-side plugin next to this executable, it must match one of our bundled names
 	bundledPath := filepath.Join(filepath.Dir(exe), "pulumi-language-nodejs")
@@ -1487,19 +1488,20 @@ func TestBundledPluginSearch(t *testing.T) {
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
+	path, err := GetPluginPath(ctx, d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, ambientPath, path)
 
 	// Lookup the plugin with ambient search turned off
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "true")
-	path, err = GetPluginPath(d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
+	path, err = GetPluginPath(ctx, d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, bundledPath, path)
 }
 
 //nolint:paralleltest // modifies environment variables
 func TestAmbientPluginsWarn(t *testing.T) {
+	ctx := context.Background()
 	// Create a fake plugin in the path
 	pathDir := t.TempDir()
 	t.Setenv("PATH", pathDir)
@@ -1516,7 +1518,7 @@ func TestAmbientPluginsWarn(t *testing.T) {
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(d, PluginSpec{Name: "mock", Kind: apitype.ResourcePlugin}, nil)
+	path, err := GetPluginPath(ctx, d, PluginSpec{Name: "mock", Kind: apitype.ResourcePlugin}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, ambientPath, path)
 
@@ -1530,6 +1532,7 @@ func TestAmbientBundledPluginsWarn(t *testing.T) {
 	// Get the path of this executable
 	exe, err := os.Executable()
 	require.NoError(t, err)
+	ctx := context.Background()
 
 	// Create a fake side-by-side plugin next to this executable, it must match one of our bundled names
 	bundledPath := filepath.Join(filepath.Dir(exe), "pulumi-language-nodejs")
@@ -1556,7 +1559,7 @@ func TestAmbientBundledPluginsWarn(t *testing.T) {
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
+	path, err := GetPluginPath(ctx, d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, ambientPath, path)
 
@@ -1568,6 +1571,7 @@ func TestAmbientBundledPluginsWarn(t *testing.T) {
 
 //nolint:paralleltest // modifies environment variables
 func TestBundledPluginsDoNotWarn(t *testing.T) {
+	ctx := context.Background()
 	// Get the path of this executable
 	exe, err := os.Executable()
 	require.NoError(t, err)
@@ -1593,7 +1597,7 @@ func TestBundledPluginsDoNotWarn(t *testing.T) {
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
+	path, err := GetPluginPath(ctx, d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, bundledPath, path)
 
@@ -1605,6 +1609,7 @@ func TestBundledPluginsDoNotWarn(t *testing.T) {
 //
 //nolint:paralleltest // modifies environment variables
 func TestSymlinkPathPluginsDoNotWarn(t *testing.T) {
+	ctx := context.Background()
 	// Get the path of this executable
 	exe, err := os.Executable()
 	require.NoError(t, err)
@@ -1634,7 +1639,7 @@ func TestSymlinkPathPluginsDoNotWarn(t *testing.T) {
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
+	path, err := GetPluginPath(ctx, d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
 	require.NoError(t, err)
 	// We expect the ambient path to be returned, but not to warn because it resolves to the same file as the
 	// bundled path.
@@ -1646,6 +1651,7 @@ func TestSymlinkPathPluginsDoNotWarn(t *testing.T) {
 //
 //nolint:paralleltest // modifies environment variables
 func TestPluginInfoShimless(t *testing.T) {
+	ctx := context.Background()
 	// Create a fake plugin in temp
 	pathDir := t.TempDir()
 
@@ -1667,7 +1673,7 @@ func TestPluginInfoShimless(t *testing.T) {
 		diag.FormatOptions{Color: "never"},
 	)
 
-	info, err := GetPluginInfo(d, PluginSpec{Kind: apitype.ResourcePlugin, Name: "mock"}, []ProjectPlugin{
+	info, err := GetPluginInfo(ctx, d, PluginSpec{Kind: apitype.ResourcePlugin, Name: "mock"}, []ProjectPlugin{
 		{
 			Name: "mock",
 			Kind: apitype.ResourcePlugin,
@@ -1685,25 +1691,28 @@ func TestPluginInfoShimless(t *testing.T) {
 
 //nolint:paralleltest // modifies environment variables
 func TestProjectPluginsWithUncleanPath(t *testing.T) {
+	ctx := context.Background()
 	tempdir := t.TempDir()
 
 	err := os.WriteFile(filepath.Join(tempdir, "pulumi-resource-aws"), []byte{}, 0o600)
 	require.NoError(t, err)
 
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(diagtest.LogSink(t), PluginSpec{Kind: apitype.ResourcePlugin, Name: "aws"}, []ProjectPlugin{
-		{
-			Name: "aws",
-			Kind: apitype.ResourcePlugin,
-			Path: tempdir + "/", // path with a trailing slash
-		},
-	})
+	path, err := GetPluginPath(ctx, diagtest.LogSink(t), PluginSpec{Kind: apitype.ResourcePlugin, Name: "aws"},
+		[]ProjectPlugin{
+			{
+				Name: "aws",
+				Kind: apitype.ResourcePlugin,
+				Path: tempdir + "/", // path with a trailing slash
+			},
+		})
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(tempdir, "pulumi-resource-aws"), path)
 }
 
 //nolint:paralleltest // modifies environment variables
 func TestProjectPluginsWithSymlink(t *testing.T) {
+	ctx := context.Background()
 	tempdir := t.TempDir()
 
 	err := os.Mkdir(filepath.Join(tempdir, "subdir"), 0o700)
@@ -1714,13 +1723,14 @@ func TestProjectPluginsWithSymlink(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(diagtest.LogSink(t), PluginSpec{Kind: apitype.ResourcePlugin, Name: "aws"}, []ProjectPlugin{
-		{
-			Name: "aws",
-			Kind: apitype.ResourcePlugin,
-			Path: filepath.Join(tempdir, "symlink"),
-		},
-	})
+	path, err := GetPluginPath(ctx, diagtest.LogSink(t), PluginSpec{Kind: apitype.ResourcePlugin, Name: "aws"},
+		[]ProjectPlugin{
+			{
+				Name: "aws",
+				Kind: apitype.ResourcePlugin,
+				Path: filepath.Join(tempdir, "symlink"),
+			},
+		})
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(tempdir, "symlink", "pulumi-resource-aws"), path)
 }


### PR DESCRIPTION
This commit changes `workspace.GetPluginPath` and `workspace.GetPluginInfo` to accept `context.Context` as their first argument.

[GitHub Search](https://github.com/search?q=workspace.GetPluginPath+-is%3Afork+language%3Ago&type=code&p=1) shows that `workspace.GetPluginPath` is only used in `pulumi/pulumi` and once in `pulumi/pulumi-terraform-bridge`.

[GitHub Search](https://github.com/search?q=workspace.GetPluginInfo+-is%3Afork+language%3Ago&type=code) shows that `workspace.GetPluginInfo` is only used in `pulumi/pulumi`.