### PR TITLE
Add PULUMI_AUTOMATION_API marker env variable and add to metadata

### DIFF
--- a/changelog/pending/20250627--sdk-go-nodejs-python--add-pulumi_automation_api.yaml
+++ b/changelog/pending/20250627--sdk-go-nodejs-python--add-pulumi_automation_api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/go,nodejs,python
+  description: Add PULUMI_AUTOMATION_API

--- a/sdk/go/auto/cmd.go
+++ b/sdk/go/auto/cmd.go
@@ -279,6 +279,7 @@ func (p pulumiCommand) Run(ctx context.Context,
 	cmd := exec.CommandContext(ctx, p.command, args...) //nolint:gosec
 	cmd.Dir = workdir
 	env := append(os.Environ(), additionalEnv...)
+	env = append(env, "PULUMI_AUTOMATION_API=true")
 	if filepath.IsAbs(p.command) {
 		pulumiBin := filepath.Dir(p.command)
 		env = fixupPath(env, pulumiBin)

--- a/sdk/nodejs/automation/cmd.ts
+++ b/sdk/nodejs/automation/cmd.ts
@@ -171,16 +171,18 @@ export class PulumiCommand {
             args.push("--non-interactive");
         }
 
+        const env = { ...additionalEnv };
         // Prepend the folder where the CLI is installed to the path to ensure
         // we pickup the matching bundled plugins.
         if (path.isAbsolute(this.command)) {
             const pulumiBin = path.dirname(this.command);
             const sep = os.platform() === "win32" ? ";" : ":";
             const envPath = pulumiBin + sep + (additionalEnv["PATH"] || process.env.PATH);
-            additionalEnv["PATH"] = envPath;
+            env["PATH"] = envPath;
         }
+        env["PULUMI_AUTOMATION_API"] = "true";
 
-        return exec(this.command, args, cwd, additionalEnv, onOutput, onError, signal);
+        return exec(this.command, args, cwd, env, onOutput, onError, signal);
     }
 }
 

--- a/sdk/python/lib/pulumi/automation/_cmd.py
+++ b/sdk/python/lib/pulumi/automation/_cmd.py
@@ -201,7 +201,11 @@ class PulumiCommand:
         # This causes commands to fail rather than prompting for input (and thus hanging indefinitely).
         if "--non-interactive" not in args:
             args.append("--non-interactive")
-        env = {**os.environ, **additional_env}
+        env = {
+            **os.environ,
+            **additional_env,
+            "PULUMI_AUTOMATION_API": "true",
+        }
         if os.path.isabs(self.command):
             env = _fixup_path(env, os.path.dirname(self.command))
         cmd = [self.command]


### PR DESCRIPTION
Always set `PULUMI_AUTOMATION_API=true` in Automation API calls and pass it through to metadata.