### PR TITLE
fix typo in changelog

### DIFF
--- a/changelog/pending/20250623--engine--fix-untargetted-resources-not-always-being-sent-to-stack-analysis.yaml
+++ b/changelog/pending/20250623--engine--fix-untargetted-resources-not-always-being-sent-to-stack-analysis.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: engine
-  description: Fix untargetted resources not always being sent to stack analysis
+  description: Fix untargeted resources not always being sent to stack analysis


### PR DESCRIPTION
Just noticed this while looking at a PR after it was already merged.