### PR TITLE
Automatic ESM configuration

### DIFF
--- a/changelog/pending/20250630--sdk-nodejs--automatic-esm-configuration.yaml
+++ b/changelog/pending/20250630--sdk-nodejs--automatic-esm-configuration.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Automatic ESM configuration

--- a/sdk/nodejs/cmd/run/hooks.ts
+++ b/sdk/nodejs/cmd/run/hooks.ts
@@ -1,0 +1,35 @@
+// Copyright 2025-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file will be loaded by Node.js to setup TypeScript transpilation import
+// hooks when we're running in automatic ESM mode.
+
+import * as tsn from "ts-node";
+
+let options: any = null;
+
+/**
+ * Called by Node.js when the hooks are registered in `run.ts`.
+ */
+export async function initialize(args: any) {
+    options = args;
+}
+
+const makeHooks = () => {
+    const service = tsn.register(options);
+    // @ts-ignore we're using a version of ts-node that has ts-node/esm available.
+    return tsn.createEsmHooks(service);
+};
+
+export const { resolve, load, getFormat, transformSource } = makeHooks();

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -22,6 +22,11 @@ import * as path from "path";
 import * as semver from "semver";
 import * as url from "url";
 import * as util from "util";
+// @ts-ignore This is available in all of our supported Node.js versions, but
+// our version of @types/node does not know this. However we can't update our
+// @types/node version because we need to continue supporting TypeScript 3.8.3.
+// https://nodejs.org/api/module.html#moduleregisterspecifier-parenturl-options
+import { register } from "module";
 import { ResourceError, RunError } from "../../errors";
 import * as log from "../../log";
 import { Inputs } from "../../output";
@@ -254,6 +259,33 @@ export async function run(
     const tsConfigPath: string = process.env["PULUMI_NODEJS_TSCONFIG_PATH"] ?? defaultTsConfigPath;
     const skipProject = !fs.existsSync(tsConfigPath);
 
+    const hasEntrypoint = argv._[0] !== ".";
+    let program: string = argv._[0];
+    if (!path.isAbsolute(program)) {
+        // If this isn't an absolute path, make it relative to the working directory.
+        program = path.join(process.cwd(), program);
+    }
+
+    const packageRoot = await npmPackageRootFromProgramPath(program);
+    const packageObject = packageObjectFromProjectRoot(packageRoot);
+
+    // If there is no entrypoint set in Pulumi.yaml via the main
+    // option, look for an entrypoint defined in package.json
+    if (!hasEntrypoint && packageObject["main"]) {
+        const packageMainPath = path.join(packageRoot, packageObject["main"]);
+        if (fs.existsSync(packageMainPath)) {
+            program = packageMainPath;
+        } else {
+            log.warn(
+                `Could not find entry point '${packageMainPath}' specified in package.json; ` +
+                    `using '${program}' instead`,
+            );
+        }
+    }
+
+    // Import path for `ts-node/esm`, if available.
+    let tsNodeESMRequire = "";
+
     span.setAttribute("typescript-enabled", typeScript);
     if (typeScript) {
         const compilerOptions = tsutils.loadTypeScriptCompilerOptions(tsConfigPath);
@@ -278,8 +310,7 @@ export async function run(
         }
 
         const { tsnodeRequire, typescriptRequire } = tsutils.typeScriptRequireStrings();
-        const tsn: typeof tsnode = require(tsnodeRequire);
-        tsn.register({
+        const options = {
             compiler: typescriptRequire,
             transpileOnly,
             // PULUMI_NODEJS_TSCONFIG_PATH might be set to a config file such as "tsconfig.pulumi.yaml" which
@@ -287,21 +318,59 @@ export async function run(
             // use (Which might just be ./tsconfig.yaml)
             project: tsConfigPath,
             skipProject: skipProject,
-            compilerOptions: {
-                target: "es6",
+            compilerOptions: {},
+        };
+
+        // See if we can use the automatic ESM mode. We require that:
+        // * the project is an ES module
+        // * have TypeScript >= 4.7, which introduces `module: "nodenext"`
+        // * node is running without any other custom loader, we don't want to interfere with any custom setup.
+        // * ts-node/esm is available, this is only available in recent ts-node versions, but we're stuck
+        //   shipping a vendored version of 7.0.1. Users are free to install a more recent version in their
+        //   project, and we'll see if we can load that.
+        const hasLoaders = process.execArgv.find((arg) => arg === "--loader");
+        const isModule = packageObject["type"] === "module";
+        try {
+            tsNodeESMRequire = require.resolve("ts-node/esm");
+        } catch (err) {
+            // ts-node/esm not available, we'll use ts-node instead
+        }
+        const ts = require(typescriptRequire);
+        const tsVersion = semver.parse(ts.version);
+
+        if (
+            isModule &&
+            !hasLoaders &&
+            tsNodeESMRequire &&
+            tsVersion &&
+            tsVersion.compare(new semver.SemVer("4.7.0")) > 0
+        ) {
+            // All the conditions for automatic ESM mode are fullfilled.
+            options.compilerOptions = {
+                target: "ES2022", // TS >= 4.6 and Node >= 20 support this
+                module: "nodenext",
+                moduleResolution: "nodenext",
+                sourceMap: "true",
+                ...compilerOptions,
+            };
+            // We're on a recent ts-node with esm, we use the offical module.register API to setup our hooks.
+            // https://nodejs.org/api/module.html#moduleregisterspecifier-parenturl-options
+            register("./hooks.js", url.pathToFileURL(__filename), {
+                data: options,
+            });
+        } else {
+            // We're not in ESM mode, or running an older version of ts-node.
+            // Let ts-node deal with registration.
+            const tsn: typeof tsnode = require(tsnodeRequire);
+            options.compilerOptions = {
+                target: "ES2020", // TypeScript 3.8 supports this
                 module: "commonjs",
                 moduleResolution: "node",
                 sourceMap: "true",
                 ...compilerOptions,
-            },
-        });
-    }
-
-    const hasEntrypoint = argv._[0] !== ".";
-    let program: string = argv._[0];
-    if (!path.isAbsolute(program)) {
-        // If this isn't an absolute path, make it relative to the working directory.
-        program = path.join(process.cwd(), program);
+            };
+            tsn.register(options);
+        }
     }
 
     // Now fake out the process-wide argv, to make the program think it was run normally.
@@ -395,23 +464,7 @@ ${defaultErrorMessage(err)}`,
         const runProgramSpan = tracing.newSpan("language-runtime.runProgram");
 
         try {
-            const packageRoot = await npmPackageRootFromProgramPath(program);
-            const packageObject = packageObjectFromProjectRoot(packageRoot);
             let programExport: any;
-
-            // If there is no entrypoint set in Pulumi.yaml via the main
-            // option, look for an entrypoint defined in package.json
-            if (!hasEntrypoint && packageObject["main"]) {
-                const packageMainPath = path.join(packageRoot, packageObject["main"]);
-                if (fs.existsSync(packageMainPath)) {
-                    program = packageMainPath;
-                } else {
-                    log.warn(
-                        `Could not find entry point '${packageMainPath}' specified in package.json; ` +
-                            `using '${program}' instead`,
-                    );
-                }
-            }
 
             // We use dynamic import instead of require for projects using native ES modules instead of commonjs
             if (packageObject["type"] === "module") {
@@ -419,7 +472,30 @@ ${defaultErrorMessage(err)}`,
                 // See https://github.com/nodejs/node/blob/master/lib/internal/modules/run_main.js#L74.
                 const mainPath: string =
                     require("module").Module._findPath(path.resolve(program), null, true) || program;
-                const main = path.isAbsolute(mainPath) ? url.pathToFileURL(mainPath).href : mainPath;
+                let main = path.isAbsolute(mainPath) ? url.pathToFileURL(mainPath).href : mainPath;
+                const stat = await fspromises.lstat(url.fileURLToPath(main));
+                const isDirectory = stat.isDirectory();
+                // If we're using ts-node/esm, we need to ensure the path to the entrypoint is a file, not a directory.
+                if (isDirectory && tsNodeESMRequire !== "") {
+                    let index;
+                    if (fs.existsSync(path.join(mainPath, "index.js"))) {
+                        index = "index.js";
+                    } else if (fs.existsSync(path.join(mainPath, "index.mjs"))) {
+                        index = "index.mjs";
+                    } else if (fs.existsSync(path.join(mainPath, "index.ts"))) {
+                        index = "index.ts";
+                    } else if (fs.existsSync(path.join(mainPath, "index.mts"))) {
+                        index = "index.mts";
+                    } else {
+                        throw new Error(`No entrypoint found in ${mainPath}`);
+                    }
+                    if (main.startsWith("file:")) {
+                        const mainFilePath = url.fileURLToPath(main);
+                        main = url.pathToFileURL(path.join(mainFilePath, index)).href;
+                    } else {
+                        main = path.join(main, index);
+                    }
+                }
                 // Import the module and capture any module outputs it exported. Finally, await the value we get
                 // back.  That way, if it is async and throws an exception, we properly capture it here
                 // and handle it.

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -68,6 +68,7 @@
         "cmd/run/index.ts",
         "cmd/run/error.ts",
         "cmd/run/run.ts",
+        "cmd/run/hooks.ts",
         "cmd/run/tracing.ts",
         "cmd/run-plugin/index.ts",
         "cmd/run-plugin/run.ts",

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1306,6 +1306,45 @@ func TestESMTSAuto(t *testing.T) {
 	e.RunCommand("pulumi", "stack", "init", stackName)
 	e.RunCommand("pulumi", "stack", "select", stackName)
 	e.RunCommand("pulumi", "up", "--yes")
+	// Validate the stack outputs
+	stdout, _ := e.RunCommand("pulumi", "stack", "export")
+	var stackExport map[string]any
+	err = json.Unmarshal([]byte(stdout), &stackExport)
+	require.NoError(t, err)
+	resources, ok := stackExport["deployment"].(map[string]any)["resources"].([]any)
+	require.True(t, ok)
+	require.Greater(t, len(resources), 0)
+	stack := resources[0].(map[string]any)
+	outputs, ok := stack["outputs"].(map[string]any)
+	require.True(t, ok)
+	expected := map[string]any{
+		"otherx": 42.0,
+		"res":    "name: esm-ts\nruntime: nodejs\ndescription: Use ECMAScript modules for a TS program, without explicitly setting ts-node/esm as a --loader option\n",
+	}
+	require.Equal(t, expected, outputs)
+	e.RunCommand("pulumi", "destroy", "--skip-preview", "--refresh=true")
+}
+
+func TestESMTSAutoTypeCheck(t *testing.T) {
+	t.Parallel()
+	dir := filepath.Join("nodejs", "esm-ts-auto-typecheck")
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+	e.ImportDirectory(dir)
+	stackName := ptesting.RandomStackName()
+	// For this test we need to properly install the core SDK instead of yarn
+	// linkining, because yarn link breaks finding an alternative ts-node
+	// installation. This would cause the test to fallback to the vendored
+	// ts-node, which does not provide ts-node/esm.
+	coreSDK, err := filepath.Abs(filepath.Join("..", "..", "sdk", "nodejs", "bin"))
+	require.NoError(t, err)
+	e.RunCommand("yarn", "install")
+	e.RunCommand("yarn", "add", coreSDK)
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.RunCommand("pulumi", "stack", "init", stackName)
+	e.RunCommand("pulumi", "stack", "select", stackName)
+	stdout, _ := e.RunCommandExpectError("pulumi", "up", "--yes")
+	require.Contains(t, stdout, "index.ts(3,14): error TS2322: Type 'number' is not assignable to type 'string'.")
 	e.RunCommand("pulumi", "destroy", "--skip-preview", "--refresh=true")
 }
 

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1319,7 +1319,10 @@ func TestESMTSAuto(t *testing.T) {
 	require.True(t, ok)
 	expected := map[string]any{
 		"otherx": 42.0,
-		"res":    "name: esm-ts\nruntime: nodejs\ndescription: Use ECMAScript modules for a TS program, without explicitly setting ts-node/esm as a --loader option\n",
+		"res": `name: esm-ts
+runtime: nodejs
+description: Use ECMAScript modules for a TS program, without explicitly setting ts-node/esm as a --loader option
+`,
 	}
 	require.Equal(t, expected, outputs)
 	e.RunCommand("pulumi", "destroy", "--skip-preview", "--refresh=true")

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1317,15 +1317,12 @@ func TestESMTSAuto(t *testing.T) {
 	stack := resources[0].(map[string]any)
 	outputs, ok := stack["outputs"].(map[string]any)
 	require.True(t, ok)
-	expected := map[string]any{
-		"otherx": 42.0,
-		"res": `name: esm-ts
-runtime: nodejs
-description: Use ECMAScript modules for a TS program, without explicitly setting ts-node/esm as a --loader option
-`,
-	}
-	require.Equal(t, expected, outputs)
-	e.RunCommand("pulumi", "destroy", "--skip-preview", "--refresh=true")
+	require.Equal(t, 42.0, outputs["otherx"])
+	require.Contains(t,
+		outputs["res"],
+		"Use ECMAScript modules for a TS program, without explicitly setting ts-node/esm as a --loader option",
+	)
+	e.RunCommand("pulumi", "destroy", "--skip-preview")
 }
 
 func TestESMTSAutoTypeCheck(t *testing.T) {

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1296,7 +1296,7 @@ func TestESMTSAuto(t *testing.T) {
 	stackName := ptesting.RandomStackName()
 	// For this test we need to properly install the core SDK instead of yarn
 	// linkining, because yarn link breaks finding an alternative ts-node
-	// installation. This would cause th test to fallback to the vendored
+	// installation. This would cause the test to fallback to the vendored
 	// ts-node, which does not provide ts-node/esm.
 	coreSDK, err := filepath.Abs(filepath.Join("..", "..", "sdk", "nodejs", "bin"))
 	require.NoError(t, err)

--- a/tests/integration/nodejs/esm-ts-auto-typecheck/Pulumi.yaml
+++ b/tests/integration/nodejs/esm-ts-auto-typecheck/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: esm-ts
+runtime: nodejs
+description: Use ECMAScript modules for a TS program, without explicitly setting ts-node/esm as a --loader option

--- a/tests/integration/nodejs/esm-ts-auto-typecheck/index.ts
+++ b/tests/integration/nodejs/esm-ts-auto-typecheck/index.ts
@@ -1,3 +1,3 @@
 // Copyright 2025, Pulumi Corporation.  All rights reserved.
 
-export const x = 42;
+export const expectTypeErrorHere: string = 123;

--- a/tests/integration/nodejs/esm-ts-auto-typecheck/package.json
+++ b/tests/integration/nodejs/esm-ts-auto-typecheck/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "esm-ts",
+    "license": "Apache-2.0",
+    "type": "module",
+    "devDependencies": {
+        "@types/node": "^20.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    },
+    "dependencies": {
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.3"
+    }
+}

--- a/tests/integration/nodejs/esm-ts-auto-typecheck/tsconfig.json
+++ b/tests/integration/nodejs/esm-ts-auto-typecheck/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "esnext",
+        "module": "nodenext",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/integration/nodejs/esm-ts-auto/Pulumi.yaml
+++ b/tests/integration/nodejs/esm-ts-auto/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: esm-ts
+runtime: nodejs
+description: Use ECMAScript modules for a TS program, without explicitly setting ts-node/esm as a --loader option

--- a/tests/integration/nodejs/esm-ts-auto/index.ts
+++ b/tests/integration/nodejs/esm-ts-auto/index.ts
@@ -1,0 +1,15 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+import * as fs from "fs";
+import { x } from "./other.js"; // this is the "by design" way to do this, even in TS
+
+// Use top-level await
+await new Promise(r => setTimeout(r, 2000));
+
+// Template Literal Types were introduced in Typescript 4.1. Include a use of
+// this syntax here, to validate we're using the project's TypeScript version,
+// and not the vendored 3.8.3 compiler that ships with Pulumi.
+type EventName<T extends string> = `on${Capitalize<T>}`;
+
+export const res = fs.readFileSync("Pulumi.yaml").toString();
+export const otherx = x;

--- a/tests/integration/nodejs/esm-ts-auto/index.ts
+++ b/tests/integration/nodejs/esm-ts-auto/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+// Copyright 2025, Pulumi Corporation.  All rights reserved.
 
 import * as fs from "fs";
 import { x } from "./other.js"; // this is the "by design" way to do this, even in TS

--- a/tests/integration/nodejs/esm-ts-auto/other.ts
+++ b/tests/integration/nodejs/esm-ts-auto/other.ts
@@ -1,0 +1,1 @@
+export const x = 42;

--- a/tests/integration/nodejs/esm-ts-auto/package.json
+++ b/tests/integration/nodejs/esm-ts-auto/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "esm-ts",
+    "license": "Apache-2.0",
+    "type": "module",
+    "devDependencies": {
+        "@types/node": "^20.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    },
+    "dependencies": {
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.3"
+    }
+}

--- a/tests/integration/nodejs/esm-ts-auto/tsconfig.json
+++ b/tests/integration/nodejs/esm-ts-auto/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "esnext",
+        "module": "nodenext",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
We support native ESM mode (meaning modules are not transpiled to CommonJS, among other things), but it requires some explicit configuration, see https://www.pulumi.com/docs/iac/languages-sdks/javascript/#native-esm-support

With this PR, we attempt to configure everything automatically.

If we detect manual configuration, we fallback to the old code path, to avoid messing with any custom configuration.
