### PR TITLE
Install the Pulumi dev release before running the direct cron build

### DIFF
--- a/.github/workflows/cron-direct-build.yml
+++ b/.github/workflows/cron-direct-build.yml
@@ -23,6 +23,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.24"
+
+      - name: Install Pulumi dev release
+        shell: bash
+        run: curl -fsSL https://get.pulumi.com | sh -s -- --version dev
+
       - name: Build
         shell: bash
         run: |

--- a/.github/workflows/cron-direct-build.yml
+++ b/.github/workflows/cron-direct-build.yml
@@ -24,9 +24,9 @@ jobs:
         with:
           go-version: "1.24"
 
-      - name: Install Pulumi dev release
-        shell: bash
-        run: curl -fsSL https://get.pulumi.com | sh -s -- --version dev
+      - uses: pulumi/actions@v6
+        with:
+          pulumi-version: dev
 
       - name: Build
         shell: bash


### PR DESCRIPTION
Rather than relying on whatever already exists on the machine.

Fixes #19227.