### PR TITLE
Fix `ResourceV3.RefreshBeforeUpdate` yaml struct tag property name

### DIFF
--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -359,7 +359,7 @@ type ResourceV3 struct {
 	ReplaceOnChanges []string `json:"replaceOnChanges,omitempty" yaml:"replaceOnChanges,omitempty"`
 	// TODO[pulumi/pulumi#19705]: RefreshBeforeUpdate and ViewOf to be moved to ResourceV4.
 	// RefreshBeforeUpdate indicates that this resource should always be refreshed prior to updates.
-	RefreshBeforeUpdate bool `json:"refreshBeforeUpdate,omitempty" yaml:"replaceOnChanges,omitempty"`
+	RefreshBeforeUpdate bool `json:"refreshBeforeUpdate,omitempty" yaml:"refreshBeforeUpdate,omitempty"`
 	// ViewOf is a reference to the resource that this resource is a view of.
 	ViewOf resource.URN `json:"viewOf,omitempty" yaml:"viewOf,omitempty"`
 	// ResourceHooks is a map of hook types to lists of hook names for the given type.


### PR DESCRIPTION
This changes fixes the wrong property name in the yaml struct tag for `ResourceV3.RefreshBeforeUpdate` (copy/paste issue), which I noticed looking at the code. I don't think it impacts anything in practice (yaml).

Note: I looked into enabling a linter to catch things like this ([Tagliatelle](https://github.com/ldez/tagliatelle) via golangci-lint), but we have a bunch of existing casing/naming inconsistencies (50+) that would have to be ignored, so punted on it for now.