### PR TITLE
retry downloads form upstream in `make ensure`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,9 @@ LIFECYCLE_TEST_FUZZ_CHECKS ?= 1000
 
 ensure: .make/ensure/go .make/ensure/phony $(SUB_PROJECTS:%=%_ensure)
 .make/ensure/phony: sdk/go.mod pkg/go.mod tests/go.mod
-	cd sdk && go mod download
-	cd pkg && go mod download
-	cd tests && go mod download
+	cd sdk && ../scripts/retry go mod download
+	cd pkg && ../scripts/retry go mod download
+	cd tests && ../scripts/retry go mod download
 	@mkdir -p .make/ensure && touch .make/ensure/phony
 
 .PHONY: build-proto build_proto

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,9 +4,9 @@ VENV = venv
 
 ensure-python:: .ensure-python.phony
 .ensure-python.phony: requirements.txt
-	python -m $(VENV) $(VENV)
-	. $(VENV)/*/activate && python -m pip install --upgrade pip setuptools wheel
-	. $(VENV)/*/activate && python -m pip install -r requirements.txt
+	../scripts/retry python -m $(VENV) $(VENV)
+	. $(VENV)/*/activate && ../scripts/retry python -m pip install --upgrade pip setuptools wheel
+	. $(VENV)/*/activate && ../scripts/retry python -m pip install -r requirements.txt
 	@touch .ensure-python.phony
 
 ensure-proto:: .ensure-proto.phony

--- a/scripts/retry
+++ b/scripts/retry
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -eo pipefail
 
 # This script implements a general retry mechanism for a command. On each iteration, parallelism
 # flags are halved and the command is retried.
@@ -40,8 +40,10 @@ run_tests() {
 
 run_tests "${@}"
 
-echo "TEST_SUCCESS=${success}" >> "$GITHUB_OUTPUT"
-echo "TEST_RETRIED=${retried}" >> "$GITHUB_OUTPUT"
+if [[ -n $GITHUB_OUTPUT ]]; then
+    echo "TEST_SUCCESS=${success}" >> "$GITHUB_OUTPUT"
+    echo "TEST_RETRIED=${retried}" >> "$GITHUB_OUTPUT"
+fi
 
 if ! "${success}"; then
     exit 1

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -20,7 +20,7 @@ export PATH:=$(shell yarn bin 2>/dev/null):$(PATH)
 
 ensure:: .make/ensure/yarn .make/ensure/node .make/ensure/phony
 .make/ensure/phony: package.json
-	yarn install --frozen-lockfile
+	../../scripts/retry yarn install --frozen-lockfile
 	@mkdir -p .make/ensure && touch .make/ensure/phony
 
 format:: ensure

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -17,8 +17,8 @@ include ../../build/common.mk
 TEST_ALL_DEPS ?= build
 
 ensure:: .make/ensure/uv
-	uv venv --allow-existing
-	uv sync --dev
+	../../scripts/retry uv venv --allow-existing
+	../../scripts/retry uv sync --dev
 
 build_package:: ensure
 	uv run -m build --outdir ./build --installer uv


### PR DESCRIPTION
In CI, `make ensure` sometimes fails because upstream servers return a 5xx or other random network issues.  We already have `scripts/retry` to retry things in CI, and these targets should retry just in case we hit a temporary hiccup, e.g. such as in
https://github.com/pulumi/pulumi/actions/runs/15272119669/job/42950379398.

`scripts/retry` sets some extra environment variables that help with `go test`, but they won't interfere with this, and it's convnient to have a single script for retrying.