### PR TITLE
Revert "Add default orgs as an API capability (#18928)"

### DIFF
--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -33,11 +33,6 @@ const (
 
 	// Indicates that the service backend supports batch encryption.
 	BatchEncrypt APICapability = "batch-encrypt"
-
-	// Indicates whether the service supports a notion of providing an opinion on a
-	// default organization among the user's org memberships, if a default org has
-	// not been explicitly defined.
-	DefaultOrg APICapability = "default-org"
 )
 
 type DeltaCheckpointUploadsConfigV2 struct {
@@ -68,11 +63,6 @@ type Capabilities struct {
 
 	// Indicates whether the service supports batch encryption.
 	BatchEncryption bool
-
-	// Indicates whether the service supports a notion of providing an opinion on a
-	// default organization among the user's org memberships, if a default org has
-	// not been explicitly defined.
-	DefaultOrg bool
 }
 
 // Parse decodes the CapabilitiesResponse into a Capabilities struct for ease of use.
@@ -96,8 +86,6 @@ func (r CapabilitiesResponse) Parse() (Capabilities, error) {
 			}
 		case BatchEncrypt:
 			parsed.BatchEncryption = true
-		case DefaultOrg:
-			parsed.DefaultOrg = true
 		default:
 			continue
 		}


### PR DESCRIPTION
This reverts commit 25150e7d40c02b073cfe5aaec0de86937be7bcff.

We ended up not using capabilities to determine whether the backend supports the GetDefaultOrg API, so removing the unused code.

Related issue: https://github.com/pulumi/pulumi-service/issues/27548