### PR TITLE
fix flaky TestExplicitDeleteBeforeReplace

### DIFF
--- a/pkg/engine/lifecycletest/delete_before_replace_test.go
+++ b/pkg/engine/lifecycletest/delete_before_replace_test.go
@@ -362,9 +362,9 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
 			evts []Event, err error,
 		) error {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
-			AssertSameSteps(t, []StepSummary{
+			AssertSameStepsUnordered(t, []StepSummary{
 				{Op: deploy.OpSame, URN: provURN},
 				{Op: deploy.OpCreateReplacement, URN: urnA},
 				{Op: deploy.OpReplace, URN: urnA},
@@ -386,7 +386,7 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
 			evts []Event, err error,
 		) error {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			AssertSameSteps(t, []StepSummary{
 				{Op: deploy.OpSame, URN: provURN},
@@ -411,7 +411,7 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
 			evts []Event, err error,
 		) error {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			AssertSameSteps(t, []StepSummary{
 				{Op: deploy.OpSame, URN: provURN},
@@ -435,9 +435,9 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
 			evts []Event, err error,
 		) error {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
-			AssertSameSteps(t, []StepSummary{
+			AssertSameStepsUnordered(t, []StepSummary{
 				{Op: deploy.OpSame, URN: provURN},
 				{Op: deploy.OpCreateReplacement, URN: urnA},
 				{Op: deploy.OpReplace, URN: urnA},
@@ -459,7 +459,7 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
 			evts []Event, err error,
 		) error {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			AssertSameSteps(t, []StepSummary{
 				{Op: deploy.OpSame, URN: provURN},
@@ -485,9 +485,9 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
 			evts []Event, err error,
 		) error {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
-			AssertSameSteps(t, []StepSummary{
+			AssertSameStepsUnordered(t, []StepSummary{
 				{Op: deploy.OpSame, URN: provURN},
 				{Op: deploy.OpCreateReplacement, URN: urnA},
 				{Op: deploy.OpReplace, URN: urnA},

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -85,6 +85,20 @@ func AssertSameSteps(t *testing.T, expected []StepSummary, actual []deploy.Step)
 	return true
 }
 
+func AssertSameStepsUnordered(t *testing.T, expected []StepSummary, actual []deploy.Step) {
+	require.Equal(t, len(expected), len(actual))
+	for _, exp := range expected {
+		found := false
+		for _, act := range actual {
+			if exp.Op == act.Op() && exp.URN == act.URN() {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "Expected step %v not found in actual steps.  Actual steps: %v", exp, actual)
+	}
+}
+
 func ExpectDiagMessage(t *testing.T, messagePattern string) lt.ValidateFunc {
 	validate := func(
 		project workspace.Project, target deploy.Target,


### PR DESCRIPTION
This test is flaky because occasionally the steps are not being generated in the same order.  In particular sometimes the Same step happens before the Replace step.  I'm assuming this is because of the recently introduced asynchronicity of the step generator.

Either way what we care about here is that all the steps are happening, not necessarily that they are always in the exact same order.  Steps do need a partial ordering, so snapshot integrity is still sustained, but we already check for snapshot integrity at every test step in the framework anyway.

Potentially we could just replace `AssertSameSteps` with the new function, but I'm not sure if ordering matters *somewhere*, so I went for the minimally necessary change for now.

Fixes https://github.com/pulumi/pulumi/issues/19063