### PR TITLE
replace assert.Len with require.Len

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,6 +76,8 @@ linters:
           msg: Use require.NoError instead
         - pattern: ^assert.NotNil$
           msg: Use require.NotNil instead
+        - pattern: ^assert.Len$
+          msg: Use require.Len instead
   exclusions:
     generated: lax
     presets:

--- a/cmd/pulumi-test-language/tests/l1_builtin_can.go
+++ b/cmd/pulumi-test-language/tests/l1_builtin_can.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -41,7 +42,7 @@ func init() {
 
 					outputs := stack.Outputs
 
-					assert.Len(l, outputs, 10, "expected 10 outputs")
+					require.Len(l, outputs, 10, "expected 10 outputs")
 					AssertPropertyMapMember(l, outputs, "plainTrySuccess", resource.NewBoolProperty(true))
 					AssertPropertyMapMember(l, outputs, "plainTryFailure", resource.NewBoolProperty(false))
 

--- a/cmd/pulumi-test-language/tests/l1_builtin_info.go
+++ b/cmd/pulumi-test-language/tests/l1_builtin_info.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -36,7 +36,7 @@ func init() {
 
 					outputs := stack.Outputs
 
-					assert.Len(l, outputs, 3, "expected 3 outputs")
+					require.Len(l, outputs, 3, "expected 3 outputs")
 					AssertPropertyMapMember(l, outputs, "stackOutput", resource.NewStringProperty("test"))
 					AssertPropertyMapMember(l, outputs, "projectOutput", resource.NewStringProperty("l1-builtin-info"))
 					AssertPropertyMapMember(l, outputs, "organizationOutput", resource.NewStringProperty("organization"))

--- a/cmd/pulumi-test-language/tests/l1_builtin_project_root.go
+++ b/cmd/pulumi-test-language/tests/l1_builtin_project_root.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -40,7 +40,7 @@ func init() {
 
 					outputs := stack.Outputs
 
-					assert.Len(l, outputs, 1, "expected 1 outputs")
+					require.Len(l, outputs, 1, "expected 1 outputs")
 					AssertPropertyMapMember(l, outputs, "rootDirectoryOutput", resource.NewStringProperty(projectDirectory))
 				},
 			},

--- a/cmd/pulumi-test-language/tests/l1_builtin_try.go
+++ b/cmd/pulumi-test-language/tests/l1_builtin_try.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -42,7 +43,7 @@ func init() {
 
 					outputs := stack.Outputs
 
-					assert.Len(l, outputs, 10, "expected 10 outputs")
+					require.Len(l, outputs, 10, "expected 10 outputs")
 					AssertPropertyMapMember(l, outputs, "plainTrySuccess", resource.NewStringProperty("MOK"))
 					AssertPropertyMapMember(l, outputs, "plainTryFailure", resource.NewStringProperty("fallback"))
 

--- a/cmd/pulumi-test-language/tests/l1_config_types.go
+++ b/cmd/pulumi-test-language/tests/l1_config_types.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -44,7 +44,7 @@ func init() {
 
 					outputs := stack.Outputs
 
-					assert.Len(l, outputs, 5, "expected 5 outputs")
+					require.Len(l, outputs, 5, "expected 5 outputs")
 					AssertPropertyMapMember(l, outputs, "theNumber", resource.NewNumberProperty(4.75))
 					AssertPropertyMapMember(l, outputs, "theString", resource.NewStringProperty("Hello World"))
 					AssertPropertyMapMember(l, outputs, "theMap", resource.NewObjectProperty(resource.PropertyMap{

--- a/cmd/pulumi-test-language/tests/l1_output_array.go
+++ b/cmd/pulumi-test-language/tests/l1_output_array.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -36,7 +36,7 @@ func init() {
 
 					outputs := stack.Outputs
 
-					assert.Len(l, outputs, 5, "expected 5 outputs")
+					require.Len(l, outputs, 5, "expected 5 outputs")
 					AssertPropertyMapMember(l, outputs, "empty", resource.NewArrayProperty([]resource.PropertyValue{}))
 					AssertPropertyMapMember(l, outputs, "small", resource.NewArrayProperty([]resource.PropertyValue{
 						resource.NewStringProperty("Hello"),

--- a/cmd/pulumi-test-language/tests/l1_output_map.go
+++ b/cmd/pulumi-test-language/tests/l1_output_map.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -36,7 +36,7 @@ func init() {
 
 					outputs := stack.Outputs
 
-					assert.Len(l, outputs, 4, "expected 4 outputs")
+					require.Len(l, outputs, 4, "expected 4 outputs")
 					AssertPropertyMapMember(l, outputs, "empty", resource.NewObjectProperty(resource.PropertyMap{}))
 					AssertPropertyMapMember(l, outputs, "strings", resource.NewObjectProperty(resource.PropertyMap{
 						"greeting": resource.NewStringProperty("Hello, world!"),

--- a/cmd/pulumi-test-language/tests/l1_output_null.go
+++ b/cmd/pulumi-test-language/tests/l1_output_null.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -36,7 +36,7 @@ func init() {
 
 					outputs := stack.Outputs
 
-					assert.Len(l, outputs, 1, "expected 1 outputs")
+					require.Len(l, outputs, 1, "expected 1 outputs")
 					// TODO(https://github.com/pulumi/pulumi/issues/19015): Ideally we'd allow for nulls in the output
 					// map and in nested maps, but to do that we need to work out how to handle optional fields in
 					// resource properties as well. Is it ok to start sending nulls for optional fields in the resource

--- a/cmd/pulumi-test-language/tests/l1_output_number.go
+++ b/cmd/pulumi-test-language/tests/l1_output_number.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -38,7 +38,7 @@ func init() {
 
 					outputs := stack.Outputs
 
-					assert.Len(l, outputs, 6, "expected 6 outputs")
+					require.Len(l, outputs, 6, "expected 6 outputs")
 					AssertPropertyMapMember(l, outputs, "zero", resource.NewNumberProperty(0))
 					AssertPropertyMapMember(l, outputs, "one", resource.NewNumberProperty(1))
 					AssertPropertyMapMember(l, outputs, "e", resource.NewNumberProperty(2.718))

--- a/cmd/pulumi-test-language/tests/l1_output_string.go
+++ b/cmd/pulumi-test-language/tests/l1_output_string.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -38,7 +38,7 @@ func init() {
 
 					outputs := stack.Outputs
 
-					assert.Len(l, outputs, 6, "expected 6 outputs")
+					require.Len(l, outputs, 6, "expected 6 outputs")
 					AssertPropertyMapMember(l, outputs, "empty", resource.NewStringProperty(""))
 					AssertPropertyMapMember(l, outputs, "small", resource.NewStringProperty("Hello world!"))
 					AssertPropertyMapMember(l, outputs, "emoji", resource.NewStringProperty("👋 \"Hello \U0001019b!\" 😊"))

--- a/cmd/pulumi-test-language/tests/l1_proxy_index.go
+++ b/cmd/pulumi-test-language/tests/l1_proxy_index.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -41,7 +41,7 @@ func init() {
 
 					outputs := stack.Outputs
 
-					assert.Len(l, outputs, 5, "expected 5 outputs")
+					require.Len(l, outputs, 5, "expected 5 outputs")
 					AssertPropertyMapMember(l, outputs, "l", resource.MakeSecret(resource.NewNumberProperty(1)))
 					AssertPropertyMapMember(l, outputs, "m", resource.MakeSecret(resource.NewBoolProperty(true)))
 					AssertPropertyMapMember(l, outputs, "c", resource.MakeSecret(resource.NewStringProperty("config")))

--- a/cmd/pulumi-test-language/tests/l1_stack_reference.go
+++ b/cmd/pulumi-test-language/tests/l1_stack_reference.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,7 +46,7 @@ func init() {
 
 					outputs := stack.Outputs
 
-					assert.Len(l, outputs, 2, "expected 2 outputs")
+					require.Len(l, outputs, 2, "expected 2 outputs")
 					AssertPropertyMapMember(l, outputs, "plain", resource.NewStringProperty("plain"))
 					AssertPropertyMapMember(l, outputs, "secret", resource.MakeSecret(resource.NewStringProperty("secret")))
 				},

--- a/cmd/pulumi-test-language/tests/l2_proxy_index.go
+++ b/cmd/pulumi-test-language/tests/l2_proxy_index.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -39,7 +39,7 @@ func init() {
 
 					outputs := stack.Outputs
 
-					assert.Len(l, outputs, 4, "expected 4 outputs")
+					require.Len(l, outputs, 4, "expected 4 outputs")
 					AssertPropertyMapMember(l, outputs, "bool", resource.NewBoolProperty(true))
 					AssertPropertyMapMember(l, outputs, "array", resource.NewBoolProperty(true))
 					AssertPropertyMapMember(l, outputs, "map", resource.NewStringProperty("100"))

--- a/cmd/pulumi-test-language/tests/policy_config.go
+++ b/cmd/pulumi-test-language/tests/policy_config.go
@@ -46,7 +46,7 @@ func init() {
 			},
 		}
 
-		assert.Len(l, policyViolations, len(expectedViolations), "expected %d policy violations", len(expectedViolations))
+		require.Len(l, policyViolations, len(expectedViolations), "expected %d policy violations", len(expectedViolations))
 
 		for _, violation := range expectedViolations {
 			assert.Contains(l, policyViolations, violation, "expected policy violation %v", violation)

--- a/cmd/pulumi-test-language/tests/policy_enforcement_config.go
+++ b/cmd/pulumi-test-language/tests/policy_enforcement_config.go
@@ -55,7 +55,7 @@ func init() {
 			})
 		}
 
-		assert.Len(l, policyViolations, len(expectedViolations), "expected %d policy violations", len(expectedViolations))
+		require.Len(l, policyViolations, len(expectedViolations), "expected %d policy violations", len(expectedViolations))
 
 		for _, violation := range expectedViolations {
 			assert.Contains(l, policyViolations, violation, "expected policy violation %v", violation)

--- a/cmd/pulumi-test-language/tests/policy_remediate.go
+++ b/cmd/pulumi-test-language/tests/policy_remediate.go
@@ -55,7 +55,7 @@ func init() {
 			},
 		}
 
-		assert.Len(l, policyRemediations, len(expectedRemediations),
+		require.Len(l, policyRemediations, len(expectedRemediations),
 			"expected %d policy remediations", len(expectedRemediations))
 
 		for _, remediations := range expectedRemediations {

--- a/cmd/pulumi-test-language/tests/policy_simple.go
+++ b/cmd/pulumi-test-language/tests/policy_simple.go
@@ -68,7 +68,7 @@ func init() {
 						},
 					}
 
-					assert.Len(l, policyViolations, len(expectedViolations), "expected %d policy violations", len(expectedViolations))
+					require.Len(l, policyViolations, len(expectedViolations), "expected %d policy violations", len(expectedViolations))
 
 					for _, violation := range expectedViolations {
 						assert.Contains(l, policyViolations, violation, "expected policy violation %v", violation)
@@ -111,7 +111,7 @@ func init() {
 						},
 					}
 
-					assert.Len(l, policyViolations, len(expectedViolations), "expected %d policy violations", len(expectedViolations))
+					require.Len(l, policyViolations, len(expectedViolations), "expected %d policy violations", len(expectedViolations))
 
 					for _, violation := range expectedViolations {
 						assert.Contains(l, policyViolations, violation, "expected policy violation %v", violation)

--- a/pkg/backend/diy/backend_legacy_test.go
+++ b/pkg/backend/diy/backend_legacy_test.go
@@ -94,7 +94,7 @@ func TestListStacksWithMultiplePassphrases_legacy(t *testing.T) {
 	stacks, outContToken, err := b.ListStacks(ctx, backend.ListStacksFilter{}, nil /* inContToken */)
 	require.NoError(t, err)
 	assert.Nil(t, outContToken)
-	assert.Len(t, stacks, 2)
+	require.Len(t, stacks, 2)
 	for _, stack := range stacks {
 		require.NotNil(t, stack.ResourceCount())
 		assert.Equal(t, 1, *stack.ResourceCount())
@@ -289,7 +289,7 @@ func TestRenameWorks_legacy(t *testing.T) {
 	// Check we can still get the history
 	history, err := b.GetHistory(ctx, cStackRef, 10, 0)
 	require.NoError(t, err)
-	assert.Len(t, history, 1)
+	require.Len(t, history, 1)
 	assert.Equal(t, apitype.DestroyUpdate, history[0].Kind)
 }
 
@@ -426,7 +426,7 @@ func TestParallelStackFetch_legacy(t *testing.T) {
 	stacks, token, err := b.ListStacks(ctx, filter, nil)
 	require.NoError(t, err)
 	assert.Nil(t, token)
-	assert.Len(t, stacks, numStacks)
+	require.Len(t, stacks, numStacks)
 
 	// Verify all stacks were fetched
 	stackNames := make(map[string]bool)

--- a/pkg/backend/diy/backend_test.go
+++ b/pkg/backend/diy/backend_test.go
@@ -320,7 +320,7 @@ func TestListStacksWithMultiplePassphrases(t *testing.T) {
 	stacks, outContToken, err := b.ListStacks(ctx, backend.ListStacksFilter{}, nil /* inContToken */)
 	require.NoError(t, err)
 	assert.Nil(t, outContToken)
-	assert.Len(t, stacks, 2)
+	require.Len(t, stacks, 2)
 	for _, stack := range stacks {
 		require.NotNil(t, stack.ResourceCount())
 		assert.Equal(t, 1, *stack.ResourceCount())
@@ -515,7 +515,7 @@ func TestRenameWorks(t *testing.T) {
 	// Check we can still get the history
 	history, err := b.GetHistory(ctx, cStackRef, 10, 0)
 	require.NoError(t, err)
-	assert.Len(t, history, 1)
+	require.Len(t, history, 1)
 	assert.Equal(t, apitype.DestroyUpdate, history[0].Kind)
 }
 
@@ -672,7 +672,7 @@ func TestRenameProjectWorks(t *testing.T) {
 	// Check we can still get the history
 	history, err := b.GetHistory(ctx, bStackRef, 10, 0)
 	require.NoError(t, err)
-	assert.Len(t, history, 1)
+	require.Len(t, history, 1)
 	assert.Equal(t, apitype.DestroyUpdate, history[0].Kind)
 }
 
@@ -805,7 +805,7 @@ func TestLegacyFolderStructure(t *testing.T) {
 	stacks, token, err := b.ListStacks(ctx, backend.ListStacksFilter{}, nil /* inContToken */)
 	require.NoError(t, err)
 	assert.Nil(t, token)
-	assert.Len(t, stacks, 1)
+	require.Len(t, stacks, 1)
 	assert.Equal(t, "a", stacks[0].Name().String())
 
 	// Create a new non-project stack
@@ -845,7 +845,7 @@ func TestListStacksFilter(t *testing.T) {
 	}, nil /* inContToken */)
 	require.NoError(t, err)
 	assert.Nil(t, token)
-	assert.Len(t, stacks, 1)
+	require.Len(t, stacks, 1)
 	assert.Equal(t, "organization/proj1/a", stacks[0].Name().String())
 }
 
@@ -992,7 +992,7 @@ func TestProjectFolderStructure(t *testing.T) {
 	stacks, token, err := b.ListStacks(ctx, backend.ListStacksFilter{}, nil /* inContToken */)
 	require.NoError(t, err)
 	assert.Nil(t, token)
-	assert.Len(t, stacks, 1)
+	require.Len(t, stacks, 1)
 	assert.Equal(t, "organization/testproj/a", stacks[0].Name().String())
 
 	// Create a new project stack
@@ -1749,7 +1749,7 @@ func TestParallelStackFetch(t *testing.T) {
 	stacks, token, err := b.ListStacks(ctx, filter, nil)
 	require.NoError(t, err)
 	assert.Nil(t, token)
-	assert.Len(t, stacks, numStacks)
+	require.Len(t, stacks, numStacks)
 
 	// Verify all stacks were fetched
 	stackNames := make(map[string]bool)
@@ -1798,7 +1798,7 @@ func TestParallelStackFetchDefaultValue(t *testing.T) {
 	stacks, token, err := b.ListStacks(ctx, filter, nil)
 	require.NoError(t, err)
 	assert.Nil(t, token)
-	assert.Len(t, stacks, numStacks)
+	require.Len(t, stacks, numStacks)
 
 	// Verify all stacks were fetched
 	stackNames := make(map[string]bool)
@@ -1846,7 +1846,7 @@ func TestListStackNames(t *testing.T) {
 	stackRefs, token, err := b.ListStackNames(ctx, filter, nil)
 	require.NoError(t, err)
 	assert.Nil(t, token)
-	assert.Len(t, stackRefs, numStacks)
+	require.Len(t, stackRefs, numStacks)
 
 	// Verify all expected stack names are present
 	actualNames := make(map[string]bool)

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -295,7 +295,7 @@ func TestGetCapabilities(t *testing.T) {
 		resp, err := c.GetCapabilities(context.Background())
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-		assert.Len(t, resp.Capabilities, 2)
+		require.Len(t, resp.Capabilities, 2)
 		assert.Equal(t, apitype.DeltaCheckpointUploads, resp.Capabilities[0].Capability)
 		assert.Equal(t, `{"checkpointCutoffSizeBytes":4194304}`,
 			string(resp.Capabilities[0].Configuration))

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -150,7 +150,7 @@ func TestSamesWithEmptyDependencies(t *testing.T) {
 	require.NoError(t, err)
 	err = mutation.End(same, true)
 	require.NoError(t, err)
-	assert.Len(t, sp.SavedSnapshots, 0, "expected no snapshots to be saved for same step")
+	require.Len(t, sp.SavedSnapshots, 0, "expected no snapshots to be saved for same step")
 }
 
 func TestSamesWithEmptyArraysInInputs(t *testing.T) {
@@ -179,7 +179,7 @@ func TestSamesWithEmptyArraysInInputs(t *testing.T) {
 	require.NoError(t, err)
 	err = mutation.End(same, true)
 	require.NoError(t, err)
-	assert.Len(t, sp.SavedSnapshots, 0, "expected no snapshots to be saved for same step")
+	require.Len(t, sp.SavedSnapshots, 0, "expected no snapshots to be saved for same step")
 }
 
 // This test challenges the naive approach of mutating resources
@@ -224,11 +224,11 @@ func TestSamesWithDependencyChanges(t *testing.T) {
 	//     a
 	// where b does not depend on anything and neither does a.
 	firstSnap := sp.SavedSnapshots[0]
-	assert.Len(t, firstSnap.Resources, 2)
+	require.Len(t, firstSnap.Resources, 2)
 	assert.Equal(t, resourceB.URN, firstSnap.Resources[0].URN)
-	assert.Len(t, firstSnap.Resources[0].Dependencies, 0)
+	require.Len(t, firstSnap.Resources[0].Dependencies, 0)
 	assert.Equal(t, resourceA.URN, firstSnap.Resources[1].URN)
-	assert.Len(t, firstSnap.Resources[1].Dependencies, 0)
+	require.Len(t, firstSnap.Resources[1].Dependencies, 0)
 
 	// The engine then generates a Same for a:
 	aSame := deploy.NewSameStep(nil, nil, resourceA, resourceAUpdated)
@@ -244,11 +244,11 @@ func TestSamesWithDependencyChanges(t *testing.T) {
 	//     a
 	// where b does not depend on anything and a depends on b.
 	secondSnap := sp.SavedSnapshots[1]
-	assert.Len(t, secondSnap.Resources, 2)
+	require.Len(t, secondSnap.Resources, 2)
 	assert.Equal(t, resourceB.URN, secondSnap.Resources[0].URN)
-	assert.Len(t, secondSnap.Resources[0].Dependencies, 0)
+	require.Len(t, secondSnap.Resources[0].Dependencies, 0)
 	assert.Equal(t, resourceA.URN, secondSnap.Resources[1].URN)
-	assert.Len(t, secondSnap.Resources[1].Dependencies, 1)
+	require.Len(t, secondSnap.Resources[1].Dependencies, 1)
 	assert.Equal(t, resourceB.URN, secondSnap.Resources[1].Dependencies[0])
 }
 
@@ -308,7 +308,7 @@ func TestWriteCheckpointOnceUnsafe(t *testing.T) {
 
 	// DEFAULT behavior would cause more than 1 snapshot to be written,
 	// but the provided flag should only create 1 Snapshot
-	assert.Len(t, sp.SavedSnapshots, 1)
+	require.Len(t, sp.SavedSnapshots, 1)
 }
 
 // This test exercises same steps with meaningful changes to properties _other_ than `Dependencies` in order to ensure
@@ -581,40 +581,40 @@ func TestVexingDeployment(t *testing.T) {
 	applyStep(deploy.NewUpdateStep(nil, MockRegisterResourceEvent{}, d, dPrime, nil, nil, nil, nil, nil))
 
 	lastSnap := sp.SavedSnapshots[len(sp.SavedSnapshots)-1]
-	assert.Len(t, lastSnap.Resources, 6)
+	require.Len(t, lastSnap.Resources, 6)
 	res := lastSnap.Resources
 
 	// Here's what the merged snapshot should look like:
 	// B should be first, and it should depend on nothing
 	assert.Equal(t, b.URN, res[0].URN)
-	assert.Len(t, res[0].Dependencies, 0)
+	require.Len(t, res[0].Dependencies, 0)
 
 	// cPrime should be next, and it should depend on B
 	assert.Equal(t, c.URN, res[1].URN)
-	assert.Len(t, res[1].Dependencies, 1)
+	require.Len(t, res[1].Dependencies, 1)
 	assert.Equal(t, b.URN, res[1].Dependencies[0])
 
 	// d should be next, and it should depend on cPrime
 	assert.Equal(t, d.URN, res[2].URN)
-	assert.Len(t, res[2].Dependencies, 1)
+	require.Len(t, res[2].Dependencies, 1)
 	assert.Equal(t, c.URN, res[2].Dependencies[0])
 
 	// a should be next, and it should depend on nothing
 	assert.Equal(t, a.URN, res[3].URN)
-	assert.Len(t, res[3].Dependencies, 0)
+	require.Len(t, res[3].Dependencies, 0)
 
 	// c should be next, it should depend on A and B and should be pending deletion
 	// this is a critical operation of snap and the crux of this test:
 	// merge MUST put c after a in the snapshot, despite never having seen a in the current plan
 	assert.Equal(t, c.URN, res[4].URN)
 	assert.True(t, res[4].Delete)
-	assert.Len(t, res[4].Dependencies, 2)
+	require.Len(t, res[4].Dependencies, 2)
 	assert.Contains(t, res[4].Dependencies, a.URN)
 	assert.Contains(t, res[4].Dependencies, b.URN)
 
 	// e should be last, it should depend on C and still be live
 	assert.Equal(t, e.URN, res[5].URN)
-	assert.Len(t, res[5].Dependencies, 1)
+	require.Len(t, res[5].Dependencies, 1)
 	assert.Equal(t, c.URN, res[5].Dependencies[0])
 }
 
@@ -637,7 +637,7 @@ func TestDeletion(t *testing.T) {
 	// the end mutation should mark the resource as "done".
 	// snap should then not put resourceA in the merged snapshot, since it has been deleted.
 	lastSnap := sp.SavedSnapshots[len(sp.SavedSnapshots)-1]
-	assert.Len(t, lastSnap.Resources, 0)
+	require.Len(t, lastSnap.Resources, 0)
 }
 
 func TestFailedDelete(t *testing.T) {
@@ -659,7 +659,7 @@ func TestFailedDelete(t *testing.T) {
 	// since we marked the mutation as not successful, the snapshot should still contain
 	// the resource we failed to delete.
 	lastSnap := sp.SavedSnapshots[len(sp.SavedSnapshots)-1]
-	assert.Len(t, lastSnap.Resources, 1)
+	require.Len(t, lastSnap.Resources, 1)
 	assert.Equal(t, resourceA.URN, lastSnap.Resources[0].URN)
 }
 
@@ -676,8 +676,8 @@ func TestRecordingCreateSuccess(t *testing.T) {
 	// Beginning the create step mutation should have placed a pending "creating" operation
 	// into the operations list
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 0)
-	assert.Len(t, snap.PendingOperations, 1)
+	require.Len(t, snap.Resources, 0)
+	require.Len(t, snap.PendingOperations, 1)
 	assert.Equal(t, resourceA.URN, snap.PendingOperations[0].Resource.URN)
 	assert.Equal(t, resource.OperationTypeCreating, snap.PendingOperations[0].Type)
 
@@ -687,8 +687,8 @@ func TestRecordingCreateSuccess(t *testing.T) {
 	// A successful creation should remove the "creating" operation from the operations list
 	// and persist the created resource in the snapshot.
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 1)
-	assert.Len(t, snap.PendingOperations, 0)
+	require.Len(t, snap.Resources, 1)
+	require.Len(t, snap.PendingOperations, 0)
 	assert.Equal(t, resourceA.URN, snap.Resources[0].URN)
 }
 
@@ -705,8 +705,8 @@ func TestRecordingCreateFailure(t *testing.T) {
 	// Beginning the create step mutation should have placed a pending "creating" operation
 	// into the operations list
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 0)
-	assert.Len(t, snap.PendingOperations, 1)
+	require.Len(t, snap.Resources, 0)
+	require.Len(t, snap.PendingOperations, 1)
 	assert.Equal(t, resourceA.URN, snap.PendingOperations[0].Resource.URN)
 	assert.Equal(t, resource.OperationTypeCreating, snap.PendingOperations[0].Type)
 
@@ -716,8 +716,8 @@ func TestRecordingCreateFailure(t *testing.T) {
 	// A failed creation should remove the "creating" operation from the operations list
 	// and not persist the created resource in the snapshot.
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 0)
-	assert.Len(t, snap.PendingOperations, 0)
+	require.Len(t, snap.Resources, 0)
+	require.Len(t, snap.PendingOperations, 0)
 }
 
 func TestRecordingUpdateSuccess(t *testing.T) {
@@ -739,8 +739,8 @@ func TestRecordingUpdateSuccess(t *testing.T) {
 	// Beginning the update mutation should have placed a pending "updating" operation into
 	// the operations list, with the resource's new inputs.
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 1)
-	assert.Len(t, snap.PendingOperations, 1)
+	require.Len(t, snap.Resources, 1)
+	require.Len(t, snap.PendingOperations, 1)
 	assert.Equal(t, resourceA.URN, snap.PendingOperations[0].Resource.URN)
 	assert.Equal(t, resource.OperationTypeUpdating, snap.PendingOperations[0].Type)
 	assert.Equal(t, resource.NewStringProperty("new"), snap.PendingOperations[0].Resource.Inputs["key"])
@@ -751,8 +751,8 @@ func TestRecordingUpdateSuccess(t *testing.T) {
 	// Completing the update should place the resource with the new inputs into the snapshot and clear the in
 	// flight operation.
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 1)
-	assert.Len(t, snap.PendingOperations, 0)
+	require.Len(t, snap.Resources, 1)
+	require.Len(t, snap.PendingOperations, 0)
 	assert.Equal(t, resourceA.URN, snap.Resources[0].URN)
 	assert.Equal(t, resource.NewStringProperty("new"), snap.Resources[0].Inputs["key"])
 }
@@ -776,8 +776,8 @@ func TestRecordingUpdateFailure(t *testing.T) {
 	// Beginning the update mutation should have placed a pending "updating" operation into
 	// the operations list, with the resource's new inputs.
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 1)
-	assert.Len(t, snap.PendingOperations, 1)
+	require.Len(t, snap.Resources, 1)
+	require.Len(t, snap.PendingOperations, 1)
 	assert.Equal(t, resourceA.URN, snap.PendingOperations[0].Resource.URN)
 	assert.Equal(t, resource.OperationTypeUpdating, snap.PendingOperations[0].Type)
 	assert.Equal(t, resource.NewStringProperty("new"), snap.PendingOperations[0].Resource.Inputs["key"])
@@ -788,8 +788,8 @@ func TestRecordingUpdateFailure(t *testing.T) {
 	// Failing the update should keep the old resource with old inputs in the snapshot while clearing the
 	// in flight operation.
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 1)
-	assert.Len(t, snap.PendingOperations, 0)
+	require.Len(t, snap.Resources, 1)
+	require.Len(t, snap.PendingOperations, 0)
 	assert.Equal(t, resourceA.URN, snap.Resources[0].URN)
 	assert.Equal(t, resource.NewStringProperty("old"), snap.Resources[0].Inputs["key"])
 }
@@ -808,8 +808,8 @@ func TestRecordingDeleteSuccess(t *testing.T) {
 
 	// Beginning the delete mutation should have placed a pending "deleting" operation into the operations list.
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 1)
-	assert.Len(t, snap.PendingOperations, 1)
+	require.Len(t, snap.Resources, 1)
+	require.Len(t, snap.PendingOperations, 1)
 	assert.Equal(t, resourceA.URN, snap.PendingOperations[0].Resource.URN)
 	assert.Equal(t, resource.OperationTypeDeleting, snap.PendingOperations[0].Type)
 	assert.Equal(t, resourceA.URN, snap.Resources[0].URN)
@@ -818,8 +818,8 @@ func TestRecordingDeleteSuccess(t *testing.T) {
 
 	// A successful delete should remove the in flight operation and deleted resource from the snapshot.
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 0)
-	assert.Len(t, snap.PendingOperations, 0)
+	require.Len(t, snap.Resources, 0)
+	require.Len(t, snap.PendingOperations, 0)
 }
 
 func TestRecordingDeleteFailure(t *testing.T) {
@@ -836,8 +836,8 @@ func TestRecordingDeleteFailure(t *testing.T) {
 
 	// Beginning the delete mutation should have placed a pending "deleting" operation into the operations list.
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 1)
-	assert.Len(t, snap.PendingOperations, 1)
+	require.Len(t, snap.Resources, 1)
+	require.Len(t, snap.PendingOperations, 1)
 	assert.Equal(t, resourceA.URN, snap.PendingOperations[0].Resource.URN)
 	assert.Equal(t, resource.OperationTypeDeleting, snap.PendingOperations[0].Type)
 	assert.Equal(t, resourceA.URN, snap.Resources[0].URN)
@@ -846,8 +846,8 @@ func TestRecordingDeleteFailure(t *testing.T) {
 
 	// A failed delete should remove the in flight operation but leave the resource in the snapshot.
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 1)
-	assert.Len(t, snap.PendingOperations, 0)
+	require.Len(t, snap.Resources, 1)
+	require.Len(t, snap.PendingOperations, 0)
 	assert.Equal(t, resourceA.URN, snap.Resources[0].URN)
 }
 
@@ -866,8 +866,8 @@ func TestRecordingReadSuccessNoPreviousResource(t *testing.T) {
 
 	// Beginning the read mutation should have placed a pending "reading" operation into the operations list.
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 0)
-	assert.Len(t, snap.PendingOperations, 1)
+	require.Len(t, snap.Resources, 0)
+	require.Len(t, snap.PendingOperations, 1)
 	assert.Equal(t, resourceA.URN, snap.PendingOperations[0].Resource.URN)
 	assert.Equal(t, resource.OperationTypeReading, snap.PendingOperations[0].Type)
 	err = mutation.End(step, true /* successful */)
@@ -875,8 +875,8 @@ func TestRecordingReadSuccessNoPreviousResource(t *testing.T) {
 
 	// A successful read should clear the in flight operation and put the new resource into the snapshot
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 1)
-	assert.Len(t, snap.PendingOperations, 0)
+	require.Len(t, snap.Resources, 1)
+	require.Len(t, snap.PendingOperations, 0)
 	assert.Equal(t, resourceA.URN, snap.Resources[0].URN)
 }
 
@@ -905,8 +905,8 @@ func TestRecordingReadSuccessPreviousResource(t *testing.T) {
 	// Beginning the read mutation should have placed a pending "reading" operation into the operations list
 	// with the inputs of the new read
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 1)
-	assert.Len(t, snap.PendingOperations, 1)
+	require.Len(t, snap.Resources, 1)
+	require.Len(t, snap.PendingOperations, 1)
 	assert.Equal(t, resourceA.URN, snap.PendingOperations[0].Resource.URN)
 	assert.Equal(t, resource.OperationTypeReading, snap.PendingOperations[0].Type)
 	assert.Equal(t, resource.NewStringProperty("new"), snap.PendingOperations[0].Resource.Inputs["key"])
@@ -917,8 +917,8 @@ func TestRecordingReadSuccessPreviousResource(t *testing.T) {
 
 	// A successful read should clear the in flight operation and replace the existing resource in the snapshot.
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 1)
-	assert.Len(t, snap.PendingOperations, 0)
+	require.Len(t, snap.Resources, 1)
+	require.Len(t, snap.PendingOperations, 0)
 	assert.Equal(t, resourceA.URN, snap.Resources[0].URN)
 	assert.Equal(t, resource.NewStringProperty("new"), snap.Resources[0].Inputs["key"])
 }
@@ -938,8 +938,8 @@ func TestRecordingReadFailureNoPreviousResource(t *testing.T) {
 
 	// Beginning the read mutation should have placed a pending "reading" operation into the operations list.
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 0)
-	assert.Len(t, snap.PendingOperations, 1)
+	require.Len(t, snap.Resources, 0)
+	require.Len(t, snap.PendingOperations, 1)
 	assert.Equal(t, resourceA.URN, snap.PendingOperations[0].Resource.URN)
 	assert.Equal(t, resource.OperationTypeReading, snap.PendingOperations[0].Type)
 	err = mutation.End(step, false /* successful */)
@@ -947,8 +947,8 @@ func TestRecordingReadFailureNoPreviousResource(t *testing.T) {
 
 	// A failed read should clear the in flight operation and leave the snapshot empty.
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 0)
-	assert.Len(t, snap.PendingOperations, 0)
+	require.Len(t, snap.Resources, 0)
+	require.Len(t, snap.PendingOperations, 0)
 }
 
 func TestRecordingReadFailurePreviousResource(t *testing.T) {
@@ -976,8 +976,8 @@ func TestRecordingReadFailurePreviousResource(t *testing.T) {
 	// Beginning the read mutation should have placed a pending "reading" operation into the operations list
 	// with the inputs of the new read
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 1)
-	assert.Len(t, snap.PendingOperations, 1)
+	require.Len(t, snap.Resources, 1)
+	require.Len(t, snap.PendingOperations, 1)
 	assert.Equal(t, resourceA.URN, snap.PendingOperations[0].Resource.URN)
 	assert.Equal(t, resource.OperationTypeReading, snap.PendingOperations[0].Type)
 	assert.Equal(t, resource.NewStringProperty("new"), snap.PendingOperations[0].Resource.Inputs["key"])
@@ -989,8 +989,8 @@ func TestRecordingReadFailurePreviousResource(t *testing.T) {
 	// A failed read should clear the in flight operation and leave the existing read in the snapshot with the
 	// old inputs.
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 1)
-	assert.Len(t, snap.PendingOperations, 0)
+	require.Len(t, snap.Resources, 1)
+	require.Len(t, snap.PendingOperations, 0)
 	assert.Equal(t, resourceA.URN, snap.Resources[0].URN)
 	assert.Equal(t, resource.NewStringProperty("old"), snap.Resources[0].Inputs["key"])
 }
@@ -1027,7 +1027,7 @@ func TestRegisterOutputs(t *testing.T) {
 
 	// It should be identical to what has already been written.
 	lastSnap := sp.LastSnap()
-	assert.Len(t, lastSnap.Resources, 1)
+	require.Len(t, lastSnap.Resources, 1)
 	assert.Equal(t, resourceA.URN, lastSnap.Resources[0].URN)
 }
 
@@ -1044,15 +1044,15 @@ func TestRecordingSameFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// There should be zero snaps performed at the start.
-	assert.Len(t, sp.SavedSnapshots, 0)
+	require.Len(t, sp.SavedSnapshots, 0)
 
 	err = mutation.End(step, false /* successful */)
 	require.NoError(t, err)
 
 	// A failed same should leave the resource in the snapshot.
 	snap = sp.LastSnap()
-	assert.Len(t, snap.Resources, 1)
-	assert.Len(t, snap.PendingOperations, 0)
+	require.Len(t, snap.Resources, 1)
+	require.Len(t, snap.PendingOperations, 0)
 	assert.Equal(t, resourceA.URN, snap.Resources[0].URN)
 }
 

--- a/pkg/cmd/pulumi/config/io_test.go
+++ b/pkg/cmd/pulumi/config/io_test.go
@@ -255,7 +255,7 @@ func TestOpenStackEnv(t *testing.T) {
 
 	openEnv, diags, err := openStackEnv(context.Background(), stack, &projectStack)
 	require.NoError(t, err)
-	assert.Len(t, diags, 0)
+	require.Len(t, diags, 0)
 	assert.Equal(t, env, openEnv.Properties)
 }
 
@@ -282,7 +282,7 @@ func TestOpenStackEnvLiteral(t *testing.T) {
 
 	openEnv, diags, err := openStackEnv(context.Background(), stack, &projectStack)
 	require.NoError(t, err)
-	assert.Len(t, diags, 0)
+	require.Len(t, diags, 0)
 	assert.Equal(t, env, openEnv.Properties)
 }
 
@@ -486,7 +486,7 @@ func TestOpenStackEnvDiags(t *testing.T) {
 
 	_, diags, err := openStackEnv(context.Background(), stack, &projectStack)
 	require.NoError(t, err)
-	assert.Len(t, diags, 1)
+	require.Len(t, diags, 1)
 }
 
 func TestOpenStackEnvError(t *testing.T) {

--- a/pkg/cmd/pulumi/operations/preview_test.go
+++ b/pkg/cmd/pulumi/operations/preview_test.go
@@ -173,7 +173,7 @@ func TestBuildImportFile_SingleResource(t *testing.T) {
 			importFile, err := importFilePromise.Result(context.Background())
 			require.NoError(t, err)
 			// There shouldn't be any thing in the name table
-			assert.Len(t, importFile.NameTable, 0)
+			require.Len(t, importFile.NameTable, 0)
 			// And there should be the one expected resource in the resources table
 			require.Len(t, importFile.Resources, 1)
 			assert.Equal(t, tt.expected, importFile.Resources[0])
@@ -271,7 +271,7 @@ func TestBuildImportFile_NewParent(t *testing.T) {
 	require.NoError(t, err)
 
 	// There shouldn't be anything in the name table
-	assert.Len(t, importFile.NameTable, 0)
+	require.Len(t, importFile.NameTable, 0)
 
 	// And there should be the two expected resources in the resources table
 	require.Len(t, importFile.Resources, 2)

--- a/pkg/cmd/pulumi/state/state_delete_test.go
+++ b/pkg/cmd/pulumi/state/state_delete_test.go
@@ -325,5 +325,5 @@ func TestStateDeleteAll(t *testing.T) {
 	deployment := apitype.DeploymentV3{}
 	err = json.Unmarshal(mockDeployment.Deployment, &deployment)
 	require.NoError(t, err)
-	assert.Len(t, deployment.Resources, 0)
+	require.Len(t, deployment.Resources, 0)
 }

--- a/pkg/cmd/pulumi/state/state_move_test.go
+++ b/pkg/cmd/pulumi/state/state_move_test.go
@@ -1343,7 +1343,7 @@ func TestMoveLockedBackendRevertsDestination(t *testing.T) {
 	destSnapshot, err := destStack.Snapshot(ctx, mp)
 	require.NoError(t, err)
 
-	assert.Len(t, destSnapshot.Resources, 0)
+	require.Len(t, destSnapshot.Resources, 0)
 
 	require.Len(t, sourceSnapshot.Resources, 4)
 	assert.Equal(t, urn.URN("urn:pulumi:sourceStack::test::pulumi:pulumi:Stack::test-sourceStack"),

--- a/pkg/codegen/hcl2/model/binder_expression_test.go
+++ b/pkg/codegen/hcl2/model/binder_expression_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -32,7 +33,7 @@ func TestBindLiteral(t *testing.T) {
 	t.Parallel()
 
 	expr, diags := BindExpressionText("false", nil, hcl.Pos{})
-	assert.Len(t, diags, 0)
+	require.Len(t, diags, 0)
 	assertConvertibleFrom(t, BoolType, expr.Type())
 	lit, ok := expr.(*LiteralValueExpression)
 	assert.True(t, ok)
@@ -40,7 +41,7 @@ func TestBindLiteral(t *testing.T) {
 	assert.Equal(t, "false", fmt.Sprintf("%v", expr))
 
 	expr, diags = BindExpressionText("true", nil, hcl.Pos{})
-	assert.Len(t, diags, 0)
+	require.Len(t, diags, 0)
 	assertConvertibleFrom(t, BoolType, expr.Type())
 	lit, ok = expr.(*LiteralValueExpression)
 	assert.True(t, ok)
@@ -48,7 +49,7 @@ func TestBindLiteral(t *testing.T) {
 	assert.Equal(t, "true", fmt.Sprintf("%v", expr))
 
 	expr, diags = BindExpressionText("0", nil, hcl.Pos{})
-	assert.Len(t, diags, 0)
+	require.Len(t, diags, 0)
 	assertConvertibleFrom(t, NumberType, expr.Type())
 	lit, ok = expr.(*LiteralValueExpression)
 	assert.True(t, ok)
@@ -56,7 +57,7 @@ func TestBindLiteral(t *testing.T) {
 	assert.Equal(t, "0", fmt.Sprintf("%v", expr))
 
 	expr, diags = BindExpressionText("3.14", nil, hcl.Pos{})
-	assert.Len(t, diags, 0)
+	require.Len(t, diags, 0)
 	assertConvertibleFrom(t, NumberType, expr.Type())
 	lit, ok = expr.(*LiteralValueExpression)
 	assert.True(t, ok)
@@ -64,11 +65,11 @@ func TestBindLiteral(t *testing.T) {
 	assert.Equal(t, "3.14", fmt.Sprintf("%v", expr))
 
 	expr, diags = BindExpressionText(`"foo"`, nil, hcl.Pos{})
-	assert.Len(t, diags, 0)
+	require.Len(t, diags, 0)
 	assertConvertibleFrom(t, StringType, expr.Type())
 	template, ok := expr.(*TemplateExpression)
 	assert.True(t, ok)
-	assert.Len(t, template.Parts, 1)
+	require.Len(t, template.Parts, 1)
 	lit, ok = template.Parts[0].(*LiteralValueExpression)
 	assert.True(t, ok)
 	assert.Equal(t, cty.StringVal("foo"), lit.Value)
@@ -140,7 +141,7 @@ func TestBindBinaryOp(t *testing.T) {
 		t.Run(c.x, func(t *testing.T) {
 			t.Parallel()
 			expr, diags := BindExpressionText(c.x, scope, hcl.Pos{})
-			assert.Len(t, diags, 0)
+			require.Len(t, diags, 0)
 			assertConvertibleFrom(t, c.t, expr.Type())
 			_, ok := expr.(*BinaryOpExpression)
 			assert.True(t, ok)
@@ -176,7 +177,7 @@ func TestBindConditional(t *testing.T) {
 		t.Run(c.x, func(t *testing.T) {
 			t.Parallel()
 			expr, diags := BindExpressionText(c.x, scope, hcl.Pos{})
-			assert.Len(t, diags, 0)
+			require.Len(t, diags, 0)
 			assertConvertibleFrom(t, c.t, expr.Type())
 			_, ok := expr.(*ConditionalExpression)
 			assert.True(t, ok)
@@ -241,7 +242,7 @@ func TestBindFor(t *testing.T) {
 		t.Run(c.x, func(t *testing.T) {
 			t.Parallel()
 			expr, diags := BindExpressionText(c.x, scope, hcl.Pos{})
-			assert.Len(t, diags, 0)
+			require.Len(t, diags, 0)
 			assertConvertibleFrom(t, c.t, expr.Type())
 			_, ok := expr.(*ForExpression)
 			assert.True(t, ok)
@@ -301,7 +302,7 @@ func TestBindFunctionCall(t *testing.T) {
 		t.Run(c.x, func(t *testing.T) {
 			t.Parallel()
 			expr, diags := BindExpressionText(c.x, scope, hcl.Pos{})
-			assert.Len(t, diags, 0)
+			require.Len(t, diags, 0)
 			assertConvertibleFrom(t, c.t, expr.Type())
 			_, ok := expr.(*FunctionCallExpression)
 			assert.True(t, ok)
@@ -373,7 +374,7 @@ func TestBindIndex(t *testing.T) {
 			t.Parallel()
 
 			expr, diags := BindExpressionText(c.x, scope, hcl.Pos{})
-			assert.Len(t, diags, 0)
+			require.Len(t, diags, 0)
 			assertConvertibleFrom(t, c.t, expr.Type())
 			_, ok := expr.(*IndexExpression)
 			assert.True(t, ok)
@@ -419,7 +420,7 @@ func TestBindObjectCons(t *testing.T) {
 			t.Parallel()
 
 			expr, diags := BindExpressionText(c.x, scope, hcl.Pos{})
-			assert.Len(t, diags, 0)
+			require.Len(t, diags, 0)
 			assertConvertibleFrom(t, c.t, expr.Type())
 			_, ok := expr.(*ObjectConsExpression)
 			assert.True(t, ok)
@@ -477,7 +478,7 @@ func TestBindRelativeTraversal(t *testing.T) {
 			t.Parallel()
 
 			expr, diags := BindExpressionText(c.x, scope, hcl.Pos{})
-			assert.Len(t, diags, 0)
+			require.Len(t, diags, 0)
 			assertConvertibleFrom(t, c.t, expr.Type())
 			_, ok := expr.(*RelativeTraversalExpression)
 			assert.True(t, ok)
@@ -552,7 +553,7 @@ func TestBindScopeTraversal(t *testing.T) {
 			t.Parallel()
 
 			expr, diags := BindExpressionText(c.x, scope, hcl.Pos{})
-			assert.Len(t, diags, 0)
+			require.Len(t, diags, 0)
 			assertConvertibleFrom(t, c.t, expr.Type())
 			_, ok := expr.(*ScopeTraversalExpression)
 			assert.True(t, ok)
@@ -624,7 +625,7 @@ func TestBindSplat(t *testing.T) {
 			t.Parallel()
 
 			expr, diags := BindExpressionText(c.x, scope, hcl.Pos{})
-			assert.Len(t, diags, 0)
+			require.Len(t, diags, 0)
 			assertConvertibleFrom(t, c.t, expr.Type())
 			_, ok := expr.(*SplatExpression)
 			assert.True(t, ok)
@@ -690,7 +691,7 @@ func TestBindTemplate(t *testing.T) {
 			t.Parallel()
 
 			expr, diags := BindExpressionText(c.x, scope, hcl.Pos{})
-			assert.Len(t, diags, 0)
+			require.Len(t, diags, 0)
 			assertConvertibleFrom(t, c.t, expr.Type())
 
 			var ok bool
@@ -730,7 +731,7 @@ func TestBindTupleCons(t *testing.T) {
 			t.Parallel()
 
 			expr, diags := BindExpressionText(c.x, scope, hcl.Pos{})
-			assert.Len(t, diags, 0)
+			require.Len(t, diags, 0)
 			assertConvertibleFrom(t, c.t, expr.Type())
 			_, ok := expr.(*TupleConsExpression)
 			assert.True(t, ok)
@@ -769,7 +770,7 @@ func TestBindUnaryOp(t *testing.T) {
 			t.Parallel()
 
 			expr, diags := BindExpressionText(c.x, scope, hcl.Pos{})
-			assert.Len(t, diags, 0)
+			require.Len(t, diags, 0)
 			assertConvertibleFrom(t, c.t, expr.Type())
 			_, ok := expr.(*UnaryOpExpression)
 			assert.True(t, ok)

--- a/pkg/codegen/hcl2/syntax/comments_test.go
+++ b/pkg/codegen/hcl2/syntax/comments_test.go
@@ -43,7 +43,7 @@ func commentString(trivia []Trivia) string {
 func validateTokenLeadingTrivia(t *testing.T, token Token) {
 	// There is nowhere to attach leading trivia to template control sequences.
 	if token.Raw.Type == hclsyntax.TokenTemplateControl {
-		assert.Len(t, token.LeadingTrivia, 0)
+		require.Len(t, token.LeadingTrivia, 0)
 		return
 	}
 
@@ -109,24 +109,23 @@ func validateTemplateStringTrivia(t *testing.T, template *hclsyntax.TemplateExpr
 
 	v, err := convert.Convert(n.Val, cty.String)
 	require.NoError(t, err)
-	if v.AsString() == "" || !assert.Len(t, tokens.Value, 1) {
+	if v.AsString() == "" {
 		return
 	}
+	require.Len(t, tokens.Value, 1)
 
 	value := tokens.Value[0]
 	if index == 0 {
-		assert.Len(t, value.LeadingTrivia, 0)
+		require.Len(t, value.LeadingTrivia, 0)
 	} else {
 		delim, ok := value.LeadingTrivia[0].(TemplateDelimiter)
 		assert.True(t, ok)
 		assert.Equal(t, hclsyntax.TokenTemplateSeqEnd, delim.Type)
 	}
 	if index == len(template.Parts)-1 {
-		assert.Len(t, value.TrailingTrivia, 0)
+		require.Len(t, value.TrailingTrivia, 0)
 	} else if len(value.TrailingTrivia) != 0 {
-		if !assert.Len(t, value.TrailingTrivia, 1) {
-			return
-		}
+		require.Len(t, value.TrailingTrivia, 1)
 		delim, ok := value.TrailingTrivia[0].(TemplateDelimiter)
 		assert.True(t, ok)
 		assert.Equal(t, hclsyntax.TokenTemplateInterp, delim.Type)
@@ -238,7 +237,7 @@ func TestComments(t *testing.T) {
 	err = parser.ParseFile(bytes.NewReader(contents), "comments_all.hcl")
 	require.NoError(t, err)
 
-	assert.Len(t, parser.Diagnostics, 0)
+	require.Len(t, parser.Diagnostics, 0)
 
 	f := parser.Files[0]
 	diags := hclsyntax.Walk(f.Body, &validator{t: t, tokens: f.Tokens})

--- a/pkg/codegen/pcl/functions_test.go
+++ b/pkg/codegen/pcl/functions_test.go
@@ -293,7 +293,7 @@ type = pulumiResourceType(res)
 name = pulumiResourceName(res)`
 	program, diags, err := ParseAndBindProgram(t, source, "program.pp")
 	require.NotNil(t, program, "The program doesn't bind")
-	assert.Len(t, diags, 0, "There are no diagnostics")
+	require.Len(t, diags, 0, "There are no diagnostics")
 	assert.Nil(t, err, "There is no bind error")
 	assert.Equal(t, len(program.Nodes), 3, "there are two nodes")
 	localVariable, ok := program.Nodes[1].(*pcl.LocalVariable)

--- a/pkg/codegen/pcl/rewrite_apply_test.go
+++ b/pkg/codegen/pcl/rewrite_apply_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type nameInfo int
@@ -194,10 +195,10 @@ func TestApplyRewriter(t *testing.T) {
 			t.Parallel()
 
 			expr, diags := model.BindExpressionText(c.input, scope, hcl.Pos{})
-			assert.Len(t, diags, 0)
+			require.Len(t, diags, 0)
 
 			expr, diags = RewriteApplies(expr, nameInfo(0), !c.skipPromises)
-			assert.Len(t, diags, 0)
+			require.Len(t, diags, 0)
 
 			assert.Equal(t, c.output, fmt.Sprintf("%v", expr))
 		})
@@ -225,10 +226,10 @@ func TestApplyRewriter(t *testing.T) {
 })`
 
 		expr, diags := model.BindExpressionText(input, scope, hcl.Pos{})
-		assert.Len(t, diags, 0)
+		require.Len(t, diags, 0)
 
 		expr, diags = RewriteAppliesWithSkipToJSON(expr, nameInfo(0), false, true /* skiToJson */)
-		assert.Len(t, diags, 0)
+		require.Len(t, diags, 0)
 
 		output := fmt.Sprintf("%v", expr)
 		assert.Equal(t, expectedOutput, output)

--- a/pkg/codegen/pcl/rewrite_convert_test.go
+++ b/pkg/codegen/pcl/rewrite_convert_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRewriteConversions(t *testing.T) {
@@ -128,14 +129,14 @@ func TestRewriteConversions(t *testing.T) {
 	})
 	for _, c := range cases {
 		expr, diags := model.BindExpressionText(c.input, scope, hcl.Pos{})
-		assert.Len(t, diags, 0)
+		require.Len(t, diags, 0)
 
 		to := c.to
 		if to == nil {
 			to = expr.Type()
 		}
 		expr, diags = RewriteConversions(expr, to)
-		assert.Len(t, diags, 0)
+		require.Len(t, diags, 0)
 		assert.Equal(t, c.output, fmt.Sprintf("%v", expr))
 	}
 }
@@ -171,11 +172,11 @@ func TestRewriteConversionsAfterApply(t *testing.T) {
 
 	for _, c := range cases {
 		expr, diags := model.BindExpressionText(c.input, scope, hcl.Pos{})
-		assert.Len(t, diags, 0)
+		require.Len(t, diags, 0)
 
 		expr, _ = RewriteApplies(expr, nameInfo(0), false)
 		expr, diags = RewriteConversions(expr, expr.Type())
-		assert.Len(t, diags, 0)
+		require.Len(t, diags, 0)
 		assert.Equal(t, c.output, fmt.Sprintf("%v", expr))
 	}
 }

--- a/pkg/codegen/python/gen_program_quotes_test.go
+++ b/pkg/codegen/python/gen_program_quotes_test.go
@@ -64,7 +64,7 @@ resource rta "aws:ec2:RouteTableAssociation" {
 	assert.True(t, ok)
 
 	x, temps := g.lowerExpression(prop.Value, prop.Type())
-	assert.Len(t, temps, 0)
+	require.Len(t, temps, 0)
 
 	x.SetLeadingTrivia(nil)
 	x.SetTrailingTrivia(nil)

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -875,7 +875,7 @@ func TestUsingReservedWordInResourcePropertiesEmitsWarning(t *testing.T) {
 	// No error as binding should work fine even with warnings
 	require.NoError(t, err)
 	// assert that there are 2 warnings in the diagnostics because of using URN as a property
-	assert.Len(t, diags, 2)
+	require.Len(t, diags, 2)
 	for _, diag := range diags {
 		assert.Equal(t, diag.Severity, hcl.DiagWarning)
 		assert.True(
@@ -925,7 +925,7 @@ func TestUsingVersionKeywordInResourcePropertiesIsOk(t *testing.T) {
 	})
 	// No error as binding should work fine even with warnings
 	require.NoError(t, err)
-	assert.Len(t, diags, 0)
+	require.Len(t, diags, 0)
 	require.NotNil(t, pkg)
 }
 
@@ -954,7 +954,7 @@ func TestUsingReservedWordInFunctionsEmitsError(t *testing.T) {
 		AllowDanglingReferences: true,
 	})
 	assert.Error(t, err)
-	assert.Len(t, diags, 1)
+	require.Len(t, diags, 1)
 	for _, diag := range diags {
 		assert.Equal(t, diag.Severity, hcl.DiagError)
 		fmt.Println(diag.Summary)
@@ -991,7 +991,7 @@ func TestUsingVersionInFunctionParamsIsOk(t *testing.T) {
 		AllowDanglingReferences: true,
 	})
 	require.NoError(t, err)
-	assert.Len(t, diags, 0)
+	require.Len(t, diags, 0)
 	require.NotNil(t, pkg)
 }
 
@@ -1020,7 +1020,7 @@ func TestUsingReservedWordInFunctionParamsIsNotOk(t *testing.T) {
 		AllowDanglingReferences: true,
 	})
 	assert.Error(t, err)
-	assert.Len(t, diags, 1)
+	require.Len(t, diags, 1)
 	assert.Nil(t, pkg)
 }
 
@@ -1050,7 +1050,7 @@ func TestUsingReservedWordInTypesEmitsError(t *testing.T) {
 		AllowDanglingReferences: true,
 	})
 	assert.Error(t, err)
-	assert.Len(t, diags, 1)
+	require.Len(t, diags, 1)
 	for _, diag := range diags {
 		assert.Equal(t, diag.Severity, hcl.DiagError)
 		assert.True(
@@ -1087,7 +1087,7 @@ func TestUsingVersionPropertyNameIsOk(t *testing.T) {
 		AllowDanglingReferences: true,
 	})
 	require.NoError(t, err)
-	assert.Len(t, diags, 0)
+	require.Len(t, diags, 0)
 	require.NotNil(t, pkg)
 }
 
@@ -1117,7 +1117,7 @@ func TestUsingReservedWordPropertyNameIsNotOk(t *testing.T) {
 		AllowDanglingReferences: true,
 	})
 	assert.Error(t, err)
-	assert.Len(t, diags, 1)
+	require.Len(t, diags, 1)
 	assert.Nil(t, pkg)
 }
 
@@ -1149,7 +1149,7 @@ func TestUsingIdInResourcePropertiesEmitsWarning(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pkg)
 	// assert that there is 1 warning in the diagnostics because of using ID as a property
-	assert.Len(t, diags, 1)
+	require.Len(t, diags, 1)
 	assert.Equal(t, diags[0].Severity, hcl.DiagWarning)
 	assert.Contains(t, diags[0].Summary, "id is a reserved property name")
 }
@@ -1168,7 +1168,7 @@ func TestOmittingVersionWhenSupportsPackEnabledGivesError(t *testing.T) {
 	_, diags, _ := BindSpec(pkgSpec, loader, ValidationOptions{
 		AllowDanglingReferences: true,
 	})
-	assert.Len(t, diags, 1)
+	require.Len(t, diags, 1)
 	assert.Equal(t, diags[0].Severity, hcl.DiagError)
 	assert.Contains(t, diags[0].Summary, "version must be provided when package supports packing")
 }
@@ -1214,11 +1214,11 @@ func TestMethods(t *testing.T) {
 		{
 			filename: "good-methods-1.json",
 			validator: func(pkg *Package) {
-				assert.Len(t, pkg.Resources, 1)
-				assert.Len(t, pkg.Resources[0].Methods, 1)
+				require.Len(t, pkg.Resources, 1)
+				require.Len(t, pkg.Resources[0].Methods, 1)
 
 				require.NotNil(t, pkg.Resources[0].Methods[0].Function.Inputs)
-				assert.Len(t, pkg.Resources[0].Methods[0].Function.Inputs.Properties, 1)
+				require.Len(t, pkg.Resources[0].Methods[0].Function.Inputs.Properties, 1)
 				inputs := pkg.Resources[0].Methods[0].Function.Inputs.Properties
 				assert.Equal(t, "__self__", inputs[0].Name)
 				assert.Equal(t, &ResourceType{
@@ -1232,12 +1232,12 @@ func TestMethods(t *testing.T) {
 				}
 
 				require.NotNil(t, objectReturnType)
-				assert.Len(t, objectReturnType.Properties, 1)
+				require.Len(t, objectReturnType.Properties, 1)
 				outputs := objectReturnType.Properties
 				assert.Equal(t, "someValue", outputs[0].Name)
 				assert.Equal(t, StringType, outputs[0].Type)
 
-				assert.Len(t, pkg.Functions, 1)
+				require.Len(t, pkg.Functions, 1)
 				assert.True(t, pkg.Functions[0].IsMethod)
 				assert.Same(t, pkg.Resources[0].Methods[0].Function, pkg.Functions[0])
 			},
@@ -1245,7 +1245,7 @@ func TestMethods(t *testing.T) {
 		{
 			filename: "good-simplified-methods.json",
 			validator: func(pkg *Package) {
-				assert.Len(t, pkg.Functions, 1)
+				require.Len(t, pkg.Functions, 1)
 				require.NotNil(t, pkg.Functions[0].ReturnType, "There should be a return type")
 				assert.Equal(t, pkg.Functions[0].ReturnType, NumberType)
 			},
@@ -1253,7 +1253,7 @@ func TestMethods(t *testing.T) {
 		{
 			filename: "good-simplified-methods.yml",
 			validator: func(pkg *Package) {
-				assert.Len(t, pkg.Functions, 1)
+				require.Len(t, pkg.Functions, 1)
 				require.NotNil(t, pkg.Functions[0].ReturnType, "There should be a return type")
 				assert.Equal(t, pkg.Functions[0].ReturnType, NumberType)
 			},
@@ -1290,19 +1290,19 @@ func TestMethods(t *testing.T) {
 		{
 			filename: "provider-methods-1.json",
 			validator: func(pkg *Package) {
-				assert.Len(t, pkg.Functions, 1)
+				require.Len(t, pkg.Functions, 1)
 			},
 		},
 		{
 			filename: "provider-methods-2.json",
 			validator: func(pkg *Package) {
-				assert.Len(t, pkg.Functions, 2)
+				require.Len(t, pkg.Functions, 2)
 			},
 		},
 		{
 			filename: "provider-methods-3.json",
 			validator: func(pkg *Package) {
-				assert.Len(t, pkg.Functions, 2)
+				require.Len(t, pkg.Functions, 2)
 			},
 		},
 	}
@@ -2345,7 +2345,7 @@ func TestResourceWithKeynameOverlapFunction(t *testing.T) {
 
 	_, diags, err := BindSpec(pkgSpec, loader, ValidationOptions{})
 	require.ErrorContains(t, err, "is a reserved name, cannot name function")
-	assert.Len(t, diags, 1)
+	require.Len(t, diags, 1)
 }
 
 func TestResourceWithKeynameOverlapResource(t *testing.T) {
@@ -2365,7 +2365,7 @@ func TestResourceWithKeynameOverlapResource(t *testing.T) {
 	}
 
 	_, diags, _ := BindSpec(pkgSpec, loader, ValidationOptions{})
-	assert.Len(t, diags, 1)
+	require.Len(t, diags, 1)
 	assert.Contains(t, diags[0].Summary, "is a reserved name, cannot name resource")
 }
 
@@ -2398,7 +2398,7 @@ func TestResourceWithKeynameOverlapType(t *testing.T) {
 
 	_, diags, err := BindSpec(pkgSpec, loader, ValidationOptions{})
 	assert.Error(t, err)
-	assert.Len(t, diags, 1)
+	require.Len(t, diags, 1)
 	assert.Contains(t, diags[0].Summary, "pulumi is a reserved name, cannot name type")
 }
 

--- a/pkg/engine/lifecycletest/alias_test.go
+++ b/pkg/engine/lifecycletest/alias_test.go
@@ -1306,7 +1306,7 @@ func TestDuplicatesDueToAliases(t *testing.T) {
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 
 	// Set mode to try and create A then a B that aliases to it, this should fail
@@ -1314,7 +1314,7 @@ func TestDuplicatesDueToAliases(t *testing.T) {
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	assert.Error(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 
 	// Set mode to try and create B first then a A, this should fail
@@ -1322,7 +1322,7 @@ func TestDuplicatesDueToAliases(t *testing.T) {
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
 	assert.Error(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	// Because we made the B first that's what should end up in the state file
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resB"), snap.Resources[1].URN)
 }
@@ -1410,7 +1410,7 @@ func TestCorrectResourceChosen(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	assert.Nil(t, snap.VerifyIntegrity())
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA$pkgA:m:typA::resB"), snap.Resources[2].URN)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resB"), snap.Resources[3].URN)
@@ -1421,10 +1421,10 @@ func TestCorrectResourceChosen(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	assert.Nil(t, snap.VerifyIntegrity())
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resB"), snap.Resources[2].URN)
-	assert.Len(t, snap.Resources[2].Aliases, 0)
+	require.Len(t, snap.Resources[2].Aliases, 0)
 }
 
 func TestComponentToCustomUpdate(t *testing.T) {
@@ -1484,7 +1484,7 @@ func TestComponentToCustomUpdate(t *testing.T) {
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 1)
+	require.Len(t, snap.Resources, 1)
 	assert.Equal(t, tokens.Type("prog::myType"), snap.Resources[0].Type)
 	assert.False(t, snap.Resources[0].Custom)
 
@@ -1503,7 +1503,7 @@ func TestComponentToCustomUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	// Now two because we'll have a provider now
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, tokens.Type("pkgA:m:typA"), snap.Resources[1].Type)
 	assert.True(t, snap.Resources[1].Custom)
 
@@ -1522,7 +1522,7 @@ func TestComponentToCustomUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	// Back to one because the provider should have been cleaned up as well
-	assert.Len(t, snap.Resources, 1)
+	require.Len(t, snap.Resources, 1)
 	assert.Equal(t, tokens.Type("prog::myType"), snap.Resources[0].Type)
 	assert.False(t, snap.Resources[0].Custom)
 }
@@ -1596,7 +1596,7 @@ func TestParentAlias(t *testing.T) {
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 
 	// Now run again with the rearranged parents, we don't expect to see any replaces
 	firstRun = false
@@ -1611,7 +1611,7 @@ func TestParentAlias(t *testing.T) {
 		}, "1")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 }
 
 func TestEmptyParentAlias(t *testing.T) {
@@ -1672,7 +1672,7 @@ func TestEmptyParentAlias(t *testing.T) {
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 
 	// Now run again with the rearranged parents, we don't expect to see any replaces
 	firstRun = false
@@ -1687,7 +1687,7 @@ func TestEmptyParentAlias(t *testing.T) {
 		}, "1")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 }
 
 func TestSplitUpdateComponentAliases(t *testing.T) {
@@ -1795,7 +1795,7 @@ func TestSplitUpdateComponentAliases(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	assert.Nil(t, snap.VerifyIntegrity())
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA$pkgA:m:typB::resB"), snap.Resources[2].URN)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[2].Parent)
@@ -1812,7 +1812,7 @@ func TestSplitUpdateComponentAliases(t *testing.T) {
 	assert.Error(t, err)
 	require.NotNil(t, snap)
 	assert.Nil(t, snap.VerifyIntegrity())
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typB::resB"), snap.Resources[0].URN)
 	assert.Equal(t, resource.URN(""), snap.Resources[0].Parent)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[2].URN)
@@ -1825,7 +1825,7 @@ func TestSplitUpdateComponentAliases(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	assert.Nil(t, snap.VerifyIntegrity())
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typB::resB"), snap.Resources[0].URN)
 	assert.Equal(t, resource.URN(""), snap.Resources[0].Parent)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typB$pkgA:m:typC::resC"), snap.Resources[2].URN)
@@ -1927,7 +1927,7 @@ func TestFailDeleteDuplicateAliases(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	assert.Nil(t, snap.VerifyIntegrity())
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 
 	// Run the next case, resA should be aliased
@@ -1936,7 +1936,7 @@ func TestFailDeleteDuplicateAliases(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	assert.Nil(t, snap.VerifyIntegrity())
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resAX"), snap.Resources[1].URN)
 
 	// Run the last case, resAX should try to delete and resA should be created. We can't possibly know that resA ==
@@ -1946,7 +1946,7 @@ func TestFailDeleteDuplicateAliases(t *testing.T) {
 	assert.Error(t, err)
 	require.NotNil(t, snap)
 	assert.Nil(t, snap.VerifyIntegrity())
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resAX"), snap.Resources[2].URN)
 }

--- a/pkg/engine/lifecycletest/analyzer_test.go
+++ b/pkg/engine/lifecycletest/analyzer_test.go
@@ -428,7 +428,7 @@ func TestSimpleAnalyzeResourceFailureRemediateDowngradedToMandatory(t *testing.T
 							violationEvents = append(violationEvents, e)
 						}
 					}
-					assert.Len(t, violationEvents, 1)
+					require.Len(t, violationEvents, 1)
 					assert.Equal(t, apitype.Mandatory,
 						violationEvents[0].Payload().(PolicyViolationEventPayload).EnforcementLevel)
 
@@ -494,7 +494,7 @@ func TestSimpleAnalyzeStackFailureRemediateDowngradedToMandatory(t *testing.T) {
 							violationEvents = append(violationEvents, e)
 						}
 					}
-					assert.Len(t, violationEvents, 1)
+					require.Len(t, violationEvents, 1)
 					assert.Equal(t, apitype.Mandatory,
 						violationEvents[0].Payload().(PolicyViolationEventPayload).EnforcementLevel)
 

--- a/pkg/engine/lifecycletest/continue_on_error_test.go
+++ b/pkg/engine/lifecycletest/continue_on_error_test.go
@@ -93,13 +93,13 @@ func TestDestroyContinueOnError(t *testing.T) {
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 7) // We expect 5 resources + 2 providers
+	require.Len(t, snap.Resources, 7) // We expect 5 resources + 2 providers
 
 	createResource = false
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	assert.ErrorContains(t, err, "intentionally failed delete")
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 4) // We expect 2 resources + 2 providers
+	require.Len(t, snap.Resources, 4) // We expect 2 resources + 2 providers
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pulumi:providers:pkgA::default"), snap.Resources[0].URN)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::dependency"), snap.Resources[1].URN)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pulumi:providers:pkgB::default"), snap.Resources[2].URN)
@@ -702,7 +702,7 @@ func TestDestroyContinueOnErrorDeleteAfterFailedUp(t *testing.T) {
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2) // We expect 1 resource + 1 provider
+	require.Len(t, snap.Resources, 2) // We expect 1 resource + 1 provider
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pulumi:providers:pkgA::default"), snap.Resources[0].URN)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::willBeDeleted"), snap.Resources[1].URN)
 
@@ -710,7 +710,7 @@ func TestDestroyContinueOnErrorDeleteAfterFailedUp(t *testing.T) {
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	assert.ErrorContains(t, err, "intentionally failed create")
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 1) // We expect 1 provider
+	require.Len(t, snap.Resources, 1) // We expect 1 provider
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pulumi:providers:pkgB::default"), snap.Resources[0].URN)
 }
 
@@ -901,7 +901,7 @@ func TestContinueOnErrorWithChangingProviderOnCreate(t *testing.T) {
 		RunStep(project, p.GetTarget(t, nil), upOptions, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 
 	assert.Equal(t, "provA", snap.Resources[0].URN.Name())
 	assert.Equal(t, "resA", snap.Resources[1].URN.Name())
@@ -949,7 +949,7 @@ func TestContinueOnErrorWithChangingProviderOnCreate(t *testing.T) {
 		RunStep(project, p.GetTarget(t, snap), replaceOptions, false, p.BackendClient, nil, "1")
 	assert.ErrorContains(t, err, "interrupt replace")
 
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, snap.Resources[0].URN.Name(), "provB")
 	assert.Equal(t, snap.Resources[1].URN.Name(), "provA")
 	assert.Equal(t, snap.Resources[2].URN.Name(), "resA")

--- a/pkg/engine/lifecycletest/delete_before_replace_test.go
+++ b/pkg/engine/lifecycletest/delete_before_replace_test.go
@@ -683,7 +683,7 @@ func TestDBRProtect(t *testing.T) {
 	// First update just create the two resources.
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 
 	// Update A to trigger a replace this should error because of the protect flag on B.
 	inputsA["A"] = resource.NewStringProperty("bar")
@@ -696,7 +696,7 @@ func TestDBRProtect(t *testing.T) {
 	snap.Resources[2].Protect = false
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), options, false, p.BackendClient, nil, "2")
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 }
 
 // Regression test for https://github.com/pulumi/pulumi/issues/19056. If a resource has "replaceOnChanges" set and a
@@ -760,7 +760,7 @@ func TestDBRReplaceOnChanges(t *testing.T) {
 	// First update just create the two resources.
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 
 	// Update value to trigger a replace this should also replace resB because of the replaceOnChanges.
 	inputsA["value"] = resource.NewStringProperty("bar")
@@ -795,7 +795,7 @@ func TestDBRReplaceOnChanges(t *testing.T) {
 	}
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), options, false, p.BackendClient, validate, "1")
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 }
 
 // Regression test for a DBR issue with parallel diff. Given two resources A and B where B depends on A, if we
@@ -905,7 +905,7 @@ func TestDBRParallel(t *testing.T) {
 			}
 			snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), options, false, p.BackendClient, nil, "0")
 			require.NoError(t, err)
-			assert.Len(t, snap.Resources, 3)
+			require.Len(t, snap.Resources, 3)
 
 			// Update A to trigger a replace with deleteBeforeReplace set, register B in parallel with no dependencies on A.
 			program = func(monitor *deploytest.ResourceMonitor) error {
@@ -934,7 +934,7 @@ func TestDBRParallel(t *testing.T) {
 
 			snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), options, false, p.BackendClient, nil, "1")
 			require.NoError(t, err)
-			assert.Len(t, snap.Resources, 3)
+			require.Len(t, snap.Resources, 3)
 		})
 	}
 }

--- a/pkg/engine/lifecycletest/destroy_test.go
+++ b/pkg/engine/lifecycletest/destroy_test.go
@@ -141,7 +141,7 @@ func TestDestroyWithProgram(t *testing.T) {
 	// Should have deleted resA and resB
 	assert.Equal(t, int32(2), deleteCalled)
 	// Resources should be deleted from state
-	assert.Len(t, snap.Resources, 0)
+	require.Len(t, snap.Resources, 0)
 }
 
 // Test that we can run a targeted destroy by executing the program for it.
@@ -250,7 +250,7 @@ func TestTargetedDestroyWithProgram(t *testing.T) {
 	// Should have deleted resA
 	assert.Equal(t, 1, deleteCalled)
 	// resA should be deleted from state
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, "resB", snap.Resources[1].URN.Name())
 }
 
@@ -381,7 +381,7 @@ func TestProviderUpdateDestroyWithProgram(t *testing.T) {
 	// Should have deleted resA and resB
 	assert.Equal(t, int32(2), deleteCalled)
 	// All the resources should be deleted from state
-	assert.Len(t, snap.Resources, 0)
+	require.Len(t, snap.Resources, 0)
 }
 
 // Test that we can run a destroy by executing the program for it, and that in that update we change provider version.
@@ -507,7 +507,7 @@ func TestExplicitProviderUpdateDestroyWithProgram(t *testing.T) {
 	// Should have deleted resA and resB
 	assert.Equal(t, int32(2), deleteCalled)
 	// All the resources should be deleted from state
-	assert.Len(t, snap.Resources, 0)
+	require.Len(t, snap.Resources, 0)
 }
 
 // Test that we can run a destroy by executing the program for it when that program creates components.
@@ -607,7 +607,7 @@ func TestDestroyWithProgramWithComponents(t *testing.T) {
 	// Should have deleted resA
 	assert.Equal(t, 1, deleteCalled)
 	// Everything should be deleted from state
-	assert.Len(t, snap.Resources, 0)
+	require.Len(t, snap.Resources, 0)
 }
 
 // Test that we can run a destroy by executing the program for it when that program creates components which
@@ -722,7 +722,7 @@ func TestDestroyWithProgramWithSkippedComponents(t *testing.T) {
 	// Should have deleted resA
 	assert.Equal(t, 1, deleteCalled)
 	// Everything should be deleted from state
-	assert.Len(t, snap.Resources, 0)
+	require.Len(t, snap.Resources, 0)
 }
 
 // Test that we can run a destroy by executing the program for it when that program now aliases _and_ skips
@@ -841,7 +841,7 @@ func TestDestroyWithProgramWithSkippedAlias(t *testing.T) {
 	// Should have deleted resA
 	assert.Equal(t, 1, deleteCalled)
 	// Everything should be deleted from state
-	assert.Len(t, snap.Resources, 0)
+	require.Len(t, snap.Resources, 0)
 }
 
 // Regression test for https://github.com/pulumi/pulumi/issues/19363. Check that a read resource (i.e.
@@ -960,5 +960,5 @@ func TestDestroyWithProgramResourceRead(t *testing.T) {
 	// Should have deleted resA
 	assert.Equal(t, 1, deleteCalled)
 	// Everything should be deleted from state
-	assert.Len(t, snap.Resources, 0)
+	require.Len(t, snap.Resources, 0)
 }

--- a/pkg/engine/lifecycletest/framework/framework.go
+++ b/pkg/engine/lifecycletest/framework/framework.go
@@ -701,7 +701,7 @@ func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
 				}
 				snap, err := entries.Snap(target.Snapshot)
 				require.NoError(t, err)
-				assert.Len(t, snap.Resources, resCount)
+				require.Len(t, snap.Resources, resCount)
 				return err
 			},
 		},
@@ -720,7 +720,7 @@ func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
 				}
 				snap, err := entries.Snap(target.Snapshot)
 				require.NoError(t, err)
-				assert.Len(t, snap.Resources, resCount)
+				require.Len(t, snap.Resources, resCount)
 				return err
 			},
 		},
@@ -739,7 +739,7 @@ func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
 				}
 				snap, err := entries.Snap(target.Snapshot)
 				require.NoError(t, err)
-				assert.Len(t, snap.Resources, resCount)
+				require.Len(t, snap.Resources, resCount)
 				return err
 			},
 		},
@@ -758,7 +758,7 @@ func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
 				}
 				snap, err := entries.Snap(target.Snapshot)
 				require.NoError(t, err)
-				assert.Len(t, snap.Resources, resCount)
+				require.Len(t, snap.Resources, resCount)
 				return err
 			},
 		},
@@ -781,7 +781,7 @@ func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
 				}
 				snap, err := entries.Snap(target.Snapshot)
 				require.NoError(t, err)
-				assert.Len(t, snap.Resources, 0)
+				require.Len(t, snap.Resources, 0)
 				return err
 			},
 		},
@@ -793,10 +793,10 @@ func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
 			) error {
 				require.NoError(t, err)
 
-				assert.Len(t, entries, 0)
+				require.Len(t, entries, 0)
 				snap, err := entries.Snap(target.Snapshot)
 				require.NoError(t, err)
-				assert.Len(t, snap.Resources, 0)
+				require.Len(t, snap.Resources, 0)
 				return err
 			},
 		},

--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -156,7 +156,7 @@ func TestImportOption(t *testing.T) {
 			return err
 		}, "0")
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, inputs, snap.Resources[1].Inputs)
 	assert.Equal(t, expectedOutputs, snap.Resources[1].Outputs)
 
@@ -179,7 +179,7 @@ func TestImportOption(t *testing.T) {
 			return err
 		}, "1")
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, readInputs, snap.Resources[1].Inputs)
 	assert.Equal(t, readOutputs, snap.Resources[1].Outputs)
 	assert.Equal(t, resource.ID("id"), snap.Resources[1].ImportID)
@@ -264,7 +264,7 @@ func TestImportOption(t *testing.T) {
 			return err
 		}, "6")
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	// This will have just called create which returns the inputs as outputs.
 	assert.Equal(t, inputs, snap.Resources[1].Inputs)
 	assert.Equal(t, inputs, snap.Resources[1].Outputs)
@@ -338,7 +338,7 @@ func TestImportOption(t *testing.T) {
 			return err
 		}, "9")
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, readInputs, snap.Resources[1].Inputs)
 	assert.Equal(t, readOutputs, snap.Resources[1].Outputs)
 
@@ -451,7 +451,7 @@ func TestImportWithDifferingImportIdentifierFormat(t *testing.T) {
 			return err
 		}, "0")
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 
 	// Now, run another update. The update should succeed and there should be no diffs.
 	_, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient,
@@ -650,7 +650,7 @@ func TestImportPlan(t *testing.T) {
 	}}).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 
 	// Import should save the ID, inputs and outputs
 	assert.Equal(t, resource.ID("actual-id"), snap.Resources[3].ID)
@@ -719,7 +719,7 @@ func TestImportIgnoreChanges(t *testing.T) {
 	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	require.NoError(t, err)
 
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, resource.NewStringProperty("bar"), snap.Resources[1].Outputs["foo"])
 }
 
@@ -810,7 +810,7 @@ func TestImportPlanExistingImport(t *testing.T) {
 		}, "2")
 
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 }
 
 func TestImportPlanEmptyState(t *testing.T) {
@@ -864,7 +864,7 @@ func TestImportPlanEmptyState(t *testing.T) {
 	}}).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 }
 
 func TestImportPlanSpecificProvider(t *testing.T) {
@@ -927,7 +927,7 @@ func TestImportPlanSpecificProvider(t *testing.T) {
 	}}).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 }
 
 func TestImportPlanSpecificProperties(t *testing.T) {
@@ -1010,7 +1010,7 @@ func TestImportPlanSpecificProperties(t *testing.T) {
 	}}).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 
 	// We should still have the baz output but will be missing its input
 	assert.Equal(t, resource.NewNumberProperty(2), snap.Resources[2].Outputs["baz"])
@@ -1076,7 +1076,7 @@ func TestImportIntoParent(t *testing.T) {
 	}).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 }
 
 func TestImportComponent(t *testing.T) {
@@ -1134,7 +1134,7 @@ func TestImportComponent(t *testing.T) {
 	}).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 
 	// Ensure that the resource 2 is the component.
 	comp := snap.Resources[2]
@@ -1208,7 +1208,7 @@ func TestImportRemoteComponent(t *testing.T) {
 	}).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 5)
+	require.Len(t, snap.Resources, 5)
 
 	// Ensure that the resource 3 is the component.
 	comp := snap.Resources[3]
@@ -1294,7 +1294,7 @@ func TestImportInputDiff(t *testing.T) {
 		}, "0")
 	require.NoError(t, err)
 	// 3 because Import magic's up a Stack resource.
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 
 	// Import should save the ID, inputs and outputs
 	assert.Equal(t, resource.ID("actual-id"), snap.Resources[2].ID)
@@ -1382,7 +1382,7 @@ func TestImportDefaultProvider(t *testing.T) {
 	}}).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 
 	// The default provider should have been created with the expected version.
 	assert.Equal(t, tokens.Type("pulumi:providers:pkgA"), snap.Resources[1].URN.Type())
@@ -1524,7 +1524,7 @@ func TestImportWithFailedUpdate(t *testing.T) {
 			return err
 		}, "0")
 	assert.ErrorContains(t, err, "step application failed: update failed")
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, readInputs, snap.Resources[1].Inputs)
 	assert.Equal(t, readOutputs, snap.Resources[1].Outputs)
 }

--- a/pkg/engine/lifecycletest/parameterized_test.go
+++ b/pkg/engine/lifecycletest/parameterized_test.go
@@ -118,7 +118,7 @@ func TestPackageRef(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 	assert.Equal(t, string(snap.Resources[0].URN)+"::"+string(snap.Resources[0].ID), snap.Resources[1].Provider)
 	assert.Equal(t, string(snap.Resources[2].URN)+"::"+string(snap.Resources[2].ID), snap.Resources[3].Provider)
 }
@@ -342,7 +342,7 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "up")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 7)
+	require.Len(t, snap.Resources, 7)
 
 	// Check that we loaded the provider thrice
 	assert.Equal(t, 3, loadCount)
@@ -364,13 +364,13 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "refresh")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 7)
+	require.Len(t, snap.Resources, 7)
 
 	snap, err = lt.TestOp(Destroy).RunStep(
 		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "destroy")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 0)
+	require.Len(t, snap.Resources, 0)
 }
 
 // TestReplacementParameterizedProviderConfig tests that we can register a parameterized provider that uses config keys
@@ -470,7 +470,7 @@ func TestReplacementParameterizedProviderConfig(t *testing.T) {
 		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "up")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 
 	// Check the state of the parameterized provider is what we expect
 	prov := snap.Resources[2]
@@ -489,13 +489,13 @@ func TestReplacementParameterizedProviderConfig(t *testing.T) {
 		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "refresh")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 
 	snap, err = lt.TestOp(Destroy).RunStep(
 		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "destroy")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 0)
+	require.Len(t, snap.Resources, 0)
 }
 
 // TestReplacementParameterizedProviderImport tests that we can register a parameterized provider that replaces a base
@@ -611,7 +611,7 @@ func TestReplacementParameterizedProviderImport(t *testing.T) {
 		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "up")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 6)
+	require.Len(t, snap.Resources, 6)
 
 	// Check that we loaded the provider thrice
 	assert.Equal(t, 3, loadCount)

--- a/pkg/engine/lifecycletest/pending_replace_test.go
+++ b/pkg/engine/lifecycletest/pending_replace_test.go
@@ -136,7 +136,7 @@ func TestPendingReplaceFailureDoesNotViolateSnapshotIntegrity(t *testing.T) {
 		RunStep(project, p.GetTarget(t, nil), upOptions, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 
-	assert.Len(t, upSnap.Resources, 3)
+	require.Len(t, upSnap.Resources, 3)
 	assert.Equal(t, "default", upSnap.Resources[0].URN.Name())
 	assert.Equal(t, "resA", upSnap.Resources[1].URN.Name())
 	assert.Equal(t, "resB", upSnap.Resources[2].URN.Name())
@@ -159,7 +159,7 @@ func TestPendingReplaceFailureDoesNotViolateSnapshotIntegrity(t *testing.T) {
 		RunStep(project, p.GetTarget(t, upSnap), replaceOptions, false, p.BackendClient, nil, "1")
 	assert.ErrorContains(t, err, "interrupt replace")
 
-	assert.Len(t, replaceSnap.Resources, 3)
+	require.Len(t, replaceSnap.Resources, 3)
 	assert.Equal(t, "default", replaceSnap.Resources[0].URN.Name())
 
 	assert.Equal(t, "resA", replaceSnap.Resources[1].URN.Name())
@@ -196,7 +196,7 @@ func TestPendingReplaceFailureDoesNotViolateSnapshotIntegrity(t *testing.T) {
 		RunStep(project, p.GetTarget(t, replaceSnap), retryOptions, false, p.BackendClient, nil, "2")
 	require.NoError(t, err)
 
-	assert.Len(t, retrySnap.Resources, 3)
+	require.Len(t, retrySnap.Resources, 3)
 	assert.Equal(t, "default", retrySnap.Resources[0].URN.Name())
 
 	assert.True(t, diffsCalled["resA"], "Diff should be called on resA")
@@ -301,7 +301,7 @@ func TestPendingReplaceResumeWithSameGoals(t *testing.T) {
 		RunStep(project, p.GetTarget(t, nil), upOptions, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 
-	assert.Len(t, upSnap.Resources, 2)
+	require.Len(t, upSnap.Resources, 2)
 	assert.Equal(t, upSnap.Resources[0].URN.Name(), "default")
 	assert.Equal(t, upSnap.Resources[1].URN.Name(), "resA")
 
@@ -325,7 +325,7 @@ func TestPendingReplaceResumeWithSameGoals(t *testing.T) {
 		RunStep(project, p.GetTarget(t, upSnap), replaceOptions, false, p.BackendClient, nil, "1")
 	assert.ErrorContains(t, err, "interrupt replace")
 
-	assert.Len(t, replaceSnap.Resources, 2)
+	require.Len(t, replaceSnap.Resources, 2)
 	assert.Equal(t, replaceSnap.Resources[0].URN.Name(), "default")
 	assert.Equal(t, replaceSnap.Resources[1].URN.Name(), "resA")
 	assert.True(t, deleteCalled, "Delete should be called as part of replacement")
@@ -354,7 +354,7 @@ func TestPendingReplaceResumeWithSameGoals(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert.
-	assert.Len(t, removeSnap.Resources, 2)
+	require.Len(t, removeSnap.Resources, 2)
 	assert.Equal(t, removeSnap.Resources[0].URN.Name(), "default")
 	assert.Equal(t, removeSnap.Resources[1].URN.Name(), "resA")
 	assert.False(t, deleteCalled, "Delete shouldn't be called a second time when resuming a replacement (same goals)")
@@ -454,7 +454,7 @@ func TestPendingReplaceResumeWithDeletedGoals(t *testing.T) {
 		RunStep(project, p.GetTarget(t, nil), upOptions, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 
-	assert.Len(t, upSnap.Resources, 2)
+	require.Len(t, upSnap.Resources, 2)
 	assert.Equal(t, upSnap.Resources[0].URN.Name(), "default")
 	assert.Equal(t, upSnap.Resources[1].URN.Name(), "resA")
 
@@ -478,7 +478,7 @@ func TestPendingReplaceResumeWithDeletedGoals(t *testing.T) {
 		RunStep(project, p.GetTarget(t, upSnap), replaceOptions, false, p.BackendClient, nil, "1")
 	assert.ErrorContains(t, err, "interrupt replace")
 
-	assert.Len(t, replaceSnap.Resources, 2)
+	require.Len(t, replaceSnap.Resources, 2)
 	assert.Equal(t, replaceSnap.Resources[0].URN.Name(), "default")
 	assert.Equal(t, replaceSnap.Resources[1].URN.Name(), "resA")
 	assert.True(t, deleteCalled, "Delete should be called as part of replacement")
@@ -514,7 +514,7 @@ func TestPendingReplaceResumeWithDeletedGoals(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert.
-	assert.Len(t, removeSnap.Resources, 0)
+	require.Len(t, removeSnap.Resources, 0)
 	assert.False(t, deleteCalled, "Delete shouldn't be called a second time when resuming a replacement (deleted goals)")
 	assert.False(t, createCalled, "Create shouldn't be called when resuming a replacement (deleted goals)")
 }
@@ -630,7 +630,7 @@ func TestPendingReplaceResumeWithUpdatedGoals(t *testing.T) {
 		RunStep(project, p.GetTarget(t, nil), upOptions, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 
-	assert.Len(t, upSnap.Resources, 2)
+	require.Len(t, upSnap.Resources, 2)
 	assert.Equal(t, upSnap.Resources[0].URN.Name(), "default")
 	assert.Equal(t, upSnap.Resources[1].URN.Name(), "resA")
 
@@ -654,7 +654,7 @@ func TestPendingReplaceResumeWithUpdatedGoals(t *testing.T) {
 		RunStep(project, p.GetTarget(t, upSnap), replaceOptions, false, p.BackendClient, nil, "1")
 	assert.ErrorContains(t, err, "interrupt replace")
 
-	assert.Len(t, replaceSnap.Resources, 2)
+	require.Len(t, replaceSnap.Resources, 2)
 	assert.Equal(t, replaceSnap.Resources[0].URN.Name(), "default")
 	assert.Equal(t, replaceSnap.Resources[1].URN.Name(), "resA")
 	assert.True(t, deleteCalled, "Delete should be called as part of replacement")
@@ -686,7 +686,7 @@ func TestPendingReplaceResumeWithUpdatedGoals(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert.
-	assert.Len(t, removeSnap.Resources, 2)
+	require.Len(t, removeSnap.Resources, 2)
 	assert.Equal(t, removeSnap.Resources[0].URN.Name(), "default")
 	assert.Equal(t, removeSnap.Resources[1].URN.Name(), "resA")
 	assert.False(t, deleteCalled, "Delete shouldn't be called a second time when resuming a replacement (updated goals)")
@@ -737,7 +737,7 @@ func TestInteruptedPendingReplace(t *testing.T) {
 		RunStep(project, p.GetTarget(t, nil), upOptions, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 
-	assert.Len(t, upSnap.Resources, 3)
+	require.Len(t, upSnap.Resources, 3)
 	assert.Equal(t, upSnap.Resources[0].URN.Name(), "default")
 	assert.Equal(t, upSnap.Resources[1].URN.Name(), "resA")
 	assert.Equal(t, upSnap.Resources[2].URN.Name(), "resB")
@@ -770,7 +770,7 @@ func TestInteruptedPendingReplace(t *testing.T) {
 		RunStep(project, p.GetTarget(t, upSnap), upOptions, false, p.BackendClient, nil, "1")
 	assert.ErrorContains(t, err, "interrupt replace")
 
-	assert.Len(t, replaceSnap.Resources, 3)
+	require.Len(t, replaceSnap.Resources, 3)
 	assert.Equal(t, replaceSnap.Resources[0].URN.Name(), "default")
 	assert.Equal(t, replaceSnap.Resources[1].URN.Name(), "resA")
 	assert.True(t, replaceSnap.Resources[1].PendingReplacement)
@@ -782,7 +782,7 @@ func TestInteruptedPendingReplace(t *testing.T) {
 		RunStep(project, p.GetTarget(t, replaceSnap), upOptions, false, p.BackendClient, nil, "2")
 	assert.ErrorContains(t, err, "interrupt replace")
 
-	assert.Len(t, secondReplaceSnap.Resources, 3)
+	require.Len(t, secondReplaceSnap.Resources, 3)
 	assert.Equal(t, secondReplaceSnap.Resources[0].URN.Name(), "default")
 	assert.Equal(t, secondReplaceSnap.Resources[1].URN.Name(), "resA")
 	assert.True(t, secondReplaceSnap.Resources[1].PendingReplacement)
@@ -816,7 +816,7 @@ func TestInteruptedPendingReplace(t *testing.T) {
 		RunStep(project, p.GetTarget(t, secondReplaceSnap), upOptions, false, p.BackendClient, nil, "3")
 	require.NoError(t, err)
 
-	assert.Len(t, secondUpSnap.Resources, 3)
+	require.Len(t, secondUpSnap.Resources, 3)
 	assert.Equal(t, secondUpSnap.Resources[0].URN.Name(), "default")
 	assert.Equal(t, secondUpSnap.Resources[1].URN.Name(), "resA")
 	assert.False(t, secondUpSnap.Resources[1].PendingReplacement)

--- a/pkg/engine/lifecycletest/protect_test.go
+++ b/pkg/engine/lifecycletest/protect_test.go
@@ -78,7 +78,7 @@ func TestMultipleProtectedDeletes(t *testing.T) {
 	snap, err := lt.TestOp(Update).
 		RunStep(p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 	assert.Equal(t, resource.RootStackType, snap.Resources[0].Type)
 
 	// Run a preview that will try and delete both resA and resB.
@@ -163,7 +163,7 @@ func TestProtectInheritance(t *testing.T) {
 	snap, err := lt.TestOp(Update).
 		RunStep(p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 	// Assert that parent and resA are protected and resB is not
 	assert.Equal(t, "parent", snap.Resources[0].URN.Name())
 	assert.Equal(t, "resA", snap.Resources[2].URN.Name())

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -158,7 +158,7 @@ func TestSingleResourceDefaultProviderUpgrade(t *testing.T) {
 		}
 		snap, err := entries.Snap(target.Snapshot)
 		require.NoError(t, err)
-		assert.Len(t, snap.Resources, 2)
+		require.Len(t, snap.Resources, 2)
 		return err
 	}
 
@@ -192,10 +192,10 @@ func TestSingleResourceDefaultProviderUpgrade(t *testing.T) {
 					t.Fatalf("unexpected resource %v", urn)
 				}
 			}
-			assert.Len(t, deleted, 2)
+			require.Len(t, deleted, 2)
 			snap, err := entries.Snap(target.Snapshot)
 			require.NoError(t, err)
-			assert.Len(t, snap.Resources, 0)
+			require.Len(t, snap.Resources, 0)
 			return err
 		},
 	}}
@@ -1599,7 +1599,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 
 				snap, err := entries.Snap(target.Snapshot)
 				require.NoError(t, err)
-				assert.Len(t, snap.Resources, 3)
+				require.Len(t, snap.Resources, 3)
 				for _, r := range snap.Resources {
 					c.validate(t, r)
 				}

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -738,12 +738,12 @@ func TestRefreshWithPendingOperations(t *testing.T) {
 	withRefresh.Refresh = true
 	new, err := op.RunStep(project, target, withRefresh, false, nil, nil, "0")
 	require.NoError(t, err)
-	assert.Len(t, new.PendingOperations, 0)
+	require.Len(t, new.PendingOperations, 0)
 
 	// Similarly, the update should succeed if performed after a separate refresh.
 	new, err = lt.TestOp(Refresh).RunStep(project, target, options, false, nil, nil, "1")
 	require.NoError(t, err)
-	assert.Len(t, new.PendingOperations, 0)
+	require.Len(t, new.PendingOperations, 0)
 
 	_, err = op.RunStep(project, p.GetTarget(t, new), options, false, nil, nil, "2")
 	require.NoError(t, err)
@@ -817,7 +817,7 @@ func TestRefreshPreservesPendingCreateOperations(t *testing.T) {
 	new, err := op.Run(project, target, withRefresh, false, nil, nil)
 	require.NoError(t, err)
 	// Assert that pending CREATE operation was preserved
-	assert.Len(t, new.PendingOperations, 1)
+	require.Len(t, new.PendingOperations, 1)
 	assert.Equal(t, resource.OperationTypeCreating, new.PendingOperations[0].Type)
 	assert.Equal(t, urnB, new.PendingOperations[0].Resource.URN)
 }
@@ -977,8 +977,8 @@ func TestUpdatePartialFailure(t *testing.T) {
 					case JournalEntrySuccess:
 						inputs := entry.Step.New().Inputs
 						outputs := entry.Step.New().Outputs
-						assert.Len(t, inputs, 1)
-						assert.Len(t, outputs, 1)
+						require.Len(t, inputs, 1)
+						require.Len(t, outputs, 1)
 						assert.Equal(t,
 							resource.NewStringProperty("old inputs"), inputs[resource.PropertyKey("input_prop")])
 						assert.Equal(t,
@@ -1941,7 +1941,7 @@ func TestCustomTimeouts(t *testing.T) {
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
 
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, snap.Resources[0].URN.Name(), "default")
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
 	require.NotNil(t, snap.Resources[1].CustomTimeouts)
@@ -2600,7 +2600,7 @@ func TestLanguageClient(t *testing.T) {
 
 	snap, err := update.Finish(nil)
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 }
 
 func TestConfigSecrets(t *testing.T) {
@@ -2637,9 +2637,7 @@ func TestConfigSecrets(t *testing.T) {
 	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	require.NoError(t, err)
 
-	if !assert.Len(t, snap.Resources, 2) {
-		return
-	}
+	require.Len(t, snap.Resources, 2)
 
 	provider := snap.Resources[0]
 	assert.True(t, provider.Inputs["secret"].IsSecret())
@@ -2742,7 +2740,7 @@ func TestProtect(t *testing.T) {
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, "created-id-0", snap.Resources[1].ID.String())
 	assert.Equal(t, 0, deleteCounter)
 
@@ -2782,7 +2780,7 @@ func TestProtect(t *testing.T) {
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, validate, "2")
 	assert.Error(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, "created-id-0", snap.Resources[1].ID.String())
 	assert.Equal(t, 0, deleteCounter)
 
@@ -2795,7 +2793,7 @@ func TestProtect(t *testing.T) {
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, validate, "3")
 	assert.Error(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, "created-id-0", snap.Resources[1].ID.String())
 	assert.Equal(t, true, snap.Resources[1].Protect)
 	assert.Equal(t, 0, deleteCounter)
@@ -2808,7 +2806,7 @@ func TestProtect(t *testing.T) {
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "4")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, "created-id-2", snap.Resources[1].ID.String())
 	assert.Equal(t, false, snap.Resources[1].Protect)
 	assert.Equal(t, 1, deleteCounter)
@@ -2818,7 +2816,7 @@ func TestProtect(t *testing.T) {
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "5")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, "created-id-2", snap.Resources[1].ID.String())
 	assert.Equal(t, true, snap.Resources[1].Protect)
 	assert.Equal(t, 1, deleteCounter)
@@ -2831,7 +2829,7 @@ func TestProtect(t *testing.T) {
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, validate, "6")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, "created-id-3", snap.Resources[1].ID.String())
 	assert.Equal(t, 2, deleteCounter)
 }
@@ -2917,7 +2915,7 @@ func TestDeletedWith(t *testing.T) {
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 	assert.Equal(t, "created-id-0", snap.Resources[1].ID.String())
 	assert.Equal(t, "created-id-1", snap.Resources[2].ID.String())
 	assert.Equal(t, "created-id-2", snap.Resources[3].ID.String())
@@ -2930,7 +2928,7 @@ func TestDeletedWith(t *testing.T) {
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 	assert.Equal(t, "created-id-3", snap.Resources[1].ID.String())
 	assert.Equal(t, "created-id-4", snap.Resources[2].ID.String())
 	assert.Equal(t, "created-id-5", snap.Resources[3].ID.String())
@@ -2940,7 +2938,7 @@ func TestDeletedWith(t *testing.T) {
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 0)
+	require.Len(t, snap.Resources, 0)
 }
 
 func TestInvalidGetIDReportsUserError(t *testing.T) {
@@ -2971,7 +2969,7 @@ func TestInvalidGetIDReportsUserError(t *testing.T) {
 	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, validate)
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 1)
+	require.Len(t, snap.Resources, 1)
 }
 
 func TestEventSecrets(t *testing.T) {
@@ -3141,7 +3139,7 @@ func TestAdditionalSecretOutputs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should have the provider and resA
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	resA := snap.Resources[1]
 	assert.Equal(t, []resource.PropertyKey{"a", "b"}, resA.AdditionalSecretOutputs)
 	assert.True(t, resA.Outputs["a"].IsSecret())
@@ -3195,7 +3193,7 @@ func TestDefaultParents(t *testing.T) {
 	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 
 	// Assert that resource 0 is the stack
 	assert.Equal(t, resource.RootStackType, snap.Resources[0].Type)
@@ -3342,7 +3340,7 @@ func TestPendingDeleteOrder(t *testing.T) {
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 
 	// Trigger a replacement of A but fail to create B
 	failCreationOfTypB = true
@@ -3353,7 +3351,7 @@ func TestPendingDeleteOrder(t *testing.T) {
 	// Assert that this fails, we should have two copies of A now, one new one and one old one pending delete
 	assert.Error(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 	assert.Equal(t, snap.Resources[1].Type, tokens.Type("pkgA:m:typA"))
 	assert.False(t, snap.Resources[1].Delete)
 	assert.Equal(t, snap.Resources[2].Type, tokens.Type("pkgA:m:typA"))
@@ -3364,7 +3362,7 @@ func TestPendingDeleteOrder(t *testing.T) {
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 }
 
 func TestPendingDeleteReplacement(t *testing.T) {
@@ -3503,7 +3501,7 @@ func TestPendingDeleteReplacement(t *testing.T) {
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 
 	// Trigger a replacement of B but fail to delete it
 	inB = "inactive"
@@ -3511,7 +3509,7 @@ func TestPendingDeleteReplacement(t *testing.T) {
 	// Assert that this fails, we should have two B's one marked to delete
 	assert.Error(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 	assert.Equal(t, snap.Resources[1].Type, tokens.Type("pkgA:m:typA"))
 	assert.False(t, snap.Resources[1].Delete)
 	assert.Equal(t, snap.Resources[2].Type, tokens.Type("pkgA:m:typB"))
@@ -3528,7 +3526,7 @@ func TestPendingDeleteReplacement(t *testing.T) {
 	// Assert this is ok, we should have just one A and B
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, snap.Resources[1].Type, tokens.Type("pkgA:m:typA"))
 	assert.False(t, snap.Resources[1].Delete)
 	assert.Equal(t, snap.Resources[2].Type, tokens.Type("pkgA:m:typB"))
@@ -3804,7 +3802,7 @@ func TestOldCheckedInputsAreSent(t *testing.T) {
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	resA := snap.Resources[1]
 	assert.Equal(t, tokens.Type("pkgA:m:typA"), resA.Type)
 	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
@@ -3825,7 +3823,7 @@ func TestOldCheckedInputsAreSent(t *testing.T) {
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	resA = snap.Resources[1]
 	assert.Equal(t, tokens.Type("pkgA:m:typA"), resA.Type)
 	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
@@ -3842,7 +3840,7 @@ func TestOldCheckedInputsAreSent(t *testing.T) {
 	snap, err = lt.TestOp(Destroy).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 0)
+	require.Len(t, snap.Resources, 0)
 }
 
 func TestResourceNames(t *testing.T) {
@@ -3979,7 +3977,7 @@ func TestSourcePositions(t *testing.T) {
 	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	require.NoError(t, err)
 
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 
 	reg := snap.Resources[1]
 	assert.Equal(t, regURN, reg.URN)
@@ -4121,7 +4119,7 @@ func TestProviderChecksums(t *testing.T) {
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	// Check the checksum was saved in the provider resource
 	assert.Equal(t, tokens.Type("pulumi:providers:pkgA"), snap.Resources[0].Type)
 	checksums := snap.Resources[0].Inputs["__internal"].ObjectValue()["pluginChecksums"].ObjectValue()
@@ -4132,7 +4130,7 @@ func TestProviderChecksums(t *testing.T) {
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 0)
+	require.Len(t, snap.Resources, 0)
 }
 
 // Regression test for https://github.com/pulumi/pulumi/issues/14040, ensure the step generators automatic
@@ -4256,7 +4254,7 @@ func TestStackOutputsProgramError(t *testing.T) {
 	}
 
 	validateSnapshot := func(snap *deploy.Snapshot, expectedResourceCount int, expectedOutputs resource.PropertyMap) {
-		assert.Len(t, snap.Resources, expectedResourceCount)
+		require.Len(t, snap.Resources, expectedResourceCount)
 		assert.Equal(t, resource.RootStackType, snap.Resources[0].Type)
 		assert.Equal(t, expectedOutputs, snap.Resources[0].Outputs)
 	}
@@ -4362,7 +4360,7 @@ func TestStackOutputsResourceError(t *testing.T) {
 	}
 
 	validateSnapshot := func(snap *deploy.Snapshot, expectedResourceCount int, expectedOutputs resource.PropertyMap) {
-		assert.Len(t, snap.Resources, expectedResourceCount)
+		require.Len(t, snap.Resources, expectedResourceCount)
 		assert.Equal(t, resource.RootStackType, snap.Resources[0].Type)
 		assert.Equal(t, expectedOutputs, snap.Resources[0].Outputs)
 	}

--- a/pkg/engine/lifecycletest/refresh_before_update_test.go
+++ b/pkg/engine/lifecycletest/refresh_before_update_test.go
@@ -122,7 +122,7 @@ func TestRefreshBeforeUpdate(t *testing.T) {
 	// First update.
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, tokens.Type("pulumi:pulumi:Stack"), snap.Resources[0].URN.Type())
 	assert.Equal(t, "default", snap.Resources[1].URN.Name())
 	assert.Equal(t, "resA", snap.Resources[2].URN.Name())
@@ -141,7 +141,7 @@ func TestRefreshBeforeUpdate(t *testing.T) {
 	}
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap = p.Run(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, tokens.Type("pulumi:pulumi:Stack"), snap.Resources[0].URN.Type())
 	assert.Equal(t, "default", snap.Resources[1].URN.Name())
 	assert.Equal(t, "resA", snap.Resources[2].URN.Name())
@@ -158,7 +158,7 @@ func TestRefreshBeforeUpdate(t *testing.T) {
 	readToken++
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap = p.Run(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, tokens.Type("pulumi:pulumi:Stack"), snap.Resources[0].URN.Type())
 	assert.Equal(t, "default", snap.Resources[1].URN.Name())
 	assert.Equal(t, "resA", snap.Resources[2].URN.Name())
@@ -176,7 +176,7 @@ func TestRefreshBeforeUpdate(t *testing.T) {
 	p.Steps = []lt.TestStep{{Op: Update}}
 	p.Options.Refresh = true
 	snap = p.Run(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, tokens.Type("pulumi:pulumi:Stack"), snap.Resources[0].URN.Type())
 	assert.Equal(t, "default", snap.Resources[1].URN.Name())
 	assert.Equal(t, "resA", snap.Resources[2].URN.Name())
@@ -194,7 +194,7 @@ func TestRefreshBeforeUpdate(t *testing.T) {
 	p.Steps = []lt.TestStep{{Op: Refresh}}
 	p.Options.Refresh = false
 	snap = p.Run(t, snap)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, tokens.Type("pulumi:pulumi:Stack"), snap.Resources[0].URN.Type())
 	assert.Equal(t, "default", snap.Resources[1].URN.Name())
 	assert.Equal(t, "resA", snap.Resources[2].URN.Name())
@@ -215,7 +215,7 @@ func TestRefreshBeforeUpdate(t *testing.T) {
 		ID:   "imported-id",
 	}})}}
 	snap = p.Run(t, snap)
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 	assert.Equal(t, tokens.Type("pulumi:pulumi:Stack"), snap.Resources[0].URN.Type())
 	assert.Equal(t, "default", snap.Resources[1].URN.Name())
 	assert.Equal(t, "resA", snap.Resources[2].URN.Name())

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -90,7 +90,7 @@ func TestParallelRefresh(t *testing.T) {
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
 
-	assert.Len(t, snap.Resources, 5)
+	require.Len(t, snap.Resources, 5)
 	assert.Equal(t, snap.Resources[0].URN.Name(), "default") // provider
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
 	assert.Equal(t, snap.Resources[2].URN.Name(), "resB")
@@ -100,7 +100,7 @@ func TestParallelRefresh(t *testing.T) {
 	p.Steps = []lt.TestStep{{Op: Refresh}}
 	snap = p.Run(t, snap)
 
-	assert.Len(t, snap.Resources, 5)
+	require.Len(t, snap.Resources, 5)
 	assert.Equal(t, snap.Resources[0].URN.Name(), "default") // provider
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
 	assert.Equal(t, snap.Resources[2].URN.Name(), "resB")
@@ -132,7 +132,7 @@ func TestExternalRefresh(t *testing.T) {
 
 	// The read should place "resA" in the snapshot with the "External" bit set.
 	snap := p.RunWithName(t, nil, "0")
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, snap.Resources[0].URN.Name(), "default") // provider
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
 	assert.True(t, snap.Resources[1].External)
@@ -144,7 +144,7 @@ func TestExternalRefresh(t *testing.T) {
 
 	snap = p.RunWithName(t, snap, "1")
 	// A refresh should leave "resA" as it is in the snapshot. The External bit should still be set.
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, snap.Resources[0].URN.Name(), "default") // provider
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
 	assert.True(t, snap.Resources[1].External)
@@ -383,7 +383,7 @@ func TestRefreshWithDelete(t *testing.T) {
 
 			// Refresh succeeds and records that the resource in the snapshot doesn't exist anymore
 			provURN := p.NewProviderURN("pkgA", "default", "")
-			assert.Len(t, snap.Resources, 1)
+			require.Len(t, snap.Resources, 1)
 			assert.Equal(t, provURN, snap.Resources[0].URN)
 		})
 	}
@@ -448,7 +448,7 @@ func TestRefreshDeletePropertyDependencies(t *testing.T) {
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
 
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, snap.Resources[0].URN.Name(), "default") // provider
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
 	assert.Equal(t, snap.Resources[2].URN.Name(), "resB")
@@ -460,7 +460,7 @@ func TestRefreshDeletePropertyDependencies(t *testing.T) {
 	p.Steps = []lt.TestStep{{Op: Refresh}}
 	snap = p.Run(t, snap)
 
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, snap.Resources[0].URN.Name(), "default") // provider
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resB")
 	assert.Empty(t, snap.Resources[1].PropertyDependencies)
@@ -508,7 +508,7 @@ func TestRefreshDeleteDeletedWith(t *testing.T) {
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
 
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, snap.Resources[0].URN.Name(), "default") // provider
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
 	assert.Equal(t, snap.Resources[2].URN.Name(), "resB")
@@ -520,7 +520,7 @@ func TestRefreshDeleteDeletedWith(t *testing.T) {
 	p.Steps = []lt.TestStep{{Op: Refresh}}
 	snap = p.Run(t, snap)
 
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, snap.Resources[0].URN.Name(), "default") // provider
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resB")
 	assert.Empty(t, snap.Resources[1].DeletedWith)
@@ -1826,7 +1826,7 @@ func TestRefreshWithProgramWithDeletedResource(t *testing.T) {
 		RunStep(p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	assert.Equal(t, 1, programExecutions)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 
 	// Change the program inputs to check we don't changed inputs to the provider
 	programInputs["foo"] = resource.NewStringProperty("qux")
@@ -1837,7 +1837,7 @@ func TestRefreshWithProgramWithDeletedResource(t *testing.T) {
 	// Should have run the program again
 	assert.Equal(t, 2, programExecutions)
 	// Should only have 2 resources now, the deleted one should be gone.
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 }
 
 // Regression test for https://github.com/pulumi/pulumi/issues/19406. Check that if we have a program with

--- a/pkg/engine/lifecycletest/retain_on_delete_test.go
+++ b/pkg/engine/lifecycletest/retain_on_delete_test.go
@@ -93,7 +93,7 @@ func TestRetainOnDelete(t *testing.T) {
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, "created-id-0", snap.Resources[1].ID.String())
 
 	// Run a new update which will cause a replace, we shouldn't see a provider delete but should get a new id
@@ -103,7 +103,7 @@ func TestRetainOnDelete(t *testing.T) {
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, "created-id-1", snap.Resources[1].ID.String())
 
 	// Run a new update which will cause a delete, we still shouldn't see a provider delete
@@ -111,5 +111,5 @@ func TestRetainOnDelete(t *testing.T) {
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 0)
+	require.Len(t, snap.Resources, 0)
 }

--- a/pkg/engine/lifecycletest/step_generator_test.go
+++ b/pkg/engine/lifecycletest/step_generator_test.go
@@ -182,7 +182,7 @@ func TestReadReplaceStep(t *testing.T) {
 			require.NotNil(t, snap)
 
 			assert.Nil(t, snap.VerifyIntegrity())
-			assert.Len(t, snap.Resources, 2)
+			require.Len(t, snap.Resources, 2)
 			assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 			assert.False(t, snap.Resources[1].External)
 
@@ -206,7 +206,7 @@ func TestReadReplaceStep(t *testing.T) {
 
 					require.NotNil(t, snap)
 					assert.Nil(t, snap.VerifyIntegrity())
-					assert.Len(t, snap.Resources, 2)
+					require.Len(t, snap.Resources, 2)
 					assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 					assert.True(t, snap.Resources[1].External)
 				})
@@ -236,7 +236,7 @@ func TestRelinquishStep(t *testing.T) {
 		Then(func(snap *deploy.Snapshot, err error) {
 			require.NotNil(t, snap)
 			assert.Nil(t, snap.VerifyIntegrity())
-			assert.Len(t, snap.Resources, 2)
+			require.Len(t, snap.Resources, 2)
 			assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 			assert.False(t, snap.Resources[1].External)
 
@@ -259,7 +259,7 @@ func TestRelinquishStep(t *testing.T) {
 
 					require.NotNil(t, snap)
 					assert.Nil(t, snap.VerifyIntegrity())
-					assert.Len(t, snap.Resources, 2)
+					require.Len(t, snap.Resources, 2)
 					assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 					assert.True(t, snap.Resources[1].External)
 				})
@@ -288,7 +288,7 @@ func TestTakeOwnershipStep(t *testing.T) {
 
 			require.NotNil(t, snap)
 			assert.Nil(t, snap.VerifyIntegrity())
-			assert.Len(t, snap.Resources, 2)
+			require.Len(t, snap.Resources, 2)
 			assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 			assert.True(t, snap.Resources[1].External)
 
@@ -314,7 +314,7 @@ func TestTakeOwnershipStep(t *testing.T) {
 
 					require.NotNil(t, snap)
 					assert.Nil(t, snap.VerifyIntegrity())
-					assert.Len(t, snap.Resources, 2)
+					require.Len(t, snap.Resources, 2)
 					assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 					assert.False(t, snap.Resources[1].External)
 				})
@@ -365,7 +365,7 @@ func TestInitErrorsStep(t *testing.T) {
 
 			require.NotNil(t, snap)
 			assert.Nil(t, snap.VerifyIntegrity())
-			assert.Len(t, snap.Resources, 2)
+			require.Len(t, snap.Resources, 2)
 			assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 			assert.Empty(t, snap.Resources[1].InitErrors)
 		})

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -2517,7 +2517,7 @@ func TestTargetDestroyDependencyErrors(t *testing.T) {
 	validateSnap := func(snap *deploy.Snapshot) {
 		require.NotNil(t, snap)
 		assert.Nil(t, snap.VerifyIntegrity())
-		assert.Len(t, snap.Resources, 3)
+		require.Len(t, snap.Resources, 3)
 		assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 		assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resB"), snap.Resources[2].URN)
 	}
@@ -2580,7 +2580,7 @@ func TestTargetDestroyChildErrors(t *testing.T) {
 	validateSnap := func(snap *deploy.Snapshot) {
 		require.NotNil(t, snap)
 		assert.Nil(t, snap.VerifyIntegrity())
-		assert.Len(t, snap.Resources, 3)
+		require.Len(t, snap.Resources, 3)
 		assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 		assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA$pkgA:m:typA::resB"), snap.Resources[2].URN)
 	}
@@ -2641,7 +2641,7 @@ func TestTargetDestroyDeleteFails(t *testing.T) {
 	validateSnap := func(snap *deploy.Snapshot) {
 		require.NotNil(t, snap)
 		assert.Nil(t, snap.VerifyIntegrity())
-		assert.Len(t, snap.Resources, 2)
+		require.Len(t, snap.Resources, 2)
 		assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 	}
 
@@ -2710,7 +2710,7 @@ func TestTargetDestroyDependencyDeleteFails(t *testing.T) {
 	validateSnap := func(snap *deploy.Snapshot) {
 		require.NotNil(t, snap)
 		assert.Nil(t, snap.VerifyIntegrity())
-		assert.Len(t, snap.Resources, 3)
+		require.Len(t, snap.Resources, 3)
 		assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 		assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resB"), snap.Resources[2].URN)
 	}
@@ -2799,7 +2799,7 @@ func TestTargetDestroyChildDeleteFails(t *testing.T) {
 	validateSnap := func(snap *deploy.Snapshot) {
 		require.NotNil(t, snap)
 		assert.Nil(t, snap.VerifyIntegrity())
-		assert.Len(t, snap.Resources, 3)
+		require.Len(t, snap.Resources, 3)
 		assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
 		assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA$pkgA:m:typA::resB"), snap.Resources[2].URN)
 	}

--- a/pkg/engine/lifecycletest/transformation_test.go
+++ b/pkg/engine/lifecycletest/transformation_test.go
@@ -241,7 +241,7 @@ func TestRemoteTransforms(t *testing.T) {
 	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	require.NoError(t, err)
 
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 	// Check Resources[1] is the resA resource
 	res := snap.Resources[1]
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), res.URN)
@@ -308,7 +308,7 @@ func TestRemoteTransformBadResponse(t *testing.T) {
 	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	assert.ErrorContains(t, err, "unmarshaling response: proto:")
 	assert.ErrorContains(t, err, "cannot parse invalid wire-format data")
-	assert.Len(t, snap.Resources, 0)
+	require.Len(t, snap.Resources, 0)
 }
 
 // Test that the engine errors if a transformation function returns an error.
@@ -351,7 +351,7 @@ func TestRemoteTransformErrorResponse(t *testing.T) {
 	project := p.GetProject()
 	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	assert.ErrorContains(t, err, "Unknown desc = bad transform")
-	assert.Len(t, snap.Resources, 0)
+	require.Len(t, snap.Resources, 0)
 }
 
 // Test that a remote transform applies to a resource inside a component construct.
@@ -426,7 +426,7 @@ func TestRemoteTransformationsConstruct(t *testing.T) {
 	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	require.NoError(t, err)
 
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 	// Check Resources[2] is the resA resource
 	res := snap.Resources[2]
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typC$pkgA:m:typA::resA"), res.URN)
@@ -543,7 +543,7 @@ func TestRemoteTransformsOptions(t *testing.T) {
 	project := p.GetProject()
 	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 5)
+	require.Len(t, snap.Resources, 5)
 	// Check Resources[4] is the resD resource
 	res := snap.Resources[4]
 	require.Equal(t, resource.URN(urnD), res.URN)
@@ -644,7 +644,7 @@ func TestRemoteTransformsDependencies(t *testing.T) {
 	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	require.NoError(t, err)
 
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 	// Check Resources[3] is the resC resource
 	res := snap.Resources[3]
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resC"), res.URN)
@@ -733,7 +733,7 @@ func TestRemoteComponentTransforms(t *testing.T) {
 	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	require.NoError(t, err)
 
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 	// Check Resources[2] is the resA resource
 	res := snap.Resources[2]
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typC$pkgA:m:typA::resA"), res.URN)

--- a/pkg/engine/lifecycletest/update_plan_test.go
+++ b/pkg/engine/lifecycletest/update_plan_test.go
@@ -110,9 +110,7 @@ func TestPlannedUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the resource's state.
-	if !assert.Len(t, snap.Resources, 1) {
-		return
-	}
+	require.Len(t, snap.Resources, 1)
 
 	// Change the provider's planned operation to a same step.
 	// Remove the provider from the plan.
@@ -137,9 +135,7 @@ func TestPlannedUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the resource's state.
-	if !assert.Len(t, snap.Resources, 2) {
-		return
-	}
+	require.Len(t, snap.Resources, 2)
 
 	expected := resource.NewPropertyMapFromMap(map[string]interface{}{
 		"foo": "bar",
@@ -212,9 +208,7 @@ func TestUnplannedCreate(t *testing.T) {
 
 	// Check nothing was was created
 	require.NotNil(t, snap)
-	if !assert.Len(t, snap.Resources, 0) {
-		return
-	}
+	require.Len(t, snap.Resources, 0)
 }
 
 func TestUnplannedDelete(t *testing.T) {
@@ -287,9 +281,7 @@ func TestUnplannedDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check both resources and the provider are still listed in the snapshot
-	if !assert.Len(t, snap.Resources, 3) {
-		return
-	}
+	require.Len(t, snap.Resources, 3)
 }
 
 func TestExpectedDelete(t *testing.T) {
@@ -372,9 +364,7 @@ func TestExpectedDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check both resources and the provider are still listed in the snapshot
-	if !assert.Len(t, snap.Resources, 3) {
-		return
-	}
+	require.Len(t, snap.Resources, 3)
 }
 
 func TestExpectedCreate(t *testing.T) {
@@ -448,9 +438,7 @@ func TestExpectedCreate(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check resA and the provider are still listed in the snapshot
-	if !assert.Len(t, snap.Resources, 2) {
-		return
-	}
+	require.Len(t, snap.Resources, 2)
 }
 
 func TestPropertySetChange(t *testing.T) {
@@ -575,9 +563,7 @@ func TestExpectedUnneededCreate(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check resA and the provider are still listed in the snapshot
-	if !assert.Len(t, snap.Resources, 2) {
-		return
-	}
+	require.Len(t, snap.Resources, 2)
 }
 
 func TestExpectedUnneededDelete(t *testing.T) {
@@ -647,9 +633,7 @@ func TestExpectedUnneededDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the resources are still gone
-	if !assert.Len(t, snap.Resources, 0) {
-		return
-	}
+	require.Len(t, snap.Resources, 0)
 }
 
 func TestResoucesWithSames(t *testing.T) {
@@ -724,9 +708,7 @@ func TestResoucesWithSames(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the resource's state.
-	if !assert.Len(t, snap.Resources, 2) {
-		return
-	}
+	require.Len(t, snap.Resources, 2)
 
 	expected := resource.NewPropertyMapFromMap(map[string]interface{}{
 		"X": "Y",
@@ -745,9 +727,7 @@ func TestResoucesWithSames(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the resource's state.
-	if !assert.Len(t, snap.Resources, 3) {
-		return
-	}
+	require.Len(t, snap.Resources, 3)
 
 	expected = resource.NewPropertyMapFromMap(map[string]interface{}{
 		"X": "Y",
@@ -938,9 +918,7 @@ func TestPlannedUpdateChangedStack(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the resource's state we shouldn't of changed anything because the update failed
-	if !assert.Len(t, snap.Resources, 2) {
-		return
-	}
+	require.Len(t, snap.Resources, 2)
 
 	expected := resource.NewPropertyMapFromMap(map[string]interface{}{
 		"foo": "bar",
@@ -1282,9 +1260,7 @@ func TestComputedCanBeDropped(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the resource's state.
-	if !assert.Len(t, snap.Resources, 3) {
-		return
-	}
+	require.Len(t, snap.Resources, 3)
 
 	assert.Equal(t, partialPropertySet, snap.Resources[1].Outputs)
 	assert.Equal(t, partialPropertySet, snap.Resources[2].Outputs)
@@ -1296,9 +1272,7 @@ func TestComputedCanBeDropped(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the resource's state.
-	if !assert.Len(t, snap.Resources, 3) {
-		return
-	}
+	require.Len(t, snap.Resources, 3)
 
 	assert.Equal(t, fullPropertySet, snap.Resources[1].Outputs)
 	assert.Equal(t, fullPropertySet, snap.Resources[2].Outputs)
@@ -1315,9 +1289,7 @@ func TestComputedCanBeDropped(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the resource's state.
-	if !assert.Len(t, snap.Resources, 3) {
-		return
-	}
+	require.Len(t, snap.Resources, 3)
 
 	assert.Equal(t, partialPropertySet, snap.Resources[1].Outputs)
 	assert.Equal(t, partialPropertySet, snap.Resources[2].Outputs)
@@ -1420,9 +1392,7 @@ func TestPlannedUpdateWithNondeterministicCheck(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the resource's state.
-	if !assert.Len(t, snap.Resources, 1) {
-		return
-	}
+	require.Len(t, snap.Resources, 1)
 }
 
 func TestPlannedUpdateWithCheckFailure(t *testing.T) {
@@ -1517,9 +1487,7 @@ func TestPlannedUpdateWithCheckFailure(t *testing.T) {
 	require.NotNil(t, snap)
 
 	// Check the resource's state.
-	if !assert.Len(t, snap.Resources, 1) {
-		return
-	}
+	require.Len(t, snap.Resources, 1)
 }
 
 func TestPluginsAreDownloaded(t *testing.T) {
@@ -1640,7 +1608,7 @@ func TestProviderDeterministicPreview(t *testing.T) {
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, expectedName, snap.Resources[1].Inputs["name"])
 	assert.Equal(t, expectedName, snap.Resources[1].Outputs["name"])
 
@@ -1652,7 +1620,7 @@ func TestProviderDeterministicPreview(t *testing.T) {
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-	assert.Len(t, snap.Resources, 2)
+	require.Len(t, snap.Resources, 2)
 	assert.NotEqual(t, expectedName, snap.Resources[1].Inputs["name"])
 	assert.NotEqual(t, expectedName, snap.Resources[1].Outputs["name"])
 }

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -124,9 +124,7 @@ func renderObjectCons(t *testing.T, x *model.ObjectConsExpression) resource.Prop
 }
 
 func renderScopeTraversal(t *testing.T, x *model.ScopeTraversalExpression) resource.PropertyValue {
-	if !assert.Len(t, x.Traversal, 1) {
-		return resource.NewNullProperty()
-	}
+	require.Len(t, x.Traversal, 1)
 
 	switch x.RootName {
 	case "parent":
@@ -149,27 +147,21 @@ func renderTupleCons(t *testing.T, x *model.TupleConsExpression) resource.Proper
 func renderFunctionCall(t *testing.T, x *model.FunctionCallExpression) resource.PropertyValue {
 	switch x.Name {
 	case "fileArchive":
-		if !assert.Len(t, x.Args, 1) {
-			return resource.NewNullProperty()
-		}
+		require.Len(t, x.Args, 1)
 		expr := renderExpr(t, x.Args[0])
 		if !assert.True(t, expr.IsString()) {
 			return resource.NewNullProperty()
 		}
 		return resource.NewStringProperty(expr.StringValue())
 	case "fileAsset":
-		if !assert.Len(t, x.Args, 1) {
-			return resource.NewNullProperty()
-		}
+		require.Len(t, x.Args, 1)
 		expr := renderExpr(t, x.Args[0])
 		if !assert.True(t, expr.IsString()) {
 			return resource.NewNullProperty()
 		}
 		return resource.NewStringProperty(expr.StringValue())
 	case "secret":
-		if !assert.Len(t, x.Args, 1) {
-			return resource.NewNullProperty()
-		}
+		require.Len(t, x.Args, 1)
 		return resource.MakeSecret(renderExpr(t, x.Args[0]))
 	default:
 		assert.Failf(t, "", "unexpected call to %v", x.Name)
@@ -191,9 +183,10 @@ func renderResource(t *testing.T, r *pcl.Resource) *resource.State {
 	if r.Options != nil {
 		if r.Options.Protect != nil {
 			v, diags := r.Options.Protect.Evaluate(&hcl.EvalContext{})
-			if assert.Len(t, diags, 0) && assert.Equal(t, cty.Bool, v.Type()) {
-				protect = v.True()
-			}
+			require.Len(t, diags, 0)
+			require.Equal(t, cty.Bool, v.Type())
+
+			protect = v.True()
 		}
 		if r.Options.Parent != nil {
 			v := renderExpr(t, r.Options.Parent)
@@ -336,9 +329,7 @@ func TestGenerateHCL2Definition(t *testing.T) {
 			require.NoError(t, err)
 			assert.False(t, diags.HasErrors())
 
-			if !assert.Len(t, p.Nodes, 1) {
-				t.Fatal()
-			}
+			require.Len(t, p.Nodes, 1)
 
 			res, isResource := p.Nodes[0].(*pcl.Resource)
 			if !assert.True(t, isResource) {

--- a/pkg/importer/language_test.go
+++ b/pkg/importer/language_test.go
@@ -73,9 +73,7 @@ func TestGenerateLanguageDefinition(t *testing.T) {
 
 			var actualState *resource.State
 			err = GenerateLanguageDefinitions(io.Discard, loader, func(_ io.Writer, p *pcl.Program) error {
-				if !assert.Len(t, p.Nodes, 1) {
-					t.Fatal()
-				}
+				require.Len(t, p.Nodes, 1)
 
 				res, isResource := p.Nodes[0].(*pcl.Resource)
 				if !assert.True(t, isResource) {

--- a/pkg/operations/operations_cloud_aws_test.go
+++ b/pkg/operations/operations_cloud_aws_test.go
@@ -43,7 +43,7 @@ func Test_functionNameFromLogGroupNameRegExp(t *testing.T) {
 	t.Parallel()
 
 	match := oldFunctionNameFromLogGroupNameRegExp.FindStringSubmatch("/aws/lambda/examples-todoc57917fa023a27bc")
-	assert.Len(t, match, 2)
+	require.Len(t, match, 2)
 	assert.Equal(t, "examples-todoc57917fa", match[1])
 }
 
@@ -51,7 +51,7 @@ func Test_oldFunctionNameFromLogGroupNameRegExp(t *testing.T) {
 	t.Parallel()
 
 	match := functionNameFromLogGroupNameRegExp.FindStringSubmatch("/aws/lambda/examples-todoc57917fa-023a27b")
-	assert.Len(t, match, 2)
+	require.Len(t, match, 2)
 	assert.Equal(t, "examples-todoc57917fa", match[1])
 }
 

--- a/pkg/resource/deploy/builtins_test.go
+++ b/pkg/resource/deploy/builtins_test.go
@@ -199,7 +199,7 @@ func TestBuiltinProvider(t *testing.T) {
 				assert.Equal(t, "res-name", resp.Properties["name"].V)
 
 				assert.Equal(t, "foo", resp.Properties["outputs"].ObjectValue()["normal"].StringValue())
-				assert.Len(t, resp.Properties["secretOutputNames"].V, 1)
+				require.Len(t, resp.Properties["secretOutputNames"].V, 1)
 			})
 		})
 		t.Run(readStackResourceOutputs, func(t *testing.T) {

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -772,7 +772,7 @@ func TestCRUDBadVersionNotString(t *testing.T) {
 		News: news,
 	})
 	require.NoError(t, err)
-	assert.Len(t, check.Failures, 1)
+	require.Len(t, check.Failures, 1)
 	assert.Equal(t, "version", string(check.Failures[0].Property))
 	assert.Nil(t, check.Properties)
 }
@@ -799,7 +799,7 @@ func TestCRUDBadVersion(t *testing.T) {
 		News: news,
 	})
 	require.NoError(t, err)
-	assert.Len(t, check.Failures, 1)
+	require.Len(t, check.Failures, 1)
 	assert.Equal(t, "version", string(check.Failures[0].Property))
 	assert.Nil(t, check.Properties)
 }
@@ -892,7 +892,7 @@ func TestConcurrentRegistryUsage(t *testing.T) {
 				News: news,
 			})
 			require.NoError(t, err)
-			assert.Len(t, check.Failures, 1)
+			require.Len(t, check.Failures, 1)
 			assert.Equal(t, "version", string(check.Failures[0].Property))
 			assert.Nil(t, check.Properties)
 		}(i)

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -1614,12 +1614,12 @@ func TestResmonCancel(t *testing.T) {
 
 func TestSourceEvalServeOptions(t *testing.T) {
 	t.Parallel()
-	assert.Len(t,
+	require.Len(t,
 		sourceEvalServeOptions(nil, opentracing.SpanFromContext(context.Background()), "" /* logFile */),
 		2,
 	)
 
-	assert.Len(t,
+	require.Len(t,
 		sourceEvalServeOptions(&plugin.Context{
 			DebugTraceMutex: &sync.Mutex{},
 		}, opentracing.SpanFromContext(context.Background()), "logFile.log"),

--- a/pkg/resource/deploy/step_test.go
+++ b/pkg/resource/deploy/step_test.go
@@ -213,7 +213,7 @@ func TestCreateStep(t *testing.T) {
 				}
 				status, _, err := s.Apply()
 				assert.ErrorContains(t, err, "intentional error")
-				assert.Len(t, s.new.InitErrors, 1)
+				require.Len(t, s.new.InitErrors, 1)
 				assert.Equal(t, resource.StatusPartialFailure, status)
 			})
 			t.Run("error create no ID", func(t *testing.T) {
@@ -472,7 +472,7 @@ func TestUpdateStep(t *testing.T) {
 			assert.Equal(t, resource.StatusPartialFailure, status)
 
 			// News should be updated.
-			assert.Len(t, s.new.InitErrors, 1)
+			require.Len(t, s.new.InitErrors, 1)
 			assert.Equal(t, resource.PropertyMap{
 				"key": resource.NewStringProperty("expected-value"),
 			}, s.new.Outputs)
@@ -582,7 +582,7 @@ func TestReadStep(t *testing.T) {
 			assert.Equal(t, resource.StatusPartialFailure, status)
 
 			// News should be updated.
-			assert.Len(t, s.new.InitErrors, 1)
+			require.Len(t, s.new.InitErrors, 1)
 			assert.Equal(t, (resource.PropertyMap)(nil), s.new.Inputs)
 			assert.Equal(t, resource.PropertyMap{
 				"outputs-key": resource.NewStringProperty("expected-value"),
@@ -935,7 +935,7 @@ func TestRefreshStep(t *testing.T) {
 			assert.Equal(t, resource.StatusPartialFailure, status)
 
 			// News should be updated.
-			assert.Len(t, s.new.InitErrors, 1)
+			require.Len(t, s.new.InitErrors, 1)
 			assert.Equal(t, resource.PropertyMap{
 				"outputs-key": resource.NewStringProperty("expected-value"),
 			}, s.new.Outputs)
@@ -1043,7 +1043,7 @@ func TestImportStep(t *testing.T) {
 				status, _, err := s.Apply()
 				assert.Error(t, err)
 				assert.Equal(t, resource.StatusOK, status)
-				assert.Len(t, s.new.InitErrors, 1)
+				require.Len(t, s.new.InitErrors, 1)
 			})
 			t.Run("resource does not exist", func(t *testing.T) {
 				t.Parallel()

--- a/pkg/resource/edit/operations_test.go
+++ b/pkg/resource/edit/operations_test.go
@@ -88,7 +88,7 @@ func TestDeletion(t *testing.T) {
 
 	err := DeleteResource(snap, b, nil, false)
 	require.NoError(t, err)
-	assert.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 3)
 	assert.Equal(t, []*resource.State{pA, a, c}, snap.Resources)
 }
 
@@ -304,7 +304,7 @@ func TestFailedDeletionProviderDependency(t *testing.T) {
 	assert.Contains(t, depErr.Dependencies, a)
 	assert.Contains(t, depErr.Dependencies, b)
 	assert.Contains(t, depErr.Dependencies, c)
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 	assert.Equal(t, []*resource.State{pA, a, b, c}, snap.Resources)
 }
 
@@ -333,7 +333,7 @@ func TestFailedDeletionRegularDependency(t *testing.T) {
 	assert.NotContains(t, depErr.Dependencies, a)
 	assert.Contains(t, depErr.Dependencies, b)
 	assert.NotContains(t, depErr.Dependencies, c)
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 	assert.Equal(t, []*resource.State{pA, a, b, c}, snap.Resources)
 }
 
@@ -479,7 +479,7 @@ func TestFailedDeletionParentDependency(t *testing.T) {
 	assert.NotContains(t, depErr.Dependencies, a)
 	assert.Contains(t, depErr.Dependencies, b)
 	assert.Contains(t, depErr.Dependencies, c)
-	assert.Len(t, snap.Resources, 4)
+	require.Len(t, snap.Resources, 4)
 	assert.Equal(t, []*resource.State{pA, a, b, c}, snap.Resources)
 }
 
@@ -519,7 +519,7 @@ func TestLocateResourceAmbiguous(t *testing.T) {
 	})
 
 	resList := LocateResource(snap, a.URN)
-	assert.Len(t, resList, 2)
+	require.Len(t, resList, 2)
 	assert.Contains(t, resList, a)
 	assert.Contains(t, resList, aPending)
 	assert.NotContains(t, resList, pA)
@@ -541,7 +541,7 @@ func TestLocateResourceExact(t *testing.T) {
 	})
 
 	resList := LocateResource(snap, a.URN)
-	assert.Len(t, resList, 1)
+	require.Len(t, resList, 1)
 	assert.Contains(t, resList, a)
 }
 
@@ -620,7 +620,7 @@ func TestRenameStack(t *testing.T) {
 
 	// Baseline. Can locate resource A.
 	resList := locateResource(deployment, a.URN)
-	assert.Len(t, resList, 1)
+	require.Len(t, resList, 1)
 	assert.Contains(t, resList, a)
 	if t.Failed() {
 		t.Fatal("Unable to find expected resource in initial checkpoint.")
@@ -640,7 +640,7 @@ func TestRenameStack(t *testing.T) {
 		}
 
 		// Confirm the previous resource by URN isn't found.
-		assert.Len(t, locateResource(deployment, baselineResourceURN), 0)
+		require.Len(t, locateResource(deployment, baselineResourceURN), 0)
 
 		// Confirm the resource has been renamed.
 		updatedResourceURN := resource.NewURN(
@@ -648,7 +648,7 @@ func TestRenameStack(t *testing.T) {
 			"test", // project name stayed the same
 			"" /*parent type*/, baselineResourceURN.Type(),
 			baselineResourceURN.Name())
-		assert.Len(t, locateResource(deployment, updatedResourceURN), 1)
+		require.Len(t, locateResource(deployment, updatedResourceURN), 1)
 	})
 
 	// Rename the stack and project.
@@ -665,6 +665,6 @@ func TestRenameStack(t *testing.T) {
 			"new-project",
 			"" /*parent type*/, baselineResourceURN.Type(),
 			baselineResourceURN.Name())
-		assert.Len(t, locateResource(deployment, updatedResourceURN), 1)
+		require.Len(t, locateResource(deployment, updatedResourceURN), 1)
 	})
 }

--- a/pkg/resource/stack/checkpoint_test.go
+++ b/pkg/resource/stack/checkpoint_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,7 +31,7 @@ func TestLoadV0Checkpoint(t *testing.T) {
 	chk, err := UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
 	require.NoError(t, err)
 	require.NotNil(t, chk.Latest)
-	assert.Len(t, chk.Latest.Resources, 30)
+	require.Len(t, chk.Latest.Resources, 30)
 }
 
 func TestLoadV1Checkpoint(t *testing.T) {
@@ -44,7 +43,7 @@ func TestLoadV1Checkpoint(t *testing.T) {
 	chk, err := UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
 	require.NoError(t, err)
 	require.NotNil(t, chk.Latest)
-	assert.Len(t, chk.Latest.Resources, 30)
+	require.Len(t, chk.Latest.Resources, 30)
 }
 
 func TestLoadV3Checkpoint(t *testing.T) {
@@ -56,7 +55,7 @@ func TestLoadV3Checkpoint(t *testing.T) {
 	chk, err := UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
 	require.NoError(t, err)
 	require.NotNil(t, chk.Latest)
-	assert.Len(t, chk.Latest.Resources, 30)
+	require.Len(t, chk.Latest.Resources, 30)
 }
 
 func TestLoadV4Checkpoint(t *testing.T) {
@@ -68,7 +67,7 @@ func TestLoadV4Checkpoint(t *testing.T) {
 	chk, err := UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
 	require.NoError(t, err)
 	require.NotNil(t, chk.Latest)
-	assert.Len(t, chk.Latest.Resources, 30)
+	require.Len(t, chk.Latest.Resources, 30)
 }
 
 func TestLoadV4CheckpointUnsupportedFeature(t *testing.T) {

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -2280,7 +2280,7 @@ func TestEnvFunctions(t *testing.T) {
 	err = s.RemoveEnvironment(ctx, "automation-api-test-env-2")
 	envs, err = s.ListEnvironments(ctx)
 	require.NoError(t, err, "listing environments failed, err: %v", err)
-	assert.Len(t, envs, 0)
+	require.Len(t, envs, 0)
 	require.NoError(t, err, "removing environment failed, err: %v", err)
 	_, err = s.GetConfig(ctx, "also")
 	assert.Error(t, err)
@@ -3310,7 +3310,7 @@ func TestListStacks(t *testing.T) {
 	stacks, err := workspace.ListStacks(ctx)
 
 	require.NoError(t, err)
-	assert.Len(t, stacks, 2)
+	require.Len(t, stacks, 2)
 	assert.Equal(t, "testorg1/testproj1/teststack1", stacks[0].Name)
 	assert.Equal(t, false, stacks[0].Current)
 	assert.Equal(t, "https://app.pulumi.com/testorg1/testproj1/teststack1", stacks[0].URL)
@@ -3370,7 +3370,7 @@ func TestListAllStacks(t *testing.T) {
 	stacks, err := workspace.ListStacks(ctx, optlist.All())
 
 	require.NoError(t, err)
-	assert.Len(t, stacks, 2)
+	require.Len(t, stacks, 2)
 	assert.Equal(t, "testorg1/testproj1/teststack1", stacks[0].Name)
 	assert.Equal(t, false, stacks[0].Current)
 	assert.Equal(t, "https://app.pulumi.com/testorg1/testproj1/teststack1", stacks[0].URL)

--- a/sdk/go/common/apitype/migrate/checkpoint_test.go
+++ b/sdk/go/common/apitype/migrate/checkpoint_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheckpointV1ToV2(t *testing.T) {
@@ -42,7 +43,7 @@ func TestCheckpointV1ToV2(t *testing.T) {
 	assert.Equal(t, config.Map{
 		config.MustMakeKey("foo", "number"): config.NewValue("42"),
 	}, v2.Config)
-	assert.Len(t, v2.Latest.Resources, 0)
+	require.Len(t, v2.Latest.Resources, 0)
 }
 
 func TestCheckpointV1ToV2NilLatest(t *testing.T) {

--- a/sdk/go/common/apitype/migrate/deployment_test.go
+++ b/sdk/go/common/apitype/migrate/deployment_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDeploymentV1ToV2(t *testing.T) {
@@ -39,7 +40,7 @@ func TestDeploymentV1ToV2(t *testing.T) {
 
 	v2 := UpToDeploymentV2(v1)
 	assert.Equal(t, v1.Manifest, v2.Manifest)
-	assert.Len(t, v1.Resources, 2)
+	require.Len(t, v1.Resources, 2)
 	assert.Equal(t, resource.URN("a"), v1.Resources[0].URN)
 	assert.Equal(t, resource.URN("b"), v1.Resources[1].URN)
 }

--- a/sdk/go/common/registry/resolve_test.go
+++ b/sdk/go/common/registry/resolve_test.go
@@ -400,7 +400,7 @@ func TestResolvePackageFromName(t *testing.T) {
 
 		// Test suggestions are available
 		suggestions := GetSuggestedPackages(err)
-		assert.Len(t, suggestions, 2)
+		require.Len(t, suggestions, 2)
 		assert.Equal(t, "community", suggestions[0].Source)
 		assert.Equal(t, "github", suggestions[1].Source)
 	})
@@ -467,7 +467,7 @@ func TestResolvePackageFromName(t *testing.T) {
 
 		// Should have suggestions
 		suggestions := GetSuggestedPackages(err)
-		assert.Len(t, suggestions, 1)
+		require.Len(t, suggestions, 1)
 		assert.Equal(t, semver.MustParse("2.0.0"), suggestions[0].Version)
 	})
 
@@ -521,7 +521,7 @@ func TestResolvePackageFromName(t *testing.T) {
 		assert.True(t, errors.Is(err, ErrNotFound))
 
 		suggestions := GetSuggestedPackages(err)
-		assert.Len(t, suggestions, 3)
+		require.Len(t, suggestions, 3)
 		assert.Equal(t, "community", suggestions[0].Source)
 		assert.Equal(t, "github", suggestions[1].Source)
 		assert.Equal(t, "custom", suggestions[2].Source)

--- a/sdk/go/common/resource/asset_test.go
+++ b/sdk/go/common/resource/asset_test.go
@@ -579,7 +579,7 @@ func TestNestedArchive(t *testing.T) {
 	defer contract.IgnoreClose(zipReader)
 	require.NoError(t, err)
 	files := zipReader.File
-	assert.Len(t, files, 3)
+	require.Len(t, files, 3)
 
 	assert.Equal(t, "foo/a.txt", filepath.ToSlash(files[0].Name))
 	assert.Equal(t, "foo/bar/b.txt", filepath.ToSlash(files[1].Name))
@@ -619,7 +619,7 @@ func TestFileReferencedThroughMultiplePaths(t *testing.T) {
 	defer contract.IgnoreClose(zipReader)
 	require.NoError(t, err)
 	files := zipReader.File
-	assert.Len(t, files, 1)
+	require.Len(t, files, 1)
 	assert.Equal(t, "foo/bar/b.txt", filepath.ToSlash(files[0].Name))
 }
 

--- a/sdk/go/common/resource/resource_id_test.go
+++ b/sdk/go/common/resource/resource_id_test.go
@@ -138,12 +138,12 @@ func TestUniqueNameNonDeterminism(t *testing.T) {
 		name, err := NewUniqueName(randomSeed, prefix, randlen, maxlen, nil)
 		require.NoError(t, err)
 		assert.True(t, strings.HasPrefix(name, prefix), "%s does not have prefix %s", name, prefix)
-		assert.Len(t, name, len(prefix)+randlen)
+		require.Len(t, name, len(prefix)+randlen)
 
 		name2, err := NewUniqueName(randomSeed, prefix, randlen, maxlen, nil)
 		require.NoError(t, err)
 		assert.True(t, strings.HasPrefix(name2, prefix), "%s does not have prefix %s", name2, prefix)
-		assert.Len(t, name2, len(prefix)+randlen)
+		require.Len(t, name2, len(prefix)+randlen)
 		assert.NotEqual(t, name, name2)
 	}
 }

--- a/sdk/go/common/util/mapper/mapper_test.go
+++ b/sdk/go/common/util/mapper/mapper_test.go
@@ -133,12 +133,12 @@ func TestMapperEncode(t *testing.T) {
 	// Nils
 	m, err = md.Encode(nil)
 	require.NoError(t, err)
-	assert.Len(t, m, 0)
+	require.Len(t, m, 0)
 
 	// Nil (interface)
 	m, err = md.Encode((AnInterface)(nil))
 	require.NoError(t, err)
-	assert.Len(t, m, 0)
+	require.Len(t, m, 0)
 
 	// Structs
 	m, err = md.encode(reflect.ValueOf(bag))

--- a/sdk/go/common/util/retry/until_test.go
+++ b/sdk/go/common/util/retry/until_test.go
@@ -110,7 +110,7 @@ func TestUntil_maxDelay(t *testing.T) {
 	assert.True(t, ok)
 	require.NoError(t, err)
 
-	assert.Len(t, afterRec.Sleeps, 100)
+	require.Len(t, afterRec.Sleeps, 100)
 	for _, d := range afterRec.Sleeps {
 		assert.LessOrEqual(t, d, maxDelay)
 	}

--- a/sdk/go/internal/state_test.go
+++ b/sdk/go/internal/state_test.go
@@ -118,7 +118,7 @@ func TestOutputDependencies(t *testing.T) {
 		ResolveOutput(out, 42, true, false, deps)
 
 		gotDeps := OutputDependencies(out)
-		assert.Len(t, gotDeps, 2)
+		require.Len(t, gotDeps, 2)
 		for i, dep := range deps {
 			assert.Same(t, dep, gotDeps[i])
 		}

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -248,7 +248,7 @@ func TestCollapseAliases(t *testing.T) {
 			require.NoError(t, err)
 			urns, err := ctx.collapseAliases(testCase.childAliases, "test:resource:child", "myres-child", &res)
 			require.NoError(t, err)
-			assert.Len(t, urns, testCase.totalAliasUrns)
+			require.Len(t, urns, testCase.totalAliasUrns)
 			var items []interface{}
 			for _, item := range urns {
 				items = append(items, item)

--- a/sdk/go/pulumi/provider_test.go
+++ b/sdk/go/pulumi/provider_test.go
@@ -911,7 +911,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			assert: func(t *testing.T, actual interface{}) {
 				v, ok := actual.(StringArray)
 				assert.True(t, ok)
-				assert.Len(t, v, 2)
+				require.Len(t, v, 2)
 				assert.Equal(t, String("hello"), v[0])
 				assertOutputEqual(t, "world", true, true, map[URN]struct{}{}, v[1])
 			},
@@ -962,7 +962,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			assert: func(t *testing.T, actual interface{}) {
 				v, ok := actual.(StringMap)
 				assert.True(t, ok)
-				assert.Len(t, v, 2)
+				require.Len(t, v, 2)
 				assert.Equal(t, String("hello"), v["foo"])
 				assertOutputEqual(t, "world", true, true, map[URN]struct{}{}, v["bar"])
 			},
@@ -983,7 +983,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			assert: func(t *testing.T, actual interface{}) {
 				v, ok := actual.(StringMap)
 				assert.True(t, ok)
-				assert.Len(t, v, 2)
+				require.Len(t, v, 2)
 				assert.Equal(t, String("hello"), v["foo"])
 				assertOutputEqual(t, "world", true, true, map[URN]struct{}{"fakeURN": {}}, v["bar"])
 			},
@@ -1004,7 +1004,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			assert: func(t *testing.T, actual interface{}) {
 				v, ok := actual.(StringMap)
 				assert.True(t, ok)
-				assert.Len(t, v, 2)
+				require.Len(t, v, 2)
 				assert.Equal(t, String("hello"), v["foo"])
 				assertOutputEqual(t, "world", true, true, map[URN]struct{}{
 					"fakeURN1": {},
@@ -1213,7 +1213,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			assert: func(t *testing.T, actual interface{}) {
 				v, ok := actual.([]StringInput)
 				assert.True(t, ok)
-				assert.Len(t, v, 2)
+				require.Len(t, v, 2)
 				assert.Equal(t, String("foo"), v[0])
 				assertOutputEqual(t, "bar", true, true, map[URN]struct{}{}, v[1])
 			},
@@ -1228,7 +1228,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			assert: func(t *testing.T, actual interface{}) {
 				v, ok := actual.([]StringInput)
 				assert.True(t, ok)
-				assert.Len(t, v, 2)
+				require.Len(t, v, 2)
 				assert.Equal(t, String("foo"), v[0])
 				assertOutputEqual(t, nil, false, false, map[URN]struct{}{}, v[1])
 			},
@@ -1264,7 +1264,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			assert: func(t *testing.T, actual interface{}) {
 				v, ok := actual.([]StringInput)
 				assert.True(t, ok)
-				assert.Len(t, v, 2)
+				require.Len(t, v, 2)
 				assert.Equal(t, String("foo"), v[0])
 				assertOutputEqual(t, "bar", true, true, map[URN]struct{}{}, v[1])
 			},
@@ -1280,7 +1280,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			assert: func(t *testing.T, actual interface{}) {
 				v, ok := actual.([]StringInput)
 				assert.True(t, ok)
-				assert.Len(t, v, 2)
+				require.Len(t, v, 2)
 				assertOutputEqual(t, "foo", true, false, map[URN]struct{}{"fakeURN": {}}, v[0])
 				assertOutputEqual(t, "bar", true, false, map[URN]struct{}{"fakeURN": {}}, v[1])
 			},
@@ -1311,7 +1311,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			assert: func(t *testing.T, actual interface{}) {
 				v, ok := actual.(map[string]StringInput)
 				assert.True(t, ok)
-				assert.Len(t, v, 2)
+				require.Len(t, v, 2)
 				assert.Equal(t, String("bar"), v["foo"])
 				assertOutputEqual(t, "qux", true, true, map[URN]struct{}{}, v["baz"])
 			},
@@ -1326,7 +1326,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			assert: func(t *testing.T, actual interface{}) {
 				v, ok := actual.(map[string]StringInput)
 				assert.True(t, ok)
-				assert.Len(t, v, 2)
+				require.Len(t, v, 2)
 				assert.Equal(t, String("bar"), v["foo"])
 				assertOutputEqual(t, nil, false, false, map[URN]struct{}{}, v["baz"])
 			},
@@ -1362,7 +1362,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			assert: func(t *testing.T, actual interface{}) {
 				v, ok := actual.(map[string]StringInput)
 				assert.True(t, ok)
-				assert.Len(t, v, 2)
+				require.Len(t, v, 2)
 				assert.Equal(t, String("bar"), v["foo"])
 				assertOutputEqual(t, "qux", true, true, map[URN]struct{}{}, v["baz"])
 			},
@@ -1378,7 +1378,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			assert: func(t *testing.T, actual interface{}) {
 				v, ok := actual.(map[string]StringInput)
 				assert.True(t, ok)
-				assert.Len(t, v, 2)
+				require.Len(t, v, 2)
 				assertOutputEqual(t, "bar", true, false, map[URN]struct{}{"fakeURN": {}}, v["foo"])
 				assertOutputEqual(t, "qux", true, false, map[URN]struct{}{"fakeURN": {}}, v["baz"])
 			},
@@ -1787,7 +1787,7 @@ func TestConstruct_resourceOptionsSnapshot(t *testing.T) {
 		snap := snapshotFromRequest(t, &pulumirpc.ConstructRequest{
 			Aliases: []string{"test"},
 		})
-		assert.Len(t, snap.Aliases, 1, "aliases were not set")
+		require.Len(t, snap.Aliases, 1, "aliases were not set")
 	})
 
 	t.Run("DependsOn", func(t *testing.T) {
@@ -1796,7 +1796,7 @@ func TestConstruct_resourceOptionsSnapshot(t *testing.T) {
 		snap := snapshotFromRequest(t, &pulumirpc.ConstructRequest{
 			Dependencies: []string{"test"},
 		})
-		assert.Len(t, snap.DependsOn, 1, "dependencies were not set")
+		require.Len(t, snap.DependsOn, 1, "dependencies were not set")
 	})
 
 	t.Run("Protect", func(t *testing.T) {
@@ -1818,7 +1818,7 @@ func TestConstruct_resourceOptionsSnapshot(t *testing.T) {
 				"baz": string(urn) + "::qux",
 			},
 		})
-		assert.Len(t, snap.Providers, 1, "providers were not set")
+		require.Len(t, snap.Providers, 1, "providers were not set")
 	})
 
 	t.Run("Parent", func(t *testing.T) {

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -1887,7 +1887,7 @@ func TestUnmarshalPropertyMap(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		assert.Len(t, actual, 2)
+		require.Len(t, actual, 2)
 		_, known, secret, _, err := awaitWithContext(ctx.Context(), actual["computed"].(AnyOutput))
 		require.NoError(t, err)
 		assert.False(t, known)
@@ -1911,7 +1911,7 @@ func TestUnmarshalPropertyMap(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		assert.Len(t, actual, 2)
+		require.Len(t, actual, 2)
 		value, known, secret, _, err := awaitWithContext(ctx.Context(), actual["secret"].(StringOutput))
 		require.NoError(t, err)
 		assert.Equal(t, "secret string", value.(string))
@@ -1965,7 +1965,7 @@ func TestUnmarshalPropertyMap(t *testing.T) {
 		require.NoError(t, err)
 
 		assertDeps := func(actual []Resource) {
-			assert.Len(t, actual, 1)
+			require.Len(t, actual, 1)
 
 			value, known, _, _, err := awaitWithContext(ctx.Context(), actual[0].URN())
 			require.NoError(t, err)
@@ -1973,7 +1973,7 @@ func TestUnmarshalPropertyMap(t *testing.T) {
 			assert.Equal(t, URN("urn:pulumi:test_stack::test_project::pkg:index:type::name"), value.(URN))
 		}
 
-		assert.Len(t, actual, 5)
+		require.Len(t, actual, 5)
 		value, known, secret, deps, err := awaitWithContext(ctx.Context(), actual["standard"].(StringOutput))
 		require.NoError(t, err)
 		assert.Equal(t, "a string", value.(string))
@@ -2021,7 +2021,7 @@ func TestUnmarshalPropertyMap(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		assert.Len(t, actual, 1)
+		require.Len(t, actual, 1)
 		value, known, secret, _, err := awaitWithContext(ctx.Context(), actual["unknown id"].(ResourceOutput))
 		require.NoError(t, err)
 		assert.True(t, known)

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -884,7 +884,7 @@ func TestApplyTOutput(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 42, v)
 		assert.Equal(t, fmt.Sprintf("%v", reflect.TypeOf(v)), "int")
-		assert.Len(t, deps, 4)
+		require.Len(t, deps, 4)
 	}
 }
 

--- a/tests/integration/backend/diy/backend_postgres_test.go
+++ b/tests/integration/backend/diy/backend_postgres_test.go
@@ -204,7 +204,7 @@ func TestPostgresBackend(t *testing.T) {
 	allStacks, token, err := b.ListStacks(ctx, backend.ListStacksFilter{}, nil)
 	require.NoError(t, err, "Failed to list all stacks")
 	assert.Nil(t, token, "Continuation token should be nil")
-	assert.Len(t, allStacks, 2, "Should have exactly 2 stacks")
+	require.Len(t, allStacks, 2, "Should have exactly 2 stacks")
 
 	// Test listing with organization filter
 	orgStacks, token, err := b.ListStacks(ctx, backend.ListStacksFilter{
@@ -212,7 +212,7 @@ func TestPostgresBackend(t *testing.T) {
 	}, nil)
 	require.NoError(t, err, "Failed to list stacks with org filter")
 	assert.Nil(t, token, "Continuation token should be nil")
-	assert.Len(t, orgStacks, 2, "Should have 2 stacks with org filter")
+	require.Len(t, orgStacks, 2, "Should have 2 stacks with org filter")
 
 	// Test listing with project filter
 	projName := string(projectName)
@@ -420,7 +420,7 @@ func TestPostgresBackend(t *testing.T) {
 	finalStacks, token, err := b.ListStacks(ctx, backend.ListStacksFilter{}, nil)
 	require.NoError(t, err, "Failed to list stacks after removal")
 	assert.Nil(t, token, "Final continuation token should be nil")
-	assert.Len(t, finalStacks, 0, "All stacks should be removed")
+	require.Len(t, finalStacks, 0, "All stacks should be removed")
 }
 
 // TestPostgresBackendMultipleTables tests that multiple backends can use different tables
@@ -475,11 +475,11 @@ func TestPostgresBackendMultipleTables(t *testing.T) {
 	// Verify each backend only sees its own stack
 	stacks1, _, err := backend1.ListStacks(ctx, backend.ListStacksFilter{}, nil)
 	require.NoError(t, err)
-	assert.Len(t, stacks1, 1)
+	require.Len(t, stacks1, 1)
 
 	stacks2, _, err := backend2.ListStacks(ctx, backend.ListStacksFilter{}, nil)
 	require.NoError(t, err)
-	assert.Len(t, stacks2, 1)
+	require.Len(t, stacks2, 1)
 
 	// Clean up
 	_, err = backend1.RemoveStack(ctx, stack1, true)
@@ -542,7 +542,7 @@ func TestPostgresBackendConcurrency(t *testing.T) {
 	allStacks, token, err := backends[0].ListStacks(ctx, backend.ListStacksFilter{}, nil)
 	require.NoError(t, err, "Failed to list stacks")
 	assert.Nil(t, token, "Continuation token should be nil")
-	assert.Len(t, allStacks, numConcurrentOperations, "Should have all created stacks")
+	require.Len(t, allStacks, numConcurrentOperations, "Should have all created stacks")
 
 	// Clean up all stacks
 	for i := 0; i < numConcurrentOperations; i++ {
@@ -555,5 +555,5 @@ func TestPostgresBackendConcurrency(t *testing.T) {
 	allStacks, token, err = backends[0].ListStacks(ctx, backend.ListStacksFilter{}, nil)
 	require.NoError(t, err, "Failed to list stacks after cleanup")
 	assert.Nil(t, token, "Continuation token should be nil")
-	assert.Len(t, allStacks, 0, "All stacks should be removed")
+	require.Len(t, allStacks, 0, "All stacks should be removed")
 }

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1437,7 +1437,7 @@ func TestESMTSNestedSrc(t *testing.T) {
 			"test": "hello world",
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-			assert.Len(t, stack.Outputs, 1)
+			require.Len(t, stack.Outputs, 1)
 			test, ok := stack.Outputs["test"]
 			assert.True(t, ok)
 			assert.Equal(t, "hello world", test)
@@ -1452,7 +1452,7 @@ func TestESMTSDefaultExport(t *testing.T) {
 		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-			assert.Len(t, stack.Outputs, 1)
+			require.Len(t, stack.Outputs, 1)
 			helloWorld, ok := stack.Outputs["helloWorld"]
 			assert.True(t, ok)
 			assert.Equal(t, helloWorld, 123.0)
@@ -2000,7 +2000,7 @@ func TestRegression12301Node(t *testing.T) {
 			return os.Rename(jsonPath, newPath)
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-			assert.Len(t, stack.Outputs, 1)
+			require.Len(t, stack.Outputs, 1)
 			assert.Contains(t, stack.Outputs, "bar")
 			assert.Equal(t, 3.0, stack.Outputs["bar"].(float64))
 		},
@@ -2018,7 +2018,7 @@ func TestPulumiConfig(t *testing.T) {
 			"pulumi-nodejs:id": "testing123",
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-			assert.Len(t, stack.Outputs, 1)
+			require.Len(t, stack.Outputs, 1)
 			assert.Contains(t, stack.Outputs, "rid")
 			assert.Equal(t, "testing123", stack.Outputs["rid"].(string))
 		},

--- a/tests/integration/integration_util_test.go
+++ b/tests/integration/integration_util_test.go
@@ -281,9 +281,8 @@ func TestSynchronouslyDo_timeout(t *testing.T) {
 	})
 
 	assert.True(t, fakeT.fatal, "must have a fatal failure")
-	if assert.Len(t, fakeT.messages, 1) {
-		assert.Contains(t, fakeT.messages[0], "timed out waiting")
-	}
+	require.Len(t, fakeT.messages, 1)
+	assert.Contains(t, fakeT.messages[0], "timed out waiting")
 }
 
 // nonfatalT wraps a testing.T to capture fatal errors.

--- a/tests/integration/transformations/transformations_test.go
+++ b/tests/integration/transformations/transformations_test.go
@@ -81,7 +81,7 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			// will not be correctly recorded in the state file, and so cannot be
 			// verified here.
 			//
-			// assert.Len(t, res.PropertyDependencies, 1)
+			// require.Len(t, res.PropertyDependencies, 1)
 			input := res.Inputs["length"]
 			require.NotNil(t, input)
 			assert.Equal(t, 5.0, input.(float64))

--- a/tests/stack/stack_test.go
+++ b/tests/stack/stack_test.go
@@ -936,7 +936,7 @@ func TestEmptyStackRm(t *testing.T) {
 		var v3deployment apitype.DeploymentV3
 		err = json.Unmarshal(deployment.Deployment, &v3deployment)
 		require.NoError(t, err)
-		assert.Len(t, v3deployment.Resources, 1, "stack should only have the default stack resource")
+		require.Len(t, v3deployment.Resources, 1, "stack should only have the default stack resource")
 
 		// Now try to remove the stack. This should succeed, even though there is the one resource in the stack.
 		e.RunCommand("pulumi", "stack", "rm", "--yes")


### PR DESCRIPTION
Similar to https://github.com/pulumi/pulumi/pull/19988 and https://github.com/pulumi/pulumi/pull/20055 previously, replace `assert.Len` with `require.Len`.  The reasoning is similar to those other two PRs, namely that after `assert.Len` we often check the elements of arrays.  If the length isn't correct, we'll panic because of trying to access an array index out of range.

Note that this isn't always the case e.g. when asserting the length is 0, but overall I think it's better to just use `require.Len` everywhere, so we don't need to think about it in every case.

This should be the last PR in this series.