### PR TITLE
Test and fix providers not being cleanly shutdown in package add

### DIFF
--- a/changelog/pending/20250609--cli--fix-package-add-always-reporting-providers-as-crashing.yaml
+++ b/changelog/pending/20250609--cli--fix-package-add-always-reporting-providers-as-crashing.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix `package add` always reporting providers as crashing

--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -666,7 +666,9 @@ func SchemaFromSchemaSource(pctx *plugin.Context, packageSource string, args []s
 	if err != nil {
 		return nil, err
 	}
-	defer p.Close()
+	defer func() {
+		contract.IgnoreError(pctx.Host.CloseProvider(p))
+	}()
 
 	var request plugin.GetSchemaRequest
 	if len(args) > 0 {

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -1285,7 +1285,10 @@ func TestPackageAddGo(t *testing.T) {
 	_, _ = e.RunCommand("pulumi", "plugin", "install", "resource", "random")
 	randomVersion := getPluginVersion(e, "random")
 	assert.NotEmpty(t, randomVersion)
-	_, _ = e.RunCommand("pulumi", "package", "add", "random")
+	stdout, stderr := e.RunCommand("pulumi", "package", "add", "random")
+	// Regression check for https://github.com/pulumi/pulumi/issues/19764. Make sure the plugins close cleanly.
+	require.NotContains(t, stdout, "exited prematurely")
+	require.NotContains(t, stderr, "exited prematurely")
 
 	modBytes, err := os.ReadFile(filepath.Join(e.CWD, "go.mod"))
 	assert.NoError(t, err)


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/19764

We were calling `Close` directly on the provider plugin client objects, which did correctly close the provider down cleanly. But it didn't remove it from the list of providers that the host object was tracking. When we then asked the host object to also close it tried to close each provider and would error that the provider had unexpectedly already shutdown.

Small fix to just use `host.CloseProvider` instead of closing the provider object directly.