### PR TITLE
Force SupportPack on for package add

### DIFF
--- a/changelog/pending/20250707--cli-package--force-new-style-go-modules-to-be-written-out-when-using-package-add.yaml
+++ b/changelog/pending/20250707--cli-package--force-new-style-go-modules-to-be-written-out-when-using-package-add.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/package
+  description: Force new style Go modules to be written out when using `package add`

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -53,6 +53,11 @@ func InstallPackage(ws pkgWorkspace.Context, pctx *plugin.Context, language, roo
 
 	local := true
 
+	// We _always_ want SupportPack turned on for `package add`, this is an option on schemas because it can change
+	// things like module paths for Go and we don't want every user using gen-sdk to be affected by that. But for
+	// `package add` we know that this is just a local package and it's ok for module paths and similar to be different.
+	pkg.SupportPack = true
+
 	err = GenSDK(
 		language,
 		tempOut,

--- a/tests/integration/packageadd-namespace/provider/schema.json
+++ b/tests/integration/packageadd-namespace/provider/schema.json
@@ -1,5 +1,6 @@
 {
   "name": "mypkg",
+  "version": "0.1.0",
   "namespace": "my-namespace",
   "resources": {
     "mypkg::Resource": {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/19519

When running `package add` we can always force `SupportPack` to true. This will result in the new style of go module files being written out, which the package add instructions are designed for.

Most uses of `package add` are probably already using schemas that set `SupportPack` (e.g any parameterised things, but also the new component library providers), so this is probably only really going to affect providers written with the Go provider framework, which as per #19519 don't really work currently anyway so risk of breaking anyone seems low.