### PR TITLE
Allow setting resource hooks in transforms

### DIFF
--- a/changelog/pending/20250716--sdk-nodejs--allow-setting-resource-hooks-in-transforms.yaml
+++ b/changelog/pending/20250716--sdk-nodejs--allow-setting-resource-hooks-in-transforms.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Allow setting resource hooks in transforms

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -23,6 +23,7 @@ import * as config from "../runtime/config";
 import * as rpc from "../runtime/rpc";
 import * as settings from "../runtime/settings";
 import * as localState from "../runtime/state";
+import { hookBindingFromProto } from "../runtime/resource";
 import { parseArgs } from "./internals";
 import { InputPropertyError, InputPropertiesError, InputPropertyErrorDetails } from "../errors";
 
@@ -395,17 +396,6 @@ class Server implements grpc.UntypedServiceImplementation {
                     }
                 }
 
-                const resourceHooks: resource.ResourceHookBinding = {};
-                const binding = req.getResourceHooks();
-                if (binding) {
-                    resourceHooks.beforeCreate = binding.getBeforeCreateList().map((n) => new StubResourceHook(n));
-                    resourceHooks.afterCreate = binding.getAfterCreateList().map((n) => new StubResourceHook(n));
-                    resourceHooks.beforeUpdate = binding.getBeforeUpdateList().map((n) => new StubResourceHook(n));
-                    resourceHooks.afterUpdate = binding.getAfterUpdateList().map((n) => new StubResourceHook(n));
-                    resourceHooks.beforeDelete = binding.getBeforeDeleteList().map((n) => new StubResourceHook(n));
-                    resourceHooks.afterDelete = binding.getAfterDeleteList().map((n) => new StubResourceHook(n));
-                }
-
                 const opts: resource.ComponentResourceOptions = {
                     aliases: req.getAliasesList(),
                     dependsOn: dependsOn,
@@ -416,7 +406,7 @@ class Server implements grpc.UntypedServiceImplementation {
                     replaceOnChanges: req.getReplaceonchangesList(),
                     customTimeouts: req.getCustomtimeouts()?.toObject(),
                     retainOnDelete: req.getRetainondelete(),
-                    hooks: resourceHooks,
+                    hooks: hookBindingFromProto(req.getResourceHooks()),
                 };
 
                 const deletedWith = req.getDeletedwith();
@@ -800,23 +790,4 @@ function createProviderResource(ref: string): resource.ProviderResource {
         return resourcePackage.constructProvider(urnName, type, urn);
     }
     return new resource.DependencyProviderResource(ref);
-}
-
-/**
- * StubResourceHook is a resource hook that does nothing.
- *
- * We need to reconstruct {@link ResourceHook} instances here to set
- * on the {@link ResourceOption}s, but we only have the name
- * available to us. We also know that these hooks have already been
- * registered when the remote component called register_resource, so we
- * can construct dummy hooks here, that will be serialized back into
- * list of hook names.
- */
-class StubResourceHook extends resource.ResourceHook {
-    constructor(n: string) {
-        super(n, () => {
-            return;
-        });
-        this.__registered = Promise.resolve(); // Mark the hook as registered.
-    }
 }

--- a/sdk/nodejs/runtime/callbacks.ts
+++ b/sdk/nodejs/runtime/callbacks.ts
@@ -40,7 +40,7 @@ import {
 } from "../resource";
 import { InvokeOptions, InvokeTransform, InvokeTransformArgs } from "../invoke";
 
-import { mapAliasesForRequest } from "./resource";
+import { hookBindingFromProto, mapAliasesForRequest, prepareHooks } from "./resource";
 import { deserializeProperties, serializeProperties, unknownValue } from "./rpc";
 import { debuggablePromise } from "./debuggable";
 import { rpcKeepAlive } from "./settings";
@@ -222,6 +222,7 @@ export class CallbackServer implements ICallbackServer {
                     delete: timeouts.getDelete(),
                 };
             }
+            ropts.hooks = hookBindingFromProto(opts.getHooks());
             ropts.deletedWith =
                 opts.getDeletedWith() !== "" ? new DependencyResource(opts.getDeletedWith()) : undefined;
             ropts.dependsOn = opts.getDependsOnList().map((dep) => new DependencyResource(dep));
@@ -321,6 +322,9 @@ export class CallbackServer implements ICallbackServer {
                     }
                     if (result.opts.version !== undefined) {
                         opts.setVersion(result.opts.version);
+                    }
+                    if (result.opts.hooks !== undefined) {
+                        opts.setHooks(await prepareHooks(result.opts.hooks, request.getName()));
                     }
 
                     if (request.getCustom()) {

--- a/tests/integration/resource_hooks/nodejs_transform/Pulumi.yaml
+++ b/tests/integration/resource_hooks/nodejs_transform/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: resource_hooks_nodejs_transform
+description: A program with a resource hook set by a transform
+runtime: nodejs

--- a/tests/integration/resource_hooks/nodejs_transform/index.ts
+++ b/tests/integration/resource_hooks/nodejs_transform/index.ts
@@ -1,0 +1,52 @@
+// Copyright 2025, Pulumi Corporation.  All rights reserved.
+
+import * as assert from "assert";
+import { log, ResourceHook, ResourceHookArgs, ResourceOptions, ResourceTransform, ResourceTransformArgs, ResourceTransformResult } from "@pulumi/pulumi";
+import { Random, Component } from "./random";
+
+
+function fun(args: ResourceHookArgs) {
+    if (args.name === "res") {
+        log.info(`fun was called with length = ${args.newInputs["length"]}`);
+        assert.strictEqual(args.name, "res", `Expected name 'res', got ${args.name}`);
+        assert.strictEqual(args.type, "testprovider:index:Random", `Expected type 'testprovider:index:Random', got ${args.type}`);
+    } else if (args.name === "comp") {
+        const childId = args.newOutputs["childId"];
+        log.info(`fun_comp was called with child = ${childId}`);
+        if (!childId) {
+            throw new Error(`expected non empty childId, got '${childId}'`);
+        }
+        assert.strictEqual(args.name, "comp", `Expected name 'comp', got ${args.name}`);
+        assert.strictEqual(args.type, "testprovider:index:Component", `Expected type 'testprovider:index:Component', got ${args.type}`);
+    } else {
+        throw new Error(`got unexpected component name: ${args.name}`);
+    }
+}
+
+const hook = new ResourceHook("hook_fun", fun);
+
+function transform(args: ResourceTransformArgs): ResourceTransformResult {
+    const opts = args.opts;
+
+    const existingAfterCreate = opts.hooks?.afterCreate || [];
+    const newHooks = {
+        ...opts.hooks,
+        afterCreate: [...existingAfterCreate, fun]
+    };
+
+    return {
+        props: args.props,
+        opts: {
+            ...opts,
+            hooks: newHooks
+        }
+    };
+}
+
+const res = new Random("res", { length: 10 }, {
+    transforms: [transform]
+});
+
+const comp = new Component("comp", { length: 7 }, {
+    transforms: [transform]
+});

--- a/tests/integration/resource_hooks/nodejs_transform/package.json
+++ b/tests/integration/resource_hooks/nodejs_transform/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "resource-hook",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "@pulumi/pulumi": "latest"
+  },
+  "dependencies": {
+    "@types/node": "^20"
+  }
+}

--- a/tests/integration/resource_hooks/nodejs_transform/random.ts
+++ b/tests/integration/resource_hooks/nodejs_transform/random.ts
@@ -1,0 +1,37 @@
+// Copyright 2025, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+interface RandomArgs {
+    length: pulumi.Input<number>;
+}
+
+export class Random extends pulumi.CustomResource {
+    public readonly length!: pulumi.Output<number>;
+    public readonly result!: pulumi.Output<string>;
+    constructor(name: string, args: RandomArgs, opts?: pulumi.CustomResourceOptions) {
+        const props = {
+            length: args.length,
+            result: undefined,
+        }
+        super("testprovider:index:Random", name, props, opts);
+    }
+}
+
+interface ComponentArgs {
+    length: pulumi.Input<number>;
+}
+
+export class Component extends pulumi.ComponentResource {
+    public readonly length!: pulumi.Output<number>;
+    public readonly childId!: pulumi.Output<string>;
+    constructor(name: string, args: ComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("testprovider:index:Component", name, args, opts, true);
+    }
+}
+
+export class TestProvider extends pulumi.ProviderResource {
+    constructor(name: string, opts?: pulumi.ResourceOptions) {
+        super("testprovider", name, {}, opts);
+    }
+}

--- a/tests/integration/resource_hooks/resource_hooks_nodejs_test.go
+++ b/tests/integration/resource_hooks/resource_hooks_nodejs_test.go
@@ -57,3 +57,37 @@ func TestNodejsResourceHooks(t *testing.T) {
 		},
 	})
 }
+
+// Test that a transform can modify resource hooks
+//
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestNodejsResourceHooksTransform(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          "nodejs_transform",
+		Dependencies: []string{"@pulumi/pulumi"},
+		LocalProviders: []integration.LocalDependency{
+			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+		},
+		Quick: true,
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			text := "fun was called with length = 10"
+			found := false
+			textComp := "fun_comp was called with child"
+			foundComp := false
+			for _, event := range stackInfo.Events {
+				if event.DiagnosticEvent != nil {
+					if strings.Contains(event.DiagnosticEvent.Message, text) {
+						found = true
+					}
+					if strings.Contains(event.DiagnosticEvent.Message, textComp) {
+						foundComp = true
+					}
+				}
+			}
+			b, err := json.Marshal(stackInfo.Events)
+			require.NoError(t, err)
+			require.True(t, found, "expected hook to print a message for the resource, got: %s", b)
+			require.True(t, foundComp, "expected hook to print a message for the component, got: %s", b)
+		},
+	})
+}


### PR DESCRIPTION
With https://github.com/pulumi/pulumi/pull/20051 in place, we can get the hooks from the current resource options inside a transform, and then modify that option.
