### PR TITLE
Mark `LoadPackageReference` as deprecated

### DIFF
--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -165,6 +165,7 @@ func NonStrictBindOptions() []BindOption {
 // BindProgram performs semantic analysis on the given set of HCL2 files that represent a single program. The given
 // host, if any, is used for loading any resource plugins necessary to extract schema information.
 func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagnostics, error) {
+	ctx := context.TODO()
 	var options bindOptions
 	for _, o := range opts {
 		o(&options)
@@ -175,7 +176,7 @@ func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagno
 		if err != nil {
 			return nil, nil, err
 		}
-		ctx, err := plugin.NewContext(context.TODO(), nil, nil, nil, nil, cwd, nil, false, nil)
+		ctx, err := plugin.NewContext(ctx, nil, nil, nil, nil, cwd, nil, false, nil)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -225,7 +226,7 @@ func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagno
 		return files[i].Name < files[j].Name
 	})
 	for _, f := range files {
-		fileDiags, err := b.declareNodes(f)
+		fileDiags, err := b.declareNodes(ctx, f)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -234,7 +235,7 @@ func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagno
 
 	// Now bind the nodes.
 	for _, n := range b.nodes {
-		diagnostics = append(diagnostics, b.bindNode(n)...)
+		diagnostics = append(diagnostics, b.bindNode(ctx, n)...)
 	}
 
 	if diagnostics.HasErrors() {
@@ -364,7 +365,7 @@ func makeObjectPropertiesOptional(objectType *model.ObjectType) *model.ObjectTyp
 // Temporarily, we load all resources first, as convert sets the highest package version seen
 // under all resources' options. Once this is supported for invokes, the order of declaration will not
 // impact which package is actually loaded.
-func (b *binder) declareNodes(file *syntax.File) (hcl.Diagnostics, error) {
+func (b *binder) declareNodes(ctx context.Context, file *syntax.File) (hcl.Diagnostics, error) {
 	var diagnostics hcl.Diagnostics
 
 	for _, item := range model.SourceOrderBody(file.Body) {
@@ -382,7 +383,7 @@ func (b *binder) declareNodes(file *syntax.File) (hcl.Diagnostics, error) {
 				declareDiags := b.declareNode(item.Labels[0], resource)
 				diagnostics = append(diagnostics, declareDiags...)
 
-				if err := b.loadReferencedPackageSchemas(resource); err != nil {
+				if err := b.loadReferencedPackageSchemas(ctx, resource); err != nil {
 					return nil, err
 				}
 			}
@@ -396,7 +397,7 @@ func (b *binder) declareNodes(file *syntax.File) (hcl.Diagnostics, error) {
 			attrDiags := b.declareNode(item.Name, v)
 			diagnostics = append(diagnostics, attrDiags...)
 
-			if err := b.loadReferencedPackageSchemas(v); err != nil {
+			if err := b.loadReferencedPackageSchemas(ctx, v); err != nil {
 				return nil, err
 			}
 		case *hclsyntax.Block:
@@ -444,7 +445,7 @@ func (b *binder) declareNodes(file *syntax.File) (hcl.Diagnostics, error) {
 				diags := b.declareNode(name, v)
 				diagnostics = append(diagnostics, diags...)
 
-				if err := b.loadReferencedPackageSchemas(v); err != nil {
+				if err := b.loadReferencedPackageSchemas(ctx, v); err != nil {
 					return nil, err
 				}
 			case "output":
@@ -469,7 +470,7 @@ func (b *binder) declareNodes(file *syntax.File) (hcl.Diagnostics, error) {
 				diags := b.declareNode(name, v)
 				diagnostics = append(diagnostics, diags...)
 
-				if err := b.loadReferencedPackageSchemas(v); err != nil {
+				if err := b.loadReferencedPackageSchemas(ctx, v); err != nil {
 					return nil, err
 				}
 			case "component":

--- a/pkg/codegen/pcl/binder_nodes.go
+++ b/pkg/codegen/pcl/binder_nodes.go
@@ -15,6 +15,8 @@
 package pcl
 
 import (
+	"context"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
@@ -55,7 +57,7 @@ func mutuallyDependantComponents(a Node, b Node) bool {
 
 // bindNode binds a single node in a program. The node's dependencies are bound prior to the node itself; it is an
 // error for a node to depend--directly or indirectly--upon itself.
-func (b *binder) bindNode(node Node) hcl.Diagnostics {
+func (b *binder) bindNode(ctx context.Context, node Node) hcl.Diagnostics {
 	if node.isBound() {
 		return nil
 	}
@@ -89,7 +91,7 @@ func (b *binder) bindNode(node Node) hcl.Diagnostics {
 			// that are components and reference each other (mutually dependant components)
 			continue
 		}
-		diags := b.bindNode(dep)
+		diags := b.bindNode(ctx, dep)
 		diagnostics = append(diagnostics, diags...)
 	}
 
@@ -101,7 +103,7 @@ func (b *binder) bindNode(node Node) hcl.Diagnostics {
 		diags := b.bindLocalVariable(node)
 		diagnostics = append(diagnostics, diags...)
 	case *Resource:
-		diags := b.bindResource(node)
+		diags := b.bindResource(ctx, node)
 		diagnostics = append(diagnostics, diags...)
 	case *Component:
 		diags := b.bindComponent(node)

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -15,6 +15,7 @@
 package pcl
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -34,10 +35,10 @@ func getResourceToken(node *Resource) (string, hcl.Range) {
 	return node.syntax.Labels[1], node.syntax.LabelRanges[1]
 }
 
-func (b *binder) bindResource(node *Resource) hcl.Diagnostics {
+func (b *binder) bindResource(ctx context.Context, node *Resource) hcl.Diagnostics {
 	var diagnostics hcl.Diagnostics
 
-	typeDiags := b.bindResourceTypes(node)
+	typeDiags := b.bindResourceTypes(ctx, node)
 	diagnostics = append(diagnostics, typeDiags...)
 
 	bodyDiags := b.bindResourceBody(node)
@@ -265,7 +266,7 @@ func (b *binder) reduceInputUnionTypes(node *Resource, inputProperties []*schema
 }
 
 // bindResourceTypes binds the input and output types for a resource.
-func (b *binder) bindResourceTypes(node *Resource) hcl.Diagnostics {
+func (b *binder) bindResourceTypes(ctx context.Context, node *Resource) hcl.Diagnostics {
 	// Set the input and output types to dynamic by default.
 	node.InputType, node.OutputType = model.DynamicType, model.DynamicType
 
@@ -301,7 +302,7 @@ func (b *binder) bindResourceTypes(node *Resource) hcl.Diagnostics {
 	if packageDescriptor, ok := b.packageDescriptors[pkg]; ok {
 		pkgSchema, err = b.options.packageCache.loadPackageSchemaFromDescriptor(b.options.loader, packageDescriptor)
 	} else {
-		pkgSchema, err = b.options.packageCache.loadPackageSchema(b.options.loader, pkg, "")
+		pkgSchema, err = b.options.packageCache.loadPackageSchema(ctx, b.options.loader, pkg, "", "")
 	}
 
 	if err != nil {

--- a/pkg/codegen/pcl/binder_schema_test.go
+++ b/pkg/codegen/pcl/binder_schema_test.go
@@ -15,6 +15,7 @@
 package pcl
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -31,7 +32,7 @@ func BenchmarkLoadPackage(b *testing.B) {
 	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
 
 	for n := 0; n < b.N; n++ {
-		_, err := NewPackageCache().loadPackageSchema(loader, "aws", "")
+		_, err := NewPackageCache().loadPackageSchema(context.Background(), loader, "aws", "", "")
 		if err != nil {
 			b.Fatalf("failed to load package schema: %v", err)
 		}

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -88,7 +88,7 @@ func (pd *PackageDescriptor) String() string {
 }
 
 type Loader interface {
-	// deprecated: use LoadPackageV2
+	// Deprecated: use LoadPackageV2
 	LoadPackage(pkg string, version *semver.Version) (*Package, error)
 
 	LoadPackageV2(ctx context.Context, descriptor *PackageDescriptor) (*Package, error)
@@ -97,7 +97,7 @@ type Loader interface {
 type ReferenceLoader interface {
 	Loader
 
-	// deprecated: use LoadPackageReferenceV2
+	// Deprecated: use LoadPackageReferenceV2
 	LoadPackageReference(pkg string, version *semver.Version) (PackageReference, error)
 
 	LoadPackageReferenceV2(ctx context.Context, descriptor *PackageDescriptor) (PackageReference, error)
@@ -222,7 +222,10 @@ func (l *pluginLoader) LoadPackageReferenceV2(
 	return p, nil
 }
 
-// deprecated: use LoadPackageReferenceV2
+// LoadPackageReference loads a package reference for the given pkg+version using the
+// given loader.
+//
+// Deprecated: use LoadPackageReferenceV2
 func LoadPackageReference(loader Loader, pkg string, version *semver.Version) (PackageReference, error) {
 	return LoadPackageReferenceV2(
 		context.TODO(),


### PR DESCRIPTION
I noticed we were using these functions and not getting lint errors, so this marks the functions as actually deprecated, and then fixes up the call sites.