### PR TITLE
Close grpc connections on host close in conformance tests

### DIFF
--- a/cmd/pulumi-test-language/test_host.go
+++ b/cmd/pulumi-test-language/test_host.go
@@ -229,6 +229,12 @@ func (h *testHost) SignalCancellation() error {
 }
 
 func (h *testHost) Close() error {
+	for _, closer := range h.connections {
+		if err := closer.Close(); err != nil {
+			return fmt.Errorf("close provider connection: %w", err)
+		}
+	}
+	h.connections = make(map[plugin.Provider]io.Closer)
 	return nil
 }
 


### PR DESCRIPTION
Noticed while adding policy tests. The host context never cleaned up all the grpc connections that it created.