### PR TITLE
Close SourceIterator

### DIFF
--- a/changelog/pending/20250605--engine--close-sourceiterator.yaml
+++ b/changelog/pending/20250605--engine--close-sourceiterator.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: engine
+  description: Close SourceIterator

--- a/pkg/engine/lifecycletest/analyzer_test.go
+++ b/pkg/engine/lifecycletest/analyzer_test.go
@@ -351,7 +351,7 @@ func TestRemediateFailure(t *testing.T) {
 
 	program := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true)
-		assert.NoError(t, err)
+		assert.ErrorContains(t, err, "context canceled")
 		return nil
 	})
 	host := deploytest.NewPluginHostF(nil, nil, program, loaders...)

--- a/pkg/engine/lifecycletest/delete_before_replace_test.go
+++ b/pkg/engine/lifecycletest/delete_before_replace_test.go
@@ -654,17 +654,20 @@ func TestDBRProtect(t *testing.T) {
 		respA, err := monitor.RegisterResource(resType, "resA", true, deploytest.ResourceOptions{
 			Inputs: inputsA,
 		})
-		assert.NoError(t, err)
 
-		inputDepsB := map[resource.PropertyKey][]resource.URN{"A": {respA.URN}}
-		protect := true
-		_, err = monitor.RegisterResource(resType, "resB", true, deploytest.ResourceOptions{
-			Inputs:       inputsB,
-			Dependencies: []resource.URN{respA.URN},
-			PropertyDeps: inputDepsB,
-			Protect:      &protect,
-		})
-		assert.NoError(t, err)
+		if err == nil {
+			inputDepsB := map[resource.PropertyKey][]resource.URN{"A": {respA.URN}}
+			protect := true
+			_, err := monitor.RegisterResource(resType, "resB", true, deploytest.ResourceOptions{
+				Inputs:       inputsB,
+				Dependencies: []resource.URN{respA.URN},
+				PropertyDeps: inputDepsB,
+				Protect:      &protect,
+			})
+			assert.NoError(t, err)
+		} else {
+			assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
+		}
 
 		return nil
 	})

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -1389,9 +1389,9 @@ func TestMultipleResourceDenyDefaultProviderLifecycle(t *testing.T) {
 			name: "default-blocked",
 			f: func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 				_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true)
-				assert.NoError(t, err)
+				assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
 				_, err = monitor.RegisterResource("pkgB:m:typB", "resB", true)
-				assert.NoError(t, err)
+				assert.ErrorContains(t, err, "rpc error: code = Unavailable")
 
 				return nil
 			},
@@ -1423,9 +1423,9 @@ func TestMultipleResourceDenyDefaultProviderLifecycle(t *testing.T) {
 			name: "wildcard",
 			f: func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 				_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true)
-				assert.NoError(t, err)
+				assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
 				_, err = monitor.RegisterResource("pkgB:m:typB", "resB", true)
-				assert.NoError(t, err)
+				assert.ErrorContains(t, err, "rpc error: code = Unavailable")
 
 				return nil
 			},

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -1340,7 +1340,7 @@ func TestLoadFailureShutdown(t *testing.T) {
 		assert.NoError(t, err)
 
 		_, err = monitor.RegisterResource(providers.MakeProviderType("pkgB"), "provB", true)
-		assert.NoError(t, err)
+		assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
 
 		return nil
 	})
@@ -2700,6 +2700,7 @@ func TestProtect(t *testing.T) {
 
 	shouldProtect := true
 	createResource := true
+	expectError := false
 
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		if createResource {
@@ -2707,7 +2708,11 @@ func TestProtect(t *testing.T) {
 				Inputs:  ins,
 				Protect: &shouldProtect,
 			})
-			assert.NoError(t, err)
+			if expectError {
+				assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
+			} else {
+				assert.NoError(t, err)
+			}
 		}
 
 		return nil
@@ -2760,6 +2765,7 @@ func TestProtect(t *testing.T) {
 
 	// Run an update which will cause a replace, we should get an error.
 	// Contrary to the preview, the error is a bail, so no resources are created.
+	expectError = true
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, validate, "2")
 	assert.Error(t, err)
 	assert.NotNil(t, snap)
@@ -2783,6 +2789,7 @@ func TestProtect(t *testing.T) {
 
 	// Run a new update to remove the protect and replace in the same update, this should delete the old one
 	// and create the new one
+	expectError = false
 	createResource = true
 	shouldProtect = false
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "4")
@@ -3302,7 +3309,11 @@ func TestPendingDeleteOrder(t *testing.T) {
 			}),
 			Dependencies: []resource.URN{resp.URN},
 		})
-		assert.NoError(t, err)
+		if failCreationOfTypB {
+			assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
+		} else {
+			assert.NoError(t, err)
+		}
 
 		return nil
 	})
@@ -4313,7 +4324,7 @@ func TestStackOutputsResourceError(t *testing.T) {
 
 		case 1:
 			_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true)
-			assert.ErrorContains(t, err, "oh no")
+			assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
 			// RegisterResourceOutputs not called here, simulating what happens in SDKs when an output of resA
 			// is exported as a stack output.
 
@@ -4325,7 +4336,7 @@ func TestStackOutputsResourceError(t *testing.T) {
 			assert.NoError(t, outsErr)
 
 			_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true)
-			assert.ErrorContains(t, err, "oh no")
+			assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
 		}
 
 		return err

--- a/pkg/engine/lifecycletest/step_generator_test.go
+++ b/pkg/engine/lifecycletest/step_generator_test.go
@@ -383,7 +383,7 @@ func TestReadNilOutputs(t *testing.T) {
 		}).
 		RunUpdate(func(info plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 			_, _, err := monitor.ReadResource("pkgA:m:typA", "resA", resourceID, "", nil, "", "", "", "")
-			assert.ErrorContains(t, err, "resource 'my-resource-id' does not exist")
+			assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
 
 			return nil
 		}, true).

--- a/pkg/engine/lifecycletest/update_plan_test.go
+++ b/pkg/engine/lifecycletest/update_plan_test.go
@@ -52,11 +52,16 @@ func TestPlannedUpdate(t *testing.T) {
 	}
 
 	var ins resource.PropertyMap
+	expectError := false
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: ins,
 		})
-		assert.NoError(t, err)
+		if expectError {
+			assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
+		} else {
+			assert.NoError(t, err)
+		}
 		return nil
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
@@ -89,6 +94,7 @@ func TestPlannedUpdate(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Attempt to run an update using the plan.
+	expectError = true
 	ins = resource.NewPropertyMapFromMap(map[string]interface{}{
 		"qux": []interface{}{
 			"alpha",
@@ -112,6 +118,7 @@ func TestPlannedUpdate(t *testing.T) {
 	plan.ResourcePlans["urn:pulumi:test::test::pulumi:providers:pkgA::default"].Ops = []display.StepOp{deploy.OpSame}
 
 	// Attempt to run an update using the plan.
+	expectError = false
 	ins = resource.NewPropertyMapFromMap(map[string]interface{}{
 		"foo": "bar",
 		"baz": map[string]interface{}{
@@ -174,7 +181,7 @@ func TestUnplannedCreate(t *testing.T) {
 			_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 				Inputs: ins,
 			})
-			assert.NoError(t, err)
+			assert.ErrorContains(t, err, "context canceled")
 		}
 		return nil
 	})
@@ -309,6 +316,7 @@ func TestExpectedDelete(t *testing.T) {
 		"foo": "bar",
 	})
 	createAllResources := true
+	expectError := false
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: ins,
@@ -316,10 +324,14 @@ func TestExpectedDelete(t *testing.T) {
 		assert.NoError(t, err)
 
 		if createAllResources {
-			_, err = monitor.RegisterResource("pkgA:m:typA", "resB", true, deploytest.ResourceOptions{
+			_, err := monitor.RegisterResource("pkgA:m:typA", "resB", true, deploytest.ResourceOptions{
 				Inputs: ins,
 			})
-			assert.NoError(t, err)
+			if expectError {
+				assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
+			} else {
+				assert.NoError(t, err)
+			}
 		}
 
 		return nil
@@ -350,6 +362,7 @@ func TestExpectedDelete(t *testing.T) {
 	// Now run but set the runtime to return resA and resB, given we expected resB to be deleted
 	// this should be an error
 	createAllResources = true
+	expectError = true
 	p.Options.Plan = plan.Clone()
 	validate := ExpectDiagMessage(t, regexp.QuoteMeta(
 		"<{%reset%}>resource urn:pulumi:test::test::pkgA:m:typA::resB violates plan: "+
@@ -461,11 +474,16 @@ func TestPropertySetChange(t *testing.T) {
 		"foo":  "bar",
 		"frob": "baz",
 	})
+	expectError := false
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: ins,
 		})
-		assert.NoError(t, err)
+		if expectError {
+			assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
+		} else {
+			assert.NoError(t, err)
+		}
 
 		return nil
 	})
@@ -490,6 +508,7 @@ func TestPropertySetChange(t *testing.T) {
 	ins = resource.NewPropertyMapFromMap(map[string]interface{}{
 		"foo": "bar",
 	})
+	expectError = true
 	p.Options.Plan = plan.Clone()
 	validate := ExpectDiagMessage(t, regexp.QuoteMeta(
 		"<{%reset%}>resource urn:pulumi:test::test::pkgA:m:typA::resA violates plan: "+
@@ -762,11 +781,16 @@ func TestPlannedPreviews(t *testing.T) {
 	}
 
 	var ins resource.PropertyMap
+	expectError := false
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: ins,
 		})
-		assert.NoError(t, err)
+		if expectError {
+			assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
+		} else {
+			assert.NoError(t, err)
+		}
 		return nil
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
@@ -799,6 +823,7 @@ func TestPlannedPreviews(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Attempt to run a new preview using the plan, given we've changed the property set this should fail
+	expectError = true
 	ins = resource.NewPropertyMapFromMap(map[string]interface{}{
 		"qux": []interface{}{
 			"alpha",
@@ -813,6 +838,7 @@ func TestPlannedPreviews(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Attempt to run an preview using the plan, such that the property set is now valid
+	expectError = false
 	ins = resource.NewPropertyMapFromMap(map[string]interface{}{
 		"foo": "bar",
 		"baz": map[string]interface{}{
@@ -850,11 +876,16 @@ func TestPlannedUpdateChangedStack(t *testing.T) {
 	}
 
 	var ins resource.PropertyMap
+	expectError := false
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: ins,
 		})
-		assert.NoError(t, err)
+		if expectError {
+			assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
+		} else {
+			assert.NoError(t, err)
+		}
 		return nil
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
@@ -894,6 +925,7 @@ func TestPlannedUpdateChangedStack(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Attempt to run an update using the plan but where we haven't updated our program for the change of zed
+	expectError = true
 	ins = resource.NewPropertyMapFromMap(map[string]interface{}{
 		"foo": "baz",
 		"zed": 24,
@@ -942,8 +974,7 @@ func TestPlannedOutputChanges(t *testing.T) {
 		resp, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{})
 		assert.NoError(t, err)
 
-		err = monitor.RegisterResourceOutputs(resp.URN, outs)
-		assert.NoError(t, err)
+		_ = monitor.RegisterResourceOutputs(resp.URN, outs)
 
 		return nil
 	})
@@ -1016,11 +1047,16 @@ func TestPlannedInputOutputDifferences(t *testing.T) {
 		"foo":  "bar",
 		"frob": "baz",
 	})
+	expectError := false
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: inputs,
 		})
-		assert.NoError(t, err)
+		if expectError {
+			assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
+		} else {
+			assert.NoError(t, err)
+		}
 
 		return nil
 	})
@@ -1058,6 +1094,7 @@ func TestPlannedInputOutputDifferences(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test the plan fails if we don't pass newBazzer
+	expectError = true
 	inputs = resource.NewPropertyMapFromMap(map[string]interface{}{
 		"foo":  "bar",
 		"frob": "differentBazzer",
@@ -1071,6 +1108,7 @@ func TestPlannedInputOutputDifferences(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check the plan succeeds if we do pass newBazzer
+	expectError = false
 	inputs = resource.NewPropertyMapFromMap(map[string]interface{}{
 		"foo":  "bar",
 		"frob": "newBazzer",
@@ -1324,18 +1362,24 @@ func TestPlannedUpdateWithNondeterministicCheck(t *testing.T) {
 	}
 
 	var ins resource.PropertyMap
+	expectError := false
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		resp, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: ins,
 		})
-		assert.NoError(t, err)
 
-		_, err = monitor.RegisterResource("pkgA:m:typA", "resB", true, deploytest.ResourceOptions{
-			Inputs: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"other": resp.Outputs["name"].StringValue(),
-			}),
-		})
-		assert.NoError(t, err)
+		if err == nil {
+			_, err := monitor.RegisterResource("pkgA:m:typA", "resB", true, deploytest.ResourceOptions{
+				Inputs: resource.NewPropertyMapFromMap(map[string]interface{}{
+					"other": resp.Outputs["name"].StringValue(),
+				}),
+			})
+			if expectError {
+				assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
+			} else {
+				assert.NoError(t, err)
+			}
+		}
 
 		return nil
 	})
@@ -1363,6 +1407,7 @@ func TestPlannedUpdateWithNondeterministicCheck(t *testing.T) {
 
 	// Attempt to run an update using the plan.
 	// This should fail because of the non-determinism
+	expectError = true
 	ins = resource.NewPropertyMapFromMap(map[string]interface{}{
 		"foo": "bar",
 		"zed": "baz",
@@ -1415,11 +1460,16 @@ func TestPlannedUpdateWithCheckFailure(t *testing.T) {
 	}
 
 	var ins resource.PropertyMap
+	expectError := false
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: ins,
 		})
-		assert.NoError(t, err)
+		if expectError {
+			assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
+		} else {
+			assert.NoError(t, err)
+		}
 		return nil
 	})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
@@ -1435,6 +1485,7 @@ func TestPlannedUpdateWithCheckFailure(t *testing.T) {
 	project := p.GetProject()
 
 	// Generate a plan with bad inputs
+	expectError = true
 	ins = resource.NewPropertyMapFromMap(map[string]interface{}{
 		"foo": "bad",
 	})
@@ -1445,6 +1496,7 @@ func TestPlannedUpdateWithCheckFailure(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Generate a plan with good inputs
+	expectError = false
 	ins = resource.NewPropertyMapFromMap(map[string]interface{}{
 		"foo": "good",
 	})
@@ -1454,6 +1506,7 @@ func TestPlannedUpdateWithCheckFailure(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Try and run against the plan with inputs that will fail Check
+	expectError = true
 	ins = resource.NewPropertyMapFromMap(map[string]interface{}{
 		"foo": "bad",
 	})
@@ -1713,20 +1766,24 @@ func TestResourcesTargeted(t *testing.T) {
 		}),
 	}
 
+	expectError := false
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: resource.PropertyMap{
 				"foo": resource.NewStringProperty("bar"),
 			},
 		})
-		assert.NoError(t, err)
+		if expectError {
+			assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
+		} else {
+			assert.NoError(t, err)
+		}
 
-		_, err = monitor.RegisterResource("pkgA:m:typA", "resB", true, deploytest.ResourceOptions{
+		_, _ = monitor.RegisterResource("pkgA:m:typA", "resB", true, deploytest.ResourceOptions{
 			Inputs: resource.PropertyMap{
 				"foo": resource.NewStringProperty("bar"),
 			},
 		})
-		assert.NoError(t, err)
 
 		return nil
 	})
@@ -1754,6 +1811,7 @@ func TestResourcesTargeted(t *testing.T) {
 
 	// Check that running an update with everything targeted fails due to our plan being constrained
 	// to the resource.
+	expectError = true
 	_, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), lt.TestUpdateOptions{
 		T:     t,
 		HostF: hostF,
@@ -1766,6 +1824,7 @@ func TestResourcesTargeted(t *testing.T) {
 	assert.Error(t, err)
 
 	// Check that running an update with the same Targets as the Plan succeeds.
+	expectError = false
 	_, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), lt.TestUpdateOptions{
 		T:     t,
 		HostF: hostF,

--- a/pkg/engine/lifecycletest/views_test.go
+++ b/pkg/engine/lifecycletest/views_test.go
@@ -379,12 +379,14 @@ func TestViewsUpdateError(t *testing.T) {
 		"foo": "bar",
 	})
 
-	creating := true
+	expectError := false
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		if creating {
-			_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
-				Inputs: ins,
-			})
+		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
+			Inputs: ins,
+		})
+		if expectError {
+			assert.Error(t, err, "resource monitor shut down while waiting on step's done channel")
+		} else {
 			assert.NoError(t, err)
 		}
 		return nil
@@ -433,6 +435,7 @@ func TestViewsUpdateError(t *testing.T) {
 	}, snap.Resources[2].Outputs)
 
 	// Run a second update, we should get an error for the view.
+	expectError = true
 	ins = resource.NewPropertyMapFromMap(map[string]any{
 		"foo": "baz",
 	})

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -181,6 +181,7 @@ func (ex *deploymentExecutor) Execute(callerCtx context.Context) (*Plan, error) 
 	if err != nil {
 		return nil, err
 	}
+	defer src.Close()
 
 	// Set up a step generator for this deployment.
 	mode := updateMode

--- a/pkg/resource/deploy/deployment_executor_test.go
+++ b/pkg/resource/deploy/deployment_executor_test.go
@@ -15,10 +15,16 @@
 package deploy
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRebuildBaseStateDanglingParentsSimple(t *testing.T) {
@@ -186,4 +192,50 @@ func makeStepsAndExecutor(states ...*resource.State) (map[*resource.State]Step, 
 	}
 
 	return steps, ex
+}
+
+type source struct {
+	iterator SourceIterator
+}
+
+func (src *source) Close() error                { return nil }
+func (src *source) Project() tokens.PackageName { return "project" }
+func (src *source) Iterate(ctx context.Context, providers ProviderSource) (SourceIterator, error) {
+	return src.iterator, nil
+}
+
+type iterator struct {
+	closed bool
+}
+
+func (iter *iterator) Close() error {
+	iter.closed = true
+	return nil
+}
+
+func (iter *iterator) Next() (SourceEvent, error) {
+	// Return an error on iteration. This makes DeploymentExecutor.Execute
+	// return fairly early, letting us get away with mocking less of the system
+	// to test the closing behaviour.
+	// It also ensures we do call `Close` in the presence of an error.
+	return nil, errors.New("error")
+}
+
+func TestSourceIteratorClose(t *testing.T) {
+	t.Parallel()
+	iter := &iterator{}
+	ex := &deploymentExecutor{
+		deployment: &Deployment{
+			source: &source{iter},
+			opts:   &Options{},
+			ctx: &plugin.Context{
+				Diag: &deploytest.NoopSink{},
+			},
+		},
+		stepGen: &stepGenerator{},
+	}
+
+	_, err := ex.Execute(context.Background())
+	require.ErrorContains(t, err, "BAIL")
+	require.True(t, iter.closed, "The source iterator should be closed after execution")
 }


### PR DESCRIPTION
We need to close the SourceIterator so it will cleanup the resource monitor. This will cancel any outstanding requests on the resource monitor, which ensures that the calls get written to the  `PULUMI_DEBUG_GRPC` log.

This required updated many of the lifecycle tests since now the `monitor.RegisterResource` calls always returns. Tests previously asserted `NoError` on these, but we never actually hit the assertion.