### PR TITLE
Add `DocLanguageHelper.GetResourceName`

### DIFF
--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -68,6 +68,10 @@ type DocLanguageHelper interface {
 	//	qualifiedName := python.GetTypeName(pkg, prop.Type, false, "")
 	//	fmt.Println(qualifiedName) // Prints "my_module.TheType"
 	GetTypeName(pkg schema.PackageReference, t schema.Type, input bool, relativeToModule string) string
+	// GetResourceName returns the name of the resource.
+	//
+	// Implements should prefer a short name if possible: "MyResource" over "Pulumi.MyPackage.MyModule.MyResource".
+	GetResourceName(r *schema.Resource) string
 	GetFunctionName(f *schema.Function) string
 
 	// GetResourceFunctionResultName returns the name of the result type when a static resource function is used to lookup

--- a/pkg/codegen/dotnet/doc.go
+++ b/pkg/codegen/dotnet/doc.go
@@ -87,6 +87,10 @@ func (d DocLanguageHelper) GetTypeName(pkg schema.PackageReference, t schema.Typ
 	return mod.typeString(t, qualifier, input, false /*state*/, true /*requireInitializers*/)
 }
 
+func (d DocLanguageHelper) GetResourceName(r *schema.Resource) string {
+	return resourceName(r)
+}
+
 func (d DocLanguageHelper) GetFunctionName(f *schema.Function) string {
 	return tokenToFunctionName(f.Token)
 }

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -126,6 +126,14 @@ func (d DocLanguageHelper) GetEnumName(e *schema.Enum, typeName string) (string,
 	return makeSafeEnumName(name, typeName)
 }
 
+func (d DocLanguageHelper) GetResourceName(r *schema.Resource) string {
+	pkg, ok := d.packages[tokenToPackage(r.PackageReference, d.goPkgInfo.ModuleToPackage, r.Token)]
+	if !ok {
+		return rawResourceName(r)
+	}
+	return disambiguatedResourceName(r, pkg)
+}
+
 func (d DocLanguageHelper) GetFunctionName(f *schema.Function) string {
 	funcName := tokenToName(f.Token)
 	if d.topLevelPkg == nil {

--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -103,6 +103,10 @@ func (d DocLanguageHelper) GetTypeName(pkg schema.PackageReference, t schema.Typ
 	return typeName
 }
 
+func (d DocLanguageHelper) GetResourceName(r *schema.Resource) string {
+	return resourceName(r)
+}
+
 func (d DocLanguageHelper) GetFunctionName(f *schema.Function) string {
 	return tokenToFunctionName(f.Token)
 }

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -108,6 +108,10 @@ func (d DocLanguageHelper) GetTypeName(pkg schema.PackageReference, t schema.Typ
 	return typeName
 }
 
+func (d DocLanguageHelper) GetResourceName(r *schema.Resource) string {
+	return resourceName(r)
+}
+
 func (d DocLanguageHelper) GetFunctionName(f *schema.Function) string {
 	return PyName(tokenToName(f.Token))
 }


### PR DESCRIPTION
This PR adds a new method to `DocLanguageHelper` (mirroring the existing `GetFunctionName`), and an implementation for every language in this repo.

Motivated by https://github.com/pulumi/pulumi-service/issues/27266: The API we want to support needs needs to provide an overview of whats in the package (resources and functions). Concretely, that means it needs to return a list of modules, where each module needs to itself have a list of the resources and functions it contains. Each element returned (module, resource, function) needs to have a language appropriate name for each language we support.

This PR is extremely similar to https://github.com/pulumi/pulumi/pull/19569.

There are already PRs for pulumi-java and pulumi-yaml:

- https://github.com/pulumi/pulumi-java/pull/1810
- https://github.com/pulumi/pulumi-yaml/pull/799