### PR TITLE
Implement a shared registry read abstraction

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/util/cancel"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -242,8 +243,17 @@ type Backend interface {
 	// to ListTemplates.
 	DownloadTemplate(ctx context.Context, orgName, sourceURL string) (TarReaderCloser, error)
 
-	// GetPackageRegistry returns a PackageRegistry object tied to this backend
+	// GetPackageRegistry returns a PackageRegistry object tied to this backend. Not
+	// all backends are required to support GetPackageRegistry. Those that don't
+	// should return a non-nil error when GetPackageRegistry is called.
+	//
+	// PackageRegistry is a superset of [registry.Registry] that supports publishing
+	// packages.
 	GetPackageRegistry() (PackageRegistry, error)
+
+	// GetReadOnlyPackageRegistry retusn a [registry.Registry] object tied to this
+	// backend. All backends should support GetReadOnlyPackageRegistry.
+	GetReadOnlyPackageRegistry() registry.Registry
 }
 
 // EnvironmentsBackend is an interface that defines an optional capability for a backend to work with environments.

--- a/pkg/backend/backenderr/backenderr.go
+++ b/pkg/backend/backenderr/backenderr.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 )
 
@@ -88,7 +89,15 @@ func (err NotFoundError) Error() string {
 func (err NotFoundError) Unwrap() error { return err.Err }
 
 func (err NotFoundError) Is(other error) bool {
-	_, ok := other.(NotFoundError)
-	_, ptr := other.(*NotFoundError)
-	return ok || ptr
+	switch other.(type) {
+	case NotFoundError, *NotFoundError,
+		// By returning true for `registry.NotFoundError`, we can return true for
+		// calling code that checks:
+		//
+		//	errors.Is(err, registry.NotFoundError)
+		registry.NotFoundError, *registry.NotFoundError:
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/backend/backenderr/backenderr_test.go
+++ b/pkg/backend/backenderr/backenderr_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2019-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,17 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package backend
+package backenderr
 
 import (
-	"context"
+	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
+	"github.com/stretchr/testify/assert"
 )
 
-type PackageRegistry interface {
-	registry.Registry
-	// Publish publishes a package to the package registry.
-	Publish(ctx context.Context, op apitype.PackagePublishOp) error
+func TestNotFoundErrorIs(t *testing.T) {
+	t.Parallel()
+	assert.ErrorIs(t, ErrNotFound, registry.ErrNotFound)
 }

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -43,6 +43,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/diy/unauthenticatedregistry"
 	sdkDisplay "github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
@@ -57,6 +58,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -1523,4 +1525,8 @@ func (b *diyBackend) getParallel() int {
 
 func (b *diyBackend) GetPackageRegistry() (backend.PackageRegistry, error) {
 	return nil, errors.New("package registry is not supported by diy backends")
+}
+
+func (b *diyBackend) GetReadOnlyPackageRegistry() registry.Registry {
+	return unauthenticatedregistry.New(b.d, b.Env)
 }

--- a/pkg/backend/diy/unauthenticatedregistry/package_registry.go
+++ b/pkg/backend/diy/unauthenticatedregistry/package_registry.go
@@ -1,0 +1,55 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unauthenticatedregistry
+
+import (
+	"context"
+	"errors"
+	"iter"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
+)
+
+type packageRegistry struct{ c *client.Client }
+
+func New(sink diag.Sink, store env.Env) registry.Registry {
+	url := "https://api.pulumi.com"
+	if override := store.GetString(env.APIURL); override != "" {
+		url = override
+	}
+	return packageRegistry{client.NewClient(url, "", false /* insecure */, sink)}
+}
+
+func (r packageRegistry) SearchByName(
+	ctx context.Context, name *string,
+) iter.Seq2[apitype.PackageMetadata, error] {
+	return r.c.SearchByName(ctx, name)
+}
+
+func (r packageRegistry) GetPackage(
+	ctx context.Context, source, publisher, name string, version *semver.Version,
+) (apitype.PackageMetadata, error) {
+	meta, err := r.c.GetPackage(ctx, source, publisher, name, version)
+	if apiErr := (&apitype.ErrorResponse{}); errors.As(err, &apiErr) && apiErr.Code == 404 {
+		return meta, backenderr.NotFoundError{Err: err}
+	}
+	return meta, err
+}

--- a/pkg/backend/diy/unauthenticatedregistry/package_registry_test.go
+++ b/pkg/backend/diy/unauthenticatedregistry/package_registry_test.go
@@ -1,0 +1,320 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unauthenticatedregistry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
+	env_core "github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPackageSpecifiedVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(`{
+  "name": "random",
+  "publisher": "pulumi",
+  "source": "pulumi",
+  "version": "4.18.0",
+  "description": "A Pulumi package to safely use randomness in Pulumi programs.",
+  "repoUrl": "https://github.com/pulumi/pulumi-random",
+  "category": "cloud",
+  "isFeatured": false,
+  "packageTypes": [
+    "bridged"
+  ],
+  "packageStatus": "ga",
+  "readmeURL": "https://artifacts.pulumi.com/providers/4f280fdc-47eb-43d4-9fd2-bf54eccbbc48/docs/index.md",
+  "schemaURL": "https://artifacts.pulumi.com/providers/4f280fdc-47eb-43d4-9fd2-bf54eccbbc48/schema.json",
+  "createdAt": "2025-04-17T16:02:41.759Z",
+  "visibility": "public"
+}
+`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	client := New(diagtest.LogSink(t), env.NewEnv(env_core.MapStore{
+		"PULUMI_API": server.URL,
+	}))
+
+	pkg, err := client.GetPackage(ctx, "pulumi", "pulumi", "random", &semver.Version{Major: 4, Minor: 18})
+	require.NoError(t, err)
+
+	assert.Equal(t, apitype.PackageMetadata{
+		Name:          "random",
+		Publisher:     "pulumi",
+		Source:        "pulumi",
+		Version:       semver.Version{Major: 4, Minor: 18},
+		Description:   "A Pulumi package to safely use randomness in Pulumi programs.",
+		LogoURL:       "",
+		RepoURL:       "https://github.com/pulumi/pulumi-random",
+		Category:      "cloud",
+		IsFeatured:    false,
+		PackageTypes:  []apitype.PackageType{"bridged"},
+		PackageStatus: apitype.PackageStatusGA,
+		ReadmeURL:     "https://artifacts.pulumi.com/providers/4f280fdc-47eb-43d4-9fd2-bf54eccbbc48/docs/index.md",
+		SchemaURL:     "https://artifacts.pulumi.com/providers/4f280fdc-47eb-43d4-9fd2-bf54eccbbc48/schema.json",
+		CreatedAt:     time.Date(2025, time.April, 17, 16, 2, 41, 759000000, time.UTC),
+		Visibility:    apitype.VisibilityPublic,
+	}, pkg)
+}
+
+func TestGetPackageUnspecifiedVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(`{
+  "name": "random",
+  "publisher": "pulumi",
+  "source": "pulumi",
+  "version": "4.18.2",
+  "description": "A Pulumi package to safely use randomness in Pulumi programs.",
+  "repoUrl": "https://github.com/pulumi/pulumi-random",
+  "category": "cloud",
+  "isFeatured": false,
+  "packageTypes": [
+    "bridged"
+  ],
+  "packageStatus": "ga",
+  "readmeURL": "https://artifacts.pulumi.com/providers/a7592522-ec15-49cf-89f2-3365191ea23b/docs/index.md",
+  "schemaURL": "https://artifacts.pulumi.com/providers/a7592522-ec15-49cf-89f2-3365191ea23b/schema.json",
+  "createdAt": "2025-04-30T22:44:41.542Z",
+  "visibility": "public"
+}
+`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	client := New(diagtest.LogSink(t), env.NewEnv(env_core.MapStore{
+		"PULUMI_API": server.URL,
+	}))
+
+	pkg, err := client.GetPackage(ctx, "pulumi", "pulumi", "random", nil /* latest version */)
+	require.NoError(t, err)
+
+	assert.Equal(t, apitype.PackageMetadata{
+		Name:      "random",
+		Publisher: "pulumi",
+		Source:    "pulumi",
+		Version: semver.Version{
+			Major: 4,
+			Minor: 18,
+			Patch: 2,
+		},
+		Description:   "A Pulumi package to safely use randomness in Pulumi programs.",
+		RepoURL:       "https://github.com/pulumi/pulumi-random",
+		Category:      "cloud",
+		PackageTypes:  []apitype.PackageType{"bridged"},
+		PackageStatus: apitype.PackageStatusGA,
+		ReadmeURL:     "https://artifacts.pulumi.com/providers/a7592522-ec15-49cf-89f2-3365191ea23b/docs/index.md",
+		SchemaURL:     "https://artifacts.pulumi.com/providers/a7592522-ec15-49cf-89f2-3365191ea23b/schema.json",
+		CreatedAt:     time.Date(2025, time.April, 30, 22, 44, 41, 542000000, time.UTC),
+		Visibility:    apitype.VisibilityPublic,
+	}, pkg)
+}
+
+func TestGetPackageNonExistantPackage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		_, err := w.Write([]byte(`{
+  "code": 404,
+  "message": "Not Found: package version 'pulumi/pulumi/does-not-exist@<nil>' not found"
+}
+`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	client := New(diagtest.LogSink(t), env.NewEnv(env_core.MapStore{
+		"PULUMI_API": server.URL,
+	}))
+
+	_, err := client.GetPackage(ctx, "pulumi", "pulumi", "does-not-exist", nil /* latest version */)
+	assert.ErrorIs(t, err, backenderr.ErrNotFound)
+	assert.ErrorIs(t, err, registry.ErrNotFound)
+}
+
+// We never have auth, so we always should return a [backenderr.ErrNotFound] when we get a 404.
+func TestGetPackagePrivatePackage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		_, err := w.Write([]byte(`{
+  "code": 404,
+  "message": "Not Found: package version 'pulumi/private/missing-credentials@<nil>' not found"
+}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	client := New(diagtest.LogSink(t), env.NewEnv(env_core.MapStore{
+		"PULUMI_API": server.URL,
+	}))
+
+	_, err := client.GetPackage(ctx, "pulumi", "private", "missing-credentials", nil /* latest version */)
+	assert.ErrorIs(t, err, registry.ErrNotFound)
+}
+
+func TestSearchByName(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(`{
+  "packages": [
+    {
+      "name": "castai",
+      "publisher": "castai",
+      "source": "pulumi",
+      "version": "0.1.78",
+      "title": "CAST AI",
+      "description": "A Pulumi package for creating and managing CAST AI cloud resources.",
+      "logoUrl": "https://raw.githubusercontent.com/castai/pulumi-castai/main/docs/images/castai-logo.png",
+      "repoUrl": "https://github.com/castai/pulumi-castai",
+      "category": "cloud",
+      "isFeatured": false,
+      "packageTypes": [
+        "bridged"
+      ],
+      "packageStatus": "public_preview",
+      "readmeURL": "https://artifacts.pulumi.com/providers/8b761e09-343e-4660-ba13-bd24c257fe0e/docs/index.md",
+      "schemaURL": "https://artifacts.pulumi.com/providers/8b761e09-343e-4660-ba13-bd24c257fe0e/schema.json",
+      "pluginDownloadURL": "github://api.github.com/castai",
+      "createdAt": "2025-05-22T17:41:08.019Z",
+      "visibility": "public"
+    },
+    {
+      "name": "castai",
+      "publisher": "castai",
+      "source": "opentofu",
+      "version": "7.52.0",
+      "description": "A Pulumi provider dynamically bridged from castai.",
+      "repoUrl": "https://github.com/castai/terraform-provider-castai",
+      "category": "cloud",
+      "isFeatured": false,
+      "packageTypes": [
+        "bridged"
+      ],
+      "packageStatus": "ga",
+      "readmeURL": "https://artifacts.pulumi.com/providers/c56b8d91-3733-4303-b026-7f4d7c66dcc2/docs/index.md",
+      "schemaURL": "https://artifacts.pulumi.com/providers/c56b8d91-3733-4303-b026-7f4d7c66dcc2/schema.json",
+      "createdAt": "2025-05-10T00:17:43.669Z",
+      "visibility": "public"
+    }
+  ]
+}
+`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	client := New(diagtest.LogSink(t), env.NewEnv(env_core.MapStore{
+		"PULUMI_API": server.URL,
+	}))
+
+	results := []apitype.PackageMetadata{}
+	for pkg, err := range client.SearchByName(ctx, ref("castai")) {
+		require.NoError(t, err)
+		results = append(results, pkg)
+	}
+
+	assert.Equal(t, []apitype.PackageMetadata{
+		{
+			Name:              "castai",
+			Publisher:         "castai",
+			Source:            "pulumi",
+			Version:           semver.Version{Major: 0, Minor: 1, Patch: 78},
+			Title:             "CAST AI",
+			Description:       "A Pulumi package for creating and managing CAST AI cloud resources.",
+			LogoURL:           "https://raw.githubusercontent.com/castai/pulumi-castai/main/docs/images/castai-logo.png",
+			RepoURL:           "https://github.com/castai/pulumi-castai",
+			Category:          "cloud",
+			PackageTypes:      []apitype.PackageType{"bridged"},
+			PackageStatus:     apitype.PackageStatusPublicPreview,
+			ReadmeURL:         "https://artifacts.pulumi.com/providers/8b761e09-343e-4660-ba13-bd24c257fe0e/docs/index.md",
+			SchemaURL:         "https://artifacts.pulumi.com/providers/8b761e09-343e-4660-ba13-bd24c257fe0e/schema.json",
+			PluginDownloadURL: "github://api.github.com/castai",
+			CreatedAt:         time.Date(2025, time.May, 22, 17, 41, 8, 19000000, time.UTC),
+			Visibility:        apitype.VisibilityPublic,
+		},
+		{
+			Name:          "castai",
+			Publisher:     "castai",
+			Source:        "opentofu",
+			Version:       semver.Version{Major: 7, Minor: 52, Patch: 0},
+			Description:   "A Pulumi provider dynamically bridged from castai.",
+			RepoURL:       "https://github.com/castai/terraform-provider-castai",
+			Category:      "cloud",
+			PackageTypes:  []apitype.PackageType{"bridged"},
+			PackageStatus: apitype.PackageStatusGA,
+			ReadmeURL:     "https://artifacts.pulumi.com/providers/c56b8d91-3733-4303-b026-7f4d7c66dcc2/docs/index.md",
+			SchemaURL:     "https://artifacts.pulumi.com/providers/c56b8d91-3733-4303-b026-7f4d7c66dcc2/schema.json",
+			CreatedAt:     time.Date(2025, time.May, 10, 0, 17, 43, 669000000, time.UTC),
+			Visibility:    apitype.VisibilityPublic,
+		},
+	}, results)
+}
+
+func TestSearchByNameNoMatches(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(`{"packages":[]}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	client := New(diagtest.LogSink(t), env.NewEnv(env_core.MapStore{
+		"PULUMI_API": server.URL,
+	}))
+
+	results := []apitype.PackageMetadata{}
+	for pkg, err := range client.SearchByName(ctx, ref("404-not-found")) {
+		require.NoError(t, err)
+		results = append(results, pkg)
+	}
+
+	assert.Equal(t, []apitype.PackageMetadata{}, results)
+}
+
+func ref[T any](v T) *T { return &v }

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -52,6 +52,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
@@ -62,11 +63,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/retry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-)
-
-const (
-	// defaultAPIEnvVar can be set to override the default cloud chosen, if `--cloud` is not present.
-	defaultURLEnvVar = "PULUMI_API"
 )
 
 type PulumiAILanguage string
@@ -148,7 +144,8 @@ func ValueOrDefaultURL(ws pkgWorkspace.Context, cloudURL string) string {
 	}
 
 	// Otherwise, respect the PULUMI_API override.
-	if cloudURL := os.Getenv(defaultURLEnvVar); cloudURL != "" {
+
+	if cloudURL := env.APIURL.Value(); cloudURL != "" {
 		return cloudURL
 	}
 
@@ -2372,4 +2369,8 @@ func (b *cloudBackend) DefaultSecretManager(*workspace.ProjectStack) (secrets.Ma
 
 func (b *cloudBackend) GetPackageRegistry() (backend.PackageRegistry, error) {
 	return newCloudPackageRegistry(b.client), nil
+}
+
+func (b *cloudBackend) GetReadOnlyPackageRegistry() registry.Registry {
+	return newCloudPackageRegistry(b.client)
 }

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -99,10 +100,11 @@ type MockBackend struct {
 
 	DefaultSecretManagerF func(ps *workspace.ProjectStack) (secrets.Manager, error)
 
-	SupportsTemplatesF  func() bool
-	ListTemplatesF      func(_ context.Context, orgName string) (apitype.ListOrgTemplatesResponse, error)
-	DownloadTemplateF   func(_ context.Context, orgName, templateSource string) (TarReaderCloser, error)
-	GetPackageRegistryF func() (PackageRegistry, error)
+	SupportsTemplatesF          func() bool
+	ListTemplatesF              func(_ context.Context, orgName string) (apitype.ListOrgTemplatesResponse, error)
+	DownloadTemplateF           func(_ context.Context, orgName, templateSource string) (TarReaderCloser, error)
+	GetPackageRegistryF         func() (PackageRegistry, error)
+	GetReadOnlyPackageRegistryF func() registry.Registry
 }
 
 var _ Backend = (*MockBackend)(nil)
@@ -483,6 +485,13 @@ func (be *MockBackend) DownloadTemplate(ctx context.Context, orgName, templateSo
 func (be *MockBackend) GetPackageRegistry() (PackageRegistry, error) {
 	if be.GetPackageRegistryF != nil {
 		return be.GetPackageRegistryF()
+	}
+	panic("not implemented")
+}
+
+func (be *MockBackend) GetReadOnlyPackageRegistry() registry.Registry {
+	if be.GetReadOnlyPackageRegistryF != nil {
+		return be.GetReadOnlyPackageRegistryF()
 	}
 	panic("not implemented")
 }

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -48,6 +48,8 @@ var Dev = env.Bool("DEV", "Enable features for hacking on pulumi itself.")
 var SkipCheckpoints = env.Bool("SKIP_CHECKPOINTS", "Skip saving state checkpoints and only save "+
 	"the final deployment. See #10668.")
 
+var APIURL = env.String("API", "The URL to use for the Pulumi service.")
+
 var DebugCommands = env.Bool("DEBUG_COMMANDS", "List commands helpful for debugging pulumi itself.")
 
 var EnableLegacyDiff = env.Bool("ENABLE_LEGACY_DIFF", "")

--- a/sdk/go/common/registry/registry.go
+++ b/sdk/go/common/registry/registry.go
@@ -1,0 +1,103 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"context"
+	"iter"
+	"sync"
+
+	"github.com/blang/semver"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// Read only methods on the registry.
+type Registry interface {
+	// Retrieve metadata about a specific package.
+	//
+	// {source}/{publisher}/{name} should form the identifier that describes the
+	// desired package.
+	//
+	// If version is nil, it will default to latest.
+	//
+	// Implementations of GetPackage should return `apitype.PackageMetadata{}, err`
+	// such that `errors.Is(err, ErrNotFound{})` returns true when the arguments to
+	// GetPackage do not point to a package.
+	GetPackage(
+		ctx context.Context, source, publisher, name string, version *semver.Version,
+	) (apitype.PackageMetadata, error)
+	// Retrieve a list of packages.
+	//
+	// If name is non-nil, it will filter to accessible packages that exactly match
+	// */*/{name}.
+	//
+	// Implementations of SearchByName should return an empty iterator and nil if
+	// there are no matching packages in the Registry.
+	SearchByName(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error]
+}
+
+var ErrNotFound = NotFoundError{}
+
+type NotFoundError struct{}
+
+func (err NotFoundError) Error() string {
+	return "not found"
+}
+
+type registryKey struct{}
+
+func Set(ctx context.Context, registry Registry) context.Context {
+	return context.WithValue(ctx, registryKey{}, registry)
+}
+
+func Get(ctx context.Context) Registry {
+	v := ctx.Value(registryKey{})
+	if v == nil {
+		return nil
+	}
+	return v.(Registry)
+}
+
+// NewOnDemandRegistry allows delaying the creation of a registry until it's necessary.
+//
+// If f returns an error, all calls to registry functions will return that error.
+func NewOnDemandRegistry(f func() (Registry, error)) Registry {
+	return &onDemandRegistry{sync.OnceValues(f)}
+}
+
+type onDemandRegistry struct{ factory func() (Registry, error) }
+
+func (r *onDemandRegistry) GetPackage(
+	ctx context.Context, source, publisher, name string, version *semver.Version,
+) (apitype.PackageMetadata, error) {
+	impl, err := r.factory()
+	if err != nil {
+		return apitype.PackageMetadata{}, err
+	}
+	return impl.GetPackage(ctx, source, publisher, name, version)
+}
+
+func (r *onDemandRegistry) SearchByName(
+	ctx context.Context, name *string,
+) iter.Seq2[apitype.PackageMetadata, error] {
+	impl, err := r.factory()
+	if err != nil {
+		return func(consumer func(apitype.PackageMetadata, error) bool) {
+			consumer(apitype.PackageMetadata{}, err)
+		}
+	}
+	return impl.SearchByName(ctx, name)
+}

--- a/sdk/go/common/registry/registry_test.go
+++ b/sdk/go/common/registry/registry_test.go
@@ -1,0 +1,124 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+type mockRegistry struct {
+	getPackage func(
+		ctx context.Context, source, publisher, name string, version *semver.Version,
+	) (apitype.PackageMetadata, error)
+}
+
+func (r mockRegistry) GetPackage(
+	ctx context.Context, source, publisher, name string, version *semver.Version,
+) (apitype.PackageMetadata, error) {
+	return r.getPackage(ctx, source, publisher, name, version)
+}
+
+func (mockRegistry) SearchByName(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+	panic("unimplemented")
+}
+
+func TestOnDemandRegistry(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		r := NewOnDemandRegistry(func() (Registry, error) {
+			return mockRegistry{
+				getPackage: func(
+					ctx context.Context, source, publisher, name string, version *semver.Version,
+				) (apitype.PackageMetadata, error) {
+					assert.Equal(t, source, "src")
+					assert.Equal(t, publisher, "pub")
+					assert.Equal(t, name, "nm")
+					assert.Equal(t, version, &semver.Version{Major: 3})
+					return apitype.PackageMetadata{
+						Name: "it worked",
+					}, nil
+				},
+			}, nil
+		})
+
+		meta, err := r.GetPackage(ctx, "src", "pub", "nm", &semver.Version{Major: 3})
+		require.NoError(t, err)
+		assert.Equal(t, apitype.PackageMetadata{
+			Name: "it worked",
+		}, meta)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		t.Parallel()
+
+		markerErr := errors.New("marker error")
+
+		r := NewOnDemandRegistry(func() (Registry, error) {
+			return nil, markerErr
+		})
+
+		_, err := r.GetPackage(ctx, "src", "pub", "nm", &semver.Version{Major: 3})
+		assert.ErrorIs(t, err, markerErr)
+	})
+
+	t.Run("once", func(t *testing.T) {
+		t.Parallel()
+
+		var count int
+		r := NewOnDemandRegistry(func() (Registry, error) {
+			count++
+			return mockRegistry{
+				getPackage: func(
+					ctx context.Context, source, publisher, name string, version *semver.Version,
+				) (apitype.PackageMetadata, error) {
+					return apitype.PackageMetadata{
+						Name:      name,
+						Publisher: publisher,
+						Source:    source,
+					}, nil
+				},
+			}, nil
+		})
+
+		call := func() {
+			result, err := r.GetPackage(ctx, "src", "pub", "nm", nil)
+			if assert.NoError(t, err) {
+				assert.Equal(t, "src", result.Source)
+				assert.Equal(t, "pub", result.Publisher)
+				assert.Equal(t, "nm", result.Name)
+			}
+		}
+
+		call()
+		call()
+		call()
+
+		assert.Equal(t, 1, count)
+	})
+}


### PR DESCRIPTION
This PR adds an interface for reading the Pulumi registry in `sdk/go/common/registry`, and extends the definition of backend to include `GetReadOnlyPackageRegistry`. 

Both backends have been adjusted to supporting returning a conforming type:

- The HTTP backend returns the same object it already returned for `GetPackageRegistry`.
- The DIY backend now returns an unauthenticated registry. Unauthenticated registries hit the service without credentials, and thus can only see publicly available packages. 

The new code is not used in this PR. This has been factored out of https://github.com/pulumi/pulumi/pull/19499, and will be consumed in follow-up PRs.