### PR TITLE
Warn more aggressively for very old CLI versions

### DIFF
--- a/changelog/pending/20250618--cli--warn-more-aggressively-for-very-old-cli-versions.yaml
+++ b/changelog/pending/20250618--cli--warn-more-aggressively-for-very-old-cli-versions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Warn more aggressively for very old CLI versions

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -76,6 +76,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/util/tracing"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -521,6 +522,7 @@ func checkForUpdate(ctx context.Context, cloudURL string, metadata map[string]st
 		willPrompt := canPrompt &&
 			((isCurVerDev && haveNewerDevVersion(devVer, curVer)) ||
 				(!isCurVerDev && oldestAllowedVer.GT(curVer)))
+
 		if willPrompt {
 			lastPromptTimestampMS = time.Now().UnixMilli() // We're prompting, update the timestamp
 		}
@@ -713,13 +715,38 @@ type cachedVersionInfo struct {
 func getUpgradeMessage(latest semver.Version, current semver.Version, isDevVersion bool) string {
 	cmd := getUpgradeCommand(isDevVersion)
 
-	msg := fmt.Sprintf("A new version of Pulumi is available. To upgrade from version '%s' to '%s', ", current, latest)
+	// If the current version is "very old", we'll return a more urgent message. "Very old" is defined as more than 24
+	// minor versions behind when the major versions are the same. Assuming a release cadence of on average 1 minor
+	// version per week, this translates to roughly 6 months. Note that we don't consider major version differences, since
+	// it's hard to know what we'd want to do in those cases. E.g. it might be that a new version of Pulumi is radically
+	// different, rather than "just improved", and so we don't want to warn about that.
+	prefix := "A new version of Pulumi is available."
+
+	minorDiff := diffMinorVersions(current, latest)
+	if minorDiff > 24 {
+		prefix = colors.SpecAttention +
+			"You are running a very old version of Pulumi and should upgrade as soon as possible." + colors.Reset
+	}
+
+	msg := fmt.Sprintf("%s To upgrade from version '%s' to '%s', ", prefix, current, latest)
 	if cmd != "" {
 		msg += "run \n   " + cmd + "\nor "
 	}
 
 	msg += "visit https://pulumi.com/docs/install/ for manual instructions and release notes."
 	return msg
+}
+
+// diffMinorVersions compares two semver versions.
+//   - If the major versions of the two versions are the same, it returns the difference in their minor versions. This
+//     difference will be a positive number if v2 is greater than v1 and a negative number if v1 is greater than v2.
+//   - If the major versions differ, it returns 0.
+func diffMinorVersions(v1 semver.Version, v2 semver.Version) int64 {
+	if v1.Major != v2.Major {
+		return 0
+	}
+
+	return (int64)(v2.Minor - v1.Minor) //nolint:gosec
 }
 
 // getUpgradeCommand returns a command that will upgrade the CLI to the newest version. If we can not determine how


### PR DESCRIPTION
When the Pulumi CLI (and as a consequence, the Pulumi engine) falls _way_ behind, it is almost guaranteed that users will have a subpar experience due to the number of issues we fix (such as snapshot integrity bugs) and improvements we ship at a regular cadence. This change tweaks the update prompt in these cases to emphasize that the running version is really very old and that updating is more advisory than opportunistic. Presently, we consider "very old" to either be a major version (unlikely in the near future, but a safe bet) or 24 minor versions (which assuming ~1 release a week is 24 weeks = 6 months, which feels reasonable).

Part of #19105