### PR TITLE
unflaky analyzer canellation test

### DIFF
--- a/pkg/engine/lifecycletest/analyzer_test.go
+++ b/pkg/engine/lifecycletest/analyzer_test.go
@@ -524,7 +524,7 @@ func TestAnalyzerCancellation(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 		cancel()
 		return nil
 	})
@@ -545,6 +545,6 @@ func TestAnalyzerCancellation(t *testing.T) {
 	op := lt.TestOp(Update)
 	_, err := op.RunWithContext(ctx, project, target, p.Options, false, nil, nil)
 
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "BAIL: canceled")
 	assert.True(t, gracefulShutdown)
 }


### PR DESCRIPTION
Increase the sleep time here, similar to what we do in language plugins.  See also [the conversation in that PR](https://github.com/pulumi/pulumi/pull/20007#discussion_r2206677998).

Also while we're there, assert on the content of the error.

Note that this test can still flake when a computer is very busy running stuff, but at least this seems better than before, and less flaky for me locally.

Fixes https://github.com/pulumi/pulumi/issues/20108
/cc @i-am-tom 