### PR TITLE
Update pulumi-java to v1.16.0

### DIFF
--- a/changelog/pending/20250716--pkg--update-pulumi-java-to-v1-16-0.yaml
+++ b/changelog/pending/20250716--pkg--update-pulumi-java-to-v1-16-0.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: pkg
+  description: Update pulumi-java to v1.16.0

--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -28,7 +28,7 @@ download_release() {
 # * When updating .Net, you should also update PulumiDotnetSDKVersion in pulumi/pkg/codegen/testing/test/helpers.go
 #
 # shellcheck disable=SC2043
-for i in "github.com/pulumi/pulumi-java java v1.13.2" "github.com/pulumi/pulumi-yaml yaml v1.21.2" "github.com/pulumi/pulumi-dotnet dotnet v3.85.1"; do
+for i in "github.com/pulumi/pulumi-java java v1.16.0" "github.com/pulumi/pulumi-yaml yaml v1.21.2" "github.com/pulumi/pulumi-dotnet dotnet v3.85.1"; do
   set -- $i # treat strings in loop as args
   REPO="$1"
   PULUMI_LANG="$2"


### PR DESCRIPTION
This updates codegen for Java publishing to default to Maven Central instead of OSSRH.