### PR TITLE
Fix before exit handler

### DIFF
--- a/changelog/pending/20250717--sdk-nodejs--fix-before-exit-handler.yaml
+++ b/changelog/pending/20250717--sdk-nodejs--fix-before-exit-handler.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix before exit handler

--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -80,8 +80,51 @@ process.on("exit", (code: number) => {
         process.exitCode = nodeJSProcessExitedAfterLoggingUserActionableMessage;
     }
 });
+
+// `beforeExit` handlers are run in FIFO order, but we want ours to run last. To
+// ensure this, we have a first handler that registers the real handler in
+// `process.nextTick`.
+//
+//   process.on('beforeExit', () => {                                // registered first
+//     if (hasRegisteredOnExit) { return };
+//     hasRegisteredOnExit = true;
+//     process.nextTick(() => {
+//       setImmediate(() => {});                                     // force another eventloop run
+//       process.on('beforeExit', () => console.log('Our Handler')); // register our real handler
+//     });
+//   });
+//   process.on('beforeExit', () => console.log('Other 1'));         // registered second
+//   process.on('beforeExit', () => console.log('Other 2'));         // registered third
+//
+// First beforeExit: schedules nextTick callback, Other 1, Other 2, runs nextTick callback to register our handler
+// ~ async work happens ~
+// Second beforeExit: Other1, Other 2, Our Handler
+//
+// Having our handler run last ensures that if any work happens in a library or
+// user provided `beforeExit` handler, we wait for that work to complete before
+// our handler is called. Our trick with `process.nextTick` does not work if
+// someone else tries the same trick. That would be very naughty.
+//
+// Concretly, aws has a handler that creates `BucketNotification` objects, see
+// https://github.com/pulumi/pulumi-aws/blob/df45f46766be1d304a5fcf7d6dc192846f7433a8/sdk/nodejs/s3/s3Mixins.ts#L187
+let hasRegisteredOnExit = false;
+process.on("beforeExit", () => {
+    process.nextTick(() => {
+        if (hasRegisteredOnExit) {
+            return;
+        }
+        hasRegisteredOnExit = true;
+        // We need to schedule more work on the event loop to ensure we call
+        // `beforeExit` handlers again.
+        setImmediate(() => {
+            return;
+        });
+        process.on("beforeExit", beforeExitHandler);
+    });
+});
+
 let hasSignaled = false;
-process.on("beforeExit", async (code) => {
+async function beforeExitHandler(code: number) {
     // Signal and wait for shutdown means a succesful program execution, so
     // first check if there were any errors and bail out immediately if so.
     if (uncaughtErrors.size > 0) {
@@ -115,7 +158,7 @@ process.on("beforeExit", async (code) => {
         }
         return;
     });
-});
+}
 
 // As the second thing we do, ensure that we're connected to v8's inspector API.  We need to do
 // this as some information is only sent out as events, without any way to query for it after the

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2951,3 +2951,17 @@ func TestNodeCanConstructNamespacedComponent(t *testing.T) {
 	e.RunCommand("pulumi", "install")
 	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview")
 }
+
+// Regression test for https://github.com/pulumi/pulumi/issues/20068
+//
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestNodejsOnBeforeExit(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          filepath.Join("nodejs", "before-exit"),
+		Dependencies: []string{"@pulumi/pulumi"},
+		LocalProviders: []integration.LocalDependency{
+			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
+		},
+		Quick: true,
+	})
+}

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2963,5 +2963,12 @@ func TestNodejsOnBeforeExit(t *testing.T) {
 			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
 		},
 		Quick: true,
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			require.Len(t, stack.Deployment.Resources, 3)
+			require.Equal(t, tokens.Type("pulumi:pulumi:Stack"), stack.Deployment.Resources[0].Type)
+			require.Equal(t, tokens.Type("pulumi:providers:testprovider"), stack.Deployment.Resources[1].Type)
+			require.Equal(t, tokens.Type("testprovider:index:Named"), stack.Deployment.Resources[2].Type)
+			require.Equal(t, "beforeExit", stack.Deployment.Resources[2].URN.Name())
+		},
 	})
 }

--- a/tests/integration/nodejs/before-exit/Pulumi.yaml
+++ b/tests/integration/nodejs/before-exit/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: before-exit
+runtime: nodejs

--- a/tests/integration/nodejs/before-exit/index.js
+++ b/tests/integration/nodejs/before-exit/index.js
@@ -1,0 +1,19 @@
+// Copyright 2025, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+class Named extends pulumi.CustomResource {
+    constructor(name, resourceName) {
+        super("testprovider:index:Named", name, { name: resourceName });
+    }
+}
+
+let done = false
+
+process.on("beforeExit", () => {
+    if (done) {
+        return;
+    }
+    done = true;
+    new Named("beforeExit");
+})

--- a/tests/integration/nodejs/before-exit/package.json
+++ b/tests/integration/nodejs/before-exit/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "before-exit",
+    "license": "Apache-2.0",
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}


### PR DESCRIPTION
The aws provider has a handler that creates `BucketNotification` objects in a `beforeExit` handler, see https://github.com/pulumi/pulumi-aws/blob/df45f46766be1d304a5fcf7d6dc192846f7433a8/sdk/nodejs/s3/s3Mixins.ts#L187

`beforeExit` handlers are run in FIFO order, and since we register [ours](https://github.com/pulumi/pulumi/blob/dbfb8f2ccd8b11fb66ccbe5cced5abb324a554f5/sdk/nodejs/cmd/run/index.ts#L84) before the program is loaded, it runs before the AWS provided one. This is problematic, because we call `SignalAndWaitForShutdown` in the handler, but then a resource registration comes in afterwards, which will fail.

To fix this, we employ a bit of a hack to ensure our handler runs last, and in fact only runs after all the async work spawned by the first set of handlers has completed.

A user or library could still attempt the same trick with `nextTick`, but we are mostly powerless to fix this. Even if we inspect the list of handlers after the program returns, there could be pending async work that will later register more handlers, etc. Generally it seems unlikely that someone would want to register resources in `beforeExit`, and of course we did this to ourselves in the AWS provider.

Fixes https://github.com/pulumi/pulumi/issues/20068