### PR TITLE
Avoid overwriting version set with `pkg@version` for `pulumi plugin install`

### DIFF
--- a/changelog/pending/20250514--cli-install--dont-overwrite-versions-embedded-in-the-plugin-spec.yaml
+++ b/changelog/pending/20250514--cli-install--dont-overwrite-versions-embedded-in-the-plugin-spec.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/install
+  description: Don't overwrite versions embedded in the plugin spec.

--- a/changelog/pending/20250514--cli-install--dont-overwrite-versions-embedded-in-the-plugin-spec.yaml
+++ b/changelog/pending/20250514--cli-install--dont-overwrite-versions-embedded-in-the-plugin-spec.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: cli/install
-  description: Don't overwrite versions embedded in the plugin spec.
+  description: Don't overwrite versions embedded in the plugin spec


### PR DESCRIPTION
For a description of the problem being addressed, see #19546. This PR is best reviewed commit by commit: the first commit is a refactor to make this testable. It does not change behavior. The second commit applies the fix with a test to lock in the correct behavior.

Fixes #19546 