### PR TITLE
Return errors if handshake fails

### DIFF
--- a/changelog/pending/20250519--engine--the-engine-will-respect-errors-from-plugin-handshake-methods.yaml
+++ b/changelog/pending/20250519--engine--the-engine-will-respect-errors-from-plugin-handshake-methods.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: engine
-  description: The engine will respect errors from plugin Handshake methods
+  description: Make the engine respect errors from plugin Handshake methods

--- a/changelog/pending/20250519--engine--the-engine-will-respect-errors-from-plugin-handshake-methods.yaml
+++ b/changelog/pending/20250519--engine--the-engine-will-respect-errors-from-plugin-handshake-methods.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: The engine will respect errors from plugin Handshake methods

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -124,6 +124,7 @@ func NewPolicyAnalyzer(
 				logging.V(7).Infof("Handshake: not supported by '%v'", bin)
 				return nil, nil
 			}
+			return nil, fmt.Errorf("failed to handshake with '%v': %w", bin, err)
 		}
 
 		logging.V(7).Infof("Handshake: success [%v]", bin)

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -850,6 +850,7 @@ func languageHandshake(
 			logging.V(7).Infof("Handshake: not supported by '%v'", bin)
 			return nil, nil
 		}
+		return nil, fmt.Errorf("failed to handshake with '%v': %w", bin, err)
 	}
 
 	logging.V(7).Infof("Handshake: success [%v]", bin)

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -325,6 +325,7 @@ func handshake(
 			logging.V(7).Infof("Handshake: not supported by '%v'", bin)
 			return nil, nil
 		}
+		return nil, fmt.Errorf("failed to handshake with '%v': %w", bin, err)
 	}
 
 	logging.V(7).Infof("Handshake: success [%v]", bin)


### PR DESCRIPTION
The engine was incorrectly throwing away any errors from plugin Handshake. While we should correctly ignore "Not implemented" errors, any other error should be bubbled up as a failure condition.