### PR TITLE
Avoid "Cannot convert object to primitive value" error when running into type errors

### DIFF
--- a/changelog/pending/20250719--sdk-nodejs--avoid-cannot-convert-object-to-primitive-value-error-when-running-into-type-errors.yaml
+++ b/changelog/pending/20250719--sdk-nodejs--avoid-cannot-convert-object-to-primitive-value-error-when-running-into-type-errors.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Avoid "Cannot convert object to primitive value" error when running into type errors

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -443,7 +443,7 @@ ${defaultErrorMessage(err)}`,
             );
         }
 
-        span.addEvent(`uncaughtError: ${err}`);
+        span.addEvent(`uncaughtError: ${defaultErrorMessage(err)}`);
         reportLoggedError(err);
     };
 

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1345,6 +1345,10 @@ func TestESMTSAutoTypeCheck(t *testing.T) {
 	e.RunCommand("pulumi", "stack", "select", stackName)
 	stdout, _ := e.RunCommandExpectError("pulumi", "up", "--yes")
 	require.Contains(t, stdout, "index.ts(3,14): error TS2322: Type 'number' is not assignable to type 'string'.")
+	// Type errors are not always easily stringified. If we simply call
+	// toString() on them, either directly or just try to print them, we can get
+	// an `Cannot convert object to primitive value` error.
+	require.NotContains(t, stdout, "Cannot convert object to primitive value")
 	e.RunCommand("pulumi", "destroy", "--skip-preview", "--refresh=true")
 }
 


### PR DESCRIPTION
We had a first fix for this in https://github.com/pulumi/pulumi/pull/18080, but I ran into another one of these errors while working on https://github.com/pulumi/pulumi/pull/20091
