### PR TITLE
Clean up a load of nolint comments

### DIFF
--- a/pkg/backend/diy/backend_legacy_test.go
+++ b/pkg/backend/diy/backend_legacy_test.go
@@ -43,7 +43,6 @@ import (
 // This duplicates those tests to run with legacy, non-project state,
 // validating that the legacy behavior is preserved.
 
-//nolint:paralleltest // mutates environment variables
 func TestListStacksWithMultiplePassphrases_legacy(t *testing.T) {
 	// Login to a temp dir diy backend
 	tmpDir := markLegacyStore(t, t.TempDir())

--- a/pkg/backend/diy/backend_test.go
+++ b/pkg/backend/diy/backend_test.go
@@ -269,7 +269,6 @@ func makeUntypedDeploymentTimestamp(
 	}, nil
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestListStacksWithMultiplePassphrases(t *testing.T) {
 	// Login to a temp dir diy backend
 	tmpDir := t.TempDir()

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -142,7 +142,6 @@ func TestDisabledFullyQualifiedStackNames(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestValueOrDefaultURL(t *testing.T) {
 	t.Run("TestValueOrDefault", func(t *testing.T) {
 		current := ""

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -257,8 +257,6 @@ func TestSamesWithDependencyChanges(t *testing.T) {
 // This test checks that we only write the Checkpoint once whether or
 // not there are important changes when asked to via
 // env.SkipCheckpoints.
-//
-//nolint:paralleltest // mutates environment variables
 func TestWriteCheckpointOnceUnsafe(t *testing.T) {
 	t.Setenv(env.SkipCheckpoints.Var().Name(), "1")
 

--- a/pkg/cmd/pulumi/metadata/metadata_test.go
+++ b/pkg/cmd/pulumi/metadata/metadata_test.go
@@ -30,8 +30,6 @@ import (
 
 // TestReadingGitRepo tests the functions which read data fom the local Git repo
 // to add metadata to any updates.
-//
-//nolint:paralleltest // mutates environment variables
 func TestReadingGitRepo(t *testing.T) {
 	// Disable our CI/CD detection code, since if this unit test is ran under CI
 	// it will change the expected behavior.
@@ -172,8 +170,6 @@ func TestReadingGitRepo(t *testing.T) {
 
 // TestReadingGitLabMetadata tests the functions which read data fom the local Git repo
 // to add metadata to any updates.
-//
-//nolint:paralleltest // mutates environment variables
 func TestReadingGitLabMetadata(t *testing.T) {
 	// Disable our CI/CD detection code, since if this unit test is ran under CI
 	// it will change the expected behavior.
@@ -315,8 +311,6 @@ func TestAddEscMetadataToEnvironment(t *testing.T) {
 }
 
 // Tests that Git metadata can be read from the environment if there is no Git repository present.
-//
-//nolint:paralleltest // mutates environment variables
 func TestGitMetadataIsReadFromEnvironmentWhenNoRepo(t *testing.T) {
 	// Disable CI/CD detection code, since we don't care about those variables for this test and we don't want its
 	// behaviour to change if it is being run in CI.
@@ -361,8 +355,6 @@ func TestGitMetadataIsReadFromEnvironmentWhenNoRepo(t *testing.T) {
 }
 
 // Tests that Git metadata is not read from the environment in the event that a real Git repository is present.
-//
-//nolint:paralleltest // mutates environment variables
 func TestGitMetadataIsNotReadFromEnvironmentWhenRepo(t *testing.T) {
 	// Disable CI/CD detection code, since we don't care about those variables for this test and we don't want its
 	// behaviour to change if it is being run in CI.

--- a/pkg/cmd/pulumi/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_test.go
@@ -919,8 +919,6 @@ Available Templates:
 
 // TestPulumiNewWithoutPulumiAccessToken checks that we won't error if we run `pulumi new
 // --list-templates` without PULUMI_ACCESS_TOKEN set.
-//
-//nolint:paralleltest // Changes environmental variables
 func TestPulumiNewWithoutPulumiAccessToken(t *testing.T) {
 	t.Setenv("PULUMI_ACCESS_TOKEN", "")
 
@@ -975,8 +973,6 @@ Available Templates:
 
 // We should be able to list the templates even when not logged in.
 // Regression test for https://github.com/pulumi/pulumi/issues/19073
-//
-//nolint:paralleltest // Modifies env
 func TestPulumiNewNotLoggedIn(t *testing.T) {
 	t.Setenv("PULUMI_ACCESS_TOKEN", "")
 

--- a/pkg/codegen/schema/docs_test.go
+++ b/pkg/codegen/schema/docs_test.go
@@ -137,14 +137,12 @@ func getDocsForPackage(pkg *Package) []doc {
 	return allDocs
 }
 
-//nolint:paralleltest // needs to set plugin acquisition env var
 func TestParseAndRenderDocs(t *testing.T) {
 	files, err := os.ReadDir(testdataPath)
 	if err != nil {
 		t.Fatalf("could not read test data: %v", err)
 	}
 
-	//nolint:paralleltest // needs to set plugin acquisition env var
 	for _, f := range files {
 		f := f
 		if filepath.Ext(f.Name()) != ".json" || strings.Contains(f.Name(), "awsx") {

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -615,7 +615,6 @@ func TestRejectDuplicateNames(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // needs to set plugin acquisition env var
 func TestImportResourceRef(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -676,7 +675,6 @@ func TestImportResourceRef(t *testing.T) {
 			},
 		},
 	}
-	//nolint:paralleltest // needs to set plugin acquisition env var
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
@@ -1900,7 +1898,6 @@ func TestFunctionToFunctionSpecTurnaround(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // using t.Setenv which is incompatible with t.Parallel
 func TestLoaderRespectsDebugProviders(t *testing.T) {
 	host := debugProvidersHelperHost(t)
 	loader := NewPluginLoader(host)

--- a/pkg/secrets/cloud/aws_test.go
+++ b/pkg/secrets/cloud/aws_test.go
@@ -63,7 +63,6 @@ func createKey(ctx context.Context, t *testing.T, cfg aws.Config) *kms.CreateKey
 	return key
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestAWSCloudManager(t *testing.T) {
 	t.Setenv("AWS_REGION", "us-west-2")
 	ctx, cfg, _ := getAwsCaller(t)
@@ -74,7 +73,6 @@ func TestAWSCloudManager(t *testing.T) {
 	testURL(ctx, t, url)
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestAWSCloudManager_SessionToken(t *testing.T) {
 	t.Setenv("AWS_REGION", "us-west-2")
 	ctx, cfg, _ := getAwsCaller(t)
@@ -93,7 +91,6 @@ func TestAWSCloudManager_SessionToken(t *testing.T) {
 	testURL(ctx, t, url)
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestAWSCloudManager_AssumedRole(t *testing.T) {
 	// Regression test for https://github.com/pulumi/pulumi/issues/11482
 	t.Setenv("AWS_REGION", "us-west-2")
@@ -194,7 +191,6 @@ func TestAWSCloudManager_AssumedRole(t *testing.T) {
 	testURL(ctx, t, url)
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestAWSKmsExistingKey(t *testing.T) {
 	t.Setenv("AWS_REGION", "us-west-2")
 	ctx, _, _ := getAwsCaller(t)
@@ -220,7 +216,6 @@ func TestAWSKmsExistingKey(t *testing.T) {
 	assert.Equal(t, "plaintext", plaintext)
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestAWSKmsExistingState(t *testing.T) {
 	t.Setenv("AWS_REGION", "us-west-2")
 	ctx, _, _ := getAwsCaller(t)
@@ -246,7 +241,6 @@ func TestAWSKmsExistingState(t *testing.T) {
 	assert.JSONEq(t, cloudState, string(manager.State()))
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestAWSKeyEditProjectStack(t *testing.T) {
 	t.Setenv("AWS_REGION", "us-west-2")
 	_, _, _ = getAwsCaller(t)

--- a/pkg/secrets/cloud/manager_test.go
+++ b/pkg/secrets/cloud/manager_test.go
@@ -97,7 +97,6 @@ func TestSecretsProviderOverride(t *testing.T) {
 		assert.NotNil(t, createSecretsManagerError, msg)
 	})
 
-	//nolint:paralleltest
 	t.Run("with override", func(t *testing.T) {
 		opener.wantURL = "test://bar"
 		t.Setenv("PULUMI_CLOUD_SECRET_OVERRIDE", "test://bar")

--- a/pkg/secrets/passphrase/manager_test.go
+++ b/pkg/secrets/passphrase/manager_test.go
@@ -28,7 +28,6 @@ const (
 	brokenState = `{"salt":"fozI5u6B030=:v1:F+6ZduL:PGMFeIzwobWRKmEAzUdaQHqC5mMRIQ=="}`
 )
 
-//nolint:paralleltest // mutates environment variables
 func TestPassphraseManagerIncorrectPassphraseReturnsErrorCrypter(t *testing.T) {
 	clearCachedSecretsManagers()
 
@@ -54,7 +53,6 @@ func TestPassphraseManagerIncorrectPassphraseReturnsErrorCrypter(t *testing.T) {
 	})
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestPassphraseManagerIncorrectStateReturnsError(t *testing.T) {
 	clearCachedSecretsManagers()
 
@@ -70,7 +68,6 @@ func TestPassphraseManagerIncorrectStateReturnsError(t *testing.T) {
 	assert.Error(t, err)
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestPassphraseManagerCorrectPassphraseReturnsSecretsManager(t *testing.T) {
 	clearCachedSecretsManagers()
 
@@ -87,7 +84,6 @@ func TestPassphraseManagerCorrectPassphraseReturnsSecretsManager(t *testing.T) {
 	assert.NotNil(t, sm)
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestPassphraseManagerNoEnvironmentVariablesReturnsError(t *testing.T) {
 	clearCachedSecretsManagers()
 
@@ -104,7 +100,6 @@ func TestPassphraseManagerNoEnvironmentVariablesReturnsError(t *testing.T) {
 		"PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE environment variables")
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestPassphraseManagerEmptyPassphraseIsValid(t *testing.T) {
 	clearCachedSecretsManagers()
 
@@ -121,7 +116,6 @@ func TestPassphraseManagerEmptyPassphraseIsValid(t *testing.T) {
 	assert.NotNil(t, sm)
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestPassphraseManagerCorrectPassfileReturnsSecretsManager(t *testing.T) {
 	clearCachedSecretsManagers()
 
@@ -144,7 +138,6 @@ func TestPassphraseManagerCorrectPassfileReturnsSecretsManager(t *testing.T) {
 	assert.NotNil(t, sm)
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestPassphraseManagerEmptyPassfileReturnsError(t *testing.T) {
 	clearCachedSecretsManagers()
 

--- a/sdk/go/auto/cmd_test.go
+++ b/sdk/go/auto/cmd_test.go
@@ -115,7 +115,6 @@ func TestErrorIncompatibleVersion(t *testing.T) {
 	require.NoError(t, err)
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestNoGlobalPulumi(t *testing.T) {
 	dir := t.TempDir()
 	version := semver.Version{Major: 3, Minor: 98, Patch: 0}

--- a/sdk/go/common/tokens/stack_name_test.go
+++ b/sdk/go/common/tokens/stack_name_test.go
@@ -115,7 +115,6 @@ func TestStackNameValidation_AssertsNonEmpty(t *testing.T) {
 	})
 }
 
-//nolint:paralleltest // Modifies the environment
 func TestStackNameValidation_CanBeDisabled(t *testing.T) {
 	t.Setenv("PULUMI_DISABLE_VALIDATION", "true")
 

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -417,7 +417,6 @@ func (c *mockSSHConfig) GetStrict(host, key string) (string, error) {
 	return c.path, c.err
 }
 
-//nolint:paralleltest // modifies environment variables
 func TestParseAuthURL(t *testing.T) {
 	//nolint: gosec
 	generateSSHKey := func(t *testing.T, passphrase string) string {
@@ -509,7 +508,6 @@ func TestParseAuthURL(t *testing.T) {
 		assert.Equal(t, &http.BasicAuth{Username: "user", Password: "password"}, auth)
 	})
 
-	//nolint:paralleltest // global environment variables
 	t.Run("with passphrase-protected key and environment variable", func(t *testing.T) {
 		passphrase := "foobar"
 		t.Setenv(env.GitSSHPassphrase.Var().Name(), passphrase)
@@ -525,7 +523,6 @@ func TestParseAuthURL(t *testing.T) {
 		assert.Contains(t, parser.sshKeys, "github.com")
 	})
 
-	//nolint:paralleltest // global environment variables
 	t.Run("with passphrase-protected key and wrong environment variable (agent available)", func(t *testing.T) {
 		l, err := nettest.NewLocalListener("unix")
 		defer contract.IgnoreClose(l)
@@ -545,7 +542,6 @@ func TestParseAuthURL(t *testing.T) {
 		assert.NotNil(t, auth)
 	})
 
-	//nolint:paralleltest // global environment variables
 	t.Run("with passphrase-protected key and wrong environment variable (agent unavailable)", func(t *testing.T) {
 		t.Setenv(env.GitSSHPassphrase.Var().Name(), "incorrect passphrase")
 		t.Setenv("SSH_AUTH_SOCK", "")
@@ -575,7 +571,6 @@ func TestParseAuthURL(t *testing.T) {
 		assert.Equal(t, "http-basic-auth - foo:<empty>", auth.String())
 	})
 
-	//nolint:paralleltest // modifies environment variables
 	t.Run("Don't cache on error", func(t *testing.T) {
 		// Regression test for https://github.com/pulumi/pulumi/issues/16637
 		t.Setenv(env.GitSSHPassphrase.Var().Name(), "incorrect passphrase")

--- a/sdk/go/common/workspace/plugins_install_nodejs_test.go
+++ b/sdk/go/common/workspace/plugins_install_nodejs_test.go
@@ -30,7 +30,6 @@ func TestNodeNPMInstall(t *testing.T) {
 	testPluginInstall(t, "node_modules", tarball)
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestNodeYarnInstall(t *testing.T) {
 	t.Setenv("PULUMI_PREFER_YARN", "true")
 	testPluginInstall(t, "node_modules", tarball)

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1460,7 +1460,6 @@ func TestMissingErrorText(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // modifies environment variables
 func TestBundledPluginSearch(t *testing.T) {
 	// Get the path of this executable
 	exe, err := os.Executable()
@@ -1499,7 +1498,6 @@ func TestBundledPluginSearch(t *testing.T) {
 	assert.Equal(t, bundledPath, path)
 }
 
-//nolint:paralleltest // modifies environment variables
 func TestAmbientPluginsWarn(t *testing.T) {
 	ctx := context.Background()
 	// Create a fake plugin in the path
@@ -1527,7 +1525,6 @@ func TestAmbientPluginsWarn(t *testing.T) {
 	assert.Equal(t, expectedMessage, stderr.String())
 }
 
-//nolint:paralleltest // modifies environment variables
 func TestAmbientBundledPluginsWarn(t *testing.T) {
 	// Get the path of this executable
 	exe, err := os.Executable()
@@ -1569,7 +1566,6 @@ func TestAmbientBundledPluginsWarn(t *testing.T) {
 	assert.Equal(t, expectedMessage, stderr.String())
 }
 
-//nolint:paralleltest // modifies environment variables
 func TestBundledPluginsDoNotWarn(t *testing.T) {
 	ctx := context.Background()
 	// Get the path of this executable
@@ -1606,8 +1602,6 @@ func TestBundledPluginsDoNotWarn(t *testing.T) {
 }
 
 // Regression test for https://github.com/pulumi/pulumi/issues/13656
-//
-//nolint:paralleltest // modifies environment variables
 func TestSymlinkPathPluginsDoNotWarn(t *testing.T) {
 	ctx := context.Background()
 	// Get the path of this executable
@@ -1689,7 +1683,6 @@ func TestPluginInfoShimless(t *testing.T) {
 	assert.Equal(t, filepath.Join(filepath.Dir(pluginPath), "schema-mock.json"), info.SchemaPath)
 }
 
-//nolint:paralleltest // modifies environment variables
 func TestProjectPluginsWithUncleanPath(t *testing.T) {
 	ctx := context.Background()
 	tempdir := t.TempDir()
@@ -1710,7 +1703,6 @@ func TestProjectPluginsWithUncleanPath(t *testing.T) {
 	assert.Equal(t, filepath.Join(tempdir, "pulumi-resource-aws"), path)
 }
 
-//nolint:paralleltest // modifies environment variables
 func TestProjectPluginsWithSymlink(t *testing.T) {
 	ctx := context.Background()
 	tempdir := t.TempDir()

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
@@ -792,7 +792,6 @@ func TestRunWithOutputDoesNotMissData(t *testing.T) {
 	require.Equal(t, 100+2 /* "x\n" */, *stderr.nWrites)
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestUseFnm(t *testing.T) {
 	// Set $PATH to to $TMPDIR/bin so that no `fnm` executable can be found.
 	tmpDir := t.TempDir()
@@ -867,7 +866,6 @@ func TestUseFnm(t *testing.T) {
 	})
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestNodeInstall(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip()

--- a/sdk/python/toolchain/pip_test.go
+++ b/sdk/python/toolchain/pip_test.go
@@ -146,7 +146,6 @@ func TestCommandNoVenv(t *testing.T) {
 	require.Nil(t, cmd.Env)
 }
 
-//nolint:paralleltest // modifies environment variables
 func TestCommandPulumiPythonCommand(t *testing.T) {
 	t.Setenv("PULUMI_PYTHON_CMD", "python-not-found")
 

--- a/sdk/python/toolchain/toolchain_test.go
+++ b/sdk/python/toolchain/toolchain_test.go
@@ -70,7 +70,6 @@ func TestValidateVenv(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // modifies environment variables
 func TestCommand(t *testing.T) {
 	// Poetry with `in-project = true` uses `.venv` as the default virtualenv directory.
 	// Use the same for pip to keep the tests consistent.
@@ -270,7 +269,6 @@ func TestAbout(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestPyenv(t *testing.T) {
 	if runtime.GOOS == windows {
 		t.Skip("pyenv is not supported on Windows")
@@ -304,7 +302,6 @@ func TestPyenv(t *testing.T) {
 	require.Equal(t, filepath.Join(tmpDir, "bin", "pyenv"), pyenvPath)
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestPyenvInstall(t *testing.T) {
 	if runtime.GOOS == windows {
 		t.Skip("pyenv is not supported on Windows")

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -816,7 +816,6 @@ func TestConstructProviderGo(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // Sets env vars
 func TestGetResourceGo(t *testing.T) {
 	// This uses the random plugin so needs to be able to download it
 	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1421,7 +1421,6 @@ func TestNpmWorkspace(t *testing.T) {
 	require.NoError(t, pt.TestLifeCycleDestroy(), "destroy")
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestYarnWorkspace(t *testing.T) {
 	t.Setenv("PULUMI_PREFER_YARN", "true")
 	preparePropject := func(projinfo *engine.Projinfo) error {
@@ -1451,7 +1450,6 @@ func TestYarnWorkspace(t *testing.T) {
 	require.NoError(t, pt.TestLifeCycleDestroy(), "destroy")
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestYarnWorkspaceNoHoist(t *testing.T) {
 	t.Setenv("PULUMI_PREFER_YARN", "true")
 	preparePropject := func(projinfo *engine.Projinfo) error {
@@ -2131,8 +2129,6 @@ func TestNodeOOM(t *testing.T) {
 }
 
 // Test a parameterized provider with nodejs.
-//
-//nolint:paralleltest // mutates environment
 func TestParameterizedNode(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
 
@@ -2667,10 +2663,7 @@ func TestNodejsComponentProviderGetSchema(t *testing.T) {
 }
 
 // Tests that we can run a Node.js component provider using component_provider_host
-//
-//nolint:paralleltest // Sets env vars
 func TestNodejsComponentProviderRun(t *testing.T) {
-	//nolint:paralleltest // Sets env vars
 	for _, runtime := range []string{"yaml", "python"} {
 		t.Run(runtime, func(t *testing.T) {
 			// This uses the random plugin so needs to be able to download it

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -197,7 +197,6 @@ func optsForConstructPython(
 	}
 }
 
-//nolint:paralleltest // Sets env vars
 func TestConstructComponentConfigureProviderPython(t *testing.T) {
 	// This uses the tls plugin so needs to be able to download it
 	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
@@ -606,7 +605,6 @@ func TestNewPythonUsesPip(t *testing.T) {
 	integration.CheckRuntimeOptions(t, e.RootPath, expected)
 }
 
-//nolint:paralleltest // Modifies env
 func TestNewPythonUsesPipNonInteractive(t *testing.T) {
 	// Force interactive mode to properly test `--yes`.
 	t.Setenv("PULUMI_TEST_INTERACTIVE", "1")
@@ -626,7 +624,6 @@ func TestNewPythonUsesPipNonInteractive(t *testing.T) {
 	integration.CheckRuntimeOptions(t, e.RootPath, expected)
 }
 
-//nolint:paralleltest // Modifies env
 func TestNewPythonChoosePoetry(t *testing.T) {
 	// The windows acceptance tests are run using git bash, but the survey library does not support this
 	// https://github.com/AlecAivazis/survey/issues/148
@@ -654,7 +651,6 @@ func TestNewPythonChoosePoetry(t *testing.T) {
 	integration.CheckRuntimeOptions(t, e.RootPath, expected)
 }
 
-//nolint:paralleltest // Modifies env
 func TestNewPythonChooseUv(t *testing.T) {
 	// The windows acceptance tests are run using git bash, but the survey library does not support this
 	// https://github.com/AlecAivazis/survey/issues/148

--- a/tests/integration/policy/policy_test.go
+++ b/tests/integration/policy/policy_test.go
@@ -27,8 +27,6 @@ import (
 
 // TestPolicyWithConfig runs integration tests against the policy pack in the policy_pack_w_config
 // directory using version 0.4.1-dev of the pulumi/policy sdk.
-//
-//nolint:paralleltest // mutates environment variables
 func TestPolicyWithConfig(t *testing.T) {
 	t.Skip("Skip test that is causing unrelated tests to fail - pulumi/pulumi#4149")
 
@@ -100,8 +98,6 @@ func TestPolicyWithConfig(t *testing.T) {
 
 // TestPolicyWithoutConfig runs integration tests against the policy pack in the policy_pack_w_config
 // directory. This tests against version 0.4.0 of the pulumi/policy sdk, prior to policy config being supported.
-//
-//nolint:paralleltest // mutates environment variables
 func TestPolicyWithoutConfig(t *testing.T) {
 	t.Skip("Skip test that is causing unrelated tests to fail - pulumi/pulumi#4149")
 

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -49,16 +49,13 @@ var Languages = map[string]string{
 }
 
 // Quick sanity tests for each downstream language to check that a minimal example can be created and run.
-//
-//nolint:paralleltest // pulumi new is not parallel safe
 func TestLanguageNewSmoke(t *testing.T) {
 	// make sure we can download needed plugins
 	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
 
+	//nolint:paralleltest // pulumi new is not parallel safe
 	for _, runtime := range Runtimes {
 		t.Run(runtime, func(t *testing.T) {
-			//nolint:paralleltest
-
 			e := ptesting.NewEnvironment(t)
 			defer e.DeleteIfNotFailed()
 
@@ -79,8 +76,6 @@ func TestLanguageNewSmoke(t *testing.T) {
 }
 
 // Quick sanity tests that YAML convert works.
-//
-//nolint:paralleltest // sets envvars
 func TestYamlConvertSmoke(t *testing.T) {
 	// make sure we can download the yaml converter plugin
 	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
@@ -238,7 +233,6 @@ func TestLanguageGenerateSmoke(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // disabled parallel because we change the plugins cache
 func TestPackageGetSchema(t *testing.T) {
 	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
 
@@ -312,7 +306,6 @@ func TestPackageGetSchema(t *testing.T) {
 	assert.Equal(t, "parameter", schema.Name)
 }
 
-//nolint:paralleltest // disabled parallel because we change the plugins cache
 func TestPackageGetMappingToFile(t *testing.T) {
 	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
 
@@ -340,7 +333,6 @@ func TestPackageGetMappingToFile(t *testing.T) {
 	require.NotNil(t, contents, "mapping contents should be non-empty")
 }
 
-//nolint:paralleltest // disabled parallel because we change the plugins cache
 func TestPackageGetMapping(t *testing.T) {
 	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
 
@@ -364,15 +356,12 @@ func TestPackageGetMapping(t *testing.T) {
 }
 
 // Quick sanity tests for each downstream language to check that import works.
-//
-//nolint:paralleltest // pulumi new is not parallel safe
 func TestLanguageImportSmoke(t *testing.T) {
 	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
 
+	//nolint:paralleltest // pulumi new is not parallel safe
 	for _, runtime := range Runtimes {
 		t.Run(runtime, func(t *testing.T) {
-			//nolint:paralleltest
-
 			e := ptesting.NewEnvironment(t)
 			defer e.DeleteIfNotFailed()
 
@@ -498,8 +487,6 @@ func TestRelativePluginPath(t *testing.T) {
 }
 
 // Quick sanity tests for https://github.com/pulumi/pulumi/issues/16248. Ensure we can run plugins and auto-fetch them.
-//
-//nolint:paralleltest // changes env vars
 func TestPluginRun(t *testing.T) {
 	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
 
@@ -562,8 +549,6 @@ func TestInstall(t *testing.T) {
 // A smoke test to ensure that secrets providers are correctly initialized and persisted to state upon stack creation.
 // We check also that when stack configuration exists before stack initialization, any compatible secrets provider
 // configuration is respected and not clobbered or overwritten.
-//
-//nolint:paralleltest // we set environment variables
 func TestSecretsProvidersInitializationSmoke(t *testing.T) {
 	// Make sure we can download needed plugins
 	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
@@ -601,14 +586,13 @@ func TestSecretsProvidersInitializationSmoke(t *testing.T) {
 		},
 	}
 
+	//nolint:paralleltest
 	for _, runtime := range Runtimes {
 		for _, c := range cases {
 			c := c
 			name := fmt.Sprintf("%s %s", runtime, c.name)
 
 			t.Run(name, func(t *testing.T) {
-				//nolint:paralleltest
-
 				e := ptesting.NewEnvironment(t)
 				defer e.DeleteIfNotFailed()
 

--- a/tests/stack/stack_test.go
+++ b/tests/stack/stack_test.go
@@ -42,7 +42,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-//nolint:paralleltest // mutates environment variables
 func TestStackCommands(t *testing.T) {
 	// stack init, stack ls, stack rm, stack ls
 	t.Run("SanityTest", func(t *testing.T) {
@@ -220,6 +219,7 @@ func TestStackCommands(t *testing.T) {
 		}
 
 		for _, deploymentVersion := range versions {
+			//nolint:paralleltest // mutates environment variables
 			t.Run(fmt.Sprintf("Version%d", deploymentVersion), func(t *testing.T) {
 				e := ptesting.NewEnvironment(t)
 				defer e.DeleteIfNotFailed()
@@ -327,7 +327,6 @@ func TestStackCommands(t *testing.T) {
 	})
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestStackBackups(t *testing.T) {
 	t.Run("StackBackupCreatedSanityTest", func(t *testing.T) {
 		e := ptesting.NewEnvironment(t)


### PR DESCRIPTION
Removing nolint comments because the linter can now see t.Setenv calls.

Prompted by https://github.com/pulumi/pulumi/pull/19593#discussion_r2096032691