### PR TITLE
[sdkgen/python] Remove unnecessary import copy

### DIFF
--- a/changelog/pending/20250718--sdkgen-python--remove-unnecessary-import-copy.yaml
+++ b/changelog/pending/20250718--sdkgen-python--remove-unnecessary-import-copy.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/python
+  description: Remove unnecessary `import copy`

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -446,7 +446,6 @@ func (mod *modContext) generateCommonImports(w io.Writer, imports imports, typin
 	relRoot := path.Dir(rel)
 	relImport := relPathToRelImport(relRoot)
 
-	fmt.Fprintf(w, "import copy\n")
 	fmt.Fprintf(w, "import warnings\n")
 	if typedDictEnabled(mod.inputTypes) {
 		fmt.Fprintf(w, "import sys\n")

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/any-type-function-15.0.0/pulumi_any_type_function/dyn_list_to_dyn.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/any-type-function-15.0.0/pulumi_any_type_function/dyn_list_to_dyn.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/any-type-function-15.0.0/pulumi_any_type_function/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/any-type-function-15.0.0/pulumi_any_type_function/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/archive_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/archive_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/asset_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/asset_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/asset-archive-5.0.0/pulumi_asset_archive/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/call-15.7.9/pulumi_call/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/call-15.7.9/pulumi_call/custom.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/call-15.7.9/pulumi_call/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/call-15.7.9/pulumi_call/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/camelNames-19.0.0/pulumi_camelNames/coolmodule/some_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/camelNames-19.0.0/pulumi_camelNames/coolmodule/some_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/camelNames-19.0.0/pulumi_camelNames/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/camelNames-19.0.0/pulumi_camelNames/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/component_callable.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/component_callable.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/custom.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-13.3.7/pulumi_component/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/config/__init__.pyi
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/config/__init__.pyi
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/config/vars.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/config/vars.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-9.0.0/pulumi_config/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/config/__init__.pyi
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/config/__init__.pyi
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/config/vars.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/config/vars.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/config_fetcher.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/config_fetcher.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/to_secret.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/config-grpc-1.0.0/pulumi_config_grpc/to_secret.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye_component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/goodbye-2.0.0/pulumi_goodbye/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/keywords-20.0.0/pulumi_keywords/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/keywords-20.0.0/pulumi_keywords/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/keywords-20.0.0/pulumi_keywords/some_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/keywords-20.0.0/pulumi_keywords/some_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/pulumi_large/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/pulumi_large/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/pulumi_large/string.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/large-4.3.2/pulumi_large/string.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/namespaced-16.0.0/a_namespace_namespaced/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/namespaced-16.0.0/a_namespace_namespaced/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/namespaced-16.0.0/a_namespace_namespaced/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/namespaced-16.0.0/a_namespace_namespaced/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/pulumi_plain/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/pulumi_plain/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/pulumi_plain/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/pulumi_plain/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/pulumi_plain/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/pulumi_plain/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/pulumi_plain/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/plain-13.0.0/pulumi_plain/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/pulumi_primitive/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/pulumi_primitive/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/pulumi_primitive/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-7.0.0/pulumi_primitive/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/ref-ref-12.0.0/pulumi_ref_ref/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/pulumi_secret/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/pulumi_secret/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/pulumi_secret/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/pulumi_secret/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/pulumi_secret/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/pulumi_secret/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/pulumi_secret/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/secret-14.0.0/pulumi_secret/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/pulumi_simple/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/pulumi_simple/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/pulumi_simple/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-2.0.0/pulumi_simple/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/my_invoke.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/my_invoke.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/secret_invoke.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/secret_invoke.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/string_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/string_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/unit.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/unit.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world_component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/subpackage-2.0.0/pulumi_subpackage/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/union-18.0.0/pulumi_union/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/union-18.0.0/pulumi_union/example.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/union-18.0.0/pulumi_union/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/sdks/union-18.0.0/pulumi_union/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/any-type-function-15.0.0/pulumi_any_type_function/dyn_list_to_dyn.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/any-type-function-15.0.0/pulumi_any_type_function/dyn_list_to_dyn.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/any-type-function-15.0.0/pulumi_any_type_function/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/any-type-function-15.0.0/pulumi_any_type_function/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/archive_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/archive_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/asset_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/asset_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/pulumi_asset_archive/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/call-15.7.9/pulumi_call/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/call-15.7.9/pulumi_call/custom.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/call-15.7.9/pulumi_call/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/call-15.7.9/pulumi_call/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/camelNames-19.0.0/pulumi_camelNames/coolmodule/some_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/camelNames-19.0.0/pulumi_camelNames/coolmodule/some_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/camelNames-19.0.0/pulumi_camelNames/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/camelNames-19.0.0/pulumi_camelNames/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/component_callable.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/component_callable.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/custom.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-13.3.7/pulumi_component/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/config/__init__.pyi
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/config/__init__.pyi
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/config/vars.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/config/vars.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-9.0.0/pulumi_config/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/config/__init__.pyi
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/config/__init__.pyi
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/config/vars.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/config/vars.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/config_fetcher.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/config_fetcher.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/to_secret.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/config-grpc-1.0.0/pulumi_config_grpc/to_secret.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye_component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/goodbye-2.0.0/pulumi_goodbye/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/keywords-20.0.0/pulumi_keywords/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/keywords-20.0.0/pulumi_keywords/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/keywords-20.0.0/pulumi_keywords/some_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/keywords-20.0.0/pulumi_keywords/some_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/pulumi_large/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/pulumi_large/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/pulumi_large/string.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/pulumi_large/string.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/namespaced-16.0.0/a_namespace_namespaced/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/namespaced-16.0.0/a_namespace_namespaced/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/namespaced-16.0.0/a_namespace_namespaced/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/namespaced-16.0.0/a_namespace_namespaced/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/pulumi_plain/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/pulumi_plain/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/pulumi_plain/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/pulumi_plain/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/pulumi_plain/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/pulumi_plain/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/pulumi_plain/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/plain-13.0.0/pulumi_plain/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/pulumi_primitive/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/pulumi_primitive/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/pulumi_primitive/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-7.0.0/pulumi_primitive/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/ref-ref-12.0.0/pulumi_ref_ref/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/pulumi_secret/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/pulumi_secret/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/pulumi_secret/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/pulumi_secret/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/pulumi_secret/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/pulumi_secret/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/pulumi_secret/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/secret-14.0.0/pulumi_secret/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/pulumi_simple/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/pulumi_simple/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/pulumi_simple/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/pulumi_simple/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/my_invoke.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/my_invoke.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/secret_invoke.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/secret_invoke.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/string_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/string_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/unit.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/unit.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world_component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/subpackage-2.0.0/pulumi_subpackage/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/union-18.0.0/pulumi_union/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/union-18.0.0/pulumi_union/example.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/union-18.0.0/pulumi_union/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/union-18.0.0/pulumi_union/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/any-type-function-15.0.0/pulumi_any_type_function/dyn_list_to_dyn.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/any-type-function-15.0.0/pulumi_any_type_function/dyn_list_to_dyn.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/any-type-function-15.0.0/pulumi_any_type_function/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/any-type-function-15.0.0/pulumi_any_type_function/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/archive_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/archive_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/asset_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/asset_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pulumi_asset_archive/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/call-15.7.9/pulumi_call/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/call-15.7.9/pulumi_call/custom.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/call-15.7.9/pulumi_call/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/call-15.7.9/pulumi_call/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/camelNames-19.0.0/pulumi_camelNames/coolmodule/some_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/camelNames-19.0.0/pulumi_camelNames/coolmodule/some_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/camelNames-19.0.0/pulumi_camelNames/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/camelNames-19.0.0/pulumi_camelNames/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/component_callable.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/component_callable.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/custom.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-13.3.7/pulumi_component/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/config/__init__.pyi
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/config/__init__.pyi
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/config/vars.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/config/vars.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-9.0.0/pulumi_config/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/config/__init__.pyi
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/config/__init__.pyi
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/config/vars.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/config/vars.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/config_fetcher.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/config_fetcher.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/to_secret.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/config-grpc-1.0.0/pulumi_config_grpc/to_secret.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/goodbye_component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/goodbye-2.0.0/pulumi_goodbye/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/keywords-20.0.0/pulumi_keywords/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/keywords-20.0.0/pulumi_keywords/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/keywords-20.0.0/pulumi_keywords/some_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/keywords-20.0.0/pulumi_keywords/some_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pulumi_large/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pulumi_large/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pulumi_large/string.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pulumi_large/string.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/namespaced-16.0.0/a_namespace_namespaced/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/namespaced-16.0.0/a_namespace_namespaced/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/namespaced-16.0.0/a_namespace_namespaced/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/namespaced-16.0.0/a_namespace_namespaced/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pulumi_plain/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pulumi_plain/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pulumi_plain/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pulumi_plain/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pulumi_plain/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pulumi_plain/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pulumi_plain/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/plain-13.0.0/pulumi_plain/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pulumi_primitive/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pulumi_primitive/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pulumi_primitive/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-7.0.0/pulumi_primitive/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/ref-ref-12.0.0/pulumi_ref_ref/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pulumi_secret/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pulumi_secret/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pulumi_secret/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pulumi_secret/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pulumi_secret/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pulumi_secret/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pulumi_secret/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/secret-14.0.0/pulumi_secret/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pulumi_simple/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pulumi_simple/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pulumi_simple/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pulumi_simple/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/my_invoke.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/my_invoke.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/secret_invoke.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/secret_invoke.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/string_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/string_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/unit.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/unit.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/hello_world_component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/subpackage-2.0.0/pulumi_subpackage/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/union-18.0.0/pulumi_union/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/union-18.0.0/pulumi_union/example.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/union-18.0.0/pulumi_union/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/union-18.0.0/pulumi_union/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/assets-and-archives/python/pulumi_example/_inputs.py
+++ b/tests/testdata/codegen/assets-and-archives/python/pulumi_example/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/assets-and-archives/python/pulumi_example/get_assets.py
+++ b/tests/testdata/codegen/assets-and-archives/python/pulumi_example/get_assets.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/assets-and-archives/python/pulumi_example/outputs.py
+++ b/tests/testdata/codegen/assets-and-archives/python/pulumi_example/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/assets-and-archives/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/assets-and-archives/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/assets-and-archives/python/pulumi_example/resource_with_assets.py
+++ b/tests/testdata/codegen/assets-and-archives/python/pulumi_example/resource_with_assets.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/documentdb/outputs.py
+++ b/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/documentdb/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/documentdb/sql_resource_sql_container.py
+++ b/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/documentdb/sql_resource_sql_container.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/provider.py
+++ b/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/config-variables/python/pulumi_example/config/__init__.pyi
+++ b/tests/testdata/codegen/config-variables/python/pulumi_example/config/__init__.pyi
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/config-variables/python/pulumi_example/config/vars.py
+++ b/tests/testdata/codegen/config-variables/python/pulumi_example/config/vars.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/config-variables/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/config-variables/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/cyclic-types/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/cyclic-types/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/_inputs.py
+++ b/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/outputs.py
+++ b/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/provider.py
+++ b/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/submodule1/foo_encrypted_bar_class.py
+++ b/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/submodule1/foo_encrypted_bar_class.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/submodule1/module_resource.py
+++ b/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/submodule1/module_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/_inputs.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/outputs.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/provider.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/tree/v1/nursery.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/tree/v1/nursery.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/different-enum/python/pulumi_plant/_inputs.py
+++ b/tests/testdata/codegen/different-enum/python/pulumi_plant/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/different-enum/python/pulumi_plant/outputs.py
+++ b/tests/testdata/codegen/different-enum/python/pulumi_plant/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/different-enum/python/pulumi_plant/provider.py
+++ b/tests/testdata/codegen/different-enum/python/pulumi_plant/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/different-enum/python/pulumi_plant/tree/v1/nursery.py
+++ b/tests/testdata/codegen/different-enum/python/pulumi_plant/tree/v1/nursery.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/different-enum/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/tests/testdata/codegen/different-enum/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/component.py
+++ b/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/crd_k8s_amazonaws_com/v1alpha1/_inputs.py
+++ b/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/crd_k8s_amazonaws_com/v1alpha1/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/crd_k8s_amazonaws_com/v1alpha1/outputs.py
+++ b/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/crd_k8s_amazonaws_com/v1alpha1/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/provider.py
+++ b/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/enum-reference-python/python/pulumi_example/gcp/gke/outputs.py
+++ b/tests/testdata/codegen/enum-reference-python/python/pulumi_example/gcp/gke/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/enum-reference-python/python/pulumi_example/mymodule/iam_resource.py
+++ b/tests/testdata/codegen/enum-reference-python/python/pulumi_example/mymodule/iam_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/enum-reference-python/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/enum-reference-python/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/enum-reference-python/python/pulumi_example/replicated_bucket.py
+++ b/tests/testdata/codegen/enum-reference-python/python/pulumi_example/replicated_bucket.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/enum-reference/python/pulumi_example/mymodule/iam_resource.py
+++ b/tests/testdata/codegen/enum-reference/python/pulumi_example/mymodule/iam_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/enum-reference/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/enum-reference/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/external-enum/python/pulumi_example/component.py
+++ b/tests/testdata/codegen/external-enum/python/pulumi_example/component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/external-enum/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/external-enum/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/cloudtrail/trail.py
+++ b/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/cloudtrail/trail.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/external-resource-schema/python/pulumi_example/_inputs.py
+++ b/tests/testdata/codegen/external-resource-schema/python/pulumi_example/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/external-resource-schema/python/pulumi_example/arg_function.py
+++ b/tests/testdata/codegen/external-resource-schema/python/pulumi_example/arg_function.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/external-resource-schema/python/pulumi_example/cat.py
+++ b/tests/testdata/codegen/external-resource-schema/python/pulumi_example/cat.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/external-resource-schema/python/pulumi_example/component.py
+++ b/tests/testdata/codegen/external-resource-schema/python/pulumi_example/component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/external-resource-schema/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/external-resource-schema/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/external-resource-schema/python/pulumi_example/workload.py
+++ b/tests/testdata/codegen/external-resource-schema/python/pulumi_example/workload.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/functions-secrets/python/pulumi_mypkg/func_with_secrets.py
+++ b/tests/testdata/codegen/functions-secrets/python/pulumi_mypkg/func_with_secrets.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/functions-secrets/python/pulumi_mypkg/provider.py
+++ b/tests/testdata/codegen/functions-secrets/python/pulumi_mypkg/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/provider.py
+++ b/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/registry_geo_replication.py
+++ b/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/registry_geo_replication.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/foo.py
+++ b/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/foo.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/outputs.py
+++ b/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/provider.py
+++ b/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/_inputs.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/ConfigMap.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/ConfigMap.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/ConfigMapList.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/ConfigMapList.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/_inputs.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/outputs.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/helm/v3/Release.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/helm/v3/Release.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/meta/v1/_inputs.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/meta/v1/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/meta/v1/outputs.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/meta/v1/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/provider.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/yaml/v2/ConfigGroup.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/yaml/v2/ConfigGroup.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/example_resource.py
+++ b/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/example_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/http_module/_inputs.py
+++ b/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/http_module/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/provider.py
+++ b/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/configurer.py
+++ b/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/configurer.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/provider.py
+++ b/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/main_component.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/main_component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/mod/component.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/mod/component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/mod/component2.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/mod/component2.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/resource.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/resource_input.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/resource_input.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/deeply/nested/module/resource.py
+++ b/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/deeply/nested/module/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/provider.py
+++ b/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/nested-module/python/pulumi_foo/nested/module/resource.py
+++ b/tests/testdata/codegen/nested-module/python/pulumi_foo/nested/module/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/nested-module/python/pulumi_foo/provider.py
+++ b/tests/testdata/codegen/nested-module/python/pulumi_foo/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/_inputs.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/list_configurations.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/list_configurations.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/list_product_families.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/list_product_families.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/outputs.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/provider.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/_inputs.py
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/get_ami_ids.py
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/get_ami_ids.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/list_storage_account_keys.py
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/list_storage_account_keys.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/outputs.py
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/provider.py
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/_inputs.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/func_with_all_optional_inputs.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/func_with_all_optional_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/func_with_const_input.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/func_with_const_input.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/func_with_default_value.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/func_with_default_value.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/func_with_dict_param.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/func_with_dict_param.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/func_with_empty_outputs.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/func_with_empty_outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/func_with_list_param.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/func_with_list_param.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/get_bastion_shareable_link.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/get_bastion_shareable_link.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/get_client_config.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/get_client_config.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/get_integration_runtime_object_metadatum.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/get_integration_runtime_object_metadatum.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/list_storage_account_keys.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/list_storage_account_keys.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/outputs.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/provider.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/module_resource.py
+++ b/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/module_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/provider.py
+++ b/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/_inputs.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/foo.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/foo.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/func_with_all_optional_inputs.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/func_with_all_optional_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/mod1/_inputs.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/mod1/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/mod2/_inputs.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/mod2/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/module_test.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/module_test.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/outputs.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/_inputs.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/foo.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/foo.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/func_with_all_optional_inputs.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/func_with_all_optional_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/mod1/_inputs.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/mod1/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/mod2/_inputs.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/mod2/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/module_test.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/module_test.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/outputs.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/_inputs.py
+++ b/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/provider.py
+++ b/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/static_page.py
+++ b/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/static_page.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/config/__init__.pyi
+++ b/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/config/__init__.pyi
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/config/_inputs.py
+++ b/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/config/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/config/outputs.py
+++ b/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/config/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/config/vars.py
+++ b/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/config/vars.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/func_with_all_optional_inputs.py
+++ b/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/func_with_all_optional_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/outputs.py
+++ b/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/provider.py
+++ b/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/provider.py
+++ b/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/submod/provider.py
+++ b/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/submod/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/_inputs.py
+++ b/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/component.py
+++ b/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/my_function.py
+++ b/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/my_function.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/outputs.py
+++ b/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/provider.py
+++ b/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import pulumi
 import pulumi.runtime

--- a/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/_inputs.py
+++ b/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/component.py
+++ b/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/my_function.py
+++ b/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/my_function.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/outputs.py
+++ b/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/provider.py
+++ b/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/_inputs.py
+++ b/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/component.py
+++ b/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/my_function.py
+++ b/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/my_function.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/outputs.py
+++ b/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/provider.py
+++ b/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-8403/python/pulumi_mongodbatlas/get_custom_db_roles.py
+++ b/tests/testdata/codegen/regress-8403/python/pulumi_mongodbatlas/get_custom_db_roles.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-8403/python/pulumi_mongodbatlas/outputs.py
+++ b/tests/testdata/codegen/regress-8403/python/pulumi_mongodbatlas/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-8403/python/pulumi_mongodbatlas/provider.py
+++ b/tests/testdata/codegen/regress-8403/python/pulumi_mongodbatlas/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-node-8110/python/pulumi_my8110/example_func.py
+++ b/tests/testdata/codegen/regress-node-8110/python/pulumi_my8110/example_func.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-node-8110/python/pulumi_my8110/provider.py
+++ b/tests/testdata/codegen/regress-node-8110/python/pulumi_my8110/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/_inputs.py
+++ b/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/outputs.py
+++ b/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/provider.py
+++ b/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childa/member_a1.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childa/member_a1.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childa/outputs.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childa/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childb/member_b1.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childb/member_b1.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childb/member_b2.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childb/member_b2.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childb/outputs.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/mymod/childb/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/provider.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-14012/python/pulumi_foo/_inputs.py
+++ b/tests/testdata/codegen/regress-py-14012/python/pulumi_foo/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-14012/python/pulumi_foo/provider.py
+++ b/tests/testdata/codegen/regress-py-14012/python/pulumi_foo/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/compute/instance/instance.py
+++ b/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/compute/instance/instance.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/compute/instancebootdisk/_inputs.py
+++ b/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/compute/instancebootdisk/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/compute/instancebootdisk/outputs.py
+++ b/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/compute/instancebootdisk/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/compute/instancebootdiskinitializeparams/_inputs.py
+++ b/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/compute/instancebootdiskinitializeparams/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/compute/instancebootdiskinitializeparams/outputs.py
+++ b/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/compute/instancebootdiskinitializeparams/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/provider.py
+++ b/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/_inputs.py
+++ b/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/config.py
+++ b/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/config.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/get_config.py
+++ b/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/get_config.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/outputs.py
+++ b/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/provider.py
+++ b/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/provider.py
+++ b/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/x/_inputs.py
+++ b/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/x/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/x/iam/get_policy_document.py
+++ b/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/x/iam/get_policy_document.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/x/outputs.py
+++ b/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/x/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/cat.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/cat.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/dog.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/dog.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/god.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/god.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/no_recursive.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/no_recursive.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/outputs.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/toy_store.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/toy_store.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/_inputs.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/outputs.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/person.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/person.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/pet.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/pet.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/resource-args-python/python/pulumi_example/_inputs.py
+++ b/tests/testdata/codegen/resource-args-python/python/pulumi_example/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/resource-args-python/python/pulumi_example/outputs.py
+++ b/tests/testdata/codegen/resource-args-python/python/pulumi_example/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/resource-args-python/python/pulumi_example/person.py
+++ b/tests/testdata/codegen/resource-args-python/python/pulumi_example/person.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/resource-args-python/python/pulumi_example/pet.py
+++ b/tests/testdata/codegen/resource-args-python/python/pulumi_example/pet.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/resource-args-python/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/resource-args-python/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/rec.py
+++ b/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/rec.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/secrets/python/pulumi_mypkg/_inputs.py
+++ b/tests/testdata/codegen/secrets/python/pulumi_mypkg/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/secrets/python/pulumi_mypkg/outputs.py
+++ b/tests/testdata/codegen/secrets/python/pulumi_mypkg/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/secrets/python/pulumi_mypkg/provider.py
+++ b/tests/testdata/codegen/secrets/python/pulumi_mypkg/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/secrets/python/pulumi_mypkg/resource.py
+++ b/tests/testdata/codegen/secrets/python/pulumi_mypkg/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/_inputs.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/outputs.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/provider.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/foo.py
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/foo.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/foo.py
+++ b/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/foo.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/nested/_inputs.py
+++ b/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/nested/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/_inputs.py
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/component.py
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/outputs.py
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/_inputs.py
+++ b/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/component.py
+++ b/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/component.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/do_foo.py
+++ b/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/do_foo.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/outputs.py
+++ b/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/arg_function.py
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/arg_function.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/other_resource.py
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/other_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/provider.py
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/resource.py
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/_inputs.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/arg_function.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/arg_function.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/bar_resource.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/bar_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/foo_resource.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/foo_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/other_resource.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/other_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/outputs.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/resource.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/type_uses.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/type_uses.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/basic_resource.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/basic_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/basic_resource_v2.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/basic_resource_v2.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/basic_resource_v3.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/basic_resource_v3.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-schema-pyproject/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-schema-pyproject/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/_inputs.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/arg_function.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/arg_function.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/other_resource.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/other_resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/outputs.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/resource.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/resource.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/type_uses.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/type_uses.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/unions-inline/python/pulumi_example/_inputs.py
+++ b/tests/testdata/codegen/unions-inline/python/pulumi_example/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/unions-inline/python/pulumi_example/example_server.py
+++ b/tests/testdata/codegen/unions-inline/python/pulumi_example/example_server.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/unions-inline/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/unions-inline/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/_inputs.py
+++ b/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/example_server.py
+++ b/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/example_server.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/outputs.py
+++ b/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/provider.py
+++ b/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/res.py
+++ b/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/res.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/test.py
+++ b/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/test.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/_inputs.py
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/_inputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/config/__init__.pyi
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/config/__init__.pyi
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/config/vars.py
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/config/vars.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/outputs.py
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/outputs.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/provider.py
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/provider.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi

--- a/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/user.py
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/user.py
@@ -3,7 +3,6 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import builtins as _builtins
-import copy
 import warnings
 import sys
 import pulumi


### PR DESCRIPTION
Stacked on top of https://github.com/pulumi/pulumi/pull/20085

---

The `copy` module is no longer used as of https://github.com/pulumi/pulumi/pull/9856, so no need to import.