### PR TITLE
Use diag.Sink for stack config warning

### DIFF
--- a/pkg/cmd/pulumi/stack/io.go
+++ b/pkg/cmd/pulumi/stack/io.go
@@ -69,7 +69,8 @@ func LoadProjectStack(
 			return nil, fmt.Errorf("checking if config file %s exists: %v", configFilePath, err)
 		}
 		if err == nil {
-			fmt.Printf("Warning: config file %s exists but will be ignored because this stack uses remote config\n",
+			sink.Warningf(
+				diag.Message("", "config file %s exists but will be ignored because this stack uses remote config"),
 				configFilePath)
 		}
 		return stack.LoadRemoteConfig(ctx, project)


### PR DESCRIPTION
Fixes #19749

Warnings are written to stderr so won't affect the JSON from the stdout.

This might break anywhere which asserts that the stderr is empty as a criteria for success.