### PR TITLE
Add `preview_destroy` for the Python Automation API

### DIFF
--- a/changelog/pending/20250625--auto-python--add-preview_destroy-to-allow-dry-runs-of-destroy-commands.yaml
+++ b/changelog/pending/20250625--auto-python--add-preview_destroy-to-allow-dry-runs-of-destroy-commands.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/python
+  description: Add `preview_destroy` to allow dry-runs of `destroy` commands


### PR DESCRIPTION
Similarly to #19900, this PR adds the `preview_destroy` command and deprecates the `preview_only` flag for `destroy`. The aforementioned PR explains the problem, but in short, the change summary for `destroy(preview_only=True)` is inaccurate.