### PR TITLE
Use the Pulumi Registry when resolving `pluginDownloadURLs` for `pulumi plugin install`.

### DIFF
--- a/changelog/pending/20250609--cli-install--resolve-plugin-download-urls-by-referencing-the-pulumi-registry.yaml
+++ b/changelog/pending/20250609--cli-install--resolve-plugin-download-urls-by-referencing-the-pulumi-registry.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/install
+  description: Resolve plugin download URLs by referencing the Pulumi Registry

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -352,7 +352,12 @@ func pulumiAPICall(ctx context.Context,
 		if err != nil {
 			return "", nil, fmt.Errorf("API call failed (%s), could not read response: %w", resp.Status, err)
 		}
-		return "", nil, decodeError(respBody, resp.StatusCode, opts)
+		err = decodeError(respBody, resp.StatusCode, opts)
+		if resp.StatusCode == 403 {
+			err = backenderr.ForbiddenError{Err: err}
+		}
+
+		return "", nil, err
 	}
 
 	return url, resp, nil

--- a/pkg/cmd/pulumi/plugin/plugin_install_test.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install_test.go
@@ -17,16 +17,19 @@ package plugin
 import (
 	"context"
 	"errors"
+	"iter"
 	"testing"
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Test for https://github.com/pulumi/pulumi/issues/11703, check we give an error when trying to install a
@@ -110,4 +113,143 @@ func TestGetLatestPluginIncludedVersion(t *testing.T) {
 
 	err := cmd.Run(context.Background(), []string{"resource", "aws@1000.78.0"})
 	assert.NoError(t, err)
+}
+
+func TestGetPluginDownloadURLFromRegistry(t *testing.T) {
+	t.Parallel()
+
+	var pluginWasInstalled bool
+	defer func() {
+		assert.True(t, pluginWasInstalled, "installPluginSpec should have been called")
+	}()
+
+	cmd := &pluginInstallCmd{
+		diag: diagtest.LogSink(t),
+		pluginGetLatestVersion: func(ps workspace.PluginSpec, ctx context.Context) (*semver.Version, error) {
+			assert.Fail(t, "GetLatestVersion should not have been called")
+			return nil, nil
+		},
+		registry: testMockRegistry{
+			searchByName: func(
+				ctx context.Context, name *string,
+			) iter.Seq2[apitype.PackageMetadata, error] {
+				return func(yield func(apitype.PackageMetadata, error) bool) {
+					yield(apitype.PackageMetadata{
+						Name:              "foo",
+						Publisher:         "pulumi",
+						Source:            "pulumi",
+						Version:           semver.Version{Major: 2},
+						PluginDownloadURL: "http://example.com/download",
+					}, nil)
+				}
+			},
+		},
+		installPluginSpec: func(
+			_ context.Context, _ string,
+			install workspace.PluginSpec, _ string,
+			_ diag.Sink, _ colors.Colorization, _ bool,
+		) error {
+			pluginWasInstalled = true
+			assert.Equal(t, workspace.PluginSpec{
+				Name: "foo",
+				Kind: apitype.ResourcePlugin,
+				Version: &semver.Version{
+					Major: 2,
+				},
+				PluginDownloadURL: "http://example.com/download",
+			}, install)
+			return nil
+		},
+	}
+
+	err := cmd.Run(context.Background(), []string{"resource", "foo@2.0.0"})
+	assert.NoError(t, err)
+}
+
+// We need to check that we don't break installs of versions that are not published into the registry.
+func TestGetPluginDownloadFromUnpublishedPackage(t *testing.T) {
+	t.Parallel()
+
+	var pluginWasInstalled bool
+	defer func() {
+		assert.True(t, pluginWasInstalled, "installPluginSpec should have been called")
+	}()
+
+	cmd := &pluginInstallCmd{
+		diag: diagtest.LogSink(t),
+		pluginGetLatestVersion: func(ps workspace.PluginSpec, ctx context.Context) (*semver.Version, error) {
+			assert.Fail(t, "GetLatestVersion should not have been called")
+			return nil, nil
+		},
+		registry: testMockRegistry{
+			getPackage: func(
+				_ context.Context, source, publisher, name string, version *semver.Version,
+			) (apitype.PackageMetadata, error) {
+				switch version.String() {
+				case "1.48.0":
+					return apitype.PackageMetadata{}, registry.ErrNotFound
+				default:
+					require.Failf(t, "unknown version requested", "found %s", version)
+					return apitype.PackageMetadata{}, nil
+				}
+			},
+			searchByName: func(
+				ctx context.Context, name *string,
+			) iter.Seq2[apitype.PackageMetadata, error] {
+				return func(yield func(apitype.PackageMetadata, error) bool) {
+					yield(apitype.PackageMetadata{
+						Name:      "random",
+						Publisher: "pulumi",
+						Source:    "pulumi",
+						Version:   semver.Version{Major: 2},
+					}, nil)
+				}
+			},
+		},
+		installPluginSpec: func(
+			_ context.Context, _ string,
+			install workspace.PluginSpec, _ string,
+			_ diag.Sink, _ colors.Colorization, _ bool,
+		) error {
+			pluginWasInstalled = true
+			assert.Equal(t, workspace.PluginSpec{
+				Name: "random",
+				Kind: apitype.ResourcePlugin,
+				Version: &semver.Version{
+					Major: 1,
+					Minor: 48,
+				},
+			}, install)
+			return nil
+		},
+	}
+
+	err := cmd.Run(context.Background(), []string{"resource", "random", "1.48.0"})
+	assert.NoError(t, err)
+}
+
+type testMockRegistry struct {
+	getPackage func(
+		ctx context.Context, source, publisher, name string, version *semver.Version,
+	) (apitype.PackageMetadata, error)
+	searchByName func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error]
+}
+
+func (r testMockRegistry) GetPackage(
+	ctx context.Context, source, publisher, name string, version *semver.Version,
+) (apitype.PackageMetadata, error) {
+	if r.getPackage != nil {
+		return r.getPackage(ctx, source, publisher, name, version)
+	}
+	panic("GetPackage not implemented")
+}
+
+func (r testMockRegistry) SearchByName(
+	ctx context.Context, name *string,
+) iter.Seq2[apitype.PackageMetadata, error] {
+	if r.searchByName != nil {
+		return r.searchByName(ctx, name)
+	}
+
+	panic("SearchByName not implemented")
 }

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -185,3 +185,5 @@ Currently this disables validation of the following formats:
 This should only be used in cases where current data does not conform to the format and either cannot be migrated
 without using the system itself, or show that the validation is too strict. Over time entries in the list above will be
 removed and enforced to be validated.`)
+
+var DisableRegistryResolve = env.Bool("DISABLE_REGISTRY_RESOLVE", "Use the Pulumi Registry to resolve package names")

--- a/sdk/go/common/registry/errors.go
+++ b/sdk/go/common/registry/errors.go
@@ -1,0 +1,39 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+var (
+	ErrNotFound     NotFoundError
+	ErrForbidden    ForbiddenError
+	ErrUnauthorized UnauthorizedError
+)
+
+type NotFoundError struct{}
+
+func (err NotFoundError) Error() string {
+	return "not found"
+}
+
+type ForbiddenError struct{}
+
+func (err ForbiddenError) Error() string {
+	return "forbidden"
+}
+
+type UnauthorizedError struct{}
+
+func (err UnauthorizedError) Error() string {
+	return "unauthorized"
+}

--- a/sdk/go/common/registry/registry.go
+++ b/sdk/go/common/registry/registry.go
@@ -49,14 +49,6 @@ type Registry interface {
 	SearchByName(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error]
 }
 
-var ErrNotFound = NotFoundError{}
-
-type NotFoundError struct{}
-
-func (err NotFoundError) Error() string {
-	return "not found"
-}
-
 type registryKey struct{}
 
 func Set(ctx context.Context, registry Registry) context.Context {

--- a/sdk/go/common/registry/registry_test.go
+++ b/sdk/go/common/registry/registry_test.go
@@ -31,6 +31,7 @@ type mockRegistry struct {
 	getPackage func(
 		ctx context.Context, source, publisher, name string, version *semver.Version,
 	) (apitype.PackageMetadata, error)
+	searchByName func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error]
 }
 
 func (r mockRegistry) GetPackage(
@@ -39,8 +40,8 @@ func (r mockRegistry) GetPackage(
 	return r.getPackage(ctx, source, publisher, name, version)
 }
 
-func (mockRegistry) SearchByName(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
-	panic("unimplemented")
+func (r mockRegistry) SearchByName(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+	return r.searchByName(ctx, name)
 }
 
 func TestOnDemandRegistry(t *testing.T) {

--- a/sdk/go/common/registry/resolve.go
+++ b/sdk/go/common/registry/resolve.go
@@ -1,0 +1,188 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// ResolvePackageFromName resolves a registry package from user input. User input may be in the following forms:
+//
+//	<source>/<publisher>/<name> -> [<source>/<publisher>/<name>]
+//
+//	<publisher>/<name>          -> [private/<publisher>/<name>, pulumi/<publisher>/<name>]
+//
+//	<name>                      -> [private/*/<name>, pulumi/*/<name>]
+//
+// The returned error will include [NotFoundError] if and only if ResolvePackageFromName
+// has determined that registry does not contain a matching package.
+//
+// If ResolvePackageFromName could not parse name into a fragment kind, it will return an
+// error that includes [InvalidIdentifierError].
+//
+// When ResolvePackageFromName is unable to find a corresponding package (and
+// [NotFoundError] is returned), a list of similar packages *may* be available from
+// calling [GetSuggestedPackages] on the returned error.
+func ResolvePackageFromName(
+	ctx context.Context, registry Registry, name string, version *semver.Version,
+) (apitype.PackageMetadata, error) {
+	parts := strings.Split(name, "/")
+	switch len(parts) {
+	case 3:
+		p, err := registry.GetPackage(ctx, parts[0], parts[1], parts[2], version)
+		return p, err
+	case 2:
+		// First check on "private"
+		pkg, err := registry.GetPackage(ctx, "private", parts[0], parts[1], version)
+		if err == nil {
+			return pkg, nil
+		} else if !errors.Is(err, ErrNotFound) && !errors.Is(err, ErrUnauthorized) && !errors.Is(err, ErrForbidden) {
+			return apitype.PackageMetadata{}, fmt.Errorf("unable to check on private/%s: %w", name, err)
+		}
+
+		// Then check on "pulumi"
+		pkg, err = registry.GetPackage(ctx, "pulumi", parts[0], parts[1], version)
+		if err == nil {
+			return pkg, nil
+		} else if !errors.Is(err, ErrNotFound) {
+			return apitype.PackageMetadata{}, fmt.Errorf("unable to check on pulumi/%s: %w", name, err)
+		}
+
+		// Both "private" and "pulumi" didn't exist, so we have successfully resolved to NotFound.
+		return apitype.PackageMetadata{}, fmt.Errorf("could not resolve %s: %w", name, ErrNotFound)
+	case 1:
+		var privatePackageMetadata, pulumiPackageMetadata *apitype.PackageMetadata
+		var suggested []apitype.PackageMetadata
+		for meta, err := range registry.SearchByName(ctx, &name) {
+			if err != nil {
+				return apitype.PackageMetadata{}, err
+			}
+
+			if meta.Source == "private" {
+				if privatePackageMetadata != nil {
+					return apitype.PackageMetadata{},
+						errorSuggestedPackages{
+							err: fmt.Errorf("%q is ambiguous, it matches both %s/%s/%s and %s/%s/%s",
+								name,
+								privatePackageMetadata.Source, privatePackageMetadata.Publisher, privatePackageMetadata.Name,
+								meta.Source, meta.Publisher, meta.Name,
+							),
+							packages: []apitype.PackageMetadata{
+								*privatePackageMetadata,
+								meta,
+							},
+						}
+				}
+				privatePackageMetadata = &meta
+			} else if meta.Source == "pulumi" && meta.Publisher == "pulumi" {
+				// We don't break here, since we might still have a dominant source: the key in "private".
+				pulumiPackageMetadata = &meta
+			} else {
+				suggested = append(suggested, meta)
+			}
+		}
+
+		// Search by name returns the latest package versions with the correct name.
+		//
+		// If a version was specified, we need to fetch that specific version with GetPackage.
+		applyVersion := func(meta apitype.PackageMetadata) (apitype.PackageMetadata, error) {
+			if version == nil || meta.Version.Equals(*version) {
+				return meta, nil
+			}
+			m, err := registry.GetPackage(ctx, meta.Source, meta.Publisher, meta.Name, version)
+			if err == nil {
+				return m, nil
+			}
+			if errors.Is(err, ErrNotFound) {
+				return apitype.PackageMetadata{}, versionMismatchError{
+					found: meta, desired: *version,
+					err: errorSuggestedPackages{
+						packages: []apitype.PackageMetadata{meta},
+						err:      ErrNotFound,
+					},
+				}
+			}
+			return apitype.PackageMetadata{}, err
+		}
+
+		if privatePackageMetadata != nil {
+			return applyVersion(*privatePackageMetadata)
+		}
+		if pulumiPackageMetadata != nil {
+			return applyVersion(*pulumiPackageMetadata)
+		}
+		var versionStr string
+		if version != nil {
+			versionStr = "@" + version.String()
+		}
+		return apitype.PackageMetadata{}, fmt.Errorf(
+			"%w: %s%s does not match a registry package", errorSuggestedPackages{
+				packages: suggested,
+				err:      ErrNotFound,
+			}, name, versionStr)
+	default:
+		return apitype.PackageMetadata{}, InvalidIdentifierError{name}
+	}
+}
+
+func GetSuggestedPackages(err error) []apitype.PackageMetadata {
+	var suggestions errorSuggestedPackages
+	errors.As(err, &suggestions)
+	return suggestions.packages
+}
+
+type errorSuggestedPackages struct {
+	err      error
+	packages []apitype.PackageMetadata
+}
+
+func (err errorSuggestedPackages) Error() string {
+	return err.err.Error()
+}
+
+func (err errorSuggestedPackages) Unwrap() error {
+	return err.err
+}
+
+// An error indicating that the registry contains the correct "package", but not the
+// correct "package version".
+type versionMismatchError struct {
+	found   apitype.PackageMetadata
+	desired semver.Version
+	err     error
+}
+
+func (err versionMismatchError) Error() string {
+	return fmt.Sprintf("%s/%s/%s exists, but version %s was not found",
+		err.found.Source, err.found.Publisher, err.found.Name, err.desired,
+	)
+}
+
+func (err versionMismatchError) Unwrap() error { return err.err }
+
+type InvalidIdentifierError struct{ given string }
+
+func (err InvalidIdentifierError) Error() string {
+	if err.given == "" {
+		return "invalid identifier"
+	}
+	return fmt.Sprintf("invalid identifier: found %q", err.given)
+}

--- a/sdk/go/common/registry/resolve_test.go
+++ b/sdk/go/common/registry/resolve_test.go
@@ -1,0 +1,651 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+func TestResolvePackageFromName(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Three-part identifier tests
+	t.Run("three-part/success", func(t *testing.T) {
+		t.Parallel()
+		mockReg := mockRegistry{
+			getPackage: func(
+				ctx context.Context, source, publisher, name string, version *semver.Version,
+			) (apitype.PackageMetadata, error) {
+				assert.Equal(t, "aws", source)
+				assert.Equal(t, "pulumi", publisher)
+				assert.Equal(t, "awsx", name)
+				return apitype.PackageMetadata{
+					Source:    source,
+					Publisher: publisher,
+					Name:      name,
+					Version:   semver.MustParse("1.0.0"),
+				}, nil
+			},
+		}
+
+		pkg, err := ResolvePackageFromName(ctx, mockReg, "aws/pulumi/awsx", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "aws", pkg.Source)
+		assert.Equal(t, "pulumi", pkg.Publisher)
+		assert.Equal(t, "awsx", pkg.Name)
+	})
+
+	t.Run("three-part/with-version-matching", func(t *testing.T) {
+		t.Parallel()
+		desiredVersion := semver.MustParse("2.1.0")
+		mockReg := mockRegistry{
+			getPackage: func(
+				ctx context.Context, source, publisher, name string, version *semver.Version,
+			) (apitype.PackageMetadata, error) {
+				assert.Equal(t, &desiredVersion, version)
+				return apitype.PackageMetadata{
+					Source:    source,
+					Publisher: publisher,
+					Name:      name,
+					Version:   desiredVersion,
+				}, nil
+			},
+		}
+
+		pkg, err := ResolvePackageFromName(ctx, mockReg, "aws/pulumi/awsx", &desiredVersion)
+		require.NoError(t, err)
+		assert.Equal(t, desiredVersion, pkg.Version)
+	})
+
+	t.Run("three-part/version-not-found", func(t *testing.T) {
+		t.Parallel()
+		mockReg := mockRegistry{
+			getPackage: func(
+				ctx context.Context, source, publisher, name string, version *semver.Version,
+			) (apitype.PackageMetadata, error) {
+				return apitype.PackageMetadata{}, ErrNotFound
+			},
+		}
+
+		_, err := ResolvePackageFromName(ctx, mockReg, "aws/pulumi/awsx", &semver.Version{Major: 999})
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNotFound))
+	})
+
+	t.Run("three-part/package-not-found", func(t *testing.T) {
+		t.Parallel()
+		mockReg := mockRegistry{
+			getPackage: func(
+				ctx context.Context, source, publisher, name string, version *semver.Version,
+			) (apitype.PackageMetadata, error) {
+				return apitype.PackageMetadata{}, ErrNotFound
+			},
+		}
+
+		_, err := ResolvePackageFromName(ctx, mockReg, "nonexistent/pub/pkg", nil)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNotFound))
+	})
+
+	t.Run("three-part/other-errors", func(t *testing.T) {
+		t.Parallel()
+		testCases := []struct {
+			name string
+			err  error
+		}{
+			{"unauthorized", ErrUnauthorized},
+			{"forbidden", ErrForbidden},
+			{"network-error", errors.New("network error")},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				mockReg := mockRegistry{
+					getPackage: func(
+						ctx context.Context, source, publisher, name string, version *semver.Version,
+					) (apitype.PackageMetadata, error) {
+						return apitype.PackageMetadata{}, tc.err
+					},
+				}
+
+				_, err := ResolvePackageFromName(ctx, mockReg, "aws/pulumi/awsx", nil)
+				assert.Error(t, err)
+				assert.True(t, errors.Is(err, tc.err))
+			})
+		}
+	})
+
+	// Two-part identifier tests
+	t.Run("two-part/private-precedence", func(t *testing.T) {
+		t.Parallel()
+		mockReg := mockRegistry{
+			getPackage: func(
+				ctx context.Context, source, publisher, name string, version *semver.Version,
+			) (apitype.PackageMetadata, error) {
+				if source == "private" {
+					return apitype.PackageMetadata{
+						Source:    "private",
+						Publisher: publisher,
+						Name:      name,
+					}, nil
+				}
+				// Should not reach pulumi since private succeeded
+				t.Fatal("Should not check pulumi when private succeeds")
+				return apitype.PackageMetadata{}, nil
+			},
+		}
+
+		pkg, err := ResolvePackageFromName(ctx, mockReg, "myorg/mypkg", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "private", pkg.Source)
+		assert.Equal(t, "myorg", pkg.Publisher)
+		assert.Equal(t, "mypkg", pkg.Name)
+	})
+
+	t.Run("two-part/fallback-to-pulumi", func(t *testing.T) {
+		t.Parallel()
+		mockReg := mockRegistry{
+			getPackage: func(
+				ctx context.Context, source, publisher, name string, version *semver.Version,
+			) (apitype.PackageMetadata, error) {
+				if source == "private" {
+					return apitype.PackageMetadata{}, ErrNotFound
+				}
+				if source == "pulumi" {
+					return apitype.PackageMetadata{
+						Source:    "pulumi",
+						Publisher: publisher,
+						Name:      name,
+					}, nil
+				}
+				return apitype.PackageMetadata{}, ErrNotFound
+			},
+		}
+
+		pkg, err := ResolvePackageFromName(ctx, mockReg, "pulumi/aws", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "pulumi", pkg.Source)
+		assert.Equal(t, "pulumi", pkg.Publisher)
+		assert.Equal(t, "aws", pkg.Name)
+	})
+
+	t.Run("two-part/both-not-found", func(t *testing.T) {
+		t.Parallel()
+		mockReg := mockRegistry{
+			getPackage: func(
+				ctx context.Context, source, publisher, name string, version *semver.Version,
+			) (apitype.PackageMetadata, error) {
+				return apitype.PackageMetadata{}, ErrNotFound
+			},
+		}
+
+		_, err := ResolvePackageFromName(ctx, mockReg, "nonexistent/pkg", nil)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNotFound))
+		assert.Contains(t, err.Error(), "could not resolve nonexistent/pkg")
+	})
+
+	t.Run("two-part/private-unauthorized-fallback", func(t *testing.T) {
+		t.Parallel()
+		testCases := []error{ErrUnauthorized, ErrForbidden}
+
+		for _, privateErr := range testCases {
+			t.Run(privateErr.Error(), func(t *testing.T) {
+				t.Parallel()
+				mockReg := mockRegistry{
+					getPackage: func(
+						ctx context.Context, source, publisher, name string, version *semver.Version,
+					) (apitype.PackageMetadata, error) {
+						if source == "private" {
+							return apitype.PackageMetadata{}, privateErr
+						}
+						if source == "pulumi" {
+							return apitype.PackageMetadata{
+								Source:    "pulumi",
+								Publisher: publisher,
+								Name:      name,
+							}, nil
+						}
+						return apitype.PackageMetadata{}, ErrNotFound
+					},
+				}
+
+				pkg, err := ResolvePackageFromName(ctx, mockReg, "pulumi/aws", nil)
+				require.NoError(t, err)
+				assert.Equal(t, "pulumi", pkg.Source)
+			})
+		}
+	})
+
+	t.Run("two-part/private-other-error", func(t *testing.T) {
+		t.Parallel()
+		networkErr := errors.New("network error")
+		mockReg := mockRegistry{
+			getPackage: func(
+				ctx context.Context, source, publisher, name string, version *semver.Version,
+			) (apitype.PackageMetadata, error) {
+				if source == "private" {
+					return apitype.PackageMetadata{}, networkErr
+				}
+				t.Fatal("Should not reach pulumi when private returns other error")
+				return apitype.PackageMetadata{}, nil
+			},
+		}
+
+		_, err := ResolvePackageFromName(ctx, mockReg, "myorg/mypkg", nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unable to check on private/myorg/mypkg")
+		assert.True(t, errors.Is(err, networkErr))
+	})
+
+	t.Run("two-part/pulumi-other-error", func(t *testing.T) {
+		t.Parallel()
+		networkErr := errors.New("network error")
+		mockReg := mockRegistry{
+			getPackage: func(
+				ctx context.Context, source, publisher, name string, version *semver.Version,
+			) (apitype.PackageMetadata, error) {
+				if source == "private" {
+					return apitype.PackageMetadata{}, ErrNotFound
+				}
+				if source == "pulumi" {
+					return apitype.PackageMetadata{}, networkErr
+				}
+				return apitype.PackageMetadata{}, ErrNotFound
+			},
+		}
+
+		_, err := ResolvePackageFromName(ctx, mockReg, "pulumi/aws", nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unable to check on pulumi/pulumi/aws")
+		assert.True(t, errors.Is(err, networkErr))
+	})
+
+	t.Run("two-part/with-version", func(t *testing.T) {
+		t.Parallel()
+		desiredVersion := semver.MustParse("1.5.0")
+		mockReg := mockRegistry{
+			getPackage: func(
+				ctx context.Context, source, publisher, name string, version *semver.Version,
+			) (apitype.PackageMetadata, error) {
+				if source == "private" {
+					return apitype.PackageMetadata{}, ErrNotFound
+				}
+				if source == "pulumi" {
+					assert.Equal(t, &desiredVersion, version)
+					return apitype.PackageMetadata{
+						Source:    "pulumi",
+						Publisher: publisher,
+						Name:      name,
+						Version:   desiredVersion,
+					}, nil
+				}
+				return apitype.PackageMetadata{}, ErrNotFound
+			},
+		}
+
+		pkg, err := ResolvePackageFromName(ctx, mockReg, "pulumi/aws", &desiredVersion)
+		require.NoError(t, err)
+		assert.Equal(t, desiredVersion, pkg.Version)
+	})
+
+	// Single identifier tests
+	t.Run("single/private-precedence", func(t *testing.T) {
+		t.Parallel()
+		mockReg := mockRegistry{
+			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+				assert.Equal(t, "aws", *name)
+				return func(yield func(apitype.PackageMetadata, error) bool) {
+					// Return private match first
+					if !yield(apitype.PackageMetadata{
+						Source:    "private",
+						Publisher: "myorg",
+						Name:      "aws",
+						Version:   semver.MustParse("1.0.0"),
+					}, nil) {
+						return
+					}
+					// Also return pulumi match, but private should take precedence
+					yield(apitype.PackageMetadata{
+						Source:    "pulumi",
+						Publisher: "pulumi",
+						Name:      "aws",
+						Version:   semver.MustParse("2.0.0"),
+					}, nil)
+				}
+			},
+		}
+
+		pkg, err := ResolvePackageFromName(ctx, mockReg, "aws", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "private", pkg.Source)
+		assert.Equal(t, "myorg", pkg.Publisher)
+		assert.Equal(t, "aws", pkg.Name)
+	})
+
+	t.Run("single/pulumi-match", func(t *testing.T) {
+		t.Parallel()
+		mockReg := mockRegistry{
+			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+				return func(yield func(apitype.PackageMetadata, error) bool) {
+					// No private match, only pulumi/pulumi
+					yield(apitype.PackageMetadata{
+						Source:    "pulumi",
+						Publisher: "pulumi",
+						Name:      "aws",
+						Version:   semver.MustParse("2.0.0"),
+					}, nil)
+				}
+			},
+		}
+
+		pkg, err := ResolvePackageFromName(ctx, mockReg, "aws", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "pulumi", pkg.Source)
+		assert.Equal(t, "pulumi", pkg.Publisher)
+		assert.Equal(t, "aws", pkg.Name)
+	})
+
+	t.Run("single/no-matches-with-suggestions", func(t *testing.T) {
+		t.Parallel()
+		mockReg := mockRegistry{
+			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+				return func(yield func(apitype.PackageMetadata, error) bool) {
+					// Return some suggestions but no exact matches
+					if !yield(apitype.PackageMetadata{
+						Source:    "community",
+						Publisher: "thirdparty",
+						Name:      "aws",
+						Version:   semver.MustParse("1.0.0"),
+					}, nil) {
+						return
+					}
+					yield(apitype.PackageMetadata{
+						Source:    "github",
+						Publisher: "someuser",
+						Name:      "aws",
+						Version:   semver.MustParse("0.5.0"),
+					}, nil)
+				}
+			},
+		}
+
+		_, err := ResolvePackageFromName(ctx, mockReg, "aws", nil)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNotFound))
+		assert.Contains(t, err.Error(), "aws does not match a registry package")
+
+		// Test suggestions are available
+		suggestions := GetSuggestedPackages(err)
+		assert.Len(t, suggestions, 2)
+		assert.Equal(t, "community", suggestions[0].Source)
+		assert.Equal(t, "github", suggestions[1].Source)
+	})
+
+	t.Run("single/version-matching", func(t *testing.T) {
+		t.Parallel()
+		desiredVersion := semver.MustParse("1.5.0")
+		mockReg := mockRegistry{
+			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+				return func(yield func(apitype.PackageMetadata, error) bool) {
+					yield(apitype.PackageMetadata{
+						Source:    "pulumi",
+						Publisher: "pulumi",
+						Name:      "aws",
+						Version:   semver.MustParse("2.0.0"), // Different version
+					}, nil)
+				}
+			},
+			getPackage: func(
+				ctx context.Context, source, publisher, name string, version *semver.Version,
+			) (apitype.PackageMetadata, error) {
+				assert.Equal(t, "pulumi", source)
+				assert.Equal(t, "pulumi", publisher)
+				assert.Equal(t, "aws", name)
+				assert.Equal(t, &desiredVersion, version)
+				return apitype.PackageMetadata{
+					Source:    source,
+					Publisher: publisher,
+					Name:      name,
+					Version:   desiredVersion,
+				}, nil
+			},
+		}
+
+		pkg, err := ResolvePackageFromName(ctx, mockReg, "aws", &desiredVersion)
+		require.NoError(t, err)
+		assert.Equal(t, desiredVersion, pkg.Version)
+	})
+
+	t.Run("single/version-mismatch", func(t *testing.T) {
+		t.Parallel()
+		desiredVersion := semver.MustParse("999.0.0")
+		mockReg := mockRegistry{
+			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+				return func(yield func(apitype.PackageMetadata, error) bool) {
+					yield(apitype.PackageMetadata{
+						Source:    "pulumi",
+						Publisher: "pulumi",
+						Name:      "aws",
+						Version:   semver.MustParse("2.0.0"),
+					}, nil)
+				}
+			},
+			getPackage: func(
+				ctx context.Context, source, publisher, name string, version *semver.Version,
+			) (apitype.PackageMetadata, error) {
+				return apitype.PackageMetadata{}, ErrNotFound
+			},
+		}
+
+		_, err := ResolvePackageFromName(ctx, mockReg, "aws", &desiredVersion)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "pulumi/pulumi/aws exists, but version 999.0.0 was not found")
+
+		// Should have suggestions
+		suggestions := GetSuggestedPackages(err)
+		assert.Len(t, suggestions, 1)
+		assert.Equal(t, semver.MustParse("2.0.0"), suggestions[0].Version)
+	})
+
+	t.Run("single/search-error", func(t *testing.T) {
+		t.Parallel()
+		searchErr := errors.New("search failed")
+		mockReg := mockRegistry{
+			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+				return func(yield func(apitype.PackageMetadata, error) bool) {
+					yield(apitype.PackageMetadata{}, searchErr)
+				}
+			},
+		}
+
+		_, err := ResolvePackageFromName(ctx, mockReg, "aws", nil)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, searchErr))
+	})
+
+	t.Run("single/multiple-suggestions", func(t *testing.T) {
+		t.Parallel()
+		mockReg := mockRegistry{
+			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+				return func(yield func(apitype.PackageMetadata, error) bool) {
+					// Return multiple non-matching packages
+					if !yield(apitype.PackageMetadata{
+						Source:    "community",
+						Publisher: "org1",
+						Name:      "aws",
+					}, nil) {
+						return
+					}
+					if !yield(apitype.PackageMetadata{
+						Source:    "github",
+						Publisher: "org2",
+						Name:      "aws",
+					}, nil) {
+						return
+					}
+					yield(apitype.PackageMetadata{
+						Source:    "custom",
+						Publisher: "org3",
+						Name:      "aws",
+					}, nil)
+				}
+			},
+		}
+
+		_, err := ResolvePackageFromName(ctx, mockReg, "aws", nil)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNotFound))
+
+		suggestions := GetSuggestedPackages(err)
+		assert.Len(t, suggestions, 3)
+		assert.Equal(t, "community", suggestions[0].Source)
+		assert.Equal(t, "github", suggestions[1].Source)
+		assert.Equal(t, "custom", suggestions[2].Source)
+	})
+
+	t.Run("single/ambiguous-resolution", func(t *testing.T) {
+		t.Parallel()
+		mockReg := mockRegistry{
+			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+				return func(yield func(apitype.PackageMetadata, error) bool) {
+					// Return multiple non-matching packages
+					if !yield(apitype.PackageMetadata{
+						Source:    "private",
+						Publisher: "org1",
+						Name:      "aws",
+					}, nil) {
+						return
+					}
+					if !yield(apitype.PackageMetadata{
+						Source:    "private",
+						Publisher: "org2",
+						Name:      "aws",
+					}, nil) {
+						return
+					}
+				}
+			},
+		}
+
+		_, err := ResolvePackageFromName(ctx, mockReg, "aws", nil)
+		assert.ErrorContains(t, err, `"aws" is ambiguous, it matches both private/org1/aws and private/org2/aws`)
+		assert.Equal(t, []apitype.PackageMetadata{
+			{
+				Source:    "private",
+				Publisher: "org1",
+				Name:      "aws",
+			},
+			{
+				Source:    "private",
+				Publisher: "org2",
+				Name:      "aws",
+			},
+		}, GetSuggestedPackages(err))
+	})
+
+	// Invalid identifier tests
+	t.Run("invalid/empty-string", func(t *testing.T) {
+		t.Parallel()
+		mockReg := mockRegistry{
+			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+				// Empty string gets treated as single identifier, but no matches will be found
+				assert.Equal(t, "", *name)
+				return func(yield func(apitype.PackageMetadata, error) bool) {
+					// Return no matches
+				}
+			},
+		}
+
+		_, err := ResolvePackageFromName(ctx, mockReg, "", nil)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNotFound))
+		assert.Contains(t, err.Error(), " does not match a registry package")
+	})
+
+	t.Run("invalid/too-many-parts", func(t *testing.T) {
+		t.Parallel()
+		mockReg := mockRegistry{}
+
+		testCases := []string{
+			"a/b/c/d",
+			"source/publisher/name/extra/parts",
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc, func(t *testing.T) {
+				t.Parallel()
+				_, err := ResolvePackageFromName(ctx, mockReg, tc, nil)
+				assert.Error(t, err)
+				var invalidErr InvalidIdentifierError
+				assert.True(t, errors.As(err, &invalidErr))
+				assert.Contains(t, err.Error(), tc)
+			})
+		}
+	})
+
+	// Nil version handling tests
+	t.Run("nil-version/three-part", func(t *testing.T) {
+		t.Parallel()
+		mockReg := mockRegistry{
+			getPackage: func(
+				ctx context.Context, source, publisher, name string, version *semver.Version,
+			) (apitype.PackageMetadata, error) {
+				assert.Nil(t, version)
+				return apitype.PackageMetadata{
+					Source:    source,
+					Publisher: publisher,
+					Name:      name,
+					Version:   semver.MustParse("1.0.0"), // Latest version
+				}, nil
+			},
+		}
+
+		pkg, err := ResolvePackageFromName(ctx, mockReg, "aws/pulumi/awsx", nil)
+		require.NoError(t, err)
+		assert.Equal(t, semver.MustParse("1.0.0"), pkg.Version)
+	})
+
+	t.Run("nil-version/single-part", func(t *testing.T) {
+		t.Parallel()
+		mockReg := mockRegistry{
+			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+				return func(yield func(apitype.PackageMetadata, error) bool) {
+					yield(apitype.PackageMetadata{
+						Source:    "pulumi",
+						Publisher: "pulumi",
+						Name:      "aws",
+						Version:   semver.MustParse("2.0.0"), // Should be returned as-is
+					}, nil)
+				}
+			},
+		}
+
+		pkg, err := ResolvePackageFromName(ctx, mockReg, "aws", nil)
+		require.NoError(t, err)
+		assert.Equal(t, semver.MustParse("2.0.0"), pkg.Version)
+	})
+}


### PR DESCRIPTION
This PR adds support for performing a registry based lookup when installing packages with `pulumi plugin install`.

Examples:

```console
$ pulumi plugin install resource aws-k8s # aws-k8s is a private package
[resource plugin aws-k8s-0.0.21] installing
Downloading plugin: 456.40 KiB / 456.40 KiB [=======================] 100.00% 0s
```

```console
$ pulumi plugin install resource azapi # azapi is in the public registry, but not published by Pulumi
error: 404 HTTP error fetching plugin from https://api.github.com/repos/pulumi/pulumi-azapi/releases/latest. If this is a private GitHub repository, try providing a token via the GITHUB_TOKEN environment variable. See: https://github.com/settings/tokens
```

```console
$ pulumi plugin install resource dirien/azapi # we need to reference the publisher
[resource plugin azapi-1.12.2] installing
Downloading plugin: 34.66 MiB / 34.66 MiB [=========================] 100.00% 2s
```

---

This PR is broken up into logical commits:

- 8dc83fad768655b7f46bc07d163148fea6388894 adds structured errors to the backend, and threads them through to the registry. It does not change behavior.
- 7ca2c610fac608bc4e16bf72efbca8a533a76339 adds an uncalled function to the public `registry` package: `ResolvePackageFromName` to resolve a slug (`aws`, `pulumi/aws`, `opentofu/1password/1password`) into a registry package. It uses the structured errors introduced by the previous commit.
- 41c64d6e62b24c36a7ed2718fdd3f7724a6728b8 Uses `registry.ResolvePackageFromName` to resolve `pluginDownloadURLs` for the `pulumi plugin install resource` command.

Fixes https://github.com/pulumi/home/issues/3990