### PR TITLE
Allow DIY backend to remove stacks with just a stack resource

### DIFF
--- a/changelog/pending/20250617--backend-diy--diy-backend-can-now-remove-stacks-that-are-empty-except-for-their-root-stack-resource-this-is-inline-with-the-behaviour-of-the-service.yaml
+++ b/changelog/pending/20250617--backend-diy--diy-backend-can-now-remove-stacks-that-are-empty-except-for-their-root-stack-resource-this-is-inline-with-the-behaviour-of-the-service.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: backend/diy
-  description: DIY backend can now remove stacks that are empty except for their root stack resource, this is inline with the behaviour of the service.
+  description: Allow DIY backend to remove stacks that are empty except for their root stack resource, inline with the behaviour of the cloud backend

--- a/changelog/pending/20250617--backend-diy--diy-backend-can-now-remove-stacks-that-are-empty-except-for-their-root-stack-resource-this-is-inline-with-the-behaviour-of-the-service.yaml
+++ b/changelog/pending/20250617--backend-diy--diy-backend-can-now-remove-stacks-that-are-empty-except-for-their-root-stack-resource-this-is-inline-with-the-behaviour-of-the-service.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/diy
+  description: DIY backend can now remove stacks that are empty except for their root stack resource, this is inline with the behaviour of the service.

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -918,7 +918,7 @@ func (b *diyBackend) RemoveStack(ctx context.Context, stack backend.Stack, force
 
 	// Don't remove stacks that still have resources.
 	if !force && checkpoint != nil && checkpoint.Latest != nil && len(checkpoint.Latest.Resources) > 0 {
-		// If the one and only resource is the root stack we can carry on, the sass allows removal from this state.
+		// If the one and only resource is the root stack we can carry on, the cloud backend allows removal from this state.
 		if len(checkpoint.Latest.Resources) > 1 || checkpoint.Latest.Resources[0].Type != tokens.RootStackType {
 			return true, errors.New("refusing to remove stack because it still contains resources")
 		}

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -918,7 +918,10 @@ func (b *diyBackend) RemoveStack(ctx context.Context, stack backend.Stack, force
 
 	// Don't remove stacks that still have resources.
 	if !force && checkpoint != nil && checkpoint.Latest != nil && len(checkpoint.Latest.Resources) > 0 {
-		return true, errors.New("refusing to remove stack because it still contains resources")
+		// If the one and only resource is the root stack we can carry on, the sass allows removal from this state.
+		if len(checkpoint.Latest.Resources) > 1 || checkpoint.Latest.Resources[0].Type != tokens.RootStackType {
+			return true, errors.New("refusing to remove stack because it still contains resources")
+		}
 	}
 
 	return false, b.removeStack(ctx, diyStackRef)

--- a/tests/stack/stack_test.go
+++ b/tests/stack/stack_test.go
@@ -922,7 +922,7 @@ func TestNewStackConflictingOrg(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest pulumi new is not parallel safe
+//nolint:paralleltest // pulumi new is not parallel safe
 func TestEmptyStackRm(t *testing.T) {
 	// This test requires the service, as we're comparing the service and diy backends.
 	if os.Getenv("PULUMI_ACCESS_TOKEN") == "" {


### PR DESCRIPTION
This was noticed in dotnet testing: https://github.com/pulumi/pulumi-dotnet/pull/650/commits/5547cc03dd70ecd500bab203739e86e99ba4fc33

Seems the service will allow the removal of a stack even if it still has it's root stack resource in it (i.e. not cleaned up completly via destroy). But the DIY backend would error that the stack still had resources.

This adds a test to show both behave the same now, and fixes the DIY backend to allow removal when there is only one resource which is the root stack.