### PR TITLE
Rename host to engine in policyx

### DIFF
--- a/sdk/go/pulumi/policyx/policy_pack.go
+++ b/sdk/go/pulumi/policyx/policy_pack.go
@@ -27,8 +27,8 @@ import (
 // HandshakeRequest is sent by the engine to the analyzer to establish a connection and provide
 // necessary information for the analyzer to start up.
 type HandshakeRequest struct {
-	// The "host" of the analyzer. This is the engine that is running the analyzer.
-	Host pulumix.Engine
+	// The engine that is running the analyzer.
+	Engine pulumix.Engine
 	// A *root directory* where the analyzer's binary, `PulumiPolicy.yaml`, or other identifying source code is located.
 	// In the event that the analyzer is *not* being booted by the engine (e.g. in the case that the engine has been
 	// asked to attach to an existing running analyzer instance via a host/port number), this field will be empty.

--- a/sdk/go/pulumi/policyx/server.go
+++ b/sdk/go/pulumi/policyx/server.go
@@ -71,18 +71,18 @@ func (srv *analyzerServer) Handshake(
 	ctx context.Context,
 	req *pulumirpc.AnalyzerHandshakeRequest,
 ) (*pulumirpc.AnalyzerHandshakeResponse, error) {
-	host, err := pulumix.NewEngine(req.GetEngineAddress())
+	engine, err := pulumix.NewEngine(req.GetEngineAddress())
 	if err != nil {
-		return nil, fmt.Errorf("failed to create host: %w", err)
+		return nil, fmt.Errorf("failed to create engine: %w", err)
 	}
 
-	srv.policyPack, err = srv.policyPackFactory(host)
+	srv.policyPack, err = srv.policyPackFactory(engine)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create policy pack: %w", err)
 	}
 
 	_, err = srv.policyPack.Handshake(ctx, HandshakeRequest{
-		Host:             host,
+		Engine:           engine,
 		RootDirectory:    req.RootDirectory,
 		ProgramDirectory: req.ProgramDirectory,
 	})


### PR DESCRIPTION
Trying to be consistent, we called this engine in dotnet. We should call it engine here as well, we'd already renamed the type here so just need to rename one field.