### PR TITLE
Pass `context.Context` to `plugin.IsLocalPluginPath`

### DIFF
--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -191,7 +191,7 @@ func installPackagesFromProject(pctx *plugin.Context, proj *workspace.Project, r
 		fmt.Printf("Installing package '%s'...\n", name)
 
 		installSource := packageSpec.Source
-		if !plugin.IsLocalPluginPath(installSource) && packageSpec.Version != "" {
+		if !plugin.IsLocalPluginPath(pctx.Base(), installSource) && packageSpec.Version != "" {
 			installSource = fmt.Sprintf("%s@%s", installSource, packageSpec.Version)
 		}
 

--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -778,7 +778,7 @@ func ProviderFromSource(pctx *plugin.Context, packageSource string) (plugin.Prov
 	// Note that if a local folder has a name that could match an downloadable plugin, we
 	// prefer the downloadable plugin.  The user can disambiguate by prepending './' to the
 	// name.
-	if !plugin.IsLocalPluginPath(packageSource) {
+	if !plugin.IsLocalPluginPath(pctx.Base(), packageSource) {
 		// We assume this was a plugin and not a path, so load the plugin.
 		provider, err := pctx.Host.Provider(descriptor)
 		if err != nil {

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -103,7 +103,7 @@ type Host interface {
 
 // IsLocalPluginPath determines if a plugin source refers to a local path rather than a downloadable plugin.
 // A plugin is considered local if it doesn't match the plugin name regexp and doesn't have a download URL.
-func IsLocalPluginPath(source string) bool {
+func IsLocalPluginPath(ctx context.Context, source string) bool {
 	// If the source starts with ./ or ../ or / it's definitely a local path
 	if strings.HasPrefix(source, "./") || strings.HasPrefix(source, "..") || strings.HasPrefix(source, "/") {
 		return true
@@ -111,7 +111,7 @@ func IsLocalPluginPath(source string) bool {
 
 	// For other cases, we need to be careful about how we interpret the source, so let's parse the spec
 	// and check if it has a download URL.
-	pluginSpec, err := workspace.NewPluginSpec(context.TODO(), source, apitype.ResourcePlugin, nil, "", nil)
+	pluginSpec, err := workspace.NewPluginSpec(ctx, source, apitype.ResourcePlugin, nil, "", nil)
 	var pluginErr workspace.PluginVersionNotFoundError
 	if err != nil && !errors.As(err, &pluginErr) {
 		// If we can't parse it as a plugin spec, assume it's a local path
@@ -160,7 +160,7 @@ func NewDefaultHost(ctx *Context, runtimeOptions map[string]interface{},
 
 	for name, pkg := range packages {
 		// Skip downloadable plugins, so that only local folder paths remain.
-		if !IsLocalPluginPath(pkg.Source) {
+		if !IsLocalPluginPath(ctx.baseContext, pkg.Source) {
 			continue
 		}
 

--- a/sdk/go/common/resource/plugin/host_test.go
+++ b/sdk/go/common/resource/plugin/host_test.go
@@ -60,6 +60,8 @@ func TestClosePanic(t *testing.T) {
 func TestIsLocalPluginPath(t *testing.T) {
 	t.Parallel()
 
+	ctx := context.Background()
+
 	tests := []struct {
 		name     string
 		path     string
@@ -141,7 +143,7 @@ func TestIsLocalPluginPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := IsLocalPluginPath(tt.path)
+			result := IsLocalPluginPath(ctx, tt.path)
 			assert.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
Context propagation is nice. More propagation is better.

A GitHub search shows that only we use `plugin.IsLocalPluginPath`:

https://github.com/search?q=%22plugin.IsLocalPluginPath%22+-is%3Afork&type=code