### PR TITLE
Add `preview_refresh` for the Python Automation API

### DIFF
--- a/changelog/pending/20250618--auto-python--add-preview_refresh-to-allow-dry-runs-of-refresh-commands.yaml
+++ b/changelog/pending/20250618--auto-python--add-preview_refresh-to-allow-dry-runs-of-refresh-commands.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/python
+  description: Add `preview_refresh` to allow dry-runs of `refresh` commands

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -630,7 +630,6 @@ class Stack:
             stdout=refresh_result.stdout, stderr=refresh_result.stderr, summary=summary
         )
 
-
     def refresh_preview(
         self,
         parallel: Optional[int] = None,

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -679,7 +679,7 @@ class Stack:
         :param suppress_progress: Suppress display of periodic progress dots
         :param run_program: Run the program in the workspace to refresh the stack
         :param config_file: Path to a Pulumi config file to use for this update.
-        :returns: RefreshResult
+        :returns: PreviewResult
         """
         extra_args = _parse_extra_args(**locals())
         args = ["refresh", "--preview-only"]

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -562,7 +562,7 @@ class Stack:
         :param parallel: Parallel is the number of resource operations to run in parallel at once.
                          (1 for no parallelism). Defaults to unbounded (2147483647).
         :param message: Message (optional) to associate with the refresh operation.
-        :param preview_only: Deprecated, use `refresh_preview` instead. Only show a preview of the refresh, but don't perform the refresh itself.
+        :param preview_only: Deprecated, use `preview_refresh` instead. Only show a preview of the refresh, but don't perform the refresh itself.
         :param target: Specify an exclusive list of resource URNs to refresh.
         :param exclude: Specify an exclusive list of resource URNs to ignore.
         :param target_dependents: Allows updating of dependent targets discovered but not specified in the Target list.
@@ -630,7 +630,7 @@ class Stack:
             stdout=refresh_result.stdout, stderr=refresh_result.stderr, summary=summary
         )
 
-    def refresh_preview(
+    def preview_refresh(
         self,
         parallel: Optional[int] = None,
         message: Optional[str] = None,

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -815,7 +815,7 @@ class TestLocalWorkspace(unittest.TestCase):
             stack.up()
 
             # pulumi refresh
-            refresh_res = stack.refresh_preview()
+            refresh_res = stack.preview_refresh()
             self.assertEqual(refresh_res.change_summary, {"same": 1})
 
             # pulumi destroy

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -815,9 +815,8 @@ class TestLocalWorkspace(unittest.TestCase):
             stack.up()
 
             # pulumi refresh
-            refresh_res = stack.refresh(preview_only=True)
-            self.assertEqual(refresh_res.summary.kind, "update")
-            self.assertEqual(refresh_res.summary.result, "succeeded")
+            refresh_res = stack.refresh_preview()
+            self.assertEqual(refresh_res.change_summary, { "same": 1 })
 
             # pulumi destroy
             destroy_res = stack.destroy()

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -816,7 +816,7 @@ class TestLocalWorkspace(unittest.TestCase):
 
             # pulumi refresh
             refresh_res = stack.refresh_preview()
-            self.assertEqual(refresh_res.change_summary, { "same": 1 })
+            self.assertEqual(refresh_res.change_summary, {"same": 1})
 
             # pulumi destroy
             destroy_res = stack.destroy()

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -825,6 +825,28 @@ class TestLocalWorkspace(unittest.TestCase):
         finally:
             stack.workspace.remove_stack(stack_name)
 
+    def test_preview_refresh_with_resource(self):
+        project_name = "inline_python"
+        stack_name = stack_namer(project_name)
+        stack = create_or_select_stack(
+            stack_name, program=pulumi_program_with_resource, project_name=project_name
+        )
+
+        try:
+            # pulumi up
+            stack.up()
+
+            # pulumi refresh
+            refresh_res = stack.preview_refresh(expect_no_changes=True)
+            self.assertEqual(refresh_res.change_summary, {"same": 2})
+
+            # pulumi destroy
+            destroy_res = stack.destroy()
+            self.assertEqual(destroy_res.summary.kind, "destroy")
+            self.assertEqual(destroy_res.summary.result, "succeeded")
+        finally:
+            stack.workspace.remove_stack(stack_name)
+
     def test_preview_destroy(self):
         project_name = "inline_python"
         stack_name = stack_namer(project_name)


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/19373, we added the `previewOnly` flag to the `refresh` command. However, this raised some issues, as commands in the automation API use the `pulumi stack history` to find the results of a given command. Because a preview command doesn't produce any new information in the `stack history`, we would instead return the results of whatever the previous command was (https://github.com/pulumi/pulumi/issues/19443).

Unfortunately, if we want the preview information, we have to make do with what we can find in the event summary, but this doesn't give us enough information to construct a full `RefreshResult`. For that reason, this PR introduces a new command, `preview_refresh` (to return everything we _can_ know, which is a `PreviewResult`), and deprecates the `preview_only` flag on `refresh`.

This problem will also exist for `destroy --preview-only`, but I'll address that in a follow-up PR, and make the equivalent changes to the other automation APIs.