### PR TITLE
stop lifecycletests form deadlocking when a `require` fails in the program function

### DIFF
--- a/pkg/resource/deploy/deploytest/languageruntime.go
+++ b/pkg/resource/deploy/deploytest/languageruntime.go
@@ -77,7 +77,25 @@ func (p *languageRuntime) Run(info plugin.RunInfo) (string, bool, error) {
 	// Run the program.
 	done := make(chan error)
 	go func() {
-		done <- p.program(info, monitor)
+		err := errors.New("program did not exit successfully, either due to panic, or t.FailNow() being called")
+		// This is a rather strange pattern. We defer a function here that sends the error
+		// to the done channel and then call the program function, instead of just sending
+		// the error directly to the done channel. This is because the program function is
+		// a test function that may use testify's `require` package. That package calls
+		// t.FailNow() when an error occurs, which in turn causes runtime.Goexit() to be
+		// called. runtime.Goexit() causes the goroutine to exit immediately, so if t.FailNow()
+		// is called we never actually send the error to the done channel.
+		//
+		// Helpfully runtime.Goexit() does allow deferred functions in the goroutine to still
+		// run before the goroutine exits, so we can use this deferred function to make sure
+		// we can always send something to the done channel, which will prevent the test from
+		// just hanging. Note that in this case it doesn't really matter that we don't return
+		// the error message, as the `require` library will already have recorded and printed
+		// the error.
+		defer func() {
+			done <- err
+		}()
+		err = p.program(info, monitor)
 	}()
 	if progerr := <-done; progerr != nil {
 		return progerr.Error(), false, nil


### PR DESCRIPTION
Since https://github.com/pulumi/pulumi/pull/19837/files#diff-984b3279d61b588030474831898bb76d093d863ca2d0015bb081d842602a9ab7R841, we're waiting for the program to finish running before shutting the engine down.

This is useful in regular operation, however it introduces a small issue in the lifecycletests.  Because programs can be canceled using by the `require.*` family of functions, we sometimes don't "finish" running the program correctly, if there are test failures.  In those cases, we currently just hang, which makes the tests much harder to debug.  Fix this.

The inline comment describes the issue a bit more carefully.