### PR TITLE
stack select: better error in non-interactive mode

### DIFF
--- a/changelog/pending/20250522--cli--improve-error-message-when-stack-select-is-run-in-non-interactive-mode.yaml
+++ b/changelog/pending/20250522--cli--improve-error-message-when-stack-select-is-run-in-non-interactive-mode.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Improve error message when stack select is run in non-interactive mode

--- a/pkg/cmd/pulumi/stack/stack_select.go
+++ b/pkg/cmd/pulumi/stack/stack_select.go
@@ -72,7 +72,7 @@ func newStackSelectCmd() *cobra.Command {
 			}
 
 			if stack == "" && !cmdutil.Interactive() {
-				return errors.New("no stack name given, and cannot prompt in non-interactive mode")
+				return errors.New("no stack name given, use --stack to specify a stack name")
 			}
 
 			if stack != "" {

--- a/pkg/cmd/pulumi/stack/stack_select.go
+++ b/pkg/cmd/pulumi/stack/stack_select.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2024, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -69,6 +69,10 @@ func newStackSelectCmd() *cobra.Command {
 				}
 
 				stack = args[0]
+			}
+
+			if stack == "" && !cmdutil.Interactive() {
+				return errors.New("no stack name given, and cannot prompt in non-interactive mode")
 			}
 
 			if stack != "" {


### PR DESCRIPTION
When `pulumi stack select` is run in non-interactive mode, and no stack name is passed in as an argument to the command, we error out with:

```
error: no stack selected; please use `pulumi stack select` or `pulumi stack init` to choose one
```

This is confusing to the user, as they are already running `pulumi stack select`. Improve the error message here, to make this less confusing to the user, and get them to either run the command in interactive mode, or pass an argument to `pulumi stack select`.