### PR TITLE
make the `build` target build the whole repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,15 +74,12 @@ generate::
 bin/pulumi: build_proto .make/ensure/go .make/ensure/phony
 	go build -C pkg -o ../$@ -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${PROJECT}
 
-.PHONY: build
-build:: bin/pulumi build_display_wasm
-
 build_display_wasm:: .make/ensure/go
 	cd pkg && GOOS=js GOARCH=wasm go build -o ../bin/pulumi-display.wasm -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ./backend/display/wasm
 
 .PHONY: build_local
-build_local: export GOBIN=$(shell realpath ./bin)
-build_local: build_proto .make/ensure/go dist
+build: export GOBIN=$(shell realpath ./bin)
+build: build_proto .make/ensure/go dist build_display_wasm
 
 install:: bin/pulumi
 	cp $< $(PULUMI_BIN)/pulumi

--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,9 @@ bin/pulumi: build_proto .make/ensure/go .make/ensure/phony
 build_display_wasm:: .make/ensure/go
 	cd pkg && GOOS=js GOARCH=wasm go build -o ../bin/pulumi-display.wasm -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ./backend/display/wasm
 
-.PHONY: build_local
-build: export GOBIN=$(shell realpath ./bin)
-build: build_proto .make/ensure/go dist build_display_wasm
+.PHONY: build
+build:: export GOBIN=$(shell realpath ./bin)
+build:: build_proto .make/ensure/go dist build_display_wasm
 
 install:: bin/pulumi
 	cp $< $(PULUMI_BIN)/pulumi

--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -47,7 +47,7 @@ test_auto:: $(TEST_ALL_DEPS)
 
 dist:: ../../bin/pulumi-language-go
 ifneq (${GOBIN},)
-	@# We need to do this dance instead of just calling `cp` because `make build_local`
+	@# We need to do this dance instead of just calling `cp` because `make build`
 	@# (from root) sets ${GOBIN} such that the copy is a no op.
 	@bash -c ' \
 	if ! [[ "$<" -ef ${GOBIN}/pulumi-language-go ]]; then \

--- a/tests/testutil/test_main_util.go
+++ b/tests/testutil/test_main_util.go
@@ -36,7 +36,7 @@ func SetupPulumiBinary() {
 	}
 	repoRoot := strings.TrimSpace(string(stdout))
 	if os.Getenv("PULUMI_INTEGRATION_REBUILD_BINARIES") == "true" {
-		cmd := exec.Command("make", "build_local")
+		cmd := exec.Command("make", "build")
 		cmd.Dir = repoRoot
 		stdout, err = cmd.CombinedOutput()
 		if err != nil {
@@ -53,7 +53,7 @@ func SetupPulumiBinary() {
 			if _, err := os.Stat(pulumiBinPath); os.IsNotExist(err) {
 				fmt.Printf("WARNING: pulumi binary not found at %s. "+
 					"Falling back to searching the $PATH. "+
-					"Run `make build_local` or set `PULUMI_INTEGRATION_REBUILD_BINARIES=true`.\n", pulumiBinPath)
+					"Run `make build` or set `PULUMI_INTEGRATION_REBUILD_BINARIES=true`.\n", pulumiBinPath)
 				return
 			}
 		}


### PR DESCRIPTION
Currently the `build` target only builds `bin/pulumi` and puts it in $REPO_ROOT/bin.  However that's confusing, as we want all binaries there usually.  Make `build_local` the default `build` target, which already does exactly that.