### PR TITLE
Tidy up TestUvWindowsError

### DIFF
--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -755,12 +755,12 @@ python = "^3.9"
 }
 
 // Regression test for https://github.com/pulumi/pulumi/issues/17877
-//
-//nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestUvWindowsError(t *testing.T) {
 	if runtime.GOOS != "windows" {
-		t.Parallel()
+		t.Skip()
 	}
+	t.Parallel()
+
 	e := ptesting.NewEnvironment(t)
 	defer e.DeleteIfNotFailed()
 


### PR DESCRIPTION
I was looking at this test while looking at https://github.com/pulumi/pulumi/issues/19834, and it looks like I committed some nonsense here when I introduced the test. Supposedly the intention was to call `skip` on non-Windows platforms.
