### PR TITLE
[convert] Ensure convert uses the output project directory as the working directory

### DIFF
--- a/changelog/pending/20250516--programgen--ensure-package-parameterization-during-convert-uses-the-output-project-directory-as-the-working-directory.yaml
+++ b/changelog/pending/20250516--programgen--ensure-package-parameterization-during-convert-uses-the-output-project-directory-as-the-working-directory.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen
+  description: Ensure convert uses the output project directory as the working directory

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -196,7 +196,10 @@ func runConvert(
 		name = filepath.Base(cwd)
 	}
 
-	pCtx, err := packagecmd.NewPluginContext(cwd)
+	// the plugin context uses the output directory as the working directory
+	// of the generated program because in general, where Pulumi.yaml lives is
+	// the root of the project.
+	pCtx, err := packagecmd.NewPluginContext(outDir)
 	if err != nil {
 		return fmt.Errorf("create plugin host: %w", err)
 	}


### PR DESCRIPTION
### Description

Converter plugins emit PCL that contains package descriptors with a parameterization value. That parameterization sometimes include relative paths that parameterized providers use to resolve assets e.g. resolving paths to local TF modules. When resolving these relative paths, they should be relative to output directory where the final Pulumi project is generated, not the current working directory where `pulumi convert` is running from which is the current behaviour today.

The current working directory where a package becomes parameterized from is the working directory of the plugin context it was loaded from. This PR changes the plugin context for the entirety of `pulumi convert` such that it uses the output directory (where the pulumi generated project will live) as the working directory of the process