### PR TITLE
Fix refresh views with --run-program

### DIFF
--- a/changelog/pending/20250618--engine--fix-views-with-refresh-run-program.yaml
+++ b/changelog/pending/20250618--engine--fix-views-with-refresh-run-program.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix views with --refresh --run-program

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -512,7 +512,8 @@ func (rsm *refreshSnapshotMutation) End(step deploy.Step, successful bool) error
 		// The exception to this is persisted refreshes, which are not elided and are treated as normal operations.
 		// These can either update or delete a resource.
 		refreshStep, isRefreshStep := step.(*deploy.RefreshStep)
-		if isRefreshStep && refreshStep.Persisted() {
+		viewStep, isViewStep := step.(*deploy.ViewStep)
+		if (isViewStep && viewStep.Persisted()) || (isRefreshStep && refreshStep.Persisted()) {
 			if successful {
 				rsm.manager.markDone(step.Old())
 				if step.New() != nil {

--- a/pkg/engine/journal.go
+++ b/pkg/engine/journal.go
@@ -112,8 +112,9 @@ func (entries JournalEntries) Snap(base *deploy.Snapshot) (*deploy.Snapshot, err
 			case deploy.OpImport, deploy.OpImportReplacement:
 				resources = append(resources, e.Step.New())
 			case deploy.OpRefresh:
-				step, ok := e.Step.(*deploy.RefreshStep)
-				if ok && step.Persisted() {
+				refreshStep, isRefreshStep := e.Step.(*deploy.RefreshStep)
+				viewStep, isViewStep := e.Step.(*deploy.ViewStep)
+				if (isViewStep && viewStep.Persisted()) || (isRefreshStep && refreshStep.Persisted()) {
 					if e.Step.New() != nil {
 						resources = append(resources, e.Step.New())
 					} else {

--- a/pkg/engine/lifecycletest/views_test.go
+++ b/pkg/engine/lifecycletest/views_test.go
@@ -215,9 +215,9 @@ func TestViewsBasic(t *testing.T) {
 		validateSummaryEvent(display.ResourceChanges{
 			deploy.OpCreate: 2,
 		}), "0")
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -234,9 +234,9 @@ func TestViewsBasic(t *testing.T) {
 		validateSummaryEvent(display.ResourceChanges{
 			deploy.OpSame: 2,
 		}), "1")
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -256,9 +256,9 @@ func TestViewsBasic(t *testing.T) {
 		validateSummaryEvent(display.ResourceChanges{
 			deploy.OpUpdate: 2,
 		}), "2")
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -276,9 +276,9 @@ func TestViewsBasic(t *testing.T) {
 		validateSummaryEvent(display.ResourceChanges{
 			deploy.OpDelete: 2,
 		}), "3")
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 0)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 0)
 }
 
 // TestViewsUpdateError tests that an error from a view update step is properly propagated.
@@ -420,9 +420,9 @@ func TestViewsUpdateError(t *testing.T) {
 		validateSummaryEvent(display.ResourceChanges{
 			deploy.OpCreate: 2,
 		}), "0")
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -573,9 +573,9 @@ func TestViewsUpdateDelete(t *testing.T) {
 		validateSummaryEvent(display.ResourceChanges{
 			deploy.OpCreate: 2,
 		}), "0")
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -596,9 +596,9 @@ func TestViewsUpdateDelete(t *testing.T) {
 			deploy.OpUpdate: 1,
 			deploy.OpDelete: 1,
 		}), "1")
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 }
 
@@ -706,8 +706,8 @@ func TestViewsRefreshSame(t *testing.T) {
 
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -721,8 +721,8 @@ func TestViewsRefreshSame(t *testing.T) {
 
 	p.Steps = []lt.TestStep{{Op: Refresh}}
 	snap = p.Run(t, snap)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -841,8 +841,8 @@ func TestViews_RefreshBeforeUpdate_Same(t *testing.T) {
 
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -856,8 +856,8 @@ func TestViews_RefreshBeforeUpdate_Same(t *testing.T) {
 
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap = p.Run(t, snap)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -978,8 +978,8 @@ func TestViewsRefreshUpdate(t *testing.T) {
 
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -993,8 +993,8 @@ func TestViewsRefreshUpdate(t *testing.T) {
 
 	p.Steps = []lt.TestStep{{Op: Refresh}}
 	snap = p.Run(t, snap)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -1118,8 +1118,8 @@ func TestViews_RefreshBeforeUpdate_Update(t *testing.T) {
 
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -1133,8 +1133,8 @@ func TestViews_RefreshBeforeUpdate_Update(t *testing.T) {
 
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap = p.Run(t, snap)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -1245,8 +1245,8 @@ func TestViewsRefreshDelete(t *testing.T) {
 
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -1260,8 +1260,8 @@ func TestViewsRefreshDelete(t *testing.T) {
 
 	p.Steps = []lt.TestStep{{Op: Refresh}}
 	snap = p.Run(t, snap)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 }
 
@@ -1366,8 +1366,8 @@ func TestViews_RefreshBeforeUpdate_Delete(t *testing.T) {
 
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -1381,8 +1381,8 @@ func TestViews_RefreshBeforeUpdate_Delete(t *testing.T) {
 
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap = p.Run(t, snap)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 }
 
@@ -1446,8 +1446,8 @@ func TestViewsImport(t *testing.T) {
 	// Initial update.
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 4)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 4)
 	assert.Equal(t, "new-id", snap.Resources[2].ID.String())
 	assert.Equal(t, snap.Resources[2].URN, snap.Resources[3].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[3].URN.Name())
@@ -1466,8 +1466,8 @@ func TestViewsImport(t *testing.T) {
 		ID:   "imported-id",
 	}})}}
 	snap = p.Run(t, snap)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 5)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 5)
 	assert.Equal(t, "new-id", snap.Resources[2].ID.String())
 	assert.Equal(t, snap.Resources[2].URN, snap.Resources[3].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[3].URN.Name())
@@ -1645,9 +1645,9 @@ func TestViewsDeleteBeforeReplace(t *testing.T) {
 		validateSummaryEvent(display.ResourceChanges{
 			deploy.OpCreate: 2,
 		}), "0")
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -1668,9 +1668,9 @@ func TestViewsDeleteBeforeReplace(t *testing.T) {
 			deploy.OpUpdate:  1,
 			deploy.OpReplace: 1,
 		}), "2")
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -1853,9 +1853,9 @@ func TestViewsCreateBeforeReplace(t *testing.T) {
 		validateSummaryEvent(display.ResourceChanges{
 			deploy.OpCreate: 2,
 		}), "0")
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -1876,9 +1876,9 @@ func TestViewsCreateBeforeReplace(t *testing.T) {
 			deploy.OpUpdate:  1,
 			deploy.OpReplace: 1,
 		}), "2")
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -2025,8 +2025,8 @@ func TestViewsRefreshDriftDeleteCreate_UpdateRefresh(t *testing.T) {
 	// Run an initial update to create the resources.
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -2042,8 +2042,8 @@ func TestViewsRefreshDriftDeleteCreate_UpdateRefresh(t *testing.T) {
 	p.Steps = []lt.TestStep{{Op: Update}}
 	p.Options.Refresh = true
 	snap = p.Run(t, snap)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
@@ -2194,8 +2194,8 @@ func TestViewsRefreshDriftDeleteCreate_RefreshBeforeUpdate(t *testing.T) {
 	// The owning resource is marked RefreshBeforeUpdate.
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.True(t, snap.Resources[1].RefreshBeforeUpdate)
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
@@ -2212,10 +2212,179 @@ func TestViewsRefreshDriftDeleteCreate_RefreshBeforeUpdate(t *testing.T) {
 	// In Read the view is deleted. In Update the view is recreated.
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap = p.Run(t, snap)
-	assert.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.True(t, snap.Resources[1].RefreshBeforeUpdate)
+	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
+	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
+	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[2].URN.Type())
+	assert.Equal(t, resource.PropertyMap{
+		"input": resource.NewProperty("baz"),
+	}, snap.Resources[2].Inputs)
+	assert.Equal(t, resource.PropertyMap{
+		"result": resource.NewProperty("baz"),
+	}, snap.Resources[2].Outputs)
+}
+
+// TestViewsRefreshDriftDeleteCreate_RefreshProgram verifies that during a `pulumi up --refresh --run-program`
+// operation, a view can be deleted from Read and created from Update. In this scenario, drift has happened
+// and the view resource is gone and should be recreated.
+func TestViewsRefreshDriftDeleteCreate_RefreshProgram(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				CreateF: func(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+					rs, err := deploytest.NewResourceStatus(req.ResourceStatusAddress)
+					require.NoError(t, err)
+					defer rs.Close()
+
+					err = rs.PublishViewSteps(req.ResourceStatusToken, []deploytest.ViewStep{
+						{
+							Op:     apitype.OpCreate,
+							Status: resource.StatusOK,
+							New: &deploytest.ViewStepState{
+								Type: tokens.Type("pkgA:m:typAView"),
+								Name: req.URN.Name() + "-child",
+								Inputs: resource.PropertyMap{
+									"input": resource.NewProperty("bar"),
+								},
+								Outputs: resource.PropertyMap{
+									"result": resource.NewProperty("bar"),
+								},
+							},
+						},
+					})
+					require.NoError(t, err)
+
+					return plugin.CreateResponse{
+						ID:         "new-id",
+						Properties: req.Properties,
+						Status:     resource.StatusOK,
+					}, nil
+				},
+				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					// Check that the old view is expected.
+					assert.Equal(t, []plugin.View{
+						{
+							Type: tokens.Type("pkgA:m:typAView"),
+							Name: req.URN.Name() + "-child",
+							Inputs: resource.PropertyMap{
+								"input": resource.NewProperty("bar"),
+							},
+							Outputs: resource.PropertyMap{
+								"result": resource.NewProperty("bar"),
+							},
+						},
+					}, req.OldViews)
+
+					rs, err := deploytest.NewResourceStatus(req.ResourceStatusAddress)
+					require.NoError(t, err)
+					defer rs.Close()
+
+					err = rs.PublishViewSteps(req.ResourceStatusToken, []deploytest.ViewStep{
+						{
+							Op:     apitype.OpDelete,
+							Status: resource.StatusOK,
+							Old: &deploytest.ViewStepState{
+								Type:    req.OldViews[0].Type,
+								Name:    req.OldViews[0].Name,
+								Inputs:  req.OldViews[0].Inputs,
+								Outputs: req.OldViews[0].Outputs,
+							},
+						},
+					})
+					require.NoError(t, err)
+
+					return plugin.ReadResponse{
+						ReadResult: plugin.ReadResult{
+							ID:      req.ID,
+							Inputs:  req.Inputs,
+							Outputs: req.State,
+						},
+						Status: resource.StatusOK,
+					}, nil
+				},
+				DiffF: func(_ context.Context, req plugin.DiffRequest) (plugin.DiffResult, error) {
+					return plugin.DiffResult{
+						Changes: plugin.DiffSome,
+					}, nil
+				},
+				UpdateF: func(_ context.Context, req plugin.UpdateRequest) (plugin.UpdateResponse, error) {
+					rs, err := deploytest.NewResourceStatus(req.ResourceStatusAddress)
+					require.NoError(t, err)
+					defer rs.Close()
+
+					err = rs.PublishViewSteps(req.ResourceStatusToken, []deploytest.ViewStep{
+						{
+							Op:     apitype.OpCreate,
+							Status: resource.StatusOK,
+							New: &deploytest.ViewStepState{
+								Type: tokens.Type("pkgA:m:typAView"),
+								Name: req.URN.Name() + "-child",
+								Inputs: resource.PropertyMap{
+									"input": resource.NewProperty("baz"),
+								},
+								Outputs: resource.PropertyMap{
+									"result": resource.NewProperty("baz"),
+								},
+							},
+						},
+					})
+					require.NoError(t, err)
+
+					return plugin.UpdateResponse{
+						Properties: req.OldOutputs,
+						Status:     resource.StatusOK,
+					}, nil
+				},
+			}, nil
+		}, deploytest.WithoutGrpc),
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true)
+		assert.NoError(t, err)
+		return nil
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			T:                t,
+			HostF:            hostF,
+			SkipDisplayTests: true,
+		},
+	}
+
+	// Run an initial update to create the resources.
+	p.Steps = []lt.TestStep{{Op: Update}}
+	snap := p.Run(t, nil)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
+	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
+	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
+	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
+	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[2].URN.Type())
+	assert.Equal(t, resource.PropertyMap{
+		"input": resource.NewProperty("bar"),
+	}, snap.Resources[2].Inputs)
+	assert.Equal(t, resource.PropertyMap{
+		"result": resource.NewProperty("bar"),
+	}, snap.Resources[2].Outputs)
+
+	// Run `pulumi up --refresh --run-program`. The owner resource will be refreshed.
+	// In Read the view is deleted. In Update the view is recreated.
+	p.Steps = []lt.TestStep{{Op: Update}}
+	p.Options.Refresh = true
+	p.Options.RefreshProgram = true
+
+	snap = p.Run(t, snap)
+	require.NotNil(t, snap)
+	require.Len(t, snap.Resources, 3)
+	assert.Equal(t, "new-id", snap.Resources[1].ID.String())
 	assert.Equal(t, snap.Resources[1].URN, snap.Resources[2].ViewOf)
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
 	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[2].URN.Type())

--- a/pkg/resource/deploy/resource_status.go
+++ b/pkg/resource/deploy/resource_status.go
@@ -72,6 +72,9 @@ type tokenInfo struct {
 	// Whether this token is for a refresh operation.
 	refresh bool
 
+	// If this is a refresh operation, whether the steps should be persisted.
+	persisted bool
+
 	// Protects the steps slice.
 	mu sync.Mutex
 
@@ -161,7 +164,7 @@ func (rs *resourceStatusServer) Address() string {
 }
 
 // ReserveToken reserves a token for a resource status operation.
-func (rs *resourceStatusServer) ReserveToken(urn resource.URN, refresh bool) (string, error) {
+func (rs *resourceStatusServer) ReserveToken(urn resource.URN, refresh bool, persisted bool) (string, error) {
 	if rs == nil {
 		return "", nil
 	}
@@ -175,8 +178,9 @@ func (rs *resourceStatusServer) ReserveToken(urn resource.URN, refresh bool) (st
 	tokenString := token.String()
 	rs.urns.Store(urn, tokenString)
 	rs.tokens.Store(tokenString, &tokenInfo{
-		urn:     urn,
-		refresh: refresh,
+		urn:       urn,
+		refresh:   refresh,
+		persisted: persisted,
 	})
 	return tokenString, nil
 }
@@ -245,7 +249,7 @@ func (rs *resourceStatusServer) PublishViewSteps(ctx context.Context,
 
 	// Unmarshal the steps.
 	steps, err := slice.MapError(req.Steps, func(step *pulumirpc.ViewStep) (Step, error) {
-		return rs.unmarshalViewStep(viewOf, step, info.refresh)
+		return rs.unmarshalViewStep(viewOf, step, info.refresh, info.persisted)
 	})
 	if err != nil {
 		logging.V(5).Infof("ResourceStatus: error unmarshaling steps: %v", err)
@@ -289,7 +293,7 @@ func (rs *resourceStatusServer) PublishViewSteps(ctx context.Context,
 }
 
 func (rs *resourceStatusServer) unmarshalViewStep(
-	viewOf resource.URN, step *pulumirpc.ViewStep, refresh bool,
+	viewOf resource.URN, step *pulumirpc.ViewStep, refresh bool, persisted bool,
 ) (Step, error) {
 	status, err := rs.unmarshalStepStatus(step.GetStatus())
 	if err != nil {
@@ -343,7 +347,9 @@ func (rs *resourceStatusServer) unmarshalViewStep(
 		op = OpRefresh
 	}
 
-	return NewViewStep(rs.deployment, op, status, step.GetError(), old, new, keys, diffs, detailedDiff, resultOp), nil
+	return NewViewStep(
+		rs.deployment, op, status, step.GetError(),
+		old, new, keys, diffs, detailedDiff, resultOp, persisted), nil
 }
 
 // unmarshalDetailedDiff unmarshals the detailed diff from a ViewStep.

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -306,7 +306,8 @@ func (s *CreateStep) Apply() (resource.Status, StepCompleteFunc, error) {
 		}
 
 		resourceStatusAddress := s.deployment.resourceStatus.Address()
-		resourceStatusToken, err := s.deployment.resourceStatus.ReserveToken(s.URN(), false /*refresh*/)
+		resourceStatusToken, err := s.deployment.resourceStatus.ReserveToken(
+			s.URN(), false /*refresh*/, false /* persisted */)
 		if err != nil {
 			return resource.StatusOK, nil, err
 		}
@@ -516,7 +517,8 @@ func (s *DeleteStep) Apply() (resource.Status, StepCompleteFunc, error) {
 		}
 
 		resourceStatusAddress := s.deployment.resourceStatus.Address()
-		resourceStatusToken, err := s.deployment.resourceStatus.ReserveToken(s.URN(), false /*refresh*/)
+		resourceStatusToken, err := s.deployment.resourceStatus.ReserveToken(
+			s.URN(), false /*refresh*/, false /* persisted */)
 		if err != nil {
 			return resource.StatusOK, nil, err
 		}
@@ -697,7 +699,8 @@ func (s *UpdateStep) Apply() (resource.Status, StepCompleteFunc, error) {
 		}
 
 		resourceStatusAddress := s.deployment.resourceStatus.Address()
-		resourceStatusToken, err := s.deployment.resourceStatus.ReserveToken(s.URN(), false /*refresh*/)
+		resourceStatusToken, err := s.deployment.resourceStatus.ReserveToken(
+			s.URN(), false /*refresh*/, false /* persisted */)
 		if err != nil {
 			return resource.StatusOK, nil, err
 		}
@@ -941,7 +944,8 @@ func (s *ReadStep) Apply() (resource.Status, StepCompleteFunc, error) {
 		}
 
 		resourceStatusAddress := s.deployment.resourceStatus.Address()
-		resourceStatusToken, err := s.deployment.resourceStatus.ReserveToken(s.URN(), false /*refresh*/)
+		resourceStatusToken, err := s.deployment.resourceStatus.ReserveToken(
+			s.URN(), false /*refresh*/, false /* persisted */)
 		if err != nil {
 			return resource.StatusOK, nil, err
 		}
@@ -1134,7 +1138,8 @@ func (s *RefreshStep) Apply() (resource.Status, StepCompleteFunc, error) {
 	}
 
 	resourceStatusAddress := s.deployment.resourceStatus.Address()
-	resourceStatusToken, err := s.deployment.resourceStatus.ReserveToken(s.URN(), true /*refresh*/)
+	resourceStatusToken, err := s.deployment.resourceStatus.ReserveToken(
+		s.URN(), true /*refresh*/, s.Persisted() /* persisted */)
 	if err != nil {
 		return resource.StatusOK, nil, err
 	}
@@ -1442,7 +1447,8 @@ func (s *ImportStep) Apply() (_ resource.Status, _ StepCompleteFunc, err error) 
 		}
 
 		resourceStatusAddress := s.deployment.resourceStatus.Address()
-		resourceStatusToken, err := s.deployment.resourceStatus.ReserveToken(s.URN(), false /*refresh*/)
+		resourceStatusToken, err := s.deployment.resourceStatus.ReserveToken(
+			s.URN(), false /*refresh*/, false /* persisted */)
 		if err != nil {
 			return resource.StatusOK, nil, err
 		}
@@ -1916,12 +1922,15 @@ type ViewStep struct {
 
 	// For refresh steps, the operation that corresponds to this resource after reading its current state, if any.
 	resultOp display.StepOp
+
+	// For refresh view steps, if this should be persisted or not
+	persisted bool
 }
 
 func NewViewStep(
 	deployment *Deployment, op display.StepOp, status resource.Status, err string, old, new *resource.State,
 	keys, diffs []resource.PropertyKey, detailedDiff map[string]plugin.PropertyDiff,
-	resultOp display.StepOp,
+	resultOp display.StepOp, persisted bool,
 ) Step {
 	return &ViewStep{
 		deployment:   deployment,
@@ -1934,9 +1943,11 @@ func NewViewStep(
 		diffs:        diffs,
 		detailedDiff: detailedDiff,
 		resultOp:     resultOp,
+		persisted:    persisted,
 	}
 }
 
+func (s *ViewStep) Persisted() bool         { return s.persisted }
 func (s *ViewStep) Op() display.StepOp      { return s.op }
 func (s *ViewStep) Deployment() *Deployment { return s.deployment }
 func (s *ViewStep) Type() tokens.Type       { return s.Res().Type }

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1565,7 +1565,7 @@ func (sg *stepGenerator) continueStepsFromDiff(diffEvent ContinueResourceDiffEve
 
 			// We're generating a same step for a resource. Generate same steps for any of its views as well.
 			viewSteps := slice.Map(sg.deployment.oldViews[urn], func(res *resource.State) Step {
-				return NewViewStep(sg.deployment, OpSame, resource.StatusOK, "", res, res.Copy(), nil, nil, nil, "")
+				return NewViewStep(sg.deployment, OpSame, resource.StatusOK, "", res, res.Copy(), nil, nil, nil, "", false)
 			})
 			for _, step := range viewSteps {
 				sg.sames[step.URN()] = true


### PR DESCRIPTION
Originally reported in https://github.com/pulumi/pulumi/issues/19755, and worked around via https://github.com/pulumi/pulumi/pull/19821 which changed the tfmodule views to refresh before the program. This didn't fix tfmodules (or other views) when used with `--refresh --run-program`.

This fixes views to write to the snapshot correctly when being refreshed, this follows the same logic as normal refresh steps. That is they can either be pre-program-run non-persisted steps, or persisted steps being run during the program.

With this fix in place we should be able to move the RefreshBeforeUpdate back to how it was, but I haven't done that in this PR.