### PR TITLE
Add `SerializeUntypedDeployment` helper

### DIFF
--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -929,19 +929,12 @@ func (eng *languageTestServer) RunLanguageTest(
 				},
 			},
 		}
-		serializedDeployment, err := stack.SerializeDeployment(ctx, snap, false)
-		if err != nil {
-			return nil, fmt.Errorf("serialize deployment: %w", err)
-		}
-		jsonDeployment, err := json.Marshal(serializedDeployment)
+
+		untypedDeployment, err := stack.SerializeUntypedDeployment(ctx, snap, nil /*opts*/)
 		if err != nil {
 			return nil, fmt.Errorf("serialize deployment: %w", err)
 		}
 
-		untypedDeployment := &apitype.UntypedDeployment{
-			Version:    apitype.DeploymentSchemaVersionCurrent,
-			Deployment: jsonDeployment,
-		}
 		err = backend.ImportStackDeployment(ctx, s, untypedDeployment)
 		if err != nil {
 			return nil, fmt.Errorf("import deployment: %w", err)

--- a/pkg/cmd/pulumi/stack/io.go
+++ b/pkg/cmd/pulumi/stack/io.go
@@ -526,23 +526,14 @@ func SaveSnapshot(ctx context.Context, s backend.Stack, snapshot *deploy.Snapsho
 
 		snapshot.PendingOperations = nil
 	}
-	sdp, err := stack.SerializeDeployment(ctx, snapshot, false /* showSecrets */)
+
+	dep, err := stack.SerializeUntypedDeployment(ctx, snapshot, nil /*opts*/)
 	if err != nil {
 		return fmt.Errorf("constructing deployment for upload: %w", err)
 	}
 
-	bytes, err := json.Marshal(sdp)
-	if err != nil {
-		return err
-	}
-
-	dep := apitype.UntypedDeployment{
-		Version:    apitype.DeploymentSchemaVersionCurrent,
-		Deployment: bytes,
-	}
-
 	// Now perform the deployment.
-	if err = backend.ImportStackDeployment(ctx, s, &dep); err != nil {
+	if err = backend.ImportStackDeployment(ctx, s, dep); err != nil {
 		return fmt.Errorf("could not import deployment: %w", err)
 	}
 	return nil

--- a/pkg/cmd/pulumi/stack/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack/stack_change_secrets_provider.go
@@ -16,7 +16,6 @@ package stack
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -27,7 +26,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -226,21 +224,11 @@ func migrateOldConfigAndCheckpointToNewSecretsProvider(
 
 	// Reserialize the Snapshopshot with the NewSecrets Manager
 	snap.SecretsManager = newSecretsManager
-	reserializedDeployment, err := stack.SerializeDeployment(ctx, snap, false /*showSecrets*/)
+	dep, err := stack.SerializeUntypedDeployment(ctx, snap, nil /*opts*/)
 	if err != nil {
 		return err
-	}
-
-	bytes, err := json.Marshal(reserializedDeployment)
-	if err != nil {
-		return err
-	}
-
-	dep := apitype.UntypedDeployment{
-		Version:    apitype.DeploymentSchemaVersionCurrent,
-		Deployment: bytes,
 	}
 
 	// Import the newly changes Deployment
-	return backend.ImportStackDeployment(ctx, currentStack, &dep)
+	return backend.ImportStackDeployment(ctx, currentStack, dep)
 }

--- a/pkg/cmd/pulumi/stack/stack_change_secrets_provider_test.go
+++ b/pkg/cmd/pulumi/stack/stack_change_secrets_provider_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
 	"github.com/pulumi/pulumi/pkg/v3/util/testutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -98,18 +97,9 @@ func TestChangeSecretsProvider_NoSecrets(t *testing.T) {
 
 	mockBackend := &backend.MockBackend{
 		ExportDeploymentF: func(ctx context.Context, _ backend.Stack) (*apitype.UntypedDeployment, error) {
-			chk, err := stack.SerializeDeployment(ctx, snapshot, false)
-			if err != nil {
-				return nil, err
-			}
-			data, err := encoding.JSON.Marshal(chk)
-			if err != nil {
-				return nil, err
-			}
-			return &apitype.UntypedDeployment{
-				Version:    3,
-				Deployment: json.RawMessage(data),
-			}, nil
+			return stack.SerializeUntypedDeployment(ctx, snapshot, &stack.SerializeOptions{
+				Pretty: true,
+			})
 		},
 		ImportDeploymentF: func(ctx context.Context, _ backend.Stack, deployment *apitype.UntypedDeployment) error {
 			snap, err := stack.DeserializeUntypedDeployment(ctx, deployment, secretsProvider)
@@ -206,18 +196,9 @@ func TestChangeSecretsProvider_WithSecrets(t *testing.T) {
 
 	mockBackend := &backend.MockBackend{
 		ExportDeploymentF: func(ctx context.Context, _ backend.Stack) (*apitype.UntypedDeployment, error) {
-			chk, err := stack.SerializeDeployment(ctx, snapshot, false)
-			if err != nil {
-				return nil, err
-			}
-			data, err := encoding.JSON.Marshal(chk)
-			if err != nil {
-				return nil, err
-			}
-			return &apitype.UntypedDeployment{
-				Version:    3,
-				Deployment: json.RawMessage(data),
-			}, nil
+			return stack.SerializeUntypedDeployment(ctx, snapshot, &stack.SerializeOptions{
+				Pretty: true,
+			})
 		},
 		ImportDeploymentF: func(ctx context.Context, _ backend.Stack, deployment *apitype.UntypedDeployment) error {
 			snap, err := stack.DeserializeUntypedDeployment(ctx, deployment, secretsProvider)

--- a/pkg/cmd/pulumi/stack/stack_export.go
+++ b/pkg/cmd/pulumi/stack/stack_export.go
@@ -106,6 +106,10 @@ func newStackExportCmd() *cobra.Command {
 					return stack.FormatDeploymentDeserializationError(err, stackName)
 				}
 
+				// Serialize with pretty formatting so that HTML characters are not escaped when serializing
+				// the deployment back to JSON. Note that if the HTML characters were already escaped as part
+				// of exporting from the backend, those escaped characters will remain escaped, this just
+				// avoids introducing additional escaping.
 				deployment, err = stack.SerializeUntypedDeployment(ctx, snap, &stack.SerializeOptions{
 					ShowSecrets: true,
 					Pretty:      true,

--- a/pkg/cmd/pulumi/stack/stack_export.go
+++ b/pkg/cmd/pulumi/stack/stack_export.go
@@ -106,19 +106,12 @@ func newStackExportCmd() *cobra.Command {
 					return stack.FormatDeploymentDeserializationError(err, stackName)
 				}
 
-				serializedDeployment, err := stack.SerializeDeployment(ctx, snap, true)
+				deployment, err = stack.SerializeUntypedDeployment(ctx, snap, &stack.SerializeOptions{
+					ShowSecrets: true,
+					Pretty:      true,
+				})
 				if err != nil {
 					return err
-				}
-
-				data, err := json.Marshal(serializedDeployment)
-				if err != nil {
-					return err
-				}
-
-				deployment = &apitype.UntypedDeployment{
-					Version:    3,
-					Deployment: data,
 				}
 
 				Log3rdPartySecretsProviderDecryptionEvent(ctx, s, "", "pulumi stack export")

--- a/pkg/cmd/pulumi/state/state_move_test.go
+++ b/pkg/cmd/pulumi/state/state_move_test.go
@@ -29,9 +29,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
@@ -47,16 +45,8 @@ func createStackWithResources(
 	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{})
 	ctx := context.Background()
 
-	sdep, err := stack.SerializeDeployment(ctx, snap, false /* showSecrets */)
+	udep, err := stack.SerializeUntypedDeployment(ctx, snap, nil /*opts*/)
 	require.NoError(t, err)
-
-	data, err := encoding.JSON.Marshal(sdep)
-	require.NoError(t, err)
-
-	udep := &apitype.UntypedDeployment{
-		Version:    3,
-		Deployment: json.RawMessage(data),
-	}
 
 	ref, err := b.ParseStackReference(stackName)
 	require.NoError(t, err)

--- a/pkg/cmd/pulumi/state/state_repair.go
+++ b/pkg/cmd/pulumi/state/state_repair.go
@@ -16,7 +16,6 @@ package state
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -32,7 +31,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -213,20 +211,12 @@ func (cmd *stateRepairCmd) run(ctx context.Context) error {
 	}
 
 	// We've managed to repair the snapshot -- import it back into the backend.
-	sdep, err := stack.SerializeDeployment(ctx, snap, false /*showSecrets*/)
-	if err != nil {
-		return fmt.Errorf("serializing deployment: %w", err)
-	}
-
-	bytes, err := json.Marshal(sdep)
+	dep, err := stack.SerializeUntypedDeployment(ctx, snap, nil /*opts*/)
 	if err != nil {
 		return err
 	}
 
-	err = backend.ImportStackDeployment(ctx, s, &apitype.UntypedDeployment{
-		Version:    apitype.DeploymentSchemaVersionCurrent,
-		Deployment: bytes,
-	})
+	err = backend.ImportStackDeployment(ctx, s, dep)
 	if err != nil {
 		return err
 	}

--- a/tests/integration/backend/diy/backend_postgres_test.go
+++ b/tests/integration/backend/diy/backend_postgres_test.go
@@ -19,7 +19,6 @@ package diy
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"runtime"
 	"testing"
@@ -338,17 +337,8 @@ func TestPostgresBackend(t *testing.T) {
 	}, nil, deploy.SnapshotMetadata{})
 
 	// Test deployment serialization - simulate what would happen during a real deployment
-	deployment, err := stackpkg.SerializeDeployment(ctx, snap, false)
+	untypedDeployment, err := stackpkg.SerializeUntypedDeployment(ctx, snap, nil /*opts*/)
 	require.NoError(t, err, "Failed to serialize deployment")
-
-	// Convert to untyped deployment for import testing
-	serializedData, err := json.Marshal(deployment)
-	require.NoError(t, err, "Failed to marshal deployment")
-
-	untypedDeployment := &apitype.UntypedDeployment{
-		Version:    apitype.DeploymentSchemaVersionCurrent,
-		Deployment: json.RawMessage(serializedData),
-	}
 
 	// Verify the untyped deployment was created successfully
 	require.NotNil(t, untypedDeployment, "Untyped deployment should not be nil")

--- a/tests/stack/testdata/html_escape/Pulumi.yaml
+++ b/tests/stack/testdata/html_escape/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: html_escape
+description: A program that exports a string that contains HTML characters
+runtime: nodejs

--- a/tests/stack/testdata/html_escape/index.ts
+++ b/tests/stack/testdata/html_escape/index.ts
@@ -1,0 +1,5 @@
+// Copyright 2025, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+export const result = pulumi.output("<html>'hello world'</html>")

--- a/tests/stack/testdata/html_escape/package.json
+++ b/tests/stack/testdata/html_escape/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "html_escape",
+    "license": "Apache-2.0",
+    "devDependencies": {
+        "typescript": "^3.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}


### PR DESCRIPTION
This change adds a new helper function for serializing a snapshot to an untyped deployment. This reduces duplication in preparation for writing version 4 when certain features are used, which will come in a subsequent change.

Part of https://github.com/pulumi/pulumi/issues/19705