### PR TITLE
Support `pulumi package add <registry ID>`

### DIFF
--- a/changelog/pending/20250623--cli-install-package--allow-using-pulumi-package-add-with-registry-identifiers.yaml
+++ b/changelog/pending/20250623--cli-install-package--allow-using-pulumi-package-add-with-registry-identifiers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/install,package
+  description: Allow using `pulumi package add` with registry identifiers

--- a/pkg/cmd/pulumi/cmd/registry.go
+++ b/pkg/cmd/pulumi/cmd/registry.go
@@ -1,0 +1,51 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
+	"github.com/pulumi/pulumi/pkg/v3/backend/diy/unauthenticatedregistry"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func NewDefaultRegistry(
+	ctx context.Context,
+	workspace pkgWorkspace.Context,
+	project *workspace.Project,
+	diag diag.Sink,
+	env env.Env,
+) registry.Registry {
+	return registry.NewOnDemandRegistry(func() (registry.Registry, error) {
+		b, err := cmdBackend.NonInteractiveCurrentBackend(
+			ctx, workspace, cmdBackend.DefaultLoginManager, project,
+		)
+		if err == nil && b != nil {
+			return b.GetReadOnlyCloudRegistry(), nil
+		}
+		if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
+			return unauthenticatedregistry.New(diag, env), nil
+		}
+		return nil, fmt.Errorf("could not get registry backend: %w", err)
+	})
+}

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -26,8 +26,6 @@ import (
 	"github.com/blang/semver"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl/v2"
-	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
-	"github.com/pulumi/pulumi/pkg/v3/backend/diy/unauthenticatedregistry"
 	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -35,7 +33,7 @@ import (
 	cmdDiag "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/diag"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/newcmd"
 
-	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packagecmd"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
@@ -308,18 +306,7 @@ func runConvert(
 				targetDirectory,
 				packageBlockDescriptors,
 				generateOnly,
-				registry.NewOnDemandRegistry(func() (registry.Registry, error) {
-					b, err := cmdBackend.NonInteractiveCurrentBackend(
-						ctx, ws, cmdBackend.DefaultLoginManager, proj,
-					)
-					if err == nil && b != nil {
-						return b.GetReadOnlyCloudRegistry(), nil
-					}
-					if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
-						return unauthenticatedregistry.New(cmdutil.Diag(), e), nil
-					}
-					return nil, fmt.Errorf("could not get registry backend: %w", err)
-				}),
+				cmdCmd.NewDefaultRegistry(ctx, ws, proj, cmdutil.Diag(), e),
 			)
 			if err != nil {
 				return diags, fmt.Errorf("error generating packages: %w", err)

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -22,8 +22,13 @@ import (
 	"strings"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
+	"github.com/pulumi/pulumi/pkg/v3/backend/diy/unauthenticatedregistry"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packagecmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/policy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 
@@ -119,7 +124,18 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 
 			// Process packages section from Pulumi.yaml. Do so before installing language-specific dependencies,
 			// so that the SDKs folder is present and references to it from package.json etc are valid.
-			if err := installPackagesFromProject(pctx, proj, root); err != nil {
+			if err := installPackagesFromProject(pctx, proj, root, registry.NewOnDemandRegistry(func() (registry.Registry, error) {
+				b, err := cmdBackend.NonInteractiveCurrentBackend(
+					cmd.Context(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, proj,
+				)
+				if err == nil && b != nil {
+					return b.GetReadOnlyCloudRegistry(), nil
+				}
+				if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
+					return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
+				}
+				return nil, fmt.Errorf("could not get registry backend: %w", err)
+			})); err != nil {
 				return fmt.Errorf("installing `packages` from Pulumi.yaml: %w", err)
 			}
 
@@ -179,7 +195,7 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 
 // installPackagesFromProject processes packages specified in the Pulumi.yaml file
 // and installs them using similar logic to the 'pulumi package add' command
-func installPackagesFromProject(pctx *plugin.Context, proj *workspace.Project, root string) error {
+func installPackagesFromProject(pctx *plugin.Context, proj *workspace.Project, root string, registry registry.Registry) error {
 	packages := proj.GetPackageSpecs()
 	if len(packages) == 0 {
 		return nil
@@ -195,8 +211,8 @@ func installPackagesFromProject(pctx *plugin.Context, proj *workspace.Project, r
 			installSource = fmt.Sprintf("%s@%s", installSource, packageSpec.Version)
 		}
 
-		_, err := packagecmd.InstallPackage(
-			pkgWorkspace.Instance, pctx, proj.Runtime.Name(), root, installSource, packageSpec.Parameters)
+		_, _, err := packagecmd.InstallPackage(
+			pkgWorkspace.Instance, pctx, proj.Runtime.Name(), root, installSource, packageSpec.Parameters, registry)
 		if err != nil {
 			return fmt.Errorf("failed to install package '%s': %w", name, err)
 		}

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -124,18 +124,19 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 
 			// Process packages section from Pulumi.yaml. Do so before installing language-specific dependencies,
 			// so that the SDKs folder is present and references to it from package.json etc are valid.
-			if err := installPackagesFromProject(pctx, proj, root, registry.NewOnDemandRegistry(func() (registry.Registry, error) {
-				b, err := cmdBackend.NonInteractiveCurrentBackend(
-					cmd.Context(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, proj,
-				)
-				if err == nil && b != nil {
-					return b.GetReadOnlyCloudRegistry(), nil
-				}
-				if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
-					return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
-				}
-				return nil, fmt.Errorf("could not get registry backend: %w", err)
-			})); err != nil {
+			if err := installPackagesFromProject(pctx, proj, root,
+				registry.NewOnDemandRegistry(func() (registry.Registry, error) {
+					b, err := cmdBackend.NonInteractiveCurrentBackend(
+						cmd.Context(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, proj,
+					)
+					if err == nil && b != nil {
+						return b.GetReadOnlyCloudRegistry(), nil
+					}
+					if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
+						return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
+					}
+					return nil, fmt.Errorf("could not get registry backend: %w", err)
+				})); err != nil {
 				return fmt.Errorf("installing `packages` from Pulumi.yaml: %w", err)
 			}
 
@@ -195,7 +196,9 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 
 // installPackagesFromProject processes packages specified in the Pulumi.yaml file
 // and installs them using similar logic to the 'pulumi package add' command
-func installPackagesFromProject(pctx *plugin.Context, proj *workspace.Project, root string, registry registry.Registry) error {
+func installPackagesFromProject(
+	pctx *plugin.Context, proj *workspace.Project, root string, registry registry.Registry,
+) error {
 	packages := proj.GetPackageSpecs()
 	if len(packages) == 0 {
 		return nil

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -22,9 +22,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
-	"github.com/pulumi/pulumi/pkg/v3/backend/diy/unauthenticatedregistry"
-	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -183,18 +181,7 @@ from the parameters, as in:
 			parameters := args[1:]
 
 			pkg, packageSpec, err := InstallPackage(ws, pctx, language, root, plugin, parameters,
-				registry.NewOnDemandRegistry(func() (registry.Registry, error) {
-					b, err := cmdBackend.NonInteractiveCurrentBackend(
-						cmd.Context(), ws, cmdBackend.DefaultLoginManager, proj,
-					)
-					if err == nil && b != nil {
-						return b.GetReadOnlyCloudRegistry(), nil
-					}
-					if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
-						return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
-					}
-					return nil, fmt.Errorf("could not get registry backend: %w", err)
-				}))
+				cmdCmd.NewDefaultRegistry(cmd.Context(), ws, proj, cmdutil.Diag(), env.Global()))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -182,18 +182,19 @@ from the parameters, as in:
 			plugin := args[0]
 			parameters := args[1:]
 
-			pkg, packageSpec, err := InstallPackage(ws, pctx, language, root, plugin, parameters, registry.NewOnDemandRegistry(func() (registry.Registry, error) {
-				b, err := cmdBackend.NonInteractiveCurrentBackend(
-					cmd.Context(), ws, cmdBackend.DefaultLoginManager, proj,
-				)
-				if err == nil && b != nil {
-					return b.GetReadOnlyCloudRegistry(), nil
-				}
-				if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
-					return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
-				}
-				return nil, fmt.Errorf("could not get registry backend: %w", err)
-			}))
+			pkg, packageSpec, err := InstallPackage(ws, pctx, language, root, plugin, parameters,
+				registry.NewOnDemandRegistry(func() (registry.Registry, error) {
+					b, err := cmdBackend.NonInteractiveCurrentBackend(
+						cmd.Context(), ws, cmdBackend.DefaultLoginManager, proj,
+					)
+					if err == nil && b != nil {
+						return b.GetReadOnlyCloudRegistry(), nil
+					}
+					if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
+						return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
+					}
+					return nil, fmt.Errorf("could not get registry backend: %w", err)
+				}))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
@@ -15,16 +15,12 @@
 package packagecmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
-	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
-	"github.com/pulumi/pulumi/pkg/v3/backend/diy/unauthenticatedregistry"
-	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -66,18 +62,8 @@ empty string.`,
 				contract.IgnoreError(pctx.Close())
 			}()
 
-			p, _, err := ProviderFromSource(pctx, source, registry.NewOnDemandRegistry(func() (registry.Registry, error) {
-				b, err := cmdBackend.NonInteractiveCurrentBackend(
-					cmd.Context(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, nil,
-				)
-				if err == nil && b != nil {
-					return b.GetReadOnlyCloudRegistry(), nil
-				}
-				if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
-					return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
-				}
-				return nil, fmt.Errorf("could not get registry backend: %w", err)
-			}))
+			registry := cmdCmd.NewDefaultRegistry(cmd.Context(), pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global())
+			p, _, err := ProviderFromSource(pctx, source, registry)
 			if err != nil {
 				return fmt.Errorf("load provider: %w", err)
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
@@ -63,12 +63,15 @@ empty string.`,
 			if err != nil {
 				return fmt.Errorf("load provider: %w", err)
 			}
-			defer p.Close()
+			defer p.Provider.Close()
 
 			// If provider parameters have been provided, parameterize the provider with them before requesting a mapping.
 			if len(args) > 3 {
+				if p.AlreadyParameterized {
+					return fmt.Errorf("cannot specify parameters since %s already refers to a parameterized provider", source)
+				}
 				parameters := args[3:]
-				_, err := p.Parameterize(pctx.Request(), plugin.ParameterizeRequest{
+				_, err := p.Provider.Parameterize(pctx.Request(), plugin.ParameterizeRequest{
 					Parameters: &plugin.ParameterizeArgs{Args: parameters},
 				})
 				if err != nil {
@@ -76,7 +79,7 @@ empty string.`,
 				}
 			}
 
-			mapping, err := p.GetMapping(cmd.Context(), plugin.GetMappingRequest{
+			mapping, err := p.Provider.GetMapping(cmd.Context(), plugin.GetMappingRequest{
 				Key:      key,
 				Provider: provider,
 			})

--- a/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
@@ -15,9 +15,16 @@
 package packagecmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
+	"github.com/pulumi/pulumi/pkg/v3/backend/diy/unauthenticatedregistry"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -59,7 +66,18 @@ empty string.`,
 				contract.IgnoreError(pctx.Close())
 			}()
 
-			p, err := ProviderFromSource(pctx, source)
+			p, _, err := ProviderFromSource(pctx, source, registry.NewOnDemandRegistry(func() (registry.Registry, error) {
+				b, err := cmdBackend.NonInteractiveCurrentBackend(
+					cmd.Context(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, nil,
+				)
+				if err == nil && b != nil {
+					return b.GetReadOnlyCloudRegistry(), nil
+				}
+				if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
+					return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
+				}
+				return nil, fmt.Errorf("could not get registry backend: %w", err)
+			}))
 			if err != nil {
 				return fmt.Errorf("load provider: %w", err)
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
@@ -16,16 +16,12 @@ package packagecmd
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 
-	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
-	"github.com/pulumi/pulumi/pkg/v3/backend/diy/unauthenticatedregistry"
-	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -59,18 +55,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 			}()
 
 			pkg, _, err := SchemaFromSchemaSource(pctx, source, args[1:],
-				registry.NewOnDemandRegistry(func() (registry.Registry, error) {
-					b, err := cmdBackend.NonInteractiveCurrentBackend(
-						cmd.Context(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, nil,
-					)
-					if err == nil && b != nil {
-						return b.GetReadOnlyCloudRegistry(), nil
-					}
-					if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
-						return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
-					}
-					return nil, fmt.Errorf("could not get registry backend: %w", err)
-				}))
+				cmdCmd.NewDefaultRegistry(cmd.Context(), pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global()))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
@@ -58,18 +58,19 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 				contract.IgnoreError(pctx.Close())
 			}()
 
-			pkg, _, err := SchemaFromSchemaSource(pctx, source, args[1:], registry.NewOnDemandRegistry(func() (registry.Registry, error) {
-				b, err := cmdBackend.NonInteractiveCurrentBackend(
-					cmd.Context(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, nil,
-				)
-				if err == nil && b != nil {
-					return b.GetReadOnlyCloudRegistry(), nil
-				}
-				if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
-					return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
-				}
-				return nil, fmt.Errorf("could not get registry backend: %w", err)
-			}))
+			pkg, _, err := SchemaFromSchemaSource(pctx, source, args[1:],
+				registry.NewOnDemandRegistry(func() (registry.Registry, error) {
+					b, err := cmdBackend.NonInteractiveCurrentBackend(
+						cmd.Context(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, nil,
+					)
+					if err == nil && b != nil {
+						return b.GetReadOnlyCloudRegistry(), nil
+					}
+					if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
+						return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
+					}
+					return nil, fmt.Errorf("could not get registry backend: %w", err)
+				}))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
@@ -16,9 +16,16 @@ package packagecmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
+	"github.com/pulumi/pulumi/pkg/v3/backend/diy/unauthenticatedregistry"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -51,7 +58,18 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 				contract.IgnoreError(pctx.Close())
 			}()
 
-			pkg, err := SchemaFromSchemaSource(pctx, source, args[1:])
+			pkg, _, err := SchemaFromSchemaSource(pctx, source, args[1:], registry.NewOnDemandRegistry(func() (registry.Registry, error) {
+				b, err := cmdBackend.NonInteractiveCurrentBackend(
+					cmd.Context(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, nil,
+				)
+				if err == nil && b != nil {
+					return b.GetReadOnlyCloudRegistry(), nil
+				}
+				if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
+					return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
+				}
+				return nil, fmt.Errorf("could not get registry backend: %w", err)
+			}))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
@@ -66,18 +66,19 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 				contract.IgnoreError(pctx.Close())
 			}()
 
-			pkg, _, err := SchemaFromSchemaSource(pctx, source, args[1:], registry.NewOnDemandRegistry(func() (registry.Registry, error) {
-				b, err := cmdBackend.NonInteractiveCurrentBackend(
-					cmd.Context(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, nil,
-				)
-				if err == nil && b != nil {
-					return b.GetReadOnlyCloudRegistry(), nil
-				}
-				if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
-					return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
-				}
-				return nil, fmt.Errorf("could not get registry backend: %w", err)
-			}))
+			pkg, _, err := SchemaFromSchemaSource(pctx, source, args[1:],
+				registry.NewOnDemandRegistry(func() (registry.Registry, error) {
+					b, err := cmdBackend.NonInteractiveCurrentBackend(
+						cmd.Context(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, nil,
+					)
+					if err == nil && b != nil {
+						return b.GetReadOnlyCloudRegistry(), nil
+					}
+					if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
+						return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
+					}
+					return nil, fmt.Errorf("could not get registry backend: %w", err)
+				}))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
@@ -15,7 +15,6 @@
 package packagecmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,13 +22,10 @@ import (
 	"github.com/blang/semver"
 	"github.com/spf13/cobra"
 
-	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
-	"github.com/pulumi/pulumi/pkg/v3/backend/diy/unauthenticatedregistry"
-	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -67,18 +63,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 			}()
 
 			pkg, _, err := SchemaFromSchemaSource(pctx, source, args[1:],
-				registry.NewOnDemandRegistry(func() (registry.Registry, error) {
-					b, err := cmdBackend.NonInteractiveCurrentBackend(
-						cmd.Context(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, nil,
-					)
-					if err == nil && b != nil {
-						return b.GetReadOnlyCloudRegistry(), nil
-					}
-					if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
-						return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
-					}
-					return nil, fmt.Errorf("could not get registry backend: %w", err)
-				}))
+				cmdCmd.NewDefaultRegistry(cmd.Context(), pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global()))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -64,18 +64,19 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 				contract.IgnoreError(pctx.Close())
 			}()
 
-			pkg, _, err := SchemaFromSchemaSource(pctx, args[0], args[1:], registry.NewOnDemandRegistry(func() (registry.Registry, error) {
-				b, err := cmdBackend.NonInteractiveCurrentBackend(
-					cmd.Context(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, nil,
-				)
-				if err == nil && b != nil {
-					return b.GetReadOnlyCloudRegistry(), nil
-				}
-				if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
-					return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
-				}
-				return nil, fmt.Errorf("could not get registry backend: %w", err)
-			}))
+			pkg, _, err := SchemaFromSchemaSource(pctx, args[0], args[1:],
+				registry.NewOnDemandRegistry(func() (registry.Registry, error) {
+					b, err := cmdBackend.NonInteractiveCurrentBackend(
+						cmd.Context(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, nil,
+					)
+					if err == nil && b != nil {
+						return b.GetReadOnlyCloudRegistry(), nil
+					}
+					if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
+						return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
+					}
+					return nil, fmt.Errorf("could not get registry backend: %w", err)
+				}))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -15,21 +15,17 @@
 package packagecmd
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"slices"
 	"strings"
 
-	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
-	"github.com/pulumi/pulumi/pkg/v3/backend/diy/unauthenticatedregistry"
-	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -65,18 +61,7 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 			}()
 
 			pkg, _, err := SchemaFromSchemaSource(pctx, args[0], args[1:],
-				registry.NewOnDemandRegistry(func() (registry.Registry, error) {
-					b, err := cmdBackend.NonInteractiveCurrentBackend(
-						cmd.Context(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, nil,
-					)
-					if err == nil && b != nil {
-						return b.GetReadOnlyCloudRegistry(), nil
-					}
-					if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
-						return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
-					}
-					return nil, fmt.Errorf("could not get registry backend: %w", err)
-				}))
+				cmdCmd.NewDefaultRegistry(cmd.Context(), pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global()))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -15,14 +15,21 @@
 package packagecmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"slices"
 	"strings"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
+	"github.com/pulumi/pulumi/pkg/v3/backend/diy/unauthenticatedregistry"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -57,7 +64,18 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 				contract.IgnoreError(pctx.Close())
 			}()
 
-			pkg, err := SchemaFromSchemaSource(pctx, args[0], args[1:])
+			pkg, _, err := SchemaFromSchemaSource(pctx, args[0], args[1:], registry.NewOnDemandRegistry(func() (registry.Registry, error) {
+				b, err := cmdBackend.NonInteractiveCurrentBackend(
+					cmd.Context(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, nil,
+				)
+				if err == nil && b != nil {
+					return b.GetReadOnlyCloudRegistry(), nil
+				}
+				if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
+					return unauthenticatedregistry.New(cmdutil.Diag(), env.Global()), nil
+				}
+				return nil, fmt.Errorf("could not get registry backend: %w", err)
+			}))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -57,8 +57,10 @@ type publishPackageArgs struct {
 
 type packagePublishCmd struct {
 	defaultOrg    func(context.Context, backend.Backend, *workspace.Project) (string, error)
-	extractSchema func(pctx *plugin.Context, packageSource string, args []string, registry registry.Registry) (*schema.Package, *workspace.PackageSpec, error)
-	pluginDir     string
+	extractSchema func(
+		pctx *plugin.Context, packageSource string, args []string, registry registry.Registry,
+	) (*schema.Package, *workspace.PackageSpec, error)
+	pluginDir string
 }
 
 func newPackagePublishCmd() *cobra.Command {

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -57,7 +57,7 @@ type publishPackageArgs struct {
 
 type packagePublishCmd struct {
 	defaultOrg    func(context.Context, backend.Backend, *workspace.Project) (string, error)
-	extractSchema func(pctx *plugin.Context, packageSource string, args []string, registry registry.Registry) (*schema.Package, error)
+	extractSchema func(pctx *plugin.Context, packageSource string, args []string, registry registry.Registry) (*schema.Package, *workspace.PackageSpec, error)
 	pluginDir     string
 }
 
@@ -146,7 +146,7 @@ func (cmd *packagePublishCmd) Run(
 	}
 	defer contract.IgnoreClose(pctx)
 
-	pkg, err := cmd.extractSchema(pctx, packageSrc, packageParams, b.GetReadOnlyCloudRegistry())
+	pkg, _, err := cmd.extractSchema(pctx, packageSrc, packageParams, b.GetReadOnlyCloudRegistry())
 	if err != nil {
 		return fmt.Errorf("failed to get schema: %w", err)
 	}

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -32,6 +32,7 @@ import (
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -56,7 +57,7 @@ type publishPackageArgs struct {
 
 type packagePublishCmd struct {
 	defaultOrg    func(context.Context, backend.Backend, *workspace.Project) (string, error)
-	extractSchema func(pctx *plugin.Context, packageSource string, args []string) (*schema.Package, error)
+	extractSchema func(pctx *plugin.Context, packageSource string, args []string, registry registry.Registry) (*schema.Package, error)
 	pluginDir     string
 }
 
@@ -145,7 +146,7 @@ func (cmd *packagePublishCmd) Run(
 	}
 	defer contract.IgnoreClose(pctx)
 
-	pkg, err := cmd.extractSchema(pctx, packageSrc, packageParams)
+	pkg, err := cmd.extractSchema(pctx, packageSrc, packageParams, b.GetReadOnlyCloudRegistry())
 	if err != nil {
 		return fmt.Errorf("failed to get schema: %w", err)
 	}

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -509,6 +509,7 @@ func TestPackagePublishCmd_IOErrors(t *testing.T) {
 						},
 					}, nil
 				},
+				GetReadOnlyCloudRegistryF: func() registry.Registry { return &backend.MockCloudRegistry{} },
 			})
 
 			cmd := &packagePublishCmd{
@@ -548,6 +549,9 @@ func TestPackagePublishCmd_BackendErrors(t *testing.T) {
 				testutil.MockBackendInstance(t, &backend.MockBackend{
 					GetCloudRegistryF: func() (backend.CloudRegistry, error) {
 						return nil, errors.New("failed to get package registry")
+					},
+					GetReadOnlyCloudRegistryF: func() registry.Registry {
+						return &backend.MockCloudRegistry{}
 					},
 				})
 			},

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/util/testutil"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -420,11 +421,13 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 
 			cmd := &packagePublishCmd{
 				defaultOrg: defaultOrg,
-				extractSchema: func(pctx *plugin.Context, packageSource string, args []string) (*schema.Package, error) {
+				extractSchema: func(
+					pctx *plugin.Context, packageSource string, args []string, registry registry.Registry,
+				) (*schema.Package, *workspace.PackageSpec, error) {
 					if tt.mockSchema == nil && tt.schemaExtractionErr == nil {
-						return nil, errors.New("mock schema extraction failed")
+						return nil, nil, errors.New("mock schema extraction failed")
 					}
-					return tt.mockSchema, tt.schemaExtractionErr
+					return tt.mockSchema, nil, tt.schemaExtractionErr
 				},
 				pluginDir: pluginDir,
 			}
@@ -517,8 +520,10 @@ func TestPackagePublishCmd_IOErrors(t *testing.T) {
 				defaultOrg: func(context.Context, backend.Backend, *workspace.Project) (string, error) {
 					return "default-org", nil
 				},
-				extractSchema: func(pctx *plugin.Context, packageSource string, args []string) (*schema.Package, error) {
-					return tt.mockSchema, nil
+				extractSchema: func(
+					pctx *plugin.Context, packageSource string, args []string, registry registry.Registry,
+				) (*schema.Package, *workspace.PackageSpec, error) {
+					return tt.mockSchema, nil, nil
 				},
 			}
 
@@ -575,8 +580,10 @@ func TestPackagePublishCmd_BackendErrors(t *testing.T) {
 				defaultOrg: func(context.Context, backend.Backend, *workspace.Project) (string, error) {
 					return "default-org", nil
 				},
-				extractSchema: func(pctx *plugin.Context, packageSource string, args []string) (*schema.Package, error) {
-					return validSchema, nil
+				extractSchema: func(
+					pctx *plugin.Context, packageSource string, args []string, registry registry.Registry,
+				) (*schema.Package, *workspace.PackageSpec, error) {
+					return validSchema, nil, nil
 				},
 			}
 
@@ -612,12 +619,14 @@ func TestPackagePublishCmd_Run_ReadProjectError(t *testing.T) {
 		defaultOrg: func(context.Context, backend.Backend, *workspace.Project) (string, error) {
 			return "", nil
 		},
-		extractSchema: func(pctx *plugin.Context, packageSource string, args []string) (*schema.Package, error) {
+		extractSchema: func(
+			pctx *plugin.Context, packageSource string, args []string, registry registry.Registry,
+		) (*schema.Package, *workspace.PackageSpec, error) {
 			pkg := &schema.Package{
 				Name:    "test-package",
 				Version: &semver.Version{Major: 1, Minor: 0, Patch: 0},
 			}
-			return pkg, nil
+			return pkg, nil, nil
 		},
 	}
 

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -410,6 +410,7 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 				GetCloudRegistryF: func() (backend.CloudRegistry, error) {
 					return mockCloudRegistry, nil
 				},
+				GetReadOnlyCloudRegistryF: func() registry.Registry { return mockCloudRegistry },
 			})
 
 			// Setup defaultOrg mock

--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -872,7 +872,6 @@ type Provider struct {
 // PLUGIN[@VERSION] | PATH_TO_PLUGIN
 func ProviderFromSource(
 	pctx *plugin.Context, packageSource string, reg registry.Registry,
-
 ) (Provider, *workspace.PackageSpec, error) {
 	pluginSpec, err := workspace.NewPluginSpec(pctx.Request(), packageSource, apitype.ResourcePlugin, nil, "", nil)
 	if err != nil {

--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -711,64 +712,72 @@ func setSpecNamespace(spec *schema.PackageSpec, pluginSpec workspace.PluginSpec)
 // optional version:
 //
 //	FILE.[json|y[a]ml] | PLUGIN[@VERSION] | PATH_TO_PLUGIN
-func SchemaFromSchemaSource(pctx *plugin.Context, packageSource string, args []string) (*schema.Package, error) {
+func SchemaFromSchemaSource(
+	pctx *plugin.Context, packageSource string, args []string, registry registry.Registry,
+) (*schema.Package, *workspace.PackageSpec, error) {
 	var spec schema.PackageSpec
-	bind := func(spec schema.PackageSpec) (*schema.Package, error) {
+	bind := func(
+		spec schema.PackageSpec, specOverride *workspace.PackageSpec,
+	) (*schema.Package, *workspace.PackageSpec, error) {
 		pkg, diags, err := schema.BindSpec(spec, nil, schema.ValidationOptions{
 			AllowDanglingReferences: true,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if diags.HasErrors() {
-			return nil, diags
+			return nil, nil, diags
 		}
-		return pkg, nil
+		return pkg, specOverride, nil
 	}
 	if ext := filepath.Ext(packageSource); ext == ".yaml" || ext == ".yml" {
 		if len(args) > 0 {
-			return nil, errors.New("parameterization arguments are not supported for yaml files")
+			return nil, nil, errors.New("parameterization arguments are not supported for yaml files")
 		}
 		f, err := os.ReadFile(packageSource)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		err = yaml.Unmarshal(f, &spec)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return bind(spec)
+		return bind(spec, nil)
 	} else if ext == ".json" {
 		if len(args) > 0 {
-			return nil, errors.New("parameterization arguments are not supported for json files")
+			return nil, nil, errors.New("parameterization arguments are not supported for json files")
 		}
 
 		f, err := os.ReadFile(packageSource)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		err = json.Unmarshal(f, &spec)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return bind(spec)
+		return bind(spec, nil)
 	}
 
-	p, err := ProviderFromSource(pctx, packageSource)
+	p, specOverride, err := ProviderFromSource(pctx, packageSource, registry)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer func() {
-		contract.IgnoreError(pctx.Host.CloseProvider(p))
+		contract.IgnoreError(pctx.Host.CloseProvider(p.Provider))
 	}()
 
 	var request plugin.GetSchemaRequest
 	if len(args) > 0 {
-		resp, err := p.Parameterize(pctx.Request(), plugin.ParameterizeRequest{
+		if p.AlreadyParameterized {
+			return nil, nil,
+				fmt.Errorf("cannot specify parameters since %s is already parameterized", packageSource)
+		}
+		resp, err := p.Provider.Parameterize(pctx.Request(), plugin.ParameterizeRequest{
 			Parameters: &plugin.ParameterizeArgs{Args: args},
 		})
 		if err != nil {
-			return nil, fmt.Errorf("parameterize: %w", err)
+			return nil, nil, fmt.Errorf("parameterize: %w", err)
 		}
 
 		request = plugin.GetSchemaRequest{
@@ -777,29 +786,30 @@ func SchemaFromSchemaSource(pctx *plugin.Context, packageSource string, args []s
 		}
 	}
 
-	schema, err := p.GetSchema(pctx.Request(), request)
+	schema, err := p.Provider.GetSchema(pctx.Request(), request)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	err = json.Unmarshal(schema.Schema, &spec)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	pluginSpec, err := workspace.NewPluginSpec(pctx.Request(), packageSource, apitype.ResourcePlugin, nil, "", nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if pluginSpec.PluginDownloadURL != "" {
 		spec.PluginDownloadURL = pluginSpec.PluginDownloadURL
 	}
 	setSpecNamespace(&spec, pluginSpec)
-	return bind(spec)
+	return bind(spec, specOverride)
 }
 
 func SchemaFromSchemaSourceValueArgs(
 	pctx *plugin.Context,
 	packageSource string,
 	parameterizationValue []byte,
+	registry registry.Registry,
 ) (*schema.Package, error) {
 	var spec schema.PackageSpec
 	bind := func(spec schema.PackageSpec) (*schema.Package, error) {
@@ -815,15 +825,19 @@ func SchemaFromSchemaSourceValueArgs(
 		return pkg, nil
 	}
 
-	p, err := ProviderFromSource(pctx, packageSource)
+	p, _, err := ProviderFromSource(pctx, packageSource, registry)
 	if err != nil {
 		return nil, err
 	}
-	defer p.Close()
+	defer p.Provider.Close()
 
 	var request plugin.GetSchemaRequest
 	if parameterizationValue != nil {
-		resp, err := p.Parameterize(pctx.Request(), plugin.ParameterizeRequest{
+		if p.AlreadyParameterized {
+			return nil,
+				fmt.Errorf("cannot specify parameters since %s is already parameterized", packageSource)
+		}
+		resp, err := p.Provider.Parameterize(pctx.Request(), plugin.ParameterizeRequest{
 			Parameters: &plugin.ParameterizeValue{Value: parameterizationValue},
 		})
 		if err != nil {
@@ -836,7 +850,7 @@ func SchemaFromSchemaSourceValueArgs(
 		}
 	}
 
-	schema, err := p.GetSchema(pctx.Request(), request)
+	schema, err := p.Provider.GetSchema(pctx.Request(), request)
 	if err != nil {
 		return nil, err
 	}
@@ -847,13 +861,22 @@ func SchemaFromSchemaSourceValueArgs(
 	return bind(spec)
 }
 
+type Provider struct {
+	Provider plugin.Provider
+
+	AlreadyParameterized bool
+}
+
 // ProviderFromSource takes a plugin name or path.
 //
 // PLUGIN[@VERSION] | PATH_TO_PLUGIN
-func ProviderFromSource(pctx *plugin.Context, packageSource string) (plugin.Provider, error) {
+func ProviderFromSource(
+	pctx *plugin.Context, packageSource string, reg registry.Registry,
+
+) (Provider, *workspace.PackageSpec, error) {
 	pluginSpec, err := workspace.NewPluginSpec(pctx.Request(), packageSource, apitype.ResourcePlugin, nil, "", nil)
 	if err != nil {
-		return nil, err
+		return Provider{}, nil, err
 	}
 	descriptor := workspace.PackageDescriptor{
 		PluginSpec: pluginSpec,
@@ -867,80 +890,150 @@ func ProviderFromSource(pctx *plugin.Context, packageSource string) (plugin.Prov
 		return info.Mode()&0o111 != 0 && !info.IsDir()
 	}
 
+	installDescriptor := func(descriptor workspace.PackageDescriptor) (Provider, error) {
+		p, err := pctx.Host.Provider(descriptor)
+		if err == nil {
+			return Provider{
+				Provider:             p,
+				AlreadyParameterized: descriptor.Parameterization != nil,
+			}, nil
+		}
+		// There is an executable or directory with the same name, so suggest that
+		if info, statErr := os.Stat(descriptor.Name); statErr == nil && (isExecutable(info) || info.IsDir()) {
+			return Provider{}, fmt.Errorf("could not find installed plugin %s, did you mean ./%[1]s: %w", descriptor.Name, err)
+		}
+
+		if descriptor.SubDir() != "" {
+			path, err := descriptor.DirPath()
+			if err != nil {
+				return Provider{}, err
+			}
+			info, statErr := os.Stat(filepath.Join(path, descriptor.SubDir()))
+			if statErr == nil && info.IsDir() {
+				// The plugin is already installed.  But since it is in a subdirectory, it could be that
+				// we previously installed a plugin in a different subdirectory of the same repository.
+				// This is why the provider might have failed to start up.  Install the dependencies
+				// and try again.
+				depErr := descriptor.InstallDependencies(pctx.Base())
+				if depErr != nil {
+					return Provider{}, fmt.Errorf("installing plugin dependencies: %w", depErr)
+				}
+				p, err := pctx.Host.Provider(descriptor)
+				if err != nil {
+					return Provider{}, err
+				}
+				return Provider{Provider: p}, nil
+			}
+		}
+
+		// Try and install the plugin if it was missing and try again, unless auto plugin installs are turned off.
+		var missingError *workspace.MissingError
+		if !errors.As(err, &missingError) || env.DisableAutomaticPluginAcquisition.Value() {
+			return Provider{}, err
+		}
+
+		log := func(sev diag.Severity, msg string) {
+			pctx.Host.Log(sev, "", msg, 0)
+		}
+
+		_, err = pkgWorkspace.InstallPlugin(pctx.Base(), descriptor.PluginSpec, log)
+		if err != nil {
+			return Provider{}, err
+		}
+
+		p, err = pctx.Host.Provider(descriptor)
+		if err != nil {
+			return Provider{}, err
+		}
+
+		return Provider{Provider: p}, nil
+	}
+
+	setupProvider := func(
+		descriptor workspace.PackageDescriptor, specOverride *workspace.PackageSpec,
+	) (Provider, *workspace.PackageSpec, error) {
+		p, err := installDescriptor(descriptor)
+		if err != nil {
+			return Provider{}, nil, err
+		}
+		if descriptor.Parameterization != nil {
+			_, err := p.Provider.Parameterize(pctx.Request(), plugin.ParameterizeRequest{
+				Parameters: &plugin.ParameterizeValue{
+					Name:    descriptor.Parameterization.Name,
+					Version: descriptor.Parameterization.Version,
+					Value:   descriptor.Parameterization.Value,
+				},
+			})
+			if err != nil {
+				return Provider{}, nil, fmt.Errorf("failed to parameterize %s: %w", p.Provider.Pkg().Name(), err)
+			}
+		}
+		return p, specOverride, nil
+	}
+
 	// For all plugins except for file paths, we try to load it from the provider host.
 	//
 	// Note that if a local folder has a name that could match an downloadable plugin, we
 	// prefer the downloadable plugin.  The user can disambiguate by prepending './' to the
 	// name.
 	if !plugin.IsLocalPluginPath(pctx.Base(), packageSource) {
-		// We assume this was a plugin and not a path, so load the plugin.
-		provider, err := pctx.Host.Provider(descriptor)
-		if err != nil {
-			// There is an executable or directory with the same name, so suggest that
-			if info, statErr := os.Stat(descriptor.Name); statErr == nil && (isExecutable(info) || info.IsDir()) {
-				return nil, fmt.Errorf("could not find installed plugin %s, did you mean ./%[1]s: %w", descriptor.Name, err)
-			}
-
-			if descriptor.SubDir() != "" {
-				path, err := descriptor.DirPath()
-				if err != nil {
-					return nil, err
+		if !env.DisableRegistryResolve.Value() && env.Experimental.Value() {
+			meta, err := registry.ResolvePackageFromName(pctx.Base(), reg, pluginSpec.Name, pluginSpec.Version)
+			if err == nil {
+				spec := workspace.PluginSpec{
+					Name:              meta.Name,
+					Kind:              apitype.ResourcePlugin,
+					Version:           &meta.Version,
+					PluginDownloadURL: meta.PluginDownloadURL,
 				}
-				info, statErr := os.Stat(filepath.Join(path, descriptor.SubDir()))
-				if statErr == nil && info.IsDir() {
-					// The plugin is already installed.  But since it is in a subdirectory, it could be that
-					// we previously installed a plugin in a different subdirectory of the same repository.
-					// This is why the provider might have failed to start up.  Install the dependencies
-					// and try again.
-					depErr := descriptor.InstallDependencies(pctx.Base())
-					if depErr != nil {
-						return nil, fmt.Errorf("installing plugin dependencies: %w", depErr)
+				var params *workspace.Parameterization
+				if meta.Parameterization != nil {
+					spec.Name = meta.Parameterization.BaseProvider.Name
+					spec.Version = &meta.Parameterization.BaseProvider.Version
+					params = &workspace.Parameterization{
+						Name:    meta.Name,
+						Version: meta.Version,
+						Value:   meta.Parameterization.Parameter,
 					}
-					return pctx.Host.Provider(descriptor)
 				}
+				return setupProvider(workspace.NewPackageDescriptor(spec, params), &workspace.PackageSpec{
+					Source:  meta.Source + "/" + meta.Publisher + "/" + meta.Name,
+					Version: meta.Version.String(),
+				})
+			} else if errors.Is(err, registry.ErrNotFound) &&
+				registry.PulumiPublishedBeforeRegistry(pluginSpec.Name) {
+				// Let's try installing it without the registry.
+				return setupProvider(descriptor, nil)
 			}
-
-			// Try and install the plugin if it was missing and try again, unless auto plugin installs are turned off.
-			var missingError *workspace.MissingError
-			if !errors.As(err, &missingError) || env.DisableAutomaticPluginAcquisition.Value() {
-				return nil, err
+			for _, suggested := range registry.GetSuggestedPackages(err) {
+				pctx.Diag.Infof(diag.Message("", "%s/%s/%s@%s is a similar package"),
+					suggested.Source, suggested.Publisher, suggested.Name,
+					suggested.Version,
+				)
 			}
-
-			log := func(sev diag.Severity, msg string) {
-				pctx.Host.Log(sev, "", msg, 0)
-			}
-
-			_, err = pkgWorkspace.InstallPlugin(pctx.Base(), descriptor.PluginSpec, log)
-			if err != nil {
-				return nil, err
-			}
-
-			p, err := pctx.Host.Provider(descriptor)
-			if err != nil {
-				return nil, err
-			}
-
-			return p, nil
+			return Provider{}, nil, fmt.Errorf("Unable to resolve package from name: %w", err)
 		}
-		return provider, nil
+
+		// We assume this was a plugin and not a path, so load the plugin.
+		return setupProvider(descriptor, nil)
 	}
 
 	// We were given a path to a binary or folder, so invoke that.
 	info, err := os.Stat(packageSource)
 	if os.IsNotExist(err) {
-		return nil, fmt.Errorf("could not find file %s", packageSource)
+		return Provider{}, nil, fmt.Errorf("could not find file %s", packageSource)
 	} else if err != nil {
-		return nil, err
+		return Provider{}, nil, err
 	} else if !info.IsDir() && !isExecutable(info) {
 		if p, err := filepath.Abs(packageSource); err == nil {
 			packageSource = p
 		}
-		return nil, fmt.Errorf("plugin at path %q not executable", packageSource)
+		return Provider{}, nil, fmt.Errorf("plugin at path %q not executable", packageSource)
 	}
 
 	p, err := plugin.NewProviderFromPath(pctx.Host, pctx, packageSource)
 	if err != nil {
-		return nil, err
+		return Provider{}, nil, err
 	}
-	return p, nil
+	return Provider{Provider: p}, nil, nil
 }

--- a/pkg/cmd/pulumi/plugin/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install.go
@@ -25,9 +25,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
-	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
-	"github.com/pulumi/pulumi/pkg/v3/backend/diy/unauthenticatedregistry"
-	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/util"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -120,18 +118,7 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 		cmd.installPluginSpec = installPluginSpec
 	}
 	if cmd.registry == nil {
-		cmd.registry = registry.NewOnDemandRegistry(func() (registry.Registry, error) {
-			b, err := cmdBackend.NonInteractiveCurrentBackend(
-				ctx, pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, nil,
-			)
-			if err == nil && b != nil {
-				return b.GetReadOnlyCloudRegistry(), nil
-			}
-			if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
-				return unauthenticatedregistry.New(cmd.diag, cmd.env), nil
-			}
-			return nil, fmt.Errorf("could not get registry backend: %w", err)
-		})
+		cmd.registry = cmdCmd.NewDefaultRegistry(ctx, pkgWorkspace.Instance, nil, cmd.diag, cmd.env)
 	}
 
 	// Parse the kind, name, and version, if specified.

--- a/pkg/cmd/pulumi/templates/cloud.go
+++ b/pkg/cmd/pulumi/templates/cloud.go
@@ -29,8 +29,8 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
-	"github.com/pulumi/pulumi/pkg/v3/backend/diy/unauthenticatedregistry"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -59,18 +59,7 @@ func (s *Source) getCloudTemplates(
 }
 
 func (s *Source) getRegistryTemplates(ctx context.Context, e env.Env, templateName string) {
-	r := registry.NewOnDemandRegistry(func() (registry.Registry, error) {
-		b, err := cmdBackend.NonInteractiveCurrentBackend(
-			ctx, pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, nil,
-		)
-		if err == nil && b != nil {
-			return b.GetReadOnlyCloudRegistry(), nil
-		}
-		if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
-			return unauthenticatedregistry.New(cmdutil.Diag(), e), nil
-		}
-		return nil, fmt.Errorf("could not get registry backend: %w", err)
-	})
+	r := cmdCmd.NewDefaultRegistry(ctx, pkgWorkspace.Instance, nil, cmdutil.Diag(), e)
 
 	// Since the templates names displayed here differ from the template names
 	// returned from ListTemplates for VCS backed templates, we need to fetch

--- a/sdk/go/common/apitype/package.go
+++ b/sdk/go/common/apitype/package.go
@@ -118,6 +118,22 @@ type PackageMetadata struct {
 	CreatedAt time.Time `json:"createdAt"`
 	// The visibility of the package.
 	Visibility Visibility `json:"visibility"`
+	// The parameterization of the provider, if any.
+	Parameterization *PackageParameterization `json:"parameterization,omitempty"`
+}
+
+type PackageParameterization struct {
+	BaseProvider ArtifactVersionNameSpec `json:"baseProvider"`
+	Parameter    []byte                  `json:"parameter"`
+}
+
+// ArtifactVersionNameSpec represents an arbitrary artifact version name for
+// serialization.
+type ArtifactVersionNameSpec struct {
+	Name      string         `json:"name"`
+	Publisher string         `json:"publisher"`
+	Source    string         `json:"source"`
+	Version   semver.Version `json:"version"`
 }
 
 type PackageType string

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -1093,3 +1093,49 @@ func TestConsoleCommandMissingStack(t *testing.T) {
 	assert.Contains(t, stdout,
 		"Stack 'this-does-not-exist' does not exist. Run `pulumi stack init` to create a new stack.")
 }
+
+// TestPulumiPackageAddForTerraformProvider checks that the CLI can correctly resolve a
+// parameterized provider all the way from the registry to a python environment.
+//
+//nolint:paralleltest // pulumi new is not parallel safe
+func TestPulumiPackageAddForTerraformProvider(t *testing.T) {
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+
+	projectDir := filepath.Join(e.RootPath, "project")
+	err := os.Mkdir(projectDir, 0o700)
+	require.NoError(t, err)
+
+	e.CWD = projectDir
+	e.Env = append(e.Env,
+		"PULUMI_EXPERIMENTAL=true",
+		"PULUMI_DISABLE_REGISTRY_RESOLVE=false",
+		"PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=false",
+	)
+
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+
+	// Create a new python project based of the local random template
+	e.RunCommand("pulumi", "new", "python", "--yes")
+	e.RunCommand("pulumi", "install")
+	e.RunCommand("pulumi", "package", "add", "opentofu/airbytehq/airbyte@0.13.0")
+
+	e.WriteTestFile("__main__.py", `import pulumi_airbyte as airbyte
+
+example = airbyte.Provider("provider")`)
+
+	e.RunCommand("pulumi", "up", "--yes")
+
+	// Remove files that wouldn't be checked in:
+	require.NoError(t, os.RemoveAll(filepath.Join(e.CWD, "sdks")))
+	require.NoError(t, os.RemoveAll(filepath.Join(e.CWD, "venv")))
+
+	// Create a new venv
+	e.RunCommand("python3", "-m", "venv", "venv")
+
+	// This should create the "sdks" folder, populate it and install the generated
+	// package into the new venv.
+	e.RunCommand("pulumi", "install")
+
+	e.RunCommand("pulumi", "up", "--yes", "--expect-no-changes")
+}


### PR DESCRIPTION
> [!IMPORTANT]  
> This feature is experimental, and only enabled when `PULUMI_EXPERIMENTAL=1` is set.

This PR adds support for using `pulumi package add <registry ID>`. As an example:

```sh
pulumi package add opentofu/airbytehq/airbyte
```

```yaml
name: ian-test-python
runtime:
  name: python
  options:
    virtualenv: venv
packages:
  airbyte: opentofu/airbytehq/airbyte@0.13.0
  # Another example of a registry based provider, this one parameterized:
  random:
    source: pulumi/pulumi/terraform-provider
    version: 0.11.0
    parameters:
      - hashicorp/random
      - 3.6.3

```

This is compatible with `pulumi install`, which correctly regenerates the SDK for the registry based provider.


## Merging

### Complications

Merging this PR will be a bit complicated, due to the inability to update all package loaders at once:

Before this PR, `plugin.IsLocalPluginPath(ctx, "opentofu/airbytehq/airbyte")` returned true. That means that binaries that have linked the `sdk/go/common` (and specifically [`plugin.NewContext`](https://github.com/pulumi/pulumi/blob/408d561e5faec3e66e87b72d8eed6e563458efae/sdk/go/common/resource/plugin/context.go#L57-L64)) believe that `airbyte: opentofu/airbytehq/airbyte@0.13.0` represents a local package located at `${PROJECT_ROOT}/opentofu/airbytehq/airbyte`. Because `plugin.NewContext` validates that all path based packages exist on creation, old binaries are unable to consume registry based `Pulumi.yaml` files. They complain that the local binary path doesn't exist:

    ```
    pulumi package add terraform-provider another/package
    error: failed to get schema: GetSchema failed: rpc error: code = Unknown desc = failed to create generator: could not make new context: no folder at path '${PROJECT_ROOT}/opentofu/airbytehq/airbyte'
    ```

Unfortunately, `pulumi` isn't the only binary who which depends on plugin loading. The above error is coming from the `terraform-provider` code, specifically [here](https://github.com/pulumi/pulumi-terraform-bridge/blob/49f3284e26fd004f03ac5e90a96136dea504d1da/pkg/tfgen/generate.go#L976-L979).

Building a new copy of `pulumi-terraform-provider` that links the changes to `sdk/go/common` in this PR resolves the error.

### Recommendation

We should split this PR into two separate steps:

1. Update `sdk/go/common` now, with the changes in this PR. This will make sources like `source/publisher/name` invalid as paths. Users can adjust to the break by prefixing the path with `./`: `./source/publisher/name` is a local path, and always will be.
2. After the first PR is released, update `pulumi-yaml`, `terraform-provider` and `terraform-module` to depend on the new code.
3. After other dependents[^1] have been released, we can merge the other half of this PR, updating package resolution to work with registry slugs. At this point, upgrading `terraform-provider` and `terraform-module` to latest will resolve all errors introduced with the newest version of `pulumi package add`.


[^1]: We don't need to update all providers built with `pulumi-terraform-bridge`, just those that do on-the-fly generation (and thus require in-project plugin loading): the parametrizable providers.

## Merging - followup

The PR for step (1) merged 3 weeks ago: https://github.com/pulumi/pulumi/pull/19930. There have been no reported issues. The bridge update was delayed by https://github.com/pulumi/pulumi/issues/19981, but https://github.com/pulumi/pulumi-terraform-bridge/pull/3138 has now merged.