### PR TITLE
codegen: always initialize cache when initializing type

### DIFF
--- a/changelog/pending/20250520--sdkgen--fix-data-race-in-codegen-type-conversions.yaml
+++ b/changelog/pending/20250520--sdkgen--fix-data-race-in-codegen-type-conversions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen
+  description: Fix data race in codegen type conversions

--- a/pkg/codegen/hcl2/model/type_const.go
+++ b/pkg/codegen/hcl2/model/type_const.go
@@ -105,9 +105,6 @@ func (t *ConstType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (t *ConstType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	if t.cache == nil {
-		t.cache = &gsync.Map[Type, cacheEntry]{}
-	}
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		if t.Type.ConversionFrom(src) != NoConversion {
 			return UnsafeConversion, nil

--- a/pkg/codegen/hcl2/model/type_enum.go
+++ b/pkg/codegen/hcl2/model/type_enum.go
@@ -73,6 +73,7 @@ func NewEnumType(token string, typ Type, elements []cty.Value, annotations ...in
 		Annotations: annotations,
 		Elements:    elements,
 		Token:       token,
+		cache:       &gsync.Map[Type, cacheEntry]{},
 	}
 }
 
@@ -152,9 +153,6 @@ func (t *EnumType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (t *EnumType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	if t.cache == nil {
-		t.cache = &gsync.Map[Type, cacheEntry]{}
-	}
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		// We have a constant, of the correct type, so we might have a safe
 		// conversion.

--- a/pkg/codegen/hcl2/model/type_list.go
+++ b/pkg/codegen/hcl2/model/type_list.go
@@ -35,7 +35,7 @@ type ListType struct {
 
 // NewListType creates a new list type with the given element type.
 func NewListType(elementType Type) *ListType {
-	return &ListType{ElementType: elementType}
+	return &ListType{ElementType: elementType, cache: &gsync.Map[Type, cacheEntry]{}}
 }
 
 // SyntaxNode returns the syntax node for the type. This is always syntax.None.
@@ -124,9 +124,6 @@ func (t *ListType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (t *ListType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	if t.cache == nil {
-		t.cache = &gsync.Map[Type, cacheEntry]{}
-	}
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *ListType:

--- a/pkg/codegen/hcl2/model/type_map.go
+++ b/pkg/codegen/hcl2/model/type_map.go
@@ -35,7 +35,7 @@ type MapType struct {
 
 // NewMapType creates a new map type with the given element type.
 func NewMapType(elementType Type) *MapType {
-	return &MapType{ElementType: elementType}
+	return &MapType{ElementType: elementType, cache: &gsync.Map[Type, cacheEntry]{}}
 }
 
 func (t *MapType) pretty(seenFormatters map[Type]pretty.Formatter) pretty.Formatter {
@@ -119,9 +119,6 @@ func (t *MapType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (t *MapType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	if t.cache == nil {
-		t.cache = &gsync.Map[Type, cacheEntry]{}
-	}
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *MapType:

--- a/pkg/codegen/hcl2/model/type_object.go
+++ b/pkg/codegen/hcl2/model/type_object.go
@@ -47,7 +47,7 @@ type ObjectType struct {
 
 // NewObjectType creates a new object type with the given properties and annotations.
 func NewObjectType(properties map[string]Type, annotations ...interface{}) *ObjectType {
-	return &ObjectType{Properties: properties, Annotations: annotations}
+	return &ObjectType{Properties: properties, Annotations: annotations, cache: &gsync.Map[Type, cacheEntry]{}}
 }
 
 // Annotate adds annotations to the object type. Annotations may be retrieved by GetObjectTypeAnnotation.
@@ -257,9 +257,6 @@ func (t *ObjectType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (t *ObjectType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	if t.cache == nil {
-		t.cache = &gsync.Map[Type, cacheEntry]{}
-	}
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *ObjectType:

--- a/pkg/codegen/hcl2/model/type_output.go
+++ b/pkg/codegen/hcl2/model/type_output.go
@@ -35,7 +35,7 @@ type OutputType struct {
 // NewOutputType creates a new output type with the given element type after replacing any output or promise types
 // within the element type with their respective element types.
 func NewOutputType(elementType Type) *OutputType {
-	return &OutputType{ElementType: ResolveOutputs(elementType)}
+	return &OutputType{ElementType: ResolveOutputs(elementType), cache: &gsync.Map[Type, cacheEntry]{}}
 }
 
 // SyntaxNode returns the syntax node for the type. This is always syntax.None.
@@ -106,9 +106,6 @@ func (t *OutputType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (t *OutputType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	if t.cache == nil {
-		t.cache = &gsync.Map[Type, cacheEntry]{}
-	}
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *OutputType:

--- a/pkg/codegen/hcl2/model/type_promise.go
+++ b/pkg/codegen/hcl2/model/type_promise.go
@@ -36,7 +36,7 @@ type PromiseType struct {
 // NewPromiseType creates a new promise type with the given element type after replacing any promise types within
 // the element type with their respective element types.
 func NewPromiseType(elementType Type) *PromiseType {
-	return &PromiseType{ElementType: ResolvePromises(elementType)}
+	return &PromiseType{ElementType: ResolvePromises(elementType), cache: &gsync.Map[Type, cacheEntry]{}}
 }
 
 // SyntaxNode returns the syntax node for the type. This is always syntax.None.
@@ -106,9 +106,6 @@ func (t *PromiseType) ConversionFrom(src Type) ConversionKind {
 func (t *PromiseType) conversionFrom(
 	src Type, unifying bool, seen map[Type]struct{},
 ) (ConversionKind, lazyDiagnostics) {
-	if t.cache == nil {
-		t.cache = &gsync.Map[Type, cacheEntry]{}
-	}
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		if src, ok := src.(*PromiseType); ok {
 			return t.ElementType.conversionFrom(src.ElementType, unifying, seen)

--- a/pkg/codegen/hcl2/model/type_set.go
+++ b/pkg/codegen/hcl2/model/type_set.go
@@ -34,7 +34,7 @@ type SetType struct {
 
 // NewSetType creates a new set type with the given element type.
 func NewSetType(elementType Type) *SetType {
-	return &SetType{ElementType: elementType}
+	return &SetType{ElementType: elementType, cache: &gsync.Map[Type, cacheEntry]{}}
 }
 
 // SyntaxNode returns the syntax node for the type. This is always syntax.None.
@@ -81,9 +81,6 @@ func (t *SetType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (t *SetType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	if t.cache == nil {
-		t.cache = &gsync.Map[Type, cacheEntry]{}
-	}
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *SetType:

--- a/pkg/codegen/hcl2/model/type_tuple.go
+++ b/pkg/codegen/hcl2/model/type_tuple.go
@@ -42,7 +42,7 @@ type TupleType struct {
 
 // NewTupleType creates a new tuple type with the given element types.
 func NewTupleType(elementTypes ...Type) Type {
-	return &TupleType{ElementTypes: elementTypes}
+	return &TupleType{ElementTypes: elementTypes, cache: &gsync.Map[Type, cacheEntry]{}}
 }
 
 func (t *TupleType) pretty(seenFormatters map[Type]pretty.Formatter) pretty.Formatter {
@@ -186,9 +186,6 @@ func (t *TupleType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (t *TupleType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	if t.cache == nil {
-		t.cache = &gsync.Map[Type, cacheEntry]{}
-	}
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *TupleType:

--- a/pkg/codegen/hcl2/model/type_union.go
+++ b/pkg/codegen/hcl2/model/type_union.go
@@ -81,7 +81,7 @@ func NewUnionTypeAnnotated(types []Type, annotations ...interface{}) Type {
 		return elementTypes[0]
 	}
 
-	return &UnionType{ElementTypes: elementTypes, Annotations: annotations}
+	return &UnionType{ElementTypes: elementTypes, Annotations: annotations, cache: &gsync.Map[Type, cacheEntry]{}}
 }
 
 // NewUnionType creates a new union type with the given element types. Any element types that are union types are
@@ -235,9 +235,6 @@ func (t *UnionType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (t *UnionType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
-	if t.cache == nil {
-		t.cache = &gsync.Map[Type, cacheEntry]{}
-	}
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		var conversionKind ConversionKind
 		var diags []lazyDiagnostics


### PR DESCRIPTION
This cache is used to cache intermediate results for type conversions (see also https://github.com/pulumi/pulumi/pull/19422). However as these functions can be called in parallel, if the cache is not initialized, there is a possibility of a data race, checking for `t.cache == nil` from one goroutine, while another writes to the variable.

We could fix this using a mutex, but this code is somewhat performance critical, so it's better to just make sure to initialize this up front, so we don't have to have a lock at every conversion.