### PR TITLE
Fix proto checksum order on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ensure: .make/ensure/go .make/ensure/phony $(SUB_PROJECTS:%=%_ensure)
 
 .PHONY: build-proto build_proto
 PROTO_FILES := $(sort $(shell find proto -type f -name '*.proto') proto/generate.sh proto/build-container/Dockerfile $(wildcard proto/build-container/scripts/*))
-PROTO_CKSUM = cksum ${PROTO_FILES} | sort --key=3
+PROTO_CKSUM = cksum ${PROTO_FILES} | LC_ALL=C sort --key=3
 build-proto: build_proto
 build_proto:
 	@printf "Protobuffer interfaces are ....... "


### PR DESCRIPTION
`sort` does not sort the same way for some characters on macOS compared to Linux, depending on the locale. By setting the locale to `C` we ensure we get the same order here.

This remove the need to manually re-order the protobuf `.checksum.txt` file when updating protobufs on macOS.