### PR TITLE
Add `object` as a simple config type.

### DIFF
--- a/sdk/go/common/workspace/project.json
+++ b/sdk/go/common/workspace/project.json
@@ -321,7 +321,8 @@
                 "string",
                 "integer",
                 "boolean",
-                "array"
+                "array",
+                "object"
             ]
         },
         "configItemsType":{


### PR DESCRIPTION
As part of my work on https://github.com/pulumi/pulumi-yaml/issues/827, I need to be able to add config variables of an opaque `object` type. However, this isn't something you can currently do because we validate YAML projects against this template, so I _think_ I have to change this before I can make any progress in `pulumi-yaml`. Please tell me if I'm wrong, though.