### PR TITLE
Fix data race in events system

### DIFF
--- a/changelog/pending/20250722--engine--fix-a-datarace-in-the-engine-event-system.yaml
+++ b/changelog/pending/20250722--engine--fix-a-datarace-in-the-engine-event-system.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix a datarace in the engine event system


### PR DESCRIPTION
Fixes a data race between the event system trying to deepcopy step metadata objects (which contain `*resource.State` objects) and the step executor that could be trying to set fields on those state objects.

The step executor was correctly trying to lock/unlock the state objects, but the event system wasn't.

This was a fairly benign race, I don't think we would of ever really seen user issues because of it but it would trigger the go race detector and fail tests.