### PR TITLE
Skip registry lookup when `--file` is passed

### DIFF
--- a/changelog/pending/20250616--cli-install--dont-consult-the-registry-when-file-is-specified.yaml
+++ b/changelog/pending/20250616--cli-install--dont-consult-the-registry-when-file-is-specified.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/install
+  description: Don't consult the registry when `--file` is specified

--- a/pkg/cmd/pulumi/plugin/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install.go
@@ -194,7 +194,8 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 
 		if pluginSpec.Kind == apitype.ResourcePlugin && // The registry only supports resource plugins
 			!cmd.env.GetBool(env.DisableRegistryResolve) &&
-			pluginSpec.PluginDownloadURL == "" { // Don't override explicit pluginDownloadURLs
+			pluginSpec.PluginDownloadURL == "" && // Don't override explicit pluginDownloadURLs
+			cmd.file == "" { // We don't need help looking up the download URL when we are not downloading a file
 			pkgMetadata, err := registry.ResolvePackageFromName(ctx, cmd.registry, pluginSpec.Name, pluginSpec.Version)
 			if err == nil {
 				pluginSpec.Name = pkgMetadata.Name


### PR DESCRIPTION
This addressed a bug that Pulumi's own insights team found when running:

```
pulumi plugin install resource some-provider ${VERSION} --file ${FILE}
```

The registry should not be consulted when `--file` has been passed, since the user has located the provider for us. This is the same reason why the registry shouldn't be consulted when `--server` (pluginDownloadURL) is passed.