### PR TITLE
always initialize model types properly

### DIFF
--- a/changelog/pending/20250611--programgen--fix-panic-in-programgen.yaml
+++ b/changelog/pending/20250611--programgen--fix-panic-in-programgen.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Fix panic in programgen

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -1162,11 +1162,7 @@ func (g *generator) rewriteThenForAllApply(
 	}
 
 	// dummy type that will produce []interface{} for argumentTypeName
-	interfaceArrayType := &model.TupleType{
-		ElementTypes: []model.Type{
-			model.BoolType, model.StringType, model.IntType,
-		},
-	}
+	interfaceArrayType := model.NewTupleType(model.BoolType, model.StringType, model.IntType)
 
 	then.Parameters = []*model.Variable{{
 		Name:         "_args",

--- a/pkg/codegen/pcl/binder_component.go
+++ b/pkg/codegen/pcl/binder_component.go
@@ -42,14 +42,12 @@ func componentVariableType(program *Program) model.Type {
 				properties[node.LogicalName()] = nodeType
 			default:
 				// otherwise, wrap it as an output
-				properties[node.LogicalName()] = &model.OutputType{
-					ElementType: nodeType,
-				}
+				properties[node.LogicalName()] = model.NewOutputType(nodeType)
 			}
 		}
 	}
 
-	return &model.ObjectType{Properties: properties}
+	return model.NewObjectType(properties)
 }
 
 type componentScopes struct {

--- a/pkg/codegen/pcl/binder_schema_test.go
+++ b/pkg/codegen/pcl/binder_schema_test.go
@@ -41,19 +41,16 @@ func BenchmarkLoadPackage(b *testing.B) {
 
 func TestGenEnum(t *testing.T) {
 	t.Parallel()
-	enum := &model.EnumType{
-		Elements: []cty.Value{
+	enum := model.NewEnumType(
+		"my.enum", model.StringType,
+		[]cty.Value{
 			cty.StringVal("foo"),
 			cty.StringVal("bar"),
 		},
-		Type:  model.StringType,
-		Token: "my:enum",
-		Annotations: []interface{}{
-			enumSchemaType{
-				Type: &schema.EnumType{Elements: []*schema.Enum{{Value: "foo"}, {Value: "bar"}}},
-			},
+		enumSchemaType{
+			Type: &schema.EnumType{Elements: []*schema.Enum{{Value: "foo"}, {Value: "bar"}}},
 		},
-	}
+	)
 	safeEnumFunc := func(member *schema.Enum) {}
 	unsafeEnumFunc := func(from model.Expression) {}
 

--- a/pkg/codegen/pcl/binder_schema_test.go
+++ b/pkg/codegen/pcl/binder_schema_test.go
@@ -42,7 +42,7 @@ func BenchmarkLoadPackage(b *testing.B) {
 func TestGenEnum(t *testing.T) {
 	t.Parallel()
 	enum := model.NewEnumType(
-		"my.enum", model.StringType,
+		"my:enum", model.StringType,
 		[]cty.Value{
 			cty.StringVal("foo"),
 			cty.StringVal("bar"),


### PR DESCRIPTION
Since https://github.com/pulumi/pulumi/pull/19604, we're doing a bit more initialization in `model.New.*Type`, namely initializing the map for caching intermediate results for type reduction.  However there were a few places where we just directly initialized the struct, which makes the map not initialized, leading to panics.  Fix this by always initializing the types properly.

Fixes https://github.com/pulumi/pulumi/issues/19828