### PR TITLE
Align the `sdk/python/Makefile` to other SDK Makefiles

### DIFF
--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -23,9 +23,12 @@ ensure:: .make/ensure/uv
 build_package:: ensure
 	uv run -m build --outdir ./build --installer uv
 
-build_plugin::
+build_plugin: ../../bin/pulumi-language-python
+
+.PHONY: ../../bin/pulumi-language-python
+../../bin/pulumi-language-python:
 	go build -C cmd/pulumi-language-python \
-		-o ../../../../bin/pulumi-language-python \
+		-o ../../$@ \
 		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" \
 		${LANGHOST_PKG}
 


### PR DESCRIPTION
Other SDK Makefiles have a target for the plugin that corresponds with the binary name. This commit extends the Python Makefile with the same support.

For example, this mirrors Go here:

https://github.com/pulumi/pulumi/blob/ac738adfb8bbb0f5770e8560c8841c407f69c1d1/sdk/go/Makefile#L25-L29