### PR TITLE
Fix `stack select` when default organizations differ

### DIFF
--- a/changelog/pending/20250707--cli--fix-stack-select-when-default-organizations-differ.yaml
+++ b/changelog/pending/20250707--cli--fix-stack-select-when-default-organizations-differ.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix `stack select` when default organizations differ


### PR DESCRIPTION
Pulumi stacks are grouped by project, which are grouped by organization. Organizations are backend-specific. DIY backends have a single constant organization which is always named `organization`. Pulumi Cloud supports multiple organizations, with various features depending on the plan being used. Both the Pulumi CLI and Pulumi Cloud are capable of setting a *default organization* for a user, in which case the CLI's choice will always take precedence.

When rendering stack names, the *fully-qualified name* takes the form `<organization>/<project>/<stack>`. This is often a mouthful, so Pulumi will make efforts to render the minimum unambiguous string in many cases. For scenarios where the default organization matches that of the stack whose name is being rendered, the organization name can be omitted (leaving e.g. `<project>/<stack>`). The project name can be omitted similarly in many cases where it is obvious and/or unambiguous.

With the CLI and Cloud backend being able to have different views on what the user's default organization is, we must be careful to pick the right choice when rendering stack names. This change fixes an issue in the `stack select` command where we were not being careful enough. `stack select` retrieves both the currently-selected stack and the list of available stacks. The former, being loaded by the CLI, will be tagged with the CLI's opinion of the default organization, while the latter, coming from the backend will be tagged with the backend's. In the case that these defaults are different, we must spot this and fully-qualify all names. Aside from being clearer to users about what organization they are working in, this fixes a bug where Survey (our CLI prompting library) would throw an error if the default option was not one of the list of options provided.

Fixes #19598