### PR TITLE
Remove dead code for stack operations

### DIFF
--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -942,7 +942,7 @@ func (eng *languageTestServer) RunLanguageTest(
 			Version:    apitype.DeploymentSchemaVersionCurrent,
 			Deployment: jsonDeployment,
 		}
-		err = s.ImportDeployment(ctx, untypedDeployment)
+		err = backend.ImportStackDeployment(ctx, s, untypedDeployment)
 		if err != nil {
 			return nil, fmt.Errorf("import deployment: %w", err)
 		}
@@ -1379,7 +1379,7 @@ func (eng *languageTestServer) RunLanguageTest(
 			eventsCts.Fulfill(events)
 		}()
 
-		plan, previewChanges, res := s.Preview(ctx, updateOperation, eventSink)
+		plan, previewChanges, res := backend.PreviewStack(ctx, s, updateOperation, eventSink)
 		close(eventSink)
 		events, err := eventsCts.Promise().Result(ctx)
 		if err != nil {
@@ -1409,7 +1409,7 @@ func (eng *languageTestServer) RunLanguageTest(
 			}
 			eventsCts.Fulfill(events)
 		}()
-		changes, res := s.Update(ctx, updateOperation, eventSink)
+		changes, res := backend.UpdateStack(ctx, s, updateOperation, eventSink)
 		close(eventSink)
 		events, err = eventsCts.Promise().Result(ctx)
 		if err != nil {

--- a/pkg/backend/diy/stack.go
+++ b/pkg/backend/diy/stack.go
@@ -20,13 +20,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
-	"github.com/pulumi/pulumi/pkg/v3/display"
-	"github.com/pulumi/pulumi/pkg/v3/engine"
-	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
@@ -81,59 +77,6 @@ func (s *diyStack) Snapshot(ctx context.Context, secretsProvider secrets.Provide
 }
 func (s *diyStack) Backend() backend.Backend              { return s.b }
 func (s *diyStack) Tags() map[apitype.StackTagName]string { return nil }
-
-func (s *diyStack) Remove(ctx context.Context, force bool) (bool, error) {
-	return backend.RemoveStack(ctx, s, force)
-}
-
-func (s *diyStack) Rename(ctx context.Context, newName tokens.QName) (backend.StackReference, error) {
-	return backend.RenameStack(ctx, s, newName)
-}
-
-func (s *diyStack) Preview(
-	ctx context.Context,
-	op backend.UpdateOperation, events chan<- engine.Event,
-) (*deploy.Plan, display.ResourceChanges, error) {
-	return backend.PreviewStack(ctx, s, op, events)
-}
-
-func (s *diyStack) Update(ctx context.Context,
-	op backend.UpdateOperation, events chan<- engine.Event,
-) (display.ResourceChanges, error) {
-	return backend.UpdateStack(ctx, s, op, events)
-}
-
-func (s *diyStack) Import(ctx context.Context, op backend.UpdateOperation,
-	imports []deploy.Import,
-) (display.ResourceChanges, error) {
-	return backend.ImportStack(ctx, s, op, imports)
-}
-
-func (s *diyStack) Refresh(ctx context.Context, op backend.UpdateOperation) (display.ResourceChanges, error) {
-	return backend.RefreshStack(ctx, s, op)
-}
-
-func (s *diyStack) Destroy(ctx context.Context, op backend.UpdateOperation) (display.ResourceChanges, error) {
-	return backend.DestroyStack(ctx, s, op)
-}
-
-func (s *diyStack) Watch(ctx context.Context, op backend.UpdateOperation, paths []string) error {
-	return backend.WatchStack(ctx, s, op, paths)
-}
-
-func (s *diyStack) GetLogs(ctx context.Context, secretsProvider secrets.Provider, cfg backend.StackConfiguration,
-	query operations.LogQuery,
-) ([]operations.LogEntry, error) {
-	return backend.GetStackLogs(ctx, secretsProvider, s, cfg, query)
-}
-
-func (s *diyStack) ExportDeployment(ctx context.Context) (*apitype.UntypedDeployment, error) {
-	return backend.ExportStackDeployment(ctx, s)
-}
-
-func (s *diyStack) ImportDeployment(ctx context.Context, deployment *apitype.UntypedDeployment) error {
-	return backend.ImportStackDeployment(ctx, s, deployment)
-}
 
 func (s *diyStack) DefaultSecretManager(info *workspace.ProjectStack) (secrets.Manager, error) {
 	return passphrase.NewPromptingPassphraseSecretsManager(info, false /* rotatePassphraseSecretsProvider */)

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -23,9 +23,6 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
-	sdkDisplay "github.com/pulumi/pulumi/pkg/v3/display"
-	"github.com/pulumi/pulumi/pkg/v3/engine"
-	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/service"
@@ -231,68 +228,6 @@ func (s *cloudStack) Snapshot(ctx context.Context, secretsProvider secrets.Provi
 
 	s.snapshot.Store(&snap)
 	return snap, nil
-}
-
-func (s *cloudStack) Remove(ctx context.Context, force bool) (bool, error) {
-	return backend.RemoveStack(ctx, s, force)
-}
-
-func (s *cloudStack) Rename(ctx context.Context, newName tokens.QName) (backend.StackReference, error) {
-	return backend.RenameStack(ctx, s, newName)
-}
-
-func (s *cloudStack) Preview(
-	ctx context.Context,
-	op backend.UpdateOperation,
-	events chan<- engine.Event,
-) (*deploy.Plan, sdkDisplay.ResourceChanges, error) {
-	return backend.PreviewStack(ctx, s, op, events)
-}
-
-func (s *cloudStack) Update(
-	ctx context.Context,
-	op backend.UpdateOperation,
-	events chan<- engine.Event,
-) (sdkDisplay.ResourceChanges,
-	error,
-) {
-	return backend.UpdateStack(ctx, s, op, events)
-}
-
-func (s *cloudStack) Import(ctx context.Context, op backend.UpdateOperation,
-	imports []deploy.Import,
-) (sdkDisplay.ResourceChanges, error) {
-	return backend.ImportStack(ctx, s, op, imports)
-}
-
-func (s *cloudStack) Refresh(ctx context.Context, op backend.UpdateOperation) (sdkDisplay.ResourceChanges,
-	error,
-) {
-	return backend.RefreshStack(ctx, s, op)
-}
-
-func (s *cloudStack) Destroy(ctx context.Context, op backend.UpdateOperation) (sdkDisplay.ResourceChanges,
-	error,
-) {
-	return backend.DestroyStack(ctx, s, op)
-}
-
-func (s *cloudStack) Watch(ctx context.Context, op backend.UpdateOperation, paths []string) error {
-	return backend.WatchStack(ctx, s, op, paths)
-}
-
-func (s *cloudStack) GetLogs(ctx context.Context, secretsProvider secrets.Provider, cfg backend.StackConfiguration,
-	query operations.LogQuery,
-) ([]operations.LogEntry, error) {
-	return backend.GetStackLogs(ctx, secretsProvider, s, cfg, query)
-}
-
-func (s *cloudStack) ExportDeployment(ctx context.Context) (*apitype.UntypedDeployment, error) {
-	return backend.ExportStackDeployment(ctx, s)
-}
-
-func (s *cloudStack) ImportDeployment(ctx context.Context, deployment *apitype.UntypedDeployment) error {
-	return backend.ImportStackDeployment(ctx, s, deployment)
 }
 
 func (s *cloudStack) DefaultSecretManager(info *workspace.ProjectStack) (secrets.Manager, error) {

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -564,28 +564,15 @@ func (be *MockEnvironmentsBackend) OpenYAMLEnvironment(
 //
 
 type MockStack struct {
-	RefF            func() StackReference
-	ConfigLocationF func() StackConfigLocation
-	LoadRemoteF     func(ctx context.Context, project *workspace.Project) (*workspace.ProjectStack, error)
-	SaveRemoteF     func(ctx context.Context, project *workspace.ProjectStack) error
-	OrgNameF        func() string
-	ConfigF         func() config.Map
-	SnapshotF       func(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error)
-	TagsF           func() map[apitype.StackTagName]string
-	BackendF        func() Backend
-	PreviewF        func(ctx context.Context, op UpdateOperation) (*deploy.Plan, sdkDisplay.ResourceChanges, error)
-	UpdateF         func(ctx context.Context, op UpdateOperation) (sdkDisplay.ResourceChanges, error)
-	ImportF         func(ctx context.Context, op UpdateOperation,
-		imports []deploy.Import) (sdkDisplay.ResourceChanges, error)
-	RefreshF func(ctx context.Context, op UpdateOperation) (sdkDisplay.ResourceChanges, error)
-	DestroyF func(ctx context.Context, op UpdateOperation) (sdkDisplay.ResourceChanges, error)
-	WatchF   func(ctx context.Context, op UpdateOperation, paths []string) error
-	RemoveF  func(ctx context.Context, force bool) (bool, error)
-	RenameF  func(ctx context.Context, newName tokens.QName) (StackReference, error)
-	GetLogsF func(ctx context.Context, secretsProvider secrets.Provider, cfg StackConfiguration,
-		query operations.LogQuery) ([]operations.LogEntry, error)
-	ExportDeploymentF     func(ctx context.Context) (*apitype.UntypedDeployment, error)
-	ImportDeploymentF     func(ctx context.Context, deployment *apitype.UntypedDeployment) error
+	RefF                  func() StackReference
+	ConfigLocationF       func() StackConfigLocation
+	LoadRemoteF           func(ctx context.Context, project *workspace.Project) (*workspace.ProjectStack, error)
+	SaveRemoteF           func(ctx context.Context, project *workspace.ProjectStack) error
+	OrgNameF              func() string
+	ConfigF               func() config.Map
+	SnapshotF             func(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error)
+	TagsF                 func() map[apitype.StackTagName]string
+	BackendF              func() Backend
 	DefaultSecretManagerF func(info *workspace.ProjectStack) (secrets.Manager, error)
 }
 
@@ -653,92 +640,6 @@ func (ms *MockStack) Backend() Backend {
 		return ms.BackendF()
 	}
 	panic("not implemented: MockStack.Backend")
-}
-
-func (ms *MockStack) Preview(
-	ctx context.Context,
-	op UpdateOperation, events chan<- engine.Event,
-) (*deploy.Plan, sdkDisplay.ResourceChanges, error) {
-	if ms.PreviewF != nil {
-		return ms.PreviewF(ctx, op)
-	}
-	panic("not implemented: MockStack.Preview")
-}
-
-func (ms *MockStack) Update(ctx context.Context,
-	op UpdateOperation, events chan<- engine.Event,
-) (sdkDisplay.ResourceChanges, error) {
-	if ms.UpdateF != nil {
-		return ms.UpdateF(ctx, op)
-	}
-	panic("not implemented: MockStack.Update")
-}
-
-func (ms *MockStack) Import(ctx context.Context, op UpdateOperation,
-	imports []deploy.Import,
-) (sdkDisplay.ResourceChanges, error) {
-	if ms.ImportF != nil {
-		return ms.ImportF(ctx, op, imports)
-	}
-	panic("not implemented: MockStack.Import")
-}
-
-func (ms *MockStack) Refresh(ctx context.Context, op UpdateOperation) (sdkDisplay.ResourceChanges, error) {
-	if ms.RefreshF != nil {
-		return ms.RefreshF(ctx, op)
-	}
-	panic("not implemented: MockStack.Refresh")
-}
-
-func (ms *MockStack) Destroy(ctx context.Context, op UpdateOperation) (sdkDisplay.ResourceChanges, error) {
-	if ms.DestroyF != nil {
-		return ms.DestroyF(ctx, op)
-	}
-	panic("not implemented: MockStack.Destroy")
-}
-
-func (ms *MockStack) Watch(ctx context.Context, op UpdateOperation, paths []string) error {
-	if ms.WatchF != nil {
-		return ms.WatchF(ctx, op, paths)
-	}
-	panic("not implemented: MockStack.Watch")
-}
-
-func (ms *MockStack) Remove(ctx context.Context, force bool) (bool, error) {
-	if ms.RemoveF != nil {
-		return ms.RemoveF(ctx, force)
-	}
-	panic("not implemented: MockStack.Remove")
-}
-
-func (ms *MockStack) Rename(ctx context.Context, newName tokens.QName) (StackReference, error) {
-	if ms.RenameF != nil {
-		return ms.RenameF(ctx, newName)
-	}
-	panic("not implemented: MockStack.Rename")
-}
-
-func (ms *MockStack) GetLogs(ctx context.Context, secretsProvider secrets.Provider, cfg StackConfiguration,
-	query operations.LogQuery,
-) ([]operations.LogEntry, error) {
-	if ms.GetLogsF != nil {
-		return ms.GetLogsF(ctx, secretsProvider, cfg, query)
-	}
-	panic("not implemented: MockStack.GetLogs")
-}
-
-func (ms *MockStack) ExportDeployment(ctx context.Context) (*apitype.UntypedDeployment, error) {
-	if ms.ExportDeploymentF != nil {
-		return ms.ExportDeploymentF(ctx)
-	}
-	panic("not implemented: MockStack.ExportDeployment")
-}
-
-func (ms *MockStack) ImportDeployment(ctx context.Context, deployment *apitype.UntypedDeployment) error {
-	if ms.ImportDeploymentF != nil {
-		return ms.ImportDeploymentF(ctx, deployment)
-	}
-	panic("not implemented: MockStack.ImportDeployment")
 }
 
 func (ms *MockStack) DefaultSecretManager(info *workspace.ProjectStack) (secrets.Manager, error) {

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -54,31 +54,6 @@ type Stack interface {
 	Backend() Backend
 	// Tags return the stack's existing tags.
 	Tags() map[apitype.StackTagName]string
-	// Preview changes to this stack if an Update was run.
-	Preview(
-		ctx context.Context, op UpdateOperation, events chan<- engine.Event,
-	) (*deploy.Plan, display.ResourceChanges, error)
-	// Update this stack.
-	Update(ctx context.Context, op UpdateOperation, events chan<- engine.Event) (display.ResourceChanges, error)
-	// Import resources into this stack.
-	Import(ctx context.Context, op UpdateOperation, imports []deploy.Import) (display.ResourceChanges, error)
-	// Refresh this stack's state from the cloud provider.
-	Refresh(ctx context.Context, op UpdateOperation) (display.ResourceChanges, error)
-	Destroy(ctx context.Context, op UpdateOperation) (display.ResourceChanges, error)
-	// Watch this stack.
-	Watch(ctx context.Context, op UpdateOperation, paths []string) error
-
-	// Remove this stack.
-	Remove(ctx context.Context, force bool) (bool, error)
-	// Rename this stack.
-	Rename(ctx context.Context, newName tokens.QName) (StackReference, error)
-	// GetLogs lists log entries for this stack.
-	GetLogs(ctx context.Context, secretsProvider secrets.Provider,
-		cfg StackConfiguration, query operations.LogQuery) ([]operations.LogEntry, error)
-	// ExportDeployment exports this stack's deployment.
-	ExportDeployment(ctx context.Context) (*apitype.UntypedDeployment, error)
-	// ImportDeployment imports the given deployment into this stack.
-	ImportDeployment(ctx context.Context, deployment *apitype.UntypedDeployment) error
 
 	// DefaultSecretManager returns the default secrets manager to use for this stack. This may be more specific than
 	// Backend.DefaultSecretManager.

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -530,7 +530,7 @@ func newConfigRefreshCmd(stk *string) *cobra.Command {
 
 			ps.Config = c
 			// Also restore the secrets provider from state
-			untypedDeployment, err := s.ExportDeployment(ctx)
+			untypedDeployment, err := backend.ExportStackDeployment(ctx, s)
 			if err != nil {
 				return fmt.Errorf("getting deployment: %w", err)
 			}

--- a/pkg/cmd/pulumi/logs/logs.go
+++ b/pkg/cmd/pulumi/logs/logs.go
@@ -23,8 +23,9 @@ import (
 
 	mobytime "github.com/moby/moby/api/types/time"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
-	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
@@ -72,7 +73,7 @@ func NewLogsCmd() *cobra.Command {
 				ctx,
 				cmdutil.Diag(),
 				ws,
-				backend.DefaultLoginManager,
+				cmdBackend.DefaultLoginManager,
 				stackName,
 				cmdStack.LoadOnly,
 				opts,
@@ -128,7 +129,7 @@ func NewLogsCmd() *cobra.Command {
 			// rendered now even though they are technically out of order.
 			shown := map[operations.LogEntry]bool{}
 			for {
-				logs, err := s.GetLogs(ctx, stack.DefaultSecretsProvider, cfg, operations.LogQuery{
+				logs, err := backend.GetStackLogs(ctx, stack.DefaultSecretsProvider, s, cfg, operations.LogQuery{
 					StartTime:      startTime,
 					ResourceFilter: resourceFilter,
 				})

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -303,7 +303,7 @@ func NewDestroyCmd() *cobra.Command {
 				DestroyProgram:            runProgram,
 			}
 
-			_, destroyErr := s.Destroy(ctx, backend.UpdateOperation{
+			_, destroyErr := backend.DestroyStack(ctx, s, backend.UpdateOperation{
 				Proj:               proj,
 				Root:               root,
 				M:                  m,
@@ -323,7 +323,7 @@ func NewDestroyCmd() *cobra.Command {
 						"associated with the stack are still maintained. \nIf you want to remove the stack "+
 						"completely, run `pulumi stack rm %s`.\n", s.Ref())
 				} else if remove {
-					_, err = s.Remove(ctx, false)
+					_, err = backend.RemoveStack(ctx, s, false)
 					if err != nil {
 						return err
 					}

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -443,7 +443,7 @@ func getCurrentDeploymentForStack(
 	ctx context.Context,
 	s backend.Stack,
 ) (*deploy.Snapshot, error) {
-	deployment, err := s.ExportDeployment(ctx)
+	deployment, err := backend.ExportStackDeployment(ctx, s)
 	if err != nil {
 		return nil, err
 	}
@@ -918,7 +918,7 @@ func NewImportCmd() *cobra.Command {
 				Experimental:         env.Experimental.Value(),
 			}
 
-			_, err = s.Import(ctx, backend.UpdateOperation{
+			_, err = backend.ImportStack(ctx, s, backend.UpdateOperation{
 				Proj:               proj,
 				Root:               root,
 				M:                  m,

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -498,7 +498,7 @@ func NewPreviewCmd() *cobra.Command {
 				importFilePromise = buildImportFile(events)
 			}
 
-			plan, changes, res := s.Preview(ctx, backend.UpdateOperation{
+			plan, changes, res := backend.PreviewStack(ctx, s, backend.UpdateOperation{
 				Proj:               proj,
 				Root:               root,
 				M:                  m,

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -302,7 +302,7 @@ func NewRefreshCmd() *cobra.Command {
 				RefreshProgram:            runProgram,
 			}
 
-			changes, err := s.Refresh(ctx, backend.UpdateOperation{
+			changes, err := backend.RefreshStack(ctx, s, backend.UpdateOperation{
 				Proj:               proj,
 				Root:               root,
 				M:                  m,

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -237,7 +237,7 @@ func NewUpCmd() *cobra.Command {
 			opts.Engine.Plan = p
 		}
 
-		changes, err := s.Update(ctx, backend.UpdateOperation{
+		changes, err := backend.UpdateStack(ctx, s, backend.UpdateOperation{
 			Proj:               proj,
 			Root:               root,
 			M:                  m,
@@ -471,7 +471,7 @@ func NewUpCmd() *cobra.Command {
 		// - attempt `destroy` on any update errors.
 		// - show template.Quickstart?
 
-		changes, err := s.Update(ctx, backend.UpdateOperation{
+		changes, err := backend.UpdateStack(ctx, s, backend.UpdateOperation{
 			Proj:               proj,
 			Root:               root,
 			M:                  m,

--- a/pkg/cmd/pulumi/operations/watch.go
+++ b/pkg/cmd/pulumi/operations/watch.go
@@ -158,7 +158,7 @@ func NewWatchCmd() *cobra.Command {
 				Experimental:              env.Experimental.Value(),
 			}
 
-			err = s.Watch(ctx, backend.UpdateOperation{
+			err = backend.WatchStack(ctx, s, backend.UpdateOperation{
 				Proj:               proj,
 				Root:               root,
 				M:                  m,

--- a/pkg/cmd/pulumi/stack/io.go
+++ b/pkg/cmd/pulumi/stack/io.go
@@ -541,7 +541,7 @@ func SaveSnapshot(ctx context.Context, s backend.Stack, snapshot *deploy.Snapsho
 	}
 
 	// Now perform the deployment.
-	if err = s.ImportDeployment(ctx, &dep); err != nil {
+	if err = backend.ImportStackDeployment(ctx, s, &dep); err != nil {
 		return fmt.Errorf("could not import deployment: %w", err)
 	}
 	return nil

--- a/pkg/cmd/pulumi/stack/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack/stack_change_secrets_provider.go
@@ -215,7 +215,7 @@ func migrateOldConfigAndCheckpointToNewSecretsProvider(
 	}
 
 	// Load the current checkpoint so those secrets can also be decrypted
-	checkpoint, err := currentStack.ExportDeployment(ctx)
+	checkpoint, err := backend.ExportStackDeployment(ctx, currentStack)
 	if err != nil {
 		return err
 	}
@@ -242,5 +242,5 @@ func migrateOldConfigAndCheckpointToNewSecretsProvider(
 	}
 
 	// Import the newly changes Deployment
-	return currentStack.ImportDeployment(ctx, &dep)
+	return backend.ImportStackDeployment(ctx, currentStack, &dep)
 }

--- a/pkg/cmd/pulumi/stack/stack_change_secrets_provider_test.go
+++ b/pkg/cmd/pulumi/stack/stack_change_secrets_provider_test.go
@@ -96,18 +96,8 @@ func TestChangeSecretsProvider_NoSecrets(t *testing.T) {
 		},
 	}
 
-	mockStack := &backend.MockStack{
-		RefF: func() backend.StackReference {
-			return &backend.MockStackReference{
-				StringV: "testStack",
-				NameV:   tokens.MustParseStackName("testStack"),
-			}
-		},
-		ConfigLocationF: func() backend.StackConfigLocation { return backend.StackConfigLocation{} },
-		SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
-			return snapshot, nil
-		},
-		ExportDeploymentF: func(ctx context.Context) (*apitype.UntypedDeployment, error) {
+	mockBackend := &backend.MockBackend{
+		ExportDeploymentF: func(ctx context.Context, _ backend.Stack) (*apitype.UntypedDeployment, error) {
 			chk, err := stack.SerializeDeployment(ctx, snapshot, false)
 			if err != nil {
 				return nil, err
@@ -121,13 +111,29 @@ func TestChangeSecretsProvider_NoSecrets(t *testing.T) {
 				Deployment: json.RawMessage(data),
 			}, nil
 		},
-		ImportDeploymentF: func(ctx context.Context, deployment *apitype.UntypedDeployment) error {
+		ImportDeploymentF: func(ctx context.Context, _ backend.Stack, deployment *apitype.UntypedDeployment) error {
 			snap, err := stack.DeserializeUntypedDeployment(ctx, deployment, secretsProvider)
 			if err != nil {
 				return err
 			}
 			snapshot = snap
 			return nil
+		},
+	}
+
+	mockStack := &backend.MockStack{
+		BackendF: func() backend.Backend {
+			return mockBackend
+		},
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{
+				StringV: "testStack",
+				NameV:   tokens.MustParseStackName("testStack"),
+			}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation { return backend.StackConfigLocation{} },
+		SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
+			return snapshot, nil
 		},
 	}
 
@@ -198,18 +204,8 @@ func TestChangeSecretsProvider_WithSecrets(t *testing.T) {
 		},
 	}
 
-	mockStack := &backend.MockStack{
-		RefF: func() backend.StackReference {
-			return &backend.MockStackReference{
-				StringV: "testStack",
-				NameV:   tokens.MustParseStackName("testStack"),
-			}
-		},
-		ConfigLocationF: func() backend.StackConfigLocation { return backend.StackConfigLocation{} },
-		SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
-			return snapshot, nil
-		},
-		ExportDeploymentF: func(ctx context.Context) (*apitype.UntypedDeployment, error) {
+	mockBackend := &backend.MockBackend{
+		ExportDeploymentF: func(ctx context.Context, _ backend.Stack) (*apitype.UntypedDeployment, error) {
 			chk, err := stack.SerializeDeployment(ctx, snapshot, false)
 			if err != nil {
 				return nil, err
@@ -223,13 +219,29 @@ func TestChangeSecretsProvider_WithSecrets(t *testing.T) {
 				Deployment: json.RawMessage(data),
 			}, nil
 		},
-		ImportDeploymentF: func(ctx context.Context, deployment *apitype.UntypedDeployment) error {
+		ImportDeploymentF: func(ctx context.Context, _ backend.Stack, deployment *apitype.UntypedDeployment) error {
 			snap, err := stack.DeserializeUntypedDeployment(ctx, deployment, secretsProvider)
 			if err != nil {
 				return err
 			}
 			snapshot = snap
 			return nil
+		},
+	}
+
+	mockStack := &backend.MockStack{
+		BackendF: func() backend.Backend {
+			return mockBackend
+		},
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{
+				StringV: "testStack",
+				NameV:   tokens.MustParseStackName("testStack"),
+			}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation { return backend.StackConfigLocation{} },
+		SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
+			return snapshot, nil
 		},
 		DefaultSecretManagerF: func(_ *workspace.ProjectStack) (secrets.Manager, error) {
 			return secretsManager, nil

--- a/pkg/cmd/pulumi/stack/stack_export.go
+++ b/pkg/cmd/pulumi/stack/stack_export.go
@@ -71,7 +71,7 @@ func newStackExportCmd() *cobra.Command {
 			// Export the latest version of the checkpoint by default. Otherwise, we require that
 			// the backend/stack implements the ability the export previous checkpoints.
 			if version == "" {
-				deployment, err = s.ExportDeployment(ctx)
+				deployment, err = backend.ExportStackDeployment(ctx, s)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/pulumi/stack/stack_rename.go
+++ b/pkg/cmd/pulumi/stack/stack_rename.go
@@ -21,9 +21,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
-	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -58,7 +59,7 @@ func newStackRenameCmd() *cobra.Command {
 				ctx,
 				cmdutil.Diag(),
 				ws,
-				backend.DefaultLoginManager,
+				cmdBackend.DefaultLoginManager,
 				stack,
 				LoadOnly,
 				opts,
@@ -73,7 +74,7 @@ func newStackRenameCmd() *cobra.Command {
 
 			// Now perform the rename and get ready to rename the existing configuration to the new project file.
 			newStackName := args[0]
-			newStackRef, err := s.Rename(ctx, tokens.QName(newStackName))
+			newStackRef, err := backend.RenameStack(ctx, s, tokens.QName(newStackName))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack/stack_rm.go
+++ b/pkg/cmd/pulumi/stack/stack_rm.go
@@ -19,7 +19,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -71,7 +72,7 @@ func newStackRmCmd() *cobra.Command {
 				ctx,
 				cmdutil.Diag(),
 				ws,
-				backend.DefaultLoginManager,
+				cmdBackend.DefaultLoginManager,
 				stack,
 				LoadOnly,
 				opts,
@@ -90,7 +91,7 @@ func newStackRmCmd() *cobra.Command {
 				return result.FprintBailf(os.Stdout, "confirmation declined")
 			}
 
-			hasResources, err := s.Remove(ctx, force)
+			hasResources, err := backend.RemoveStack(ctx, s, force)
 			if err != nil {
 				if hasResources {
 					return fmt.Errorf(

--- a/pkg/cmd/pulumi/state/io.go
+++ b/pkg/cmd/pulumi/state/io.go
@@ -178,7 +178,7 @@ func TotalStateEdit(
 		Version:    apitype.DeploymentSchemaVersionCurrent,
 		Deployment: bytes,
 	}
-	return s.ImportDeployment(ctx, &dep)
+	return backend.ImportStackDeployment(ctx, s, &dep)
 }
 
 // locateStackResource attempts to find a unique resource associated with the given URN in the given snapshot. If the

--- a/pkg/cmd/pulumi/state/state_delete_test.go
+++ b/pkg/cmd/pulumi/state/state_delete_test.go
@@ -85,8 +85,24 @@ func TestNoProject(t *testing.T) {
 func TestStateDeleteURN(t *testing.T) {
 	t.Parallel()
 
+	var mockStack *backend.MockStack
+
 	var savedDeployment *apitype.UntypedDeployment
-	mockStack := &backend.MockStack{
+	mockBackend := &backend.MockBackend{
+		GetStackF: func(_ context.Context, ref backend.StackReference) (backend.Stack, error) {
+			assert.Equal(t, "stk", ref.String())
+			return mockStack, nil
+		},
+		ImportDeploymentF: func(_ context.Context, _ backend.Stack, deployment *apitype.UntypedDeployment) error {
+			savedDeployment = deployment
+			return nil
+		},
+	}
+
+	mockStack = &backend.MockStack{
+		BackendF: func() backend.Backend {
+			return mockBackend
+		},
 		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
 			return &deploy.Snapshot{
 				Resources: []*resource.State{
@@ -95,16 +111,6 @@ func TestStateDeleteURN(t *testing.T) {
 					},
 				},
 			}, nil
-		},
-		ImportDeploymentF: func(_ context.Context, deployment *apitype.UntypedDeployment) error {
-			savedDeployment = deployment
-			return nil
-		},
-	}
-	mockBackend := &backend.MockBackend{
-		GetStackF: func(_ context.Context, ref backend.StackReference) (backend.Stack, error) {
-			assert.Equal(t, "stk", ref.String())
-			return mockStack, nil
 		},
 	}
 	ws := &pkgWorkspace.MockContext{
@@ -191,8 +197,24 @@ func TestStateDeleteDependency(t *testing.T) {
 func TestStateDeleteProtected(t *testing.T) {
 	t.Parallel()
 
+	var mockStack *backend.MockStack
+
 	var savedDeployment *apitype.UntypedDeployment
-	mockStack := &backend.MockStack{
+	mockBackend := &backend.MockBackend{
+		GetStackF: func(_ context.Context, ref backend.StackReference) (backend.Stack, error) {
+			assert.Equal(t, "stk", ref.String())
+			return mockStack, nil
+		},
+		ImportDeploymentF: func(_ context.Context, _ backend.Stack, deployment *apitype.UntypedDeployment) error {
+			savedDeployment = deployment
+			return nil
+		},
+	}
+
+	mockStack = &backend.MockStack{
+		BackendF: func() backend.Backend {
+			return mockBackend
+		},
 		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
 			return &deploy.Snapshot{
 				Resources: []*resource.State{
@@ -202,16 +224,6 @@ func TestStateDeleteProtected(t *testing.T) {
 					},
 				},
 			}, nil
-		},
-		ImportDeploymentF: func(_ context.Context, deployment *apitype.UntypedDeployment) error {
-			savedDeployment = deployment
-			return nil
-		},
-	}
-	mockBackend := &backend.MockBackend{
-		GetStackF: func(_ context.Context, ref backend.StackReference) (backend.Stack, error) {
-			assert.Equal(t, "stk", ref.String())
-			return mockStack, nil
 		},
 	}
 	ws := &pkgWorkspace.MockContext{
@@ -265,20 +277,26 @@ func TestStateDeleteAll(t *testing.T) {
 		},
 	}
 
+	var mockStack *backend.MockStack
+
 	var mockDeployment *apitype.UntypedDeployment
-	mockStack := &backend.MockStack{
-		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
-			return snapshot, nil
-		},
-		ImportDeploymentF: func(_ context.Context, deployment *apitype.UntypedDeployment) error {
-			mockDeployment = deployment
-			return nil
-		},
-	}
 	mockBackend := &backend.MockBackend{
 		GetStackF: func(_ context.Context, ref backend.StackReference) (backend.Stack, error) {
 			assert.Equal(t, "stk", ref.String())
 			return mockStack, nil
+		},
+		ImportDeploymentF: func(_ context.Context, _ backend.Stack, deployment *apitype.UntypedDeployment) error {
+			mockDeployment = deployment
+			return nil
+		},
+	}
+
+	mockStack = &backend.MockStack{
+		BackendF: func() backend.Backend {
+			return mockBackend
+		},
+		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
+			return snapshot, nil
 		},
 	}
 	ws := &pkgWorkspace.MockContext{

--- a/pkg/cmd/pulumi/state/state_repair.go
+++ b/pkg/cmd/pulumi/state/state_repair.go
@@ -223,7 +223,7 @@ func (cmd *stateRepairCmd) run(ctx context.Context) error {
 		return err
 	}
 
-	err = s.ImportDeployment(ctx, &apitype.UntypedDeployment{
+	err = backend.ImportStackDeployment(ctx, s, &apitype.UntypedDeployment{
 		Version:    apitype.DeploymentSchemaVersionCurrent,
 		Deployment: bytes,
 	})

--- a/tests/integration/backend/diy/backend_postgres_test.go
+++ b/tests/integration/backend/diy/backend_postgres_test.go
@@ -235,7 +235,7 @@ func TestPostgresBackend(t *testing.T) {
 	assert.NotNil(t, exportedDeployment.Deployment, "Deployment data should not be nil")
 
 	// Test stack-level export
-	stackExport, err := stack1.ExportDeployment(ctx)
+	stackExport, err := backend.ExportStackDeployment(ctx, stack1)
 	require.NoError(t, err, "Failed to export stack deployment")
 	require.NotNil(t, stackExport, "Stack export should not be nil")
 
@@ -244,7 +244,7 @@ func TestPostgresBackend(t *testing.T) {
 	require.NoError(t, err, "Failed to import deployment")
 
 	// Test stack-level import
-	err = stack2.ImportDeployment(ctx, exportedDeployment)
+	err = backend.ImportStackDeployment(ctx, stack2, exportedDeployment)
 	require.NoError(t, err, "Failed to import stack deployment")
 
 	// Test history and update information
@@ -376,7 +376,7 @@ func TestPostgresBackend(t *testing.T) {
 
 	// Test stack-level rename
 	anotherNewName := tokens.QName("another-" + renamedStackName)
-	anotherNewRef, err := stack2.Rename(ctx, anotherNewName)
+	anotherNewRef, err := backend.RenameStack(ctx, stack2, anotherNewName)
 	if err != nil {
 		t.Logf("Stack-level rename failed: %v", err)
 		// Continue with original reference for cleanup
@@ -403,7 +403,7 @@ func TestPostgresBackend(t *testing.T) {
 	assert.False(t, removed1, "Stack 1 should be removed without confirmation")
 
 	// Test stack removal (stack level)
-	removed2, err := stack2.Remove(ctx, true)
+	removed2, err := backend.RemoveStack(ctx, stack2, true)
 	require.NoError(t, err, "Failed to remove stack 2")
 	assert.False(t, removed2, "Stack 2 should be removed without confirmation")
 


### PR DESCRIPTION
The `Stack` interface has a series of methods whose implementations always delegate to the underlying `Backend`. These serve only to widen the interface unnecessarily (making it harder to identify what code is _actually_ backend-specific) and can be replaced with a single set of stack-agnostic functions. These functions actually already exist; they are just not used consistently. This change removes the interface methods and rolls out the functions uniformly, removing a bunch of code and nicely shrinking the `Stack` interface to something more fundamental.