### PR TITLE
Update yaml to the latest version

### DIFF
--- a/changelog/pending/20250613--sdk-yaml--enable-support-for-views-by-default.yaml
+++ b/changelog/pending/20250613--sdk-yaml--enable-support-for-views-by-default.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/yaml
+  description: Enable support for views by default

--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -28,7 +28,7 @@ download_release() {
 # * When updating .Net, you should also update PulumiDotnetSDKVersion in pulumi/pkg/codegen/testing/test/helpers.go
 #
 # shellcheck disable=SC2043
-for i in "github.com/pulumi/pulumi-java java v1.13.0" "github.com/pulumi/pulumi-yaml yaml v1.20.0" "github.com/pulumi/pulumi-dotnet dotnet v3.83.2"; do
+for i in "github.com/pulumi/pulumi-java java v1.13.0" "github.com/pulumi/pulumi-yaml yaml v1.21.0" "github.com/pulumi/pulumi-dotnet dotnet v3.83.2"; do
   set -- $i # treat strings in loop as args
   REPO="$1"
   PULUMI_LANG="$2"


### PR DESCRIPTION
This version of pulumi-yaml allows modules to be used without having to set the `PULUMI_ENABLE_VIEWS_PREVIEW` envvar.

Part of https://github.com/pulumi/pulumi-terraform-module/issues/403