### PR TITLE
Allow clientLanguageRuntimeHost to use other standard language plugins

### DIFF
--- a/changelog/pending/20250604--engine--fix-loading-of-non-client-language-runtimes-when-running-inline-programs.yaml
+++ b/changelog/pending/20250604--engine--fix-loading-of-non-client-language-runtimes-when-running-inline-programs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix loading of non-client language runtimes when running inline programs

--- a/pkg/engine/plugin_host.go
+++ b/pkg/engine/plugin_host.go
@@ -49,6 +49,9 @@ func (host *clientLanguageRuntimeHost) LanguageRuntime(
 	runtime string,
 	info plugin.ProgramInfo,
 ) (plugin.LanguageRuntime, error) {
+	// If the system has asked for the special "client" runtime, return the connection we have to the language runtime
+	// plugin. Else, delegate to the host's LanguageRuntime method for loading other actual runtimes like
+	// nodejs/python/etc.
 	if runtime == clientRuntimeName {
 		return host.languageRuntime, nil
 	}


### PR DESCRIPTION
Should fix the issues with policy pack install, and also fix the use of shimless with inline programs. Neither of these are tested right now because we hit a load of other issues trying to put automatic tests in place for them. But this _should_ fix the use of language runtimes in inline programs.