### PR TITLE
Copy some of the policy tests from pulumi-policy

### DIFF
--- a/tests/policy/integration_test.go
+++ b/tests/policy/integration_test.go
@@ -1,0 +1,274 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+type Runtime int
+
+const (
+	NodeJS Runtime = iota
+	Python
+)
+
+type PolicyConfig map[string]interface{}
+
+// policyTestScenario describes an iteration of the
+type policyTestScenario struct {
+	// WantErrors is the error message we expect to see in the command's output.
+	WantErrors []string
+	// Whether the error messages are advisory, and don't actually fail the operation.
+	Advisory bool
+	// The Policy Pack configuration to use for the test scenario.
+	PolicyPackConfig map[string]PolicyConfig
+}
+
+// runPolicyPackIntegrationTest creates a new Pulumi stack and then runs through
+// a sequence of test scenarios where a configuration value is set and then
+// the stack is updated or previewed, confirming the expected result.
+func runPolicyPackIntegrationTest(
+	t *testing.T, testDirName string,
+	initialConfig map[string]string, scenarios []policyTestScenario,
+) {
+	t.Logf("Running Policy Pack Integration Test from directory %q", testDirName)
+
+	// Get the directory for the policy pack to run.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Error getting working directory")
+	}
+	rootDir := filepath.Join(cwd, testDirName)
+
+	// The Pulumi project name matches the test dir name in these tests.
+	t.Setenv("PULUMI_TEST_PROJECT", testDirName)
+
+	// Copy the root directory to /tmp and run various operations within that directory.
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+	e.ImportDirectory(rootDir)
+
+	// Change to the Policy Pack directory.
+	packDirs := []string{filepath.Join(e.RootPath, "policy-pack"), filepath.Join(e.RootPath, "policy-pack-python")}
+
+	for _, packDir := range packDirs {
+		e.CWD = packDir
+
+		// Get dependencies.
+		e.RunCommand("pulumi", "install")
+
+		// Change to the Pulumi program directory.
+		programDir := filepath.Join(e.RootPath, "program")
+		e.CWD = programDir
+
+		stackName := fmt.Sprintf("%s-%s", testDirName, ptesting.RandomStackName())
+		t.Setenv("PULUMI_TEST_STACK", stackName)
+
+		// Create the stack.
+		e.RunCommand("pulumi", "login", "--local")
+		e.RunCommand("pulumi", "stack", "init", stackName)
+		e.RunCommand("pulumi", "install")
+
+		// Initial configuration.
+		for k, v := range initialConfig {
+			e.RunCommand("pulumi", "config", "set", k, v)
+		}
+
+		// After this point, we want be sure to cleanup the stack, so we don't accidentally leak
+		// any cloud resources.
+		defer func() {
+			t.Log("Cleaning up Stack")
+			e.RunCommand("pulumi", "destroy", "--yes")
+			e.RunCommand("pulumi", "stack", "rm", "--yes")
+		}()
+
+		assert.True(t, len(scenarios) > 0, "no test scenarios provided")
+		runScenarios := func(policyPackDirectoryPath string) {
+			t.Run(policyPackDirectoryPath, func(t *testing.T) {
+				e.T = t
+
+				// Clean up the stack after running through the scenarios, so that subsequent runs
+				// begin on a clean slate.
+				defer func() {
+					e.RunCommand("pulumi", "destroy", "--yes")
+				}()
+
+				for idx, scenario := range scenarios {
+					// Create a sub-test so go test will output data incrementally, which will let
+					// a CI system like Travis know not to kill the job if no output is sent after 10m.
+					// idx+1 to make it 1-indexed.
+					scenarioName := fmt.Sprintf("scenario_%d", idx+1)
+					t.Run(scenarioName, func(t *testing.T) {
+						e.T = t
+
+						e.RunCommand("pulumi", "config", "set", "scenario", strconv.Itoa(idx+1))
+
+						cmd := "pulumi"
+						args := []string{"up", "--yes", "--policy-pack", policyPackDirectoryPath}
+
+						// If there is config for the scenario, write it out to a file and pass the file path
+						// as a --policy-pack-config argument.
+						if len(scenario.PolicyPackConfig) > 0 {
+							// Marshal the config to JSON, with indentation for easier debugging.
+							bytes, err := json.MarshalIndent(scenario.PolicyPackConfig, "", "    ")
+							if err != nil {
+								t.Fatalf("error marshalling policy config to JSON: %v", err)
+							}
+
+							// Change to the config directory.
+							configDir := filepath.Join(e.RootPath, "config", scenarioName)
+							e.CWD = configDir
+
+							// Write the JSON to a file.
+							filename := "policy-config.json"
+							e.WriteTestFile(filename, string(bytes))
+
+							// Add the policy config argument.
+							policyConfigFile := filepath.Join(configDir, filename)
+							args = append(args, "--policy-pack-config", policyConfigFile)
+
+							// Change back to the program directory to proceed with the update.
+							e.CWD = programDir
+						}
+
+						if len(scenario.WantErrors) == 0 {
+							t.Log("No errors are expected.")
+							e.RunCommand(cmd, args...)
+						} else {
+							var stdout, stderr string
+							if scenario.Advisory {
+								stdout, stderr = e.RunCommand(cmd, args...)
+							} else {
+								stdout, stderr = e.RunCommandExpectError(cmd, args...)
+							}
+
+							for _, wantErr := range scenario.WantErrors {
+								inSTDOUT := strings.Contains(stdout, wantErr)
+								inSTDERR := strings.Contains(stderr, wantErr)
+
+								if !inSTDOUT && !inSTDERR {
+									t.Errorf("Did not find expected error %q", wantErr)
+								}
+							}
+
+							if t.Failed() {
+								t.Logf("Command output:\nSTDOUT:\n%v\n\nSTDERR:\n%v\n\n", stdout, stderr)
+							}
+						}
+					})
+				}
+			})
+		}
+		runScenarios(packDir)
+
+		e.T = t
+		t.Log("Finished test scenarios.")
+		// Cleanup already registered via defer.
+	}
+}
+
+// Test basic resource validation.
+//
+//nolint:paralleltest // Not designed to be run in parallel.
+func TestValidateResource(t *testing.T) {
+	runPolicyPackIntegrationTest(t, "validate_resource", nil, []policyTestScenario{
+		// Test scenario 1: no resources.
+		{
+			WantErrors: nil,
+		},
+		// Test scenario 2: no violations.
+		{
+			WantErrors: nil,
+		},
+		// Test scenario 3: violates the first policy.
+		{
+			WantErrors: []string{
+				"validate-resource-test-policy@v0.0.1 ",
+				"[mandatory]  dynamic-no-state-with-value-1  (pulumi-nodejs:dynamic:Resource: a)",
+				"Prohibits setting state to 1 on dynamic resources.",
+				"'state' must not have the value 1.",
+			},
+		},
+		// Test scenario 4: violates the second policy.
+		{
+			WantErrors: []string{
+				"validate-resource-test-policy@v0.0.1 ",
+				"[mandatory]  dynamic-no-state-with-value-2  (pulumi-nodejs:dynamic:Resource: b)",
+				"Prohibits setting state to 2 on dynamic resources.",
+				"'state' must not have the value 2.",
+			},
+		},
+		// Test scenario 5: violates the first validation function of the third policy.
+		{
+			WantErrors: []string{
+				"validate-resource-test-policy@v0.0.1 ",
+				"[mandatory]  dynamic-no-state-with-value-3-or-4  (pulumi-nodejs:dynamic:Resource: c)",
+				"Prohibits setting state to 3 or 4 on dynamic resources.",
+				"'state' must not have the value 3.",
+			},
+		},
+		// Test scenario 6: violates the second validation function of the third policy.
+		{
+			WantErrors: []string{
+				"validate-resource-test-policy@v0.0.1 ",
+				"[mandatory]  dynamic-no-state-with-value-3-or-4  (pulumi-nodejs:dynamic:Resource: d)",
+				"Prohibits setting state to 3 or 4 on dynamic resources.",
+				"'state' must not have the value 4.",
+			},
+		},
+		// Test scenario 7: violates the fourth policy.
+		{
+			WantErrors: []string{
+				"validate-resource-test-policy@v0.0.1 ",
+				"[mandatory]  randomuuid-no-keepers  (random:index/randomUuid:RandomUuid: r1)",
+				"Prohibits creating a RandomUuid without any 'keepers'.",
+				"RandomUuid must not have an empty 'keepers'.",
+			},
+		},
+		// Test scenario 8: no violations.
+		{
+			WantErrors: nil,
+		},
+		// Test scenario 9: violates the fifth policy.
+		{
+			WantErrors: []string{
+				"validate-resource-test-policy@v0.0.1 ",
+				"[mandatory]  dynamic-no-state-with-value-5  (pulumi-nodejs:dynamic:Resource: e)",
+				"Prohibits setting state to 5 on dynamic resources.",
+				"'state' must not have the value 5.",
+			},
+		},
+		// Test scenario 10: no violations.
+		{
+			WantErrors: nil,
+		},
+		// Test scenario 11: no violations.
+		// Test the ability to send large gRPC messages (>4mb).
+		// Issue: https://github.com/pulumi/pulumi/issues/4155
+		{
+			WantErrors: nil,
+		},
+	})
+}

--- a/tests/policy/main_test.go
+++ b/tests/policy/main_test.go
@@ -1,0 +1,29 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"os"
+	"testing"
+
+	"github.com/pulumi/pulumi/tests/testutil"
+)
+
+func TestMain(m *testing.M) {
+	testutil.SetupPulumiBinary()
+
+	code := m.Run()
+	os.Exit(code)
+}

--- a/tests/policy/validate_resource/policy-pack-python/PulumiPolicy.yaml
+++ b/tests/policy/validate_resource/policy-pack-python/PulumiPolicy.yaml
@@ -1,0 +1,1 @@
+runtime: python

--- a/tests/policy/validate_resource/policy-pack-python/__main__.py
+++ b/tests/policy/validate_resource/policy-pack-python/__main__.py
@@ -1,0 +1,91 @@
+# Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+from pulumi_policy import (
+    EnforcementLevel,
+    PolicyPack,
+    ReportViolation,
+    ResourceValidationArgs,
+    ResourceValidationPolicy,
+)
+
+def dynamic_no_state_with_value_1(args: ResourceValidationArgs, report_violation: ReportViolation):
+    if args.resource_type == "pulumi-nodejs:dynamic:Resource":
+        if "state" in args.props and args.props["state"] == 1:
+            report_violation("'state' must not have the value 1.")
+
+def dynamic_no_state_with_value_2(args: ResourceValidationArgs, report_violation: ReportViolation):
+    if args.resource_type == "pulumi-nodejs:dynamic:Resource":
+        if "state" in args.props and args.props["state"] == 2:
+            report_violation("'state' must not have the value 2.")
+
+def dynamic_no_state_with_value_3(args: ResourceValidationArgs, report_violation: ReportViolation):
+    if args.resource_type == "pulumi-nodejs:dynamic:Resource":
+        if "state" in args.props and args.props["state"] == 3:
+            report_violation("'state' must not have the value 3.")
+
+def dynamic_no_state_with_value_4(args: ResourceValidationArgs, report_violation: ReportViolation):
+    if args.resource_type == "pulumi-nodejs:dynamic:Resource":
+        if "state" in args.props and args.props["state"] == 4:
+            report_violation("'state' must not have the value 4.")
+
+# Note: In the NodeJS Policy Pack, this is a strongly-typed policy, but since Python
+# does not yet support filtering by type, this is checking the type directly.
+def randomuuid_no_keepers(args: ResourceValidationArgs, report_violation: ReportViolation):
+    if args.resource_type == "random:index/randomUuid:RandomUuid":
+        if "keepers" not in args.props or not args.props["keepers"]:
+            report_violation("RandomUuid must not have an empty 'keepers'.")
+
+def dynamic_no_state_with_value_5(args: ResourceValidationArgs, report_violation: ReportViolation):
+    if args.resource_type == "pulumi-nodejs:dynamic:Resource":
+        if "state" in args.props and args.props["state"] == 5:
+            report_violation("'state' must not have the value 5.", "some-urn")
+
+def large_resource(args: ResourceValidationArgs, report_violation: ReportViolation):
+    if args.resource_type == "pulumi-nodejs:dynamic:Resource":
+        if "state" in args.props and args.props["state"] == 6:
+            long_string = "a" * 5 * 1024 * 1024
+            expected = len(long_string)
+            result = len(args.props["longString"])
+            if result != expected:
+                report_violation(f"'longString' had expected length of {expected}, got {result}")
+
+
+PolicyPack(
+    name="validate-resource-test-policy",
+    enforcement_level=EnforcementLevel.MANDATORY,
+    policies=[
+        ResourceValidationPolicy(
+            name="dynamic-no-state-with-value-1",
+            description="Prohibits setting state to 1 on dynamic resources.",
+            validate=dynamic_no_state_with_value_1,
+        ),
+        ResourceValidationPolicy(
+            name="dynamic-no-state-with-value-2",
+            description="Prohibits setting state to 2 on dynamic resources.",
+            validate=dynamic_no_state_with_value_2,
+        ),
+        ResourceValidationPolicy(
+            name="dynamic-no-state-with-value-3-or-4",
+            description="Prohibits setting state to 3 or 4 on dynamic resources.",
+            validate=[
+                dynamic_no_state_with_value_3,
+                dynamic_no_state_with_value_4,
+            ],
+        ),
+        ResourceValidationPolicy(
+            name="randomuuid-no-keepers",
+            description="Prohibits creating a RandomUuid without any 'keepers'.",
+            validate=randomuuid_no_keepers,
+        ),
+        ResourceValidationPolicy(
+            name="dynamic-no-state-with-value-5",
+            description="Prohibits setting state to 5 on dynamic resources.",
+            validate=dynamic_no_state_with_value_5,
+        ),
+        ResourceValidationPolicy(
+            name="large-resource",
+            description="Ensures that large string properties are set properly.",
+            validate=large_resource,
+        )
+    ],
+)

--- a/tests/policy/validate_resource/policy-pack/PulumiPolicy.yaml
+++ b/tests/policy/validate_resource/policy-pack/PulumiPolicy.yaml
@@ -1,0 +1,2 @@
+description: A Policy Pack for validating test resources.
+runtime: nodejs

--- a/tests/policy/validate_resource/policy-pack/index.ts
+++ b/tests/policy/validate_resource/policy-pack/index.ts
@@ -1,0 +1,119 @@
+// Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
+
+import { PolicyPack, validateResourceOfType } from "@pulumi/policy";
+import * as random from "@pulumi/random";
+
+new PolicyPack("validate-resource-test-policy", {
+    policies: [
+        {
+            name: "dynamic-no-state-with-value-1",
+            description: "Prohibits setting state to 1 on dynamic resources.",
+            enforcementLevel: "mandatory",
+            validateResource: (args, reportViolation) => {
+                if (args.type === "pulumi-nodejs:dynamic:Resource") {
+                    if (args.props.state === 1) {
+                        reportViolation("'state' must not have the value 1.")
+                    }
+                }
+            },
+        },
+        // More than one policy.
+        {
+            name: "dynamic-no-state-with-value-2",
+            description: "Prohibits setting state to 2 on dynamic resources.",
+            enforcementLevel: "mandatory",
+            validateResource: (args, reportViolation) => {
+                if (args.type === "pulumi-nodejs:dynamic:Resource") {
+                    if (args.props.state === 2) {
+                        reportViolation("'state' must not have the value 2.")
+                    }
+                }
+            },
+        },
+        // Multiple validateResource callbacks.
+        {
+            name: "dynamic-no-state-with-value-3-or-4",
+            description: "Prohibits setting state to 3 or 4 on dynamic resources.",
+            enforcementLevel: "mandatory",
+            validateResource: [
+                (args, reportViolation) => {
+                    if (args.type === "pulumi-nodejs:dynamic:Resource") {
+                        if (args.props.state === 3) {
+                            reportViolation("'state' must not have the value 3.")
+                        }
+                    }
+                },
+                (args, reportViolation) => {
+                    if (args.type === "pulumi-nodejs:dynamic:Resource") {
+                        if (args.props.state === 4) {
+                            reportViolation("'state' must not have the value 4.")
+                        }
+                    }
+                },
+            ],
+        },
+        // Strongly-typed.
+        {
+            name: "randomuuid-no-keepers",
+            description: "Prohibits creating a RandomUuid without any 'keepers'.",
+            enforcementLevel: "mandatory",
+            validateResource: validateResourceOfType(random.RandomUuid, (it, args, reportViolation) => {
+                if (!it.keepers || Object.keys(it.keepers).length === 0) {
+                    reportViolation("RandomUuid must not have an empty 'keepers'.")
+                }
+            }),
+        },
+        // Specifying a URN explicitly has no affect for validateResource.
+        {
+            name: "dynamic-no-state-with-value-5",
+            description: "Prohibits setting state to 5 on dynamic resources.",
+            enforcementLevel: "mandatory",
+            validateResource: (args, reportViolation) => {
+                if (args.type === "pulumi-nodejs:dynamic:Resource") {
+                    if (args.props.state === 5) {
+                        reportViolation("'state' must not have the value 5.", "some-urn")
+                    }
+                }
+            },
+        },
+        // Validate other type checks work as expected.
+        {
+            name: "test-type-checks",
+            description: "Policy used to test type checks.",
+            enforcementLevel: "mandatory",
+            validateResource: (args, reportViolation) => {
+                if (args.type !== "random:index/randomPassword:RandomPassword") {
+                    return;
+                }
+                if (!args.isType(random.RandomPassword)) {
+                    throw new Error("`isType` did not return the expected value.");
+                }
+                const randomPassword = args.asType(random.RandomPassword);
+                if (!randomPassword) {
+                    throw new Error("`asType` did not return the expected value.");
+                }
+                if (randomPassword.length !== 42) {
+                    throw new Error("`randomPassword.length` did not return the expected value.");
+                }
+            },
+        },
+        // Ensure that the resource can contain large strings.
+        {
+            name: "large-resource",
+            description: "Ensures that large string properties are set properly.",
+            enforcementLevel: "mandatory",
+            validateResource: (args) => {
+                if (args.type === "pulumi-nodejs:dynamic:Resource") {
+                    if (args.props.state === 6) {
+                        const longString = "a".repeat(5 * 1024 * 1024);
+                        const expected = longString.length;
+                        const result = args.props.longString.length;
+                        if (result !== expected) {
+                            throw new Error(`'longString' had expected length of ${expected}, got ${result}`);
+                        }
+                    }
+                }
+            },
+        }
+    ],
+});

--- a/tests/policy/validate_resource/policy-pack/package.json
+++ b/tests/policy/validate_resource/policy-pack/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "aws-typescript",
+    "version": "0.0.1",
+    "dependencies": {
+        "@pulumi/policy": "latest",
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/random": "^4.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    }
+}

--- a/tests/policy/validate_resource/policy-pack/tsconfig.json
+++ b/tests/policy/validate_resource/policy-pack/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": false,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true,
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/policy/validate_resource/program/Pulumi.yaml
+++ b/tests/policy/validate_resource/program/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: validate_resource
+runtime: nodejs
+description: A program that creates some dynamic resources for testing.

--- a/tests/policy/validate_resource/program/index.ts
+++ b/tests/policy/validate_resource/program/index.ts
@@ -1,0 +1,70 @@
+// Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+import { Resource } from "./resource";
+
+const config = new pulumi.Config();
+const testScenario = config.requireNumber("scenario");
+
+switch (testScenario) {
+    case 1:
+        // Don't create any resources.
+        break;
+
+    case 2:
+        // Create a resource that doesn't violate any policies.
+        const hello = new Resource("hello", { hello: "world" });
+        break;
+
+    case 3:
+        // Violates the first policy.
+        const a = new Resource("a", { state: 1 });
+        break;
+
+    case 4:
+        // Violates the second policy.
+        const b = new Resource("b", { state: 2 });
+        break;
+
+    case 5:
+        // Violates the first validation function of the third policy.
+        const c = new Resource("c", { state: 3 });
+        break;
+
+    case 6:
+        // Violates the second validation function of the third policy.
+        const d = new Resource("d", { state: 4 });
+        break;
+
+    case 7:
+        // Violates the fourth policy.
+        const r1 = new random.RandomUuid("r1");
+        break;
+
+    case 8:
+        // Doesn't violate the fourth policy.
+        const r2 = new random.RandomUuid("r2", {
+            keepers: {
+                foo: "bar",
+            },
+        });
+        break;
+
+    case 9:
+        // Violates the fifth policy.
+        const e = new Resource("e", { state: 5 });
+        break;
+
+    case 10:
+        // Create a resource to test the strongly-typed helpers.
+        const pass = new random.RandomPassword("pass", {
+            length: 42,
+        });
+        break;
+
+    case 11:
+        // Create a resource with a large string property. This passes as specified.
+        const longString = "a".repeat(5 * 1024 * 1024);
+        const largeStringResource = new Resource("large-resource", { state: 6, longString })
+}

--- a/tests/policy/validate_resource/program/package.json
+++ b/tests/policy/validate_resource/program/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "typescript",
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^2.1.0",
+        "@pulumi/random": "^4.0.0"
+    }
+}

--- a/tests/policy/validate_resource/program/resource.ts
+++ b/tests/policy/validate_resource/program/resource.ts
@@ -1,0 +1,26 @@
+// Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+let currentID = 0;
+
+export class Provider implements pulumi.dynamic.ResourceProvider {
+    public static readonly instance = new Provider();
+
+    public async create(inputs: any) {
+        return {
+            id: (currentID++).toString(),
+            outs: undefined,
+        };
+    }
+}
+
+export class Resource extends pulumi.dynamic.Resource {
+    public isInstance(o: any): o is Resource {
+        return o.__pulumiType === "pulumi-nodejs:dynamic:Resource";
+    }
+
+    constructor(name: string, props: pulumi.Inputs, opts?: pulumi.ResourceOptions) {
+        super(Provider.instance, name, props, opts);
+    }
+}

--- a/tests/policy/validate_resource/program/tsconfig.json
+++ b/tests/policy/validate_resource/program/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts",
+        "resource.ts"
+    ]
+}

--- a/tests/policy_new/main_test.go
+++ b/tests/policy_new/main_test.go
@@ -1,0 +1,29 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/pulumi/pulumi/tests/testutil"
+)
+
+func TestMain(m *testing.M) {
+	testutil.SetupPulumiBinary()
+
+	code := m.Run()
+	os.Exit(code)
+}


### PR DESCRIPTION
This copies some of the tests from the pulumi policy repo to this repo. This is just enough to sanity check that policy is working given changes made in pu/pu. We'll mostly cover policy tests via the conformance system, but that isn't in yet.