### PR TITLE
Alias `pulumi esc` to `pulumi env`

### DIFF
--- a/changelog/pending/20250521--cli--add-pulumi-esc-as-an-alias-for-pulumi-env.yaml
+++ b/changelog/pending/20250521--cli--add-pulumi-esc-as-an-alias-for-pulumi-env.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi esc` as an alias for `pulumi env`

--- a/pkg/cmd/pulumi/env/env.go
+++ b/pkg/cmd/pulumi/env/env.go
@@ -33,7 +33,9 @@ func NewEnvCmd() *cobra.Command {
 		UserAgent:       client.UserAgent(),
 	})
 
-	// Add the `env` command to the root.
+	// Add the `env` command to the root. We'll add an alias so that users can also use `pulumi esc` to run the command.
 	envCommand := escCLI.Commands()[0]
+	envCommand.Aliases = append(envCommand.Aliases, "esc")
+
 	return envCommand
 }


### PR DESCRIPTION
This feels like a net positive, especially for heavy users of both ESC and Pulumi IaC that may have muscle memory that `pulumi env` breaks.

Fixes #15682.