### PR TITLE
Simplify cron-test-all branch selection

### DIFF
--- a/.github/workflows/cron-test-all.yml
+++ b/.github/workflows/cron-test-all.yml
@@ -7,13 +7,7 @@ permissions:
 on:
   schedule:
     - cron: "27 5 * * *"
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: "Branch to run tests on"
-        required: true
-        default: "master"
-        type: string
+  workflow_dispatch: {}
 
 jobs:
   info:
@@ -22,7 +16,7 @@ jobs:
     permissions:
       contents: read
     with:
-      ref: ${{ github.event.inputs.branch || github.ref }}
+      ref: ${{ github.ref }}
       is-snapshot: true
     secrets: inherit
 
@@ -34,7 +28,7 @@ jobs:
       contents: read
       id-token: write
     with:
-      ref: ${{ github.event.inputs.branch || github.ref }}
+      ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}
       lint: true
       # codegen tests are not the fastest, but we want to run all
@@ -58,7 +52,7 @@ jobs:
     permissions:
       contents: read
     with:
-      ref: ${{ github.event.inputs.branch || github.ref }}
+      ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}
       test-version-sets: 'all'
       performance-test-platforms: ubuntu-latest


### PR DESCRIPTION
I just added this in https://github.com/pulumi/pulumi/pull/19987, but when manually running a job, you can select the branch via the GitHub UI, there’s no need to make this a separate input.
