### PR TITLE
Fix the AI prompt flow for pulumi new

### DIFF
--- a/changelog/pending/20250702--cli-new--fix-the-ai-prompt-flow-of-pulumi-new-command.yaml
+++ b/changelog/pending/20250702--cli-new--fix-the-ai-prompt-flow-of-pulumi-new-command.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Fix the AI prompt flow of pulumi new command

--- a/pkg/cmd/pulumi/newcmd/new_ai_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_ai_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/util/testutil"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 //nolint:paralleltest // changes directory
@@ -54,8 +55,6 @@ func TestErrorsOnNonHTTPBackend(t *testing.T) {
 
 //nolint:paralleltest // changes directory for process, mocks backendInstance
 func TestGeneratingProjectWithAIPromptSucceeds(t *testing.T) {
-	// skipIfShortOrNoPulumiAccessToken(t)
-
 	tempdir := tempProjectDir(t)
 	chdir(t, tempdir)
 
@@ -84,8 +83,8 @@ func TestGeneratingProjectWithAIPromptSucceeds(t *testing.T) {
 	}
 
 	err := runNew(context.Background(), args)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	proj := loadProject(t, tempdir)
-	assert.Equal(t, projectName, proj.Name.String())
+	require.Equal(t, projectName, proj.Name.String())
 }

--- a/pkg/cmd/pulumi/newcmd/new_ai_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_ai_test.go
@@ -19,7 +19,9 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/util/testutil"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,10 +38,11 @@ func TestErrorsOnNonHTTPBackend(t *testing.T) {
 	})
 
 	testNewArgs := newArgs{
-		aiPrompt:        "prompt",
-		aiLanguage:      "typescript",
-		interactive:     true,
-		secretsProvider: "default",
+		aiPrompt:              "prompt",
+		aiLanguage:            "typescript",
+		interactive:           true,
+		secretsProvider:       "default",
+		promptForAIProjectURL: promptForAIProjectURL,
 	}
 
 	assert.ErrorContains(t,
@@ -47,4 +50,42 @@ func TestErrorsOnNonHTTPBackend(t *testing.T) {
 			context.Background(), testNewArgs,
 		),
 		"please log in to Pulumi Cloud to use Pulumi AI")
+}
+
+//nolint:paralleltest // changes directory for process, mocks backendInstance
+func TestGeneratingProjectWithAIPromptSucceeds(t *testing.T) {
+	// skipIfShortOrNoPulumiAccessToken(t)
+
+	tempdir := tempProjectDir(t)
+	chdir(t, tempdir)
+
+	testutil.MockBackendInstance(t, &backend.MockBackend{
+		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
+			return true, nil
+		},
+		SupportsTemplatesF: func() bool { return false },
+		NameF:              func() string { return "mock" },
+	})
+
+	// Generate-only command is not creating any stacks, so don't bother with with the name uniqueness check.
+	args := newArgs{
+		generateOnly: true,
+		interactive:  true,
+		prompt:       promptMock(projectName, ""),
+		promptForAIProjectURL: func(ctx context.Context, ws pkgWorkspace.Context,
+			args newArgs, opts display.Options,
+		) (string, error) {
+			// Return a plain template name so that we don't have to rely or a hard-coded AI path.
+			// This has the same effect and is good enough for the mock-based testing.
+			return "typescript", nil
+		},
+		secretsProvider:   "default",
+		templateNameOrURL: "", // <-- must be empty to trigger the AI flow
+	}
+
+	err := runNew(context.Background(), args)
+	assert.NoError(t, err)
+
+	proj := loadProject(t, tempdir)
+	assert.Equal(t, projectName, proj.Name.String())
 }


### PR DESCRIPTION
Fix https://github.com/pulumi/pulumi/issues/19994 which is a regression from https://github.com/pulumi/pulumi/pull/18627

The change is essentially moving the block which assigns `args.templateNameOrURL` above the call to `cmdTemplates.New` which uses `args.templateNameOrURL`. With the existing order, `args.templateNameOrURL` set to the AI URL was ignored.

The rest of the change is refactoring the AI prompting to a separate function and a test that mocks that function to a hard-coded value. 