### PR TITLE
Allow plugin names to include up to 3 slashes

### DIFF
--- a/changelog/pending/20250623--cli--do-not-assume-that-package-sources-without-file-path-prefixes-are-file-paths.yaml
+++ b/changelog/pending/20250623--cli--do-not-assume-that-package-sources-without-file-path-prefixes-are-file-paths.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Do not assume that package sources without file path prefixes (`./`, `../`) are file paths

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -2649,7 +2649,13 @@ func getCandidateExtensions() []string {
 	return []string{""}
 }
 
-var PluginNameRegexp = regexp.MustCompile(`^(?P<Name>[a-zA-Z0-9-][a-zA-Z0-9-_.]*[a-zA-Z0-9])$`)
+var PluginNameRegexp = func() *regexp.Regexp {
+	part := func(name string) string {
+		return "(?P<" + name + ">[a-zA-Z0-9-][a-zA-Z0-9-_.]*[a-zA-Z0-9])"
+	}
+
+	return regexp.MustCompile(`^((` + part("Source") + `/)?(` + part("Publisher") + `/))?` + part("Name") + `$`)
+}()
 
 // pluginRegexp matches plugin directory names: pulumi-KIND-NAME-VERSION.
 var pluginRegexp = regexp.MustCompile(

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -43,6 +43,69 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestPluginNameRegexp(t *testing.T) {
+	t.Parallel()
+
+	type expect struct{ Source, Publisher, Name string }
+	tests := []struct {
+		input    string
+		expected *expect
+	}{
+		{
+			input:    "",
+			expected: nil,
+		},
+		{
+			input:    "plain",
+			expected: &expect{Name: "plain"},
+		},
+		{
+			input:    "publisher/name",
+			expected: &expect{Publisher: "publisher", Name: "name"},
+		},
+		{
+			input:    "source/publisher/name",
+			expected: &expect{Source: "source", Publisher: "publisher", Name: "name"},
+		},
+		{
+			input:    "extra/source/publisher/name",
+			expected: nil,
+		},
+		{
+			input:    "long-name",
+			expected: &expect{Name: "long-name"},
+		},
+		{
+			input:    "./some/path",
+			expected: nil,
+		},
+		{
+			input:    "/leading/slash",
+			expected: nil,
+		},
+		{
+			input:    "../file",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
+			match := PluginNameRegexp.FindStringSubmatch(tt.input)
+			if match == nil {
+				require.Nil(t, tt.expected)
+				return
+			}
+
+			assert.Equal(t, tt.expected.Name, match[PluginNameRegexp.SubexpIndex("Name")], "Name")
+			assert.Equal(t, tt.expected.Publisher, match[PluginNameRegexp.SubexpIndex("Publisher")], "Publisher")
+			assert.Equal(t, tt.expected.Source, match[PluginNameRegexp.SubexpIndex("Source")], "Source")
+		})
+	}
+}
+
 func TestLegacyPluginSelection_Prerelease(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
In preparation for https://github.com/pulumi/pulumi/pull/19928.

This is a minor breaking change, since `packages:` blocks in `Pulumi.yaml` that specified path based packages with less then 4 slashes and no leading `./`, `../` or `/` will stop working. The problem can be addressed by appending a `./` to the package.