### PR TITLE
Add `(registry.Registry).{Get,List}Template(s)`

### DIFF
--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -394,7 +394,7 @@ func TestDeploymentSettingsApi(t *testing.T) {
 	})
 }
 
-func TestListTemplates(t *testing.T) {
+func TestListOrgTemplates(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 

--- a/pkg/backend/httpstate/cloud_registry.go
+++ b/pkg/backend/httpstate/cloud_registry.go
@@ -18,6 +18,7 @@ import (
 	ctx "context"
 	"errors"
 	"iter"
+	"net/http"
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -53,6 +54,22 @@ func (r *cloudRegistry) GetPackage(
 ) (apitype.PackageMetadata, error) {
 	meta, err := r.cl.GetPackage(ctx, source, publisher, name, version)
 	if apiErr := (&apitype.ErrorResponse{}); errors.As(err, &apiErr) && apiErr.Code == 404 {
+		return meta, backenderr.NotFoundError{Err: err}
+	}
+	return meta, err
+}
+
+func (r *cloudRegistry) ListTemplates(
+	ctx ctx.Context, name *string,
+) iter.Seq2[apitype.TemplateMetadata, error] {
+	return r.cl.ListTemplates(ctx, name)
+}
+
+func (r *cloudRegistry) GetTemplate(
+	ctx ctx.Context, source, publisher, name string, version *semver.Version,
+) (apitype.TemplateMetadata, error) {
+	meta, err := r.cl.GetTemplate(ctx, source, publisher, name, version)
+	if apiErr := (&apitype.ErrorResponse{}); errors.As(err, &apiErr) && apiErr.Code == http.StatusNotFound {
 		return meta, backenderr.NotFoundError{Err: err}
 	}
 	return meta, err

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -813,6 +813,10 @@ type MockCloudRegistry struct {
 		ctx context.Context, source, publisher, name string, version *semver.Version,
 	) (apitype.PackageMetadata, error)
 	ListPackagesF func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error]
+	GetTemplateF  func(
+		ctx context.Context, source, publisher, name string, version *semver.Version,
+	) (apitype.TemplateMetadata, error)
+	ListTemplatesF func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error]
 }
 
 var _ CloudRegistry = (*MockCloudRegistry)(nil)
@@ -838,6 +842,24 @@ func (mr *MockCloudRegistry) ListPackages(
 ) iter.Seq2[apitype.PackageMetadata, error] {
 	if mr.ListPackagesF != nil {
 		return mr.ListPackagesF(ctx, name)
+	}
+	panic("not implemented")
+}
+
+func (mr *MockCloudRegistry) GetTemplate(
+	ctx context.Context, source, publisher, name string, version *semver.Version,
+) (apitype.TemplateMetadata, error) {
+	if mr.GetTemplateF != nil {
+		return mr.GetTemplateF(ctx, source, publisher, name, version)
+	}
+	panic("not implemented")
+}
+
+func (mr *MockCloudRegistry) ListTemplates(
+	ctx context.Context, name *string,
+) iter.Seq2[apitype.TemplateMetadata, error] {
+	if mr.ListTemplatesF != nil {
+		return mr.ListTemplatesF(ctx, name)
 	}
 	panic("not implemented")
 }

--- a/sdk/go/common/apitype/templates.go
+++ b/sdk/go/common/apitype/templates.go
@@ -16,9 +16,41 @@ package apitype
 
 import (
 	"io"
+	"time"
 
 	"github.com/blang/semver"
 )
+
+// TemplateMetadata represents a template query, as returned by the service's registry
+// APIs.
+type TemplateMetadata struct {
+	Name        string  `json:"name"`
+	Publisher   string  `json:"publisher"`
+	Source      string  `json:"source"`
+	DisplayName string  `json:"displayName"`
+	Description *string `json:"description,omitempty"`
+	// The language that the template is in.
+	Language string `json:"language"`
+	// ReadmeURL is just a pre-signed URL, derived from the artifact key.
+	ReadmeURL string `json:"readmeURL"`
+	// An URL, valid for at least 5 minutes that you can retrieve the full download
+	// bundle for your template.
+	//
+	// The bundle will be a .tar.gz.
+	DownloadURL string `json:"downloadURL"`
+	// A link to the hosting repository.
+	//
+	// Non-VCS backed templates do not have a repo slug as of now.
+	RepoSlug   *string           `json:"repoSlug,omitempty"`
+	Visibility Visibility        `json:"visibility"`
+	UpdatedAt  time.Time         `json:"updatedAt"`
+	Metadata   map[string]string `json:"metadata,omitempty"`
+}
+
+type ListTemplatesResponse struct {
+	Templates         []TemplateMetadata `json:"templates"`
+	ContinuationToken *string            `json:"continuationToken,omitempty"`
+}
 
 // A pulumi template remote where the source URL contains
 // a valid Pulumi.yaml file.

--- a/sdk/go/common/registry/registry_test.go
+++ b/sdk/go/common/registry/registry_test.go
@@ -31,7 +31,12 @@ type mockRegistry struct {
 	getPackage func(
 		ctx context.Context, source, publisher, name string, version *semver.Version,
 	) (apitype.PackageMetadata, error)
-	searchByName func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error]
+	listPackages func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error]
+
+	getTemplate func(
+		ctx context.Context, source, publisher, name string, version *semver.Version,
+	) (apitype.TemplateMetadata, error)
+	listTemplates func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error]
 }
 
 func (r mockRegistry) GetPackage(
@@ -41,7 +46,17 @@ func (r mockRegistry) GetPackage(
 }
 
 func (r mockRegistry) ListPackages(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
-	return r.searchByName(ctx, name)
+	return r.listPackages(ctx, name)
+}
+
+func (r mockRegistry) GetTemplate(
+	ctx context.Context, source, publisher, name string, version *semver.Version,
+) (apitype.TemplateMetadata, error) {
+	return r.getTemplate(ctx, source, publisher, name, version)
+}
+
+func (r mockRegistry) ListTemplates(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+	return r.listTemplates(ctx, name)
 }
 
 func TestOnDemandRegistry(t *testing.T) {

--- a/sdk/go/common/registry/resolve_test.go
+++ b/sdk/go/common/registry/resolve_test.go
@@ -316,7 +316,7 @@ func TestResolvePackageFromName(t *testing.T) {
 	t.Run("single/private-precedence", func(t *testing.T) {
 		t.Parallel()
 		mockReg := mockRegistry{
-			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+			listPackages: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
 				assert.Equal(t, "aws", *name)
 				return func(yield func(apitype.PackageMetadata, error) bool) {
 					// Return private match first
@@ -349,7 +349,7 @@ func TestResolvePackageFromName(t *testing.T) {
 	t.Run("single/pulumi-match", func(t *testing.T) {
 		t.Parallel()
 		mockReg := mockRegistry{
-			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+			listPackages: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
 				return func(yield func(apitype.PackageMetadata, error) bool) {
 					// No private match, only pulumi/pulumi
 					yield(apitype.PackageMetadata{
@@ -372,7 +372,7 @@ func TestResolvePackageFromName(t *testing.T) {
 	t.Run("single/no-matches-with-suggestions", func(t *testing.T) {
 		t.Parallel()
 		mockReg := mockRegistry{
-			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+			listPackages: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
 				return func(yield func(apitype.PackageMetadata, error) bool) {
 					// Return some suggestions but no exact matches
 					if !yield(apitype.PackageMetadata{
@@ -409,7 +409,7 @@ func TestResolvePackageFromName(t *testing.T) {
 		t.Parallel()
 		desiredVersion := semver.MustParse("1.5.0")
 		mockReg := mockRegistry{
-			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+			listPackages: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
 				return func(yield func(apitype.PackageMetadata, error) bool) {
 					yield(apitype.PackageMetadata{
 						Source:    "pulumi",
@@ -444,7 +444,7 @@ func TestResolvePackageFromName(t *testing.T) {
 		t.Parallel()
 		desiredVersion := semver.MustParse("999.0.0")
 		mockReg := mockRegistry{
-			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+			listPackages: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
 				return func(yield func(apitype.PackageMetadata, error) bool) {
 					yield(apitype.PackageMetadata{
 						Source:    "pulumi",
@@ -475,7 +475,7 @@ func TestResolvePackageFromName(t *testing.T) {
 		t.Parallel()
 		searchErr := errors.New("search failed")
 		mockReg := mockRegistry{
-			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+			listPackages: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
 				return func(yield func(apitype.PackageMetadata, error) bool) {
 					yield(apitype.PackageMetadata{}, searchErr)
 				}
@@ -490,7 +490,7 @@ func TestResolvePackageFromName(t *testing.T) {
 	t.Run("single/multiple-suggestions", func(t *testing.T) {
 		t.Parallel()
 		mockReg := mockRegistry{
-			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+			listPackages: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
 				return func(yield func(apitype.PackageMetadata, error) bool) {
 					// Return multiple non-matching packages
 					if !yield(apitype.PackageMetadata{
@@ -530,7 +530,7 @@ func TestResolvePackageFromName(t *testing.T) {
 	t.Run("single/ambiguous-resolution", func(t *testing.T) {
 		t.Parallel()
 		mockReg := mockRegistry{
-			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+			listPackages: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
 				return func(yield func(apitype.PackageMetadata, error) bool) {
 					// Return multiple non-matching packages
 					if !yield(apitype.PackageMetadata{
@@ -570,7 +570,7 @@ func TestResolvePackageFromName(t *testing.T) {
 	t.Run("single/very-ambiguous-resolution", func(t *testing.T) {
 		t.Parallel()
 		mockReg := mockRegistry{
-			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+			listPackages: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
 				return func(yield func(apitype.PackageMetadata, error) bool) {
 					// Return multiple non-matching packages
 					if !yield(apitype.PackageMetadata{
@@ -624,7 +624,7 @@ func TestResolvePackageFromName(t *testing.T) {
 	t.Run("invalid/empty-string", func(t *testing.T) {
 		t.Parallel()
 		mockReg := mockRegistry{
-			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+			listPackages: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
 				// Empty string gets treated as single identifier, but no matches will be found
 				assert.Equal(t, "", *name)
 				return func(yield func(apitype.PackageMetadata, error) bool) {
@@ -685,7 +685,7 @@ func TestResolvePackageFromName(t *testing.T) {
 	t.Run("nil-version/single-part", func(t *testing.T) {
 		t.Parallel()
 		mockReg := mockRegistry{
-			searchByName: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+			listPackages: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
 				return func(yield func(apitype.PackageMetadata, error) bool) {
 					yield(apitype.PackageMetadata{
 						Source:    "pulumi",


### PR DESCRIPTION
This PR adds two new functions to `(registry.Registry)`: `GetTemplate` and `ListTemplates`. These functions will be used to incorporate Private Registry backed templates into the Pulumi CLI.

Related to https://github.com/pulumi/pulumi-service/issues/29500

Stacked on https://github.com/pulumi/pulumi/pull/19936