### PR TITLE
Log callback requests

### DIFF
--- a/changelog/pending/20250530--engine--log-callbacks-requests.yaml
+++ b/changelog/pending/20250530--engine--log-callbacks-requests.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: engine
+  description: Log callbacks requests


### PR DESCRIPTION
Use the plugin context’s GRPC dial options for callback clients so that requests are logged when using `PULUMI_DEBUG_GRPC`.
