### PR TITLE
Prioritise `PULUMI_TEST_ORG` in NodeJS automation tests

### DIFF
--- a/sdk/nodejs/tests/automation/util.ts
+++ b/sdk/nodejs/tests/automation/util.ts
@@ -21,10 +21,10 @@ export function getTestSuffix() {
 
 /** @internal */
 export function getTestOrg() {
+    if (process.env.PULUMI_TEST_ORG) {
+        return process.env.PULUMI_TEST_ORG;
+    }
     if (process.env.PULUMI_ACCESS_TOKEN) {
-        if (process.env.PULUMI_TEST_ORG) {
-            return process.env.PULUMI_TEST_ORG;
-        }
         return "pulumi-test";
     }
     return "organization";


### PR DESCRIPTION
This PR ensures that, if you set `PULUMI_TEST_ORG`, the organisation you set will take priority when choosing the organisation for creating stacks in integration tests. We could probably change `pulumi-test` to `moolumi` here to make it fully compatible with Python, but let's not tear down two fences at once.