### PR TITLE
Bump `pulumi-java` for the next release

### DIFF
--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -28,7 +28,7 @@ download_release() {
 # * When updating .Net, you should also update PulumiDotnetSDKVersion in pulumi/pkg/codegen/testing/test/helpers.go
 #
 # shellcheck disable=SC2043
-for i in "github.com/pulumi/pulumi-java java v1.13.1" "github.com/pulumi/pulumi-yaml yaml v1.21.1" "github.com/pulumi/pulumi-dotnet dotnet v3.84.0"; do
+for i in "github.com/pulumi/pulumi-java java v1.13.2" "github.com/pulumi/pulumi-yaml yaml v1.21.1" "github.com/pulumi/pulumi-dotnet dotnet v3.84.0"; do
   set -- $i # treat strings in loop as args
   REPO="$1"
   PULUMI_LANG="$2"


### PR DESCRIPTION
`pulumi-java` is now on `v1.13.2`.