### PR TITLE
include full command path in the metadata

### DIFF
--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -559,7 +559,7 @@ func getCLIMetadata(cmd *cobra.Command) map[string]string {
 		return nil
 	}
 
-	command := cmd.Name()
+	command := cmd.CommandPath()
 
 	var flags strings.Builder
 	i := 0


### PR DESCRIPTION
Currently we only include the name of the command in the CLI metadata. This can be confusing in some cases, as e.g. `pulumi stack rename` and `pulumi state rename` both exist, and `cmd.Name()` would return `rename` for both.  Make this information a little more useful by including the full command path, which would make the name `pulumi stack rename` and `pulumi state rename` respecively, making it possible to distinguish them.