### PR TITLE
run unit tests for all requested version sets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
             --kind unit-test \
             "$CODEGEN_TESTS_FLAG" \
             --platform ubuntu-latest \
-            --version-set current \
+            --version-set "${VERSION_SETS_TO_TEST[@]}" \
             --partition-module cmd/pulumi-test-language 1 \
             --partition-module pkg "$PKG_UNIT_TEST_PARTITIONS" \
             --partition-module sdk 1 \

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1962,13 +1962,18 @@ func TestGitSourceDownloadSemver(t *testing.T) {
 	require.NoError(t, err)
 
 	tarReader := tar.NewReader(zip)
-	header, err := tarReader.Next()
-	require.NoError(t, err)
-	require.Equal(t, "path/", header.Name)
-
-	header, err = tarReader.Next()
-	require.NoError(t, err)
-	require.Equal(t, "path/test", header.Name)
+	for {
+		header, err := tarReader.Next()
+		require.NoError(t, err)
+		if header.Name == "path/" {
+			// Some of the implementations of tar in Go (in particular Go 1.23 and earlier) don't
+			// include the directory entry in the tar stream.  So we can skip over that here, and
+			// make sure we find the file entry we really care about.
+			continue
+		}
+		require.Equal(t, "path/test", header.Name)
+		break
+	}
 
 	buf, err := io.ReadAll(tarReader)
 	require.NoError(t, err)
@@ -2005,13 +2010,18 @@ func TestGitSourceDownloadHEAD(t *testing.T) {
 	require.NoError(t, err)
 
 	tarReader := tar.NewReader(zip)
-	header, err := tarReader.Next()
-	require.NoError(t, err)
-	require.Equal(t, "path/", header.Name)
-
-	header, err = tarReader.Next()
-	require.NoError(t, err)
-	require.Equal(t, "path/test", header.Name)
+	for {
+		header, err := tarReader.Next()
+		require.NoError(t, err)
+		if header.Name == "path/" {
+			// Some of the implementations of tar in Go (in particular Go 1.23 and earlier) don't
+			// include the directory entry in the tar stream.  So we can skip over that here, and
+			// make sure we find the file entry we really care about.
+			continue
+		}
+		require.Equal(t, "path/test", header.Name)
+		break
+	}
 
 	buf, err := io.ReadAll(tarReader)
 	require.NoError(t, err)
@@ -2048,13 +2058,18 @@ func TestGitSourceDownloadHash(t *testing.T) {
 	require.NoError(t, err)
 
 	tarReader := tar.NewReader(zip)
-	header, err := tarReader.Next()
-	require.NoError(t, err)
-	require.Equal(t, "path/", header.Name)
-
-	header, err = tarReader.Next()
-	require.NoError(t, err)
-	require.Equal(t, "path/test", header.Name)
+	for {
+		header, err := tarReader.Next()
+		require.NoError(t, err)
+		if header.Name == "path/" {
+			// Some of the implementations of tar in Go (in particular Go 1.23 and earlier) don't
+			// include the directory entry in the tar stream.  So we can skip over that here, and
+			// make sure we find the file entry we really care about.
+			continue
+		}
+		require.Equal(t, "path/test", header.Name)
+		break
+	}
 
 	buf, err := io.ReadAll(tarReader)
 	require.NoError(t, err)


### PR DESCRIPTION
Currently we run unit tests only for the "current" version set.  This seems mostly okay, as they don't do much with NodeJS or Python, however for Go it's probably better if we do run the unit tests through all the version sets as well.  We have enough CI capacity to just do that without worrying too much, so let's do it here.

This requires a small update for a test which behaves differently in Go 1.23 and 1.24.

Noticed this while looking into https://github.com/pulumi/pulumi/pull/19653 (though it's probably less important than that).