### PR TITLE
Rename PackageRegistry to CloudRegistry

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -255,17 +255,17 @@ type Backend interface {
 	// to ListTemplates.
 	DownloadTemplate(ctx context.Context, orgName, sourceURL string) (TarReaderCloser, error)
 
-	// GetPackageRegistry returns a PackageRegistry object tied to this backend. Not
-	// all backends are required to support GetPackageRegistry. Those that don't
-	// should return a non-nil error when GetPackageRegistry is called.
+	// GetCloudRegistry returns a CloudRegistry object tied to this backend. Not
+	// all backends are required to support GetCloudRegistry. Those that don't
+	// should return a non-nil error when GetCloudRegistry is called.
 	//
-	// PackageRegistry is a superset of [registry.Registry] that supports publishing
+	// CloudRegistry is a superset of [registry.Registry] that supports publishing
 	// packages.
-	GetPackageRegistry() (PackageRegistry, error)
+	GetCloudRegistry() (CloudRegistry, error)
 
-	// GetReadOnlyPackageRegistry retusn a [registry.Registry] object tied to this
-	// backend. All backends should support GetReadOnlyPackageRegistry.
-	GetReadOnlyPackageRegistry() registry.Registry
+	// GetReadOnlyCloudRegistry retusn a [registry.Registry] object tied to this
+	// backend. All backends should support GetReadOnlyCloudRegistry.
+	GetReadOnlyCloudRegistry() registry.Registry
 }
 
 // EnvironmentsBackend is an interface that defines an optional capability for a backend to work with environments.

--- a/pkg/backend/cloud_registry.go
+++ b/pkg/backend/cloud_registry.go
@@ -21,8 +21,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 )
 
-type PackageRegistry interface {
+type CloudRegistry interface {
 	registry.Registry
-	// Publish publishes a package to the package registry.
-	Publish(ctx context.Context, op apitype.PackagePublishOp) error
+	// PublishPackage publishes a package to the registry.
+	PublishPackage(ctx context.Context, op apitype.PackagePublishOp) error
 }

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1546,10 +1546,10 @@ func (b *diyBackend) getParallel() int {
 	return parallel
 }
 
-func (b *diyBackend) GetPackageRegistry() (backend.PackageRegistry, error) {
-	return nil, errors.New("package registry is not supported by diy backends")
+func (b *diyBackend) GetCloudRegistry() (backend.CloudRegistry, error) {
+	return nil, errors.New("cloud registry is not supported by diy backends")
 }
 
-func (b *diyBackend) GetReadOnlyPackageRegistry() registry.Registry {
+func (b *diyBackend) GetReadOnlyCloudRegistry() registry.Registry {
 	return unauthenticatedregistry.New(b.d, b.Env)
 }

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -2392,10 +2392,10 @@ func (b *cloudBackend) DefaultSecretManager(*workspace.ProjectStack) (secrets.Ma
 	return nil, nil
 }
 
-func (b *cloudBackend) GetPackageRegistry() (backend.PackageRegistry, error) {
-	return newCloudPackageRegistry(b.client), nil
+func (b *cloudBackend) GetCloudRegistry() (backend.CloudRegistry, error) {
+	return newCloudRegistry(b.client), nil
 }
 
-func (b *cloudBackend) GetReadOnlyPackageRegistry() registry.Registry {
-	return newCloudPackageRegistry(b.client)
+func (b *cloudBackend) GetReadOnlyCloudRegistry() registry.Registry {
+	return newCloudRegistry(b.client)
 }

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -323,7 +323,7 @@ func TestDisableIntegrityChecking(t *testing.T) {
 	assert.NotNil(t, snap)
 }
 
-func TestCloudBackend_GetPackageRegistry(t *testing.T) {
+func TestCloudBackend_GetCloudRegistry(t *testing.T) {
 	t.Parallel()
 	mockClient := &client.Client{}
 	b := &cloudBackend{
@@ -331,12 +331,12 @@ func TestCloudBackend_GetPackageRegistry(t *testing.T) {
 		d:      diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never}),
 	}
 
-	registry, err := b.GetPackageRegistry()
+	registry, err := b.GetCloudRegistry()
 	assert.NoError(t, err)
 	assert.NotNil(t, registry)
 
-	_, ok := registry.(*cloudPackageRegistry)
-	assert.True(t, ok, "expected registry to be a cloudPackageRegistry")
+	_, ok := registry.(*cloudRegistry)
+	assert.True(t, ok, "expected registry to be a cloudRegistry")
 }
 
 // Bit of an integration test.

--- a/pkg/backend/httpstate/cloud_registry.go
+++ b/pkg/backend/httpstate/cloud_registry.go
@@ -26,29 +26,29 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
-type cloudPackageRegistry struct {
+type cloudRegistry struct {
 	cl *client.Client
 }
 
-func newCloudPackageRegistry(cl *client.Client) *cloudPackageRegistry {
-	return &cloudPackageRegistry{
+func newCloudRegistry(cl *client.Client) *cloudRegistry {
+	return &cloudRegistry{
 		cl: cl,
 	}
 }
 
-var _ backend.PackageRegistry = (*cloudPackageRegistry)(nil)
+var _ backend.CloudRegistry = (*cloudRegistry)(nil)
 
-func (r *cloudPackageRegistry) Publish(ctx ctx.Context, op apitype.PackagePublishOp) error {
+func (r *cloudRegistry) PublishPackage(ctx ctx.Context, op apitype.PackagePublishOp) error {
 	return r.cl.PublishPackage(ctx, op)
 }
 
-func (r *cloudPackageRegistry) SearchByName(
+func (r *cloudRegistry) SearchByName(
 	ctx ctx.Context, name *string,
 ) iter.Seq2[apitype.PackageMetadata, error] {
 	return r.cl.SearchByName(ctx, name)
 }
 
-func (r *cloudPackageRegistry) GetPackage(
+func (r *cloudRegistry) GetPackage(
 	ctx ctx.Context, source, publisher, name string, version *semver.Version,
 ) (apitype.PackageMetadata, error) {
 	meta, err := r.cl.GetPackage(ctx, source, publisher, name, version)

--- a/pkg/backend/httpstate/mock.go
+++ b/pkg/backend/httpstate/mock.go
@@ -43,7 +43,7 @@ type MockHTTPBackend struct {
 		deploymentInitiator string,
 		suppressStreamLogs bool,
 	) error
-	FGetPackageRegistry func() (backend.PackageRegistry, error)
+	FGetCloudRegistry func() (backend.CloudRegistry, error)
 }
 
 func (b *MockHTTPBackend) Client() *client.Client {
@@ -91,8 +91,8 @@ func (b *MockHTTPBackend) Capabilities(context.Context) apitype.Capabilities {
 	return apitype.Capabilities{}
 }
 
-func (b *MockHTTPBackend) GetPackageRegistry() (backend.PackageRegistry, error) {
-	return b.FGetPackageRegistry()
+func (b *MockHTTPBackend) GetCloudRegistry() (backend.CloudRegistry, error) {
+	return b.FGetCloudRegistry()
 }
 
 var _ Backend = (*MockHTTPBackend)(nil)

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -102,9 +102,9 @@ type MockBackend struct {
 
 	DefaultSecretManagerF func(ps *workspace.ProjectStack) (secrets.Manager, error)
 
-	SupportsTemplatesF          func() bool
-	ListTemplatesF              func(_ context.Context, orgName string) (apitype.ListOrgTemplatesResponse, error)
-	DownloadTemplateF           func(_ context.Context, orgName, templateSource string) (TarReaderCloser, error)
+	SupportsTemplatesF        func() bool
+	ListTemplatesF            func(_ context.Context, orgName string) (apitype.ListOrgTemplatesResponse, error)
+	DownloadTemplateF         func(_ context.Context, orgName, templateSource string) (TarReaderCloser, error)
 	GetCloudRegistryF         func() (CloudRegistry, error)
 	GetReadOnlyCloudRegistryF func() registry.Registry
 }

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -105,8 +105,8 @@ type MockBackend struct {
 	SupportsTemplatesF          func() bool
 	ListTemplatesF              func(_ context.Context, orgName string) (apitype.ListOrgTemplatesResponse, error)
 	DownloadTemplateF           func(_ context.Context, orgName, templateSource string) (TarReaderCloser, error)
-	GetPackageRegistryF         func() (PackageRegistry, error)
-	GetReadOnlyPackageRegistryF func() registry.Registry
+	GetCloudRegistryF         func() (CloudRegistry, error)
+	GetReadOnlyCloudRegistryF func() registry.Registry
 }
 
 var _ Backend = (*MockBackend)(nil)
@@ -493,16 +493,16 @@ func (be *MockBackend) DownloadTemplate(ctx context.Context, orgName, templateSo
 	panic("not implemented")
 }
 
-func (be *MockBackend) GetPackageRegistry() (PackageRegistry, error) {
-	if be.GetPackageRegistryF != nil {
-		return be.GetPackageRegistryF()
+func (be *MockBackend) GetCloudRegistry() (CloudRegistry, error) {
+	if be.GetCloudRegistryF != nil {
+		return be.GetCloudRegistryF()
 	}
 	panic("not implemented")
 }
 
-func (be *MockBackend) GetReadOnlyPackageRegistry() registry.Registry {
-	if be.GetReadOnlyPackageRegistryF != nil {
-		return be.GetReadOnlyPackageRegistryF()
+func (be *MockBackend) GetReadOnlyCloudRegistry() registry.Registry {
+	if be.GetReadOnlyCloudRegistryF != nil {
+		return be.GetReadOnlyCloudRegistryF()
 	}
 	panic("not implemented")
 }
@@ -806,24 +806,24 @@ func (m MockTarReader) Tar() *tar.Reader {
 	return tar.NewReader(&b)
 }
 
-type MockPackageRegistry struct {
-	PublishF    func(context.Context, apitype.PackagePublishOp) error
-	GetPackageF func(
+type MockCloudRegistry struct {
+	PublishPackageF func(context.Context, apitype.PackagePublishOp) error
+	GetPackageF     func(
 		ctx context.Context, source, publisher, name string, version *semver.Version,
 	) (apitype.PackageMetadata, error)
 	SearchByNameF func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error]
 }
 
-var _ PackageRegistry = (*MockPackageRegistry)(nil)
+var _ CloudRegistry = (*MockCloudRegistry)(nil)
 
-func (mr *MockPackageRegistry) Publish(ctx context.Context, op apitype.PackagePublishOp) error {
-	if mr.PublishF != nil {
-		return mr.PublishF(ctx, op)
+func (mr *MockCloudRegistry) PublishPackage(ctx context.Context, op apitype.PackagePublishOp) error {
+	if mr.PublishPackageF != nil {
+		return mr.PublishPackageF(ctx, op)
 	}
-	panic("not implemented: MockPackageRegistry.Publish")
+	panic("not implemented: MockCloudRegistry.PublishPackage")
 }
 
-func (mr *MockPackageRegistry) GetPackage(
+func (mr *MockCloudRegistry) GetPackage(
 	ctx context.Context, source, publisher, name string, version *semver.Version,
 ) (apitype.PackageMetadata, error) {
 	if mr.GetPackageF != nil {
@@ -832,7 +832,7 @@ func (mr *MockPackageRegistry) GetPackage(
 	panic("not implemented")
 }
 
-func (mr *MockPackageRegistry) SearchByName(
+func (mr *MockCloudRegistry) SearchByName(
 	ctx context.Context, name *string,
 ) iter.Seq2[apitype.PackageMetadata, error] {
 	if mr.SearchByNameF != nil {

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -196,9 +196,9 @@ func (cmd *packagePublishCmd) Run(
 		return fmt.Errorf("failed to marshal schema: %w", err)
 	}
 
-	registry, err := b.GetPackageRegistry()
+	registry, err := b.GetCloudRegistry()
 	if err != nil {
-		return fmt.Errorf("failed to get package registry: %w", err)
+		return fmt.Errorf("failed to get cloud registry: %w", err)
 	}
 
 	// We need to set the content-size header for S3 puts. For byte buffers (or deterministic readers)
@@ -244,7 +244,7 @@ func (cmd *packagePublishCmd) Run(
 		publishInput.InstallDocs = installDocsBytes
 	}
 
-	err = registry.Publish(ctx, publishInput)
+	err = registry.PublishPackage(ctx, publishInput)
 	if err != nil {
 		return fmt.Errorf("failed to publish package: %w", err)
 	}

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -546,7 +546,7 @@ func TestPackagePublishCmd_BackendErrors(t *testing.T) {
 			name: "error getting package registry",
 			setupBackend: func(t *testing.T) {
 				testutil.MockBackendInstance(t, &backend.MockBackend{
-					GetPackageRegistryF: func() (backend.PackageRegistry, error) {
+					GetCloudRegistryF: func() (backend.CloudRegistry, error) {
 						return nil, errors.New("failed to get package registry")
 					},
 				})

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -362,8 +362,8 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 				tt.args.installDocsPath = installDocsPath
 			}
 
-			mockPackageRegistry := &backend.MockPackageRegistry{
-				PublishF: func(ctx context.Context, op apitype.PackagePublishOp) error {
+			mockCloudRegistry := &backend.MockCloudRegistry{
+				PublishPackageF: func(ctx context.Context, op apitype.PackagePublishOp) error {
 					schemaBytes, err := io.ReadAll(op.Schema)
 					require.NoError(t, err)
 					packageSpec, err := unmarshalSchema(schemaBytes)
@@ -407,8 +407,8 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 			}
 
 			testutil.MockBackendInstance(t, &backend.MockBackend{
-				GetPackageRegistryF: func() (backend.PackageRegistry, error) {
-					return mockPackageRegistry, nil
+				GetCloudRegistryF: func() (backend.CloudRegistry, error) {
+					return mockCloudRegistry, nil
 				},
 			})
 
@@ -502,9 +502,9 @@ func TestPackagePublishCmd_IOErrors(t *testing.T) {
 
 			// Mock the backend
 			testutil.MockBackendInstance(t, &backend.MockBackend{
-				GetPackageRegistryF: func() (backend.PackageRegistry, error) {
-					return &backend.MockPackageRegistry{
-						PublishF: func(ctx context.Context, op apitype.PackagePublishOp) error {
+				GetCloudRegistryF: func() (backend.CloudRegistry, error) {
+					return &backend.MockCloudRegistry{
+						PublishPackageF: func(ctx context.Context, op apitype.PackagePublishOp) error {
 							return nil
 						},
 					}, nil

--- a/pkg/cmd/pulumi/plugin/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install.go
@@ -125,7 +125,7 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 				ctx, pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, nil,
 			)
 			if err == nil && b != nil {
-				return b.GetReadOnlyPackageRegistry(), nil
+				return b.GetReadOnlyCloudRegistry(), nil
 			}
 			if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
 				return unauthenticatedregistry.New(cmd.diag, cmd.env), nil


### PR DESCRIPTION
The registry handles not just packages but also templates and other resources, so CloudRegistry is a more accurate name.