### PR TITLE
Improve diagnostic event capture for cloud backends

### DIFF
--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -299,7 +299,7 @@ func (pc *Client) GetPulumiAccountDetails(ctx context.Context) (string, []string
 func (pc *Client) GetCLIVersionInfo(
 	ctx context.Context,
 	metadata map[string]string,
-) (semver.Version, semver.Version, semver.Version, error) {
+) (semver.Version, semver.Version, semver.Version, int64, error) {
 	var versionInfo apitype.CLIVersionResponse
 
 	headers := map[string][]string{}
@@ -320,32 +320,32 @@ func (pc *Client) GetCLIVersionInfo(
 		},
 	)
 	if err != nil {
-		return semver.Version{}, semver.Version{}, semver.Version{}, err
+		return semver.Version{}, semver.Version{}, semver.Version{}, 0, err
 	}
 
 	latestSem, err := semver.ParseTolerant(versionInfo.LatestVersion)
 	if err != nil {
-		return semver.Version{}, semver.Version{}, semver.Version{}, err
+		return semver.Version{}, semver.Version{}, semver.Version{}, 0, err
 	}
 
 	oldestSem, err := semver.ParseTolerant(versionInfo.OldestWithoutWarning)
 	if err != nil {
-		return semver.Version{}, semver.Version{}, semver.Version{}, err
+		return semver.Version{}, semver.Version{}, semver.Version{}, 0, err
 	}
 
 	// If there is no dev version, return the latest and oldest
 	// versions.  This can happen if the server does not include
 	// https://github.com/pulumi/pulumi-service/pull/17429 yet
 	if versionInfo.LatestDevVersion == "" {
-		return latestSem, oldestSem, semver.Version{}, nil
+		return latestSem, oldestSem, semver.Version{}, versionInfo.CacheMS, nil
 	}
 
 	devSem, err := semver.ParseTolerant(versionInfo.LatestDevVersion)
 	if err != nil {
-		return semver.Version{}, semver.Version{}, semver.Version{}, err
+		return semver.Version{}, semver.Version{}, semver.Version{}, 0, err
 	}
 
-	return latestSem, oldestSem, devSem, nil
+	return latestSem, oldestSem, devSem, versionInfo.CacheMS, nil
 }
 
 // GetDefaultOrg lists the backend's opinion of which user organization to use, if default organization

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -299,7 +299,7 @@ func (pc *Client) GetPulumiAccountDetails(ctx context.Context) (string, []string
 func (pc *Client) GetCLIVersionInfo(
 	ctx context.Context,
 	metadata map[string]string,
-) (semver.Version, semver.Version, semver.Version, int64, error) {
+) (semver.Version, semver.Version, semver.Version, int, error) {
 	var versionInfo apitype.CLIVersionResponse
 
 	headers := map[string][]string{}

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -75,11 +75,6 @@ var newClient = func(apiURL, apiToken string, insecure bool, d diag.Sink) *Clien
 		httpClient = http.DefaultClient
 	}
 
-	httpClient.Transport = &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		Proxy:           http.ProxyFromEnvironment,
-	}
-
 	return &Client{
 		apiURL:     apiURL,
 		apiToken:   apiAccessToken(apiToken),

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -75,6 +75,11 @@ var newClient = func(apiURL, apiToken string, insecure bool, d diag.Sink) *Clien
 		httpClient = http.DefaultClient
 	}
 
+	httpClient.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		Proxy:           http.ProxyFromEnvironment,
+	}
+
 	return &Client{
 		apiURL:     apiURL,
 		apiToken:   apiAccessToken(apiToken),
@@ -291,8 +296,16 @@ func (pc *Client) GetPulumiAccountDetails(ctx context.Context) (string, []string
 
 // GetCLIVersionInfo asks the service for information about versions of the CLI (the newest version as well as the
 // oldest version before the CLI should warn about an upgrade, and the current dev version).
-func (pc *Client) GetCLIVersionInfo(ctx context.Context) (semver.Version, semver.Version, semver.Version, error) {
+func (pc *Client) GetCLIVersionInfo(
+	ctx context.Context,
+	metadata map[string]string,
+) (semver.Version, semver.Version, semver.Version, error) {
 	var versionInfo apitype.CLIVersionResponse
+
+	headers := map[string][]string{}
+	for k, v := range metadata {
+		headers["X-Pulumi-"+k] = []string{v}
+	}
 
 	err := pc.restCallWithOptions(
 		ctx,
@@ -303,6 +316,7 @@ func (pc *Client) GetCLIVersionInfo(ctx context.Context) (semver.Version, semver
 		&versionInfo, // response
 		httpCallOptions{
 			RetryPolicy: retryNone,
+			Header:      http.Header(headers),
 		},
 	)
 	if err != nil {

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -140,7 +140,7 @@ func TestAPIVersionMetadataHeaders(t *testing.T) {
 		assert.Equal(t, "foo", req.Header.Get("X-Pulumi-First"))
 		assert.Equal(t, "bar", req.Header.Get("X-Pulumi-Second"))
 		assert.Empty(t, req.Header.Get("X-Pulumi-Third"))
-		return "{}"
+		return `{"latestVersion": "1.0.0", "oldestWithoutWarning": "0.1.0", "latestDevVersion": "1.0.0-11-gdeadbeef"}`
 	})
 	defer server.Close()
 	client := newMockClient(server)

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -82,7 +82,7 @@ func TestAPIErrorResponses(t *testing.T) {
 		defer unauthorizedServer.Close()
 
 		unauthorizedClient := newMockClient(unauthorizedServer)
-		_, _, _, unauthorizedErr := unauthorizedClient.GetCLIVersionInfo(context.Background(), nil)
+		_, _, _, _, unauthorizedErr := unauthorizedClient.GetCLIVersionInfo(context.Background(), nil)
 
 		assert.EqualError(t, unauthorizedErr, "this command requires logging in; try running `pulumi login` first")
 	})
@@ -94,7 +94,7 @@ func TestAPIErrorResponses(t *testing.T) {
 		defer rateLimitedServer.Close()
 
 		rateLimitedClient := newMockClient(rateLimitedServer)
-		_, _, _, rateLimitErr := rateLimitedClient.GetCLIVersionInfo(context.Background(), nil)
+		_, _, _, _, rateLimitErr := rateLimitedClient.GetCLIVersionInfo(context.Background(), nil)
 
 		assert.EqualError(t, rateLimitErr, "pulumi service: request rate-limit exceeded")
 	})
@@ -106,7 +106,7 @@ func TestAPIErrorResponses(t *testing.T) {
 		defer defaultErrorServer.Close()
 
 		defaultErrorClient := newMockClient(defaultErrorServer)
-		_, _, _, defaultErrorErr := defaultErrorClient.GetCLIVersionInfo(context.Background(), nil)
+		_, _, _, _, defaultErrorErr := defaultErrorClient.GetCLIVersionInfo(context.Background(), nil)
 
 		assert.Error(t, defaultErrorErr)
 	})
@@ -122,7 +122,7 @@ func TestAPIVersionResponses(t *testing.T) {
 	defer versionServer.Close()
 
 	versionClient := newMockClient(versionServer)
-	latestVersion, oldestWithoutWarning, latestDevVersion, err := versionClient.GetCLIVersionInfo(
+	latestVersion, oldestWithoutWarning, latestDevVersion, _, err := versionClient.GetCLIVersionInfo(
 		context.Background(), nil,
 	)
 
@@ -146,7 +146,7 @@ func TestAPIVersionMetadataHeaders(t *testing.T) {
 	client := newMockClient(server)
 
 	// Act.
-	_, _, _, err := client.GetCLIVersionInfo(context.Background(), map[string]string{
+	_, _, _, _, err := client.GetCLIVersionInfo(context.Background(), map[string]string{
 		"First":  "foo",
 		"Second": "bar",
 	})

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -525,7 +525,7 @@ func checkForUpdate(ctx context.Context, cloudURL string, cmd *cobra.Command) *d
 			LatestVersion:         latestVer.String(),
 			OldestWithoutWarning:  oldestAllowedVer.String(),
 			LatestDevVersion:      devVer.String(),
-			CacheMS:               cacheMS,
+			CacheMS:               int64(cacheMS),
 			LastPromptTimeStampMS: lastPromptTimestampMS,
 		})
 		if err != nil {
@@ -579,7 +579,7 @@ func getCLIVersionInfo(
 	ctx context.Context,
 	cloudURL string,
 	metadata map[string]string,
-) (semver.Version, semver.Version, semver.Version, int64, error) {
+) (semver.Version, semver.Version, semver.Version, int, error) {
 	creds, err := workspace.GetStoredCredentials()
 	if err != nil || creds.Current != cloudURL {
 		metadata = nil

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -604,7 +604,8 @@ func getCLIVersionInfo(
 		latest, oldest, dev = brewLatest, brewLatest, brewLatest
 	}
 
-	return latest, oldest, dev, cacheMS, err
+	// Don't return the err from getLatestBrewFormulaVersion here, we just log that above.
+	return latest, oldest, dev, cacheMS, nil
 }
 
 // cacheVersionInfo saves version information in a cache file to be looked up later.

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -516,7 +516,9 @@ func checkForUpdate(ctx context.Context, cloudURL string, cmd *cobra.Command) *d
 				"(set `%s=true` to skip update checks): %s", env.SkipUpdateCheck.Var().Name(), err)
 		}
 
-		willPrompt := canPrompt && ((isCurVerDev && haveNewerDevVersion(devVer, curVer)) || (!isCurVerDev && oldestAllowedVer.GT(curVer)))
+		willPrompt := canPrompt &&
+			((isCurVerDev && haveNewerDevVersion(devVer, curVer)) ||
+				(!isCurVerDev && oldestAllowedVer.GT(curVer)))
 		if willPrompt {
 			lastPromptTimestampMS = time.Now().UnixMilli() // We're prompting, update the timestamp
 		}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -586,6 +586,8 @@ func getCLIVersionInfo(
 	}
 
 	client := client.NewClient(cloudURL, "" /*apiToken*/, false, cmdutil.Diag())
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
 	latest, oldest, dev, cacheMS, err := client.GetCLIVersionInfo(ctx, metadata)
 	if err != nil {
 		return semver.Version{}, semver.Version{}, semver.Version{}, 0, err

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -668,9 +668,9 @@ func checkVersionCache(devVersion bool) (bool, bool, int64) {
 	}
 
 	// Prompt at most once a day for regular versions, and at most once an hour for dev versions.
-	promptCacheTIme := 24 * time.Hour
+	promptCacheTime := 24 * time.Hour
 	if devVersion {
-		promptCacheTIme = 1 * time.Hour
+		promptCacheTime = 1 * time.Hour
 	}
 
 	// Fallback to the file modification date if we didn't save a last prompt timestamp yet.
@@ -679,7 +679,7 @@ func checkVersionCache(devVersion bool) (bool, bool, int64) {
 		lastPrompt = time.UnixMilli(info.LastPromptTimeStampMS)
 	}
 
-	nextPrompt := lastPrompt.Add(promptCacheTIme)
+	nextPrompt := lastPrompt.Add(promptCacheTime)
 	expired := nextPrompt.Before(time.Now())
 
 	query := true

--- a/pkg/cmd/pulumi/pulumi_test.go
+++ b/pkg/cmd/pulumi/pulumi_test.go
@@ -107,12 +107,12 @@ func TestGetCLIVersionInfo_Simple(t *testing.T) {
 	latestVer, oldestAllowedVer, devVer, cacheMS, err := getCLIVersionInfo(ctx, srv.URL, nil)
 
 	// Assert.
-	assert.NoError(t, err)
-	assert.Equal(t, 1, callCount, "should have called API once")
-	assert.Equal(t, "1.2.3", latestVer.String())
-	assert.Equal(t, "1.2.0", oldestAllowedVer.String())
-	assert.Equal(t, "0.0.0", devVer.String())
-	assert.Equal(t, 86400000, cacheMS)
+	require.NoError(t, err)
+	require.Equal(t, 1, callCount, "should have called API once")
+	require.Equal(t, "1.2.3", latestVer.String())
+	require.Equal(t, "1.2.0", oldestAllowedVer.String())
+	require.Equal(t, "0.0.0", devVer.String())
+	require.Equal(t, 86400000, cacheMS)
 }
 
 //nolint:paralleltest // changes environment variables and globals
@@ -150,7 +150,7 @@ func TestGetCLIVersionInfo_TimesOut(t *testing.T) {
 	_, _, _, _, err := getCLIVersionInfo(ctx, srv.URL, nil)
 
 	// Assert.
-	assert.ErrorContains(t, err, "context deadline exceeded")
+	require.ErrorContains(t, err, "context deadline exceeded")
 }
 
 //nolint:paralleltest // changes environment variables and globals
@@ -213,10 +213,10 @@ func TestGetCLIVersionInfo_SendsMetadataToPulumiCloud(t *testing.T) {
 	_, _, _, _, err = getCLIVersionInfo(ctx, srv.URL, metadata)
 
 	// Assert.
-	assert.NoError(t, err)
-	assert.True(t, called, "should have called API")
-	assert.Equal(t, metadata["Command"], commandHeader)
-	assert.Equal(t, metadata["Flags"], flagsHeader)
+	require.NoError(t, err)
+	require.True(t, called, "should have called API")
+	require.Equal(t, metadata["Command"], commandHeader)
+	require.Equal(t, metadata["Flags"], flagsHeader)
 }
 
 //nolint:paralleltest // changes environment variables and globals
@@ -279,10 +279,10 @@ func TestGetCLIVersionInfo_DoesNotSendMetadataToOtherBackends(t *testing.T) {
 	_, _, _, _, err = getCLIVersionInfo(ctx, srv.URL, metadata)
 
 	// Assert.
-	assert.NoError(t, err)
-	assert.True(t, called, "should have called API")
-	assert.Empty(t, commandHeader)
-	assert.Empty(t, flagsHeader)
+	require.NoError(t, err)
+	require.True(t, called, "should have called API")
+	require.Empty(t, commandHeader)
+	require.Empty(t, flagsHeader)
 }
 
 func TestGetCLIMetadata(t *testing.T) {
@@ -381,7 +381,7 @@ func TestGetCLIMetadata(t *testing.T) {
 			metadata := getCLIMetadata(c.cmd)
 
 			// Assert.
-			assert.Equal(t, c.metadata, metadata)
+			require.Equal(t, c.metadata, metadata)
 		})
 	}
 }
@@ -422,7 +422,7 @@ func TestCheckForUpdate_AlwaysChecksVersion(t *testing.T) {
 	checkForUpdate(ctx, srv.URL, nil)
 
 	// Assert.
-	assert.Equal(t, 3, callCount, "should call API every time")
+	require.Equal(t, 3, callCount, "should call API every time")
 }
 
 //nolint:paralleltest // changes environment variables and globals
@@ -461,7 +461,7 @@ func TestCheckForUpdate_RespectsServerCache(t *testing.T) {
 	checkForUpdate(ctx, srv.URL, nil)
 
 	// Assert.
-	assert.Equal(t, 1, callCount, "should respect the cache on the 2nd call")
+	require.Equal(t, 1, callCount, "should respect the cache on the 2nd call")
 
 	// Arrange.
 	time.Sleep(1500 * time.Millisecond) // Wait for the cache to expire
@@ -470,13 +470,13 @@ func TestCheckForUpdate_RespectsServerCache(t *testing.T) {
 	checkForUpdate(ctx, srv.URL, nil)
 
 	// Assert.
-	assert.Equal(t, 2, callCount, "the cache should have expired")
+	require.Equal(t, 2, callCount, "the cache should have expired")
 
 	// Act.
 	checkForUpdate(ctx, srv.URL, nil)
 
 	// Assert.
-	assert.Equal(t, 2, callCount, "should respect the cache")
+	require.Equal(t, 2, callCount, "should respect the cache")
 }
 
 //nolint:paralleltest // changes environment variables and globals
@@ -530,16 +530,16 @@ func TestCheckForUpdate_CachesPrompts(t *testing.T) {
 	expired := checkForUpdate(ctx, srv.URL, nil)
 
 	// Assert.
-	assert.Equal(t, 4, callCount, "should call API every time")
+	require.Equal(t, 4, callCount, "should call API every time")
 
-	assert.Contains(t, uncached.Message, "A new version of Pulumi is available")
-	assert.Contains(t, uncached.Message, "upgrade from version '1.0.0' to '1.2.3'")
+	require.Contains(t, uncached.Message, "A new version of Pulumi is available")
+	require.Contains(t, uncached.Message, "upgrade from version '1.0.0' to '1.2.3'")
 
-	assert.Nil(t, cached)
-	assert.Nil(t, cachedAgain)
+	require.Nil(t, cached)
+	require.Nil(t, cachedAgain)
 
-	assert.Contains(t, expired.Message, "A new version of Pulumi is available")
-	assert.Contains(t, expired.Message, "upgrade from version '1.0.0' to '1.2.3'")
+	require.Contains(t, expired.Message, "A new version of Pulumi is available")
+	require.Contains(t, expired.Message, "upgrade from version '1.0.0' to '1.2.3'")
 }
 
 func TestCheckForUpdate_HandlesAPIFailures(t *testing.T) {
@@ -569,9 +569,9 @@ func TestCheckForUpdate_HandlesAPIFailures(t *testing.T) {
 	second := checkForUpdate(ctx, srv.URL, nil)
 
 	// Assert.
-	assert.Equal(t, 2, callCount, "should call API every time")
-	assert.Nil(t, first)
-	assert.Nil(t, second)
+	require.Equal(t, 2, callCount, "should call API every time")
+	require.Nil(t, first)
+	require.Nil(t, second)
 }
 
 //nolint:paralleltest // changes environment variables and globals
@@ -626,16 +626,16 @@ func TestCheckForUpdate_WorksCorrectlyWithDevVersions(t *testing.T) {
 	expired := checkForUpdate(ctx, srv.URL, nil)
 
 	// Assert.
-	assert.Equal(t, 4, callCount, "should call API every time")
+	require.Equal(t, 4, callCount, "should call API every time")
 
-	assert.Contains(t, uncached.Message, "A new version of Pulumi is available")
-	assert.Contains(t, uncached.Message, "upgrade from version '1.0.0-11-g4ff08363' to '1.0.0-12-gdeadbeef'")
+	require.Contains(t, uncached.Message, "A new version of Pulumi is available")
+	require.Contains(t, uncached.Message, "upgrade from version '1.0.0-11-g4ff08363' to '1.0.0-12-gdeadbeef'")
 
-	assert.Nil(t, cached)
-	assert.Nil(t, cachedAgain)
+	require.Nil(t, cached)
+	require.Nil(t, cachedAgain)
 
-	assert.Contains(t, expired.Message, "A new version of Pulumi is available")
-	assert.Contains(t, expired.Message, "upgrade from version '1.0.0-11-g4ff08363' to '1.0.0-12-gdeadbeef'")
+	require.Contains(t, expired.Message, "A new version of Pulumi is available")
+	require.Contains(t, expired.Message, "upgrade from version '1.0.0-11-g4ff08363' to '1.0.0-12-gdeadbeef'")
 }
 
 //nolint:paralleltest // changes environment variables and globals
@@ -681,8 +681,8 @@ func TestCheckForUpdate_WorksCorrectlyWithLocalVersions(t *testing.T) {
 	alwaysNilDiag := checkForUpdate(ctx, srv.URL, nil)
 
 	// Assert.
-	assert.Equal(t, 0, callCount, "local versions don't trigger API calls")
-	assert.Nil(t, nilDiag)
-	assert.Nil(t, stillNilDiag)
-	assert.Nil(t, alwaysNilDiag)
+	require.Equal(t, 0, callCount, "local versions don't trigger API calls")
+	require.Nil(t, nilDiag)
+	require.Nil(t, stillNilDiag)
+	require.Nil(t, alwaysNilDiag)
 }

--- a/pkg/cmd/pulumi/pulumi_test.go
+++ b/pkg/cmd/pulumi/pulumi_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -73,24 +74,16 @@ func TestHaveNewerDevVersion(t *testing.T) {
 }
 
 //nolint:paralleltest // changes environment variables and globals
-func TestCheckForUpdate(t *testing.T) {
-	realVersion := version.Version
-	t.Cleanup(func() {
-		version.Version = realVersion
-	})
-	version.Version = "v1.0.0"
-
-	// Cached version information is stored in PULUMI_HOME.
+func TestGetCLIVersionInfo_Simple(t *testing.T) {
+	// Arrange.
 	pulumiHome := t.TempDir()
 	t.Setenv("PULUMI_HOME", pulumiHome)
 
-	// If the cached version is missing or outdated,
-	// the HTTP server receives a request.
-	var requestCounter int // number of requests
+	callCount := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/cli/version":
-			requestCounter++
+			callCount++
 			w.WriteHeader(http.StatusOK)
 			_, err := w.Write([]byte(`{
 				"latestVersion": "v1.2.3",
@@ -106,56 +99,53 @@ func TestCheckForUpdate(t *testing.T) {
 		}
 	}))
 	t.Cleanup(srv.Close)
-	t.Setenv("PULUMI_API", srv.URL)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	msg := checkForUpdate(ctx)
-	require.NotNil(t, msg)
-	assert.Contains(t, msg.Message, "A new version of Pulumi is available")
-	assert.Contains(t, msg.Message, "upgrade from version '1.0.0' to '1.2.3'")
-	assert.Equal(t, 1, requestCounter,
-		"expected exactly one request to the HTTP server")
+	// Act.
+	latestVer, oldestAllowedVer, devVer, err := getCLIVersionInfo(ctx, srv.URL, nil)
 
-	t.Run("cached", func(t *testing.T) {
-		// Once we have cached version information,
-		// we will not warn the user again until the cache expires.
-		requestCounter = 0
-		require.Nil(t, checkForUpdate(ctx))
-		assert.Equal(t, 0, requestCounter,
-			"no requests are expected to the HTTP server")
-	})
-
-	t.Run("cache expired", func(t *testing.T) {
-		// Expire the cached version information
-		// and verify that we query the server again.
-
-		versionCachePath, err := workspace.GetCachedVersionFilePath()
-		require.NoError(t, err)
-
-		expiredTime := time.Now().Add(-25 * time.Hour)
-		require.NoError(t,
-			os.Chtimes(versionCachePath, expiredTime, expiredTime))
-
-		requestCounter = 0
-		require.NotNil(t, checkForUpdate(ctx))
-		assert.Equal(t, 1, requestCounter)
-	})
+	// Assert.
+	assert.NoError(t, err)
+	assert.Equal(t, 1, callCount, "should have called API once")
+	assert.Equal(t, "1.2.3", latestVer.String())
+	assert.Equal(t, "1.2.0", oldestAllowedVer.String())
+	assert.Equal(t, "0.0.0", devVer.String())
 }
 
 //nolint:paralleltest // changes environment variables and globals
-func TestCheckForUpdate_allFail(t *testing.T) {
-	// Cached version information is stored in PULUMI_HOME.
+func TestGetCLIVersionInfo_SendsMetadataToPulumiCloud(t *testing.T) {
+	// Arrange.
 	pulumiHome := t.TempDir()
 	t.Setenv("PULUMI_HOME", pulumiHome)
 
-	var requestCounter int // number of requests
+	metadata := map[string]string{
+		"Command": "test-command",
+		"Flags":   "--foo",
+	}
+
+	token := time.Now().String()
+
+	called := false
+	commandHeader := ""
+	flagsHeader := ""
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/cli/version":
-			requestCounter++
-			http.Error(w, "great sadness", http.StatusInternalServerError)
+			called = true
+			commandHeader = r.Header.Get("X-Pulumi-Command")
+			flagsHeader = r.Header.Get("X-Pulumi-Flags")
+
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{
+				"latestVersion": "v1.2.3",
+				"oldestWithoutWarning": "v1.2.0"
+			}`))
+			if !assert.NoError(t, err) {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
 
 		default:
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -163,34 +153,350 @@ func TestCheckForUpdate_allFail(t *testing.T) {
 		}
 	}))
 	t.Cleanup(srv.Close)
-	t.Setenv("PULUMI_API", srv.URL)
+
+	err := workspace.StoreCredentials(workspace.Credentials{
+		Current: srv.URL,
+		Accounts: map[string]workspace.Account{
+			srv.URL: {
+				AccessToken: token,
+			},
+		},
+		AccessTokens: map[string]string{
+			srv.URL: token,
+		},
+	})
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	msg := checkForUpdate(ctx)
-	assert.Nil(t, msg)
+	// Act.
+	_, _, _, err = getCLIVersionInfo(ctx, srv.URL, metadata)
 
-	// We should not make more than one attempt to get this information.
-	assert.Equal(t, 1, requestCounter)
+	// Assert.
+	assert.NoError(t, err)
+	assert.True(t, called, "should have called API")
+	assert.Equal(t, metadata["Command"], commandHeader)
+	assert.Equal(t, metadata["Flags"], flagsHeader)
 }
 
 //nolint:paralleltest // changes environment variables and globals
-func TestCheckForUpdate_devVersion(t *testing.T) {
+func TestGetCLIVersionInfo_DoesNotSendMetadataToOtherBackends(t *testing.T) {
+	// Arrange.
+	pulumiHome := t.TempDir()
+	t.Setenv("PULUMI_HOME", pulumiHome)
+
+	metadata := map[string]string{
+		"Command": "test-command",
+		"Flags":   "--foo",
+	}
+
+	token := time.Now().String()
+
+	called := false
+	commandHeader := ""
+	flagsHeader := ""
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/cli/version":
+			called = true
+			commandHeader = r.Header.Get("X-Pulumi-Command")
+			flagsHeader = r.Header.Get("X-Pulumi-Flags")
+
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{
+				"latestVersion": "v1.2.3",
+				"oldestWithoutWarning": "v1.2.0"
+			}`))
+			if !assert.NoError(t, err) {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	err := workspace.StoreCredentials(workspace.Credentials{
+		Current: "https://example.com",
+		Accounts: map[string]workspace.Account{
+			srv.URL: {
+				AccessToken: token,
+			},
+		},
+		AccessTokens: map[string]string{
+			srv.URL: token,
+		},
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Act.
+	_, _, _, err = getCLIVersionInfo(ctx, srv.URL, metadata)
+
+	// Assert.
+	assert.NoError(t, err)
+	assert.True(t, called, "should have called API")
+	assert.Empty(t, commandHeader)
+	assert.Empty(t, flagsHeader)
+}
+
+func TestGetCLIMetadata(t *testing.T) {
+	t.Parallel()
+
+	// Arrange.
+	cases := []struct {
+		name     string
+		cmd      *cobra.Command
+		metadata map[string]string
+	}{
+		{
+			name:     "nil",
+			cmd:      nil,
+			metadata: nil,
+		},
+		{
+			name: "no set flags",
+			cmd: (func() *cobra.Command {
+				cmd := &cobra.Command{Use: "no-set"}
+				cmd.Flags().Bool("bool", false, "bool flag")
+				cmd.Flags().String("string", "", "string flag")
+				return cmd
+			})(),
+			metadata: map[string]string{
+				"Command": "no-set",
+				"Flags":   "",
+			},
+		},
+		{
+			name: "one set bool flag",
+			cmd: (func() *cobra.Command {
+				cmd := &cobra.Command{Use: "one-set"}
+				cmd.Flags().Bool("bool", false, "bool flag")
+				cmd.Flags().String("string", "", "string flag")
+
+				cmd.SetArgs([]string{"--bool"})
+
+				err := cmd.Execute()
+				require.NoError(t, err)
+
+				return cmd
+			})(),
+			metadata: map[string]string{
+				"Command": "one-set",
+				"Flags":   "--bool",
+			},
+		},
+		{
+			name: "one set string flag",
+			cmd: (func() *cobra.Command {
+				cmd := &cobra.Command{Use: "one-set"}
+				cmd.Flags().Bool("bool", false, "bool flag")
+				cmd.Flags().String("string", "", "string flag")
+
+				cmd.SetArgs([]string{"--string=value"})
+
+				err := cmd.Execute()
+				require.NoError(t, err)
+
+				return cmd
+			})(),
+			metadata: map[string]string{
+				"Command": "one-set",
+				"Flags":   "--string",
+			},
+		},
+		{
+			name: "multiple set flags",
+			cmd: (func() *cobra.Command {
+				cmd := &cobra.Command{Use: "multiple-set"}
+				cmd.Flags().Bool("bool", false, "bool flag")
+				cmd.Flags().String("string", "", "string flag")
+
+				cmd.SetArgs([]string{"--string=value", "--bool"})
+
+				err := cmd.Execute()
+				require.NoError(t, err)
+
+				return cmd
+			})(),
+			metadata: map[string]string{
+				"Command": "multiple-set",
+				"Flags":   "--bool --string",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act.
+			metadata := getCLIMetadata(c.cmd)
+
+			// Assert.
+			assert.Equal(t, c.metadata, metadata)
+		})
+	}
+}
+
+//nolint:paralleltest // changes environment variables and globals
+func TestCheckForUpdate_AlwaysChecksVersion(t *testing.T) {
+	// Arrange.
+	pulumiHome := t.TempDir()
+	t.Setenv("PULUMI_HOME", pulumiHome)
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/cli/version":
+			callCount++
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{
+				"latestVersion": "v1.2.3",
+				"oldestWithoutWarning": "v1.2.0"
+			}`))
+			if !assert.NoError(t, err) {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Act.
+	checkForUpdate(ctx, srv.URL, nil)
+	checkForUpdate(ctx, srv.URL, nil)
+	checkForUpdate(ctx, srv.URL, nil)
+
+	// Assert.
+	assert.Equal(t, 3, callCount, "should call API every time")
+}
+
+//nolint:paralleltest // changes environment variables and globals
+func TestCheckForUpdate_CachesPrompts(t *testing.T) {
+	// Arrange.
+	realVersion := version.Version
+	t.Cleanup(func() {
+		version.Version = realVersion
+	})
+	version.Version = "v1.0.0"
+
+	pulumiHome := t.TempDir()
+	t.Setenv("PULUMI_HOME", pulumiHome)
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/cli/version":
+			callCount++
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{
+				"latestVersion": "v1.2.3",
+				"oldestWithoutWarning": "v1.2.0"
+			}`))
+			if !assert.NoError(t, err) {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Act.
+	uncached := checkForUpdate(ctx, srv.URL, nil)
+	cached := checkForUpdate(ctx, srv.URL, nil)
+	cachedAgain := checkForUpdate(ctx, srv.URL, nil)
+
+	versionCachePath, err := workspace.GetCachedVersionFilePath()
+	require.NoError(t, err)
+
+	expiredTime := time.Now().Add(-25 * time.Hour)
+	require.NoError(t, os.Chtimes(versionCachePath, expiredTime, expiredTime))
+
+	expired := checkForUpdate(ctx, srv.URL, nil)
+
+	// Assert.
+	assert.Equal(t, 4, callCount, "should call API every time")
+
+	assert.Contains(t, uncached.Message, "A new version of Pulumi is available")
+	assert.Contains(t, uncached.Message, "upgrade from version '1.0.0' to '1.2.3'")
+
+	assert.Nil(t, cached)
+	assert.Nil(t, cachedAgain)
+
+	assert.Contains(t, expired.Message, "A new version of Pulumi is available")
+	assert.Contains(t, expired.Message, "upgrade from version '1.0.0' to '1.2.3'")
+}
+
+func TestCheckForUpdate_HandlesAPIFailures(t *testing.T) {
+	// Arrange.
+	pulumiHome := t.TempDir()
+	t.Setenv("PULUMI_HOME", pulumiHome)
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/cli/version":
+			callCount++
+			http.NotFound(w, r)
+
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Act.
+	first := checkForUpdate(ctx, srv.URL, nil)
+	second := checkForUpdate(ctx, srv.URL, nil)
+
+	// Assert.
+	assert.Equal(t, 2, callCount, "should call API every time")
+	assert.Nil(t, first)
+	assert.Nil(t, second)
+}
+
+//nolint:paralleltest // changes environment variables and globals
+func TestCheckForUpdate_WorksCorrectlyWithDevVersions(t *testing.T) {
+	// Arrange.
 	realVersion := version.Version
 	t.Cleanup(func() {
 		version.Version = realVersion
 	})
 	version.Version = "v1.0.0-11-g4ff08363"
+
 	pulumiHome := t.TempDir()
 	t.Setenv("PULUMI_HOME", pulumiHome)
 
-	// Cached version information is stored in PULUMI_HOME.
-	var requestCounter int // number of requests
+	callCount := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/cli/version":
-			requestCounter++
+			callCount++
 			w.WriteHeader(http.StatusOK)
 			_, err := w.Write([]byte(`{
 				"latestVersion": "v1.2.3",
@@ -207,40 +513,81 @@ func TestCheckForUpdate_devVersion(t *testing.T) {
 		}
 	}))
 	t.Cleanup(srv.Close)
-	t.Setenv("PULUMI_API", srv.URL)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	msg := checkForUpdate(ctx)
-	require.NotNil(t, msg)
-	assert.Contains(t, msg.Message, "A new version of Pulumi is available")
-	assert.Contains(t, msg.Message, "upgrade from version '1.0.0-11-g4ff08363' to '1.0.0-12-gdeadbeef'")
-	assert.Equal(t, 1, requestCounter,
-		"expected exactly one request to the HTTP server")
+	// Act.
+	uncached := checkForUpdate(ctx, srv.URL, nil)
+	cached := checkForUpdate(ctx, srv.URL, nil)
+	cachedAgain := checkForUpdate(ctx, srv.URL, nil)
 
-	t.Run("cached", func(t *testing.T) {
-		// Once we have cached version information,
-		// we will not warn the user again until the cache expires.
-		requestCounter = 0
-		require.Nil(t, checkForUpdate(ctx))
-		assert.Equal(t, 0, requestCounter,
-			"no requests are expected to the HTTP server")
+	versionCachePath, err := workspace.GetCachedVersionFilePath()
+	require.NoError(t, err)
+
+	expiredTime := time.Now().Add(-25 * time.Hour)
+	require.NoError(t, os.Chtimes(versionCachePath, expiredTime, expiredTime))
+
+	expired := checkForUpdate(ctx, srv.URL, nil)
+
+	// Assert.
+	assert.Equal(t, 4, callCount, "should call API every time")
+
+	assert.Contains(t, uncached.Message, "A new version of Pulumi is available")
+	assert.Contains(t, uncached.Message, "upgrade from version '1.0.0-11-g4ff08363' to '1.0.0-12-gdeadbeef'")
+
+	assert.Nil(t, cached)
+	assert.Nil(t, cachedAgain)
+
+	assert.Contains(t, expired.Message, "A new version of Pulumi is available")
+	assert.Contains(t, expired.Message, "upgrade from version '1.0.0-11-g4ff08363' to '1.0.0-12-gdeadbeef'")
+}
+
+//nolint:paralleltest // changes environment variables and globals
+func TestCheckForUpdate_WorksCorrectlyWithLocalVersions(t *testing.T) {
+	// Arrange.
+	realVersion := version.Version
+	t.Cleanup(func() {
+		version.Version = realVersion
 	})
+	version.Version = "v1.0.0-beta.1590772212"
 
-	t.Run("cache expired", func(t *testing.T) {
-		// Expire the cached version information
-		// and verify that we query the server again.
+	pulumiHome := t.TempDir()
+	t.Setenv("PULUMI_HOME", pulumiHome)
 
-		versionCachePath, err := workspace.GetCachedVersionFilePath()
-		require.NoError(t, err)
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/cli/version":
+			callCount++
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{
+				"latestVersion": "v1.2.3",
+				"oldestWithoutWarning": "v1.2.0",
+				"latestDevVersion": "v1.0.0-12-gdeadbeef"
+			}`))
+			if !assert.NoError(t, err) {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
 
-		expiredTime := time.Now().Add(-2 * time.Hour)
-		require.NoError(t,
-			os.Chtimes(versionCachePath, expiredTime, expiredTime))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
 
-		requestCounter = 0
-		require.NotNil(t, checkForUpdate(ctx))
-		assert.Equal(t, 1, requestCounter)
-	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Act.
+	nilDiag := checkForUpdate(ctx, srv.URL, nil)
+	stillNilDiag := checkForUpdate(ctx, srv.URL, nil)
+	alwaysNilDiag := checkForUpdate(ctx, srv.URL, nil)
+
+	// Assert.
+	assert.Equal(t, 0, callCount, "local versions don't trigger API calls")
+	assert.Nil(t, nilDiag)
+	assert.Nil(t, stillNilDiag)
+	assert.Nil(t, alwaysNilDiag)
 }

--- a/pkg/cmd/pulumi/pulumi_test.go
+++ b/pkg/cmd/pulumi/pulumi_test.go
@@ -112,7 +112,7 @@ func TestGetCLIVersionInfo_Simple(t *testing.T) {
 	assert.Equal(t, "1.2.3", latestVer.String())
 	assert.Equal(t, "1.2.0", oldestAllowedVer.String())
 	assert.Equal(t, "0.0.0", devVer.String())
-	assert.Equal(t, int64(86400000), cacheMS)
+	assert.Equal(t, 86400000, cacheMS)
 }
 
 //nolint:paralleltest // changes environment variables and globals

--- a/sdk/go/common/apitype/cli.go
+++ b/sdk/go/common/apitype/cli.go
@@ -19,5 +19,5 @@ type CLIVersionResponse struct {
 	LatestVersion        string `json:"latestVersion"`
 	OldestWithoutWarning string `json:"oldestWithoutWarning"`
 	LatestDevVersion     string `json:"latestDevVersion"`
-	CacheMS              int    `json:"cacheMS"`
+	CacheMS              int    `json:"cacheMS,omitempty"`
 }

--- a/sdk/go/common/apitype/cli.go
+++ b/sdk/go/common/apitype/cli.go
@@ -19,5 +19,5 @@ type CLIVersionResponse struct {
 	LatestVersion        string `json:"latestVersion"`
 	OldestWithoutWarning string `json:"oldestWithoutWarning"`
 	LatestDevVersion     string `json:"latestDevVersion"`
-	CacheMS              int    `json:"cacheMS,omitempty"`
+	CacheMS              int    `json:"cacheMS"`
 }


### PR DESCRIPTION
Use the server provided `cacheMS` to store the duration for which version information should be cached.