### PR TITLE
Re-enable lifecycle tests on MacOS

### DIFF
--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -142,7 +142,7 @@ func pickURN(t *testing.T, urns []resource.URN, names []string, target string) r
 
 func TestMain(m *testing.M) {
 	grpcDefault := flag.Bool("grpc-plugins", false, "enable or disable gRPC providers by default")
-	if (runtime.GOOS == "windows" || runtime.GOOS == "darwin") && os.Getenv("PULUMI_FORCE_RUN_TESTS") == "" {
+	if (runtime.GOOS == "windows") && os.Getenv("PULUMI_FORCE_RUN_TESTS") == "" {
 		// These tests are skipped as part of enabling running unit tests on windows and MacOS in
 		// https://github.com/pulumi/pulumi/pull/19653. These tests currently fail on Windows, and
 		// re-enabling them is left as future work.

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -143,11 +143,11 @@ func pickURN(t *testing.T, urns []resource.URN, names []string, target string) r
 func TestMain(m *testing.M) {
 	grpcDefault := flag.Bool("grpc-plugins", false, "enable or disable gRPC providers by default")
 	if (runtime.GOOS == "windows") && os.Getenv("PULUMI_FORCE_RUN_TESTS") == "" {
-		// These tests are skipped as part of enabling running unit tests on windows and MacOS in
+		// These tests are skipped as part of enabling running unit tests on windows in
 		// https://github.com/pulumi/pulumi/pull/19653. These tests currently fail on Windows, and
 		// re-enabling them is left as future work.
-		// TODO[pulumi/pulumi#19675]: Re-enable tests on windows and MacOS once they are fixed.
-		fmt.Println("Skip tests on windows and MacOS until they are fixed")
+		// TODO[pulumi/pulumi#19675]: Re-enable tests on windows once they are fixed.
+		fmt.Println("Skip tests on windows until they are fixed")
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
These seem to work, so I guess we can probably switch them on.