### PR TITLE
run unit tests on all platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
             --kind unit-test \
             "$CODEGEN_TESTS_FLAG" \
             --platform "${INTEGRATION_PLATFORMS[@]}" "${ACCEPTANCE_PLATFORMS[@]}" \
-            --version-set "${VERSION_SETS_TO_TEST[@]}" \
+            --version-set current \
             --partition-module cmd/pulumi-test-language 1 \
             --partition-module pkg "$PKG_UNIT_TEST_PARTITIONS" \
             --partition-module sdk 1 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
             generate-matrix \
             --kind unit-test \
             "$CODEGEN_TESTS_FLAG" \
-            --platform ubuntu-latest \
+            --platform "${INTEGRATION_PLATFORMS[@]}" "${ACCEPTANCE_PLATFORMS[@]}" \
             --version-set "${VERSION_SETS_TO_TEST[@]}" \
             --partition-module cmd/pulumi-test-language 1 \
             --partition-module pkg "$PKG_UNIT_TEST_PARTITIONS" \

--- a/cmd/pulumi-test-language/main_test.go
+++ b/cmd/pulumi-test-language/main_test.go
@@ -1,0 +1,34 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if runtime.GOOS == "windows" {
+		// These tests are skipped as part of enabling running unit tests on windows and MacOS in
+		// https://github.com/pulumi/pulumi/pull/19653. These tests currently fail on Windows, and
+		// re-enabling them is left as future work.
+		// TODO[pulumi/pulumi#19675]: Re-enable tests on windows once they are fixed.
+		fmt.Println("Skip tests on windows until they are fixed")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}

--- a/pkg/backend/apply_test.go
+++ b/pkg/backend/apply_test.go
@@ -17,6 +17,7 @@ package backend
 import (
 	"context"
 	"errors"
+	"runtime"
 	"testing"
 	"time"
 
@@ -86,6 +87,11 @@ func (e *errorExplainer) IsExplainPreviewEnabled(ctx context.Context, opts backe
 
 func TestConfirmBeforeUpdating_ExplainerErrorDoesNotCrash(t *testing.T) {
 	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		// TODO[pulumi/pulumi#19675]: Fix this test on Windows.
+		t.Skip("Skipping test on Windows")
+	}
 
 	// Set up the console with a timeout to avoid hangs
 	console, err := expect.NewConsole(expect.WithDefaultTimeout(2 * time.Second))

--- a/pkg/backend/display/progress_test.go
+++ b/pkg/backend/display/progress_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display/internal/terminal"
@@ -110,6 +111,10 @@ func testProgressEvents(
 
 //nolint:paralleltest // sets the TERM environment variable
 func TestProgressEvents(t *testing.T) {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		// TODO[pulumi/pulumi#19675]: Fix this test on Windows and MacOS
+		t.Skip("Skipping tests on Windows and MacOS.")
+	}
 	t.Setenv("TERM", "vt102")
 
 	accept := cmdutil.IsTruthy(os.Getenv("PULUMI_ACCEPT"))

--- a/pkg/backend/diy/main_test.go
+++ b/pkg/backend/diy/main_test.go
@@ -1,0 +1,34 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diy
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if runtime.GOOS == "windows" {
+		// These tests are skipped as part of enabling running unit tests on windows and MacOS in
+		// https://github.com/pulumi/pulumi/pull/19653. These tests currently fail on Windows, and
+		// re-enabling them is left as future work.
+		// TODO[pulumi/pulumi#19675]: Re-enable tests on windows once they are fixed.
+		fmt.Println("Skip tests on windows until they are fixed")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}

--- a/pkg/backend/httpstate/main_test.go
+++ b/pkg/backend/httpstate/main_test.go
@@ -1,0 +1,34 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpstate
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if runtime.GOOS == "windows" {
+		// These tests are skipped as part of enabling running unit tests on windows and MacOS in
+		// https://github.com/pulumi/pulumi/pull/19653. These tests currently fail on Windows, and
+		// re-enabling them is left as future work.
+		// TODO[pulumi/pulumi#19675]: Re-enable tests on windows once they are fixed.
+		fmt.Println("Skip tests on windows until they are fixed")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}

--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -28,6 +28,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -560,6 +561,11 @@ func TestDiffStackRecorded(t *testing.T) {
 
 func TestMarshalDeployment(t *testing.T) {
 	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		// TODO[pulumi/pulumi#19675]: Fix this test on Windows.
+		t.Skip("Skipping test on Windows")
+	}
 
 	testOrBenchmarkDiffStack(t, testMarshalDeployment, dynamicCases)
 	testOrBenchmarkDiffStack(t, testMarshalDeployment, recordedCases)

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -127,6 +128,14 @@ func pickURN(t *testing.T, urns []resource.URN, names []string, target string) r
 
 func TestMain(m *testing.M) {
 	grpcDefault := flag.Bool("grpc-plugins", false, "enable or disable gRPC providers by default")
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		// These tests are skipped as part of enabling running unit tests on windows and MacOS in
+		// https://github.com/pulumi/pulumi/pull/19653. These tests currently fail on Windows, and
+		// re-enabling them is left as future work.
+		// TODO[pulumi/pulumi#19675]: Re-enable tests on windows and MacOS once they are fixed.
+		fmt.Println("Skip tests on windows and MacOS until they are fixed")
+		os.Exit(0)
+	}
 
 	flag.Parse()
 

--- a/pkg/engine/progress_test.go
+++ b/pkg/engine/progress_test.go
@@ -15,6 +15,7 @@
 package engine
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,6 +23,11 @@ import (
 
 func TestProgressReportingCloser(t *testing.T) {
 	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		// TODO[pulumi/pulumi#19675]: Fix this test on Windows.
+		t.Skip("Skipping test on Windows")
+	}
 
 	// Arrange.
 	events := make(chan Event)

--- a/pkg/resource/deploy/deploytest/main_test.go
+++ b/pkg/resource/deploy/deploytest/main_test.go
@@ -1,0 +1,34 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploytest
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if runtime.GOOS == "windows" {
+		// These tests are skipped as part of enabling running unit tests on windows and MacOS in
+		// https://github.com/pulumi/pulumi/pull/19653. These tests currently fail on Windows, and
+		// re-enabling them is left as future work.
+		// TODO[pulumi/pulumi#19675]: Re-enable tests on windows once they are fixed.
+		fmt.Println("Skip tests on windows until they are fixed")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}

--- a/pkg/resource/deploy/main_test.go
+++ b/pkg/resource/deploy/main_test.go
@@ -1,0 +1,34 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if runtime.GOOS == "windows" {
+		// These tests are skipped as part of enabling running unit tests on windows and MacOS in
+		// https://github.com/pulumi/pulumi/pull/19653. These tests currently fail on Windows, and
+		// re-enabling them is left as future work.
+		// TODO[pulumi/pulumi#19675]: Re-enable tests on windows once they are fixed.
+		fmt.Println("Skip tests on windows until they are fixed")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}

--- a/pkg/secrets/passphrase/manager_test.go
+++ b/pkg/secrets/passphrase/manager_test.go
@@ -16,7 +16,9 @@ package passphrase
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,6 +29,18 @@ const (
 	state       = `{"salt":"v1:fozI5u6B030=:v1:F+6ZduKKd8G0/V7L:PGMFeIzwobWRKmEAzUdaQHqC5mMRIQ=="}`
 	brokenState = `{"salt":"fozI5u6B030=:v1:F+6ZduL:PGMFeIzwobWRKmEAzUdaQHqC5mMRIQ=="}`
 )
+
+func TestMain(m *testing.M) {
+	if runtime.GOOS == "windows" {
+		// These tests are skipped as part of enabling running unit tests on windows and MacOS in
+		// https://github.com/pulumi/pulumi/pull/19653. These tests currently fail on Windows, and
+		// re-enabling them is left as future work.
+		// TODO[pulumi/pulumi#19675]: Re-enable tests on windows once they are fixed.
+		fmt.Println("Skip tests on windows until they are fixed")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
 
 func TestPassphraseManagerIncorrectPassphraseReturnsErrorCrypter(t *testing.T) {
 	clearCachedSecretsManagers()

--- a/sdk/go/common/resource/config/repr_test.go
+++ b/sdk/go/common/resource/config/repr_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -114,6 +115,10 @@ func (o *gobObject) UnmarshalYAML(unmarshal func(v any) error) error {
 }
 
 func TestRepr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// TODO[pulumi/pulumi#19675]: Fix this test on Windows.
+		t.Skip("Skipping test on Windows")
+	}
 	t.Parallel()
 
 	type expectedValue struct {

--- a/sdk/go/common/resource/plugin/main_test.go
+++ b/sdk/go/common/resource/plugin/main_test.go
@@ -1,0 +1,34 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if runtime.GOOS == "windows" {
+		// These tests are skipped as part of enabling running unit tests on windows and MacOS in
+		// https://github.com/pulumi/pulumi/pull/19653. These tests currently fail on Windows, and
+		// re-enabling them is left as future work.
+		// TODO[pulumi/pulumi#19675]: Re-enable tests on windows once they are fixed.
+		fmt.Println("Skip tests on windows until they are fixed")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}

--- a/sdk/go/common/tail/tail_test.go
+++ b/sdk/go/common/tail/tail_test.go
@@ -15,6 +15,7 @@ import (
 	_ "fmt"
 	"io"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -41,6 +42,14 @@ func ExampleFile() {
 }
 
 func TestMain(m *testing.M) {
+	if runtime.GOOS == "windows" {
+		// These tests are skipped as part of enabling running unit tests on windows and MacOS in
+		// https://github.com/pulumi/pulumi/pull/19653. These tests currently fail on Windows, and
+		// re-enabling them is left as future work.
+		// TODO[pulumi/pulumi#19675]: Re-enable tests on windows once they are fixed.
+		fmt.Println("Skip tests on windows until they are fixed")
+		os.Exit(0)
+	}
 	// Use a smaller poll duration for faster test runs. Keep it below
 	// 100ms (which value is used as common delays for tests)
 	watch.POLL_DURATION = 5 * time.Millisecond

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -20,9 +20,11 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -38,6 +40,18 @@ import (
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
+
+func TestMain(m *testing.M) {
+	if runtime.GOOS == "windows" {
+		// These tests are skipped as part of enabling running unit tests on windows and MacOS in
+		// https://github.com/pulumi/pulumi/pull/19653. These tests currently fail on Windows, and
+		// re-enabling them is left as future work.
+		// TODO[pulumi/pulumi#19675]: Re-enable tests on windows once they are fixed.
+		fmt.Println("Skip tests on windows until they are fixed")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
 
 func TestParseGitRepoURL(t *testing.T) {
 	t.Parallel()

--- a/sdk/go/common/workspace/main_test.go
+++ b/sdk/go/common/workspace/main_test.go
@@ -1,0 +1,34 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if runtime.GOOS == "windows" {
+		// These tests are skipped as part of enabling running unit tests on windows and MacOS in
+		// https://github.com/pulumi/pulumi/pull/19653. These tests currently fail on Windows, and
+		// re-enabling them is left as future work.
+		// TODO[pulumi/pulumi#19675]: Re-enable tests on windows once they are fixed.
+		fmt.Println("Skip tests on windows until they are fixed")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
 	"testing"
 	"time"
 
@@ -1526,6 +1527,10 @@ func TestAmbientPluginsWarn(t *testing.T) {
 }
 
 func TestAmbientBundledPluginsWarn(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		// TODO[pulumi/pulumi#19675]: Fix this test on MacOS
+		t.Skip("Skipping tests on MacOS")
+	}
 	// Get the path of this executable
 	exe, err := os.Executable()
 	require.NoError(t, err)

--- a/sdk/go/internal/gen-pux-applyn/main_test.go
+++ b/sdk/go/internal/gen-pux-applyn/main_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"io/fs"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,6 +28,10 @@ import (
 // If the parameters in pulumix/gen.go ever change,
 // this test should be updated.
 func TestPulumixIsUpToDate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// TODO[pulumi/pulumi#19675]: Fix this test on Windows
+		t.Skip("Skipping tests on Windows")
+	}
 	t.Parallel()
 
 	outDir := t.TempDir()

--- a/sdk/go/pulumi/generate/main_test.go
+++ b/sdk/go/pulumi/generate/main_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,10 +28,10 @@ func TestTemplateFilePath(t *testing.T) {
 		give string
 		want string
 	}{
-		{"foo-bar.go.template", "foo/bar.go"},
+		{"foo-bar.go.template", filepath.Join("foo", "bar.go")},
 		{"bar.go.template", "bar.go"},
-		{"fizz-buz-bar.go.template", "fizz/buz/bar.go"},
-		{"foo-bar.tmpl.template", "foo/bar.tmpl"},
+		{"fizz-buz-bar.go.template", filepath.Join("fizz", "buz", "bar.go")},
+		{"foo-bar.tmpl.template", filepath.Join("foo", "bar.tmpl")},
 	}
 
 	for _, tt := range tests {

--- a/sdk/python/toolchain/pip_test.go
+++ b/sdk/python/toolchain/pip_test.go
@@ -130,6 +130,10 @@ func TestRunningPipInVirtualEnvironment(t *testing.T) {
 }
 
 func TestCommandNoVenv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// TODO[pulumi/pulumi#19675]: Fix this test on Windows
+		t.Skip("Skipping tests on Windows")
+	}
 	t.Parallel()
 
 	tc, err := newPip(".", "")

--- a/sdk/python/toolchain/pyproject_test.go
+++ b/sdk/python/toolchain/pyproject_test.go
@@ -17,12 +17,17 @@ package toolchain
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestBuildablePackage(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// TODO[pulumi/pulumi#19675]: Fix this test on Windows
+		t.Skip("Skipping tests on Windows")
+	}
 	t.Parallel()
 	tests := []struct {
 		name               string

--- a/sdk/python/toolchain/toolchain_test.go
+++ b/sdk/python/toolchain/toolchain_test.go
@@ -71,6 +71,10 @@ func TestValidateVenv(t *testing.T) {
 }
 
 func TestCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// TODO[pulumi/pulumi#19675]: Fix this test on Windows
+		t.Skip("Skipping tests on Windows")
+	}
 	// Poetry with `in-project = true` uses `.venv` as the default virtualenv directory.
 	// Use the same for pip to keep the tests consistent.
 	venvDir := ".venv"
@@ -127,6 +131,11 @@ func TestCommand(t *testing.T) {
 }
 
 func TestListPackages(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// TODO[pulumi/pulumi#19675]: Fix this test on Windows
+		t.Skip("Skipping tests on Windows")
+	}
+
 	t.Parallel()
 
 	// Build the mock package before running the tests, so parallel tests don't
@@ -241,6 +250,10 @@ func TestListPackages(t *testing.T) {
 }
 
 func TestAbout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// TODO[pulumi/pulumi#19675]: Fix this test on Windows
+		t.Skip("Skipping tests on Windows")
+	}
 	t.Parallel()
 
 	for _, opts := range []PythonOptions{


### PR DESCRIPTION
We currently run unit tests on linux only.  However we have enough compute capacity to run them on all platforms, and it's safer to do so.  Do so.

Note that a bunch of tests don't succeed on Windows (and some don't succeed on MacOS).  For the most part I just excluded them from being run on those platforms here, leaving the cleanup for follow up PRs.  This gets us to a place where *new* tests are going to be run on all platforms, so we don't have more regressions, and we can clean up the platform specific excludes as we go.  Some excludes are using a `TestMain` in the package, which is because most of the tests in that package do not run successfully, and it was too much work to go through test by test.