### PR TITLE
Don't return a backend with no logged in user

### DIFF
--- a/pkg/cmd/pulumi/backend/login_manager.go
+++ b/pkg/cmd/pulumi/backend/login_manager.go
@@ -30,6 +30,8 @@ import (
 // LoginManager provides a slim wrapper around functions related to backend logins.
 type LoginManager interface {
 	// Current returns the currently logged in backend instance for the given url.
+	//
+	// If the user does not have a logged in backend, then Current will return (nil, nil).
 	Current(
 		ctx context.Context,
 		ws pkgWorkspace.Context,
@@ -64,8 +66,8 @@ func (f *lm) Current(
 
 	insecure := pkgWorkspace.GetCloudInsecure(ws, url)
 	lm := httpstate.NewLoginManager()
-	_, err := lm.Current(ctx, url, insecure, setCurrent)
-	if err != nil {
+	account, err := lm.Current(ctx, url, insecure, setCurrent)
+	if err != nil || account == nil {
 		return nil, err
 	}
 	return httpstate.New(ctx, sink, url, project, insecure)

--- a/pkg/cmd/pulumi/templates/org.go
+++ b/pkg/cmd/pulumi/templates/org.go
@@ -62,6 +62,9 @@ func (s *Source) getOrgTemplates(
 		}
 		logging.Infof("could not get a backend for org templates")
 		return
+	} else if b == nil {
+		logging.Infof("no current logged in user")
+		return
 	}
 
 	// Attempt to retrieve the current user


### PR DESCRIPTION
This function is only called in 2 places, and they handle the situation correctly:

It's handled directly in `getOrgTemplates`:

https://github.com/pulumi/pulumi/blob/559d223ac7b2d1b63226f62ac4c3f057f414aa80/pkg/cmd/pulumi/templates/org.go#L65-L68

It's handled as the result of `NonInteractiveCurrentBackend` in `getSummaryAbout`:

https://github.com/pulumi/pulumi/blob/559d223ac7b2d1b63226f62ac4c3f057f414aa80/pkg/cmd/pulumi/backend/backend.go#L65-L66

https://github.com/pulumi/pulumi/blob/559d223ac7b2d1b63226f62ac4c3f057f414aa80/pkg/cmd/pulumi/about/about.go#L187-L190