### PR TITLE
Run uv sync on uv command

### DIFF
--- a/changelog/pending/20250723--sdk-python--run-uv-sync-on-uv-command.yaml
+++ b/changelog/pending/20250723--sdk-python--run-uv-sync-on-uv-command.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Run uv sync on uv command

--- a/sdk/python/toolchain/testdata/project/pyproject.toml
+++ b/sdk/python/toolchain/testdata/project/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "test-uv"
+version = "0.1.0"
+description = "Ensure we setup the venv when running a command"
+dependencies = ['wheel']

--- a/sdk/python/toolchain/uv_test.go
+++ b/sdk/python/toolchain/uv_test.go
@@ -15,8 +15,10 @@
 package toolchain
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/blang/semver"
@@ -96,4 +98,64 @@ func TestUvVersion(t *testing.T) {
 
 	_, err := ParseUvVersion("uv 0.4.25")
 	require.ErrorContains(t, err, "less than the minimum required version")
+}
+
+func TestUvCommandSyncsEnvironment(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	pyproject, err := os.ReadFile(filepath.Join("testdata", "project", "pyproject.toml"))
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(root, "pyproject.toml"), pyproject, 0o600)
+	require.NoError(t, err)
+
+	uv, err := newUv(root, "")
+	require.NoError(t, err)
+
+	// Run a python command, this should run `uv sync` as side effect
+	cmd, err := uv.Command(context.Background(), "-c", "print('hello')")
+	require.NoError(t, err)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err)
+	require.Equal(t, "hello", strings.TrimSpace(string(out)))
+
+	// check that .venv exists
+	require.DirExists(t, filepath.Join(root, ".venv"))
+
+	// `wheel`, the project's dependency, should be installed
+	cmd, err = uv.ModuleCommand(context.Background(), "wheel", "version")
+	require.NoError(t, err)
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err)
+	require.True(t, strings.Contains(string(out), "wheel"), "unexpected output: %s", out)
+}
+
+func TestUvCommandSyncsEnvironmentCustomVenv(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	pyproject, err := os.ReadFile(filepath.Join("testdata", "project", "pyproject.toml"))
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(root, "pyproject.toml"), pyproject, 0o600)
+	require.NoError(t, err)
+
+	uv, err := newUv(root, "my_venv")
+	require.NoError(t, err)
+
+	// Run a python command, this should run `uv sync` as side effect
+	cmd, err := uv.Command(context.Background(), "-c", "print('hello')")
+	require.NoError(t, err)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err)
+	require.Equal(t, "hello", strings.TrimSpace(string(out)))
+
+	// check that my_venv exists
+	require.DirExists(t, filepath.Join(root, "my_venv"))
+
+	// `wheel`, the project's dependency, should be installed
+	cmd, err = uv.ModuleCommand(context.Background(), "wheel", "version")
+	require.NoError(t, err)
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err)
+	require.True(t, strings.Contains(string(out), "wheel"), "unexpected output: %s", out)
 }


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/18054 we added a workaround for https://github.com/astral-sh/uv/issues/11817, however this had the unintended effect that we were no longer automatically updating the virtual environment whenever a `uv run` command runs.

Fixes https://github.com/pulumi/pulumi/issues/19834
