### PR TITLE
Prioritise `PULUMI_TEST_ORG` over `PULUMI_ACCESS_TOKEN` in `get_test_org`

### DIFF
--- a/sdk/python/lib/test/automation/test_utils.py
+++ b/sdk/python/lib/test/automation/test_utils.py
@@ -19,12 +19,12 @@ from pulumi.automation import fully_qualified_stack_name
 
 
 def get_test_org():
+    env_var = os.getenv("PULUMI_TEST_ORG")
+    if env_var is not None:
+        return env_var
     if os.getenv("PULUMI_ACCESS_TOKEN") is None:
         return "organization"
     test_org = "moolumi"
-    env_var = os.getenv("PULUMI_TEST_ORG")
-    if env_var is not None:
-        test_org = env_var
     return test_org
 
 


### PR DESCRIPTION
I don't know whether this affects anyone else in any way, but my access token does not point to an account whose organisation is `organization`. What I currently have to do is comment out the access token check and then run `PULUMI_TEST_ORG=pulumi pytest ...`. However, I feel that `get_test_org` should prioritise the thing called `test_org`, and this would mean that I don't have to comment this out every time I want to run a pytest.