### PR TITLE
Add a test for Node.js's type stripping

### DIFF
--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1366,6 +1366,27 @@ func TestESMWithPackageExports(t *testing.T) {
 	})
 }
 
+func TestTSTypeStripping(t *testing.T) {
+	t.Parallel()
+	// Skip this test if Node.js version is too old for automatic type stripping
+	nodeVersionOutput, err := exec.Command("node", "--version").Output()
+	require.NoError(t, err, "unable to determine Node.js version: %v", nodeVersionOutput)
+	nodeVersionStr := strings.TrimSpace(string(nodeVersionOutput))
+	nodeVersionStr = strings.TrimPrefix(nodeVersionStr, "v")
+	var major, minor int
+	_, err = fmt.Sscanf(nodeVersionStr, "%d.%d", &major, &minor)
+	require.NoError(t, err, "unable to parse Node.js version %s", nodeVersionStr)
+	if major < 23 || (major == 23 && minor < 6) {
+		t.Skipf("Skipping: Node.js version %d.%d is less than 23.6", major, minor)
+	}
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		NoParallel:   true,
+		Dir:          filepath.Join("nodejs", "ts-type-stripping"),
+		Dependencies: []string{"@pulumi/pulumi"},
+		Quick:        true,
+	})
+}
+
 //nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestTSWithPackageJsonInParentDir(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{

--- a/tests/integration/nodejs/ts-type-stripping/Pulumi.yaml
+++ b/tests/integration/nodejs/ts-type-stripping/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: ts-type-stripping
+runtime:
+  name: nodejs
+  options:
+    typescript: false # Disable running via ts-node
+description: Run Pulumi without ts-node, using Node.js's type stripping

--- a/tests/integration/nodejs/ts-type-stripping/main.ts
+++ b/tests/integration/nodejs/ts-type-stripping/main.ts
@@ -1,0 +1,11 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+import * as fs from "fs";
+import { x } from "./other.ts"; // When using type stripping, we use `.ts`, unlike ESM where you have to use `.js`.
+
+
+// Use top-level await
+await new Promise(r => setTimeout(r, 2000));
+
+export const res = fs.readFileSync("Pulumi.yaml").toString();
+export const otherx = x;

--- a/tests/integration/nodejs/ts-type-stripping/other.ts
+++ b/tests/integration/nodejs/ts-type-stripping/other.ts
@@ -1,0 +1,1 @@
+export const x = 42;

--- a/tests/integration/nodejs/ts-type-stripping/package.json
+++ b/tests/integration/nodejs/ts-type-stripping/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "esm-js-main",
+    "license": "Apache-2.0",
+    "type": "module",
+    "main": "main.ts",
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}


### PR DESCRIPTION
Starting with Node.js v23.6.0, types are automatically stripped from .ts
files and we can run without ts-node.

This only adds a properly configured test case. We want to continue
using ts-node by default, as it does typechecking, which is the default
Pulumi behaviour.

Note that versions above v22.6.0 also support a
`--experimental-strip-types` flag to enable this behaviour and users can
opt into that via the `nodeargs` option.

https://nodejs.org/en/learn/typescript/run-natively