### PR TITLE
Use #/provider rather than #/resources/pulumi:providers:pkg

### DIFF
--- a/tests/testdata/codegen/schema/provider-methods-1.json
+++ b/tests/testdata/codegen/schema/provider-methods-1.json
@@ -11,7 +11,7 @@
             "inputs": {
                 "properties": {
                     "__self__": {
-                        "$ref": "#/resources/pulumi:providers:xyz"
+                        "$ref": "#/provider"
                     }
                 },
                 "required": ["__self__"]

--- a/tests/testdata/codegen/schema/provider-methods-2.json
+++ b/tests/testdata/codegen/schema/provider-methods-2.json
@@ -37,7 +37,7 @@
             "inputs": {
                 "properties": {
                     "__self__": {
-                        "$ref": "#/resources/pulumi:providers:xyz"
+                        "$ref": "#/provider"
                     }
                 },
                 "required": ["__self__"]

--- a/tests/testdata/codegen/schema/provider-methods-3.json
+++ b/tests/testdata/codegen/schema/provider-methods-3.json
@@ -36,7 +36,7 @@
             "inputs": {
                 "properties": {
                     "__self__": {
-                        "$ref": "#/resources/pulumi:providers:pulumi"
+                        "$ref": "#/provider"
                     }
                 },
                 "required": ["__self__"]


### PR DESCRIPTION
Raised by a customer that some providers were using "#/resources/pulumi:providers:pkg" instead of just "#/provider". Which looks odd as a JSON ref because "resources/pulumi:providers:pkg" wouldn't have been a path to valid object in the json document.

We have these tests using that odd format, but they pass just fine using the "#/provider" style, so lets fix them up as a first step to sanitizing things here.