### PR TITLE
Don't build all SDKs in the direct build job

### DIFF
--- a/.github/workflows/cron-direct-build.yml
+++ b/.github/workflows/cron-direct-build.yml
@@ -15,7 +15,7 @@ jobs:
           go-version: "1.24"
       - name: Build
         shell: bash
-        run: GOPROXY=direct make build
+        run: GOPROXY=direct SDKS="" make build
   sdk:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The `cron-direct-build` GitHub Action tests that Pulumi can be built when all modules are downloaded from version-controlled source (using `GOPROXY=direct`, see https://go.dev/ref/mod) rather than through a module proxy. Recent changes mean that `make build` will now attempt to build all SDKs by default. In the direct build workflow, these builds fail due to missing toolchains. This change restores the behaviour of the workflow by opting out of these sub-builds.

Fixes #20003