### PR TITLE
update java and yaml to latest version

### DIFF
--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -28,7 +28,7 @@ download_release() {
 # * When updating .Net, you should also update PulumiDotnetSDKVersion in pulumi/pkg/codegen/testing/test/helpers.go
 #
 # shellcheck disable=SC2043
-for i in "github.com/pulumi/pulumi-java java v1.12.0" "github.com/pulumi/pulumi-yaml yaml v1.19.2" "github.com/pulumi/pulumi-dotnet dotnet v3.82.1"; do
+for i in "github.com/pulumi/pulumi-java java v1.13.0" "github.com/pulumi/pulumi-yaml yaml v1.20.0" "github.com/pulumi/pulumi-dotnet dotnet v3.82.1"; do
   set -- $i # treat strings in loop as args
   REPO="$1"
   PULUMI_LANG="$2"


### PR DESCRIPTION
Updating ahead of the release.  Note that we don't update the dotnet version for now, since the release for the language plugin binary failed, and there are no new updates here, so we can defer this for next week.