### PR TITLE
Thread RefreshProgram through up

### DIFF
--- a/changelog/pending/20250528--cli--fix-up-refresh-run-program-to-use-the-new-program-based-refresh-logic.yaml
+++ b/changelog/pending/20250528--cli--fix-up-refresh-run-program-to-use-the-new-program-based-refresh-logic.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix `up --refresh --run-program` to use the new program based refresh logic

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -206,6 +206,7 @@ func NewUpCmd() *cobra.Command {
 			Parallel:                  parallel,
 			Debug:                     debug,
 			Refresh:                   refreshOption,
+			RefreshProgram:            runProgram,
 			ReplaceTargets:            deploy.NewUrnTargets(replaceURNs),
 			UseLegacyDiff:             env.EnableLegacyDiff.Value(),
 			UseLegacyRefreshDiff:      env.EnableLegacyRefreshDiff.Value(),


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/19562

We'd threaded this option through the `UpdateOptions` for template based `up`, but for working directory based `up`.