### PR TITLE
Print stdout/err if go test --list fails

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -210,6 +210,8 @@ def run_list_tests(pkg_dir: str, tags: List[str]) -> List[str]:
     except sp.CalledProcessError as err:
         message=f"Failed to list tests in package dir '{pkg_dir}', usually this implies a Go compilation error. Check that `make lint` succeeds. Also check that `make tidy` has been run."
         print(f"::error {message}", file=sys.stderr)
+        print(f"::stdout {err.stdout}", file=sys.stderr)
+        print(f"::stderr {err.stderr}", file=sys.stderr)
         raise Exception(message) from err
 
     tests: List[str] = []


### PR DESCRIPTION
The error message we print here suggests that go compliation may have failed and to try `make lint`, but `go test --list` can also fail due to errors in test main functions.

To help debug those cases, and also to make the compilation errors more clear lets just print stdout and stderr from the failing command as well as our summary error message.