### PR TITLE
send informational output for policy pack installation to stderr

### DIFF
--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -81,7 +81,7 @@ func (rp *cloudRequiredPolicy) Install(ctx *plugin.Context) (string, error) {
 		return policyPackPath, nil
 	}
 
-	fmt.Printf("Installing policy pack %s %s...\r\n", policy.Name, version)
+	fmt.Fprintf(os.Stderr, "Installing policy pack %s %s...\r\n", policy.Name, version)
 
 	// PolicyPack has not been downloaded and installed. Do this now.
 
@@ -332,8 +332,8 @@ func installRequiredPolicy(ctx *plugin.Context, finalDir string, tgz io.ReadClos
 		return fmt.Errorf("installing dependencies: %w", err)
 	}
 
-	fmt.Println("Finished installing policy pack\r")
-	fmt.Println()
+	fmt.Fprintln(os.Stderr, "Finished installing policy pack\r")
+	fmt.Fprintln(os.Stderr)
 
 	return nil
 }


### PR DESCRIPTION
Typically stdout is used for content the user expects the command to print, e.g. in `curl -v` the data that actually comes back from the website, while stderr is used for additional informational output, e.g. in `curl -v` all the HTTP information.

Whether policy packs are installed is information output that the user doesn't necessarily need, so it should go to stderr.  This also makes the `--json` flag e.g. in `pulumi preview` work as expected, as the JSON output will be on stdout, and can be redirected to a file/piped to further commands separately, while the informational output still goes to stderr, and will be visible to the user, but won't interfere with redirection of the main data stream.

Fixes https://github.com/pulumi/pulumi/issues/19775