### PR TITLE
Fix plan generation for imported resources

### DIFF
--- a/changelog/pending/20250605--engine--fix-panic-when-importing-resources.yaml
+++ b/changelog/pending/20250605--engine--fix-panic-when-importing-resources.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix panic when importing resources.

--- a/pkg/engine/lifecycletest/framework/framework.go
+++ b/pkg/engine/lifecycletest/framework/framework.go
@@ -238,6 +238,9 @@ func (op TestOp) runWithContext(
 	}
 
 	updateOpts := opts.Options()
+	// We want to always run with plan generation to ensure that plans _can_ be generated.
+	// This is to prevent regressions such as https://github.com/pulumi/pulumi/pull/19750.
+	updateOpts.GeneratePlan = true
 	defer func() {
 		if updateOpts.Host != nil {
 			contract.IgnoreClose(updateOpts.Host)

--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
 	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -120,7 +121,7 @@ func TestImportOption(t *testing.T) {
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
 	p := &lt.TestPlan{
-		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF, UpdateOptions: engine.UpdateOptions{GeneratePlan: true}},
 	}
 	provURN := p.NewProviderURN("pkgA", "default", "")
 	resURN := p.NewURN("pkgA:m:typA", "resA", "")

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -905,6 +905,7 @@ func (sg *stepGenerator) continueStepsFromRefresh(event ContinueResourceRefreshE
 				invalid:               event.Invalid(),
 				recreating:            recreating,
 				randomSeed:            randomSeed,
+				isImported:            true,
 			}
 		}()
 
@@ -928,6 +929,7 @@ func (sg *stepGenerator) continueStepsFromRefresh(event ContinueResourceRefreshE
 		invalid:               event.Invalid(),
 		recreating:            recreating,
 		randomSeed:            randomSeed,
+		isImported:            false,
 	}
 
 	return sg.continueStepsFromImport(continueEvent)
@@ -964,6 +966,7 @@ func (sg *stepGenerator) continueStepsFromImport(event ContinueResourceImportEve
 	invalid := event.Invalid()
 	recreating := event.Recreating()
 	randomSeed := event.RandomSeed()
+	imported := event.IsImported()
 
 	// If the import failed just exit out, the step executor will already have signaled the error to the
 	// deployment.
@@ -1073,8 +1076,8 @@ func (sg *stepGenerator) continueStepsFromImport(event ContinueResourceImportEve
 		}
 		inputDiff := oldInputs.Diff(inputs)
 
-		// Generate the output goal plan, if we're recreating this it should already exist
-		if recreating {
+		// Generate the output goal plan, if we're recreating or imported this it should already exist
+		if recreating || imported {
 			plan, ok := sg.deployment.newPlans.get(urn)
 			if !ok {
 				return nil, false, fmt.Errorf("no plan for resource %v", urn)

--- a/pkg/resource/deploy/step_generator_events.go
+++ b/pkg/resource/deploy/step_generator_events.go
@@ -147,6 +147,7 @@ type ContinueResourceImportEvent interface {
 	Invalid() bool
 	Recreating() bool
 	RandomSeed() []byte
+	IsImported() bool
 }
 
 type continueResourceImportEvent struct {
@@ -159,6 +160,9 @@ type continueResourceImportEvent struct {
 	invalid    bool
 	recreating bool
 	randomSeed []byte
+	// whether the resource is actually imported, or if we're just continuing the step generation for a
+	// normal resource.
+	isImported bool
 }
 
 var _ ContinueResourceImportEvent = (*continueResourceImportEvent)(nil)
@@ -195,4 +199,8 @@ func (g *continueResourceImportEvent) Recreating() bool {
 
 func (g *continueResourceImportEvent) RandomSeed() []byte {
 	return g.randomSeed
+}
+
+func (g *continueResourceImportEvent) IsImported() bool {
+	return g.isImported
 }


### PR DESCRIPTION
Engine tests weren't running with plan generation turned on, but in the CLI we always enable this. That missed that we could hit a panic for imported resources because it hit an error that it's plan already unexpectedly existed.

It would be worth our time ensuring engine tests always test this flag.