### PR TITLE
Set GOCOVERDIR in addition to PULUMI_GOCOVERDIR in tests

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -170,8 +170,12 @@ jobs:
           # variable when the '-cover' flag is used. Use
           # $PULUMI_GOCOVERDIR instead, which the integration tests
           # then turn into $GOCOVERDIR.  See also https://github.com/golang/go/issues/66225.
+          #
+          # Also set `GOCOVERDIR` for tests that don't use `go test` (e.g.
+          # automation API tests)
           coverdir="$(mktemp -d)"
           echo "PULUMI_GOCOVERDIR=$coverdir" >> "$GITHUB_ENV"
+          echo "GOCOVERDIR=$coverdir" >> "$GITHUB_ENV"
       - name: Configure Go Cache Key
         env:
           CACHE_KEY: "${{ fromJson(inputs.version-set).go }}-${{ runner.os }}-${{ runner.arch }}"


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/18719, we started using a `$PULUMI_GOCOVERDIR` variable, which we would translate into `$GOCOVERDIR` before running the `pulumi` binary in integration tests. This is because `go test` overwrites the `$GOCOVERDIR` variable otherwise, which resulted in us not having coverage data in integration tests.

However what we missed there is that other tests, such as the automation API tests also run the pulumi binary, but we have nothing that translates from `$PULUMI_GOCOVERDIR` to `$GOCOVERDIR` there (and nothing would need to, since nothing overwrites the env variable).  To fix this also set the $GOCOVERDIR` env variable for those tests that don't run under `go test -cover`, so we get coverage data from those tests as well.

Noticed this because a flaky test was complaining about `$GOCOVERDIR` being unset: https://github.com/pulumi/pulumi/actions/runs/15043605846/job/42281156308?pr=19553

```
>           raise create_command_error(result)
E           pulumi.automation.errors.StackAlreadyExistsError: 
E            code: 255
E            stdout: 
E            stderr: warning: GOCOVERDIR not set, no coverage data emitted
E           error: stack 'moolumi/testrefresh/int_test_891333' already exists
```