### PR TITLE
Revert "Add `on_error` callbacks to the Python Automation API operations"

### DIFF
--- a/changelog/pending/20250527--auto-python--revert-add-on_error-callback-for-capturing-incremental-stderr-output.yaml
+++ b/changelog/pending/20250527--auto-python--revert-add-on_error-callback-for-capturing-incremental-stderr-output.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/python
+  description: "Revert: Add `on_error` callback for capturing incremental stderr output, which used a library not compatible with Windows"

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -636,16 +636,13 @@ class LocalWorkspace(Workspace):
         return "--remote-inherit-settings" in help_string
 
     def _run_pulumi_cmd_sync(
-        self,
-        args: List[str],
-        on_output: Optional[OnOutput] = None,
-        on_error: Optional[OnOutput] = None,
+        self, args: List[str], on_output: Optional[OnOutput] = None
     ) -> CommandResult:
         envs = {"PULUMI_HOME": self.pulumi_home} if self.pulumi_home else {}
         if self._remote:
             envs["PULUMI_EXPERIMENTAL"] = "true"
         envs = {**envs, **self.env_vars}
-        return self.pulumi_command.run(args, self.work_dir, envs, on_output, on_error)
+        return self.pulumi_command.run(args, self.work_dir, envs, on_output)
 
     def _remote_args(self) -> List[str]:
         args: List[str] = []

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -278,7 +278,6 @@ class Stack:
         replace: Optional[List[str]] = None,
         color: Optional[str] = None,
         on_output: Optional[OnOutput] = None,
-        on_error: Optional[OnOutput] = None,
         on_event: Optional[OnEvent] = None,
         program: Optional[PulumiFn] = None,
         plan: Optional[str] = None,
@@ -312,7 +311,6 @@ class Stack:
         :param exclude_dependents: Allows ignoring of dependent targets discovered but not specified in the Exclude list.
         :param replace: Specify resources to replace.
         :param on_output: A function to process the stdout stream.
-        :param on_error: A function to process the stderr stream.
         :param on_event: A function to process structured events from the Pulumi event stream.
         :param program: The inline program.
         :param color: Colorize output. Choices are: always, never, raw, auto (default "auto")
@@ -381,7 +379,7 @@ class Stack:
             log_watcher_thread.start()
 
         try:
-            up_result = self._run_pulumi_cmd_sync(args, on_output, on_error)
+            up_result = self._run_pulumi_cmd_sync(args, on_output)
             outputs = self.outputs()
             # If it's a remote workspace, explicitly set show_secrets to False to prevent attempting to
             # load the project file.
@@ -412,7 +410,6 @@ class Stack:
         replace: Optional[List[str]] = None,
         color: Optional[str] = None,
         on_output: Optional[OnOutput] = None,
-        on_error: Optional[OnOutput] = None,
         on_event: Optional[OnEvent] = None,
         program: Optional[PulumiFn] = None,
         plan: Optional[str] = None,
@@ -445,7 +442,6 @@ class Stack:
         :param exclude_dependents: Allows ignoring of dependent targets discovered but not specified in the Exclude list.
         :param replace: Specify resources to replace.
         :param on_output: A function to process the stdout stream.
-        :param on_error: A function to process the stderr stream.
         :param on_event: A function to process structured events from the Pulumi event stream.
         :param program: The inline program.
         :param color: Colorize output. Choices are: always, never, raw, auto (default "auto")
@@ -521,7 +517,7 @@ class Stack:
         log_watcher_thread.start()
 
         try:
-            preview_result = self._run_pulumi_cmd_sync(args, on_output, on_error)
+            preview_result = self._run_pulumi_cmd_sync(args, on_output)
         finally:
             _cleanup(temp_dir, log_watcher_thread, stop_event, on_exit)
 
@@ -547,7 +543,6 @@ class Stack:
         clear_pending_creates: Optional[bool] = None,
         color: Optional[str] = None,
         on_output: Optional[OnOutput] = None,
-        on_error: Optional[OnOutput] = None,
         on_event: Optional[OnEvent] = None,
         show_secrets: bool = True,
         log_flow: Optional[bool] = None,
@@ -575,7 +570,6 @@ class Stack:
         :param expect_no_changes: Return an error if any changes occur during this update.
         :param clear_pending_creates: Clear all pending creates, dropping them from the state.
         :param on_output: A function to process the stdout stream.
-        :param on_error: A function to process the stderr stream.
         :param on_event: A function to process structured events from the Pulumi event stream.
         :param color: Colorize output. Choices are: always, never, raw, auto (default "auto")
         :param show_secrets: Include config secrets in the RefreshResult summary.
@@ -624,7 +618,7 @@ class Stack:
             log_watcher_thread.start()
 
         try:
-            refresh_result = self._run_pulumi_cmd_sync(args, on_output, on_error)
+            refresh_result = self._run_pulumi_cmd_sync(args, on_output)
         finally:
             _cleanup(temp_dir, log_watcher_thread, stop_event)
 
@@ -640,7 +634,6 @@ class Stack:
         self,
         stack_name: str,
         on_output: Optional[OnOutput] = None,
-        on_error: Optional[OnOutput] = None,
         show_secrets: bool = False,
     ) -> RenameResult:
         """
@@ -648,7 +641,6 @@ class Stack:
 
         :param stack_name: The new name for the stack.
         :param on_output: A function to process the stdout stream.
-        :param on_error: A function to process the stderr stream.
         :param show_secrets: Include config secrets in the RefreshResult summary.
         :returns: RenameResult
         """
@@ -657,7 +649,7 @@ class Stack:
         args.extend(extra_args)
 
         args.extend(self._remote_args())
-        rename_result = self._run_pulumi_cmd_sync(args, on_output, on_error)
+        rename_result = self._run_pulumi_cmd_sync(args, on_output)
 
         if self._remote and show_secrets:
             raise RuntimeError("can't enable `showSecrets` for remote workspaces")
@@ -676,7 +668,6 @@ class Stack:
         target_dependents: Optional[bool] = None,
         color: Optional[str] = None,
         on_output: Optional[OnOutput] = None,
-        on_error: Optional[OnOutput] = None,
         on_event: Optional[OnEvent] = None,
         show_secrets: bool = True,
         log_flow: Optional[bool] = None,
@@ -703,7 +694,6 @@ class Stack:
         :param target: Specify an exclusive list of resource URNs to destroy.
         :param target_dependents: Allows updating of dependent targets discovered but not specified in the Target list.
         :param on_output: A function to process the stdout stream.
-        :param on_error: A function to process the stderr stream.
         :param on_event: A function to process structured events from the Pulumi event stream.
         :param color: Colorize output. Choices are: always, never, raw, auto (default "auto")
         :param show_secrets: Include config secrets in the DestroyResult summary.
@@ -756,7 +746,7 @@ class Stack:
             log_watcher_thread.start()
 
         try:
-            destroy_result = self._run_pulumi_cmd_sync(args, on_output, on_error)
+            destroy_result = self._run_pulumi_cmd_sync(args, on_output)
         finally:
             _cleanup(temp_dir, log_watcher_thread, stop_event)
 
@@ -786,7 +776,6 @@ class Stack:
         converter: Optional[str] = None,
         converter_args: Optional[List[str]] = None,
         on_output: Optional[OnOutput] = None,
-        on_error: Optional[OnOutput] = None,
         show_secrets: bool = True,
     ) -> ImportResult:
         """
@@ -805,7 +794,6 @@ class Stack:
         :param converter: The converter plugin to use for the import operation
         :param converter_args: Additional arguments to pass to the converter plugin
         :param on_output: A function to process the stdout stream.
-        :param on_error: A function to process the stderr stream.
         :param show_secrets: Include config secrets in the ImportResult summary.
         """
         args = ["import", "--yes", "--skip-preview"]
@@ -836,7 +824,7 @@ class Stack:
                     args.append("--")
                     args.extend(converter_args)
 
-            import_result = self._run_pulumi_cmd_sync(args, on_output, on_error)
+            import_result = self._run_pulumi_cmd_sync(args, on_output)
             summary = self.info(show_secrets and not self._remote)
             generated_code = ""
             if generate_code is not False:
@@ -1070,10 +1058,7 @@ class Stack:
         return self.workspace.import_stack(self.name, state)
 
     def _run_pulumi_cmd_sync(
-        self,
-        args: List[str],
-        on_output: Optional[OnOutput] = None,
-        on_error: Optional[OnOutput] = None,
+        self, args: List[str], on_output: Optional[OnOutput] = None
     ) -> CommandResult:
         envs = {"PULUMI_DEBUG_COMMANDS": "true"}
         if self._remote:
@@ -1086,7 +1071,7 @@ class Stack:
         args.extend(additional_args)
         args.extend(["--stack", self.name])
         result = self.workspace.pulumi_command.run(
-            args, self.workspace.work_dir, envs, on_output, on_error
+            args, self.workspace.work_dir, envs, on_output
         )
         self.workspace.post_command_callback(self.name)
         return result

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -803,69 +803,6 @@ class TestLocalWorkspace(unittest.TestCase):
         finally:
             stack.workspace.remove_stack(stack_name)
 
-    def test_on_error(self):
-        project_name = "inline_python"
-        stack_name = stack_namer(project_name)
-        stack = create_stack(
-            stack_name, program=pulumi_program, project_name=project_name
-        )
-
-        try:
-            error = ""
-
-            def logger(e):
-                nonlocal error
-                error += e
-
-            try:
-                stack.up(color="vibrant grey", on_error=logger)
-            except:
-                self.assertNotEqual(error, "")
-
-            self.assertIn("error: unsupported color", error)
-            error = ""
-
-            up_res = stack.up()
-            self.assertEqual(up_res.summary.kind, "update")
-            self.assertEqual(up_res.summary.result, "succeeded")
-
-            # pulumi preview
-            try:
-                stack.preview(color="plum yellow", on_error=logger)
-            except:
-                self.assertNotEqual(error, "")
-
-            self.assertIn("error: unsupported color", error)
-            error = ""
-
-            # pulumi refresh
-            try:
-                stack.refresh(color="inquisitive heliotrope", on_error=logger)
-            except:
-                self.assertNotEqual(error, "")
-
-            self.assertIn("error: unsupported color", error)
-            error = ""
-
-            refresh_res = stack.refresh()
-            self.assertEqual(refresh_res.summary.kind, "refresh")
-            self.assertEqual(refresh_res.summary.result, "succeeded")
-
-            # pulumi destroy
-            try:
-                stack.refresh(color="violent orange", on_error=logger)
-            except:
-                self.assertNotEqual(error, "")
-
-            self.assertIn("error: unsupported color", error)
-            error = ""
-
-            destroy_res = stack.destroy()
-            self.assertEqual(destroy_res.summary.kind, "destroy")
-            self.assertEqual(destroy_res.summary.result, "succeeded")
-        finally:
-            stack.workspace.remove_stack(stack_name)
-
     def test_preview_refresh(self):
         project_name = "inline_python"
         stack_name = stack_namer(project_name)


### PR DESCRIPTION
Reverts pulumi/pulumi#19541.

`select` isn't Windows-friendly. We have a feeling that replacing `select` with `selectors` might be all that is required to fix this, but we're not certain. So, we're going to revert this change, fix CI to run the tests against Windows, and then we'll know for sure.