### PR TITLE
Don’t use automatic ESM mode when `--import` or `--require` is set

### DIFF
--- a/changelog/pending/20250719--sdk-nodejs--dont-use-automatic-esm-mode-when-import-or-require-is-set.yaml
+++ b/changelog/pending/20250719--sdk-nodejs--dont-use-automatic-esm-mode-when-import-or-require-is-set.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Don’t use automatic ESM mode when `—import` or `—require` is set

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -357,7 +357,9 @@ export async function run(
         const isModule = packageObject["type"] === "module";
         const ts = require(typescriptRequire);
         const tsVersion = semver.parse(ts.version);
-        const hasLoaders = process.execArgv.find((arg) => arg === "--loader");
+        const hasLoaders = process.execArgv.find(
+            (arg) => arg === "--loader" || arg === "--import" || arg === "--require",
+        );
         try {
             tsNodeESMRequire = require.resolve("ts-node/esm");
         } catch (err) {
@@ -371,6 +373,7 @@ export async function run(
             !hasLoaders &&
             tsNodeESMRequire
         ) {
+            log.debug("Using automatic ESM mode");
             // All the conditions for automatic ESM mode are fullfilled.
             options.compilerOptions = {
                 target: "ES2022", // TS >= 4.6 and Node >= 20 support this

--- a/tests/integration/nodejs/esm-tsx/Pulumi.yaml
+++ b/tests/integration/nodejs/esm-tsx/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: esm-tsx
+runtime:
+  name: nodejs
+  options:
+    nodeargs: "--import tsx"
+description: Use ECMAScript modules for a TS program using TSX to handle loading of TS files.

--- a/tests/integration/nodejs/esm-tsx/index.ts
+++ b/tests/integration/nodejs/esm-tsx/index.ts
@@ -1,0 +1,17 @@
+// Copyright 2025, Pulumi Corporation.  All rights reserved.
+
+import * as fs from "fs";
+import { x } from "./other.js"; // this is the "by design" way to do this, even in TS
+import * as process from "process";
+
+// Use top-level await
+await new Promise(r => setTimeout(r, 2000));
+
+
+export const res = fs.readFileSync("Pulumi.yaml").toString();
+export const otherx = x;
+
+export const something = (arg: string): unknown => arg;
+
+// Type error, but TSC does not type check
+export const s: string = something("hello");

--- a/tests/integration/nodejs/esm-tsx/other.ts
+++ b/tests/integration/nodejs/esm-tsx/other.ts
@@ -1,0 +1,3 @@
+// Copyright 2025, Pulumi Corporation.  All rights reserved.
+
+export const x = 42;

--- a/tests/integration/nodejs/esm-tsx/package.json
+++ b/tests/integration/nodejs/esm-tsx/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "esm-tsx",
+    "license": "Apache-2.0",
+    "type": "module",
+    "devDependencies": {
+        "@types/node": "^20.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    },
+    "dependencies": {
+        "tsx": "^4.20.0",
+        "typescript": "^5.8.0",
+        "ts-node": "^10.8.0"
+    },
+    "//": "We include ts-node as a dependency here, even though we're using tsx. This is to simulate a case where ts-node is somewhere in the (maybe indirect) dependencies. Because we have the `--import` flag in Pulumi.yaml, we don't want to use automatic ESM mode in this test case, even though we have ts-node/esm available."
+}

--- a/tests/integration/nodejs/esm-tsx/tsconfig.json
+++ b/tests/integration/nodejs/esm-tsx/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "nodenext",
+        "moduleResolution": "nodenext",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts",
+        "other.ts"
+    ]
+}


### PR DESCRIPTION
Similar to how we skip automatic ESM mode when there is a `--loader` flag, skip it in the presence of `--import` or `--require` flags. For example [tsx](https://tsx.is) is often used with `--import tsx`.

Usually we wouldn’t hit this case, because we require a recent version of `ts-node` to activate automatic ESM mode, and when using `tsx` there’s no reason to have `ts-node` explicitly installed. It might still be present though, either directly in `package.json` for some other use, or as an indirect dependency.

This could lead to a setup where code would first run though `tsx`, stripping the types, and then through `ts-node/esm`, which could then potentially fail with a type error since it was now dealing with a lot of `any` and `unknown` types.
