### PR TITLE
skip tests that are missing environment setup

### DIFF
--- a/pkg/cmd/pulumi/newcmd/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_acceptance_test.go
@@ -299,8 +299,8 @@ func removeStack(t *testing.T, dir, name string) {
 }
 
 func skipIfShortOrNoPulumiAccessToken(t *testing.T) {
-	_, ok := os.LookupEnv("PULUMI_ACCESS_TOKEN")
-	if !ok {
+	token, ok := os.LookupEnv("PULUMI_ACCESS_TOKEN")
+	if !ok || token == "" {
 		t.Skipf("Skipping: PULUMI_ACCESS_TOKEN is not set")
 	}
 	if testing.Short() {

--- a/pkg/secrets/cloud/azure_test.go
+++ b/pkg/secrets/cloud/azure_test.go
@@ -17,8 +17,10 @@ package cloud
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -30,8 +32,11 @@ import (
 func getAzureCaller(ctx context.Context, t *testing.T) *azidentity.DefaultAzureCredential {
 	credentials, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
-		t.Logf("Skipping, could not load azure config: %s", err)
-		t.SkipNow()
+		t.Skipf("Skipping, could not load azure config: %s", err)
+	}
+	_, err = credentials.GetToken(ctx, policy.TokenRequestOptions{})
+	if err != nil && strings.Contains(err.Error(), "failed to acquire a token") {
+		t.Skipf("Skipping, could not acquire Azure token: %s", err)
 	}
 	return credentials
 }

--- a/tests/config/config_test.go
+++ b/tests/config/config_test.go
@@ -411,6 +411,9 @@ func TestConfigCommandsUsingEnvironments(t *testing.T) {
 	if getTestOrg() != pulumiTestOrg {
 		t.Skip("Skipping test because the required environment is in the moolumi org.")
 	}
+	if os.Getenv("PULUMI_ACCESS_TOKEN") == "" {
+		t.Skip("Skipping test because PULUMI_ACCESS_TOKEN is not set.")
+	}
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)

--- a/tests/integration/backend/diy/backend_azure_test.go
+++ b/tests/integration/backend/diy/backend_azure_test.go
@@ -38,8 +38,8 @@ func TestAzureLoginSasToken(t *testing.T) {
 	t.Setenv("AZURE_CLIENT_SECRET", "")
 	t.Setenv("AZURE_TENANT_ID", "")
 
-	_, ok := os.LookupEnv("AZURE_STORAGE_SAS_TOKEN")
-	if !ok {
+	token, ok := os.LookupEnv("AZURE_STORAGE_SAS_TOKEN")
+	if !ok || token == "" {
 		t.Skip("AZURE_STORAGE_SAS_TOKEN not set, skipping test")
 	}
 
@@ -59,10 +59,10 @@ func TestAzureLoginAzLogin(t *testing.T) {
 		require.NoError(t, err)
 	})
 	cloudURL := "azblob://pulumitesting?storage_account=pulumitesting"
-	_, clientIDSet := os.LookupEnv("AZURE_CLIENT_ID")
-	_, clientSecretSet := os.LookupEnv("AZURE_CLIENT_SECRET")
-	_, tenantIDSet := os.LookupEnv("AZURE_TENANT_ID")
-	if !clientIDSet || !clientSecretSet || !tenantIDSet {
+	clientID, clientIDSet := os.LookupEnv("AZURE_CLIENT_ID")
+	clientSecret, clientSecretSet := os.LookupEnv("AZURE_CLIENT_SECRET")
+	tenantID, tenantIDSet := os.LookupEnv("AZURE_TENANT_ID")
+	if !clientIDSet || !clientSecretSet || !tenantIDSet || clientID == "" || clientSecret == "" || tenantID == "" {
 		t.Skip("AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_TENANT_ID not set, skipping test")
 	}
 

--- a/tests/integration/backend/diy/backend_gcp_test.go
+++ b/tests/integration/backend/diy/backend_gcp_test.go
@@ -30,7 +30,7 @@ func TestGcpLogin(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	if _, ok := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS"); !ok {
+	if creds, ok := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS"); !ok || creds == "" {
 		t.Skip("GOOGLE_APPLICATION_CREDENTIALS not set, skipping test")
 	}
 

--- a/tests/stack/stack_test.go
+++ b/tests/stack/stack_test.go
@@ -473,6 +473,9 @@ func TestStackRenameAfterCreate(t *testing.T) {
 // TestStackRenameServiceAfterCreateBackend tests a few edge cases about renaming
 // stacks owned by organizations in the service backend.
 func TestStackRenameAfterCreateServiceBackend(t *testing.T) {
+	if os.Getenv("PULUMI_ACCESS_TOKEN") == "" {
+		t.Skipf("Skipping: PULUMI_ACCESS_TOKEN is not set")
+	}
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)


### PR DESCRIPTION
We have a few tests that need environment variables set up to run. These fail in CI for either tests from external contributors, or dependabot PRs.  Skip these tests when the right environment setup is missing.

This is a little annoying to test, since it's not going to fail on any of our PRs, and just submitting a PR from an external account doesn't work either, as the tests don't run (see
https://github.com/pulumi/pulumi/pull/17192). So I just picked the failing tests out from a dependabot PR.  I might have missed some here, but this is hopefully moving in the right direction.

Note that this doesn't solve anything for the automation API tests yet.

Also interestingly, it seems that in CI we do set the enviornment variable in some cases, but to an empty value, which means we also need to check for that, and can't just use the `ok` return from `LookupEnv`.