### PR TITLE
[AutomationAPI/Python] Fix Parallelism

### DIFF
--- a/changelog/pending/20250613--auto-python--respect-parallelism-settings.yaml
+++ b/changelog/pending/20250613--auto-python--respect-parallelism-settings.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/python
+  description: Fix parallelism issue when running inline programs with the automation API

--- a/sdk/python/lib/pulumi/automation/_server.py
+++ b/sdk/python/lib/pulumi/automation/_server.py
@@ -17,6 +17,7 @@ import logging
 import sys
 import traceback
 import contextvars
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 
 import grpc
@@ -77,6 +78,11 @@ class LanguageServer(LanguageRuntimeServicer):
             # The strategy here is derived from sdk/python/cmd/pulumi-language-python-exec
             result = language_pb2.RunResponse()
             loop = asyncio.new_event_loop()
+            if request.parallel is not None:
+                request.parallel = max(request.parallel, 1)
+                loop.set_default_executor(
+                    ThreadPoolExecutor(max_workers=request.parallel)
+                )
 
             loop.set_exception_handler(self._exception_handler)
             try:


### PR DESCRIPTION
When running an inline python program using the automation API, deployments are limited to 16 concurrent actions.

We can notice the issue in this demo, which uses the automation API (with an inline program) : [https://asciinema.org/a/01HCUcmfWo27RUyuEJtnPoMHt](https://asciinema.org/a/01HCUcmfWo27RUyuEJtnPoMHt)
We can see that 16 resources are created (which takes 10 seconds), then the 14 last resources are created. This results in waiting 20 seconds, while it was expected to create all resources simultaneously.

This demo runs the exact same program but using the pulumi binary : [https://asciinema.org/a/olWRUsZGfrVNZ4FdBzLUDqUxF](https://asciinema.org/a/olWRUsZGfrVNZ4FdBzLUDqUxF)

I found out that unlike the `sdk/python/cmd/pulumi-language-python-exec` script, `the sdk/python/lib/pulumi/automation/_server.py` file does not define a new ThreadPoolExecutor for the asyncio loop.