### PR TITLE
Fix `package add` command when using uv 0.8.0 or later

### DIFF
--- a/changelog/pending/20250718--cli-package--fix-package-add-command-when-using-uv-0-8-0-or-later.yaml
+++ b/changelog/pending/20250718--cli-package--fix-package-add-command-when-using-uv-0-8-0-or-later.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/package
+  description: Fix `package add` command when using uv 0.8.0 or later

--- a/sdk/python/toolchain/uv.go
+++ b/sdk/python/toolchain/uv.go
@@ -328,10 +328,22 @@ func (u *uv) uvVersion() (semver.Version, error) {
 	if err != nil {
 		return semver.Version{}, fmt.Errorf("failed to get uv version: %w", err)
 	}
-	return u.parseUvVersion(string(versionString))
+	return ParseUvVersion(string(versionString))
 }
 
-func (u *uv) parseUvVersion(versionString string) (semver.Version, error) {
+func (u *uv) pythonExecutable() (string, string) {
+	name := "python"
+	if runtime.GOOS == windows {
+		name = name + ".exe"
+	}
+	return name, filepath.Join(u.virtualenvPath, virtualEnvBinDirName(), name)
+}
+
+func (u *uv) VirtualEnvPath(_ context.Context) (string, error) {
+	return u.virtualenvPath, nil
+}
+
+func ParseUvVersion(versionString string) (semver.Version, error) {
 	versionString = strings.TrimSpace(versionString)
 	re := regexp.MustCompile(`uv (?P<version>\d+\.\d+(.\d+)?).*`)
 	matches := re.FindStringSubmatch(versionString)
@@ -349,16 +361,4 @@ func (u *uv) parseUvVersion(versionString string) (semver.Version, error) {
 			versionString, minUvVersion)
 	}
 	return sem, nil
-}
-
-func (u *uv) pythonExecutable() (string, string) {
-	name := "python"
-	if runtime.GOOS == windows {
-		name = name + ".exe"
-	}
-	return name, filepath.Join(u.virtualenvPath, virtualEnvBinDirName(), name)
-}
-
-func (u *uv) VirtualEnvPath(_ context.Context) (string, error) {
-	return u.virtualenvPath, nil
 }

--- a/sdk/python/toolchain/uv_test.go
+++ b/sdk/python/toolchain/uv_test.go
@@ -84,19 +84,16 @@ func TestUvVirtualenvPath(t *testing.T) {
 func TestUvVersion(t *testing.T) {
 	t.Parallel()
 
-	uv, err := newUv(".", "")
-	require.NoError(t, err)
-
 	for _, versionString := range []string{
 		"uv 0.4.26",
 		"uv 0.4.26 (Homebrew 2024-10-23)",
 		"uv 0.4.26 (d2cd09bbd 2024-10-25)",
 	} {
-		v, err := uv.parseUvVersion(versionString)
+		v, err := ParseUvVersion(versionString)
 		require.NoError(t, err)
 		require.Equal(t, semver.MustParse("0.4.26"), v)
 	}
 
-	_, err = uv.parseUvVersion("uv 0.4.25")
+	_, err := ParseUvVersion("uv 0.4.25")
 	require.ErrorContains(t, err, "less than the minimum required version")
 }


### PR DESCRIPTION
Starting with version 0.8.0, uv will automatically add packages in subdirectories as workspace members. However the generated SDK might not have a `pyproject.toml`, which is required for uv workspace members. To add the generated SDK as a normal dependency, we can run `uv add --no-workspace`, but this flag is only available on version 0.8.0 and up.g
