### PR TITLE
Fix arbitrary file access during archive extraction cloud zipslip 

### DIFF
--- a/pkg/cmd/pulumi/templates/cloud.go
+++ b/pkg/cmd/pulumi/templates/cloud.go
@@ -320,11 +320,12 @@ func writeTar(ctx context.Context, reader *tar.Reader, dst string) error {
 		logging.V(8).Infof("Decompressing %q", header.Name)
 
 		path := filepath.Clean(header.Name)
-		if !filepath.IsLocal(path) {
-			return fmt.Errorf("refusing to write non-local path %q", path)
-		}
-
 		target := filepath.Join(dst, path)
+
+		// Ensure the target path is within the destination directory
+		if !strings.HasPrefix(target, filepath.Clean(dst)+string(os.PathSeparator)) {
+			return fmt.Errorf("refusing to write outside destination directory: %q", target)
+		}
 
 		// Ensure that we can write the directory
 		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {


### PR DESCRIPTION
https://github.com/pulumi/pulumi/blob/dbfb8f2ccd8b11fb66ccbe5cced5abb324a554f5/pkg/cmd/pulumi/templates/cloud.go#L313-L313
https://github.com/pulumi/pulumi/blob/dbfb8f2ccd8b11fb66ccbe5cced5abb324a554f5/pkg/cmd/pulumi/templates/cloud.go#L323-L326
Extracting files from a malicious zip file, or similar type of archive, is at risk of directory traversal attacks if filenames from the archive are not properly validated. archive paths. zip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (..). If these file paths are used to create a filesystem path, then a file operation may happen in an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.



fix this vulnerability, we need to ensure that the resolved file paths for extracted archive entries are within the intended destination directory (`dst`). This can be done by validating that the cleaned, resolved path (`target`) has the `dst` directory as its prefix. If the resolved path escapes the `dst` directory, we should log an error or skip the entry. the fix involves:
- Using `filepath.Clean` to normalize the entry path.
- Creating the full path (`target`) and ensuring it is within the `dst` directory using `filepath.HasPrefix` or equivalent logic.
- Skipping or rejecting archive entries that do not pass this validation.