### PR TITLE
Use the Private Registry for template lookup

### DIFF
--- a/changelog/pending/20250624--cli-new--reflect-templates-published-with-pulumi-template-publish-in-the-results-of-pulumi-new.yaml
+++ b/changelog/pending/20250624--cli-new--reflect-templates-published-with-pulumi-template-publish-in-the-results-of-pulumi-new.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/new
+  description: Reflect templates published with `pulumi template publish` in the results of `pulumi new`

--- a/pkg/backend/diy/unauthenticatedregistry/package_registry.go
+++ b/pkg/backend/diy/unauthenticatedregistry/package_registry.go
@@ -17,6 +17,7 @@ package unauthenticatedregistry
 import (
 	"context"
 	"errors"
+	"io"
 	"iter"
 	"net/http"
 
@@ -69,4 +70,12 @@ func (r registryClient) GetTemplate(
 		return meta, backenderr.NotFoundError{Err: err}
 	}
 	return meta, err
+}
+
+func (r registryClient) DownloadTemplate(ctx context.Context, downloadURL string) (io.ReadCloser, error) {
+	bytes, err := r.c.DownloadTemplate(ctx, downloadURL)
+	if apiErr := (&apitype.ErrorResponse{}); errors.As(err, &apiErr) && apiErr.Code == http.StatusNotFound {
+		return bytes, backenderr.NotFoundError{Err: err}
+	}
+	return bytes, err
 }

--- a/pkg/backend/httpstate/cloud_registry.go
+++ b/pkg/backend/httpstate/cloud_registry.go
@@ -17,6 +17,7 @@ package httpstate
 import (
 	ctx "context"
 	"errors"
+	"io"
 	"iter"
 	"net/http"
 
@@ -77,4 +78,8 @@ func (r *cloudRegistry) GetTemplate(
 
 func (r *cloudRegistry) PublishTemplate(ctx ctx.Context, op apitype.TemplatePublishOp) error {
 	return r.cl.PublishTemplate(ctx, op)
+}
+
+func (r *cloudRegistry) DownloadTemplate(ctx ctx.Context, downloadURL string) (io.ReadCloser, error) {
+	return r.cl.DownloadTemplate(ctx, downloadURL)
 }

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -18,6 +18,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"io"
 	"iter"
 	"slices"
 	"strings"
@@ -816,7 +817,8 @@ type MockCloudRegistry struct {
 	GetTemplateF  func(
 		ctx context.Context, source, publisher, name string, version *semver.Version,
 	) (apitype.TemplateMetadata, error)
-	ListTemplatesF func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error]
+	ListTemplatesF    func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error]
+	DownloadTemplateF func(ctx context.Context, downloadURL string) (io.ReadCloser, error)
 }
 
 var _ CloudRegistry = (*MockCloudRegistry)(nil)
@@ -869,4 +871,11 @@ func (mr *MockCloudRegistry) PublishTemplate(ctx context.Context, op apitype.Tem
 		return mr.PublishTemplateF(ctx, op)
 	}
 	panic("not implemented: MockCloudRegistry.PublishTemplate")
+}
+
+func (mr *MockCloudRegistry) DownloadTemplate(ctx context.Context, downloadURL string) (io.ReadCloser, error) {
+	if mr.DownloadTemplateF != nil {
+		return mr.DownloadTemplateF(ctx, downloadURL)
+	}
+	panic("not implemented: MockCloudRegistry.DownloadTemplate")
 }

--- a/pkg/cmd/pulumi/newcmd/new.go
+++ b/pkg/cmd/pulumi/newcmd/new.go
@@ -176,7 +176,7 @@ func runNew(ctx context.Context, args newArgs) error {
 		scope = cmdTemplates.ScopeLocal
 	}
 	templateSource := cmdTemplates.New(ctx,
-		args.templateNameOrURL, scope, workspace.TemplateKindPulumiProject)
+		args.templateNameOrURL, scope, workspace.TemplateKindPulumiProject, env.Global())
 	defer func() { contract.IgnoreError(templateSource.Close()) }()
 
 	// List the templates from the repo.
@@ -479,7 +479,7 @@ func NewNewCmd() *cobra.Command {
 			scope = cmdTemplates.ScopeLocal
 		}
 		// Attempt to retrieve available templates.
-		s := cmdTemplates.New(ctx, "", scope, workspace.TemplateKindPulumiProject)
+		s := cmdTemplates.New(ctx, "", scope, workspace.TemplateKindPulumiProject, env.Global())
 		t, err := s.Templates()
 		return t, s, err
 	}

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -272,7 +272,7 @@ func NewUpCmd() *cobra.Command {
 		// Retrieve the template repo.
 		templateSource := cmdTemplates.New(ctx,
 			templateNameOrURL, cmdTemplates.ScopeAll,
-			workspace.TemplateKindPulumiProject)
+			workspace.TemplateKindPulumiProject, env.Global())
 		defer func() {
 			contract.IgnoreError(templateSource.Close())
 		}()

--- a/pkg/cmd/pulumi/templates/templates_test.go
+++ b/pkg/cmd/pulumi/templates/templates_test.go
@@ -15,8 +15,12 @@
 package templates
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"errors"
+	"io"
+	"iter"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,6 +32,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,8 +41,6 @@ import (
 
 //nolint:paralleltest // replaces global backend instance
 func TestFilterOnName(t *testing.T) {
-	ctx := testContext(t)
-
 	template1 := &apitype.PulumiTemplateRemote{
 		ProjectTemplate: apitype.ProjectTemplate{},
 		Name:            "name1",
@@ -44,59 +48,118 @@ func TestFilterOnName(t *testing.T) {
 		TemplateURL:     "example.com/source1/name1",
 	}
 
-	mockBackend := &backend.MockBackend{
-		SupportsTemplatesF: func() bool { return true },
-		CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
-			return "doe", []string{"org1"}, &workspace.TokenInformation{}, nil
-		},
-		ListTemplatesF: func(_ context.Context, orgName string) (apitype.ListOrgTemplatesResponse, error) {
-			assert.Equal(t, "org1", orgName)
+	testFilterOnName := func(t *testing.T, mapStore env.MapStore) {
+		ctx := testContext(t)
 
-			return apitype.ListOrgTemplatesResponse{
-				Templates: map[string][]*apitype.PulumiTemplateRemote{
-					"source1": {template1},
-					"source2": {
-						{
-							ProjectTemplate: apitype.ProjectTemplate{},
-							Name:            "name2",
-							SourceName:      "source2",
-							TemplateURL:     "example.com/source2/name1",
+		source := newImpl(ctx, "name1",
+			ScopeAll, workspace.TemplateKindPulumiProject,
+			templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+			env.NewEnv(mapStore),
+		)
+
+		template, err := source.Templates()
+		require.NoError(t, err)
+		require.Len(t, template, 1)
+		assert.Equal(t, "name1", template[0].Name())
+		assert.Equal(t, "", template[0].Description())
+		assert.Equal(t, "", template[0].ProjectDescription())
+		assert.Nil(t, template[0].Error())
+	}
+
+	t.Run("org-backed-templates", func(t *testing.T) {
+		mockBackend := &backend.MockBackend{
+			SupportsTemplatesF: func() bool { return true },
+			CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
+				return "doe", []string{"org1"}, &workspace.TokenInformation{}, nil
+			},
+			ListTemplatesF: func(_ context.Context, orgName string) (apitype.ListOrgTemplatesResponse, error) {
+				assert.Equal(t, "org1", orgName)
+
+				return apitype.ListOrgTemplatesResponse{
+					Templates: map[string][]*apitype.PulumiTemplateRemote{
+						"source1": {template1},
+						"source2": {
+							{
+								ProjectTemplate: apitype.ProjectTemplate{},
+								Name:            "name2",
+								SourceName:      "source2",
+								TemplateURL:     "example.com/source2/name1",
+							},
 						},
 					},
-				},
-				OrgHasTemplates: true,
-			}, nil
-		},
-	}
-	testutil.MockBackendInstance(t, mockBackend)
+					OrgHasTemplates: true,
+				}, nil
+			},
+		}
+		testutil.MockBackendInstance(t, mockBackend)
 
-	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
-		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-			url string, project *workspace.Project, setCurrent bool,
-		) (backend.Backend, error) {
-			return mockBackend, nil
-		},
-		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-			url string, project *workspace.Project, setCurrent bool, color colors.Colorization,
-		) (backend.Backend, error) {
-			return mockBackend, nil
-		},
+		testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+			CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+				url string, project *workspace.Project, setCurrent bool,
+			) (backend.Backend, error) {
+				return mockBackend, nil
+			},
+			LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+				url string, project *workspace.Project, setCurrent bool, color colors.Colorization,
+			) (backend.Backend, error) {
+				return mockBackend, nil
+			},
+		})
+		testFilterOnName(t, env.MapStore{
+			"PULUMI_DISABLE_REGISTRY_RESOLVE": "true",
+		})
 	})
 
-	source := newImpl(ctx, "name1",
-		ScopeAll, workspace.TemplateKindPulumiProject,
-		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
-	)
+	t.Run("org-backed-templates", func(t *testing.T) {
+		listTemplates := func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+			assert.Nil(t, name)
+			return func(yield func(apitype.TemplateMetadata, error) bool) {
+				if !yield(apitype.TemplateMetadata{
+					Name:      "name1",
+					Publisher: "publisher1",
+					Source:    "source1",
+				}, nil) {
+					return
+				}
+				if !yield(apitype.TemplateMetadata{
+					Name:      "name2",
+					Publisher: "publisher2",
+					Source:    "source2",
+				}, nil) {
+					return
+				}
+			}
+		}
+		mockBackend := &backend.MockBackend{
+			GetReadOnlyCloudRegistryF: func() registry.Registry {
+				return &backend.MockCloudRegistry{
+					ListTemplatesF: listTemplates,
+				}
+			},
+		}
+		testutil.MockBackendInstance(t, mockBackend)
 
-	template, err := source.Templates()
-	require.NoError(t, err)
-	assert.Equal(t,
-		[]Template{orgTemplate{t: template1, org: "org1", source: source, backend: cmdBackend.BackendInstance}},
-		template)
+		testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+			CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+				url string, project *workspace.Project, setCurrent bool,
+			) (backend.Backend, error) {
+				return mockBackend, nil
+			},
+			LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+				url string, project *workspace.Project, setCurrent bool, color colors.Colorization,
+			) (backend.Backend, error) {
+				return mockBackend, nil
+			},
+		})
+		testFilterOnName(t, env.MapStore{
+			"PULUMI_DISABLE_REGISTRY_RESOLVE": "false",
+			"PULUMI_EXPERIMENTAL":             "true",
+		})
+	})
 }
 
 //nolint:paralleltest // replaces global backend instance
-func TestMultipleTemplateSources(t *testing.T) {
+func TestMultipleTemplateSources_OrgTemplates(t *testing.T) {
 	ctx := testContext(t)
 
 	template1 := &apitype.PulumiTemplateRemote{
@@ -159,7 +222,9 @@ description: An ASP.NET application running a simple container in a EKS Cluster
 
 	source := newImpl(ctx, "",
 		ScopeAll, workspace.TemplateKindPulumiProject,
-		repoTemplates,
+		repoTemplates, env.NewEnv(env.MapStore{
+			"PULUMI_DISABLE_REGISTRY_RESOLVE": "true",
+		}),
 	)
 
 	template, err := source.Templates()
@@ -179,7 +244,7 @@ description: An ASP.NET application running a simple container in a EKS Cluster
 }
 
 //nolint:paralleltest // replaces global backend instance
-func TestSurfaceListTemplateErrors(t *testing.T) {
+func TestSurfaceListTemplateErrors_OrgTemplates(t *testing.T) {
 	ctx := testContext(t)
 
 	somethingWentWrong := errors.New("something went wrong")
@@ -212,6 +277,7 @@ func TestSurfaceListTemplateErrors(t *testing.T) {
 	source := newImpl(ctx, "name1",
 		ScopeAll, workspace.TemplateKindPulumiProject,
 		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+		env.NewEnv(env.MapStore{"PULUMI_DISABLE_REGISTRY_RESOLVE": "true"}),
 	)
 
 	_, err := source.Templates()
@@ -219,7 +285,52 @@ func TestSurfaceListTemplateErrors(t *testing.T) {
 }
 
 //nolint:paralleltest // replaces global backend instance
-func TestSurfaceOnEmptyError(t *testing.T) {
+func TestSurfaceListTemplateErrors_RegistryTemplates(t *testing.T) {
+	ctx := testContext(t)
+
+	somethingWentWrong := errors.New("something went wrong")
+
+	mockRegistry := &backend.MockCloudRegistry{
+		ListTemplatesF: func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+			return func(yield func(apitype.TemplateMetadata, error) bool) {
+				yield(apitype.TemplateMetadata{}, somethingWentWrong)
+			}
+		},
+	}
+
+	mockBackend := &backend.MockBackend{
+		GetReadOnlyCloudRegistryF: func() registry.Registry { return mockRegistry },
+	}
+	testutil.MockBackendInstance(t, mockBackend)
+
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+	})
+
+	source := newImpl(ctx, "name1",
+		ScopeAll, workspace.TemplateKindPulumiProject,
+		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+		env.NewEnv(env.MapStore{
+			"PULUMI_DISABLE_REGISTRY_RESOLVE": "false",
+			"PULUMI_EXPERIMENTAL":             "true",
+		}),
+	)
+
+	_, err := source.Templates()
+	assert.ErrorIs(t, err, somethingWentWrong)
+}
+
+//nolint:paralleltest // replaces global backend instance
+func TestSurfaceOnEmptyError_OrgTemplates(t *testing.T) {
 	ctx := testContext(t)
 
 	mockBackend := &backend.MockBackend{
@@ -250,6 +361,9 @@ func TestSurfaceOnEmptyError(t *testing.T) {
 	source := newImpl(ctx, "name1",
 		ScopeAll, workspace.TemplateKindPulumiProject,
 		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+		env.NewEnv(env.MapStore{
+			"PULUMI_DISABLE_REGISTRY_RESOLVE": "true",
+		}),
 	)
 
 	_, err := source.Templates()
@@ -258,7 +372,50 @@ func TestSurfaceOnEmptyError(t *testing.T) {
 }
 
 //nolint:paralleltest // replaces global backend instance
-func TestOrgTemplateDownload(t *testing.T) {
+func TestSurfaceOnEmptyError_RegistryTemplates(t *testing.T) {
+	ctx := testContext(t)
+
+	mockRegistry := &backend.MockCloudRegistry{
+		ListTemplatesF: func(_ context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+			return func(func(apitype.TemplateMetadata, error) bool) {}
+		},
+	}
+	mockBackend := &backend.MockBackend{
+		GetReadOnlyCloudRegistryF: func() registry.Registry {
+			return mockRegistry
+		},
+	}
+	testutil.MockBackendInstance(t, mockBackend)
+
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+	})
+
+	source := newImpl(ctx, "name1",
+		ScopeAll, workspace.TemplateKindPulumiProject,
+		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+		env.NewEnv(env.MapStore{
+			"PULUMI_DISABLE_REGISTRY_RESOLVE": "false",
+			"PULUMI_EXPERIMENTAL":             "true",
+		}),
+	)
+
+	_, err := source.Templates()
+	var expected workspace.TemplateNotFoundError
+	assert.ErrorAsf(t, err, &expected, "what's in %#v", source.errorOnEmpty)
+}
+
+//nolint:paralleltest // replaces global backend instance
+func TestTemplateDownload_Org(t *testing.T) {
 	ctx := testContext(t)
 
 	template1 := &apitype.PulumiTemplateRemote{
@@ -317,6 +474,9 @@ description: An ASP.NET application running a simple container in a EKS Cluster
 	source := newImpl(ctx, "name1",
 		ScopeAll, workspace.TemplateKindPulumiProject,
 		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+		env.NewEnv(env.MapStore{
+			"PULUMI_DISABLE_REGISTRY_RESOLVE": "true",
+		}),
 	)
 
 	template, err := source.Templates()
@@ -343,6 +503,201 @@ description: An ASP.NET application running a simple container in a EKS Cluster
 	}
 }
 
+//nolint:paralleltest // replaces global backend instance
+func TestTemplateDownload_Registry(t *testing.T) {
+	ctx := testContext(t)
+
+	pulumiYAML := `name: template1
+runtime: dotnet
+description: An ASP.NET application running a simple container in a EKS Cluster
+`
+	anotherFile := `This is another file`
+
+	mockRegistry := &backend.MockCloudRegistry{
+		ListTemplatesF: func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+			return func(yield func(apitype.TemplateMetadata, error) bool) {
+				yield(apitype.TemplateMetadata{
+					Name:        "name1",
+					DownloadURL: "example.com/download/name",
+				}, nil)
+			}
+		},
+		DownloadTemplateF: func(ctx context.Context, downloadURL string) (io.ReadCloser, error) {
+			assert.Equal(t, "example.com/download/name", downloadURL)
+			var target bytes.Buffer
+			w := tar.NewWriter(&target)
+
+			// Write Pulumi.yaml
+			require.NoError(t, w.WriteHeader(&tar.Header{
+				Name: "Pulumi.yaml",
+				Size: int64(len(pulumiYAML)),
+				Mode: 0o600,
+			}))
+			_, err := w.Write([]byte(pulumiYAML))
+			require.NoError(t, err)
+
+			// Write other.txt
+			require.NoError(t, w.WriteHeader(&tar.Header{
+				Name: "other.txt",
+				Size: int64(len(anotherFile)),
+				Mode: 0o600,
+			}))
+			_, err = w.Write([]byte(anotherFile))
+			require.NoError(t, err)
+
+			// Close the writers
+			require.NoError(t, w.Close())
+
+			return io.NopCloser(&target), nil
+		},
+	}
+	mockBackend := &backend.MockBackend{
+		GetReadOnlyCloudRegistryF: func() registry.Registry { return mockRegistry },
+	}
+	testutil.MockBackendInstance(t, mockBackend)
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{ /* panic on use */ })
+
+	source := newImpl(ctx, "name1",
+		ScopeAll, workspace.TemplateKindPulumiProject,
+		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+		env.NewEnv(env.MapStore{
+			"PULUMI_DISABLE_REGISTRY_RESOLVE": "false",
+			"PULUMI_EXPERIMENTAL":             "true",
+		}),
+	)
+
+	template, err := source.Templates()
+	require.NoError(t, err)
+	require.Len(t, template, 1)
+	assert.Equal(t, "name1", template[0].Name())
+	t.Cleanup(func() {
+		assert.NoError(t, source.Close())
+	})
+
+	wTemplate, err := template[0].Download(ctx)
+	require.NoError(t, err)
+
+	{ // Pulumi.yaml
+		file, err := os.ReadFile(filepath.Join(wTemplate.Dir, "Pulumi.yaml"))
+		require.NoError(t, err)
+		assert.Equal(t, pulumiYAML, string(file))
+	}
+	{ // other.txt
+		file, err := os.ReadFile(filepath.Join(wTemplate.Dir, "other.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, anotherFile, string(file))
+	}
+}
+
+//nolint:paralleltest // replaces global backend instance
+func TestVCSBasedTemplateNames(t *testing.T) {
+	ctx := testContext(t)
+	mockRegistry := &backend.MockCloudRegistry{
+		ListTemplatesF: func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+			assert.Nil(t, name)
+			return func(yield func(apitype.TemplateMetadata, error) bool) {
+				if !yield(apitype.TemplateMetadata{
+					Name:      "gh-org/repo/name",
+					Source:    "github",
+					Publisher: "pulumi-org",
+				}, nil) {
+					return
+				}
+				if !yield(apitype.TemplateMetadata{
+					Name:      "gl-org/repo/name",
+					Source:    "gitlab",
+					Publisher: "pulumi-org",
+				}, nil) {
+					return
+				}
+				if !yield(apitype.TemplateMetadata{
+					Name:      "just/has/slashes",
+					Source:    "private",
+					Publisher: "pulumi-org",
+				}, nil) {
+					return
+				}
+			}
+		},
+	}
+	mockBackend := &backend.MockBackend{
+		GetReadOnlyCloudRegistryF: func() registry.Registry { return mockRegistry },
+	}
+	testutil.MockBackendInstance(t, mockBackend)
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{ /* panic on use */ })
+
+	source := newImpl(ctx, "", ScopeAll, workspace.TemplateKindPulumiProject,
+		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+		env.NewEnv(env.MapStore{
+			"PULUMI_DISABLE_REGISTRY_RESOLVE": "false",
+			"PULUMI_EXPERIMENTAL":             "true",
+		}))
+
+	templates, err := source.Templates()
+	require.NoError(t, err)
+	require.Len(t, templates, 3)
+
+	assert.Equal(t, "name", templates[0].Name())
+	assert.Equal(t, "name", templates[1].Name())
+	assert.Equal(t, "just/has/slashes", templates[2].Name())
+}
+
+//nolint:paralleltest // replaces global backend instance
+func TestVCSBasedTemplateNameFilter(t *testing.T) {
+	ctx := testContext(t)
+	mockRegistry := &backend.MockCloudRegistry{
+		ListTemplatesF: func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+			assert.Nil(t, name)
+			return func(yield func(apitype.TemplateMetadata, error) bool) {
+				if !yield(apitype.TemplateMetadata{
+					Name:        "gh-org/repo/target",
+					Source:      "github",
+					Description: ref("This is from GH"),
+					Publisher:   "pulumi-org",
+				}, nil) {
+					return
+				}
+				if !yield(apitype.TemplateMetadata{
+					Name:      "gl-org/repo/name",
+					Source:    "gitlab",
+					Publisher: "pulumi-org",
+				}, nil) {
+					return
+				}
+				if !yield(apitype.TemplateMetadata{
+					Name:        "target",
+					Source:      "private",
+					Description: ref("This is from the registry"),
+					Publisher:   "pulumi-org",
+				}, nil) {
+					return
+				}
+			}
+		},
+	}
+	mockBackend := &backend.MockBackend{
+		GetReadOnlyCloudRegistryF: func() registry.Registry { return mockRegistry },
+	}
+	testutil.MockBackendInstance(t, mockBackend)
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{ /* panic on use */ })
+
+	source := newImpl(ctx, "target", ScopeAll, workspace.TemplateKindPulumiProject,
+		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+		env.NewEnv(env.MapStore{
+			"PULUMI_DISABLE_REGISTRY_RESOLVE": "false",
+			"PULUMI_EXPERIMENTAL":             "true",
+		}))
+
+	templates, err := source.Templates()
+	require.NoError(t, err)
+	require.Len(t, templates, 2)
+
+	assert.Equal(t, "target", templates[0].Name())
+	assert.Equal(t, "This is from GH", templates[0].ProjectDescription())
+	assert.Equal(t, "target", templates[1].Name())
+	assert.Equal(t, "This is from the registry", templates[1].ProjectDescription())
+}
+
 func templateRepository(repo workspace.TemplateRepository, err error) getWorkspaceTemplateFunc {
 	return func(ctx context.Context, templateNamePathOrURL string, offline bool,
 		templateKind workspace.TemplateKind,
@@ -357,3 +712,5 @@ func testContext(t *testing.T) context.Context {
 	t.Cleanup(cancel)
 	return ctx
 }
+
+func ref[T any](v T) *T { return &v }

--- a/sdk/go/common/registry/registry.go
+++ b/sdk/go/common/registry/registry.go
@@ -16,6 +16,7 @@ package registry
 
 import (
 	"context"
+	"io"
 	"iter"
 	"sync"
 
@@ -60,6 +61,10 @@ type Registry interface {
 	// plan for deprecation. The safest way to do this is to flag functionality behind
 	// `PULUMI_EXPERIMENTAL`, which removes any backwards comparability requirements.
 	ListTemplates(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error]
+
+	// DownloadTemplate downloads a template given the value of
+	// [apitype.TemplateMetadata].DownloadURL.
+	DownloadTemplate(ctx context.Context, downloadURL string) (io.ReadCloser, error)
 }
 
 type registryKey struct{}
@@ -127,4 +132,14 @@ func (r *onDemandRegistry) ListTemplates(
 		}
 	}
 	return impl.ListTemplates(ctx, name)
+}
+
+func (r *onDemandRegistry) DownloadTemplate(
+	ctx context.Context, downloadURL string,
+) (io.ReadCloser, error) {
+	impl, err := r.factory()
+	if err != nil {
+		return nil, err
+	}
+	return impl.DownloadTemplate(ctx, downloadURL)
 }

--- a/sdk/go/common/registry/registry_test.go
+++ b/sdk/go/common/registry/registry_test.go
@@ -17,6 +17,7 @@ package registry
 import (
 	"context"
 	"errors"
+	"io"
 	"iter"
 	"testing"
 
@@ -37,6 +38,8 @@ type mockRegistry struct {
 		ctx context.Context, source, publisher, name string, version *semver.Version,
 	) (apitype.TemplateMetadata, error)
 	listTemplates func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error]
+
+	downloadTemplate func(ctx context.Context, downloadURL string) (io.ReadCloser, error)
 }
 
 func (r mockRegistry) GetPackage(
@@ -57,6 +60,10 @@ func (r mockRegistry) GetTemplate(
 
 func (r mockRegistry) ListTemplates(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
 	return r.listTemplates(ctx, name)
+}
+
+func (r mockRegistry) DownloadTemplate(ctx context.Context, downloadURL string) (io.ReadCloser, error) {
+	return r.downloadTemplate(ctx, downloadURL)
 }
 
 func TestOnDemandRegistry(t *testing.T) {


### PR DESCRIPTION
> [!IMPORTANT]  
> This feature is experimental, and only enabled when `PULUMI_EXPERIMENTAL=1` is set.

Use the new Pulumi Registry based API for template lookup. This replaces org based template lookup by default. As with registry based package and plugin name resolution, setting `PULUMI_DISABLE_REGISTRY_RESOLVE` disables the new behavior.

The new endpoint is faster, much more ergonomic and includes the templates published with `pulumi template publish`.

Fixes https://github.com/pulumi/pulumi-service/issues/29500