### PR TITLE
Make color of Copilot summarize-error output more readable

### DIFF
--- a/changelog/pending/20250523--cli-display--fix-color-of-copilot-summarize-error-so-its-more-readable-on-light-terminals.yaml
+++ b/changelog/pending/20250523--cli-display--fix-color-of-copilot-summarize-error-so-its-more-readable-on-light-terminals.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Fix color of Copilot summarize-error so its more readable on light terminals

--- a/pkg/backend/display/ai.go
+++ b/pkg/backend/display/ai.go
@@ -70,7 +70,7 @@ func RenderCopilotErrorSummary(summary *CopilotErrorSummaryMetadata, err error, 
 
 	summaryLines := strings.Split(summary.Summary, "\n")
 	for _, line := range summaryLines {
-		fmt.Fprintln(out, "  "+opts.Color.Colorize(colors.BrightGreen+line+colors.Reset))
+		fmt.Fprintln(out, "  "+opts.Color.Colorize(colors.Green+line+colors.Reset))
 	}
 
 	fmt.Fprintln(out)

--- a/pkg/backend/display/ai.go
+++ b/pkg/backend/display/ai.go
@@ -70,7 +70,7 @@ func RenderCopilotErrorSummary(summary *CopilotErrorSummaryMetadata, err error, 
 
 	summaryLines := strings.Split(summary.Summary, "\n")
 	for _, line := range summaryLines {
-		fmt.Fprintln(out, "  "+opts.Color.Colorize(colors.Green+line+colors.Reset))
+		fmt.Fprintln(out, "  "+line)
 	}
 
 	fmt.Fprintln(out)


### PR DESCRIPTION
Fixes #19641 

- BrightGreen + light background in terminal is not great
- The point of the color was to draw the eye to the short summary. Once that is "loaded" you can more quickly scan the diagnostics section if needed.
- Does the ✨ alone bring enough attention?

Below are 3 variations on the existing colors:
1. Soften the green to make it more readable on light terminals
2. Remove the color
3. Remove the color and shift the ✨ 

## Decision

Here, after below discussion, we select variant 2.

## Variation: (non-bright) Green

<img width="800" alt="Screenshot 2025-05-23 at 14 50 39" src="https://github.com/user-attachments/assets/23dfb4cd-0644-4613-b19c-b78c3dbd6304" />

<img width="800" alt="Screenshot 2025-05-23 at 14 50 06" src="https://github.com/user-attachments/assets/468fb30c-f479-478c-a909-0c1d8d296275" />

## Variation: No color

<img width="800" alt="Screenshot 2025-05-23 at 14 51 02" src="https://github.com/user-attachments/assets/55f11649-897b-401e-a1d6-2544a0d0b644" />

<img width="800" alt="Screenshot 2025-05-23 at 14 49 50" src="https://github.com/user-attachments/assets/cb096638-916e-4931-bc03-6315c3709bba" />

## Variation: move the ✨ to the next line

<img width="800" alt="Screenshot 2025-05-23 at 15 25 47" src="https://github.com/user-attachments/assets/c8744cfe-30c6-4c20-ac08-42aef3ea2a59" />

<img width="800" alt="Screenshot 2025-05-23 at 15 26 20" src="https://github.com/user-attachments/assets/56ced797-c174-46e6-a0f7-6dd32a1f0cec" />


