### PR TITLE
Fix panic in console command

### DIFF
--- a/changelog/pending/20250714--cli--fix-a-panic-in-the-console-command-when-a-non-existant-stack-was-passed-as-a-stack-argument.yaml
+++ b/changelog/pending/20250714--cli--fix-a-panic-in-the-console-command-when-a-non-existant-stack-was-passed-as-a-stack-argument.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix a panic in the `console` command when a non-existant stack was passed as a --stack argument

--- a/pkg/cmd/pulumi/console/console.go
+++ b/pkg/cmd/pulumi/console/console.go
@@ -69,6 +69,11 @@ func NewConsoleCmd(ws pkgWorkspace.Context) *cobra.Command {
 					if err != nil {
 						return err
 					}
+					if stack == nil {
+						fmt.Printf("Stack '%s' does not exist. "+
+							"Run `pulumi stack init` to create a new stack.\n", ref.Name())
+						return nil
+					}
 				} else {
 					stack, err = state.CurrentStack(ctx, currentBackend)
 					if err != nil {

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -1090,5 +1090,6 @@ func TestConsoleCommandMissingStack(t *testing.T) {
 	defer e.DeleteIfNotFailed()
 
 	stdout, _ := e.RunCommand("pulumi", "console", "--stack", "no-org/no-project/this-does-not-exist")
-	assert.Contains(t, stdout, "Stack 'this-does-not-exist' does not exist. Run `pulumi stack init` to create a new stack.")
+	assert.Contains(t, stdout,
+		"Stack 'this-does-not-exist' does not exist. Run `pulumi stack init` to create a new stack.")
 }

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -1081,3 +1081,14 @@ func TestParallelCgroups(t *testing.T) {
 	// Assert that the limited parallel count is 4, i.e. 1 CPU x 4.
 	assert.Equal(t, 4, limitedParallel, "Expected --parallel=4 in limited CPU context")
 }
+
+// Test for https://github.com/pulumi/pulumi/issues/20035 check --stack missing doesn't panic for the console command
+func TestConsoleCommandMissingStack(t *testing.T) {
+	t.Parallel()
+
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+
+	stdout, _ := e.RunCommand("pulumi", "console", "--stack", "no-org/no-project/this-does-not-exist")
+	assert.Contains(t, stdout, "Stack 'this-does-not-exist' does not exist. Run `pulumi stack init` to create a new stack.")
+}


### PR DESCRIPTION
`GetStack` can potentially return nil if the given stack name isn't found, as opposed to "not found" error.

This wasn't checked for in the console command and later code tried to dereference the stack object to get the string reference for it.

Fixes https://github.com/pulumi/pulumi/issues/20035