### PR TITLE
Fix `get-schema` to use the loaded plugin host

### DIFF
--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -779,12 +779,8 @@ func ProviderFromSource(pctx *plugin.Context, packageSource string) (plugin.Prov
 	// prefer the downloadable plugin.  The user can disambiguate by prepending './' to the
 	// name.
 	if !plugin.IsLocalPluginPath(packageSource) {
-		host, err := plugin.NewDefaultHost(pctx, nil, false, nil, nil, nil, nil, "")
-		if err != nil {
-			return nil, err
-		}
 		// We assume this was a plugin and not a path, so load the plugin.
-		provider, err := host.Provider(descriptor)
+		provider, err := pctx.Host.Provider(descriptor)
 		if err != nil {
 			// There is an executable or directory with the same name, so suggest that
 			if info, statErr := os.Stat(descriptor.Name); statErr == nil && (isExecutable(info) || info.IsDir()) {
@@ -806,7 +802,7 @@ func ProviderFromSource(pctx *plugin.Context, packageSource string) (plugin.Prov
 					if depErr != nil {
 						return nil, fmt.Errorf("installing plugin dependencies: %w", depErr)
 					}
-					return host.Provider(descriptor)
+					return pctx.Host.Provider(descriptor)
 				}
 			}
 
@@ -817,7 +813,7 @@ func ProviderFromSource(pctx *plugin.Context, packageSource string) (plugin.Prov
 			}
 
 			log := func(sev diag.Severity, msg string) {
-				host.Log(sev, "", msg, 0)
+				pctx.Host.Log(sev, "", msg, 0)
 			}
 
 			_, err = pkgWorkspace.InstallPlugin(pctx.Base(), descriptor.PluginSpec, log)
@@ -825,7 +821,7 @@ func ProviderFromSource(pctx *plugin.Context, packageSource string) (plugin.Prov
 				return nil, err
 			}
 
-			p, err := host.Provider(descriptor)
+			p, err := pctx.Host.Provider(descriptor)
 			if err != nil {
 				return nil, err
 			}

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -298,6 +298,25 @@ func TestPackageGetSchema(t *testing.T) {
 	// Sub-schema is a very simple empty schema with the name set from the argument given
 	assert.Equal(t, "parameter", schema.Name)
 
+	// Now try and get the parameterized schema from within a Pulumi project with a packages declaration.
+	err = os.WriteFile(
+		filepath.Join(e.CWD, "Pulumi.yaml"),
+		[]byte(fmt.Sprintf(`name: project
+runtime: yaml
+packages:
+  tp: %s
+backend:
+  url: '%s'`,
+			providerDir,
+			e.LocalURL(),
+		)), 0o600)
+	require.NoError(t, err)
+
+	schemaJSON, _ = e.RunCommand("pulumi", "package", "get-schema", "tp", "parameter")
+	schema = bindSchema("testprovider", schemaJSON)
+	// Sub-schema is a very simple empty schema with the name set from the argument given
+	assert.Equal(t, "parameter", schema.Name)
+
 	// get-schema '.' works
 	e.CWD = providerDir
 	schemaJSON, _ = e.RunCommand("pulumi", "package", "get-schema", ".", "parameter")


### PR DESCRIPTION
When running `pulumi package get-schema`, a plugin host is constructed using the active Pulumi project where available. Later on, however, we don't use this host to load plugins for retrieving the schema, instead constructing a new one. This means that, if a `Pulumi.yaml` file defines `packages`, these packages are not consulted by `pulumi package get-schema` and their schema can't be retrieved. This change fixes that by using the already-constructed `pctx.Host`.