### PR TITLE
Unify `UpdateInfo` implementations

### DIFF
--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1199,7 +1199,7 @@ func (b *diyBackend) apply(
 	var manager *backend.SnapshotManager
 	if kind != apitype.PreviewUpdate && !opts.DryRun {
 		persister := b.newSnapshotPersister(ctx, diyStackRef)
-		manager = backend.NewSnapshotManager(persister, op.SecretsManager, update.GetTarget().Snapshot)
+		manager = backend.NewSnapshotManager(persister, op.SecretsManager, update.Target.Snapshot)
 	}
 	engineCtx := &engine.Context{
 		Cancel:          scope.Context(),
@@ -1270,7 +1270,7 @@ func (b *diyBackend) apply(
 		StartTime:   start,
 		Message:     op.M.Message,
 		Environment: op.M.Environment,
-		Config:      update.GetTarget().Config,
+		Config:      update.Target.Config,
 		Result:      backendUpdateResult,
 		EndTime:     end,
 		// IDEA: it would be nice to populate the *Deployment, so that addToHistory below doesn't need to

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -99,8 +99,6 @@ func ProjectInfoContext(projinfo *Projinfo, host plugin.Host,
 // newDeploymentContext creates a context for a subsequent deployment. Callers must call Close on the context after the
 // associated deployment completes.
 func newDeploymentContext(u UpdateInfo, opName string, parentSpan opentracing.SpanContext) (*deploymentContext, error) {
-	contract.Requiref(u != nil, "u", "must not be nil")
-
 	// Create a root span for the operation
 	opts := []opentracing.StartSpanOption{}
 	if opName != "" {
@@ -172,15 +170,14 @@ func newDeployment(
 	opts *deploymentOptions,
 ) (*deployment, error) {
 	contract.Assertf(info != nil, "a deployment context must be provided")
-	contract.Assertf(info.Update != nil, "update info cannot be nil")
 	contract.Assertf(opts.SourceFunc != nil, "a source factory must be provided")
 
 	// First, load the package metadata and the deployment target in preparation for executing the package's program
 	// and creating resources.  This includes fetching its pwd and main overrides.
-	proj, target := info.Update.GetProject(), info.Update.GetTarget()
+	proj, target := info.Update.Project, info.Update.Target
 	contract.Assertf(proj != nil, "update project cannot be nil")
 	contract.Assertf(target != nil, "update target cannot be nil")
-	projinfo := &Projinfo{Proj: proj, Root: info.Update.GetRoot()}
+	projinfo := &Projinfo{Proj: proj, Root: info.Update.Root}
 
 	// Decrypt the configuration.
 	config, err := target.Config.Decrypt(target.Decrypter)
@@ -361,7 +358,7 @@ func (deployment *deployment) run(cancelCtx *Context) (*deploy.Plan, display.Res
 
 	// Emit an appropriate prelude event.
 	deployment.Options.Events.preludeEvent(
-		deployment.Options.DryRun, deployment.Ctx.Update.GetTarget().Config)
+		deployment.Options.DryRun, deployment.Ctx.Update.Target.Config)
 
 	// Execute the deployment.
 	start := time.Now()

--- a/pkg/engine/deployment_test.go
+++ b/pkg/engine/deployment_test.go
@@ -31,30 +31,14 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-type updateInfo struct {
-	project workspace.Project
-	target  deploy.Target
-}
-
-func (u *updateInfo) GetRoot() string {
-	return ""
-}
-
-func (u *updateInfo) GetProject() *workspace.Project {
-	return &u.project
-}
-
-func (u *updateInfo) GetTarget() *deploy.Target {
-	return &u.target
-}
-
-func makeUpdateInfo() *updateInfo {
-	return &updateInfo{
-		project: workspace.Project{
+func makeUpdateInfo() UpdateInfo {
+	return UpdateInfo{
+		Root: "",
+		Project: &workspace.Project{
 			Name:    "test",
 			Runtime: workspace.NewProjectRuntimeInfo("test", nil),
 		},
-		target: deploy.Target{Name: tokens.MustParseStackName("test")},
+		Target: &deploy.Target{Name: tokens.MustParseStackName("test")},
 	}
 }
 

--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -33,7 +33,6 @@ func Destroy(
 	opts UpdateOptions,
 	dryRun bool,
 ) (*deploy.Plan, display.ResourceChanges, error) {
-	contract.Requiref(u != nil, "u", "cannot be nil")
 	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
 	contract.Requiref(!opts.DestroyProgram, "opts.DestroyProgram", "must be false")
 
@@ -54,7 +53,7 @@ func Destroy(
 	logging.V(7).Infof("*** Starting Destroy(preview=%v) ***", dryRun)
 	defer logging.V(7).Infof("*** Destroy(preview=%v) complete ***", dryRun)
 
-	if err := checkTargets(opts.Targets, opts.Excludes, u.GetTarget().Snapshot); err != nil {
+	if err := checkTargets(opts.Targets, opts.Excludes, u.Target.Snapshot); err != nil {
 		return nil, nil, err
 	}
 
@@ -140,7 +139,6 @@ func DestroyV2(
 	opts UpdateOptions,
 	dryRun bool,
 ) (*deploy.Plan, display.ResourceChanges, error) {
-	contract.Requiref(u != nil, "u", "cannot be nil")
 	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
 
 	defer func() { ctx.Events <- NewCancelEvent() }()
@@ -163,7 +161,7 @@ func DestroyV2(
 	logging.V(7).Infof("*** Starting Destroy(preview=%v) ***", dryRun)
 	defer logging.V(7).Infof("*** Destroy(preview=%v) complete ***", dryRun)
 
-	if err := checkTargets(opts.Targets, opts.Excludes, u.GetTarget().Snapshot); err != nil {
+	if err := checkTargets(opts.Targets, opts.Excludes, u.Target.Snapshot); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -23,16 +23,16 @@ import (
 )
 
 // UpdateInfo handles information common to resource operations (update, preview, destroy, import, refresh).
-type UpdateInfo interface {
-	// GetRoot returns the root directory for this update. This defines the scope for any filesystem resources
-	// accessed by this update.
-	GetRoot() string
-	// GetProject returns information about the project associated with this update. This includes information such as
-	// the runtime that will be used to execute the Pulumi program and the program's relative working directory.
-	GetProject() *workspace.Project
-	// GetTarget returns information about the target of this update. This includes the name of the stack being
-	// updated, the configuration values associated with the target and the target's latest snapshot.
-	GetTarget() *deploy.Target
+type UpdateInfo struct {
+	// Root is the root directory for this update. This defines the scope for any filesystem resources accessed by this
+	// update.
+	Root string
+	// Project is the project associated with this update. This includes information such as the runtime that will be used
+	// to execute the Pulumi program and the program's relative working directory.
+	Project *workspace.Project
+	// Target is the target of this update. This includes the name of the stack being updated, the configuration values
+	// associated with the target and the target's latest snapshot.
+	Target *deploy.Target
 }
 
 // Context provides cancellation, termination, and eventing options for an engine operation. It also provides

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -312,7 +312,7 @@ type StepEventStateMetadata struct {
 }
 
 func makeEventEmitter(events chan<- Event, update UpdateInfo) (eventEmitter, error) {
-	target := update.GetTarget()
+	target := update.Target
 	var secrets []string
 	if target != nil && target.Config.HasSecureValue() {
 		for k, v := range target.Config {

--- a/pkg/engine/import.go
+++ b/pkg/engine/import.go
@@ -23,7 +23,6 @@ import (
 func Import(u UpdateInfo, ctx *Context, opts UpdateOptions, imports []deploy.Import,
 	dryRun bool,
 ) (*deploy.Plan, display.ResourceChanges, error) {
-	contract.Requiref(u != nil, "u", "cannot be nil")
 	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
 
 	defer func() { ctx.Events <- NewCancelEvent() }()

--- a/pkg/engine/lifecycletest/framework/framework.go
+++ b/pkg/engine/lifecycletest/framework/framework.go
@@ -129,22 +129,13 @@ func snapshotEqual(journal, manager *deploy.Snapshot) error {
 	return nil
 }
 
-type updateInfo struct {
-	project workspace.Project
-	target  deploy.Target
-}
-
-func (u *updateInfo) GetRoot() string {
-	// These tests run in-memory, so we don't have a real root. Just pretend we're at the filesystem root.
-	return "/"
-}
-
-func (u *updateInfo) GetProject() *workspace.Project {
-	return &u.project
-}
-
-func (u *updateInfo) GetTarget() *deploy.Target {
-	return &u.target
+func NewUpdateInfo(project workspace.Project, target deploy.Target) engine.UpdateInfo {
+	return engine.UpdateInfo{
+		// The tests run in-memory, so we don't have a real root. Just pretend we're at the filesystem root.
+		Root:    "/",
+		Project: &project,
+		Target:  &target,
+	}
 }
 
 func ImportOp(imports []deploy.Import) TestOp {
@@ -207,7 +198,7 @@ func (op TestOp) runWithContext(
 	backendClient deploy.BackendClient, validate ValidateFunc, name string,
 ) (*deploy.Plan, *deploy.Snapshot, error) {
 	// Create an appropriate update info and context.
-	info := &updateInfo{project: project, target: target}
+	info := NewUpdateInfo(project, target)
 
 	cancelCtx, cancelSrc := cancel.NewContext(context.Background())
 	done := make(chan bool)

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -34,7 +34,6 @@ func Refresh(
 	opts UpdateOptions,
 	dryRun bool,
 ) (*deploy.Plan, display.ResourceChanges, error) {
-	contract.Requiref(u != nil, "u", "cannot be nil")
 	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
 
 	defer func() { ctx.Events <- NewCancelEvent() }()
@@ -57,7 +56,7 @@ func Refresh(
 	logging.V(7).Infof("*** Starting Refresh(preview=%v) ***", dryRun)
 	defer logging.V(7).Infof("*** Refresh(preview=%v) complete ***", dryRun)
 
-	if err := checkTargets(opts.Targets, opts.Excludes, u.GetTarget().Snapshot); err != nil {
+	if err := checkTargets(opts.Targets, opts.Excludes, u.Target.Snapshot); err != nil {
 		return nil, nil, err
 	}
 
@@ -135,7 +134,6 @@ func RefreshV2(
 	opts UpdateOptions,
 	dryRun bool,
 ) (*deploy.Plan, display.ResourceChanges, error) {
-	contract.Requiref(u != nil, "u", "cannot be nil")
 	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
 
 	defer func() { ctx.Events <- NewCancelEvent() }()
@@ -159,7 +157,7 @@ func RefreshV2(
 	logging.V(7).Infof("*** Starting Refresh(preview=%v) ***", dryRun)
 	defer logging.V(7).Infof("*** Refresh(preview=%v) complete ***", dryRun)
 
-	if err := checkTargets(opts.Targets, opts.Excludes, u.GetTarget().Snapshot); err != nil {
+	if err := checkTargets(opts.Targets, opts.Excludes, u.Target.Snapshot); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -219,7 +219,6 @@ func HasChanges(changes display.ResourceChanges) bool {
 func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (
 	*deploy.Plan, display.ResourceChanges, error,
 ) {
-	contract.Requiref(u != nil, "update", "cannot be nil")
 	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
 	defer func() { ctx.Events <- NewCancelEvent() }()
 

--- a/pkg/engine/update_test.go
+++ b/pkg/engine/update_test.go
@@ -76,7 +76,7 @@ func TestDeletingComponentResourceProducesResourceOutputsEvent(t *testing.T) {
 
 	acts := newUpdateActions(&Context{
 		Cancel: cancelCtx,
-	}, nil, &deploymentOptions{})
+	}, UpdateInfo{}, &deploymentOptions{})
 	eventsChan := make(chan Event, 10)
 	acts.Opts.Events.ch = eventsChan
 


### PR DESCRIPTION
The `engine.UpdateInfo` type captures information about a Pulumi update (where an update is a general term for a Pulumi operation, and not just e.g. a `pulumi up`). Until now, it has been an interface exposing information about the Pulumi project being operated on and the selected target (stack, configuration, etc.), with implementations for both DIY and Cloud (`httpstate`) backends.

It turns out that these implementations are in fact largely the same -- data structures carrying the relevant `Project` and `Target`, with some backend-specific bits tacked on. Hoisting out these backend-specific bits into the code that actually cares about them allows us to make `UpdateInfo` a dumb struct instead. This reduces the amount of update code that is actually backend-specific, and should make it simpler to further unify the code paths for DIY and HTTP backends when it comes to application (see #19866 for a first pass at this prior to this refactoring). In turn, this should make it easier to think about multi-stack updates later on, where a single backend-agnostic engine should be able to juggle multiple backends simultaneously.