### PR TITLE
Allow running lifecycle tests on macOS

### DIFF
--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -127,7 +127,7 @@ func pickURN(t *testing.T, urns []resource.URN, names []string, target string) r
 
 func TestMain(m *testing.M) {
 	grpcDefault := flag.Bool("grpc-plugins", false, "enable or disable gRPC providers by default")
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+	if (runtime.GOOS == "windows" || runtime.GOOS == "darwin") && os.Getenv("PULUMI_FORCE_RUN_TESTS") == "" {
 		// These tests are skipped as part of enabling running unit tests on windows and MacOS in
 		// https://github.com/pulumi/pulumi/pull/19653. These tests currently fail on Windows, and
 		// re-enabling them is left as future work.


### PR DESCRIPTION
A recent change causes these to be skipped on macOS, preventing them from being run locally during development. This change allows an envvar to be set to force allow running the tests.