### PR TITLE
[convert] Fix converting program to NodeJS when it depends on multiple parameterized packages

### DIFF
--- a/changelog/pending/20250716--programgen-nodejs--fix-converting-program-to-nodejs-when-it-depends-on-multiple-parameterized-packages.yaml
+++ b/changelog/pending/20250716--programgen-nodejs--fix-converting-program-to-nodejs-when-it-depends-on-multiple-parameterized-packages.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/nodejs
+  description: Fix converting program to NodeJS when it depends on multiple parameterized packages

--- a/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
@@ -63,7 +63,10 @@ empty string.`,
 			if err != nil {
 				return fmt.Errorf("load provider: %w", err)
 			}
-			defer p.Close()
+
+			defer func() {
+				contract.IgnoreError(pctx.Host.CloseProvider(p))
+			}()
 
 			// If provider parameters have been provided, parameterize the provider with them before requesting a mapping.
 			if len(args) > 3 {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-converter-terraform/issues/352

The issue is actually in the CLI because the generated PCL looks fine and it can be easily repro'ed using the following program and command

```
pulumi convert --from pcl --language typescript
```


<details>
<summary>See full PCL program:</summary>

```
package "aws" {
  baseProviderName = "aws"
}

package "cloudinit" {
  baseProviderName = "cloudinit"
}

package "random" {
  baseProviderName = "random"
}

package "tls" {
  baseProviderName = "tls"
}

package "vpcmod" {
  baseProviderName    = "terraform-module"
  baseProviderVersion = "0.1.4"
  parameterization {
    name    = "vpcmod"
    version = "5.8.1"
    // encoded parameterization values:
    // module: registry.terraform.io/terraform-aws-modules/vpc/aws
    // version: 5.8.1
    // packageName: vpcmod
    value = "eyJtb2R1bGUiOiJyZWdpc3RyeS50ZXJyYWZvcm0uaW8vdGVycmFmb3JtLWF3cy1tb2R1bGVzL3ZwYy9hd3MiLCJwYWNrYWdlTmFtZSI6InZwY21vZCIsInZlcnNpb24iOiI1LjguMSJ9"
  }
}

package "eksmod" {
  baseProviderName    = "terraform-module"
  baseProviderVersion = "0.1.4"
  parameterization {
    name    = "eksmod"
    version = "20.8.5"
    // encoded parameterization values:
    // module: registry.terraform.io/terraform-aws-modules/eks/aws
    // version: 20.8.5
    // packageName: eksmod
    value = "eyJtb2R1bGUiOiJyZWdpc3RyeS50ZXJyYWZvcm0uaW8vdGVycmFmb3JtLWF3cy1tb2R1bGVzL2Vrcy9hd3MiLCJwYWNrYWdlTmFtZSI6ImVrc21vZCIsInZlcnNpb24iOiIyMC44LjUifQ=="
  }
}



# Filter out local zones, which are not currently supported 
# with managed node groups
available = invoke("aws:index/getAvailabilityZones:getAvailabilityZones", {
  filters = [{
    name   = "opt-in-status"
    values = ["opt-in-not-required"]
  }]
})
clusterName = "education-eks-${suffix.result}"

resource "suffix" "random:index/randomString:RandomString" {
  length  = 8
  special = false
}
resource "vpc" "vpcmod:index:Module" {
  name = "education-vpc"
  cidr = "10.0.0.0/16"
  azs = invoke("std:index:slice", {
    list = available.names
    from = 0
    to   = 3
  }).result
  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
  enable_nat_gateway   = true
  single_nat_gateway   = true
  enable_dns_hostnames = true

  public_subnet_tags = {
    "kubernetes.io/role/elb" = 1
  }
  private_subnet_tags = {
    "kubernetes.io/role/internal-elb" = 1
  }
}
resource "eks" "eksmod:index:Module" {
  cluster_name                             = clusterName
  cluster_version                          = "1.29"
  cluster_endpoint_public_access           = true
  enable_cluster_creator_admin_permissions = true


  vpc_id     = vpc.vpc_id
  subnet_ids = vpc.private_subnets
  eks_managed_node_group_defaults = {
    ami_type = "AL2_x86_64"
  }
  eks_managed_node_groups = {
    one = {
      name           = "node-group-1"
      instance_types = ["t3.small"]

      min_size     = 1
      max_size     = 3
      desired_size = 2
    }
    two = {
      name           = "node-group-2"
      instance_types = ["t3.small"]

      min_size     = 1
      max_size     = 2
      desired_size = 1
    }
  }
}



# https://aws.amazon.com/blogs/containers/amazon-ebs-csi-driver-is-now-generally-available-in-amazon-eks-add-ons/ 
ebsCsiPolicy = invoke("aws:iam/getPolicy:getPolicy", {
  arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
})

```
</details>

The issue happens for nodejs because `GenerateProject` receives `localDependencies: nil` then all referenced parameterized packages in the PCL program are emitted in the form of `@pulumi/<packageName>: <version>` in the `dependencies` list of the `package.json`. This is incorrect because these local packages should be referenced via a local path to the locally generated SDKs.

When we get to the step of linking the locally generated SDKs, these references are updated from versions to their local paths correctly. _HOWEVER_, it fails if there are **multiple** packages because while referencing a path for one package, `npm add` errors out as it tries to resolve the other local packages (which are referenced via a version)

> NOTE: the problem goes away if `--generate-only` is supplied since it skips `npm add <...>` step that is failing but then the generated package.json file is incorrect and packages are pointing to non-existing versions

This fix here is supply the list of `localDependencies` so that the dependencies list is correct when generating the project, not fixed after the fact during package linking. 