### PR TITLE
improve error handling in lifecycletest framework

### DIFF
--- a/pkg/engine/lifecycletest/framework/framework.go
+++ b/pkg/engine/lifecycletest/framework/framework.go
@@ -673,17 +673,12 @@ func (p *TestPlan) RunWithName(t TB, snapshot *deploy.Snapshot, name string) *de
 			continue
 		}
 
-		if err != nil {
-			if result.IsBail(err) {
-				t.Logf("Got unexpected bail result: %v", err)
-				t.FailNow()
-			} else {
-				t.Logf("Got unexpected error result: %v", err)
-				t.FailNow()
-			}
+		errString := "unexpected error result"
+		if result.IsBail(err) {
+			errString = "unexpected bail result"
 		}
 
-		assert.NoError(t, err)
+		require.NoError(t, err, errString)
 	}
 
 	p.run++


### PR DESCRIPTION
Small improvement to the lifecycletest framework.  Currently if there's an error, we log it and call `t.FailNow()` (and then unnecessarily still assert that there's no error).  Refactor this, so it's all a single `require.NoError`, which in addition to being cleaner (and more importantly) also provides the full backtrace for the error, which makes it easier to debug.

Tiny thing I noticed while working with lifecycletests.