### PR TITLE
Restore hash values in assets and archives after transforms

### DIFF
--- a/changelog/pending/20250626--engine--restore-asset-and-archive-hash-values-after-transforms.yaml
+++ b/changelog/pending/20250626--engine--restore-asset-and-archive-hash-values-after-transforms.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Restore asset and archive hash values after transforms

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -1456,11 +1456,12 @@ func (rm *resmon) wrapTransformCallback(cb *pulumirpc.Callback) (TransformFuncti
 			name, typ, custom, parent, props, opts)
 
 		mopts := plugin.MarshalOptions{
-			KeepUnknowns:     true,
-			KeepSecrets:      true,
-			KeepResources:    true,
-			KeepOutputValues: true,
-			WorkingDirectory: rm.workingDirectory,
+			KeepUnknowns:       true,
+			KeepSecrets:        true,
+			KeepResources:      true,
+			KeepOutputValues:   true,
+			WorkingDirectory:   rm.workingDirectory,
+			ComputeAssetHashes: true,
 		}
 
 		mprops, err := plugin.MarshalProperties(props, mopts)


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/17792

Not all SDKs maintain the 'hash' values of asset and archive objects in their in-memory model. As such when running transforms even if the transform is just the `id` function the asset and archive objects can lose their hash values. Providers rely on these values for diff'ing so this can lead to recurring diffs.

This fixes the engine to recompute hashes when reading values from transforms, the same as we recompute them when reading the initial values from the program.