### PR TITLE
io.Copy never returns EOF

### DIFF
--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -113,21 +113,21 @@ func newPluginRunCmd() *cobra.Command {
 			go func() {
 				defer wg.Done()
 				_, err := io.Copy(os.Stdout, plugin.Stdout)
-				if err != nil && !errors.Is(err, io.EOF) {
+				if err != nil {
 					fmt.Fprintf(os.Stderr, "error reading plugin stdout: %v\n", err)
 				}
 			}()
 			go func() {
 				defer wg.Done()
 				_, err := io.Copy(os.Stderr, plugin.Stderr)
-				if err != nil && !errors.Is(err, io.EOF) {
+				if err != nil {
 					fmt.Fprintf(os.Stderr, "error reading plugin stderr: %v\n", err)
 				}
 			}()
 			go func() {
 				defer wg.Done()
 				_, err := io.Copy(plugin.Stdin, os.Stdin)
-				if err != nil && !errors.Is(err, io.EOF) {
+				if err != nil {
 					fmt.Fprintf(os.Stderr, "error copying plugin stdin: %v\n", err)
 				}
 			}()


### PR DESCRIPTION
Little simplification, `io.Copy` will never return an EOF error so no need to check for that.