### PR TITLE
Add ListStackNames method to Backend interface and implementations

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -164,6 +164,10 @@ type Backend interface {
 	// ListStacks returns a list of stack summaries for all known stacks in the target backend.
 	ListStacks(ctx context.Context, filter ListStacksFilter, inContToken ContinuationToken) (
 		[]StackSummary, ContinuationToken, error)
+	// ListStackNames returns a list of stack references without metadata for all known stacks in the target backend.
+	// This is a more efficient method for scenarios like stack selection where only stack names are needed.
+	ListStackNames(ctx context.Context, filter ListStacksFilter, inContToken ContinuationToken) (
+		[]StackReference, ContinuationToken, error)
 
 	// RenameStack renames the given stack to a new name, and then returns an updated stack reference that
 	// can be used to refer to the newly renamed stack.

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1071,6 +1071,25 @@ func (b *cloudBackend) ListStacks(
 	return backendSummaries, outContToken, nil
 }
 
+func (b *cloudBackend) ListStackNames(
+	ctx context.Context, filter backend.ListStacksFilter, inContToken backend.ContinuationToken) (
+	[]backend.StackReference, backend.ContinuationToken, error,
+) {
+	// For the cloud backend, we can reuse ListStacks since the API already returns data efficiently.
+	// We just extract the stack references from the summaries.
+	summaries, outContToken, err := b.ListStacks(ctx, filter, inContToken)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	stackRefs := slice.Prealloc[backend.StackReference](len(summaries))
+	for _, summary := range summaries {
+		stackRefs = append(stackRefs, summary.Name())
+	}
+
+	return stackRefs, outContToken, nil
+}
+
 func (b *cloudBackend) RemoveStack(ctx context.Context, stack backend.Stack, force bool) (bool, error) {
 	stackID, err := b.getCloudStackIdentifier(stack.Ref())
 	if err != nil {

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -67,6 +67,8 @@ type MockBackend struct {
 	RemoveStackF func(context.Context, Stack, bool) (bool, error)
 	ListStacksF  func(context.Context, ListStacksFilter, ContinuationToken) (
 		[]StackSummary, ContinuationToken, error)
+	ListStackNamesF func(context.Context, ListStacksFilter, ContinuationToken) (
+		[]StackReference, ContinuationToken, error)
 	RenameStackF                          func(context.Context, Stack, tokens.QName) (StackReference, error)
 	GetStackCrypterF                      func(StackReference) (config.Crypter, error)
 	GetLatestConfigurationF               func(context.Context, Stack) (config.Map, error)
@@ -267,6 +269,15 @@ func (be *MockBackend) ListStacks(ctx context.Context, filter ListStacksFilter, 
 ) {
 	if be.ListStacksF != nil {
 		return be.ListStacksF(ctx, filter, inContToken)
+	}
+	panic("not implemented")
+}
+
+func (be *MockBackend) ListStackNames(ctx context.Context, filter ListStacksFilter, inContToken ContinuationToken) (
+	[]StackReference, ContinuationToken, error,
+) {
+	if be.ListStackNamesF != nil {
+		return be.ListStackNamesF(ctx, filter, inContToken)
 	}
 	panic("not implemented")
 }

--- a/pkg/cmd/pulumi/stack/io.go
+++ b/pkg/cmd/pulumi/stack/io.go
@@ -214,16 +214,16 @@ func ChooseStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 	project := string(proj.Name)
 
 	var (
-		allSummaries []backend.StackSummary
+		allStackRefs []backend.StackReference
 		inContToken  backend.ContinuationToken
 	)
 	for {
-		summaries, outContToken, err := b.ListStacks(ctx, backend.ListStacksFilter{Project: &project}, inContToken)
+		stackRefs, outContToken, err := b.ListStackNames(ctx, backend.ListStacksFilter{Project: &project}, inContToken)
 		if err != nil {
 			return nil, fmt.Errorf("could not query backend for stacks: %w", err)
 		}
 
-		allSummaries = append(allSummaries, summaries...)
+		allStackRefs = append(allStackRefs, stackRefs...)
 
 		if outContToken == nil {
 			break
@@ -231,9 +231,9 @@ func ChooseStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 		inContToken = outContToken
 	}
 
-	options := slice.Prealloc[string](len(allSummaries))
-	for _, summary := range allSummaries {
-		name := summary.Name().String()
+	options := slice.Prealloc[string](len(allStackRefs))
+	for _, stackRef := range allStackRefs {
+		name := stackRef.String()
 		options = append(options, name)
 	}
 	sort.Strings(options)


### PR DESCRIPTION
This commit introduces the ListStackNames method to the Backend interface, allowing for efficient retrieval of stack references without metadata. The implementation includes:

- Addition of ListStackNames to the DIY and cloud backends, leveraging existing ListStacks functionality for the cloud backend.
- Mock backend support for ListStackNames to facilitate testing.
- Comprehensive unit tests for ListStackNames across different backends to ensure correctness and expected behavior.

This enhancement improves performance in scenarios where only stack names are needed, such as stack selection.

Fixes https://github.com/pulumi/pulumi/issues/19700