### PR TITLE
Go automation API: permit setting SkipPreview and PreviewOnly

### DIFF
--- a/changelog/pending/20250530--auto-go--add-optdestroy-skippreview-previewonly-options-to-control-destroy-previews.yaml
+++ b/changelog/pending/20250530--auto-go--add-optdestroy-skippreview-previewonly-options-to-control-destroy-previews.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Add optdestroy.{SkipPreview,PreviewOnly} options to control destroy previews

--- a/sdk/go/auto/optdestroy/optdestroy.go
+++ b/sdk/go/auto/optdestroy/optdestroy.go
@@ -165,6 +165,20 @@ func RunProgram(f bool) Option {
 	})
 }
 
+// SkipPreview(true) disables calculating a preview before performing the destroy.
+func SkipPreview(doSkipPreview bool) Option {
+	return optionFunc(func(opts *Options) {
+		opts.SkipPreview = doSkipPreview
+	})
+}
+
+// PreviewOnly(true) only shows a preview of the destroy, but does not perform the destroy itself.
+func PreviewOnly(previewDestroy bool) Option {
+	return optionFunc(func(opts *Options) {
+		opts.PreviewOnly = previewDestroy
+	})
+}
+
 // Option is a parameter to be applied to a Stack.Destroy() operation
 type Option interface {
 	ApplyOption(*Options)
@@ -216,6 +230,10 @@ type Options struct {
 	ConfigFile string
 	// When set to true, run the program in the workspace to perform the destroy.
 	RunProgram *bool
+	// Disable calculating a preview before performing the destroy.
+	SkipPreview bool
+	// Only show a preview of the destroy, but does not perform the destroy itself.
+	PreviewOnly bool
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -1063,6 +1063,12 @@ func destroyOptsToCmd(destroyOpts *optdestroy.Options, s *Stack) []string {
 			args = append(args, "--run-program=false")
 		}
 	}
+	if destroyOpts.SkipPreview {
+		args = append(args, "--skip-preview")
+	}
+	if destroyOpts.PreviewOnly {
+		args = append(args, "--preview-only")
+	}
 
 	execKind := constant.ExecKindAutoLocal
 	if s.Workspace().Program() != nil {


### PR DESCRIPTION
Expose --skip-preview and --preview-only options for `pulumi destroy` through Go Automation API.