### PR TITLE
Add sdk changes to python to enable non-object function call returns

### DIFF
--- a/changelog/pending/20250528--sdkgen-python--add-sdkgen-for-non-object-method-invoke-return-values.yaml
+++ b/changelog/pending/20250528--sdkgen-python--add-sdkgen-for-non-object-method-invoke-return-values.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/python
+  description: Add sdkgen for non object method invoke return values

--- a/sdk/python/lib/pulumi/runtime/__init__.py
+++ b/sdk/python/lib/pulumi/runtime/__init__.py
@@ -53,8 +53,10 @@ from .stack import (
 
 from .invoke import (
     invoke,
+    invoke_single,
     invoke_async,
     invoke_output,
+    invoke_output_single,
     call,
     call_single,
 )
@@ -100,8 +102,10 @@ __all__ = [
     "register_invoke_transform",
     # invoke
     "invoke",
+    "invoke_single",
     "invoke_async",
     "invoke_output",
+    "invoke_output_single",
     "call",
     "call_single",
     # _json

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018, Pulumi Corporation.
+# Copyright 2016-2025, Pulumi Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -127,6 +127,20 @@ def invoke(
     return _sync_await(awaitableInvokeResult)
 
 
+def invoke_single(
+    tok: str,
+    props: "Inputs",
+    opts: Optional[InvokeOptions] = None,
+    typ: Optional[type] = None,
+    package_ref: Optional[Awaitable[Optional[str]]] = None,
+) -> Any:
+    """
+    Similar to `invoke`, but extracts a singular value from the result (eg { "foo": "bar" } => "bar").
+    """
+    result = invoke(tok, props, opts, typ, package_ref)
+    return _extract_single_value(result)
+
+
 def invoke_output(
     tok: str,
     props: "Inputs",
@@ -172,6 +186,22 @@ def invoke_output(
 
     asyncio.ensure_future(_get_rpc_manager().do_rpc("invoke", do_invoke_output)())
     return out
+
+
+def invoke_output_single(
+    tok: str,
+    props: "Inputs",
+    opts: Optional[Union[InvokeOptions, InvokeOutputOptions]] = None,
+    typ: Optional[type] = None,
+    package_ref: Optional[Awaitable[Optional[str]]] = None,
+) -> "Output[Any]":
+    """
+    invoke_output_single performs the same action as invoke_output, but expects the function tok to return
+    an object containing a single value, which it then extracts and returns.
+    """
+    return invoke_output(tok, props, opts, typ, package_ref).apply(
+        _extract_single_value
+    )
 
 
 async def invoke_async(


### PR DESCRIPTION
Much like #19387 which adds method call scalar returns, this change adds
sdk changes for scalar invoke returns in python (a feature already in nodejs)

This is the SDK changes only which must be relesed before the sdkgen
changes which are in #19661 

Part of #19388
