### PR TITLE
Rename `(registry.Registry).SearchByName` to `ListPackages`

### DIFF
--- a/pkg/backend/diy/unauthenticatedregistry/package_registry.go
+++ b/pkg/backend/diy/unauthenticatedregistry/package_registry.go
@@ -38,10 +38,10 @@ func New(sink diag.Sink, store env.Env) registry.Registry {
 	return packageRegistry{client.NewClient(url, "", false /* insecure */, sink)}
 }
 
-func (r packageRegistry) SearchByName(
+func (r packageRegistry) ListPackages(
 	ctx context.Context, name *string,
 ) iter.Seq2[apitype.PackageMetadata, error] {
-	return r.c.SearchByName(ctx, name)
+	return r.c.ListPackages(ctx, name)
 }
 
 func (r packageRegistry) GetPackage(

--- a/pkg/backend/diy/unauthenticatedregistry/package_registry_test.go
+++ b/pkg/backend/diy/unauthenticatedregistry/package_registry_test.go
@@ -192,7 +192,7 @@ func TestGetPackagePrivatePackage(t *testing.T) {
 	assert.ErrorIs(t, err, registry.ErrNotFound)
 }
 
-func TestSearchByName(t *testing.T) {
+func TestListPackages(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -251,7 +251,7 @@ func TestSearchByName(t *testing.T) {
 	}))
 
 	results := []apitype.PackageMetadata{}
-	for pkg, err := range client.SearchByName(ctx, ref("castai")) {
+	for pkg, err := range client.ListPackages(ctx, ref("castai")) {
 		require.NoError(t, err)
 		results = append(results, pkg)
 	}
@@ -293,7 +293,7 @@ func TestSearchByName(t *testing.T) {
 	}, results)
 }
 
-func TestSearchByNameNoMatches(t *testing.T) {
+func TestListPackagesNoMatches(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -309,7 +309,7 @@ func TestSearchByNameNoMatches(t *testing.T) {
 	}))
 
 	results := []apitype.PackageMetadata{}
-	for pkg, err := range client.SearchByName(ctx, ref("404-not-found")) {
+	for pkg, err := range client.ListPackages(ctx, ref("404-not-found")) {
 		require.NoError(t, err)
 		results = append(results, pkg)
 	}

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1671,7 +1671,7 @@ func (pc *Client) GetPackage(
 	return resp, err
 }
 
-func (pc *Client) SearchByName(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+func (pc *Client) ListPackages(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
 	url := "/api/preview/registry/packages?limit=499"
 	if name != nil {
 		url += "&name=" + *name

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -567,7 +567,7 @@ func TestGetPackage(t *testing.T) {
 	})
 }
 
-func TestSearchByName(t *testing.T) {
+func TestListPackages(t *testing.T) {
 	t.Parallel()
 
 	t.Run("no-continuation-token", func(t *testing.T) {
@@ -610,10 +610,10 @@ func TestSearchByName(t *testing.T) {
 
 		mockClient := newMockClient(mockServer)
 
-		// Call SearchByName and collect results
+		// Call ListPackages and collect results
 		searchName := "my-package"
 		searchResults := []apitype.PackageMetadata{}
-		for pkg, err := range mockClient.SearchByName(context.Background(), &searchName) {
+		for pkg, err := range mockClient.ListPackages(context.Background(), &searchName) {
 			require.NoError(t, err)
 			searchResults = append(searchResults, pkg)
 		}
@@ -707,7 +707,7 @@ func TestSearchByName(t *testing.T) {
 
 		searchName := "my-package"
 		searchResults := []apitype.PackageMetadata{}
-		for pkg, err := range mockClient.SearchByName(context.Background(), &searchName) {
+		for pkg, err := range mockClient.ListPackages(context.Background(), &searchName) {
 			require.NoError(t, err)
 			searchResults = append(searchResults, pkg)
 		}

--- a/pkg/backend/httpstate/cloud_registry.go
+++ b/pkg/backend/httpstate/cloud_registry.go
@@ -42,10 +42,10 @@ func (r *cloudRegistry) PublishPackage(ctx ctx.Context, op apitype.PackagePublis
 	return r.cl.PublishPackage(ctx, op)
 }
 
-func (r *cloudRegistry) SearchByName(
+func (r *cloudRegistry) ListPackages(
 	ctx ctx.Context, name *string,
 ) iter.Seq2[apitype.PackageMetadata, error] {
-	return r.cl.SearchByName(ctx, name)
+	return r.cl.ListPackages(ctx, name)
 }
 
 func (r *cloudRegistry) GetPackage(

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -812,7 +812,7 @@ type MockCloudRegistry struct {
 	GetPackageF      func(
 		ctx context.Context, source, publisher, name string, version *semver.Version,
 	) (apitype.PackageMetadata, error)
-	SearchByNameF func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error]
+	ListPackagesF func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error]
 }
 
 var _ CloudRegistry = (*MockCloudRegistry)(nil)
@@ -833,11 +833,11 @@ func (mr *MockCloudRegistry) GetPackage(
 	panic("not implemented")
 }
 
-func (mr *MockCloudRegistry) SearchByName(
+func (mr *MockCloudRegistry) ListPackages(
 	ctx context.Context, name *string,
 ) iter.Seq2[apitype.PackageMetadata, error] {
-	if mr.SearchByNameF != nil {
-		return mr.SearchByNameF(ctx, name)
+	if mr.ListPackagesF != nil {
+		return mr.ListPackagesF(ctx, name)
 	}
 	panic("not implemented")
 }

--- a/pkg/cmd/pulumi/plugin/plugin_install_test.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install_test.go
@@ -328,12 +328,12 @@ func (r testMockRegistry) GetPackage(
 	panic("GetPackage not implemented")
 }
 
-func (r testMockRegistry) SearchByName(
+func (r testMockRegistry) ListPackages(
 	ctx context.Context, name *string,
 ) iter.Seq2[apitype.PackageMetadata, error] {
 	if r.searchByName != nil {
 		return r.searchByName(ctx, name)
 	}
 
-	panic("SearchByName not implemented")
+	panic("ListPackages not implemented")
 }

--- a/sdk/go/common/registry/registry.go
+++ b/sdk/go/common/registry/registry.go
@@ -44,9 +44,9 @@ type Registry interface {
 	// If name is non-nil, it will filter to accessible packages that exactly match
 	// */*/{name}.
 	//
-	// Implementations of SearchByName should return an empty iterator and nil if
+	// Implementations of ListPackages should return an empty iterator and nil if
 	// there are no matching packages in the Registry.
-	SearchByName(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error]
+	ListPackages(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error]
 }
 
 type registryKey struct{}
@@ -82,7 +82,7 @@ func (r *onDemandRegistry) GetPackage(
 	return impl.GetPackage(ctx, source, publisher, name, version)
 }
 
-func (r *onDemandRegistry) SearchByName(
+func (r *onDemandRegistry) ListPackages(
 	ctx context.Context, name *string,
 ) iter.Seq2[apitype.PackageMetadata, error] {
 	impl, err := r.factory()
@@ -91,5 +91,5 @@ func (r *onDemandRegistry) SearchByName(
 			consumer(apitype.PackageMetadata{}, err)
 		}
 	}
-	return impl.SearchByName(ctx, name)
+	return impl.ListPackages(ctx, name)
 }

--- a/sdk/go/common/registry/registry_test.go
+++ b/sdk/go/common/registry/registry_test.go
@@ -40,7 +40,7 @@ func (r mockRegistry) GetPackage(
 	return r.getPackage(ctx, source, publisher, name, version)
 }
 
-func (r mockRegistry) SearchByName(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+func (r mockRegistry) ListPackages(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
 	return r.searchByName(ctx, name)
 }
 

--- a/sdk/go/common/registry/resolve.go
+++ b/sdk/go/common/registry/resolve.go
@@ -72,7 +72,7 @@ func ResolvePackageFromName(
 		var pulumiPackageMetadata *apitype.PackageMetadata
 		var privatePackageMetadata []apitype.PackageMetadata
 		var suggested []apitype.PackageMetadata
-		for meta, err := range registry.SearchByName(ctx, &name) {
+		for meta, err := range registry.ListPackages(ctx, &name) {
 			if err != nil {
 				return apitype.PackageMetadata{}, err
 			}


### PR DESCRIPTION
`SearchByName` calls into the `ListPackages` endpoint in the registry, and this name is more descriptive. This is in preparation for adding `ListTemplates` and `GetTemplates` to the registry here.