### PR TITLE
Unskip a "temporary" assert

### DIFF
--- a/pkg/cmd/pulumi/metadata/metadata_test.go
+++ b/pkg/cmd/pulumi/metadata/metadata_test.go
@@ -166,7 +166,7 @@ func TestReadingGitRepo(t *testing.T) {
 		name, ok := test.Environment[backend.GitHeadName]
 		t.Log(name)
 		assert.True(t, ok, "Expected 'git.headName' key, from CI util.")
-		// assert.Equal(t, "branch-from-ci", name) # see https://github.com/pulumi/pulumi/issues/5303
+		assert.Equal(t, "branch-from-ci", name)
 	}
 }
 


### PR DESCRIPTION
We created #5303 to track skipping an assertion when we migrated from Travis to GitHub actions. This change finally unskips it -- hopefully it works!

Fixes #5303