### PR TITLE
disable coverage reporting in daily test runs

### DIFF
--- a/.github/workflows/cron-test-all.yml
+++ b/.github/workflows/cron-test-all.yml
@@ -30,13 +30,18 @@ jobs:
       ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}
       lint: true
-      # codegen tests are not the fastest, but we want to run them
-      # on PR to get correct coverage numbers.
+      # codegen tests are not the fastest, but we want to run all
+      # tests daily
       test-codegen: true
       test-version-sets: 'all'
       integration-test-platforms: ubuntu-latest
       acceptance-test-platforms: 'macos-latest windows-latest'
-      enable-coverage: true
+      # Disable coverage in daily runs.  This is unfortunately flaky
+      # on windows, and the daily cron job runs the most extensive set
+      # of tests, leading to quite a bit of flakyness.  We get coverage
+      # data on every merge to main, so getting it in the daily cro
+      # job is not important.
+      enable-coverage: false
     secrets: inherit
 
   performance-gate:


### PR DESCRIPTION
Collecting coverage data on windows is quite flaky (see https://github.com/pulumi/pulumi/issues/16490). Since we're running the most extensive test suite in the daily test run, this unfortunately comes up quite often here.

We already get coverage data on each merge, which won't change during the daily run (maybe it's a tiny bit higher since we run more test jobs daily, but that's another reason to disable it here, so we get more consistent data).

Disable the coverage reporting here to reduce the flakyness hopefully.

Fixes https://github.com/pulumi/pulumi/issues/19639