### PR TITLE
skip flaky go/common/tail tests

### DIFF
--- a/sdk/go/common/tail/tail_test.go
+++ b/sdk/go/common/tail/tail_test.go
@@ -79,6 +79,9 @@ func TestMustExist(t *testing.T) {
 func TestWaitsForFileToExist(t *testing.T) {
 	t.Parallel()
 
+	// TODO[pulumi/pulumi#19888]: Skipping flaky test
+	t.Skip("Skipping because the tail library is flaky.  See pulumi/pulumi#19888")
+
 	tailTest, cleanup := NewTailTest("waits-for-file-to-exist", t)
 	defer cleanup()
 	tail := tailTest.StartTail("test.txt", Config{})
@@ -91,6 +94,9 @@ func TestWaitsForFileToExist(t *testing.T) {
 
 //nolint:paralleltest // this test is not parallel because it changes the working directory
 func TestWaitsForFileToExistRelativePath(t *testing.T) {
+	// TODO[pulumi/pulumi#19888]: Skipping flaky test
+	t.Skip("Skipping because the tail library is flaky.  See pulumi/pulumi#19888")
+
 	tailTest, cleanup := NewTailTest("waits-for-file-to-exist-relative", t)
 	defer cleanup()
 
@@ -324,6 +330,8 @@ func TestLocationMiddle(t *testing.T) {
 
 func TestReOpenInotify(t *testing.T) {
 	t.Parallel()
+	// TODO[pulumi/pulumi#19888]: Skipping flaky test
+	t.Skip("Skipping because the tail library is flaky.  See pulumi/pulumi#19888")
 
 	reOpen(t, false)
 }


### PR DESCRIPTION
These tests are flaky, because of races in the underlying tail library.  I haven't been able to figure out those races so far, but these test flakes are quite annoying.

/xref https://github.com/pulumi/pulumi/issues/19888
Fixes https://github.com/pulumi/pulumi/issues/19919