### PR TITLE
Add `Features` to `PatchUpdateCheckpointRequest`

### DIFF
--- a/sdk/go/common/apitype/updates.go
+++ b/sdk/go/common/apitype/updates.go
@@ -244,6 +244,7 @@ type CompleteUpdateRequest struct {
 type PatchUpdateCheckpointRequest struct {
 	IsInvalid  bool            `json:"isInvalid"`
 	Version    int             `json:"version"`
+	Features   []string        `json:"features,omitempty"`
 	Deployment json.RawMessage `json:"deployment,omitempty"`
 }
 


### PR DESCRIPTION
This change adds a `Features` field to the `PatchUpdateCheckpointRequest` struct, for sending this additional metadata to the service. The actual sending of this additional data will be added in a subsequent change.

Part of https://github.com/pulumi/pulumi/issues/19705