### PR TITLE
[issue-20020] Fix stack rename in python automation api

### DIFF
--- a/changelog/pending/20250710--sdk-python--fix--automation-stack-rename.yaml
+++ b/changelog/pending/20250710--sdk-python--fix--automation-stack-rename.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python/automation
+  description: Fix wrong name after stack rename 

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -760,13 +760,22 @@ class Stack:
         args.extend(extra_args)
 
         args.extend(self._remote_args())
-        rename_result = self._run_pulumi_cmd_sync(args, on_output)
 
+        # --- ISSUE #20020 ---
+        # Get summary from stack before renaming
         if self._remote and show_secrets:
             raise RuntimeError("can't enable `showSecrets` for remote workspaces")
 
+        # Summary can be None, this case can happen if the stack was empty and had no history.
         summary = self.info(show_secrets and not self._remote)
-        assert summary is not None
+        # Execute the rename command.
+        rename_result = self._run_pulumi_cmd_sync(args, on_output)
+
+        # After the rename is successful in the backend, the internal state of this
+        # Stack object MUST be updated to reflect the new name
+        self.name = new_stack_name
+        # --- END ISSUE ---
+
         return RenameResult(
             stdout=rename_result.stdout, stderr=rename_result.stderr, summary=summary
         )

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -761,13 +761,12 @@ class Stack:
 
         args.extend(self._remote_args())
 
-        # https://github.com/pulumi/pulumi/issues/20020
         if self._remote and show_secrets:
             raise RuntimeError("can't enable `showSecrets` for remote workspaces")
 
-        # Execute the rename command.
         rename_result = self._run_pulumi_cmd_sync(args, on_output)
 
+        # https://github.com/pulumi/pulumi/issues/20020
         # After the rename is successful in the backend, the internal state of this
         # Stack object MUST be updated to reflect the new name
         self.name = new_stack_name

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -761,20 +761,19 @@ class Stack:
 
         args.extend(self._remote_args())
 
-        # --- ISSUE #20020 ---
-        # Get summary from stack before renaming
+        # https://github.com/pulumi/pulumi/issues/20020
         if self._remote and show_secrets:
             raise RuntimeError("can't enable `showSecrets` for remote workspaces")
 
-        # Summary can be None, this case can happen if the stack was empty and had no history.
-        summary = self.info(show_secrets and not self._remote)
         # Execute the rename command.
         rename_result = self._run_pulumi_cmd_sync(args, on_output)
 
         # After the rename is successful in the backend, the internal state of this
         # Stack object MUST be updated to reflect the new name
         self.name = new_stack_name
-        # --- END ISSUE ---
+
+        # Summary can be None, this case can happen if the stack was empty and had no history.
+        summary = self.info(show_secrets and not self._remote)
 
         return RenameResult(
             stdout=rename_result.stdout, stderr=rename_result.stderr, summary=summary

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -180,7 +180,7 @@ class RefreshResult(BaseResult):
 
 
 class RenameResult(BaseResult):
-    def __init__(self, stdout: str, stderr: str, summary: UpdateSummary):
+    def __init__(self, stdout: str, stderr: str, summary: Optional[UpdateSummary]):
         super().__init__(stdout, stderr)
         self.summary = summary
 
@@ -769,7 +769,7 @@ class Stack:
         # https://github.com/pulumi/pulumi/issues/20020
         # After the rename is successful in the backend, the internal state of this
         # Stack object MUST be updated to reflect the new name
-        self.name = new_stack_name
+        self.name = stack_name
 
         # Summary can be None, this case can happen if the stack was empty and had no history.
         summary = self.info(show_secrets and not self._remote)


### PR DESCRIPTION
Fix the stack renaming logic in the Python automation API by ensuring the object's name is updated after a rename operation. Also, support None as a valid value for the history attribute when the stack is empty.