### PR TITLE
Add support for stack tags in DIY backend

### DIFF
--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -65,6 +65,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -650,7 +651,7 @@ func (b *diyBackend) ListPolicyPacks(ctx context.Context, orgName string, _ back
 }
 
 func (b *diyBackend) SupportsTags() bool {
-	return false
+	return true
 }
 
 func (b *diyBackend) SupportsTemplates() bool {
@@ -815,8 +816,8 @@ func (b *diyBackend) ListStacks(
 	// Get the parallel value from environment variable or use a default value
 	parallel := b.getParallel()
 
-	// Note that the provided stack filter is only partially honored, since fields like organizations and tags
-	// aren't persisted in the diy backend.
+	// First pass: filter by project and organizations
+	// Note that organization filtering is not supported for DIY backends
 	filteredStacks := slice.Prealloc[*diyBackendReference](len(stacks))
 	for _, stackRef := range stacks {
 		// We can check for project name filter here, but be careful about legacy stores where project is always blank.
@@ -825,6 +826,47 @@ func (b *diyBackend) ListStacks(
 			continue
 		}
 		filteredStacks = append(filteredStacks, stackRef)
+	}
+
+	// Second pass: filter by tags if requested
+	// This requires loading tags for each stack, so we do it separately
+	if filter.TagName != nil || filter.TagValue != nil {
+		tagFilteredStacks := slice.Prealloc[*diyBackendReference](len(filteredStacks))
+		for _, stackRef := range filteredStacks {
+			tags, err := b.loadStackTags(ctx, stackRef)
+			if err != nil {
+				// Skip stacks where we can't load tags, but log the error
+				logging.V(7).Infof("Failed to load tags for stack %s: %v", stackRef.String(), err)
+				continue
+			}
+
+			// Apply tag filtering
+			if filter.TagName != nil {
+				tagValue, exists := tags[*filter.TagName]
+				if !exists {
+					continue // Stack doesn't have the requested tag
+				}
+				if filter.TagValue != nil && tagValue != *filter.TagValue {
+					continue // Stack has the tag but with wrong value
+				}
+			}
+			// If we're only filtering by TagValue without TagName, search all tags
+			if filter.TagName == nil && filter.TagValue != nil {
+				found := false
+				for _, value := range tags {
+					if value == *filter.TagValue {
+						found = true
+						break
+					}
+				}
+				if !found {
+					continue
+				}
+			}
+
+			tagFilteredStacks = append(tagFilteredStacks, stackRef)
+		}
+		filteredStacks = tagFilteredStacks
 	}
 
 	// Create a worker pool to process stacks in parallel
@@ -1454,8 +1496,31 @@ func (b *diyBackend) getStacks(ctx context.Context) ([]*diyBackendReference, err
 func (b *diyBackend) UpdateStackTags(ctx context.Context,
 	stack backend.Stack, tags map[apitype.StackTagName]string,
 ) error {
-	// The diy backend does not currently persist tags.
-	return errors.New("stack tags not supported in diy mode")
+	ref, ok := stack.Ref().(*diyBackendReference)
+	if !ok {
+		return errors.New("invalid stack reference type")
+	}
+
+	// Make a copy of the tags to avoid mutating the input
+	newTags := make(map[apitype.StackTagName]string)
+	for k, v := range tags {
+		newTags[k] = v
+	}
+
+	// Add system tags from metadata
+	b.updateStackTagsFromMetadata(newTags, ref)
+
+	// Save the tags
+	if err := b.saveStackTags(ctx, ref, newTags); err != nil {
+		return fmt.Errorf("failed to save stack tags: %w", err)
+	}
+
+	// Invalidate the cached tags in the stack
+	if diyStack, ok := stack.(*diyStack); ok {
+		diyStack.tags.Store(&newTags)
+	}
+
+	return nil
 }
 
 func (b *diyBackend) EncryptStackDeploymentSettingsSecret(ctx context.Context,

--- a/pkg/backend/diy/backend_tags_integration_test.go
+++ b/pkg/backend/diy/backend_tags_integration_test.go
@@ -1,0 +1,368 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+// +build integration
+
+package diy
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gocloud.dev/blob/fileblob"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// TestStackTagsWithFileBackend tests stack tags with the file:// backend
+func TestStackTagsWithFileBackend(t *testing.T) {
+	t.Parallel()
+
+	// Create temporary directory for backend storage
+	tmpDir, err := ioutil.TempDir("", "pulumi-test-backend-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ctx := context.Background()
+
+	// Create file-based backend
+	bucket, err := fileblob.OpenBucket(tmpDir, nil)
+	require.NoError(t, err)
+	defer bucket.Close()
+
+	// Create backend with project store
+	backend := &diyBackend{
+		bucket: bucket,
+		store: newProjectReferenceStore(bucket, func() *workspace.Project {
+			return &workspace.Project{Name: "integration-test"}
+		}),
+	}
+
+	// Test SupportsTags
+	assert.True(t, backend.SupportsTags())
+
+	// Create a stack reference
+	ref := &diyBackendReference{
+		project: tokens.Name("integration-test"),
+		name:    tokens.MustParseStackName("test-stack"),
+		store:   backend.store,
+	}
+
+	// Create stack
+	stack := newStack(ref, backend)
+
+	// Test initial tags (should be empty)
+	initialTags := stack.Tags()
+	assert.Empty(t, initialTags)
+
+	// Test setting tags
+	testTags := map[apitype.StackTagName]string{
+		"environment": "test",
+		"owner":       "integration-tests",
+		"cost-center": "engineering",
+		"version":     "1.0.0",
+	}
+
+	err = backend.UpdateStackTags(ctx, stack, testTags)
+	require.NoError(t, err)
+
+	// Verify tags were set
+	updatedTags := stack.Tags()
+	assert.Equal(t, "test", updatedTags["environment"])
+	assert.Equal(t, "integration-tests", updatedTags["owner"])
+	assert.Equal(t, "engineering", updatedTags["cost-center"])
+	assert.Equal(t, "1.0.0", updatedTags["version"])
+	assert.Equal(t, "integration-test", updatedTags["pulumi:project"]) // System tag
+
+	// Verify tags persist after recreating the stack
+	newStack := newStack(ref, backend)
+	persistedTags := newStack.Tags()
+	assert.Equal(t, updatedTags, persistedTags)
+
+	// Test updating tags (replace all)
+	replaceTags := map[apitype.StackTagName]string{
+		"environment": "production",
+		"owner":       "ops-team",
+		"release":     "v2.0",
+	}
+
+	err = backend.UpdateStackTags(ctx, stack, replaceTags)
+	require.NoError(t, err)
+
+	finalTags := stack.Tags()
+	assert.Equal(t, "production", finalTags["environment"])
+	assert.Equal(t, "ops-team", finalTags["owner"])
+	assert.Equal(t, "v2.0", finalTags["release"])
+	assert.Equal(t, "integration-test", finalTags["pulumi:project"])
+	assert.NotContains(t, finalTags, "cost-center") // Should be removed
+	assert.NotContains(t, finalTags, "version")     // Should be removed
+
+	// Test that tags file was created in the correct location
+	expectedTagsPath := filepath.Join(tmpDir, ".pulumi", "stacks", "integration-test", "test-stack.pulumi-tags")
+	_, err = os.Stat(expectedTagsPath)
+	assert.NoError(t, err, "Tags file should exist at %s", expectedTagsPath)
+
+	// Verify file content
+	content, err := ioutil.ReadFile(expectedTagsPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "environment")
+	assert.Contains(t, string(content), "production")
+	assert.Contains(t, string(content), "\"version\": 1")
+}
+
+// TestStackTagsFilteringIntegration tests stack filtering by tags
+func TestStackTagsFilteringIntegration(t *testing.T) {
+	t.Parallel()
+
+	// Create temporary directory for backend storage
+	tmpDir, err := ioutil.TempDir("", "pulumi-test-filtering-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ctx := context.Background()
+
+	// Create file-based backend
+	bucket, err := fileblob.OpenBucket(tmpDir, nil)
+	require.NoError(t, err)
+	defer bucket.Close()
+
+	backend := &diyBackend{
+		bucket: bucket,
+		store: newProjectReferenceStore(bucket, func() *workspace.Project {
+			return &workspace.Project{Name: "filter-test"}
+		}),
+	}
+
+	// Create multiple stacks with different tags
+	stacks := []struct {
+		name string
+		tags map[apitype.StackTagName]string
+	}{
+		{
+			name: "dev-api",
+			tags: map[apitype.StackTagName]string{
+				"environment": "development",
+				"component":   "api",
+				"team":        "backend",
+			},
+		},
+		{
+			name: "dev-ui",
+			tags: map[apitype.StackTagName]string{
+				"environment": "development",
+				"component":   "ui",
+				"team":        "frontend",
+			},
+		},
+		{
+			name: "prod-api",
+			tags: map[apitype.StackTagName]string{
+				"environment": "production",
+				"component":   "api",
+				"team":        "backend",
+			},
+		},
+		{
+			name: "staging-db",
+			tags: map[apitype.StackTagName]string{
+				"environment": "staging",
+				"component":   "database",
+				"team":        "data",
+			},
+		},
+		{
+			name: "no-tags",
+			tags: map[apitype.StackTagName]string{},
+		},
+	}
+
+	// Create stacks and set their tags
+	for _, s := range stacks {
+		ref := &diyBackendReference{
+			project: tokens.Name("filter-test"),
+			name:    tokens.MustParseStackName(s.name),
+			store:   backend.store,
+		}
+		stack := newStack(ref, backend)
+
+		err = backend.UpdateStackTags(ctx, stack, s.tags)
+		require.NoError(t, err)
+	}
+
+	// Test filtering by environment=development  
+	// We'll test the filtering logic directly by simulating the tag check
+	allRefs := []*diyBackendReference{
+		{project: "filter-test", name: tokens.MustParseStackName("dev-api"), store: backend.store},
+		{project: "filter-test", name: tokens.MustParseStackName("dev-ui"), store: backend.store},
+		{project: "filter-test", name: tokens.MustParseStackName("prod-api"), store: backend.store},
+		{project: "filter-test", name: tokens.MustParseStackName("staging-db"), store: backend.store},
+		{project: "filter-test", name: tokens.MustParseStackName("no-tags"), store: backend.store},
+	}
+
+	// Filter by environment=development
+	var devStacks []*diyBackendReference
+	for _, ref := range allRefs {
+		tags, err := backend.loadStackTags(ctx, ref)
+		require.NoError(t, err)
+
+		if env, exists := tags["environment"]; exists && env == "development" {
+			devStacks = append(devStacks, ref)
+		}
+	}
+
+	// Should match dev-api and dev-ui
+	assert.Len(t, devStacks, 2)
+	devNames := make([]string, len(devStacks))
+	for i, ref := range devStacks {
+		devNames[i] = ref.name.String()
+	}
+	assert.Contains(t, devNames, "dev-api")
+	assert.Contains(t, devNames, "dev-ui")
+
+	// Filter by team=backend
+	var backendStacks []*diyBackendReference
+	for _, ref := range allRefs {
+		tags, err := backend.loadStackTags(ctx, ref)
+		require.NoError(t, err)
+
+		if team, exists := tags["team"]; exists && team == "backend" {
+			backendStacks = append(backendStacks, ref)
+		}
+	}
+
+	// Should match dev-api and prod-api
+	assert.Len(t, backendStacks, 2)
+	backendNames := make([]string, len(backendStacks))
+	for i, ref := range backendStacks {
+		backendNames[i] = ref.name.String()
+	}
+	assert.Contains(t, backendNames, "dev-api")
+	assert.Contains(t, backendNames, "prod-api")
+}
+
+// TestStackTagsWithLegacyBackend tests stack tags with legacy (non-project) backend
+func TestStackTagsWithLegacyBackend(t *testing.T) {
+	t.Parallel()
+
+	// Create temporary directory for backend storage
+	tmpDir, err := ioutil.TempDir("", "pulumi-test-legacy-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ctx := context.Background()
+
+	// Create file-based backend
+	bucket, err := fileblob.OpenBucket(tmpDir, nil)
+	require.NoError(t, err)
+	defer bucket.Close()
+
+	// Create backend with legacy store (no project)
+	backend := &diyBackend{
+		bucket: bucket,
+		store:  newLegacyReferenceStore(bucket),
+	}
+
+	// Create a legacy stack reference (no project)
+	ref := &diyBackendReference{
+		project: "", // Empty for legacy
+		name:    tokens.MustParseStackName("legacy-stack"),
+		store:   backend.store,
+	}
+
+	// Create stack
+	stack := newStack(ref, backend)
+
+	// Test setting tags
+	testTags := map[apitype.StackTagName]string{
+		"environment": "legacy-env",
+		"owner":       "legacy-owner",
+	}
+
+	err = backend.UpdateStackTags(ctx, stack, testTags)
+	require.NoError(t, err)
+
+	// Verify tags were set
+	updatedTags := stack.Tags()
+	assert.Equal(t, "legacy-env", updatedTags["environment"])
+	assert.Equal(t, "legacy-owner", updatedTags["owner"])
+	// Should not have pulumi:project tag since project is empty
+	assert.NotContains(t, updatedTags, "pulumi:project")
+
+	// Test that tags file was created in the correct location (legacy path)
+	expectedTagsPath := filepath.Join(tmpDir, ".pulumi", "stacks", "legacy-stack.pulumi-tags")
+	_, err = os.Stat(expectedTagsPath)
+	assert.NoError(t, err, "Tags file should exist at %s", expectedTagsPath)
+}
+
+// TestStackDeletionCleansUpTags tests that deleting a stack also removes its tags
+func TestStackDeletionCleansUpTags(t *testing.T) {
+	t.Parallel()
+
+	// Create temporary directory for backend storage
+	tmpDir, err := ioutil.TempDir("", "pulumi-test-deletion-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ctx := context.Background()
+
+	// Create file-based backend
+	bucket, err := fileblob.OpenBucket(tmpDir, nil)
+	require.NoError(t, err)
+	defer bucket.Close()
+
+	backend := &diyBackend{
+		bucket: bucket,
+		store: newProjectReferenceStore(bucket, func() *workspace.Project {
+			return &workspace.Project{Name: "deletion-test"}
+		}),
+	}
+
+	// Create a stack reference
+	ref := &diyBackendReference{
+		project: tokens.Name("deletion-test"),
+		name:    tokens.MustParseStackName("temp-stack"),
+		store:   backend.store,
+	}
+
+	// Create stack and set tags
+	stack := newStack(ref, backend)
+	testTags := map[apitype.StackTagName]string{
+		"temporary": "true",
+		"owner":     "test",
+	}
+
+	err = backend.UpdateStackTags(ctx, stack, testTags)
+	require.NoError(t, err)
+
+	// Verify tags file exists
+	expectedTagsPath := filepath.Join(tmpDir, ".pulumi", "stacks", "deletion-test", "temp-stack.pulumi-tags")
+	_, err = os.Stat(expectedTagsPath)
+	require.NoError(t, err, "Tags file should exist before deletion")
+
+	// Delete the stack (simulate removal)
+	err = backend.removeStack(ctx, ref)
+	require.NoError(t, err)
+
+	// Verify tags file was deleted
+	_, err = os.Stat(expectedTagsPath)
+	assert.True(t, os.IsNotExist(err), "Tags file should be deleted after stack removal")
+}

--- a/pkg/backend/diy/stack_tags.go
+++ b/pkg/backend/diy/stack_tags.go
@@ -1,0 +1,147 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"gocloud.dev/gcerrors"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+)
+
+// stackTagsFile represents the structure of the stack tags file.
+type stackTagsFile struct {
+	Version int                             `json:"version"`
+	Tags    map[apitype.StackTagName]string `json:"tags"`
+}
+
+const stackTagsVersion = 1
+
+// stackTagsPath returns the path to the stack tags file for a given stack reference.
+func (b *diyBackend) stackTagsPath(ref *diyBackendReference) string {
+	// Use the same pattern as stack files but with .pulumi-tags extension
+	// This avoids confusion with .json stack files during stack discovery
+	return ref.StackBasePath() + ".pulumi-tags"
+}
+
+// loadStackTags loads tags for a stack from the storage backend.
+// Returns an empty map if no tags file exists (backward compatibility).
+func (b *diyBackend) loadStackTags(
+	ctx context.Context, ref *diyBackendReference,
+) (map[apitype.StackTagName]string, error) {
+	contract.Requiref(ref != nil, "ref", "ref cannot be nil")
+
+	tagsPath := b.stackTagsPath(ref)
+	logging.V(9).Infof("Loading stack tags from %s", tagsPath)
+
+	// Try to read the tags file
+	tagsBytes, err := b.bucket.ReadAll(ctx, tagsPath)
+	if err != nil {
+		// If the file doesn't exist, return empty tags (backward compatibility)
+		if gcerrors.Code(err) == gcerrors.NotFound {
+			logging.V(9).Infof("No tags file found for stack %s, returning empty tags", ref.String())
+			return make(map[apitype.StackTagName]string), nil
+		}
+		return nil, fmt.Errorf("failed to read stack tags file: %w", err)
+	}
+
+	// Parse the tags file
+	var tagsFile stackTagsFile
+	if err := json.Unmarshal(tagsBytes, &tagsFile); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal stack tags: %w", err)
+	}
+
+	// Validate version
+	if tagsFile.Version != stackTagsVersion {
+		return nil, fmt.Errorf("unsupported stack tags version: %d (expected %d)", tagsFile.Version, stackTagsVersion)
+	}
+
+	if tagsFile.Tags == nil {
+		tagsFile.Tags = make(map[apitype.StackTagName]string)
+	}
+
+	logging.V(9).Infof("Loaded %d tags for stack %s", len(tagsFile.Tags), ref.String())
+	return tagsFile.Tags, nil
+}
+
+// saveStackTags saves tags for a stack to the storage backend.
+func (b *diyBackend) saveStackTags(
+	ctx context.Context, ref *diyBackendReference, tags map[apitype.StackTagName]string,
+) error {
+	contract.Requiref(ref != nil, "ref", "ref cannot be nil")
+	contract.Requiref(tags != nil, "tags", "tags cannot be nil")
+
+	tagsPath := b.stackTagsPath(ref)
+	logging.V(9).Infof("Saving %d stack tags to %s", len(tags), tagsPath)
+
+	// Create the tags file structure
+	tagsFile := stackTagsFile{
+		Version: stackTagsVersion,
+		Tags:    tags,
+	}
+
+	// Marshal to JSON
+	tagsBytes, err := json.MarshalIndent(tagsFile, "", "    ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal stack tags: %w", err)
+	}
+
+	// Write to storage
+	if err := b.bucket.WriteAll(ctx, tagsPath, tagsBytes, nil); err != nil {
+		return fmt.Errorf("failed to write stack tags: %w", err)
+	}
+
+	logging.V(9).Infof("Successfully saved stack tags for stack %s", ref.String())
+	return nil
+}
+
+// deleteStackTags removes the tags file for a stack.
+// This is called when a stack is deleted to clean up associated metadata.
+func (b *diyBackend) deleteStackTags(ctx context.Context, ref *diyBackendReference) error {
+	contract.Requiref(ref != nil, "ref", "ref cannot be nil")
+
+	tagsPath := b.stackTagsPath(ref)
+	logging.V(9).Infof("Deleting stack tags file %s", tagsPath)
+
+	err := b.bucket.Delete(ctx, tagsPath)
+	if err != nil && gcerrors.Code(err) != gcerrors.NotFound {
+		return fmt.Errorf("failed to delete stack tags file: %w", err)
+	}
+
+	logging.V(9).Infof("Successfully deleted stack tags for stack %s", ref.String())
+	return nil
+}
+
+// updateStackTagsFromMetadata ensures that system tags (like pulumi:project)
+// are set in the tags based on available metadata.
+// This function only adds system tags if they don't already exist (preserves user overrides).
+// This is a placeholder for future enhancements to extract metadata from checkpoints.
+func (b *diyBackend) updateStackTagsFromMetadata(tags map[apitype.StackTagName]string, stackRef *diyBackendReference) {
+	// For now, we can set basic metadata based on the stack reference
+	// Only set if not already present (preserve user overrides)
+	if stackRef.project != "" {
+		if _, exists := tags["pulumi:project"]; !exists {
+			tags["pulumi:project"] = string(stackRef.project)
+		}
+	}
+
+	// Additional system tags could be added here in the future
+	// by reading from the checkpoint or project files
+}

--- a/pkg/backend/diy/stack_tags_test.go
+++ b/pkg/backend/diy/stack_tags_test.go
@@ -1,0 +1,593 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diy
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gocloud.dev/blob/memblob"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// setupTestBackend creates a test backend with in-memory storage
+func setupTestBackend(_ *testing.T) (*diyBackend, context.Context) {
+	bucket := memblob.OpenBucket(nil)
+	b := &diyBackend{
+		bucket: bucket,
+		store: newProjectReferenceStore(bucket, func() *workspace.Project {
+			return &workspace.Project{Name: "test-project"}
+		}),
+	}
+	ctx := context.Background()
+	return b, ctx
+}
+
+// createTestStackRef creates a test stack reference
+func createTestStackRef(project, stack string) *diyBackendReference {
+	return &diyBackendReference{
+		project: tokens.Name(project),
+		name:    tokens.MustParseStackName(stack),
+		store:   nil, // Will be set when needed
+	}
+}
+
+func TestStackTagsBasicOperations(t *testing.T) {
+	t.Parallel()
+
+	b, ctx := setupTestBackend(t)
+	ref := createTestStackRef("myproject", "mystack")
+	ref.store = b.store
+
+	// Test loading tags from non-existent file - should return empty map
+	tags, err := b.loadStackTags(ctx, ref)
+	require.NoError(t, err)
+	assert.Empty(t, tags)
+
+	// Test saving tags
+	testTags := map[apitype.StackTagName]string{
+		"env":            "dev",
+		"owner":          "team-foo",
+		"pulumi:project": "myproject",
+		"custom:tag":     "value123",
+	}
+
+	err = b.saveStackTags(ctx, ref, testTags)
+	require.NoError(t, err)
+
+	// Test loading saved tags
+	loadedTags, err := b.loadStackTags(ctx, ref)
+	require.NoError(t, err)
+	assert.Equal(t, testTags, loadedTags)
+
+	// Test updating tags (partial update)
+	updatedTags := map[apitype.StackTagName]string{
+		"env":            "prod",
+		"owner":          "team-bar",
+		"pulumi:project": "myproject",
+		"new:tag":        "newvalue",
+	}
+
+	err = b.saveStackTags(ctx, ref, updatedTags)
+	require.NoError(t, err)
+
+	loadedTags, err = b.loadStackTags(ctx, ref)
+	require.NoError(t, err)
+	assert.Equal(t, updatedTags, loadedTags)
+
+	// Verify old tags are gone and new ones are present
+	assert.Equal(t, "prod", loadedTags["env"])
+	assert.Equal(t, "newvalue", loadedTags["new:tag"])
+	assert.NotContains(t, loadedTags, "custom:tag")
+}
+
+func TestStackTagsDeletion(t *testing.T) {
+	t.Parallel()
+
+	b, ctx := setupTestBackend(t)
+	ref := createTestStackRef("myproject", "mystack")
+	ref.store = b.store
+
+	// Save some tags first
+	testTags := map[apitype.StackTagName]string{
+		"env":   "dev",
+		"owner": "team-foo",
+	}
+
+	err := b.saveStackTags(ctx, ref, testTags)
+	require.NoError(t, err)
+
+	// Verify tags exist
+	loadedTags, err := b.loadStackTags(ctx, ref)
+	require.NoError(t, err)
+	assert.Equal(t, testTags, loadedTags)
+
+	// Delete tags
+	err = b.deleteStackTags(ctx, ref)
+	require.NoError(t, err)
+
+	// Verify tags are gone - should return empty map for non-existent file
+	loadedTags, err = b.loadStackTags(ctx, ref)
+	require.NoError(t, err)
+	assert.Empty(t, loadedTags)
+
+	// Test deleting non-existent tags (should not error)
+	err = b.deleteStackTags(ctx, ref)
+	require.NoError(t, err)
+}
+
+func TestStackTagsPath(t *testing.T) {
+	t.Parallel()
+
+	b, _ := setupTestBackend(t)
+
+	// Test project-scoped reference
+	ref := createTestStackRef("myproject", "mystack")
+	ref.store = b.store
+	expectedPath := ".pulumi/stacks/myproject/mystack.pulumi-tags"
+	assert.Equal(t, expectedPath, b.stackTagsPath(ref))
+
+	// Test legacy reference (no project)
+	legacyRef := &diyBackendReference{
+		project: "",
+		name:    tokens.MustParseStackName("mystack"),
+		store:   newLegacyReferenceStore(b.bucket),
+	}
+	expectedLegacyPath := ".pulumi/stacks/mystack.pulumi-tags"
+	assert.Equal(t, expectedLegacyPath, b.stackTagsPath(legacyRef))
+}
+
+func TestStackTagsEmptyAndNilValues(t *testing.T) {
+	t.Parallel()
+
+	b, ctx := setupTestBackend(t)
+	ref := createTestStackRef("myproject", "mystack")
+	ref.store = b.store
+
+	// Test saving empty tags map
+	emptyTags := make(map[apitype.StackTagName]string)
+	err := b.saveStackTags(ctx, ref, emptyTags)
+	require.NoError(t, err)
+
+	loadedTags, err := b.loadStackTags(ctx, ref)
+	require.NoError(t, err)
+	assert.Empty(t, loadedTags)
+
+	// Test saving tags with empty values
+	tagsWithEmptyValues := map[apitype.StackTagName]string{
+		"nonempty": "value",
+		"empty":    "",
+	}
+	err = b.saveStackTags(ctx, ref, tagsWithEmptyValues)
+	require.NoError(t, err)
+
+	loadedTags, err = b.loadStackTags(ctx, ref)
+	require.NoError(t, err)
+	assert.Equal(t, tagsWithEmptyValues, loadedTags)
+	assert.Equal(t, "value", loadedTags["nonempty"])
+	assert.Equal(t, "", loadedTags["empty"])
+}
+
+func TestUpdateStackTagsFromMetadata(t *testing.T) {
+	t.Parallel()
+
+	b, _ := setupTestBackend(t)
+	ref := createTestStackRef("myproject", "mystack")
+
+	// Test system tags are added
+	tags := make(map[apitype.StackTagName]string)
+	b.updateStackTagsFromMetadata(tags, ref)
+
+	assert.Equal(t, "myproject", tags["pulumi:project"])
+
+	// Test system tags don't overwrite existing user tags
+	tags["pulumi:project"] = "user-override"
+	b.updateStackTagsFromMetadata(tags, ref)
+	assert.Equal(t, "user-override", tags["pulumi:project"]) // Should remain unchanged
+
+	// Test with empty project name
+	emptyRef := createTestStackRef("", "mystack")
+	emptyTags := make(map[apitype.StackTagName]string)
+	b.updateStackTagsFromMetadata(emptyTags, emptyRef)
+	assert.NotContains(t, emptyTags, "pulumi:project")
+}
+
+func TestBackendUpdateStackTags(t *testing.T) {
+	t.Parallel()
+
+	b, ctx := setupTestBackend(t)
+	ref := createTestStackRef("myproject", "mystack")
+	ref.store = b.store
+
+	// Create a stack
+	stack := newStack(ref, b)
+
+	// Test SupportsTags returns true
+	assert.True(t, b.SupportsTags())
+
+	// Test UpdateStackTags
+	testTags := map[apitype.StackTagName]string{
+		"env":   "dev",
+		"owner": "team-foo",
+	}
+
+	err := b.UpdateStackTags(ctx, stack, testTags)
+	require.NoError(t, err)
+
+	// Verify tags were saved and system tags were added
+	savedTags, err := b.loadStackTags(ctx, ref)
+	require.NoError(t, err)
+	assert.Equal(t, "dev", savedTags["env"])
+	assert.Equal(t, "team-foo", savedTags["owner"])
+	assert.Equal(t, "myproject", savedTags["pulumi:project"]) // System tag should be added
+
+	// Test that stack caching works
+	stackTags := stack.Tags()
+	assert.Equal(t, savedTags, stackTags)
+
+	// Test updating tags again (should invalidate cache)
+	newTags := map[apitype.StackTagName]string{
+		"env": "prod",
+	}
+
+	err = b.UpdateStackTags(ctx, stack, newTags)
+	require.NoError(t, err)
+
+	// Verify cache was updated
+	stackTags = stack.Tags()
+	assert.Equal(t, "prod", stackTags["env"])
+	assert.Equal(t, "myproject", stackTags["pulumi:project"])
+	assert.NotContains(t, stackTags, "owner") // Should be gone
+}
+
+func TestStackTagsFiltering(t *testing.T) {
+	t.Parallel()
+
+	b, ctx := setupTestBackend(t)
+
+	// Create multiple stacks with different tags
+	stacks := []struct {
+		name string
+		tags map[apitype.StackTagName]string
+	}{
+		{
+			name: "stack1",
+			tags: map[apitype.StackTagName]string{
+				"env":   "dev",
+				"team":  "backend",
+				"owner": "alice",
+			},
+		},
+		{
+			name: "stack2",
+			tags: map[apitype.StackTagName]string{
+				"env":   "prod",
+				"team":  "frontend",
+				"owner": "bob",
+			},
+		},
+		{
+			name: "stack3",
+			tags: map[apitype.StackTagName]string{
+				"env":     "dev",
+				"team":    "backend",
+				"feature": "experimental",
+			},
+		},
+		{
+			name: "stack4",
+			tags: map[apitype.StackTagName]string{}, // No tags
+		},
+	}
+
+	// Save all stacks and their tags
+	for _, s := range stacks {
+		ref := createTestStackRef("testproject", s.name)
+		ref.store = b.store
+		err := b.saveStackTags(ctx, ref, s.tags)
+		require.NoError(t, err)
+
+		// Mock the store to return these stacks
+		// This is a simplified test - in real usage, ListReferences would return these
+	}
+
+	// Create mock references for testing
+	refs := make([]*diyBackendReference, len(stacks))
+	for i, s := range stacks {
+		refs[i] = createTestStackRef("testproject", s.name)
+		refs[i].store = b.store
+	}
+
+	// Test filtering by tag name only
+	tagName := "env"
+	var matchedRefs []*diyBackendReference
+	for _, ref := range refs {
+		tags, err := b.loadStackTags(ctx, ref)
+		require.NoError(t, err)
+		if _, exists := tags[tagName]; exists {
+			matchedRefs = append(matchedRefs, ref)
+		}
+	}
+	assert.Len(t, matchedRefs, 3) // stack1, stack2, stack3 have "env" tag
+
+	// Test filtering by tag name and value
+	tagValue := "dev"
+	matchedRefs = nil
+	for _, ref := range refs {
+		tags, err := b.loadStackTags(ctx, ref)
+		require.NoError(t, err)
+		if value, exists := tags[tagName]; exists && value == tagValue {
+			matchedRefs = append(matchedRefs, ref)
+		}
+	}
+	assert.Len(t, matchedRefs, 2) // stack1, stack3 have env=dev
+
+	// Test filtering by tag value only (search all tags)
+	tagValue = "backend"
+	matchedRefs = nil
+	for _, ref := range refs {
+		tags, err := b.loadStackTags(ctx, ref)
+		require.NoError(t, err)
+		found := false
+		for _, value := range tags {
+			if value == tagValue {
+				found = true
+				break
+			}
+		}
+		if found {
+			matchedRefs = append(matchedRefs, ref)
+		}
+	}
+	assert.Len(t, matchedRefs, 2) // stack1, stack3 have team=backend
+}
+
+func TestStackTagsJSONFormat(t *testing.T) {
+	t.Parallel()
+
+	b, ctx := setupTestBackend(t)
+	ref := createTestStackRef("myproject", "mystack")
+	ref.store = b.store
+
+	// Save tags
+	testTags := map[apitype.StackTagName]string{
+		"env":   "dev",
+		"owner": "team-foo",
+	}
+
+	err := b.saveStackTags(ctx, ref, testTags)
+	require.NoError(t, err)
+
+	// Read the raw JSON from storage and verify format
+	tagsPath := b.stackTagsPath(ref)
+	rawData, err := b.bucket.ReadAll(ctx, tagsPath)
+	require.NoError(t, err)
+
+	// Verify it's valid JSON with expected structure
+	var tagsFile stackTagsFile
+	err = json.Unmarshal(rawData, &tagsFile)
+	require.NoError(t, err)
+
+	assert.Equal(t, stackTagsVersion, tagsFile.Version)
+	assert.Equal(t, testTags, tagsFile.Tags)
+
+	// Verify the JSON is properly formatted (indented)
+	assert.Contains(t, string(rawData), "    ") // Should contain indentation
+	assert.Contains(t, string(rawData), "\"version\"")
+	assert.Contains(t, string(rawData), "\"tags\"")
+}
+
+func TestInvalidStackReference(t *testing.T) {
+	t.Parallel()
+
+	b, ctx := setupTestBackend(t)
+
+	// Mock the Ref() method with invalid reference type
+	mockStackWithRef := &mockStackForTesting{
+		ref: &struct{ backend.StackReference }{}, // Invalid type
+	}
+
+	tags := map[apitype.StackTagName]string{"test": "value"}
+	err := b.UpdateStackTags(ctx, mockStackWithRef, tags)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid stack reference type")
+}
+
+// mockStackForTesting is a minimal stack implementation for testing
+type mockStackForTesting struct {
+	ref backend.StackReference
+}
+
+func (m *mockStackForTesting) Ref() backend.StackReference { return m.ref }
+func (m *mockStackForTesting) ConfigLocation() backend.StackConfigLocation {
+	return backend.StackConfigLocation{}
+}
+
+func (m *mockStackForTesting) LoadRemoteConfig(
+	context.Context, *workspace.Project,
+) (*workspace.ProjectStack, error) {
+	return nil, nil
+}
+
+func (m *mockStackForTesting) SaveRemoteConfig(context.Context, *workspace.ProjectStack) error {
+	return nil
+}
+
+func (m *mockStackForTesting) Snapshot(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+	return nil, nil
+}
+func (m *mockStackForTesting) Backend() backend.Backend              { return nil }
+func (m *mockStackForTesting) Tags() map[apitype.StackTagName]string { return nil }
+func (m *mockStackForTesting) DefaultSecretManager(*workspace.ProjectStack) (secrets.Manager, error) {
+	return nil, nil
+}
+
+// TestStackTagsDoNotInterfereWithStackDiscovery tests that stack tags files
+// do not interfere with normal stack discovery and listing operations.
+// This is a regression test for the issue where .tags.json files were being
+// discovered as stack files, causing JSON parsing errors.
+func TestStackTagsDoNotInterfereWithStackDiscovery(t *testing.T) {
+	t.Parallel()
+
+	bucket := memblob.OpenBucket(nil)
+	backend := &diyBackend{
+		bucket: bucket,
+		store: newProjectReferenceStore(bucket, func() *workspace.Project {
+			return &workspace.Project{Name: "test-project"}
+		}),
+	}
+	ctx := context.Background()
+
+	// Create a stack reference
+	ref := &diyBackendReference{
+		project: tokens.Name("test-project"),
+		name:    tokens.MustParseStackName("dev"),
+		store:   backend.store,
+	}
+
+	// Create a minimal stack checkpoint file manually
+	// (normally this would be done by stack operations)
+	stackPath := ref.StackBasePath() + ".json"
+	checkpointContent := `{
+		"version": 3,
+		"checkpoint": {
+			"stack": "dev",
+			"config": {},
+			"latest": null
+		}
+	}`
+	err := bucket.WriteAll(ctx, stackPath, []byte(checkpointContent), nil)
+	require.NoError(t, err)
+
+	// Create stack and add tags
+	stack := newStack(ref, backend)
+	testTags := map[apitype.StackTagName]string{
+		"environment": "development",
+		"owner":       "test-team",
+	}
+
+	err = backend.UpdateStackTags(ctx, stack, testTags)
+	require.NoError(t, err)
+
+	// Verify that ListReferences only returns the actual stack, not the tags file
+	references, err := backend.store.ListReferences(ctx)
+	require.NoError(t, err)
+	require.Len(t, references, 1, "Should find exactly one stack reference")
+
+	foundRef := references[0]
+	assert.Equal(t, "test-project", string(foundRef.project))
+	assert.Equal(t, "dev", foundRef.name.String())
+
+	// Verify that getStacks also works correctly
+	stacks, err := backend.getStacks(ctx)
+	require.NoError(t, err)
+	require.Len(t, stacks, 1, "Should find exactly one stack")
+
+	foundStack := stacks[0]
+	assert.Equal(t, "test-project", string(foundStack.project))
+	assert.Equal(t, "dev", foundStack.name.String())
+
+	// Verify that stackPath returns the correct path for the actual stack file
+	actualStackPath := backend.stackPath(ctx, ref)
+	assert.Contains(t, actualStackPath, "dev.json", "Stack path should point to the .json checkpoint file")
+	assert.NotContains(t, actualStackPath, ".pulumi-tags", "Stack path should not point to tags file")
+
+	// Verify that tags still work correctly
+	stackTags := stack.Tags()
+	assert.Equal(t, "development", stackTags["environment"])
+	assert.Equal(t, "test-team", stackTags["owner"])
+	assert.Equal(t, "test-project", stackTags["pulumi:project"])
+
+	// Verify that the tags file exists but doesn't interfere
+	tagsPath := backend.stackTagsPath(ref)
+	assert.Contains(t, tagsPath, ".pulumi-tags", "Tags path should use .pulumi-tags extension")
+
+	// Check that tags file exists
+	exists, err := bucket.Exists(ctx, tagsPath)
+	require.NoError(t, err)
+	assert.True(t, exists, "Tags file should exist")
+
+	// Check that the checkpoint file also exists
+	exists, err = bucket.Exists(ctx, actualStackPath)
+	require.NoError(t, err)
+	assert.True(t, exists, "Checkpoint file should exist")
+}
+
+// TestLegacyStackTagsDoNotInterfereWithStackDiscovery tests the same with legacy store
+func TestLegacyStackTagsDoNotInterfereWithStackDiscovery(t *testing.T) {
+	t.Parallel()
+
+	bucket := memblob.OpenBucket(nil)
+	backend := &diyBackend{
+		bucket: bucket,
+		store:  newLegacyReferenceStore(bucket),
+	}
+	ctx := context.Background()
+
+	// Create a legacy stack reference (no project)
+	ref := &diyBackendReference{
+		project: "",
+		name:    tokens.MustParseStackName("legacy-stack"),
+		store:   backend.store,
+	}
+
+	// Create a minimal stack checkpoint file manually
+	stackPath := ref.StackBasePath() + ".json"
+	checkpointContent := `{
+		"version": 3,
+		"checkpoint": {
+			"stack": "legacy-stack",
+			"config": {},
+			"latest": null
+		}
+	}`
+	err := bucket.WriteAll(ctx, stackPath, []byte(checkpointContent), nil)
+	require.NoError(t, err)
+
+	// Create stack and add tags
+	stack := newStack(ref, backend)
+	testTags := map[apitype.StackTagName]string{
+		"environment": "legacy",
+		"owner":       "legacy-team",
+	}
+
+	err = backend.UpdateStackTags(ctx, stack, testTags)
+	require.NoError(t, err)
+
+	// Verify that ListReferences only returns the actual stack, not the tags file
+	references, err := backend.store.ListReferences(ctx)
+	require.NoError(t, err)
+	require.Len(t, references, 1, "Should find exactly one stack reference")
+
+	foundRef := references[0]
+	assert.Equal(t, "", string(foundRef.project)) // Legacy has no project
+	assert.Equal(t, "legacy-stack", foundRef.name.String())
+
+	// Verify that tags still work correctly
+	stackTags := stack.Tags()
+	assert.Equal(t, "legacy", stackTags["environment"])
+	assert.Equal(t, "legacy-team", stackTags["owner"])
+	// No pulumi:project tag for legacy stacks with empty project
+	assert.NotContains(t, stackTags, "pulumi:project")
+}

--- a/pkg/backend/diy/state.go
+++ b/pkg/backend/diy/state.go
@@ -308,6 +308,12 @@ func (b *diyBackend) removeStack(ctx context.Context, ref *diyBackendReference) 
 	file := b.stackPath(ctx, ref)
 	backupTarget(ctx, b.bucket, file, false)
 
+	// Also remove the tags file if it exists
+	if err := b.deleteStackTags(ctx, ref); err != nil {
+		// Log the error but don't fail the removal for this
+		logging.V(5).Infof("error deleting stack tags: %v", err)
+	}
+
 	historyDir := ref.HistoryDir()
 	return removeAllByPrefix(ctx, b.bucket, historyDir)
 }


### PR DESCRIPTION
This pull request introduces support for stack tags in the DIY backend, enabling metadata tagging for stacks and filtering based on tags. It includes changes to implement tag management, enhance stack filtering, and add integration tests for these features.

### Tag Management Enhancements:
* Added a `Tags` method to the `diyStack` struct to load and cache stack tags from storage. If tags cannot be loaded, an empty map is returned for backward compatibility (`pkg/backend/diy/stack.go`). [[1]](diffhunk://#diff-05229b53f6048ec10c3aeef70ed584e5dfa04424cd4553e094c67353c65f3a18R40-R42) [[2]](diffhunk://#diff-05229b53f6048ec10c3aeef70ed584e5dfa04424cd4553e094c67353c65f3a18L79-R98)
* Implemented `loadStackTags`, `saveStackTags`, and `deleteStackTags` methods in a new `stack_tags.go` file to handle tag persistence in storage. Tags are stored in a dedicated `.pulumi-tags` file (`pkg/backend/diy/stack_tags.go`).
* Updated the `UpdateStackTags` method to persist tags for stacks, including system tags such as `pulumi:project` (`pkg/backend/diy/backend.go`).

### Stack Filtering Improvements:
* Enhanced the `ListStacks` method to support filtering stacks by tags. Tag filtering is performed in a second pass to minimize unnecessary operations (`pkg/backend/diy/backend.go`). [[1]](diffhunk://#diff-ed7099609c75aa22735a65a680e719b45cadcd665566634183f39fd0df5136b1L818-R820) [[2]](diffhunk://#diff-ed7099609c75aa22735a65a680e719b45cadcd665566634183f39fd0df5136b1R831-R871)

### Integration Tests:
* Added comprehensive integration tests to validate tag management and filtering functionality, including tests for legacy backends, stack deletion, and tag persistence (`pkg/backend/diy/backend_tags_integration_test.go`).

### Minor Updates:
* Updated the `removeStack` method to delete associated tag files when a stack is removed (`pkg/backend/diy/state.go`).
* Modified the `SupportsTags` method in the DIY backend to return `true`, indicating support for tags (`pkg/backend/diy/backend.go`).
* Added the `logging` package to imports for enhanced debugging and error logging (`pkg/backend/diy/backend.go`).