### PR TITLE
Fix ListStacks to use the same default-org logic as loading a single stack

### DIFF
--- a/changelog/pending/20250707--cli--fix-stack-select-when-local-default-org-differs-from-the-service-setting-for-default-org.yaml
+++ b/changelog/pending/20250707--cli--fix-stack-select-when-local-default-org-differs-from-the-service-setting-for-default-org.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix `stack select` when local default-org differs from the service setting for default-org

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1046,7 +1046,7 @@ func (b *cloudBackend) ListStacks(
 	// Since ListStacks is also a potentially long-running operation for power users with many stacks,
 	// this has the added benefit of ensuring that the default org is consistent for the duration of the
 	// operation, even if the user changes their default org mid-process.
-	defaultOrg, err := b.GetDefaultOrg(ctx)
+	defaultOrg, err := backend.GetDefaultOrg(ctx, b, b.currentProject)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/19598

There was an inconsistency between GetStack and ListStacks on deciding what the default org was. This could result in stacks from GetStack thinking the default org was A, and stacks from ListStacks thinking the default org was B.

When rendering out the names this could result in the same stack being rendered different. GetStack for "A/proj/stk" would print "stk" because it thought A was the default org, while ListStack would render "A/proj/stk" because it thought B was the default org.

When used in stack select code this could result in an error from the survey library as we gave it a list of stacks (including "A/proj/stk") but told it the default was just "stk" (which wasn't in the list).