### PR TITLE
Fix parameterised packages in node mocks

### DIFF
--- a/changelog/pending/20250620--sdk-nodejs--fix-the-use-of-parameterised-packages-and-mocks.yaml
+++ b/changelog/pending/20250620--sdk-nodejs--fix-the-use-of-parameterised-packages-and-mocks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix the use of parameterised packages and mocks

--- a/sdk/nodejs/log/index.ts
+++ b/sdk/nodejs/log/index.ts
@@ -17,7 +17,7 @@
 import * as engrpc from "../proto/engine_grpc_pb";
 import * as engproto from "../proto/engine_pb";
 import * as resourceTypes from "../resource";
-import { getEngine, rpcKeepAlive } from "../runtime/settings";
+import { excessiveDebugOutput, getEngine, rpcKeepAlive } from "../runtime/settings";
 import { getStore } from "../runtime/state";
 
 let lastLog: Promise<any> = Promise.resolve();
@@ -44,6 +44,9 @@ export function debug(msg: string, resource?: resourceTypes.Resource, streamId?:
     if (engine) {
         return log(engine, engproto.LogSeverity.DEBUG, msg, resource, streamId, ephemeral);
     } else {
+        if (excessiveDebugOutput) {
+            console.log(`debug: [runtime] ${msg}`);
+        }
         return Promise.resolve();
     }
 }

--- a/sdk/nodejs/runtime/mocks.ts
+++ b/sdk/nodejs/runtime/mocks.ts
@@ -279,4 +279,5 @@ export async function setMocks(
     store.supportsDeletedWith = true;
     store.supportsAliasSpecs = true;
     store.supportsTransforms = false;
+    store.supportsParameterization = true;
 }

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -726,6 +726,7 @@ export function registerResource(
                 });
             })
             .catch((err) => {
+                log.debug(`RegisterResource RPC failed: t=${t}, name=${name}, err=${err}`);
                 // If we fail to prepare the resource, we need to ensure that we still call done to prevent a hang.
                 done();
                 throw err;

--- a/tests/integration/go/parameterized/actual_program_test.txt
+++ b/tests/integration/go/parameterized/actual_program_test.txt
@@ -2,8 +2,10 @@ package main
 
 import (
 	"testing"
+	"context"
 
 	"example.com/pulumi-pkg/sdk/go/pkg"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/require"
@@ -25,10 +27,26 @@ func (mocks) MethodCall(args pulumi.MockCallArgs) (resource.PropertyMap, error) 
 
 func TestParameterized(t *testing.T) {
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
-		_, err := pkg.NewRandom(ctx, "random", &pkg.RandomArgs{
+		res, err := pkg.NewRandom(ctx, "random", &pkg.RandomArgs{
 			Length: pulumi.Int(8),
 		})
-		return err
+		if err != nil {
+			return err
+		}
+
+		// Wait for res.Id and assert it is "random_id"
+		pcs := &promise.CompletionSource[string]{}
+		res.ID().ApplyT(func(id string) (string, error) {
+			pcs.Fulfill(id)
+			return "", nil
+		})
+		result, err := pcs.Promise().Result(context.Background())
+		if err != nil {
+			return err
+		}
+
+		require.Equal(t, "random_id", result)
+		return nil
 	}, pulumi.WithMocks("project", "stack", mocks(1)))
 	require.NoError(t, err)
 }

--- a/tests/integration/nodejs/parameterized/index.spec.ts
+++ b/tests/integration/nodejs/parameterized/index.spec.ts
@@ -1,7 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as pkg from "@pulumi/pkg";
 import { describe, it } from "mocha";
-
+import * as assert from "assert";
 class Mocks implements pulumi.runtime.Mocks {
     call(args: pulumi.runtime.MockCallArgs): Record<string, any> {
         throw new Error(`unknown function ${args.token}`);
@@ -20,5 +20,17 @@ pulumi.runtime.setMocks(new Mocks(), "project", "stack", false);
 describe("Parameterized", function () {
     it("should create a Random resource", async function () {
         const random = new pkg.Random("random", { length: 8 });
+
+        const result = await new Promise((resolve, reject) => {
+            random.id.apply(id => {
+                if (id) {
+                    resolve(id);
+                } else {
+                    reject(new Error("Resource ID is undefined"));
+                }
+            });
+        });
+
+        assert.equal("random_id", result);
     });
 });

--- a/tests/integration/python/parameterized/test.py
+++ b/tests/integration/python/parameterized/test.py
@@ -12,7 +12,10 @@ class Mocks(pulumi.runtime.Mocks):
 pulumi.runtime.set_mocks(Mocks(), project="project", stack="stack", preview=False)
 
 class TestPackage(unittest.TestCase):
-    def test_should_create_random_resource(self):
-        import pulumi_pkg as pkg  # Assuming 'pkg' is the generated Python SDK for your provider
+    async def test_should_create_random_resource(self):
+        import pulumi_pkg as pkg
         random = pkg.Random("random", length=8)
         assert random is not None
+
+        result = await random.id.promise()
+        assert result == "random_id"


### PR DESCRIPTION
This tests and fixes the use of parameterised packages in Node mocks.

Firstly there is the actual fix, we need to set `store.supportsParameterization` to true when using mocks.
Secondly, I've added tests to Node and Go and Python, to check that the resource registration _actually_ runs.
Thirdly, I've added some more debug logs to the node codebase that I found useful tracking down what was happening here.