### PR TITLE
Python component initialize methods

### DIFF
--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021, Pulumi Corporation.
+# Copyright 2016-2025, Pulumi Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 import asyncio
 import copy
+import contextvars
 import warnings
 from typing import (
     Awaitable,
@@ -43,7 +44,7 @@ from .runtime.resource import (
     collapse_alias_to_urn,
     create_urn as create_urn_internal,
 )
-from .runtime.settings import get_root_resource
+from .runtime.settings import get_root_resource, _get_rpc_manager, ambient_parent
 from .output import _is_prompt, _map_input, _map2_input, Output
 from . import urn as urn_util
 from . import log
@@ -888,7 +889,13 @@ class Resource:
         # provided properties and options assigned to this resource.
         parent = opts.parent
         if parent is None:
-            parent = get_root_resource()
+            # If the ambient parent context is set use that
+            parent = ambient_parent.get()
+            if parent is None:
+                parent = get_root_resource()
+        opts = opts._copy()
+        opts.parent = parent
+
         parent_transformations = (
             (parent._transformations or []) if parent is not None else []
         )
@@ -1191,6 +1198,17 @@ class ComponentResource(Resource):
             self.__dict__["id"] = None
         self._remote = remote
 
+        async def do_initialize():
+            async def do_initialize_inner():
+                ambient_parent.set(self)
+                awaitable = self.initialize(name, props, opts)
+                if awaitable is not None:
+                    await awaitable
+            ctx = contextvars.copy_context()
+            return await ctx.run(do_initialize_inner)
+
+        asyncio.ensure_future(_get_rpc_manager().do_rpc("initialize resource", do_initialize)())
+
     def register_outputs(self, outputs: "Inputs"):
         """
         Register synthetic outputs that a component has initialized, usually by allocating other child
@@ -1199,6 +1217,19 @@ class ComponentResource(Resource):
         :param dict output: A dictionary of outputs to associate with this resource.
         """
         register_resource_outputs(self, outputs)
+
+    def initialize(self,
+                   name: str,
+                   props: Optional["Inputs"],
+                   opts: Optional[ResourceOptions],
+                   ) -> None | Awaitable[None]:
+        """
+        Initialize the component resource, this can be used instead of the constructor to set up child resources. It has
+        the advantage that it runs in an async context, the parent resource option will be automatically set to the
+        component resource for all resources created in this context, and register_outputs will always be called to mark
+        the component as done.
+        """
+        return None
 
 
 class ProviderResource(CustomResource):

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018, Pulumi Corporation.
+# Copyright 2016-2025, Pulumi Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,6 +43,11 @@ _GRPC_CHANNEL_OPTIONS = [("grpc.max_receive_message_length", _MAX_RPC_MESSAGE_SI
 
 # excessive_debug_output enables, well, pretty excessive debug output pertaining to resources and properties.
 excessive_debug_output = False
+
+# current ambient parent resource, this is set for component resource initialization methods.
+ambient_parent: ContextVar[Optional[Resource]] = ContextVar(
+    "ambient_parent", default=None
+)
 
 
 class Settings:

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -2467,3 +2467,29 @@ func TestOrganization(t *testing.T) {
 		Quick: true,
 	})
 }
+
+// Tests that component resource initialization methods work correctly.
+//
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestComponentInitializationPython(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir: filepath.Join("python", "component_initalize"),
+		Dependencies: []string{
+			filepath.Join("..", "..", "sdk", "python"),
+		},
+		Quick: true,
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			// Find the Random resource
+			var randomResource *apitype.ResourceV3
+			for _, res := range stackInfo.Deployment.Resources {
+				if res.URN.Name() == "foo-random" {
+					randomResource = &res
+					break
+				}
+			}
+			assert.NotNil(t, randomResource)
+			// Check it's parent is the component resource
+			assert.Equal(t, "foo", randomResource.Parent.Name())
+		},
+	})
+}

--- a/tests/integration/python/component_initalize/Pulumi.yaml
+++ b/tests/integration/python/component_initalize/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: component-initialize
+runtime:
+  name: python

--- a/tests/integration/python/component_initalize/__main__.py
+++ b/tests/integration/python/component_initalize/__main__.py
@@ -1,0 +1,31 @@
+import asyncio
+import binascii
+import os
+from pulumi import ComponentResource
+from pulumi.dynamic import Resource, ResourceProvider, CreateResult
+
+
+class RandomResourceProvider(ResourceProvider):
+    def create(self, props):
+        val = binascii.b2a_hex(os.urandom(15)).decode("ascii")
+        return CreateResult(val, {"val": val})
+
+
+class Random(Resource):
+    val: str
+
+    def __init__(self, name, opts=None):
+        super().__init__(RandomResourceProvider(), name, {"val": ""}, opts)
+
+class RandomComponent(ComponentResource):
+    def __init__(self, name, opts=None):
+        super().__init__("component:RandomComponent", name, {}, opts)
+
+    async def initialize(self, name, props, opts):
+        # Simulate some async initialization work
+        await asyncio.sleep(1)
+        # Don't explicitly set the parent resource, it will be set automatically
+        self.r = Random(name + "-random")
+        self.register_outputs({"val": self.r.val})
+
+r = RandomComponent("foo")


### PR DESCRIPTION
Adds a new over-ridable initialisation method to python component resources.

This is inspired by the initialize method in TypeScript but with some modern improvements. 

Firstly unlike TypeScript we can't ensure that `RegisterResourceOutputs` is always called, this is sad but I don't see a way to coordinate the super-class constructor potentially calling `register_output` with our async task also calling it.

Secondly, like TypeScript the initialize method is async allowing the use of await.
Thirdly, we automatically set the `ResourceOptions.parent` setting for all resources created in initialize. I think it will be possible to do this for TypeScript as well.