### PR TITLE
auto/nodejs: rename stack internally when calling rename()

### DIFF
--- a/changelog/pending/20250612--auto-nodejs--fix-stack-name-in-object-after-rename-operations.yaml
+++ b/changelog/pending/20250612--auto-nodejs--fix-stack-name-in-object-after-rename-operations.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/nodejs
+  description: Fix stack name in object after rename operations

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -47,7 +47,7 @@ export class Stack {
     /**
      * The name identifying the stack.
      */
-    readonly name: string;
+    name: string;
 
     /**
      * The {@link Workspace} the stack was created from.
@@ -661,6 +661,8 @@ Event: ${line}\n${e.toString()}`);
         if (this.isRemote && options?.showSecrets) {
             throw new Error("can't enable `showSecrets` for remote workspaces");
         }
+
+	this.name = options.stackName;
 
         const summary = await this.info(!this.isRemote && options?.showSecrets);
 

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -662,7 +662,7 @@ Event: ${line}\n${e.toString()}`);
             throw new Error("can't enable `showSecrets` for remote workspaces");
         }
 
-	this.name = options.stackName;
+        this.name = options.stackName;
 
         const summary = await this.info(!this.isRemote && options?.showSecrets);
 

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -927,11 +927,11 @@ describe("LocalWorkspace", () => {
         const suffix = `int_test${getTestSuffix()}`;
 
         const stackName = fullyQualifiedStackName(getTestOrg(), "inline_node", suffix);
-	let shortName = getTestOrg() + "/" + suffix;
-	if (!process.env.PULUMI_ACCESS_TOKEN) {
-	    // If we are running with a filestate backend, there's no prefix in the name
-	    shortName = suffix;
-	}
+        let shortName = getTestOrg() + "/" + suffix;
+        if (!process.env.PULUMI_ACCESS_TOKEN) {
+            // If we are running with a filestate backend, there's no prefix in the name
+            shortName = suffix;
+        }
 
         const stackRenamed = stackName + "_renamed";
         const shortRenamed = shortName + "_renamed";
@@ -957,10 +957,10 @@ describe("LocalWorkspace", () => {
         assert.strictEqual(returned, `Renamed ${shortName} to ${shortRenamed}\n`);
         assert.strictEqual(after?.name, shortRenamed);
 
-	if (process.env.PULUMI_ACCESS_TOKEN) {
-	    // TODO: We don't have the right summary.kind for rename operations in the filestate backend.
+        if (process.env.PULUMI_ACCESS_TOKEN) {
+            // TODO: We don't have the right summary.kind for rename operations in the filestate backend.
             assert.strictEqual(renameRes.summary.kind, "rename");
-	}
+        }
         assert.strictEqual(renameRes.summary.result, "succeeded");
 
         // pulumi destroy
@@ -968,7 +968,7 @@ describe("LocalWorkspace", () => {
         assert.strictEqual(destroyRes.summary.kind, "destroy");
         assert.strictEqual(destroyRes.summary.result, "succeeded");
 
-	await stack.workspace.removeStack(stackRenamed);
+        await stack.workspace.removeStack(stackRenamed);
     });
     it(`refreshes with refresh option`, async () => {
         // We create a simple program, and scan the output for an indication

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -927,7 +927,11 @@ describe("LocalWorkspace", () => {
         const suffix = `int_test${getTestSuffix()}`;
 
         const stackName = fullyQualifiedStackName(getTestOrg(), "inline_node", suffix);
-        const shortName = getTestOrg() + "/" + suffix;
+	let shortName = getTestOrg() + "/" + suffix;
+	if (!process.env.PULUMI_ACCESS_TOKEN) {
+	    // If we are running with a filestate backend, there's no prefix in the name
+	    shortName = suffix;
+	}
 
         const stackRenamed = stackName + "_renamed";
         const shortRenamed = shortName + "_renamed";
@@ -953,13 +957,18 @@ describe("LocalWorkspace", () => {
         assert.strictEqual(returned, `Renamed ${shortName} to ${shortRenamed}\n`);
         assert.strictEqual(after?.name, shortRenamed);
 
-        assert.strictEqual(renameRes.summary.kind, "rename");
+	if (process.env.PULUMI_ACCESS_TOKEN) {
+	    // TODO: We don't have the right summary.kind for rename operations in the filestate backend.
+            assert.strictEqual(renameRes.summary.kind, "rename");
+	}
         assert.strictEqual(renameRes.summary.result, "succeeded");
 
         // pulumi destroy
         const destroyRes = await stack.destroy({ userAgent });
         assert.strictEqual(destroyRes.summary.kind, "destroy");
         assert.strictEqual(destroyRes.summary.result, "succeeded");
+
+	await stack.workspace.removeStack(stackRenamed);
     });
     it(`refreshes with refresh option`, async () => {
         // We create a simple program, and scan the output for an indication


### PR DESCRIPTION
Currently when using `stack.rename()` in the NodeJS automation API, we rename the stack, but internally keep using the old name.  This means any subsequent operations on that stack object will also use that old name.

For the cloud backend this *kinda* works, as I think the cloud just redirects from the old name to the new one, as long as there's no new stack that took over the old name.  However for the filestate backend this doesn't work at all, since the stack is no longer available.

Fix this by setting the name of the stack correctly internally as well.

Also fix the test so it works when `PULUMI_ACCESS_TOKEN` is not set. Note that there's a little oddity here, as for local backends we don't have a summary event for the rename here.  Not sure how to deal with that correctly.