### PR TITLE
SDK version bumps for next release

### DIFF
--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -380,4 +380,4 @@ const (
 )
 
 // PulumiDotnetSDKVersion is the version of the Pulumi .NET SDK to use in program-gen tests
-const PulumiDotnetSDKVersion = "3.81.0"
+const PulumiDotnetSDKVersion = "3.82.0"

--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -28,7 +28,7 @@ download_release() {
 # * When updating .Net, you should also update PulumiDotnetSDKVersion in pulumi/pkg/codegen/testing/test/helpers.go
 #
 # shellcheck disable=SC2043
-for i in "github.com/pulumi/pulumi-java java v1.11.0" "github.com/pulumi/pulumi-yaml yaml v1.19.0" "github.com/pulumi/pulumi-dotnet dotnet v3.81.0"; do
+for i in "github.com/pulumi/pulumi-java java v1.12.0" "github.com/pulumi/pulumi-yaml yaml v1.19.1" "github.com/pulumi/pulumi-dotnet dotnet v3.82.0"; do
   set -- $i # treat strings in loop as args
   REPO="$1"
   PULUMI_LANG="$2"


### PR DESCRIPTION
The three SDKs in other repos have been released; this PR updates their versions in `pulumi/pulumi`.