### PR TITLE
Add inline program support to refresh/destroy

### DIFF
--- a/changelog/pending/20250706--auto-go-nodejs-python--support-run-program-for-inline-programs-in-refresh-and-destroy-operations.yaml
+++ b/changelog/pending/20250706--auto-go-nodejs-python--support-run-program-for-inline-programs-in-refresh-and-destroy-operations.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go,nodejs,python
+  description: Support --run-program for inline programs in refresh and destroy operations

--- a/sdk/go/auto/stack_test.go
+++ b/sdk/go/auto/stack_test.go
@@ -265,12 +265,13 @@ func TestDestroyOptsConfigFile(t *testing.T) {
 	stack, err := NewStackLocalSource(ctx, stackName, pDir)
 	require.NoError(t, err)
 
-	args := destroyOptsToCmd(
+	args, err := destroyOptsToCmd(
 		&optdestroy.Options{
 			ConfigFile: filepath.Join(stack.workspace.WorkDir(), "test.yaml"),
 		},
 		&stack,
 	)
+	require.NoError(t, err)
 
 	assert.Contains(t, args, "destroy")
 
@@ -292,13 +293,14 @@ func TestRefreshOptsConfigFile(t *testing.T) {
 	stack, err := NewStackLocalSource(ctx, stackName, pDir)
 	require.NoError(t, err)
 
-	args := refreshOptsToCmd(
+	args, err := refreshOptsToCmd(
 		&optrefresh.Options{
 			ConfigFile: filepath.Join(stack.workspace.WorkDir(), "test.yaml"),
 		},
 		&stack,
 		true,
 	)
+	require.NoError(t, err)
 
 	assert.Contains(t, args, "refresh")
 
@@ -318,10 +320,12 @@ func TestRefreshOptsDiff(t *testing.T) {
 	stack, err := NewStackLocalSource(ctx, ptesting.RandomStackName(), pDir)
 	require.NoError(t, err)
 
-	argsUp := refreshOptsToCmd(&optrefresh.Options{Diff: true}, &stack, true)
+	argsUp, err := refreshOptsToCmd(&optrefresh.Options{Diff: true}, &stack, true)
+	require.NoError(t, err)
 	assert.Contains(t, argsUp, "--diff", argsUp)
 
-	argsPreview := refreshOptsToCmd(&optrefresh.Options{Diff: true}, &stack, false)
+	argsPreview, err := refreshOptsToCmd(&optrefresh.Options{Diff: true}, &stack, false)
+	require.NoError(t, err)
 	assert.Contains(t, argsPreview, "--diff", argsUp)
 }
 
@@ -339,13 +343,14 @@ func TestRefreshOptsClearPendingCreates(t *testing.T) {
 	stack, err := NewStackLocalSource(ctx, stackName, pDir)
 	require.NoError(t, err)
 
-	args := refreshOptsToCmd(
+	args, err := refreshOptsToCmd(
 		&optrefresh.Options{
 			ClearPendingCreates: true,
 		},
 		&stack,
 		true,
 	)
+	require.NoError(t, err)
 
 	assert.Contains(t, args, "--clear-pending-creates")
 }

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -545,6 +545,22 @@ class Stack:
             change_summary=summary_events[0].resource_changes,
         )
 
+    def _check_inline_support(self) -> None:
+        """
+        Check the installed version of the Pulumi CLI supports inline programs for refresh and destroy operations.
+        """
+        # Assume an old version. Doesn't really matter what this is as long as it's pre-3.181.
+        ver = VersionInfo(3)
+        if self.workspace.pulumi_command.version is not None:
+            ver = self.workspace.pulumi_command.version
+
+        # 3.181 added support for --client (https://github.com/pulumi/pulumi/releases/tag/v3.181.0)
+        if not (ver >= VersionInfo(3, 181)):
+            raise InvalidVersionError(
+                "The installed version of the CLI does not support this operation. Please "
+                "upgrade to at least version 3.181.0."
+            )
+
     def refresh(
         self,
         parallel: Optional[int] = None,
@@ -623,17 +639,7 @@ class Stack:
         on_exit = None
 
         if program:
-            # Assume an old version. Doesn't really matter what this is as long as it's pre-3.181.
-            ver = VersionInfo(3)
-            if self.workspace.pulumi_command.version is not None:
-                ver = self.workspace.pulumi_command.version
-
-            # 3.181 added support for --client (https://github.com/pulumi/pulumi/releases/tag/v3.181.0)
-            if not (ver >= VersionInfo(3, 181)):
-                raise InvalidVersionError(
-                    "The installed version of the CLI does not support this operation. Please "
-                    "upgrade to at least version 3.181.0."
-                )
+            self._check_inline_support()
 
             kind = ExecKind.INLINE.value
             server = grpc.server(
@@ -885,17 +891,7 @@ class Stack:
         on_exit = None
 
         if program:
-            # Assume an old version. Doesn't really matter what this is as long as it's pre-3.181.
-            ver = VersionInfo(3)
-            if self.workspace.pulumi_command.version is not None:
-                ver = self.workspace.pulumi_command.version
-
-            # 3.181 added support for --client (https://github.com/pulumi/pulumi/releases/tag/v3.181.0)
-            if not (ver >= VersionInfo(3, 181)):
-                raise InvalidVersionError(
-                    "The installed version of the CLI does not support this operation. Please "
-                    "upgrade to at least version 3.181.0."
-                )
+            self._check_inline_support()
 
             kind = ExecKind.INLINE.value
             server = grpc.server(

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -31,10 +31,11 @@ from typing import (
     TypedDict,
 )
 import grpc
+from semver import VersionInfo
 
 from ._cmd import CommandResult, OnOutput
 from ._config import ConfigValue, ConfigMap
-from .errors import StackNotFoundError
+from .errors import StackNotFoundError, InvalidVersionError
 from .events import OpMap, EngineEvent, SummaryEvent
 from ._output import OutputMap
 from ._server import LanguageServer
@@ -568,6 +569,7 @@ class Stack:
         suppress_progress: Optional[bool] = None,
         run_program: Optional[bool] = None,
         config_file: Optional[str] = None,
+        program: Optional[PulumiFn] = None,
     ) -> RefreshResult:
         """
         Compares the current stack’s resource state with the state known to exist in the actual
@@ -598,6 +600,7 @@ class Stack:
         :param config_file: Path to a Pulumi config file to use for this update.
         :returns: RefreshResult
         """
+        program = program or self.workspace.program
         extra_args = _parse_extra_args(**locals())
         args = ["refresh"]
 
@@ -616,7 +619,42 @@ class Stack:
         args.extend(extra_args)
         args.extend(self._remote_args())
 
-        kind = ExecKind.INLINE.value if self.workspace.program else ExecKind.LOCAL.value
+        kind = ExecKind.LOCAL.value
+        on_exit = None
+
+        if program:
+            # Assume an old version. Doesn't really matter what this is as long as it's pre-3.181.
+            ver = VersionInfo(3)
+            if self.workspace.pulumi_command.version is not None:
+                ver = self.workspace.pulumi_command.version
+
+            # 3.181 added support for --client (https://github.com/pulumi/pulumi/releases/tag/v3.181.0)
+            if not (ver >= VersionInfo(3, 181)):
+                raise InvalidVersionError(
+                    "The installed version of the CLI does not support this operation. Please "
+                    "upgrade to at least version 3.181.0."
+                )
+
+            kind = ExecKind.INLINE.value
+            server = grpc.server(
+                futures.ThreadPoolExecutor(max_workers=4),
+                options=_GRPC_CHANNEL_OPTIONS,
+            )
+            language_server = LanguageServer(program)
+            language_pb2_grpc.add_LanguageRuntimeServicer_to_server(
+                language_server, server
+            )
+
+            port = server.add_insecure_port(address="127.0.0.1:0")
+            server.start()
+
+            def on_exit_fn():
+                server.stop(0)
+
+            on_exit = on_exit_fn
+
+            args.append(f"--client=127.0.0.1:{port}")
+
         args.extend(["--exec-kind", kind])
 
         log_watcher_thread = None
@@ -634,7 +672,7 @@ class Stack:
         try:
             refresh_result = self._run_pulumi_cmd_sync(args, on_output)
         finally:
-            _cleanup(temp_dir, log_watcher_thread, stop_event)
+            _cleanup(temp_dir, log_watcher_thread, stop_event, on_exit)
 
         # If it's a remote workspace, explicitly set show_secrets to False to prevent attempting to
         # load the project file.
@@ -795,6 +833,7 @@ class Stack:
         preview_only: Optional[bool] = None,
         run_program: Optional[bool] = None,
         config_file: Optional[str] = None,
+        program: Optional[PulumiFn] = None,
     ) -> DestroyResult:
         """
         Destroy deletes all resources in a stack, leaving all history and configuration intact.
@@ -824,6 +863,7 @@ class Stack:
         :param config_file: Path to a Pulumi config file to use for this update.
         :returns: DestroyResult
         """
+        program = program or self.workspace.program
         extra_args = _parse_extra_args(**locals())
         args = ["destroy"]
 
@@ -841,7 +881,42 @@ class Stack:
         args.extend(extra_args)
         args.extend(self._remote_args())
 
-        kind = ExecKind.INLINE.value if self.workspace.program else ExecKind.LOCAL.value
+        kind = ExecKind.LOCAL.value
+        on_exit = None
+
+        if program:
+            # Assume an old version. Doesn't really matter what this is as long as it's pre-3.181.
+            ver = VersionInfo(3)
+            if self.workspace.pulumi_command.version is not None:
+                ver = self.workspace.pulumi_command.version
+
+            # 3.181 added support for --client (https://github.com/pulumi/pulumi/releases/tag/v3.181.0)
+            if not (ver >= VersionInfo(3, 181)):
+                raise InvalidVersionError(
+                    "The installed version of the CLI does not support this operation. Please "
+                    "upgrade to at least version 3.181.0."
+                )
+
+            kind = ExecKind.INLINE.value
+            server = grpc.server(
+                futures.ThreadPoolExecutor(max_workers=4),
+                options=_GRPC_CHANNEL_OPTIONS,
+            )
+            language_server = LanguageServer(program)
+            language_pb2_grpc.add_LanguageRuntimeServicer_to_server(
+                language_server, server
+            )
+
+            port = server.add_insecure_port(address="127.0.0.1:0")
+            server.start()
+
+            def on_exit_fn():
+                server.stop(0)
+
+            on_exit = on_exit_fn
+
+            args.append(f"--client=127.0.0.1:{port}")
+
         args.extend(["--exec-kind", kind])
 
         log_watcher_thread = None
@@ -859,7 +934,7 @@ class Stack:
         try:
             destroy_result = self._run_pulumi_cmd_sync(args, on_output)
         finally:
-            _cleanup(temp_dir, log_watcher_thread, stop_event)
+            _cleanup(temp_dir, log_watcher_thread, stop_event, on_exit)
 
         # If it's a remote workspace, explicitly set show_secrets to False to prevent attempting to
         # load the project file.


### PR DESCRIPTION
Add support for inline programs with `--run-program` for refresh and destroy operations. This required an engine fix to support `--client` for these operations which was released in [3.181](https://github.com/pulumi/pulumi/releases/tag/v3.181.0).