### PR TITLE
Cache go deps when building CI matrix

### DIFF
--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -49,6 +49,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+      - uses: actions/setup-go@v5
+        with:
+          cache: true
+          cache-dependency-path: pkg/go.sum
+          go-version-file: pkg/go.mod
       - name: Install CLI
         run: SDKS='' make install
       - name: build matrix

--- a/.github/workflows/ci-performance-gate.yml
+++ b/.github/workflows/ci-performance-gate.yml
@@ -71,6 +71,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+      - uses: actions/setup-go@v5
+        with:
+          cache: true
+          cache-dependency-path: pkg/go.sum
+          go-version-file: pkg/go.mod
       - name: Install CLI
         run: SDKS='' make install
       - name: build matrix


### PR DESCRIPTION
We have to build the CLI before we can build the matrix because of https://github.com/pulumi/pulumi/pull/19580/files#diff-35f0237533998a7ed8096d74035a0dc62347b33535080d232c14ccfc4e8c270e

Cache the go deps to make this a little faster
