### PR TITLE
allow filtering the runnable types that can be debugged

### DIFF
--- a/cmd/pulumi-test-language/test_host.go
+++ b/cmd/pulumi-test-language/test_host.go
@@ -218,7 +218,7 @@ func (h *testHost) StartDebugging(plugin.DebuggingInfo) error {
 	panic("not implemented")
 }
 
-func (h *testHost) AttachDebugger() bool {
+func (h *testHost) AttachDebugger(plugin.DebugSpec) bool {
 	return false
 }
 

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -282,7 +282,7 @@ func NewPreviewCmd() *cobra.Command {
 	var targetReplaces []string
 	var targetDependents bool
 	var excludeDependents bool
-	var attachDebugger bool
+	var attachDebugger []string
 
 	// Flags for Copilot.
 	var copilotEnabled bool
@@ -311,6 +311,12 @@ func NewPreviewCmd() *cobra.Command {
 		Args: cmdArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+
+			err := validateAttachDebuggerFlag(attachDebugger)
+			if err != nil {
+				return err
+			}
+
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 			ws := pkgWorkspace.Instance
 			displayType := display.DisplayProgress
@@ -670,9 +676,11 @@ func NewPreviewCmd() *cobra.Command {
 		&suppressPermalink, "suppress-permalink", "",
 		"Suppress display of the state permalink")
 	cmd.Flag("suppress-permalink").NoOptDefVal = "false"
-	cmd.PersistentFlags().BoolVar(
-		&attachDebugger, "attach-debugger", false,
-		"Enable the ability to attach a debugger to the program being executed")
+	//nolint:lll // long description
+	cmd.PersistentFlags().StringArrayVar(
+		&attachDebugger, "attach-debugger", []string{},
+		"Enable the ability to attach a debugger to the program and source based plugins being executed. Can limit debug type to 'program', 'plugins', 'plugin=<name>' or 'all'.")
+	cmd.Flag("attach-debugger").NoOptDefVal = "program"
 
 	cmd.PersistentFlags().BoolVar(
 		&copilotEnabled, "copilot", false,

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -679,7 +679,7 @@ func NewPreviewCmd() *cobra.Command {
 	//nolint:lll // long description
 	cmd.PersistentFlags().StringArrayVar(
 		&attachDebugger, "attach-debugger", []string{},
-		"Enable the ability to attach a debugger to the program and source based plugins being executed. Can limit debug type to 'program', 'plugins', 'plugin=<name>' or 'all'.")
+		"Enable the ability to attach a debugger to the program and source based plugins being executed. Can limit debug type to 'program', 'plugins', 'plugin:<name>' or 'all'.")
 	cmd.Flag("attach-debugger").NoOptDefVal = "program"
 
 	cmd.PersistentFlags().BoolVar(

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -762,7 +762,7 @@ func NewUpCmd() *cobra.Command {
 	//nolint:lll // long description
 	cmd.PersistentFlags().StringArrayVar(
 		&attachDebugger, "attach-debugger", []string{},
-		"Enable the ability to attach a debugger to the program and source based plugins being executed. Can limit debug type to 'program', 'plugins', 'plugin=<name>' or 'all'.")
+		"Enable the ability to attach a debugger to the program and source based plugins being executed. Can limit debug type to 'program', 'plugins', 'plugin:<name>' or 'all'.")
 	cmd.Flag("attach-debugger").NoOptDefVal = "program"
 
 	cmd.PersistentFlags().StringVar(
@@ -826,7 +826,7 @@ func validatePolicyPackConfig(policyPackPaths []string, policyPackConfigPaths []
 
 func validateAttachDebuggerFlag(args []string) error {
 	for _, arg := range args {
-		if arg != "program" && arg != "plugins" && arg != "all" && !strings.HasPrefix(arg, "plugin=") {
+		if arg != "program" && arg != "plugins" && arg != "all" && !strings.HasPrefix(arg, "plugin:") {
 			return fmt.Errorf("invalid --attach-debugger flag value: %s", arg)
 		}
 	}

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -117,7 +118,7 @@ func NewUpCmd() *cobra.Command {
 	var targetDependents bool
 	var excludeDependents bool
 	var planFilePath string
-	var attachDebugger bool
+	var attachDebugger []string
 
 	// Flags for Copilot.
 	var copilotEnabled bool
@@ -525,6 +526,11 @@ func NewUpCmd() *cobra.Command {
 				)
 			}
 
+			err := validateAttachDebuggerFlag(attachDebugger)
+			if err != nil {
+				return err
+			}
+
 			opts, err := updateFlagsToOptions(interactive, skipPreview, yes, false /* previewOnly */)
 			if err != nil {
 				return err
@@ -753,9 +759,11 @@ func NewUpCmd() *cobra.Command {
 		&continueOnError, "continue-on-error", env.ContinueOnError.Value(),
 		"Continue updating resources even if an error is encountered "+
 			"(can also be set with PULUMI_CONTINUE_ON_ERROR environment variable)")
-	cmd.PersistentFlags().BoolVar(
-		&attachDebugger, "attach-debugger", false,
-		"Enable the ability to attach a debugger to the program being executed")
+	//nolint:lll // long description
+	cmd.PersistentFlags().StringArrayVar(
+		&attachDebugger, "attach-debugger", []string{},
+		"Enable the ability to attach a debugger to the program and source based plugins being executed. Can limit debug type to 'program', 'plugins', 'plugin=<name>' or 'all'.")
+	cmd.Flag("attach-debugger").NoOptDefVal = "program"
 
 	cmd.PersistentFlags().StringVar(
 		&planFilePath, "plan", "",
@@ -813,6 +821,16 @@ func validatePolicyPackConfig(policyPackPaths []string, policyPackConfigPaths []
 				`the number of "--policy-pack-config" flags must match the number of "--policy-pack" flags`)
 		}
 	}
+	return nil
+}
+
+func validateAttachDebuggerFlag(args []string) error {
+	for _, arg := range args {
+		if arg != "program" && arg != "plugins" && arg != "all" && !strings.HasPrefix(arg, "plugin=") {
+			return fmt.Errorf("invalid --attach-debugger flag value: %s", arg)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/engine/debugging.go
+++ b/pkg/engine/debugging.go
@@ -51,7 +51,7 @@ func (s *debugContext) AttachDebugger(spec plugin.DebugSpec) bool {
 		return true
 	}
 	for _, requested := range s.attachDebugger {
-		if name := strings.TrimPrefix(requested, "plugin="); name == spec.Name {
+		if name := strings.TrimPrefix(requested, "plugin:"); name == spec.Name {
 			return true
 		}
 	}

--- a/pkg/engine/debugging.go
+++ b/pkg/engine/debugging.go
@@ -15,10 +15,13 @@
 package engine
 
 import (
+	"slices"
+	"strings"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 )
 
-func newDebugContext(events eventEmitter, attachDebugger bool) plugin.DebugContext {
+func newDebugContext(events eventEmitter, attachDebugger []string) plugin.DebugContext {
 	return &debugContext{
 		attachDebugger: attachDebugger,
 		events:         events,
@@ -26,7 +29,7 @@ func newDebugContext(events eventEmitter, attachDebugger bool) plugin.DebugConte
 }
 
 type debugContext struct {
-	attachDebugger bool         // whether debugging is enabled.
+	attachDebugger []string     // the debugger types to attach to.
 	events         eventEmitter // the channel to emit events into.
 }
 
@@ -37,6 +40,20 @@ func (s *debugContext) StartDebugging(info plugin.DebuggingInfo) error {
 	return nil
 }
 
-func (s *debugContext) AttachDebugger() bool {
-	return s.attachDebugger
+func (s *debugContext) AttachDebugger(spec plugin.DebugSpec) bool {
+	if slices.Contains(s.attachDebugger, "all") {
+		return true
+	}
+	if spec.Type == plugin.DebugTypeProgram && slices.Contains(s.attachDebugger, "program") {
+		return true
+	}
+	if slices.Contains(s.attachDebugger, "plugins") {
+		return true
+	}
+	for _, requested := range s.attachDebugger {
+		if name := strings.TrimPrefix(requested, "plugin="); name == spec.Name {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/engine/debugging_test.go
+++ b/pkg/engine/debugging_test.go
@@ -1,0 +1,102 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttachDebugger(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		attachDebugger []string
+		spec           plugin.DebugSpec
+		expected       bool
+	}{
+		{
+			name:           "all",
+			attachDebugger: []string{"all"},
+			spec: plugin.DebugSpec{
+				Type: plugin.DebugTypeProgram,
+			},
+			expected: true,
+		},
+		{
+			name:           "program",
+			attachDebugger: []string{"program"},
+			spec: plugin.DebugSpec{
+				Type: plugin.DebugTypeProgram,
+			},
+			expected: true,
+		},
+		{
+			name:           "plugins",
+			attachDebugger: []string{"plugins"},
+			spec: plugin.DebugSpec{
+				Type: plugin.DebugTypePlugin,
+				Name: "test-plugin",
+			},
+			expected: true,
+		},
+		{
+			name:           "plugin=plugin-name",
+			attachDebugger: []string{"plugin=plugin-name"},
+			spec: plugin.DebugSpec{
+				Type: plugin.DebugTypePlugin,
+				Name: "plugin-name",
+			},
+			expected: true,
+		},
+		{
+			name:           "plugin=other-plugin-name",
+			attachDebugger: []string{"plugin=plugin-name"},
+			spec: plugin.DebugSpec{
+				Type: plugin.DebugTypePlugin,
+				Name: "other-plugin-name",
+			},
+			expected: false,
+		},
+		{
+			name:           "program with plugin spec",
+			attachDebugger: []string{"program"},
+			spec: plugin.DebugSpec{
+				Type: plugin.DebugTypePlugin,
+				Name: "test-plugin",
+			},
+			expected: false,
+		},
+		{
+			name:           "plugin with program spec",
+			attachDebugger: []string{"plugin=plugin-name"},
+			spec: plugin.DebugSpec{
+				Type: plugin.DebugTypeProgram,
+			},
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			debugContext := newDebugContext(eventEmitter{}, test.attachDebugger)
+			result := debugContext.AttachDebugger(test.spec)
+			require.Equal(t, test.expected, result)
+		})
+	}
+}

--- a/pkg/engine/debugging_test.go
+++ b/pkg/engine/debugging_test.go
@@ -56,8 +56,8 @@ func TestAttachDebugger(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:           "plugin=plugin-name",
-			attachDebugger: []string{"plugin=plugin-name"},
+			name:           "plugin:plugin-name",
+			attachDebugger: []string{"plugin:plugin-name"},
 			spec: plugin.DebugSpec{
 				Type: plugin.DebugTypePlugin,
 				Name: "plugin-name",
@@ -65,8 +65,8 @@ func TestAttachDebugger(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:           "plugin=other-plugin-name",
-			attachDebugger: []string{"plugin=plugin-name"},
+			name:           "plugin:other-plugin-name",
+			attachDebugger: []string{"plugin:plugin-name"},
 			spec: plugin.DebugSpec{
 				Type: plugin.DebugTypePlugin,
 				Name: "other-plugin-name",
@@ -84,7 +84,7 @@ func TestAttachDebugger(t *testing.T) {
 		},
 		{
 			name:           "plugin with program spec",
-			attachDebugger: []string{"plugin=plugin-name"},
+			attachDebugger: []string{"plugin:plugin-name"},
 			spec: plugin.DebugSpec{
 				Type: plugin.DebugTypeProgram,
 			},

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -189,8 +189,8 @@ type UpdateOptions struct {
 	// ContinueOnError is true if the engine should continue processing resources after an error is encountered.
 	ContinueOnError bool
 
-	// AttachDebugger to launch the language host in debug mode.
-	AttachDebugger bool
+	// AttachDebugger is the list of things to debug.  This can be "program", "all", "plugins", or "plugin=<plugin-name>".
+	AttachDebugger []string
 
 	// Autonamer can resolve user's preference for custom autonaming options for a given resource.
 	Autonamer autonaming.Autonamer

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -189,7 +189,7 @@ type UpdateOptions struct {
 	// ContinueOnError is true if the engine should continue processing resources after an error is encountered.
 	ContinueOnError bool
 
-	// AttachDebugger is the list of things to debug.  This can be "program", "all", "plugins", or "plugin=<plugin-name>".
+	// AttachDebugger is the list of things to debug.  This can be "program", "all", "plugins", or "plugin:<plugin-name>".
 	AttachDebugger []string
 
 	// Autonamer can resolve user's preference for custom autonaming options for a given resource.

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -443,7 +443,7 @@ func (host *pluginHost) StartDebugging(info plugin.DebuggingInfo) error {
 	return nil
 }
 
-func (host *pluginHost) AttachDebugger() bool {
+func (host *pluginHost) AttachDebugger(_ plugin.DebugSpec) bool {
 	return false
 }
 

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -112,7 +112,7 @@ func (host *testPluginHost) StartDebugging(info plugin.DebuggingInfo) error {
 	return nil
 }
 
-func (host *testPluginHost) AttachDebugger() bool {
+func (host *testPluginHost) AttachDebugger(_ plugin.DebugSpec) bool {
 	return false
 }
 

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -87,7 +87,7 @@ type EvalSourceOptions struct {
 	DisableResourceReferences bool
 	// true to disable output value support.
 	DisableOutputValues bool
-	// AttachDebugger is the list of things to debug.  This can be "program", "all", "plugins", or "plugin=<plugin-name>".
+	// AttachDebugger is the list of things to debug.  This can be "program", "all", "plugins", or "plugin:<plugin-name>".
 	AttachDebugger []string
 }
 

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -87,8 +87,8 @@ type EvalSourceOptions struct {
 	DisableResourceReferences bool
 	// true to disable output value support.
 	DisableOutputValues bool
-	// AttachDebugger to launch the language host in debug mode.
-	AttachDebugger bool
+	// AttachDebugger is the list of things to debug.  This can be "program", "all", "plugins", or "plugin=<plugin-name>".
+	AttachDebugger []string
 }
 
 // NewEvalSource returns a planning source that fetches resources by evaluating a package with a set of args and
@@ -281,7 +281,7 @@ func (iter *evalSourceIterator) forkRun(
 				Organization:   string(iter.src.runinfo.Target.Organization),
 				Info:           programInfo,
 				LoaderAddress:  iter.loaderServer.Addr(),
-				AttachDebugger: iter.src.opts.AttachDebugger,
+				AttachDebugger: iter.src.plugctx.Host.AttachDebugger(plugin.DebugSpec{Type: plugin.DebugTypeProgram}),
 			})
 
 			// Check if we were asked to Bail.  This a special random constant used for that

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -78,7 +78,7 @@ func NewAnalyzer(host Host, ctx *Context, name tokens.QName) (Analyzer, error) {
 
 	plug, _, err := newPlugin(ctx, ctx.Pwd, path, fmt.Sprintf("%v (analyzer)", name),
 		apitype.AnalyzerPlugin, []string{host.ServerAddr(), ctx.Pwd}, nil, /*env*/
-		testConnection, dialOpts, host.AttachDebugger())
+		testConnection, dialOpts, host.AttachDebugger(DebugSpec{Type: DebugTypePlugin, Name: string(name)}))
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +197,8 @@ func NewPolicyAnalyzer(
 
 		plug, _, err = newPlugin(ctx, pwd, pluginPath, fmt.Sprintf("%v (analyzer)", name),
 			apitype.AnalyzerPlugin, args, env, handshake,
-			analyzerPluginDialOptions(ctx, fmt.Sprintf("%v", name)), host.AttachDebugger())
+			analyzerPluginDialOptions(ctx, fmt.Sprintf("%v", name)),
+			host.AttachDebugger(DebugSpec{Type: DebugTypePlugin, Name: string(name)}))
 	} else {
 		// Else we _did_ get a lanuage plugin so just use RunPlugin to invoke the policy pack.
 
@@ -210,7 +211,8 @@ func NewPolicyAnalyzer(
 
 		plug, _, err = newPlugin(ctx, ctx.Pwd, policyPackPath, fmt.Sprintf("%v (analyzer)", name),
 			apitype.AnalyzerPlugin, []string{host.ServerAddr()}, os.Environ(),
-			handshake, analyzerPluginDialOptions(ctx, string(name)), host.AttachDebugger())
+			handshake, analyzerPluginDialOptions(ctx, string(name)),
+			host.AttachDebugger(DebugSpec{Type: DebugTypePlugin, Name: string(name)}))
 	}
 
 	if err != nil {

--- a/sdk/go/common/resource/plugin/converter_plugin.go
+++ b/sdk/go/common/resource/plugin/converter_plugin.go
@@ -58,7 +58,7 @@ func NewConverter(ctx *Context, name string, version *semver.Version) (Converter
 	plug, _, err := newPlugin(ctx, ctx.Pwd, path, prefix,
 		apitype.ConverterPlugin, []string{}, os.Environ(),
 		testConnection, converterPluginDialOptions(ctx, name, ""),
-		ctx.Host.AttachDebugger())
+		ctx.Host.AttachDebugger(DebugSpec{Type: DebugTypePlugin, Name: name}))
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/common/resource/plugin/debugging.go
+++ b/sdk/go/common/resource/plugin/debugging.go
@@ -14,12 +14,29 @@
 
 package plugin
 
+type DebugType int
+
+const (
+	// DebugTypeProgram indicates that the debug session is for a program.
+	DebugTypeProgram DebugType = iota
+	// DebugTypePlugin indicates that the debug session is for a plugin.
+	DebugTypePlugin
+)
+
+type DebugSpec struct {
+	// Type is the type of the thing to debug. Can be "program" or "plugin".
+	Type DebugType
+
+	// Name is the name of the plugin. Only used if Type is DebugTypePlugin.
+	Name string
+}
+
 type DebugContext interface {
 	// StartDebugging asks the host to start a debug session for the given configuration.
 	StartDebugging(info DebuggingInfo) error
 
 	// AttachDebugger returns true if debugging is enabled.
-	AttachDebugger() bool
+	AttachDebugger(spec DebugSpec) bool
 }
 
 type DebuggingInfo struct {

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -96,7 +96,7 @@ type Host interface {
 	StartDebugging(info DebuggingInfo) error
 
 	// AttachDebugger returns true if debugging is enabled.
-	AttachDebugger() bool
+	AttachDebugger(spec DebugSpec) bool
 
 	// Close reclaims any resources associated with the host.
 	Close() error
@@ -351,8 +351,8 @@ func (host *defaultHost) StartDebugging(info DebuggingInfo) error {
 	return host.debugContext.StartDebugging(info)
 }
 
-func (host *defaultHost) AttachDebugger() bool {
-	return host.debugContext != nil && host.debugContext.AttachDebugger()
+func (host *defaultHost) AttachDebugger(spec DebugSpec) bool {
+	return host.debugContext != nil && host.debugContext.AttachDebugger(spec)
 }
 
 // loadPlugin sends an appropriate load request to the plugin loader and returns the loaded plugin (if any) and error.

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -135,7 +135,7 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime, workingDirectory strin
 			nil, /*env*/
 			testConnection,
 			langRuntimePluginDialOptions(ctx, runtime),
-			host.AttachDebugger(),
+			host.AttachDebugger(DebugSpec{Type: DebugTypePlugin, Name: runtime}),
 		)
 		if err != nil {
 			return nil, err

--- a/sdk/go/common/resource/plugin/mock.go
+++ b/sdk/go/common/resource/plugin/mock.go
@@ -40,7 +40,7 @@ type MockHost struct {
 	SignalCancellationF func() error
 	CloseF              func() error
 	StartDebuggingF     func(info DebuggingInfo) error
-	AttachDebuggerF     func() bool
+	AttachDebuggerF     func(spec DebugSpec) bool
 }
 
 var _ Host = (*MockHost)(nil)
@@ -150,9 +150,9 @@ func (m *MockHost) StartDebugging(info DebuggingInfo) error {
 	return nil
 }
 
-func (m *MockHost) AttachDebugger() bool {
+func (m *MockHost) AttachDebugger(spec DebugSpec) bool {
 	if m.AttachDebuggerF != nil {
-		return m.AttachDebuggerF()
+		return m.AttachDebuggerF(spec)
 	}
 	return false
 }

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -256,7 +256,7 @@ func NewProvider(host Host, ctx *Context, spec workspace.PluginSpec,
 		plug, handshakeRes, err = newPlugin(ctx, ctx.Pwd, path, prefix,
 			apitype.ResourcePlugin, []string{host.ServerAddr()}, env,
 			handshake, providerPluginDialOptions(ctx, pkg, ""),
-			host.AttachDebugger())
+			host.AttachDebugger(DebugSpec{Type: DebugTypePlugin, Name: spec.Name}))
 		if err != nil {
 			return nil, err
 		}
@@ -381,7 +381,7 @@ func NewProviderFromPath(host Host, ctx *Context, path string) (Provider, error)
 	plug, handshakeRes, err := newPlugin(ctx, ctx.Pwd, path, "",
 		apitype.ResourcePlugin, []string{host.ServerAddr()}, env,
 		handshake, providerPluginDialOptions(ctx, "", path),
-		host.AttachDebugger())
+		host.AttachDebugger(DebugSpec{Type: DebugTypePlugin, Name: path}))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently `--attach-debugger` only allows debugging programs. However we are introducing functionality to allow debugging source based plugins as well. For that, we want users to be able to filter what they want to debug.

By default users will be debugging programs, which is probably the most common case for most users. However we also allow debugging either all plugins, or plugins filtered by name.  These can be specified using `--attach-debugger plugins` or
`--attach-debugger plugin=<name>`.