### PR TITLE
Filter delete steps while building

### DIFF
--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1903,7 +1903,7 @@ func (sg *stepGenerator) GenerateDeletes(targetsOpt UrnTargets, excludesOpt UrnT
 		return nil, err
 	}
 
-	filter := func(res *resource.State) bool {
+	isTargeted := func(res *resource.State) bool {
 		if allowedResourcesToDelete != nil {
 			_, has := allowedResourcesToDelete[res.URN]
 			return has
@@ -1925,7 +1925,7 @@ func (sg *stepGenerator) GenerateDeletes(targetsOpt UrnTargets, excludesOpt UrnT
 				continue
 			}
 
-			if filter(res) {
+			if isTargeted(res) {
 				// If this resource is explicitly marked for deletion or wasn't seen at all, delete it.
 				if res.Delete {
 					// The below assert is commented-out because it's believed to be wrong.
@@ -1987,7 +1987,7 @@ func (sg *stepGenerator) GenerateDeletes(targetsOpt UrnTargets, excludesOpt UrnT
 	// We also need to delete all the new resources that we created/updated/samed if this is a destroy
 	// operation.
 	for _, res := range sg.toDelete {
-		if filter(res) {
+		if isTargeted(res) {
 			sg.deletes[res.URN] = true
 			oldViews := sg.deployment.GetOldViews(res.URN)
 			steps = append(steps, NewDeleteStep(sg.deployment, sg.deletes, res, oldViews))

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1887,6 +1887,34 @@ func (sg *stepGenerator) GenerateRefreshes(
 // registered in the new snapshot. It also generates delete steps for any resources that were marked for deletion
 // because of `destroy` mode.
 func (sg *stepGenerator) GenerateDeletes(targetsOpt UrnTargets, excludesOpt UrnTargets) ([]Step, error) {
+	// If -target was provided to either `pulumi update` or `pulumi destroy` then only delete
+	// resources that were specified.
+	var allowedResourcesToDelete map[resource.URN]bool
+	var forbiddenResourcesToDelete map[resource.URN]bool
+	var err error
+
+	if targetsOpt.IsConstrained() {
+		allowedResourcesToDelete, err = sg.determineAllowedResourcesToDeleteFromTargets(targetsOpt)
+	} else if excludesOpt.IsConstrained() {
+		forbiddenResourcesToDelete, err = sg.determineForbiddenResourcesToDeleteFromExcludes(excludesOpt)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	filter := func(res *resource.State) bool {
+		if allowedResourcesToDelete != nil {
+			_, has := allowedResourcesToDelete[res.URN]
+			return has
+		}
+		if forbiddenResourcesToDelete != nil {
+			_, has := forbiddenResourcesToDelete[res.URN]
+			return !has
+		}
+		return true
+	}
+
 	// Doesn't matter what order we build this list of steps in as we'll sort them in ScheduleDeletes.
 	steps := slice.Prealloc[Step](len(sg.toDelete))
 	if prev := sg.deployment.prev; prev != nil {
@@ -1897,56 +1925,61 @@ func (sg *stepGenerator) GenerateDeletes(targetsOpt UrnTargets, excludesOpt UrnT
 				continue
 			}
 
-			// If this resource is explicitly marked for deletion or wasn't seen at all, delete it.
-			if res.Delete {
-				// The below assert is commented-out because it's believed to be wrong.
-				//
-				// The original justification for this assert is that the author (swgillespie) believed that
-				// it was impossible for a single URN to be deleted multiple times in the same program.
-				// This has empirically been proven to be false - it is possible using today engine to construct
-				// a series of actions that puts arbitrarily many pending delete resources with the same URN in
-				// the snapshot.
-				//
-				// It is not clear whether or not this is OK. I (swgillespie), the author of this comment, have
-				// seen no evidence that it is *not* OK. However, concerns were raised about what this means for
-				// structural resources, and so until that question is answered, I am leaving this comment and
-				// assert in the code.
-				//
-				// Regardless, it is better to admit strange behavior in corner cases than it is to crash the CLI
-				// whenever we see multiple deletes for the same URN.
-				// contract.Assert(!sg.deletes[res.URN])
-				if sg.pendingDeletes[res] {
-					logging.V(7).Infof(
-						"Planner ignoring pending-delete resource (%v, %v) that was already deleted", res.URN, res.ID)
-					continue
-				}
+			if filter(res) {
+				// If this resource is explicitly marked for deletion or wasn't seen at all, delete it.
+				if res.Delete {
+					// The below assert is commented-out because it's believed to be wrong.
+					//
+					// The original justification for this assert is that the author (swgillespie) believed that
+					// it was impossible for a single URN to be deleted multiple times in the same program.
+					// This has empirically been proven to be false - it is possible using today engine to construct
+					// a series of actions that puts arbitrarily many pending delete resources with the same URN in
+					// the snapshot.
+					//
+					// It is not clear whether or not this is OK. I (swgillespie), the author of this comment, have
+					// seen no evidence that it is *not* OK. However, concerns were raised about what this means for
+					// structural resources, and so until that question is answered, I am leaving this comment and
+					// assert in the code.
+					//
+					// Regardless, it is better to admit strange behavior in corner cases than it is to crash the CLI
+					// whenever we see multiple deletes for the same URN.
+					// contract.Assert(!sg.deletes[res.URN])
+					if sg.pendingDeletes[res] {
+						logging.V(7).Infof(
+							"Planner ignoring pending-delete resource (%v, %v) that was already deleted", res.URN, res.ID)
+						continue
+					}
 
-				if sg.deletes[res.URN] {
-					logging.V(7).Infof(
-						"Planner is deleting pending-delete urn '%v' that has already been deleted", res.URN)
-				}
+					if sg.deletes[res.URN] {
+						logging.V(7).Infof(
+							"Planner is deleting pending-delete urn '%v' that has already been deleted", res.URN)
+					}
 
-				logging.V(7).Infof("Planner decided to delete '%v' due to replacement", res.URN)
-				sg.deletes[res.URN] = true
-				oldViews := sg.deployment.GetOldViews(res.URN)
-				steps = append(steps, NewDeleteReplacementStep(sg.deployment, sg.deletes, res, false, oldViews))
-			} else if sg.isOperatedOn(res.URN) {
-				logging.V(7).Infof("Planner decided to delete '%v'", res.URN)
-				sg.deletes[res.URN] = true
-				if !res.PendingReplacement {
+					logging.V(7).Infof("Planner decided to delete '%v' due to replacement", res.URN)
+					sg.deletes[res.URN] = true
 					oldViews := sg.deployment.GetOldViews(res.URN)
-					steps = append(steps, NewDeleteStep(sg.deployment, sg.deletes, res, oldViews))
-				} else {
-					steps = append(steps, NewRemovePendingReplaceStep(sg.deployment, res))
+					steps = append(steps, NewDeleteReplacementStep(sg.deployment, sg.deletes, res, false, oldViews))
+				} else if sg.isOperatedOn(res.URN) {
+					logging.V(7).Infof("Planner decided to delete '%v'", res.URN)
+					sg.deletes[res.URN] = true
+					if !res.PendingReplacement {
+						oldViews := sg.deployment.GetOldViews(res.URN)
+						steps = append(steps, NewDeleteStep(sg.deployment, sg.deletes, res, oldViews))
+					} else {
+						steps = append(steps, NewRemovePendingReplaceStep(sg.deployment, res))
+					}
 				}
-			}
 
-			// We just added a Delete step, so we need to ensure the provider for this resource is available.
-			if sg.deletes[res.URN] {
-				err := sg.deployment.EnsureProvider(res.Provider)
-				if err != nil {
-					return nil, fmt.Errorf("could not load provider for resource %v: %w", res.URN, err)
+				// We just added a Delete step, so we need to ensure the provider for this resource is available.
+				if sg.deletes[res.URN] {
+					err := sg.deployment.EnsureProvider(res.Provider)
+					if err != nil {
+						return nil, fmt.Errorf("could not load provider for resource %v: %w", res.URN, err)
+					}
 				}
+			} else {
+				// Add this resource to the deployment.news so that it shows up in analysis.
+				sg.deployment.news.Store(res.URN, res)
 			}
 		}
 	}
@@ -1954,9 +1987,14 @@ func (sg *stepGenerator) GenerateDeletes(targetsOpt UrnTargets, excludesOpt UrnT
 	// We also need to delete all the new resources that we created/updated/samed if this is a destroy
 	// operation.
 	for _, res := range sg.toDelete {
-		sg.deletes[res.URN] = true
-		oldViews := sg.deployment.GetOldViews(res.URN)
-		steps = append(steps, NewDeleteStep(sg.deployment, sg.deletes, res, oldViews))
+		if filter(res) {
+			sg.deletes[res.URN] = true
+			oldViews := sg.deployment.GetOldViews(res.URN)
+			steps = append(steps, NewDeleteStep(sg.deployment, sg.deletes, res, oldViews))
+		} else {
+			// Add this resource to the deployment.news so that it shows up in analysis.
+			sg.deployment.news.Store(res.URN, res)
+		}
 	}
 
 	// Check each proposed delete against the relevant resource plan
@@ -1994,49 +2032,6 @@ func (sg *stepGenerator) GenerateDeletes(targetsOpt UrnTargets, excludesOpt UrnT
 			}
 			resourcePlan.Ops = append(resourcePlan.Ops, s.Op())
 		}
-	}
-
-	// If -target was provided to either `pulumi update` or `pulumi destroy` then only delete
-	// resources that were specified.
-	var allowedResourcesToDelete map[resource.URN]bool
-	var forbiddenResourcesToDelete map[resource.URN]bool
-	var err error
-
-	if targetsOpt.IsConstrained() {
-		allowedResourcesToDelete, err = sg.determineAllowedResourcesToDeleteFromTargets(targetsOpt)
-	} else if excludesOpt.IsConstrained() {
-		forbiddenResourcesToDelete, err = sg.determineForbiddenResourcesToDeleteFromExcludes(excludesOpt)
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	if allowedResourcesToDelete != nil {
-		filtered := []Step{}
-		for _, step := range steps {
-			if _, has := allowedResourcesToDelete[step.URN()]; has {
-				filtered = append(filtered, step)
-			} else {
-				// Add this step to the deployment.news so that it shows up in analysis.
-				sg.deployment.news.Store(step.URN(), step.Old())
-			}
-		}
-
-		steps = filtered
-	}
-
-	if forbiddenResourcesToDelete != nil {
-		filtered := []Step{}
-		for _, step := range steps {
-			if _, has := forbiddenResourcesToDelete[step.URN()]; !has {
-				filtered = append(filtered, step)
-			} else {
-				sg.deployment.news.Store(step.URN(), step.Old())
-			}
-		}
-
-		steps = filtered
 	}
 
 	deletingUnspecifiedTarget := false


### PR DESCRIPTION
Rather than building all the delete steps then filtering them by --targets and --excludes, just run the filtering logic as we build the steps. This also saves old providers being started up by "EnsureProvider" just to go unused.