### PR TITLE
Fix `refresh --preview-only` in the NodeJS Automation API

### DIFF
--- a/changelog/pending/20250513--auto-nodejs--make-refresh-with-previewonly-true-report-the-correct-summary.yaml
+++ b/changelog/pending/20250513--auto-nodejs--make-refresh-with-previewonly-true-report-the-correct-summary.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/nodejs
+  description: "Make `refresh` with `previewOnly: true` report the correct summary."

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -542,7 +542,7 @@ Event: ${line}\n${e.toString()}`);
         // load the project file.
         const summary = await this.info(!this.isRemote && opts?.showSecrets);
 
-        // `this.info` will return the last successful operration. However, if
+        // `this.info` will return the last successful operation. However, if
         // we're in `--preview-only` mode, the last successful operation is not
         // the one we're interested in. In this case, we use the summary event
         // we found in the event log.

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -513,18 +513,20 @@ Event: ${line}\n${e.toString()}`);
         let loggedSummary: OpMap | undefined;
 
         // Set up event log tailing
-        logFile = createLogFile("refresh");
-        args.push("--event-log", logFile);
+        if (opts?.previewOnly || opts?.onEvent) {
+          logFile = createLogFile("refresh");
+          args.push("--event-log", logFile);
 
-        logPromise = this.readLines(logFile, (event) => {
-            if (event.summaryEvent) {
-              loggedSummary = event.summaryEvent.resourceChanges
-            }
+          logPromise = this.readLines(logFile, (event) => {
+              if (event.summaryEvent) {
+                loggedSummary = event.summaryEvent.resourceChanges
+              }
 
-            if (opts?.onEvent) {
-              opts?.onEvent(event);
-            }
-        });
+              if (opts?.onEvent) {
+                opts?.onEvent(event);
+              }
+          });
+        }
 
         const kind = this.workspace.program ? execKind.inline : execKind.local;
         args.push("--exec-kind", kind);

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -514,18 +514,18 @@ Event: ${line}\n${e.toString()}`);
 
         // Set up event log tailing
         if (opts?.previewOnly || opts?.onEvent) {
-          logFile = createLogFile("refresh");
-          args.push("--event-log", logFile);
+            logFile = createLogFile("refresh");
+            args.push("--event-log", logFile);
 
-          logPromise = this.readLines(logFile, (event) => {
-              if (event.summaryEvent) {
-                loggedSummary = event.summaryEvent.resourceChanges
-              }
+            logPromise = this.readLines(logFile, (event) => {
+                if (opts?.previewOnly && event.summaryEvent) {
+                    loggedSummary = event.summaryEvent.resourceChanges;
+                }
 
-              if (opts?.onEvent) {
-                opts?.onEvent(event);
-              }
-          });
+                if (opts?.onEvent) {
+                    opts?.onEvent(event);
+                }
+            });
         }
 
         const kind = this.workspace.program ? execKind.inline : execKind.local;
@@ -547,7 +547,7 @@ Event: ${line}\n${e.toString()}`);
         // the one we're interested in. In this case, we use the summary event
         // we found in the event log.
         if (summary && opts?.previewOnly) {
-          summary.resourceChanges = loggedSummary
+            summary.resourceChanges = loggedSummary;
         }
 
         return {

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -628,6 +628,7 @@ describe("LocalWorkspace", () => {
         const refRes = await stack.refresh({ userAgent, previewOnly: true });
         assert.strictEqual(refRes.summary.kind, "update");
         assert.strictEqual(refRes.summary.result, "succeeded");
+        assert.deepStrictEqual(refRes.summary.resourceChanges, { same: 1 });
 
         await stack.workspace.removeStack(stackName);
     });


### PR DESCRIPTION
I think this is going to be the first of a fair few PRs.

When an operation runs in the automation API, we use `pulumi stack history` to find the last successful operation, and return it in the operation summary. This works fine _unless_ you're running in `--preview-only` mode, at which point the last successful operation is whatever happened _before_ the preview. This means that the summary for `refresh --preview-only` never gives you the right information _unless_ the last operation before the preview happened to return the same data.

This PR checks for `--preview-only`, and when enabled, searches instead through the event log for the current command run to find the summary event.

* https://github.com/pulumi/pulumi/issues/19443