### PR TITLE
Registry search methods in `backend`

### DIFF
--- a/pkg/backend/backenderr/backenderr.go
+++ b/pkg/backend/backenderr/backenderr.go
@@ -22,6 +22,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 )
 
+var ErrNotFound = NotFoundError{}
+
 // ErrNoPreviousDeployment is returned when there isn't a previous deployment.
 var ErrNoPreviousDeployment = errors.New("no previous deployment")
 
@@ -68,4 +70,25 @@ type MissingEnvVarForNonInteractiveError struct {
 
 func (err MissingEnvVarForNonInteractiveError) Error() string {
 	return err.Var.Name() + " must be set for login during non-interactive CLI sessions"
+}
+
+// NotFoundError wraps another error, indicating that the underlying problem was that a
+// resource was not found.
+type NotFoundError struct {
+	Err error
+}
+
+func (err NotFoundError) Error() string {
+	if err.Err == nil {
+		return "not found"
+	}
+	return err.Err.Error()
+}
+
+func (err NotFoundError) Unwrap() error { return err.Err }
+
+func (err NotFoundError) Is(other error) bool {
+	_, ok := other.(NotFoundError)
+	_, ptr := other.(*NotFoundError)
+	return ok || ptr
 }

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -449,3 +450,247 @@ func TestGetDefaultOrg(t *testing.T) {
 		assert.Empty(t, resp.GitHubLogin)
 	})
 }
+
+func TestGetPackage(t *testing.T) {
+	t.Parallel()
+
+	const metadataJSON = `{
+  "name": "my-package",
+  "publisher": "my-publisher",
+  "source": "my-source",
+  "version": "1.0.0",
+  "title": "Example Package",
+  "description": "This is an example package.",
+  "logoUrl": "https://example.com/logo.png",
+  "repoUrl": "https://github.com/example/package",
+  "category": "utilities",
+  "isFeatured": true,
+  "packageTypes": ["native", "component"],
+  "packageStatus": "ga",
+  "readmeURL": "https://example.com/readme",
+  "schemaURL": "https://example.com/schema",
+  "pluginDownloadURL": "https://example.com/download",
+  "createdAt": "2023-10-01T12:00:00Z",
+  "visibility": "public"
+}`
+
+	metadata := func() apitype.PackageMetadata {
+		return apitype.PackageMetadata{
+			Name:              "my-package",
+			Publisher:         "my-publisher",
+			Source:            "my-source",
+			Version:           semver.Version{Major: 1},
+			Title:             "Example Package",
+			Description:       "This is an example package.",
+			LogoURL:           "https://example.com/logo.png",
+			RepoURL:           "https://github.com/example/package",
+			Category:          "utilities",
+			IsFeatured:        true,
+			PackageTypes:      []apitype.PackageType{"native", "component"},
+			PackageStatus:     apitype.PackageStatusGA,
+			ReadmeURL:         "https://example.com/readme",
+			SchemaURL:         "https://example.com/schema",
+			PluginDownloadURL: "https://example.com/download",
+			CreatedAt:         time.Date(2023, time.October, 1, 12, 0, 0, 0, time.UTC),
+			Visibility:        apitype.VisibilityPublic,
+		}
+	}
+
+	t.Run("latest-latest", func(t *testing.T) {
+		t.Parallel()
+		s := newMockServerRequestProcessor(200, func(req *http.Request) string {
+			assert.Contains(t, req.URL.String(), "my-source/my-publisher/my-package/versions/latest")
+			return metadataJSON
+		})
+		defer s.Close()
+
+		c := newMockClient(s)
+
+		resp, err := c.GetPackage(context.Background(), "my-source", "my-publisher", "my-package", nil)
+		require.NoError(t, err)
+		assert.Equal(t, metadata(), resp)
+	})
+
+	t.Run("404", func(t *testing.T) {
+		t.Parallel()
+		s := newMockServer(404, ``)
+		defer s.Close()
+
+		c := newMockClient(s)
+
+		_, err := c.GetPackage(context.Background(), "my-source", "my-publisher", "my-package", nil)
+		var apiError *apitype.ErrorResponse
+		require.ErrorAs(t, err, &apiError, "actual error type %T", err)
+		assert.Equal(t, 404, apiError.Code)
+	})
+
+	t.Run("specific-version", func(t *testing.T) {
+		t.Parallel()
+		s := newMockServerRequestProcessor(200, func(req *http.Request) string {
+			assert.Contains(t, req.URL.String(), "my-source/my-publisher/my-package/versions/1.0.0")
+			return metadataJSON
+		})
+		defer s.Close()
+
+		c := newMockClient(s)
+
+		resp, err := c.GetPackage(context.Background(), "my-source", "my-publisher", "my-package", &semver.Version{
+			Major: 1,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, metadata(), resp)
+	})
+}
+
+func TestSearchByName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no-continuation-token", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a mock response with package metadata
+		expectedPackages := []apitype.PackageMetadata{
+			{
+				Name:          "my-package-1",
+				Publisher:     "my-publisher",
+				Source:        "my-source",
+				Version:       semver.Version{Major: 1},
+				PackageStatus: apitype.PackageStatusGA,
+				Visibility:    apitype.VisibilityPrivate,
+			},
+			{
+				Name:          "my-package-2",
+				Publisher:     "my-publisher",
+				Source:        "my-source",
+				Version:       semver.Version{Major: 2},
+				PackageStatus: apitype.PackageStatusGA,
+				Visibility:    apitype.VisibilityPrivate,
+			},
+		}
+
+		mockResponse := apitype.ListPackagesResponse{
+			Packages: expectedPackages,
+		}
+
+		// Set up mock server
+		mockServer := newMockServerRequestProcessor(200, func(req *http.Request) string {
+			assert.Contains(t, req.URL.String(), "/preview/registry/packages?limit=499")
+			assert.Equal(t, "GET", req.Method)
+
+			data, err := json.Marshal(mockResponse)
+			require.NoError(t, err)
+			return string(data)
+		})
+		defer mockServer.Close()
+
+		mockClient := newMockClient(mockServer)
+
+		// Call SearchByName and collect results
+		searchName := "my-package"
+		searchResults := []apitype.PackageMetadata{}
+		for pkg, err := range mockClient.SearchByName(context.Background(), &searchName) {
+			require.NoError(t, err)
+			searchResults = append(searchResults, pkg)
+		}
+		assert.Equal(t, expectedPackages, searchResults)
+	})
+
+	t.Run("with-continuation-token", func(t *testing.T) {
+		t.Parallel()
+
+		// First page response
+		firstPagePackages := []apitype.PackageMetadata{
+			{
+				Name:          "my-package-1",
+				Publisher:     "my-publisher",
+				Source:        "my-source",
+				Version:       semver.Version{Major: 1},
+				PackageStatus: apitype.PackageStatusGA,
+				Visibility:    apitype.VisibilityPrivate,
+			},
+		}
+
+		secondPagePackages := []apitype.PackageMetadata{
+			{
+				Name:          "my-package-2",
+				Publisher:     "my-publisher",
+				Source:        "my-source",
+				Version:       semver.Version{Major: 2},
+				PackageStatus: apitype.PackageStatusGA,
+				Visibility:    apitype.VisibilityPrivate,
+			},
+		}
+
+		thirdPagePackages := []apitype.PackageMetadata{
+			{
+				Name:          "my-package-3",
+				Publisher:     "my-publisher",
+				Source:        "my-source",
+				Version:       semver.Version{Major: 3},
+				PackageStatus: apitype.PackageStatusGA,
+				Visibility:    apitype.VisibilityPrivate,
+			},
+		}
+
+		// Track which request is being made
+		requestCount := 0
+
+		// Set up mock server
+		mockServer := newMockServerRequestProcessor(200, func(req *http.Request) string {
+			assert.Equal(t, "GET", req.Method)
+
+			var responseData []byte
+			var err error
+
+			switch requestCount {
+			case 0:
+				assert.Equal(t, "/preview/registry/packages?limit=499&name=my-package", req.URL.String())
+				assert.NotContains(t, "continuationToken", req.URL.String())
+
+				responseData, err = json.Marshal(apitype.ListPackagesResponse{
+					Packages:          firstPagePackages,
+					ContinuationToken: ptr("next-page-token-1"),
+				})
+				require.NoError(t, err)
+			case 1:
+				assert.Equal(t,
+					"/preview/registry/packages?limit=499&name=my-package&continuationToken=next-page-token-1",
+					req.URL.String())
+
+				responseData, err = json.Marshal(apitype.ListPackagesResponse{
+					Packages:          secondPagePackages,
+					ContinuationToken: ptr("next-page-token-2"),
+				})
+				require.NoError(t, err)
+			case 2:
+				assert.Equal(t,
+					"/preview/registry/packages?limit=499&name=my-package&continuationToken=next-page-token-2",
+					req.URL.String())
+
+				responseData, err = json.Marshal(apitype.ListPackagesResponse{
+					Packages: thirdPagePackages,
+				})
+				require.NoError(t, err)
+			}
+
+			requestCount++
+			return string(responseData)
+		})
+		defer mockServer.Close()
+
+		mockClient := newMockClient(mockServer)
+
+		searchName := "my-package"
+		searchResults := []apitype.PackageMetadata{}
+		for pkg, err := range mockClient.SearchByName(context.Background(), &searchName) {
+			require.NoError(t, err)
+			searchResults = append(searchResults, pkg)
+		}
+
+		expectedPackages := append(append(firstPagePackages, secondPagePackages...), thirdPagePackages...)
+		assert.Equal(t, expectedPackages, searchResults)
+		assert.Equal(t, 3, requestCount) // Ensure both requests were made
+	})
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/pkg/backend/httpstate/package_registry.go
+++ b/pkg/backend/httpstate/package_registry.go
@@ -16,8 +16,12 @@ package httpstate
 
 import (
 	ctx "context"
+	"errors"
+	"iter"
 
+	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
@@ -36,4 +40,20 @@ var _ backend.PackageRegistry = (*cloudPackageRegistry)(nil)
 
 func (r *cloudPackageRegistry) Publish(ctx ctx.Context, op apitype.PackagePublishOp) error {
 	return r.cl.PublishPackage(ctx, op)
+}
+
+func (r *cloudPackageRegistry) SearchByName(
+	ctx ctx.Context, name *string,
+) iter.Seq2[apitype.PackageMetadata, error] {
+	return r.cl.SearchByName(ctx, name)
+}
+
+func (r *cloudPackageRegistry) GetPackage(
+	ctx ctx.Context, source, publisher, name string, version *semver.Version,
+) (apitype.PackageMetadata, error) {
+	meta, err := r.cl.GetPackage(ctx, source, publisher, name, version)
+	if apiErr := (&apitype.ErrorResponse{}); errors.As(err, &apiErr) && apiErr.Code == 404 {
+		return meta, backenderr.NotFoundError{Err: err}
+	}
+	return meta, err
 }

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -18,10 +18,12 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"iter"
 	"slices"
 	"strings"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/pulumi/esc"
 	sdkDisplay "github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -857,7 +859,11 @@ func (m MockTarReader) Tar() *tar.Reader {
 }
 
 type MockPackageRegistry struct {
-	PublishF func(context.Context, apitype.PackagePublishOp) error
+	PublishF    func(context.Context, apitype.PackagePublishOp) error
+	GetPackageF func(
+		ctx context.Context, source, publisher, name string, version *semver.Version,
+	) (apitype.PackageMetadata, error)
+	SearchByNameF func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error]
 }
 
 var _ PackageRegistry = (*MockPackageRegistry)(nil)
@@ -865,6 +871,24 @@ var _ PackageRegistry = (*MockPackageRegistry)(nil)
 func (mr *MockPackageRegistry) Publish(ctx context.Context, op apitype.PackagePublishOp) error {
 	if mr.PublishF != nil {
 		return mr.PublishF(ctx, op)
+	}
+	panic("not implemented")
+}
+
+func (mr *MockPackageRegistry) GetPackage(
+	ctx context.Context, source, publisher, name string, version *semver.Version,
+) (apitype.PackageMetadata, error) {
+	if mr.GetPackageF != nil {
+		return mr.GetPackageF(ctx, source, publisher, name, version)
+	}
+	panic("not implemented")
+}
+
+func (mr *MockPackageRegistry) SearchByName(
+	ctx context.Context, name *string,
+) iter.Seq2[apitype.PackageMetadata, error] {
+	if mr.SearchByNameF != nil {
+		return mr.SearchByNameF(ctx, name)
 	}
 	panic("not implemented")
 }

--- a/pkg/backend/package_registry.go
+++ b/pkg/backend/package_registry.go
@@ -15,12 +15,31 @@
 package backend
 
 import (
-	ctx "context"
+	"context"
+	"iter"
+
+	"github.com/blang/semver"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
 type PackageRegistry interface {
 	// Publish publishes a package to the package registry.
-	Publish(ctx ctx.Context, op apitype.PackagePublishOp) error
+	Publish(ctx context.Context, op apitype.PackagePublishOp) error
+
+	// Retrieve metadata about a specific package.
+	//
+	// {source}/{publisher}/{name} should form the identifier that describes the
+	// desired package.
+	//
+	// If version is nil, it will default to latest.
+	GetPackage(
+		ctx context.Context, source, publisher, name string, version *semver.Version,
+	) (apitype.PackageMetadata, error)
+
+	// Retrieve a list of packages.
+	//
+	// If name is non-nil, it will filter to accessible packages that exactly match
+	// */*/{name}.
+	SearchByName(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error]
 }


### PR DESCRIPTION
This PR exposes the registry's get and list APIs for resource plugins.

This is motivated by https://github.com/pulumi/home/issues/3990.

`apitype.PackageMetadata` and `apitype.ListPackageResponse` are copied from the service.