### PR TITLE
prep-for-goreleaser: retry downloads

### DIFF
--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -19,7 +19,7 @@ download_release() {
   if "${USE_GH}"; then
     gh release download "${tag}" --repo "pulumi/pulumi-${lang}" -p "${filename}"
   else
-    curl -OL --fail "https://github.com/pulumi/pulumi-${lang}/releases/download/${tag}/${filename}"
+    curl -OL --fail --retry 3 "https://github.com/pulumi/pulumi-${lang}/releases/download/${tag}/${filename}"
   fi
 }
 

--- a/scripts/get-pulumi-watch.sh
+++ b/scripts/get-pulumi-watch.sh
@@ -41,13 +41,13 @@ for i in \
   OUTDIR="$(mktemp -d)"
   case "${EXT}" in
     "tar.gz")
-      curl -OL --fail "https://github.com/pulumi/watchutil-rs/releases/download/${TAG}/${FILENAME}"
+      curl -OL --fail --retry 3 "https://github.com/pulumi/watchutil-rs/releases/download/${TAG}/${FILENAME}"
       tar -xzvf "${FILENAME}" --strip-components=1 -C "${OUTDIR}"
       mv "${OUTDIR}/pulumi-watch" "${DIST_DIR}"
       rm "${FILENAME}"
       ;;
     "zip")
-      curl -OL --fail "https://github.com/pulumi/watchutil-rs/releases/download/${TAG}/${FILENAME}"
+      curl -OL --fail --retry 3 "https://github.com/pulumi/watchutil-rs/releases/download/${TAG}/${FILENAME}"
       unzip -j "${FILENAME}" -d "${OUTDIR}"
       mv "${OUTDIR}/pulumi-watch.exe" "${DIST_DIR}"
       rm "${FILENAME}"


### PR DESCRIPTION
Downloading release files from GitHub occasionally fails with a 500 error.  This always indicates a GitHub issue, as the download should always just work.  Rather than giving up immediately, retry the download a few times (I arbitrarily picked 3 here, but we can tweak that), so hopefully the building binaries step becomes less flaky.

Note that this option is using an exponential backoff strategy, so the first retry should wait 1 sec and subsequent retries should double that.

Noticed the failure here: https://github.com/pulumi/pulumi/actions/runs/15107205192/job/42458428394?pr=19532.  Hopefully this will make things less flaky (unless GitHub has a proper outage of course)