### PR TITLE
Add `DocLanguageHelper.GetModuleName`

### DIFF
--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -23,6 +23,14 @@ import (
 // DocLanguageHelper is an interface for extracting language-specific information from a Pulumi schema.
 // See the implementation for this interface under each of the language code generators.
 type DocLanguageHelper interface {
+	// GetModuleName returns the in-language name of the module.
+	//
+	// For example, lets get the hypothetical name of the module for the "pkg:module/nestedMod:Type" token in python:
+	//
+	//	var python python_codegen.DocLanguageHelper
+	//	python.GetModuleName(pkgRef, pkgRef.TokenToModule("pkg:module/nestedMod:Type")) // "module.nestedmod"
+	GetModuleName(pkg schema.PackageReference, modName string) string
+
 	GetPropertyName(p *schema.Property) (string, error)
 	GetEnumName(e *schema.Enum, typeName string) (string, error)
 	// GetTypeName gets the name of a type in the language of the DocLanguageHelper.

--- a/pkg/codegen/dotnet/doc.go
+++ b/pkg/codegen/dotnet/doc.go
@@ -102,6 +102,12 @@ func (d DocLanguageHelper) GetMethodName(m *schema.Method) string {
 	return Title(m.Name)
 }
 
+func (d DocLanguageHelper) GetModuleName(pkg schema.PackageReference, module string) string {
+	a, _ := pkg.Language("csharp")
+	info, _ := a.(CSharpPackageInfo)
+	return namespaceName(info.Namespaces, module)
+}
+
 func (d DocLanguageHelper) GetMethodResultName(pkg schema.PackageReference, modName string, r *schema.Resource,
 	m *schema.Method,
 ) string {

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -88,6 +88,10 @@ func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(pkg *schema.Pa
 	return link + "Args"
 }
 
+func (d DocLanguageHelper) GetModuleName(pkg schema.PackageReference, module string) string {
+	return moduleToPackage(d.goPkgInfo.ModuleToPackage, module)
+}
+
 // GetLanguageTypeString returns the Go-specific type given a Pulumi schema type.
 func (d DocLanguageHelper) GetTypeName(pkg schema.PackageReference, t schema.Type, input bool, relativeToModule string) string {
 	goPkg := moduleToPackage(d.goPkgInfo.ModuleToPackage, relativeToModule)

--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -68,6 +68,10 @@ func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(pkg *schema.Pa
 	return d.GetDocLinkForResourceInputOrOutputType(pkg, modName, typeName, input)
 }
 
+func (d DocLanguageHelper) GetModuleName(pkg schema.PackageReference, module string) string {
+	return moduleName(module, pkg)
+}
+
 // GetLanguageTypeString returns the language-specific type given a Pulumi schema type.
 func (d DocLanguageHelper) GetTypeName(pkg schema.PackageReference, t schema.Type, input bool, relativeToModule string) string {
 	// Remove the union with `undefined` for optional types,

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -73,6 +73,15 @@ func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(pkg *schema.Pa
 	return ""
 }
 
+func (d DocLanguageHelper) GetModuleName(pkg schema.PackageReference, module string) string {
+	var info PackageInfo
+	if a, err := pkg.Language("python"); err == nil {
+		info, _ = a.(PackageInfo)
+	}
+
+	return moduleToPythonModule(module, info.ModuleNameOverrides)
+}
+
 // GetLanguageTypeString returns the Python-specific type given a Pulumi schema type.
 func (d DocLanguageHelper) GetTypeName(pkg schema.PackageReference, t schema.Type, input bool, relativeToModule string) string {
 	var info PackageInfo


### PR DESCRIPTION
This PR includes the new method, and an implementation for every language in this repo.

Motivated by https://github.com/pulumi/pulumi-service/issues/27266: The API we want to support needs needs to provide an overview of whats in the package (resources and functions). Concretely, that means it needs to return a list of modules, where each module needs to itself have a list of the resources and functions it contains. Each element returned (module, resource, function) needs to have a language appropriate name for each language we support.

I already have PRs to implement this in Java and YAML:

- https://github.com/pulumi/pulumi-java/pull/1808
- https://github.com/pulumi/pulumi-yaml/pull/797