### PR TITLE
Enable lifecycle tests on Windows

### DIFF
--- a/pkg/engine/lifecycletest/framework/framework.go
+++ b/pkg/engine/lifecycletest/framework/framework.go
@@ -269,7 +269,10 @@ func (op TestOp) runWithContext(
 		return plan, nil, errors.Join(errs...)
 	}
 
-	if !opts.SkipDisplayTests {
+	// We always skip display tests on Windows to avoid issues where snapshots generated on Linux or macOS are not
+	// compatible with Windows due to e.g. line endings ("\n" vs "\r\n").
+	skipDisplayTests := opts.SkipDisplayTests || runtime.GOOS == "windows"
+	if !skipDisplayTests {
 		// base64 encode the name if it contains special characters
 		if ok, err := regexp.MatchString(`^[0-9A-Za-z-_]*$`, name); !ok && name != "" {
 			require.NoError(opts.T, err)

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -142,12 +142,12 @@ func pickURN(t *testing.T, urns []resource.URN, names []string, target string) r
 
 func TestMain(m *testing.M) {
 	grpcDefault := flag.Bool("grpc-plugins", false, "enable or disable gRPC providers by default")
-	if (runtime.GOOS == "windows" || runtime.GOOS == "darwin") && os.Getenv("PULUMI_FORCE_RUN_TESTS") == "" {
+	if runtime.GOOS == "darwin" && os.Getenv("PULUMI_FORCE_RUN_TESTS") == "" {
 		// These tests are skipped as part of enabling running unit tests on windows and MacOS in
-		// https://github.com/pulumi/pulumi/pull/19653. These tests currently fail on Windows, and
+		// https://github.com/pulumi/pulumi/pull/19653. These tests currently fail on MacOS, and
 		// re-enabling them is left as future work.
-		// TODO[pulumi/pulumi#19675]: Re-enable tests on windows and MacOS once they are fixed.
-		fmt.Println("Skip tests on windows and MacOS until they are fixed")
+		// TODO[pulumi/pulumi#19675]: Re-enable tests on MacOS once they are fixed.
+		fmt.Println("Skip tests on MacOS until they are fixed")
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
Lifecycle tests on Windows are currently disabled in CI. After some discussion and investigation, it appears that this might be due to failures caused by line ending differences in Windows-generated outputs and POSIX-generated snapshots. If this is the case, we might be able to run the tests simply by disabling comparing snapshots, which would be a great start. This change does just that, by setting the `SkipDisplayTests` flag for a test to true if the OS is Windows, regardless of the setting passed in.

Part of #19675