### PR TITLE
Add PolicyPacks to preview/up options in Go autoapi

### DIFF
--- a/changelog/pending/20250603--auto-go--add-policypacks-to-preview-up-options.yaml
+++ b/changelog/pending/20250603--auto-go--add-policypacks-to-preview-up-options.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Add PolicyPacks to preview/up options

--- a/sdk/go/auto/optpreview/optpreview.go
+++ b/sdk/go/auto/optpreview/optpreview.go
@@ -178,6 +178,20 @@ func ConfigFile(path string) Option {
 	})
 }
 
+// PolicyPacks specifies one or more policy packs to run as part of this update
+func PolicyPacks(packs ...string) Option {
+	return optionFunc(func(opts *Options) {
+		opts.PolicyPacks = packs
+	})
+}
+
+// PolicyPackConfigs specifies one or more paths to JSON files containing the config for the policy pack
+func PolicyPackConfigs(paths ...string) Option {
+	return optionFunc(func(opts *Options) {
+		opts.PolicyPackConfigs = paths
+	})
+}
+
 // Option is a parameter to be applied to a Stack.Preview() operation
 type Option interface {
 	ApplyOption(*Options)

--- a/sdk/go/auto/optup/optup.go
+++ b/sdk/go/auto/optup/optup.go
@@ -185,6 +185,20 @@ func ConfigFile(path string) Option {
 	})
 }
 
+// PolicyPacks specifies one or more policy packs to run as part of this update
+func PolicyPacks(packs ...string) Option {
+	return optionFunc(func(opts *Options) {
+		opts.PolicyPacks = packs
+	})
+}
+
+// PolicyPackConfigs specifies one or more paths to JSON files containing the config for the policy pack
+func PolicyPackConfigs(paths ...string) Option {
+	return optionFunc(func(opts *Options) {
+		opts.PolicyPackConfigs = paths
+	})
+}
+
 // Option is a parameter to be applied to a Stack.Up() operation
 type Option interface {
 	ApplyOption(*Options)


### PR DESCRIPTION
This was already plumbed into the main options struct and the command code, we just never exposed a method to users to actually set them.