### PR TITLE
Fix makefile for osx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ build_display_wasm:: .make/ensure/go
 	cd pkg && GOOS=js GOARCH=wasm go build -o ../bin/pulumi-display.wasm -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ./backend/display/wasm
 
 .PHONY: build
-build:: export GOBIN=$(shell realpath ./bin)
+build:: export GOBIN=$(shell mkdir -p ./bin; realpath ./bin)
 build:: build_proto .make/ensure/go dist build_display_wasm
 
 install:: bin/pulumi

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ include build/common.mk
 
 PROJECT         := github.com/pulumi/pulumi/pkg/v3/cmd/pulumi
 
+# Ensure bin directory exists before targets are evaluated
+# to avoid issues like realpath failing on macOS if the directory doesn't exist.
+_ := $(shell mkdir -p bin)
+
 PKG_CODEGEN := github.com/pulumi/pulumi/pkg/v3/codegen
 # nodejs and python codegen tests are much slower than go/dotnet:
 PROJECT_PKGS    := $(shell cd ./pkg && go list ./... | grep -v -E '^${PKG_CODEGEN}/(dotnet|go|nodejs|python)')
@@ -78,9 +82,6 @@ build_display_wasm:: .make/ensure/go
 	cd pkg && GOOS=js GOARCH=wasm go build -o ../bin/pulumi-display.wasm -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ./backend/display/wasm
 
 .PHONY: build
-# Before anything else
-_ := $(shell mkdir -p bin)
-# ...
 build:: export GOBIN=$(shell realpath ./bin)
 build:: build_proto .make/ensure/go dist build_display_wasm
 

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,10 @@ build_display_wasm:: .make/ensure/go
 	cd pkg && GOOS=js GOARCH=wasm go build -o ../bin/pulumi-display.wasm -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ./backend/display/wasm
 
 .PHONY: build
-build:: export GOBIN=$(shell mkdir -p ./bin; realpath ./bin)
+# Before anything else
+_ := $(shell mkdir -p bin)
+# ...
+build:: export GOBIN=$(shell realpath ./bin)
 build:: build_proto .make/ensure/go dist build_display_wasm
 
 install:: bin/pulumi


### PR DESCRIPTION
Realpath returns "" on macos for non-existent files, which then causes all our binaries to build to ~/go/bin instead of ./bin. Fix it by just making sure the folder exists with a mkdir first.