### PR TITLE
Use plugin.ExecPlugin in plugin run

### DIFF
--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -17,9 +17,9 @@ package plugin
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
-	"os/exec"
-	"syscall"
+	"sync"
 
 	"github.com/spf13/cobra"
 
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -94,27 +95,51 @@ func newPluginRunCmd() *cobra.Command {
 
 			pluginArgs := args[1:]
 
-			pluginCmd := exec.Command(path, pluginArgs...)
-			pluginCmd.Stdout = os.Stdout
-			pluginCmd.Stderr = os.Stderr
-			pluginCmd.Stdin = os.Stdin
-			if err := pluginCmd.Run(); err != nil {
-				var pathErr *os.PathError
-				if errors.As(err, &pathErr) {
-					syscallErr, ok := pathErr.Err.(syscall.Errno)
-					if ok && syscallErr == syscall.ENOENT {
-						return fmt.Errorf("could not find execute plugin %s, binary not found at %s", pluginDesc, path)
-					}
-				}
+			pctx, err := plugin.NewContext(ctx, nil, nil, nil, nil, ".", nil, false, nil)
+			if err != nil {
+				return fmt.Errorf("could not create plugin context: %w", err)
+			}
 
-				var exitErr *exec.ExitError
-				if errors.As(err, &exitErr) {
-					os.Exit(exitErr.ExitCode())
-				}
-
+			plugin, err := plugin.ExecPlugin(pctx, path, pluginDesc, kind, pluginArgs, "", nil, false)
+			if err != nil {
 				return fmt.Errorf("could not execute plugin %s (%s): %w", pluginDesc, path, err)
 			}
 
+			// Copy the plugin's stdout and stderr to the current process's stdout and stderr, and stdin to the
+			// plugin's stdin.
+
+			var wg sync.WaitGroup
+			wg.Add(3)
+			go func() {
+				defer wg.Done()
+				_, err := io.Copy(os.Stdout, plugin.Stdout)
+				if err != nil && !errors.Is(err, io.EOF) {
+					fmt.Fprintf(os.Stderr, "error reading plugin stdout: %v\n", err)
+				}
+			}()
+			go func() {
+				defer wg.Done()
+				_, err := io.Copy(os.Stderr, plugin.Stderr)
+				if err != nil && !errors.Is(err, io.EOF) {
+					fmt.Fprintf(os.Stderr, "error reading plugin stderr: %v\n", err)
+				}
+			}()
+			go func() {
+				defer wg.Done()
+				_, err := io.Copy(plugin.Stdin, os.Stdin)
+				if err != nil && !errors.Is(err, io.EOF) {
+					fmt.Fprintf(os.Stderr, "error copying plugin stdin: %v\n", err)
+				}
+			}()
+
+			// Wait for the plugin to finish.
+			code, err := plugin.Wait()
+			if err != nil {
+				return fmt.Errorf("plugin %s exited with error: %w", pluginDesc, err)
+			}
+			if code != 0 {
+				os.Exit(code)
+			}
 			return nil
 		},
 	}

--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -132,8 +132,9 @@ func newPluginRunCmd() *cobra.Command {
 				}
 			}()
 
-			// Wait for the plugin to finish.
+			// Wait for the plugin and IO to finish.
 			code, err := plugin.Wait()
+			wg.Wait()
 			if err != nil {
 				return fmt.Errorf("plugin %s exited with error: %w", pluginDesc, err)
 			}

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -50,7 +50,7 @@ import (
 type analyzer struct {
 	ctx     *Context
 	name    tokens.QName
-	plug    *plugin
+	plug    *Plugin
 	client  pulumirpc.AnalyzerClient
 	version string
 }
@@ -141,7 +141,7 @@ func NewPolicyAnalyzer(
 	// https://github.com/pulumi/pulumi-policy-opa continue to work (although in time they could probably be moved to
 	// just be language runtimes like the rest).
 
-	var plug *plugin
+	var plug *Plugin
 	var foundLanguagePlugin bool
 	// Try to load the language plugin for the runtime, except for python and node that _for now_ continue using the
 	// legacy behavior.

--- a/sdk/go/common/resource/plugin/converter_plugin.go
+++ b/sdk/go/common/resource/plugin/converter_plugin.go
@@ -37,7 +37,7 @@ import (
 // converter reflects a converter plugin, loaded dynamically from another process over gRPC.
 type converter struct {
 	name      string
-	plug      *plugin                   // the actual plugin process wrapper.
+	plug      *Plugin                   // the actual plugin process wrapper.
 	clientRaw pulumirpc.ConverterClient // the raw provider client; usually unsafe to use directly.
 }
 

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -51,7 +51,7 @@ import (
 type langhost struct {
 	ctx     *Context
 	runtime string
-	plug    *plugin
+	plug    *Plugin
 	client  pulumirpc.LanguageRuntimeClient
 }
 
@@ -64,7 +64,7 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime, workingDirectory strin
 		return nil, err
 	}
 
-	var plug *plugin
+	var plug *Plugin
 	var client pulumirpc.LanguageRuntimeClient
 	if attachPort != nil {
 		port := *attachPort
@@ -97,7 +97,7 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime, workingDirectory strin
 			)
 		}
 
-		plug = &plugin{
+		plug = &Plugin{
 			Conn: conn,
 			// Nothing to kill.
 			Kill: func() error {

--- a/sdk/go/common/resource/plugin/plugin_test.go
+++ b/sdk/go/common/resource/plugin/plugin_test.go
@@ -105,7 +105,7 @@ func TestParsePort(t *testing.T) {
 func TestHealthCheck(t *testing.T) {
 	t.Parallel()
 
-	startServer := func(healthService bool) (*grpc.Server, *plugin) {
+	startServer := func(healthService bool) (*grpc.Server, *Plugin) {
 		listener, _ := net.Listen("tcp", "127.0.0.1:0")
 		server := grpc.NewServer()
 
@@ -134,7 +134,7 @@ func TestHealthCheck(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		return server, &plugin{Conn: conn}
+		return server, &Plugin{Conn: conn}
 	}
 
 	tests := []struct {

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -83,7 +83,7 @@ type provider struct {
 
 	ctx                    *Context                         // a plugin context for caching, etc.
 	pkg                    tokens.Package                   // the Pulumi package containing this provider's resources.
-	plug                   *plugin                          // the actual plugin process wrapper.
+	plug                   *Plugin                          // the actual plugin process wrapper.
 	clientRaw              pulumirpc.ResourceProviderClient // the raw provider client; usually unsafe to use directly.
 	disableProviderPreview bool                             // true if previews for Create and Update are disabled.
 	legacyPreview          bool                             // enables legacy behavior for unconfigured provider previews.
@@ -174,7 +174,7 @@ func NewProvider(host Host, ctx *Context, spec workspace.PluginSpec,
 	projectName tokens.PackageName,
 ) (Provider, error) {
 	// See if this is a provider we just want to attach to
-	var plug *plugin
+	var plug *Plugin
 	var handshakeRes *ProviderHandshakeResponse
 
 	pkg := tokens.Package(spec.Name)
@@ -212,7 +212,7 @@ func NewProvider(host Host, ctx *Context, spec workspace.PluginSpec,
 		}
 
 		// Done; store the connection and return the plugin info.
-		plug = &plugin{
+		plug = &Plugin{
 			Conn: conn,
 			// Nothing to kill
 			Kill: func() error { return nil },


### PR DESCRIPTION
Rather than using `exec.Cmd` just re-use the execution logic we already have in the plugin system for `plugin run`.

This has a difference that we're `io.Copy`ing the standard io streams rather than assigning `os.Stdout/err` directly to the commands io streams. Should be fine for the simple uses of `plugin run` we have, but if we want to support rich tty style things here we'd need to be smarter about this.