### PR TITLE
upgrade pulumi-dotnet to latest

### DIFF
--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -380,4 +380,4 @@ const (
 )
 
 // PulumiDotnetSDKVersion is the version of the Pulumi .NET SDK to use in program-gen tests
-const PulumiDotnetSDKVersion = "3.82.1"
+const PulumiDotnetSDKVersion = "3.83.2"

--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -28,7 +28,7 @@ download_release() {
 # * When updating .Net, you should also update PulumiDotnetSDKVersion in pulumi/pkg/codegen/testing/test/helpers.go
 #
 # shellcheck disable=SC2043
-for i in "github.com/pulumi/pulumi-java java v1.13.0" "github.com/pulumi/pulumi-yaml yaml v1.20.0" "github.com/pulumi/pulumi-dotnet dotnet v3.82.1"; do
+for i in "github.com/pulumi/pulumi-java java v1.13.0" "github.com/pulumi/pulumi-yaml yaml v1.20.0" "github.com/pulumi/pulumi-dotnet dotnet v3.83.2"; do
   set -- $i # treat strings in loop as args
   REPO="$1"
   PULUMI_LANG="$2"


### PR DESCRIPTION
This isn't going into this weeks release, but we should upgrade the version anyway, as once providers start depending on the newer SDK version our integration tests will start failing if we don't update now.