### PR TITLE
Allow plugin run to run a local plugin file directly

### DIFF
--- a/changelog/pending/20250610--cli-plugin--plugin-run-can-run-local-binary-plugins.yaml
+++ b/changelog/pending/20250610--cli-plugin--plugin-run-can-run-local-binary-plugins.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/plugin
+  description: `plugin run` can run local binary plugins

--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -37,7 +37,7 @@ func newPluginRunCmd() *cobra.Command {
 	var kind string
 
 	cmd := &cobra.Command{
-		Use:    "run NAME[@VERSION] [ARGS]",
+		Use:    "run PATH|NAME[@VERSION] [ARGS]",
 		Args:   cmdutil.MinimumNArgs(1),
 		Hidden: !env.Dev.Value(),
 		Short:  "Run a command on a plugin binary",
@@ -52,44 +52,51 @@ func newPluginRunCmd() *cobra.Command {
 			}
 			kind := apitype.PluginKind(kind)
 
-			// TODO: Add support for --server and --checksums.
-			pluginSpec, err := workspace.NewPluginSpec(ctx, args[0], kind, nil, "", nil)
-			if err != nil {
-				return err
-			}
+			source := args[0]
 
-			if !tokens.IsName(pluginSpec.Name) {
-				return fmt.Errorf("invalid plugin name %q", pluginSpec.Name)
-			}
-
-			pluginDesc := fmt.Sprintf("%s %s", pluginSpec.Kind, pluginSpec.Name)
-			if pluginSpec.Version != nil {
-				pluginDesc = fmt.Sprintf("%s@%s", pluginDesc, pluginSpec.Version)
-			}
-
-			d := diag.DefaultSink(os.Stdout, os.Stderr, diag.FormatOptions{Color: cmdutil.GetGlobalColorization()})
-
-			path, err := workspace.GetPluginPath(ctx, d, pluginSpec, nil)
-			if err != nil {
-				// Try to install the plugin, unless auto plugin installs are turned off.
-				var me *workspace.MissingError
-				if !errors.As(err, &me) || env.DisableAutomaticPluginAcquisition.Value() {
-					// Not a MissingError, return the original error.
-					return fmt.Errorf("could not get plugin path: %w", err)
-				}
-
-				log := func(sev diag.Severity, msg string) {
-					d.Logf(sev, diag.RawMessage("", msg))
-				}
-
-				_, err = pkgWorkspace.InstallPlugin(ctx, pluginSpec, log)
+			var path string
+			if plugin.IsLocalPluginPath(ctx, source) {
+				path = source
+			} else {
+				// TODO: Add support for --server and --checksums.
+				pluginSpec, err := workspace.NewPluginSpec(ctx, source, kind, nil, "", nil)
 				if err != nil {
 					return err
 				}
 
+				if !tokens.IsName(pluginSpec.Name) {
+					return fmt.Errorf("invalid plugin name %q", pluginSpec.Name)
+				}
+
+				source = fmt.Sprintf("%s %s", pluginSpec.Kind, pluginSpec.Name)
+				if pluginSpec.Version != nil {
+					source = fmt.Sprintf("%s@%s", source, pluginSpec.Version)
+				}
+
+				d := diag.DefaultSink(os.Stdout, os.Stderr, diag.FormatOptions{Color: cmdutil.GetGlobalColorization()})
+
 				path, err = workspace.GetPluginPath(ctx, d, pluginSpec, nil)
 				if err != nil {
-					return fmt.Errorf("could not get plugin path: %w", err)
+					// Try to install the plugin, unless auto plugin installs are turned off.
+					var me *workspace.MissingError
+					if !errors.As(err, &me) || env.DisableAutomaticPluginAcquisition.Value() {
+						// Not a MissingError, return the original error.
+						return fmt.Errorf("could not get plugin path: %w", err)
+					}
+
+					log := func(sev diag.Severity, msg string) {
+						d.Logf(sev, diag.RawMessage("", msg))
+					}
+
+					_, err = pkgWorkspace.InstallPlugin(ctx, pluginSpec, log)
+					if err != nil {
+						return err
+					}
+
+					path, err = workspace.GetPluginPath(ctx, d, pluginSpec, nil)
+					if err != nil {
+						return fmt.Errorf("could not get plugin path: %w", err)
+					}
 				}
 			}
 
@@ -100,9 +107,14 @@ func newPluginRunCmd() *cobra.Command {
 				return fmt.Errorf("could not create plugin context: %w", err)
 			}
 
-			plugin, err := plugin.ExecPlugin(pctx, path, pluginDesc, kind, pluginArgs, "", nil, false)
+			plugin, err := plugin.ExecPlugin(pctx, path, source, kind, pluginArgs, "", nil, false)
 			if err != nil {
-				return fmt.Errorf("could not execute plugin %s (%s): %w", pluginDesc, path, err)
+				desc := fmt.Sprintf("%s (%s)", source, path)
+				// don't print the value twice if it's the same
+				if source == path {
+					desc = source
+				}
+				return fmt.Errorf("could not execute plugin %s: %w", desc, err)
 			}
 
 			// Copy the plugin's stdout and stderr to the current process's stdout and stderr, and stdin to the
@@ -136,7 +148,7 @@ func newPluginRunCmd() *cobra.Command {
 			code, err := plugin.Wait()
 			wg.Wait()
 			if err != nil {
-				return fmt.Errorf("plugin %s exited with error: %w", pluginDesc, err)
+				return fmt.Errorf("plugin %s exited with error: %w", source, err)
 			}
 			if code != 0 {
 				os.Exit(code)

--- a/tests/testprovider/main.go
+++ b/tests/testprovider/main.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"slices"
 	"strings"
 
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -97,6 +99,11 @@ func providerForURN(urn string) (testProvider, string, bool) {
 
 //nolint:unused
 func main() {
+	if slices.Contains(os.Args, "--help") {
+		fmt.Fprint(os.Stderr, "Usage: testprovider")
+		os.Exit(255)
+	}
+
 	if err := provider.Main(providerName, func(host *provider.HostClient) (rpc.ResourceProviderServer, error) {
 		return makeProvider(host, providerName, version)
 	}); err != nil {


### PR DESCRIPTION
Was going to use this for testing `plugin run` but it will also be useful for allowing shimless plugins where the local path is a folder rather than a file. That doesn't work quite yet because it needs some supporting work I'm doing in another PR, but this change is part of it and small enough to go in by itself.