### PR TITLE
Add in venv backcompat for python when installing policy

### DIFF
--- a/changelog/pending/20250516--cli-install--fix-installation-of-python-policies-to-default-to-virtualenv-rather-than-site-packages.yaml
+++ b/changelog/pending/20250516--cli-install--fix-installation-of-python-policies-to-default-to-virtualenv-rather-than-site-packages.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/install
+  description: Fix installation of python policies to default to virtualenv rather than site-packages

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -305,6 +305,18 @@ func installRequiredPolicy(ctx *plugin.Context, finalDir string, tgz io.ReadClos
 		return fmt.Errorf("failed to load policy project at %s: %w", finalDir, err)
 	}
 
+	// Workaround for python, most of our templates don't specify a venv but we want to use one
+	if proj.Runtime.Name() == "python" {
+		// If the template does give virtualenv use it, else default to "venv"
+		if _, has := proj.Runtime.Options()["virtualenv"]; !has {
+			proj.Runtime.SetOption("virtualenv", "venv")
+			err = proj.Save(projPath)
+			if err != nil {
+				return fmt.Errorf("failed to save policy project at %s: %w", finalDir, err)
+			}
+		}
+	}
+
 	info := plugin.NewProgramInfo(finalDir, finalDir, ".", proj.Runtime.Options())
 	language, err := ctx.Host.LanguageRuntime(proj.Runtime.Name(), info)
 	if err != nil {

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -305,9 +305,9 @@ func installRequiredPolicy(ctx *plugin.Context, finalDir string, tgz io.ReadClos
 		return fmt.Errorf("failed to load policy project at %s: %w", finalDir, err)
 	}
 
-	// Workaround for python, most of our templates don't specify a venv but we want to use one
+	// Workaround for python, some policy packs don't specify a venv but we want to use one
 	if proj.Runtime.Name() == "python" {
-		// If the template does give virtualenv use it, else default to "venv"
+		// If the policy's options provide a virtualenv use it, else default to "venv"
 		if _, has := proj.Runtime.Options()["virtualenv"]; !has {
 			proj.Runtime.SetOption("virtualenv", "venv")
 			err = proj.Save(projPath)


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/19568

In https://github.com/pulumi/pulumi/pull/19477 we change policy installation to use the language runtimes `InstallDependencies` function. Unfortunately this doesn't auto-set the virtualenv option for python, because for programs the logic has never been to auto-set it. But policy packs _did_ autoset it to "venv" if it wasn't set and moving to InstallDependencies lost that.

This adds a small special case to policy install to set the option, we have very similar code in policy new.