### PR TITLE
Return Copilot explainPreview errors to the user

### DIFF
--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -174,6 +174,7 @@ func PreviewThenPrompt(ctx context.Context, kind apitype.UpdateKind, stack Stack
 // confirmBeforeUpdating asks the user whether to proceed. A nil error means yes.
 func confirmBeforeUpdating(ctx context.Context, kind apitype.UpdateKind, stackRef StackReference, op UpdateOperation,
 	events []engine.Event, plan *deploy.Plan, explainer Explainer,
+	// askOpts is used for testing to control stdin/stdout
 	askOpts ...survey.AskOpt,
 ) (*deploy.Plan, error) {
 	for {
@@ -259,7 +260,10 @@ func confirmBeforeUpdating(ctx context.Context, kind apitype.UpdateKind, stackRe
 				stdout = os.Stdout
 			}
 			if err != nil {
-				_, err = stdout.Write([]byte("An error occurred while explaining the changes:\n" + err.Error() + "\n"))
+				_, err = stdout.Write([]byte(
+					opts.Display.Color.Colorize(
+						"An error occurred while explaining the changes:\n" +
+							colors.BrightRed + err.Error() + colors.Reset + "\n\n")))
 				contract.IgnoreError(err)
 				continue
 			}

--- a/pkg/backend/apply_test.go
+++ b/pkg/backend/apply_test.go
@@ -79,7 +79,10 @@ func (e *errorExplainer) Explain(
 ) (string, error) {
 	return "", errors.New("explainer failed")
 }
-func (e *errorExplainer) IsCopilotFeatureEnabled(opts backenddisplay.Options) bool { return true }
+
+func (e *errorExplainer) IsExplainPreviewEnabled(ctx context.Context, opts backenddisplay.Options) bool {
+	return true
+}
 
 func TestConfirmBeforeUpdating_ExplainerErrorDoesNotCrash(t *testing.T) {
 	t.Parallel()

--- a/pkg/backend/apply_test.go
+++ b/pkg/backend/apply_test.go
@@ -15,14 +15,23 @@
 package backend
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/Netflix/go-expect"
+	backenddisplay "github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestComputeUpdateStats tests that the number of non-stack resources and the number of retained resources is correct.
@@ -60,4 +69,70 @@ func makeResourcePreEvent(urn, resType string, op display.StepOp, retainOnDelete
 	})
 
 	return event
+}
+
+// errorExplainer always returns an error for Explain and enables the feature.
+type errorExplainer struct{}
+
+func (e *errorExplainer) Explain(
+	ctx context.Context, stackRef StackReference, kind apitype.UpdateKind, op UpdateOperation, events []engine.Event,
+) (string, error) {
+	return "", errors.New("explainer failed")
+}
+func (e *errorExplainer) IsCopilotFeatureEnabled(opts backenddisplay.Options) bool { return true }
+
+func TestConfirmBeforeUpdating_ExplainerErrorDoesNotCrash(t *testing.T) {
+	t.Parallel()
+
+	// Set up the console with a timeout to avoid hangs
+	console, err := expect.NewConsole(expect.WithDefaultTimeout(2 * time.Second))
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, console.Close())
+	}()
+
+	displayOpts := backenddisplay.Options{
+		Color:  colors.Never,
+		Stdout: console.Tty(),
+	}
+
+	ctx := context.Background()
+	kind := apitype.UpdateUpdate
+	var stackRef StackReference
+	op := UpdateOperation{
+		Opts: UpdateOptions{
+			Display: displayOpts,
+		},
+	}
+	events := []engine.Event{}
+	plan := &deploy.Plan{}
+	explainer := &errorExplainer{}
+
+	done := make(chan struct{})
+	var resultPlan *deploy.Plan
+	var callErr error
+	go func() {
+		defer close(done)
+		askOpt := survey.WithStdio(console.Tty(), console.Tty(), console.Tty())
+		resultPlan, callErr = confirmBeforeUpdating(ctx, kind, stackRef, op, events, plan, explainer, askOpt)
+	}()
+
+	_, err = console.ExpectString("Do you want to perform this update?")
+	require.NoError(t, err)
+	_, err = console.SendLine("explain")
+	require.NoError(t, err)
+	_, err = console.ExpectString("An error occurred while explaining the changes:")
+	require.NoError(t, err)
+	// this is on the next line
+	_, err = console.ExpectString("explainer failed")
+	require.NoError(t, err)
+	_, err = console.SendLine("no")
+	require.NoError(t, err)
+
+	<-done
+
+	// Instead of waiting for EOF, just assert on the error and result
+	require.Nil(t, resultPlan)
+	require.Error(t, callErr)
+	require.Contains(t, callErr.Error(), "confirmation declined")
 }

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1222,6 +1222,10 @@ func (b *cloudBackend) Explain(
 	orgID := stackID.Owner
 	summary, err := b.client.ExplainPreviewWithCopilot(ctx, orgID, string(kind), output)
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			// Format a better error message for the user
+			return "", fmt.Errorf("request to %s timed out after %s", b.client.URL(), client.CopilotRequestTimeout.String())
+		}
 		return "", err
 	}
 

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -45,6 +45,11 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+const (
+	// 20s before we give up on a copilot request
+	CopilotRequestTimeout = 20 * time.Second
+)
+
 // Client provides a slim wrapper around the Pulumi HTTP/REST API.
 type Client struct {
 	apiURL     string
@@ -1443,10 +1448,7 @@ func (pc *Client) callCopilot(ctx context.Context, requestBody interface{}) (str
 		return "", fmt.Errorf("preparing request: %w", err)
 	}
 
-	// Requests that take longer that 20 seconds will result in this message being printed to the user:
-	// "Error summarizing update output: making request: Post "https://api.pulumi.com/api/ai/chat/preview":
-	// context deadline exceeded" Copilot backend will see this in telemetry as well
-	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, CopilotRequestTimeout)
 	defer cancel()
 
 	url := pc.apiURL + "/api/ai/chat/preview"


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi.ai/issues/1856

- Rather than erroring out pulumi.
- Errors maybe timeouts / network errors that can be retried
- Add tests

Looks like this:

<img width="857" alt="image" src="https://github.com/user-attachments/assets/e0259dee-832d-4a6f-be32-f261d9d46186" />
