### PR TITLE
Thread a context to plugin Wait

### DIFF
--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -133,7 +133,7 @@ func newPluginRunCmd() *cobra.Command {
 			}()
 
 			// Wait for the plugin and IO to finish.
-			code, err := plugin.Wait()
+			code, err := plugin.Wait(ctx)
 			wg.Wait()
 			if err != nil {
 				return fmt.Errorf("plugin %s exited with error: %w", pluginDesc, err)


### PR DESCRIPTION
Cleans up a `context.TODO`, waiting is an async action that can be cancelled if the context cancels.