### PR TITLE
upgrade runner images to ubuntu-latest

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -20,7 +20,7 @@ on:
         type: string
       build-platform:
         required: false
-        default: ubuntu-22.04
+        default: ubuntu-latest
         description: 'Build platform (i.e.: runs-on) for job'
         type: string
       artifact-suffix:

--- a/.github/workflows/ci-build-sdks.yml
+++ b/.github/workflows/ci-build-sdks.yml
@@ -40,7 +40,7 @@ env:
 jobs:
   build_python_sdk:
     name: python
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -74,7 +74,7 @@ jobs:
 
   build_node_sdk:
     name: nodejs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   gather-info:
     name: gather-info
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,7 +44,7 @@ jobs:
       version: ${{ inputs.version }}
 
   matrix:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -77,7 +77,7 @@ jobs:
       matrix:
         os: ["linux", "darwin", "windows"]
         arch: ["amd64", "arm64"]
-        build-platform: ["ubuntu-22.04"]
+        build-platform: ["ubuntu-latest"]
     uses: ./.github/workflows/ci-build-binaries.yml
     with:
       ref: ${{ inputs.ref }}
@@ -111,7 +111,7 @@ jobs:
   # Check if we need to create a new SDK dev release
   sdk-check-release:
     name: sdk-check-release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -138,7 +138,7 @@ jobs:
 
   nodejs-dev-sdk-release:
     needs: [gather-info, build-sdks, sdk-check-release, matrix]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: ${{ needs.sdk-check-release.outputs.nodejs-release == 'true' }}
     steps:
       - name: Checkout
@@ -182,7 +182,7 @@ jobs:
 
   python-dev-sdk-release:
     needs: [gather-info, build-sdks, sdk-check-release, matrix]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: ${{ needs.sdk-check-release.outputs.python-release == 'true' }}
     steps:
       - name: Checkout
@@ -224,7 +224,7 @@ jobs:
 
   s3-blobs:
     name: s3 blobs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: [sign, gather-info]
     steps:
       - name: Configure AWS Credentials

--- a/.github/workflows/ci-info.yml
+++ b/.github/workflows/ci-info.yml
@@ -30,7 +30,7 @@ defaults:
 jobs:
   info:
     name: gather
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   golangci:
     name: Lint Go
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,7 +50,7 @@ jobs:
         run: make lint_golang
   tidy:
     name: go mod tidy
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -65,7 +65,7 @@ jobs:
 
   gen:
     name: Generate Go SDK
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -87,7 +87,7 @@ jobs:
 
   protobuf-lint:
     name: Lint Protobufs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -98,7 +98,7 @@ jobs:
 
   sdk-lint:
     name: Lint SDKs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -151,7 +151,7 @@ jobs:
 
   actionlint:
     name: Lint GHA
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -166,7 +166,7 @@ jobs:
 
   pulumi-json:
     name: Lint pulumi.json
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-performance-gate.yml
+++ b/.github/workflows/ci-performance-gate.yml
@@ -29,7 +29,7 @@ on:
         type: string
       performance-test-platforms:
         required: false
-        default: ubuntu-22.04
+        default: ubuntu-latest
         description: Platforms on which to run performance tests, as a space delimited list
         type: string
       fail-fast:
@@ -64,7 +64,7 @@ on:
 
 jobs:
   matrix:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
     steps:
@@ -81,9 +81,9 @@ jobs:
           readarray -td' ' VERSION_SETS_TO_TEST < <(echo -n "$TEST_VERSION_SETS"); declare -p VERSION_SETS_TO_TEST;
           readarray -td' ' PERFORMANCE_TEST_PLATFORMS < <(echo -n "$INPUT_PERFORMANCE_TEST_PLATFORMS"); declare -p PERFORMANCE_TEST_PLATFORMS;
           BUILD_TARGETS='[
-              { "os": "linux",   "arch": "amd64", "build-platform": "ubuntu-22.04" },
-              { "os": "windows", "arch": "amd64", "build-platform": "ubuntu-22.04" },
-              { "os": "darwin",  "arch": "arm64", "build-platform": "ubuntu-22.04" }
+              { "os": "linux",   "arch": "amd64", "build-platform": "ubuntu-latest" },
+              { "os": "windows", "arch": "amd64", "build-platform": "ubuntu-latest" },
+              { "os": "darwin",  "arch": "arm64", "build-platform": "ubuntu-latest" }
           ]'
 
           PERFORMANCE_TEST_MATRIX=$(

--- a/.github/workflows/ci-prepare-release.yml
+++ b/.github/workflows/ci-prepare-release.yml
@@ -50,7 +50,7 @@ jobs:
   publish:
     name: release
     needs: [sign]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -15,7 +15,7 @@ on:
         description: "Version to produce"
         type: string
       platform:
-        description: "OS to run tests on, e.g.: ubuntu-22.04"
+        description: "OS to run tests on, e.g.: ubuntu-latest"
         required: true
         type: string
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ on:
         type: string
       integration-test-platforms:
         required: false
-        default: ubuntu-22.04
+        default: ubuntu-latest
         description: Platforms on which to run integration tests, as a space delimited list
         type: string
       acceptance-test-platforms:
@@ -80,7 +80,7 @@ on:
 
 jobs:
   matrix:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
     steps:
@@ -136,12 +136,12 @@ jobs:
           readarray -td' ' INTEGRATION_PLATFORMS < <(echo -n "$INPUT_INTEGRATION_TEST_PLATFORMS"); declare -p INTEGRATION_PLATFORMS;
           readarray -td' ' ACCEPTANCE_PLATFORMS < <(echo -n "$INPUT_ACCEPTANCE_TEST_PLATFORMS"); declare -p ACCEPTANCE_PLATFORMS;
           BUILD_TARGETS='[
-              { "os": "linux",   "arch": "amd64", "build-platform": "ubuntu-22.04" },
-              { "os": "linux",   "arch": "arm64", "build-platform": "ubuntu-22.04" },
-              { "os": "windows", "arch": "amd64", "build-platform": "ubuntu-22.04" },
-              { "os": "windows", "arch": "arm64", "build-platform": "ubuntu-22.04" },
-              { "os": "darwin",  "arch": "amd64", "build-platform": "ubuntu-22.04" },
-              { "os": "darwin",  "arch": "arm64", "build-platform": "ubuntu-22.04" }
+              { "os": "linux",   "arch": "amd64", "build-platform": "ubuntu-latest" },
+              { "os": "linux",   "arch": "arm64", "build-platform": "ubuntu-latest" },
+              { "os": "windows", "arch": "amd64", "build-platform": "ubuntu-latest" },
+              { "os": "windows", "arch": "arm64", "build-platform": "ubuntu-latest" },
+              { "os": "darwin",  "arch": "amd64", "build-platform": "ubuntu-latest" },
+              { "os": "darwin",  "arch": "arm64", "build-platform": "ubuntu-latest" }
           ]'
 
           CODEGEN_TESTS_FLAG=--codegen-tests
@@ -157,7 +157,7 @@ jobs:
             generate-matrix \
             --kind unit-test \
             "$CODEGEN_TESTS_FLAG" \
-            --platform ubuntu-22.04 \
+            --platform ubuntu-latest \
             --version-set current \
             --partition-module cmd/pulumi-test-language 1 \
             --partition-module pkg "$PKG_UNIT_TEST_PARTITIONS" \
@@ -307,7 +307,7 @@ jobs:
       version: ${{ inputs.version }}
       os: js
       arch: wasm
-      build-platform: "ubuntu-22.04"
+      build-platform: "ubuntu-latest"
       version-set: ${{ needs.matrix.outputs.version-set }}
     secrets: inherit
 
@@ -436,7 +436,7 @@ jobs:
   test-collect-reports:
     needs: [unit-test, integration-test, acceptance-test-macos]
     if: ${{ always() }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/cache@v4
         with:
@@ -457,7 +457,7 @@ jobs:
   test-collect-coverage:
     needs: [unit-test, integration-test]
     if: ${{ inputs.enable-coverage }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       # Check that there are no failed tests.
       - name: Check tests completed successfully.

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   command-dispatch:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Dispatch command
         uses: peter-evans/slash-command-dispatch@v2

--- a/.github/workflows/cron-direct-build.yml
+++ b/.github/workflows/cron-direct-build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pkg:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -17,7 +17,7 @@ jobs:
         shell: bash
         run: GOPROXY=direct make build
   sdk:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/cron-test-all.yml
+++ b/.github/workflows/cron-test-all.yml
@@ -34,7 +34,7 @@ jobs:
       # on PR to get correct coverage numbers.
       test-codegen: true
       test-version-sets: 'all'
-      integration-test-platforms: ubuntu-22.04
+      integration-test-platforms: ubuntu-latest
       acceptance-test-platforms: 'macos-latest windows-latest'
       enable-coverage: true
     secrets: inherit
@@ -49,14 +49,14 @@ jobs:
       ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}
       test-version-sets: 'all'
-      performance-test-platforms: ubuntu-22.04
+      performance-test-platforms: ubuntu-latest
     secrets: inherit
 
   ci-ok:
     name: ci-ok
     needs: [ci, performance-gate]
     if: always()
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: CI failed
         if: ${{ needs.ci.result != 'success' }}

--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -60,7 +60,7 @@ jobs:
       - run: ls -la
   linux-direct-install:
     name: Install Pulumi via script on Ubuntu
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Remove existing version
         run: sudo rm /usr/local/bin/pulumi
@@ -79,7 +79,7 @@ jobs:
           exit 1
   linux-verify-download-link:
     name: Verify Direct Download link on Linux
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Direct Download
         run: curl -L -o pulumi.tar.gz "https://get.pulumi.com/releases/sdk/pulumi-v$(curl -sS https://www.pulumi.com/latest-version)-linux-x64.tar.gz"
@@ -184,7 +184,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "windows-latest", "macos-13"]
+        os: ["ubuntu-latest", "windows-latest", "macos-13"]
     steps:
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1

--- a/.github/workflows/on-community-pr.yml
+++ b/.github/workflows/on-community-pr.yml
@@ -18,7 +18,7 @@ jobs:
     name: Maintainer comment
     # We only care about commenting on a PR if the PR is from a fork
     if: github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@1.0.1

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -61,7 +61,7 @@ jobs:
       test-version-sets: 'minimum current'
       fail-fast: true
       test-retries: 2
-      performance-test-platforms: ubuntu-22.04
+      performance-test-platforms: ubuntu-latest
     secrets: inherit
 
   prepare-release:
@@ -83,7 +83,7 @@ jobs:
     name: ci-ok
     needs: [ci, performance-gate, prepare-release]
     if: always() # always report a status
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: CI failed
         if: ${{ needs.ci.result != 'success' }}

--- a/.github/workflows/on-pr-close.yml
+++ b/.github/workflows/on-pr-close.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     cleanup:
       name: Remove Existing Codegen PRs
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-latest
       continue-on-error: true
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}

--- a/.github/workflows/on-pr-default.yml
+++ b/.github/workflows/on-pr-default.yml
@@ -15,14 +15,14 @@ on:
 jobs:
   no-op:
     name: Skip CI on .version changes
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Skip CI on .version changes
         run: echo 'No need to run CI tests when only .version changes'
 
   ci-ok:
     name: ci-ok
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: CI succeeded
         run: exit 0

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -37,7 +37,7 @@ jobs:
   inspect:
     name: Inspect changed files
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: dorny/paths-filter@v3
         id: changes
@@ -79,7 +79,7 @@ jobs:
           && 'minimum current'
           || 'current'
         }}
-      integration-test-platforms: ubuntu-22.04
+      integration-test-platforms: ubuntu-latest
       acceptance-test-platforms: >- # No newlines or trailing newline.
         ${{
           contains(github.event.pull_request.labels.*.name, 'ci/test')
@@ -100,14 +100,14 @@ jobs:
       ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}
       test-version-sets: 'minimum current'
-      performance-test-platforms: ubuntu-22.04
+      performance-test-platforms: ubuntu-latest
     secrets: inherit
 
   ci-ok:
     name: ci-ok
     needs: [ci, performance-gate]
     if: always()
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       # If the PR is a community PR, we don't run the usual checks, but instead
       # require maintainers to run them manually by commenting with

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -36,7 +36,7 @@ jobs:
   update-dev-version:
     name: update-dev-version
     needs: [dev-release, info]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -69,7 +69,7 @@ jobs:
 
   tag-pkg:
     name: tag-pkg
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -15,7 +15,7 @@ concurrency: release
 jobs:
   info:
     name: gather
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       version: "${{ fromJSON(steps.version.outputs.version) }}"
     steps:

--- a/.github/workflows/pr-test-acceptance-on-dispatch.yml
+++ b/.github/workflows/pr-test-acceptance-on-dispatch.yml
@@ -33,7 +33,7 @@ jobs:
     secrets: inherit
 
   comment-notification:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: ${{ github.event_name == 'repository_dispatch' }}
     permissions:
       contents: read
@@ -62,7 +62,7 @@ jobs:
       version: ${{ needs.info.outputs.version }}
       lint: true
       test-version-sets: current
-      integration-test-platforms: ubuntu-22.04
+      integration-test-platforms: ubuntu-latest
       acceptance-test-platforms: 'windows-latest'
       # We'll only upload coverage artifacts with the periodic-coverage cron workflow.
       enable-coverage: false

--- a/.github/workflows/pr-test-codegen-downstream.yml
+++ b/.github/workflows/pr-test-codegen-downstream.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
     cleanup:
       name: Remove Existing Codegen PRs
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-latest
       continue-on-error: true
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
@@ -25,7 +25,7 @@ jobs:
       name: Test ${{ matrix.provider }} (bridged)
       needs: ["cleanup"]
       timeout-minutes: 240
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-latest
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
       strategy:
@@ -65,7 +65,7 @@ jobs:
     #   name: Test AWSX
     #   needs: ["cleanup"]
     #   timeout-minutes: 240
-    #   runs-on: ubuntu-22.04
+    #   runs-on: ubuntu-latest
     #   env:
     #     GOVERSION: ">=1.19.0" # from awsx: decoupled from version sets, track latest for codegen
     #     NODEVERSION: "18.x"

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -5,7 +5,7 @@ on:
 jobs:  
   rebase:
     name: Rebase
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: >-
       contains(fromJSON('["COLLABORATOR", "MEMBER", "OWNER"]'), github.event.comment.author_association) &&
       github.event.issue.pull_request != '' && 

--- a/.github/workflows/release-homebrew-tap.yml
+++ b/.github/workflows/release-homebrew-tap.yml
@@ -42,7 +42,7 @@ env:
 jobs:
   update-homebrew-tap:
     name: Update Homebrew Tap
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -33,7 +33,7 @@ on:
 jobs:
   version-bump:
     name: version bump
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ env:
 jobs:
   sdks:
     name: ${{ matrix.language }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -103,7 +103,7 @@ jobs:
 
   s3-blobs:
     name: s3 blobs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -146,7 +146,7 @@ jobs:
   dispatch:
     name: ${{ matrix.job.name }}
     if: inputs.run-dispatch-commands && !contains(inputs.version, '-')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: [pr]
     strategy:
       fail-fast: false

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   sign:
     name: sign
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/trigger-homebrew-event.yml
+++ b/.github/workflows/trigger-homebrew-event.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   homebrew:
     name: Bump Homebrew formula
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Add Homebrew to the PATH
         run: |

--- a/.github/workflows/trigger-release-docs-event.yml
+++ b/.github/workflows/trigger-release-docs-event.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   docs:
     name: Build Package Docs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@
 
 version: 2
 build:
-  os: ubuntu-22.04
+  os: ubuntu-latest
   tools:
     python: "3.12"
   commands:

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -129,7 +129,7 @@ MAKEFILE_PERFORMANCE_TESTS: List[MakefileTest] = [
     {"name": "performance tests", "run": "./scripts/retry make test_performance", "eta": 10},
 ]
 
-ALL_PLATFORMS = ["ubuntu-22.04", "windows-latest", "macos-latest"]
+ALL_PLATFORMS = ["ubuntu-latest", "windows-latest", "macos-latest"]
 
 
 # When updating the minumum and current versions, consider also updating the


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/18229, we pinned the runner images to ubuntu 22.04 because we couldn't handle the upgrade. However eventually we should upgrade to latest again, as 22.04 will be deprecated eventually, and there shouldn't be a reason why we couldn't run on latest.

I noticed https://github.com/pulumi/pulumi/actions/runs/15181755005/job/42692561187?pr=19603 didn't have any available ubuntu runner to pick up my job (though that's maybe more related to actions being in a degraded state now)