### PR TITLE
Elide `StackReference` outputs that fail to decrypt

### DIFF
--- a/changelog/pending/20250519--engine--elide-stackreference-outputs-that-fail-to-decrypt.yaml
+++ b/changelog/pending/20250519--engine--elide-stackreference-outputs-that-fail-to-decrypt.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Elide `StackReference` outputs that fail to decrypt

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -2307,7 +2307,11 @@ type httpstateBackendClient struct {
 	backend deploy.BackendClient
 }
 
-func (c httpstateBackendClient) GetStackOutputs(ctx context.Context, name string) (resource.PropertyMap, error) {
+func (c httpstateBackendClient) GetStackOutputs(
+	ctx context.Context,
+	name string,
+	onDecryptError func(error) error,
+) (resource.PropertyMap, error) {
 	// When using the cloud backend, require that stack references are fully qualified so they
 	// look like "<org>/<project>/<stack>"
 	if strings.Count(name, "/") != 2 {
@@ -2316,7 +2320,7 @@ func (c httpstateBackendClient) GetStackOutputs(ctx context.Context, name string
 			"for more information.")
 	}
 
-	return c.backend.GetStackOutputs(ctx, name)
+	return c.backend.GetStackOutputs(ctx, name, onDecryptError)
 }
 
 func (c httpstateBackendClient) GetStackResourceOutputs(

--- a/pkg/backend/secrets.go
+++ b/pkg/backend/secrets.go
@@ -1,0 +1,155 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+)
+
+// errorCatchingSecretsProvider decorates a secrets.Provider with the ability to catch and control the response to
+// certain kinds of errors, such as those encountered when decrypting a value. This can be used to, for example, ignore
+// errors caused by secret decryption so that plain/insecure values can still be used.
+type errorCatchingSecretsProvider struct {
+	// The underlying secrets.Provider that will be used to perform actual operations.
+	delegateProvider secrets.Provider
+
+	// A callback that will be invoked when an error is encountered during decryption. The callback can return a new error
+	// to be returned, or nil to indicate that the error should be ignored and that one or more empty objects should be
+	// returned as plaintext(s) instead.
+	onDecryptError func(error) error
+}
+
+var _ secrets.Provider = (*errorCatchingSecretsProvider)(nil)
+
+// newErrorCatchingSecretsProvider creates a new errorCatchingSecretsProvider that wraps the given delegate
+// secrets.Provider. The onDecryptError callback will be invoked when an error is encountered during decryption. The
+// callback can return a new error to be returned, or nil to indicate that the error should be ignored and that one or
+// more empty objects should be returned as plaintext(s) instead.
+func newErrorCatchingSecretsProvider(
+	delegate secrets.Provider,
+	onDecryptError func(error) error,
+) *errorCatchingSecretsProvider {
+	return &errorCatchingSecretsProvider{
+		delegateProvider: delegate,
+		onDecryptError:   onDecryptError,
+	}
+}
+
+func (p *errorCatchingSecretsProvider) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
+	delegateManager, err := p.delegateProvider.OfType(ty, state)
+	if err != nil {
+		return nil, err
+	}
+
+	manager := &errorCatchingSecretsManager{
+		delegateManager: delegateManager,
+		onDecryptError:  p.onDecryptError,
+	}
+
+	return manager, nil
+}
+
+// errorCatchingSecretsManager decorates a secrets.Manager with the ability to catch and control the response to certain
+// kinds of errors, such as those encountered when decrypting a value. errorCatchingSecretsManager is used to wrap
+// results returned by errorCatchingSecretsProvider.OfType.
+type errorCatchingSecretsManager struct {
+	// The underlying secrets.Manager that will be used to perform actual operations.
+	delegateManager secrets.Manager
+	// A callback that will be invoked when an error is encountered during decryption. The callback can return a new error
+	// to be returned, or nil to indicate that the error should be ignored and that one or more empty objects should be
+	// returned as plaintext(s) instead.
+	onDecryptError func(error) error
+}
+
+var _ secrets.Manager = (*errorCatchingSecretsManager)(nil)
+
+func (m *errorCatchingSecretsManager) Type() string {
+	return m.delegateManager.Type()
+}
+
+func (m *errorCatchingSecretsManager) State() json.RawMessage {
+	return m.delegateManager.State()
+}
+
+func (m *errorCatchingSecretsManager) Encrypter() config.Encrypter {
+	return m
+}
+
+func (m *errorCatchingSecretsManager) Decrypter() config.Decrypter {
+	return m
+}
+
+func (m *errorCatchingSecretsManager) EncryptValue(ctx context.Context, plaintext string) (string, error) {
+	return "", errors.New("error catching secrets manager does not support encryption")
+}
+
+func (m *errorCatchingSecretsManager) BatchEncrypt(ctx context.Context, secrets []string) ([]string, error) {
+	return nil, errors.New("error catching secrets manager does not support batch encryption")
+}
+
+func (m *errorCatchingSecretsManager) DecryptValue(ctx context.Context, ciphertext string) (string, error) {
+	dec := m.delegateManager.Decrypter()
+	if dec == nil {
+		return "", errors.New("error catching secrets manager delegate returned a nil decrypter")
+	}
+
+	plaintext, err := dec.DecryptValue(ctx, ciphertext)
+	if err == nil {
+		return plaintext, nil
+	}
+
+	// We encountered an error decrypting the value. Pass it to our onDecryptError and return any error that the callback
+	// returns.
+	rethrownErr := m.onDecryptError(err)
+	if rethrownErr != nil {
+		return "", rethrownErr
+	}
+
+	// onDecryptError returned nil, so we will smother the error and return an empty object.
+	return "{}", nil
+}
+
+func (m *errorCatchingSecretsManager) BatchDecrypt(ctx context.Context, ciphertexts []string) ([]string, error) {
+	dec := m.delegateManager.Decrypter()
+	if dec == nil {
+		return nil, errors.New("error catching secrets manager delegate returned a nil decrypter")
+	}
+
+	plaintexts, err := dec.BatchDecrypt(ctx, ciphertexts)
+	if err == nil {
+		return plaintexts, nil
+	}
+
+	// We encountered an error decrypting the values. Pass it to our onDecryptError and return any error that the callback
+	// returns.
+	rethrownErr := m.onDecryptError(err)
+	if rethrownErr != nil {
+		return nil, rethrownErr
+	}
+
+	// onDecryptError returned nil, so we will smother the error and return a slice of empty objects whose length matches
+	// that of the slice of ciphertexts we were given.
+	results := make([]string, len(ciphertexts))
+	for i := range ciphertexts {
+		results[i] = "{}"
+	}
+
+	return results, nil
+}

--- a/pkg/backend/secrets_test.go
+++ b/pkg/backend/secrets_test.go
@@ -1,0 +1,450 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// Tests that an errorCatchingSecretsProvider correctly delegates its OfType method to the underlying provider.
+func TestErrorCatchingSecretsProvider_OfType_Success(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	delegate := &MockProviderManager{}
+	provider := newErrorCatchingSecretsProvider(delegate, func(err error) error { return err })
+
+	// Act
+	manager, err := provider.OfType("test", nil)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.NotNil(t, manager)
+	assert.IsType(t, &errorCatchingSecretsManager{}, manager)
+	assert.True(t, delegate.ofTypeCalled)
+}
+
+// Tests that an errorCatchingSecretsProvider correctly propagates an error from the underlying provider's OfType
+// method.
+func TestErrorCatchingSecretsProvider_OfType_Error(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	delegateErr := errors.New("delegate error")
+	delegate := &MockProviderManager{ofTypeErr: delegateErr}
+
+	provider := newErrorCatchingSecretsProvider(delegate, func(err error) error { return err })
+
+	// Act
+	manager, err := provider.OfType("test", nil)
+
+	// Assert
+	assert.Error(t, err)
+	assert.Nil(t, manager)
+	assert.Equal(t, delegateErr, err)
+	assert.True(t, delegate.ofTypeCalled)
+}
+
+// Tests that an errorCatchingSecretsManager correctly delegates its Type method to the underlying provider.
+func TestErrorCatchingSecretsManager_Type(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	expectedType := "testType"
+	delegateManager := &MockProviderManager{typeStr: expectedType}
+
+	manager := &errorCatchingSecretsManager{delegateManager: delegateManager}
+
+	// Act
+	result := manager.Type()
+
+	// Assert
+	assert.Equal(t, expectedType, result)
+}
+
+// Tests that an errorCatchingSecretsManager correctly delegates its State method to the underlying provider.
+func TestErrorCatchingSecretsManager_State(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	expectedState := json.RawMessage(`{"key": "value"}`)
+	delegateManager := &MockProviderManager{state: expectedState}
+
+	manager := &errorCatchingSecretsManager{delegateManager: delegateManager}
+
+	// Act
+	result := manager.State()
+
+	// Assert
+	assert.Equal(t, expectedState, result)
+}
+
+// Tests that an errorCatchingSecretsManager is its own Encrypter.
+func TestErrorCatchingSecretsManager_Encrypter(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	delegateManager := &MockProviderManager{}
+	manager := &errorCatchingSecretsManager{delegateManager: delegateManager}
+
+	// Act
+	encrypter := manager.Encrypter()
+
+	// Assert
+	assert.Equal(t, manager, encrypter)
+}
+
+// Tests that an errorCatchingSecretsManager is its own Decrypter.
+func TestErrorCatchingSecretsManager_Decrypter(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	delegateManager := &MockProviderManager{}
+	manager := &errorCatchingSecretsManager{delegateManager: delegateManager}
+
+	// Act
+	decrypter := manager.Decrypter()
+
+	// Assert
+	assert.Equal(t, manager, decrypter)
+}
+
+// Tests that an errorCatchingSecretsManager's encrypter (itself) does not support encryption.
+func TestErrorCatchingSecretsManager_EncryptValue(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	delegateManager := &MockProviderManager{}
+	manager := &errorCatchingSecretsManager{delegateManager: delegateManager}
+
+	// Act
+	_, err := manager.EncryptValue(context.Background(), "test")
+
+	// Assert
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support encryption")
+}
+
+// Tests that an errorCatchingSecretsManager's encrypter (itself) does not support batch encryption.
+func TestErrorCatchingSecretsManager_BatchEncrypt(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	delegateManager := &MockProviderManager{}
+	manager := &errorCatchingSecretsManager{delegateManager: delegateManager}
+
+	// Act
+	_, err := manager.BatchEncrypt(context.Background(), []string{"test"})
+
+	// Assert
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support batch encryption")
+}
+
+// Tests that an errorCatchingSecretsManager's decrypter (itself) supports decryption by delegating to the underlying
+// provider.
+func TestErrorCatchingSecretsManager_DecryptValue_Success(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	expectedValue := "decrypted"
+	encDecrypter := &MockEncrypterDecrypter{decryptValue: expectedValue}
+
+	delegateManager := &MockProviderManager{encrypterDecrypter: encDecrypter}
+
+	manager := &errorCatchingSecretsManager{
+		delegateManager: delegateManager,
+		onDecryptError:  func(err error) error { return err },
+	}
+
+	// Act
+	plaintext, err := manager.DecryptValue(context.Background(), "encrypted")
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, expectedValue, plaintext)
+	assert.True(t, encDecrypter.decryptValueCalled)
+}
+
+// Tests that an errorCatchingSecretsManager's decrypter (itself) propagates decryption errors from the underlying
+// provider to the supplied onDecryptError callback, propagating the error to the caller if the callback returns an
+// error.
+func TestErrorCatchingSecretsManager_DecryptValue_ErrorPropagated(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	decryptErr := errors.New("decryption error")
+	encDecrypter := &MockEncrypterDecrypter{decryptErr: decryptErr}
+
+	delegateManager := &MockProviderManager{encrypterDecrypter: encDecrypter}
+
+	onDecryptErrorCalled := false
+	manager := &errorCatchingSecretsManager{
+		delegateManager: delegateManager,
+		onDecryptError: func(err error) error {
+			onDecryptErrorCalled = true
+			return err
+		},
+	}
+
+	// Act
+	_, err := manager.DecryptValue(context.Background(), "encrypted")
+
+	// Assert
+	assert.Error(t, err)
+	assert.Equal(t, decryptErr, err)
+	assert.True(t, encDecrypter.decryptValueCalled)
+	assert.True(t, onDecryptErrorCalled)
+}
+
+// Tests that an errorCatchingSecretsManager's decrypter (itself) propagates decryption errors from the underlying
+// provider to the supplied onDecryptError callback, ignoring the error if the callback returns nil.
+func TestErrorCatchingSecretsManager_DecryptValue_ErrorIgnored(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	encDecrypter := &MockEncrypterDecrypter{decryptErr: errors.New("decryption error")}
+	delegateManager := &MockProviderManager{encrypterDecrypter: encDecrypter}
+
+	onDecryptErrorCalled := false
+	manager := &errorCatchingSecretsManager{
+		delegateManager: delegateManager,
+		onDecryptError: func(err error) error {
+			onDecryptErrorCalled = true
+			return nil
+		},
+	}
+
+	// Act
+	plaintext, err := manager.DecryptValue(context.Background(), "encrypted")
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, "{}", plaintext)
+	assert.True(t, encDecrypter.decryptValueCalled)
+	assert.True(t, onDecryptErrorCalled)
+}
+
+// Tests that an errorCatchingSecretsManager's decrypter (itself) returns an error when decrypting if the underlying
+// provider's decrypter is nil.
+func TestErrorCatchingSecretsManager_DecryptValue_NilDecrypter(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	delegateManager := &MockProviderManager{}
+	manager := &errorCatchingSecretsManager{
+		delegateManager: delegateManager,
+		onDecryptError:  func(err error) error { return err },
+	}
+
+	// Act
+	_, err := manager.DecryptValue(context.Background(), "encrypted")
+
+	// Assert
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nil decrypter")
+}
+
+// Tests that an errorCatchingSecretsManager's decrypter (itself) supports batch decryption by delegating to the
+// underlying provider.
+func TestErrorCatchingSecretsManager_BatchDecrypt_Success(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	expectedValues := []string{"decrypted1", "decrypted2"}
+	encDecrypter := &MockEncrypterDecrypter{batchDecryptValues: expectedValues}
+	delegateManager := &MockProviderManager{encrypterDecrypter: encDecrypter}
+
+	manager := &errorCatchingSecretsManager{
+		delegateManager: delegateManager,
+		onDecryptError:  func(err error) error { return err },
+	}
+
+	// Act
+	plaintexts, err := manager.BatchDecrypt(context.Background(), []string{"encrypted1", "encrypted2"})
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, expectedValues, plaintexts)
+	assert.True(t, encDecrypter.batchDecryptCalled)
+}
+
+// Tests that an errorCatchingSecretsManager's decrypter (itself) propagates batch decryption errors from the underlying
+// provider to the supplied onDecryptError callback, propagating the error to the caller if the callback returns an
+// error.
+func TestErrorCatchingSecretsManager_BatchDecrypt_ErrorPropagated(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	batchDecryptErr := errors.New("batch decryption error")
+	encDecrypter := &MockEncrypterDecrypter{batchDecryptErr: batchDecryptErr}
+	delegateManager := &MockProviderManager{encrypterDecrypter: encDecrypter}
+
+	onDecryptErrorCalled := false
+	manager := &errorCatchingSecretsManager{
+		delegateManager: delegateManager,
+		onDecryptError: func(err error) error {
+			onDecryptErrorCalled = true
+			return err
+		},
+	}
+
+	// Act
+	_, err := manager.BatchDecrypt(context.Background(), []string{"encrypted1", "encrypted2"})
+
+	// Assert
+	assert.Error(t, err)
+	assert.Equal(t, batchDecryptErr, err)
+	assert.True(t, encDecrypter.batchDecryptCalled)
+	assert.True(t, onDecryptErrorCalled)
+}
+
+// Tests that an errorCatchingSecretsManager's decrypter (itself) propagates batch decryption errors from the underlying
+// provider to the supplied onDecryptError callback, ignoring the error if the callback returns nil.
+func TestErrorCatchingSecretsManager_BatchDecrypt_ErrorIgnored(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	encDecrypter := &MockEncrypterDecrypter{batchDecryptErr: errors.New("batch decryption error")}
+	delegateManager := &MockProviderManager{encrypterDecrypter: encDecrypter}
+
+	onDecryptErrorCalled := false
+	manager := &errorCatchingSecretsManager{
+		delegateManager: delegateManager,
+		onDecryptError: func(err error) error {
+			onDecryptErrorCalled = true
+			return nil
+		},
+	}
+
+	// Act
+	plaintexts, err := manager.BatchDecrypt(context.Background(), []string{"encrypted1", "encrypted2"})
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"{}", "{}"}, plaintexts)
+	assert.True(t, encDecrypter.batchDecryptCalled)
+	assert.True(t, onDecryptErrorCalled)
+}
+
+// Tests that an errorCatchingSecretsManager's decrypter (itself) returns an error when batch decrypting if the
+// underlying provider's decrypter is nil.
+func TestErrorCatchingSecretsManager_BatchDecrypt_NilDecrypter(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	delegateManager := &MockProviderManager{encrypterDecrypter: nil}
+	manager := &errorCatchingSecretsManager{
+		delegateManager: delegateManager,
+		onDecryptError:  func(err error) error { return err },
+	}
+
+	// Act
+	_, err := manager.BatchDecrypt(context.Background(), []string{"encrypted1", "encrypted2"})
+
+	// Assert
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nil decrypter")
+}
+
+// MockProviderManager implements both secrets.Manager and secrets.Provider interfaces for testing.
+type MockProviderManager struct {
+	typeStr            string
+	state              json.RawMessage
+	encrypterDecrypter *MockEncrypterDecrypter
+	ofTypeCalled       bool
+	ofTypeErr          error
+}
+
+func (m *MockProviderManager) Type() string {
+	return m.typeStr
+}
+
+func (m *MockProviderManager) State() json.RawMessage {
+	return m.state
+}
+
+func (m *MockProviderManager) Encrypter() config.Encrypter {
+	// If m.encrypterDecrypter is nil, we return an explicit nil value to avoid falling foul of Go's "nil interface" pain,
+	// whereby a caller will receive a nil interface value, which does not equal nil but will panic if used.
+	if m.encrypterDecrypter != nil {
+		return m.encrypterDecrypter
+	}
+
+	return nil
+}
+
+func (m *MockProviderManager) Decrypter() config.Decrypter {
+	// If m.encrypterDecrypter is nil, we return an explicit nil value to avoid falling foul of Go's "nil interface" pain,
+	// whereby a caller will receive a nil interface value, which does not equal nil but will panic if used.
+	if m.encrypterDecrypter != nil {
+		return m.encrypterDecrypter
+	}
+
+	return nil
+}
+
+func (m *MockProviderManager) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
+	m.ofTypeCalled = true
+	if m.ofTypeErr != nil {
+		return nil, m.ofTypeErr
+	}
+	return m, nil
+}
+
+// MockEncrypterDecrypter combines the config.Encrypter and config.Decrypter interfaces for testing.
+type MockEncrypterDecrypter struct {
+	encryptValueCalled bool
+	encryptValueErr    error
+	batchEncryptCalled bool
+	batchEncryptErr    error
+	decryptValueCalled bool
+	decryptErr         error
+	decryptValue       string
+	batchDecryptCalled bool
+	batchDecryptErr    error
+	batchDecryptValues []string
+}
+
+func (m *MockEncrypterDecrypter) EncryptValue(ctx context.Context, plaintext string) (string, error) {
+	m.encryptValueCalled = true
+	return "encrypted", m.encryptValueErr
+}
+
+func (m *MockEncrypterDecrypter) BatchEncrypt(ctx context.Context, secrets []string) ([]string, error) {
+	m.batchEncryptCalled = true
+	result := make([]string, len(secrets))
+	for i := range secrets {
+		result[i] = "encrypted" + string(rune(i+'0'))
+	}
+	return result, m.batchEncryptErr
+}
+
+func (m *MockEncrypterDecrypter) DecryptValue(ctx context.Context, ciphertext string) (string, error) {
+	m.decryptValueCalled = true
+	return m.decryptValue, m.decryptErr
+}
+
+func (m *MockEncrypterDecrypter) BatchDecrypt(ctx context.Context, ciphertexts []string) ([]string, error) {
+	m.batchDecryptCalled = true
+	return m.batchDecryptValues, m.batchDecryptErr
+}

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2024, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -996,7 +996,7 @@ func TestStackReference(t *testing.T) {
 	})
 	p := &lt.TestPlan{
 		BackendClient: &deploytest.BackendClient{
-			GetStackOutputsF: func(ctx context.Context, name string) (resource.PropertyMap, error) {
+			GetStackOutputsF: func(ctx context.Context, name string, _ func(error) error) (resource.PropertyMap, error) {
 				switch name {
 				case "other":
 					return resource.NewPropertyMapFromMap(map[string]interface{}{
@@ -1154,7 +1154,7 @@ func TestStackReferenceRegister(t *testing.T) {
 
 	p := &lt.TestPlan{
 		BackendClient: &deploytest.BackendClient{
-			GetStackOutputsF: func(ctx context.Context, name string) (resource.PropertyMap, error) {
+			GetStackOutputsF: func(ctx context.Context, name string, _ func(error) error) (resource.PropertyMap, error) {
 				switch name {
 				case "other":
 					return resource.NewPropertyMapFromMap(map[string]interface{}{

--- a/pkg/resource/deploy/builtins_test.go
+++ b/pkg/resource/deploy/builtins_test.go
@@ -176,7 +176,7 @@ func TestBuiltinProvider(t *testing.T) {
 				var called bool
 				p := &builtinProvider{
 					backendClient: &deploytest.BackendClient{
-						GetStackOutputsF: func(ctx context.Context, name string) (resource.PropertyMap, error) {
+						GetStackOutputsF: func(ctx context.Context, name string, _ func(error) error) (resource.PropertyMap, error) {
 							called = true
 							return resource.PropertyMap{
 								"normal": resource.NewStringProperty("foo"),

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -40,8 +40,14 @@ import (
 
 // BackendClient is used to retrieve information about stacks from a backend.
 type BackendClient interface {
-	// GetStackOutputs returns the outputs (if any) for the named stack or an error if the stack cannot be found.
-	GetStackOutputs(ctx context.Context, name string) (resource.PropertyMap, error)
+	// GetStackOutputs returns the outputs (if any) for the named stack, returning an error if the stack cannot be found
+	// or loaded. If the stack contains secrets that cannot be decrypted, the onDecryptError callback will be called
+	// with the error. The callback should return a new error to be returned to the caller, or nil to ignore the error.
+	GetStackOutputs(
+		ctx context.Context,
+		name string,
+		onDecryptError func(error) error,
+	) (resource.PropertyMap, error)
 
 	// GetStackResourceOutputs returns the resource outputs for a stack, or an error if the stack
 	// cannot be found. Resources are retrieved from the latest stack snapshot, which may include

--- a/pkg/resource/deploy/deploytest/backendclient.go
+++ b/pkg/resource/deploy/deploytest/backendclient.go
@@ -22,13 +22,24 @@ import (
 
 // BackendClient provides a simple implementation of deploy.BackendClient that defers to a function value.
 type BackendClient struct {
-	GetStackOutputsF         func(ctx context.Context, name string) (resource.PropertyMap, error)
+	GetStackOutputsF func(
+		ctx context.Context,
+		name string,
+		onDecryptError func(error) error,
+	) (resource.PropertyMap, error)
+
 	GetStackResourceOutputsF func(ctx context.Context, name string) (resource.PropertyMap, error)
 }
 
-// GetStackOutputs returns the outputs (if any) for the named stack or an error if the stack cannot be found.
-func (b *BackendClient) GetStackOutputs(ctx context.Context, name string) (resource.PropertyMap, error) {
-	return b.GetStackOutputsF(ctx, name)
+// GetStackOutputs returns the outputs (if any) for the named stack, returning an error if the stack cannot be found or
+// loaded. If the stack contains secrets that cannot be decrypted, the onDecryptError callback will be called with the
+// error. The callback should return a new error to be returned to the caller, or nil to ignore the error.
+func (b *BackendClient) GetStackOutputs(
+	ctx context.Context,
+	name string,
+	onDecryptError func(error) error,
+) (resource.PropertyMap, error) {
+	return b.GetStackOutputsF(ctx, name, onDecryptError)
 }
 
 // GetStackResourceOutputs returns the resource outputs for a stack, or an error if the stack


### PR DESCRIPTION
`StackReference` is a resource offered by all core Pulumi SDKs, backed internally by the built-in provider. `StackReference`s allow stacks to read and refer to the outputs of other stacks. For example, given two stacks A and B, here written in TypeScript:

```typescript
// a/index.ts

export = async () => {
  return {
    aString: "from-a",
  }
}

// b/index.ts

export = async () => {
  const aRef = new pulumi.StackReference("organization/a/dev");

  const aString = aRef.getOutput("aString")

  return {
    bString: pulumi.interpolate`from-b-and-${aString}`,
  }
}
```

Here, A produces a single output, `aString`, with the value `from-a`. B creates a `StackReference` to A and loads the `aString` output, before including it in its own output, yielding `bString: "from-b-and-from-a"`.

This all works well, and can in theory handle any output value that can be serialized to state. Even secret values are supported, albeit with one limitation -- the referencing stack (here B) must be able to _decrypt_ the secrets of the referenced stack (here A). If both stacks are e.g. using the same secrets manager (such as is the case with the Pulumi service), everything is fine. If they are not, a decryption error will likely be thrown, stopping the execution of the referencing stack. This happens even if the referencing stack only uses non-secret values (since presently, all outputs are loaded at once), causing issues such as #11109.

In this case, we remove the requirement for `StackReference`s to be able to decrypt secrets in referenced stacks. If a decryption fails, a dummy value (that will likely cause errors if used) is returned, allowing plain values to be shared freely. Additionally, in such cases, an `info` diagnostic is emitted informing the user that secret values have been elided, with an accompanying `debug` diagnostic (which is not visible by default) holding the last encountered error message details.

Fixes #11109