### PR TITLE
Add engine events to conformance tests

### DIFF
--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -47,6 +47,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -1211,17 +1212,35 @@ func (eng *languageTestServer) RunLanguageTest(
 		if assertPreview == nil {
 			// if no assertPreview is provided for the test run, we create a default implementation
 			// where we simply assert that the preview changes did not error
-			assertPreview = func(l *tests.L, proj string, err error, p *deploy.Plan, changes display.ResourceChanges) {
+			assertPreview = func(
+				l *tests.L, proj string, err error, p *deploy.Plan,
+				changes display.ResourceChanges, events []engine.Event,
+			) {
 				assert.NoErrorf(l, err, "expected no error in preview")
 			}
 		}
 
 		// Perform a preview on the stack
-		plan, previewChanges, res := s.Preview(ctx, updateOperation, nil)
+		eventsCts := &promise.CompletionSource[[]engine.Event]{}
+		eventSink := make(chan engine.Event, 1)
+		go func() {
+			events := []engine.Event{}
+			for event := range eventSink {
+				events = append(events, event)
+			}
+			eventsCts.Fulfill(events)
+		}()
+
+		plan, previewChanges, res := s.Preview(ctx, updateOperation, eventSink)
+		close(eventSink)
+		events, err := eventsCts.Promise().Result(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("preview events: %w", err)
+		}
 
 		// assert preview results
 		previewResult := tests.WithL(func(l *tests.L) {
-			assertPreview(l, projectDir, res, plan, previewChanges)
+			assertPreview(l, projectDir, res, plan, previewChanges, events)
 		})
 
 		if previewResult.Failed {
@@ -1233,6 +1252,15 @@ func (eng *languageTestServer) RunLanguageTest(
 			}, nil
 		}
 
+		eventsCts = &promise.CompletionSource[[]engine.Event]{}
+		eventSink = make(chan engine.Event, 1)
+		go func() {
+			events := []engine.Event{}
+			for event := range eventSink {
+				events = append(events, event)
+			}
+			eventsCts.Fulfill(events)
+		}()
 		changes, res := s.Update(ctx, updateOperation)
 
 		var snap *deploy.Snapshot
@@ -1257,7 +1285,7 @@ func (eng *languageTestServer) RunLanguageTest(
 		}
 
 		result = tests.WithL(func(l *tests.L) {
-			run.Assert(l, projectDir, res, snap, changes)
+			run.Assert(l, projectDir, res, snap, changes, events)
 		})
 		if result.Failed {
 			return &testingrpc.RunLanguageTestResponse{

--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -1261,7 +1261,12 @@ func (eng *languageTestServer) RunLanguageTest(
 			}
 			eventsCts.Fulfill(events)
 		}()
-		changes, res := s.Update(ctx, updateOperation)
+		changes, res := s.Update(ctx, updateOperation, eventSink)
+		close(eventSink)
+		events, err = eventsCts.Promise().Result(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("preview events: %w", err)
+		}
 
 		var snap *deploy.Snapshot
 		if res == nil {

--- a/cmd/pulumi-test-language/tests/l1_builtin_can.go
+++ b/cmd/pulumi-test-language/tests/l1_builtin_can.go
@@ -16,6 +16,7 @@ package tests
 
 import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -33,6 +34,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")

--- a/cmd/pulumi-test-language/tests/l1_builtin_info.go
+++ b/cmd/pulumi-test-language/tests/l1_builtin_info.go
@@ -16,6 +16,7 @@ package tests
 
 import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")

--- a/cmd/pulumi-test-language/tests/l1_builtin_project_root.go
+++ b/cmd/pulumi-test-language/tests/l1_builtin_project_root.go
@@ -16,6 +16,7 @@ package tests
 
 import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -32,6 +33,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")

--- a/cmd/pulumi-test-language/tests/l1_builtin_try.go
+++ b/cmd/pulumi-test-language/tests/l1_builtin_try.go
@@ -16,6 +16,7 @@ package tests
 
 import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -33,6 +34,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l1_config_types.go
+++ b/cmd/pulumi-test-language/tests/l1_config_types.go
@@ -16,6 +16,7 @@ package tests
 
 import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -36,6 +37,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")

--- a/cmd/pulumi-test-language/tests/l1_empty.go
+++ b/cmd/pulumi-test-language/tests/l1_empty.go
@@ -16,6 +16,7 @@ package tests
 
 import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 )
 
@@ -26,6 +27,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					AssertStackResource(l, err, changes)
 				},

--- a/cmd/pulumi-test-language/tests/l1_keyword_overlap.go
+++ b/cmd/pulumi-test-language/tests/l1_keyword_overlap.go
@@ -16,6 +16,7 @@ package tests
 
 import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
@@ -27,6 +28,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")

--- a/cmd/pulumi-test-language/tests/l1_main.go
+++ b/cmd/pulumi-test-language/tests/l1_main.go
@@ -16,6 +16,7 @@ package tests
 
 import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
@@ -28,6 +29,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")

--- a/cmd/pulumi-test-language/tests/l1_output_array.go
+++ b/cmd/pulumi-test-language/tests/l1_output_array.go
@@ -16,6 +16,7 @@ package tests
 
 import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")

--- a/cmd/pulumi-test-language/tests/l1_output_bool.go
+++ b/cmd/pulumi-test-language/tests/l1_output_bool.go
@@ -16,6 +16,7 @@ package tests
 
 import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
@@ -27,6 +28,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")

--- a/cmd/pulumi-test-language/tests/l1_output_map.go
+++ b/cmd/pulumi-test-language/tests/l1_output_map.go
@@ -16,6 +16,7 @@ package tests
 
 import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")

--- a/cmd/pulumi-test-language/tests/l1_output_null.go
+++ b/cmd/pulumi-test-language/tests/l1_output_null.go
@@ -16,6 +16,7 @@ package tests
 
 import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")

--- a/cmd/pulumi-test-language/tests/l1_output_number.go
+++ b/cmd/pulumi-test-language/tests/l1_output_number.go
@@ -18,6 +18,7 @@ import (
 	"math"
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
@@ -30,6 +31,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")

--- a/cmd/pulumi-test-language/tests/l1_output_string.go
+++ b/cmd/pulumi-test-language/tests/l1_output_string.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
@@ -30,6 +31,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")

--- a/cmd/pulumi-test-language/tests/l1_proxy_index.go
+++ b/cmd/pulumi-test-language/tests/l1_proxy_index.go
@@ -16,6 +16,7 @@ package tests
 
 import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -33,6 +34,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")

--- a/cmd/pulumi-test-language/tests/l1_stack_reference.go
+++ b/cmd/pulumi-test-language/tests/l1_stack_reference.go
@@ -16,6 +16,7 @@ package tests
 
 import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
@@ -35,6 +36,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")

--- a/cmd/pulumi-test-language/tests/l2_component_call_simple.go
+++ b/cmd/pulumi-test-language/tests/l2_component_call_simple.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_component_component_resource_ref.go
+++ b/cmd/pulumi-test-language/tests/l2_component_component_resource_ref.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	deployProviders "github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -33,6 +34,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_component_program_resource_ref.go
+++ b/cmd/pulumi-test-language/tests/l2_component_program_resource_ref.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	deployProviders "github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -33,6 +34,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_component_property_deps.go
+++ b/cmd/pulumi-test-language/tests/l2_component_property_deps.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_destroy.go
+++ b/cmd/pulumi-test-language/tests/l2_destroy.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					require.Len(l, snap.Resources, 4, "expected 4 resources in snapshot")
@@ -48,6 +50,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					assert.Equal(l, 1, changes[deploy.OpDelete], "expected a delete operation")
 					require.Len(l, snap.Resources, 3, "expected 3 resources in snapshot")

--- a/cmd/pulumi-test-language/tests/l2_engine_update_options.go
+++ b/cmd/pulumi-test-language/tests/l2_engine_update_options.go
@@ -36,6 +36,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					require.Len(l, snap.Resources, 3, "expected 2 resource in snapshot")

--- a/cmd/pulumi-test-language/tests/l2_explicit_parameterized_provider.go
+++ b/cmd/pulumi-test-language/tests/l2_explicit_parameterized_provider.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -32,6 +33,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_explicit_provider.go
+++ b/cmd/pulumi-test-language/tests/l2_explicit_provider.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -32,6 +33,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_explicit_providers.go
+++ b/cmd/pulumi-test-language/tests/l2_explicit_providers.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	deployProviders "github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_failed_create_continue_on_error.go
+++ b/cmd/pulumi-test-language/tests/l2_failed_create_continue_on_error.go
@@ -59,6 +59,19 @@ func init() {
 					snap *deploy.Snapshot, changes display.ResourceChanges,
 					events []engine.Event,
 				) {
+					// Expect the error diagnostic for the failed resource
+					found := false
+					for _, evt := range events {
+						if d, ok := evt.Payload().(engine.DiagEventPayload); ok {
+							if d.Severity == "error" && d.URN.Name() == "failing" {
+								require.Equal(l, "<{%reset%}>Preview failed: failed create<{%reset%}>\n", d.Message)
+								found = true
+								break
+							}
+						}
+					}
+					require.True(l, found, "expected to find error diagnostic for failing resource")
+
 					require.True(l, result.IsBail(err), "expected a bail result")
 					require.Equal(l, 1, len(changes), "expected 1 StepOp")
 					require.Equal(l, 2, changes[deploy.OpCreate], "expected 2 Creates")

--- a/cmd/pulumi-test-language/tests/l2_failed_create_continue_on_error.go
+++ b/cmd/pulumi-test-language/tests/l2_failed_create_continue_on_error.go
@@ -37,12 +37,27 @@ func init() {
 				AssertPreview: func(l *L,
 					projectDirectory string, err error,
 					plan *deploy.Plan, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					require.True(l, result.IsBail(err), "expected a bail result on preview")
+
+					// Expect the error diagnostic for the failed resource
+					found := false
+					for _, evt := range events {
+						if d, ok := evt.Payload().(engine.DiagEventPayload); ok {
+							if d.Severity == "error" && d.URN.Name() == "failing" {
+								require.Equal(l, "<{%reset%}>Preview failed: failed create<{%reset%}>\n", d.Message)
+								found = true
+								break
+							}
+						}
+					}
+					require.True(l, found, "expected to find error diagnostic for failing resource")
 				},
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					require.True(l, result.IsBail(err), "expected a bail result")
 					require.Equal(l, 1, len(changes), "expected 1 StepOp")

--- a/cmd/pulumi-test-language/tests/l2_failed_create_continue_on_error.go
+++ b/cmd/pulumi-test-language/tests/l2_failed_create_continue_on_error.go
@@ -64,7 +64,7 @@ func init() {
 					for _, evt := range events {
 						if d, ok := evt.Payload().(engine.DiagEventPayload); ok {
 							if d.Severity == "error" && d.URN.Name() == "failing" {
-								require.Equal(l, "<{%reset%}>Preview failed: failed create<{%reset%}>\n", d.Message)
+								require.Equal(l, "<{%reset%}>failed create<{%reset%}>\n", d.Message)
 								found = true
 								break
 							}

--- a/cmd/pulumi-test-language/tests/l2_invoke_dependencies.go
+++ b/cmd/pulumi-test-language/tests/l2_invoke_dependencies.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -34,6 +35,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					var first *resource.State

--- a/cmd/pulumi-test-language/tests/l2_invoke_options.go
+++ b/cmd/pulumi-test-language/tests/l2_invoke_options.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					require.Len(l, snap.Resources, 2, "expected 2 resource")

--- a/cmd/pulumi-test-language/tests/l2_invoke_options_depends_on.go
+++ b/cmd/pulumi-test-language/tests/l2_invoke_options_depends_on.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					require.Len(l, snap.Resources, 5, "expected 5 resources")

--- a/cmd/pulumi-test-language/tests/l2_invoke_scalar.go
+++ b/cmd/pulumi-test-language/tests/l2_invoke_scalar.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_invoke_secrets.go
+++ b/cmd/pulumi-test-language/tests/l2_invoke_secrets.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -34,6 +35,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					var stack *resource.State

--- a/cmd/pulumi-test-language/tests/l2_invoke_simple.go
+++ b/cmd/pulumi-test-language/tests/l2_invoke_simple.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_invoke_variants.go
+++ b/cmd/pulumi-test-language/tests/l2_invoke_variants.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_large_string.go
+++ b/cmd/pulumi-test-language/tests/l2_large_string.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -33,6 +34,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					require.Len(l, snap.Resources, 3, "expected 3 resources in snapshot")

--- a/cmd/pulumi-test-language/tests/l2_map_keys.go
+++ b/cmd/pulumi-test-language/tests/l2_map_keys.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -35,6 +36,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_namespaced_provider.go
+++ b/cmd/pulumi-test-language/tests/l2_namespaced_provider.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_parameterized_resource.go
+++ b/cmd/pulumi-test-language/tests/l2_parameterized_resource.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")

--- a/cmd/pulumi-test-language/tests/l2_plain.go
+++ b/cmd/pulumi-test-language/tests/l2_plain.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -32,6 +33,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_primitive_ref.go
+++ b/cmd/pulumi-test-language/tests/l2_primitive_ref.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -32,6 +33,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_provider_call.go
+++ b/cmd/pulumi-test-language/tests/l2_provider_call.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -35,6 +36,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_provider_call_explicit.go
+++ b/cmd/pulumi-test-language/tests/l2_provider_call_explicit.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_provider_grpc_config.go
+++ b/cmd/pulumi-test-language/tests/l2_provider_grpc_config.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					g := &grpcTestContext{l: l, s: snap}
 

--- a/cmd/pulumi-test-language/tests/l2_provider_grpc_config_schema_secret.go
+++ b/cmd/pulumi-test-language/tests/l2_provider_grpc_config_schema_secret.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -32,6 +33,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					g := &grpcTestContext{l: l, s: snap}
 

--- a/cmd/pulumi-test-language/tests/l2_provider_grpc_config_secret.go
+++ b/cmd/pulumi-test-language/tests/l2_provider_grpc_config_secret.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -32,6 +33,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					g := &grpcTestContext{l: l, s: snap}
 

--- a/cmd/pulumi-test-language/tests/l2_proxy_index.go
+++ b/cmd/pulumi-test-language/tests/l2_proxy_index.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")

--- a/cmd/pulumi-test-language/tests/l2_ref_ref.go
+++ b/cmd/pulumi-test-language/tests/l2_ref_ref.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -32,6 +33,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_resource_alpha.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_alpha.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -32,6 +33,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_resource_asset_archive.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_asset_archive.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -35,6 +36,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_resource_config.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_config.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -36,6 +37,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					require.Len(l, snap.Resources, 4, "expected 4 resources in snapshot")

--- a/cmd/pulumi-test-language/tests/l2_resource_invoke_dynamic_function.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_invoke_dynamic_function.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_resource_keyword_overlap.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_keyword_overlap.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/stretchr/testify/assert"
@@ -30,6 +31,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_resource_option_deleted_with.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_option_deleted_with.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	deployProviders "github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_resource_option_import.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_option_import.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/stretchr/testify/require"
@@ -30,6 +31,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_resource_option_protect.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_option_protect.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	deployProviders "github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_resource_option_retain_on_delete.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_option_retain_on_delete.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	deployProviders "github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_resource_parent_inheritance.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_parent_inheritance.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	deployProviders "github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -31,6 +32,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_resource_primitives.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_primitives.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -32,6 +33,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_resource_secret.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_secret.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -32,6 +33,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_resource_simple.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_simple.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -32,6 +33,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_rtti.go
+++ b/cmd/pulumi-test-language/tests/l2_rtti.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -32,6 +33,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/l2_target_up_with_new_dependency.go
+++ b/cmd/pulumi-test-language/tests/l2_target_up_with_new_dependency.go
@@ -31,6 +31,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 					require.Len(l, snap.Resources, 4, "expected 4 resources in snapshot")
@@ -54,6 +55,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					require.Len(l, snap.Resources, 4, "expected 4 resources in snapshot")
 

--- a/cmd/pulumi-test-language/tests/l3_component_simple.go
+++ b/cmd/pulumi-test-language/tests/l3_component_simple.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/cmd/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -32,6 +33,7 @@ func init() {
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,
+					events []engine.Event,
 				) {
 					RequireStackResource(l, err, changes)
 

--- a/cmd/pulumi-test-language/tests/types.go
+++ b/cmd/pulumi-test-language/tests/types.go
@@ -234,9 +234,9 @@ type TestRun struct {
 	// This can be used to set a main value for the test.
 	Main string
 	// TODO: This should just return "string", if == "" then ok, else fail
-	Assert func(*L, string, error, *deploy.Snapshot, display.ResourceChanges)
+	Assert func(*L, string, error, *deploy.Snapshot, display.ResourceChanges, []engine.Event)
 	// Assert resource changes during preview runs.
-	AssertPreview func(*L, string, error, *deploy.Plan, display.ResourceChanges)
+	AssertPreview func(*L, string, error, *deploy.Plan, display.ResourceChanges, []engine.Event)
 	// updateOptions can be used to set the update options for the engine.
 	UpdateOptions engine.UpdateOptions
 }

--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -275,7 +275,7 @@ func confirmBeforeUpdating(ctx context.Context, kind apitype.UpdateKind, stackRe
 }
 
 func PreviewThenPromptThenExecute(ctx context.Context, kind apitype.UpdateKind, stack Stack,
-	op UpdateOperation, apply Applier, explainer Explainer,
+	op UpdateOperation, apply Applier, explainer Explainer, events chan<- engine.Event,
 ) (sdkDisplay.ResourceChanges, error) {
 	// Preview the operation to the user and ask them if they want to proceed.
 	if !op.Opts.SkipPreview {
@@ -313,7 +313,7 @@ func PreviewThenPromptThenExecute(ctx context.Context, kind apitype.UpdateKind, 
 	// No need to generate a plan at this stage, there's no way for the system or user to extract the plan
 	// after here.
 	op.Opts.Engine.GeneratePlan = false
-	_, changes, res := apply(ctx, kind, stack, op, opts, nil /*events*/)
+	_, changes, res := apply(ctx, kind, stack, op, opts, events)
 	return changes, res
 }
 

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -173,7 +173,8 @@ type Backend interface {
 		ctx context.Context, stack Stack, op UpdateOperation, events chan<- engine.Event,
 	) (*deploy.Plan, sdkDisplay.ResourceChanges, error)
 	// Update updates the target stack with the current workspace's contents (config and code).
-	Update(ctx context.Context, stack Stack, op UpdateOperation) (sdkDisplay.ResourceChanges, error)
+	Update(ctx context.Context, stack Stack, op UpdateOperation, events chan<- engine.Event,
+	) (sdkDisplay.ResourceChanges, error)
 	// Import imports resources into a stack.
 	Import(ctx context.Context, stack Stack, op UpdateOperation,
 		imports []deploy.Import) (sdkDisplay.ResourceChanges, error)

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1014,7 +1014,7 @@ func (b *diyBackend) Preview(ctx context.Context, stack backend.Stack,
 }
 
 func (b *diyBackend) Update(ctx context.Context, stack backend.Stack,
-	op backend.UpdateOperation,
+	op backend.UpdateOperation, events chan<- engine.Event,
 ) (sdkDisplay.ResourceChanges, error) {
 	err := b.Lock(ctx, stack.Ref())
 	if err != nil {
@@ -1022,7 +1022,7 @@ func (b *diyBackend) Update(ctx context.Context, stack backend.Stack,
 	}
 	defer b.Unlock(ctx, stack.Ref())
 
-	return backend.PreviewThenPromptThenExecute(ctx, apitype.UpdateUpdate, stack, op, b.apply, nil)
+	return backend.PreviewThenPromptThenExecute(ctx, apitype.UpdateUpdate, stack, op, b.apply, nil, events)
 }
 
 func (b *diyBackend) Import(ctx context.Context, stack backend.Stack,
@@ -1049,7 +1049,7 @@ func (b *diyBackend) Import(ctx context.Context, stack backend.Stack,
 		return changes, err
 	}
 
-	return backend.PreviewThenPromptThenExecute(ctx, apitype.ResourceImportUpdate, stack, op, b.apply, nil)
+	return backend.PreviewThenPromptThenExecute(ctx, apitype.ResourceImportUpdate, stack, op, b.apply, nil, nil)
 }
 
 func (b *diyBackend) Refresh(ctx context.Context, stack backend.Stack,
@@ -1074,7 +1074,7 @@ func (b *diyBackend) Refresh(ctx context.Context, stack backend.Stack,
 		return changes, err
 	}
 
-	return backend.PreviewThenPromptThenExecute(ctx, apitype.RefreshUpdate, stack, op, b.apply, nil)
+	return backend.PreviewThenPromptThenExecute(ctx, apitype.RefreshUpdate, stack, op, b.apply, nil, nil)
 }
 
 func (b *diyBackend) Destroy(ctx context.Context, stack backend.Stack,
@@ -1099,7 +1099,7 @@ func (b *diyBackend) Destroy(ctx context.Context, stack backend.Stack,
 		return changes, err
 	}
 
-	return backend.PreviewThenPromptThenExecute(ctx, apitype.DestroyUpdate, stack, op, b.apply, nil)
+	return backend.PreviewThenPromptThenExecute(ctx, apitype.DestroyUpdate, stack, op, b.apply, nil, nil)
 }
 
 func (b *diyBackend) Watch(ctx context.Context, stk backend.Stack,

--- a/pkg/backend/diy/stack.go
+++ b/pkg/backend/diy/stack.go
@@ -85,8 +85,10 @@ func (s *diyStack) Preview(
 	return backend.PreviewStack(ctx, s, op, events)
 }
 
-func (s *diyStack) Update(ctx context.Context, op backend.UpdateOperation) (display.ResourceChanges, error) {
-	return backend.UpdateStack(ctx, s, op)
+func (s *diyStack) Update(ctx context.Context,
+	op backend.UpdateOperation, events chan<- engine.Event,
+) (display.ResourceChanges, error) {
+	return backend.UpdateStack(ctx, s, op, events)
 }
 
 func (s *diyStack) Import(ctx context.Context, op backend.UpdateOperation,

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1150,9 +1150,9 @@ func (b *cloudBackend) Preview(ctx context.Context, stack backend.Stack,
 }
 
 func (b *cloudBackend) Update(ctx context.Context, stack backend.Stack,
-	op backend.UpdateOperation,
+	op backend.UpdateOperation, events chan<- engine.Event,
 ) (sdkDisplay.ResourceChanges, error) {
-	return backend.PreviewThenPromptThenExecute(ctx, apitype.UpdateUpdate, stack, op, b.apply, b)
+	return backend.PreviewThenPromptThenExecute(ctx, apitype.UpdateUpdate, stack, op, b.apply, b, events)
 }
 
 // IsExplainPreviewEnabled implements the "explainer" interface.
@@ -1256,7 +1256,7 @@ func (b *cloudBackend) Import(ctx context.Context, stack backend.Stack,
 		return changes, err
 	}
 
-	return backend.PreviewThenPromptThenExecute(ctx, apitype.ResourceImportUpdate, stack, op, b.apply, b)
+	return backend.PreviewThenPromptThenExecute(ctx, apitype.ResourceImportUpdate, stack, op, b.apply, b, nil)
 }
 
 func (b *cloudBackend) Refresh(ctx context.Context, stack backend.Stack,
@@ -1274,7 +1274,7 @@ func (b *cloudBackend) Refresh(ctx context.Context, stack backend.Stack,
 			ctx, apitype.RefreshUpdate, stack, op, opts, nil /*events*/)
 		return changes, err
 	}
-	return backend.PreviewThenPromptThenExecute(ctx, apitype.RefreshUpdate, stack, op, b.apply, b)
+	return backend.PreviewThenPromptThenExecute(ctx, apitype.RefreshUpdate, stack, op, b.apply, b, nil)
 }
 
 func (b *cloudBackend) Destroy(ctx context.Context, stack backend.Stack,
@@ -1292,7 +1292,7 @@ func (b *cloudBackend) Destroy(ctx context.Context, stack backend.Stack,
 			ctx, apitype.DestroyUpdate, stack, op, opts, nil /*events*/)
 		return changes, err
 	}
-	return backend.PreviewThenPromptThenExecute(ctx, apitype.DestroyUpdate, stack, op, b.apply, b)
+	return backend.PreviewThenPromptThenExecute(ctx, apitype.DestroyUpdate, stack, op, b.apply, b, nil)
 }
 
 func (b *cloudBackend) Watch(ctx context.Context, stk backend.Stack,

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -186,10 +186,14 @@ func (s *cloudStack) Preview(
 	return backend.PreviewStack(ctx, s, op, events)
 }
 
-func (s *cloudStack) Update(ctx context.Context, op backend.UpdateOperation) (sdkDisplay.ResourceChanges,
+func (s *cloudStack) Update(
+	ctx context.Context,
+	op backend.UpdateOperation,
+	events chan<- engine.Event,
+) (sdkDisplay.ResourceChanges,
 	error,
 ) {
-	return backend.UpdateStack(ctx, s, op)
+	return backend.UpdateStack(ctx, s, op, events)
 }
 
 func (s *cloudStack) Import(ctx context.Context, op backend.UpdateOperation,

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -295,7 +295,7 @@ func (be *MockBackend) Preview(ctx context.Context, stack Stack,
 }
 
 func (be *MockBackend) Update(ctx context.Context, stack Stack,
-	op UpdateOperation,
+	op UpdateOperation, events chan<- engine.Event,
 ) (sdkDisplay.ResourceChanges, error) {
 	if be.UpdateF != nil {
 		return be.UpdateF(ctx, stack, op)
@@ -631,7 +631,9 @@ func (ms *MockStack) Preview(
 	panic("not implemented")
 }
 
-func (ms *MockStack) Update(ctx context.Context, op UpdateOperation) (sdkDisplay.ResourceChanges, error) {
+func (ms *MockStack) Update(ctx context.Context,
+	op UpdateOperation, events chan<- engine.Event,
+) (sdkDisplay.ResourceChanges, error) {
 	if ms.UpdateF != nil {
 		return ms.UpdateF(ctx, op)
 	}

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -46,7 +46,7 @@ type Stack interface {
 		ctx context.Context, op UpdateOperation, events chan<- engine.Event,
 	) (*deploy.Plan, display.ResourceChanges, error)
 	// Update this stack.
-	Update(ctx context.Context, op UpdateOperation) (display.ResourceChanges, error)
+	Update(ctx context.Context, op UpdateOperation, events chan<- engine.Event) (display.ResourceChanges, error)
 	// Import resources into this stack.
 	Import(ctx context.Context, op UpdateOperation, imports []deploy.Import) (display.ResourceChanges, error)
 	// Refresh this stack's state from the cloud provider.
@@ -93,8 +93,13 @@ func PreviewStack(
 }
 
 // UpdateStack updates the target stack with the current workspace's contents (config and code).
-func UpdateStack(ctx context.Context, s Stack, op UpdateOperation) (display.ResourceChanges, error) {
-	return s.Backend().Update(ctx, s, op)
+func UpdateStack(
+	ctx context.Context,
+	s Stack,
+	op UpdateOperation,
+	events chan<- engine.Event,
+) (display.ResourceChanges, error) {
+	return s.Backend().Update(ctx, s, op, events)
 }
 
 // ImportStack updates the target stack with the current workspace's contents (config and code).

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -244,7 +244,7 @@ func NewUpCmd() *cobra.Command {
 			SecretsManager:     sm,
 			SecretsProvider:    stack.DefaultSecretsProvider,
 			Scopes:             backend.CancellationScopes,
-		})
+		}, nil /* events */)
 		switch {
 		case err == context.Canceled:
 			return errors.New("update cancelled")
@@ -477,7 +477,7 @@ func NewUpCmd() *cobra.Command {
 			SecretsManager:     sm,
 			SecretsProvider:    stack.DefaultSecretsProvider,
 			Scopes:             backend.CancellationScopes,
-		})
+		}, nil /* events */)
 		switch {
 		case err == context.Canceled:
 			return errors.New("update cancelled")


### PR DESCRIPTION
We'll need this for testing policy in conformance tests, but there's probably some tests that could be improved with this as well. I've fixed up one preview test to check we actually see the expected error message.