### PR TITLE
Support runProgram for preview/up in auto sdk

### DIFF
--- a/changelog/pending/20250604--auto-pass-run-program-to-preview-and-up.yaml
+++ b/changelog/pending/20250604--auto-pass-run-program-to-preview-and-up.yaml
@@ -1,0 +1,4 @@
+changes:
+  - type: feat
+    scope: auto
+    description: Support providing runProgram to `preview` and `up` in auto sdk

--- a/sdk/go/auto/optpreview/optpreview.go
+++ b/sdk/go/auto/optpreview/optpreview.go
@@ -178,6 +178,13 @@ func ConfigFile(path string) Option {
 	})
 }
 
+// RunProgram runs the program in the workspace to perform the refresh.
+func RunProgram(f bool) Option {
+	return optionFunc(func(opts *Options) {
+		opts.RunProgram = &f
+	})
+}
+
 // PolicyPacks specifies one or more policy packs to run as part of this update
 func PolicyPacks(packs ...string) Option {
 	return optionFunc(func(opts *Options) {
@@ -250,6 +257,8 @@ type Options struct {
 	AttachDebugger bool
 	// Run using the configuration values in the specified file rather than detecting the file name
 	ConfigFile string
+	// When set to true, run the program in the workspace to perform the refresh.
+	RunProgram *bool
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/optup/optup.go
+++ b/sdk/go/auto/optup/optup.go
@@ -185,6 +185,13 @@ func ConfigFile(path string) Option {
 	})
 }
 
+// RunProgram runs the program in the workspace to perform the refresh.
+func RunProgram(f bool) Option {
+	return optionFunc(func(opts *Options) {
+		opts.RunProgram = &f
+	})
+}
+
 // PolicyPacks specifies one or more policy packs to run as part of this update
 func PolicyPacks(packs ...string) Option {
 	return optionFunc(func(opts *Options) {
@@ -259,6 +266,8 @@ type Options struct {
 	AttachDebugger bool
 	// Run using the configuration values in the specified file rather than detecting the file name
 	ConfigFile string
+	// When set to true, run the program in the workspace to perform the refresh.
+	RunProgram *bool
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -292,6 +292,13 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 	if preOpts.ConfigFile != "" {
 		sharedArgs = append(sharedArgs, "--config-file="+preOpts.ConfigFile)
 	}
+	if preOpts.RunProgram != nil {
+		if *preOpts.RunProgram {
+			sharedArgs = append(sharedArgs, "--run-program=true")
+		} else {
+			sharedArgs = append(sharedArgs, "--run-program=false")
+		}
+	}
 
 	// Apply the remote args, if needed.
 	sharedArgs = append(sharedArgs, s.remoteArgs()...)
@@ -436,6 +443,13 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 	}
 	if upOpts.ConfigFile != "" {
 		sharedArgs = append(sharedArgs, "--config-file="+upOpts.ConfigFile)
+	}
+	if upOpts.RunProgram != nil {
+		if *upOpts.RunProgram {
+			sharedArgs = append(sharedArgs, "--run-program=true")
+		} else {
+			sharedArgs = append(sharedArgs, "--run-program=false")
+		}
 	}
 
 	// Apply the remote args, if needed.

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -229,6 +229,13 @@ Event: ${line}\n${e.toString()}`);
             if (opts.attachDebugger) {
                 args.push("--attach-debugger");
             }
+            if (opts.runProgram !== undefined) {
+                if (opts.runProgram) {
+                    args.push("--run-program=true");
+                } else {
+                    args.push("--run-program=false");
+                }
+            }
             applyGlobalOpts(opts, args);
         }
 
@@ -375,6 +382,13 @@ Event: ${line}\n${e.toString()}`);
             }
             if (opts.attachDebugger) {
                 args.push("--attach-debugger");
+            }
+            if (opts.runProgram !== undefined) {
+                if (opts.runProgram) {
+                    args.push("--run-program=true");
+                } else {
+                    args.push("--run-program=false");
+                }
             }
             applyGlobalOpts(opts, args);
         }
@@ -1483,6 +1497,11 @@ export interface UpOptions extends GlobalOpts {
      * A signal to abort an ongoing operation.
      */
     signal?: AbortSignal;
+
+    /**
+     * Run the program in the workspace to perform the refresh.
+     */
+    runProgram?: boolean;
 }
 
 /**
@@ -1588,6 +1607,11 @@ export interface PreviewOptions extends GlobalOpts {
      * A signal to abort an ongoing operation.
      */
     signal?: AbortSignal;
+
+    /**
+     * Run the program in the workspace to perform the refresh.
+     */
+    runProgram?: boolean;
 }
 
 /**

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -339,7 +339,7 @@ class Stack:
             args.append("--plan")
             args.append(plan)
 
-        if run_program is not None:Add commentMore actions
+        if run_program is not None:
             if run_program:
                 args.append("--run-program=true")
             else:

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -293,6 +293,7 @@ class Stack:
         attach_debugger: Optional[bool] = None,
         refresh: Optional[bool] = None,
         config_file: Optional[str] = None,
+        run_program: Optional[bool] = None,
     ) -> UpResult:
         """
         Creates or updates the resources in a stack by executing the program in the Workspace.
@@ -337,6 +338,12 @@ class Stack:
         if plan is not None:
             args.append("--plan")
             args.append(plan)
+
+        if run_program is not None:Add commentMore actions
+            if run_program:
+                args.append("--run-program=true")
+            else:
+                args.append("--run-program=false")
 
         args.extend(self._remote_args())
 
@@ -424,6 +431,7 @@ class Stack:
         attach_debugger: Optional[bool] = None,
         refresh: Optional[bool] = None,
         config_file: Optional[str] = None,
+        run_program: Optional[bool] = None,
     ) -> PreviewResult:
         """
         Performs a dry-run update to a stack, returning pending changes.
@@ -471,6 +479,12 @@ class Stack:
         if plan is not None:
             args.append("--save-plan")
             args.append(plan)
+
+        if run_program is not None:
+            if run_program:
+                args.append("--run-program=true")
+            else:
+                args.append("--run-program=false")
 
         args.extend(self._remote_args())
 


### PR DESCRIPTION
https://github.com/pulumi/pulumi/pull/19218 introduces runProgram to the automation api, but only for destroy/preview. https://github.com/pulumi/pulumi/pull/19667 introduces support to feed runProgram into pulumi up in the auto sdk. https://github.com/pulumi/pulumi/pull/19449/files already added support for preview/up.

The following change adds the similar support for preview/up in the sdk for go/nodejs/python.