### PR TITLE
Add support for qualified registry template names in `pulumi new`

### DIFF
--- a/changelog/pending/20250724--cli-new--add-support-for-qualified-registry-template-names.yaml
+++ b/changelog/pending/20250724--cli-new--add-support-for-qualified-registry-template-names.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/new
+  description: Add support for qualified registry template names in `pulumi new`

--- a/sdk/go/common/registry/urls.go
+++ b/sdk/go/common/registry/urls.go
@@ -1,0 +1,219 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/blang/semver"
+)
+
+const RegistryURLScheme = "registry"
+
+type URLInfo struct {
+	resourceType string
+	source       string
+	publisher    string
+	name         string
+	version      *semver.Version // optional
+}
+
+func (u *URLInfo) ResourceType() string {
+	return u.resourceType
+}
+
+func (u *URLInfo) Source() string {
+	return u.source
+}
+
+func (u *URLInfo) Publisher() string {
+	return u.publisher
+}
+
+func (u *URLInfo) Name() string {
+	return u.name
+}
+
+func (u *URLInfo) Version() *semver.Version {
+	return u.version
+}
+
+func ParseRegistryURL(registryURL string) (*URLInfo, error) {
+	parsedURL, err := url.Parse(registryURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid registry URL: %w", err)
+	}
+
+	if parsedURL.Scheme != RegistryURLScheme {
+		return nil, fmt.Errorf("invalid registry URL scheme: expected %s, got %s", RegistryURLScheme, parsedURL.Scheme)
+	}
+
+	resourceType := parsedURL.Host
+	if resourceType == "" {
+		return nil, fmt.Errorf("invalid registry URL: missing resource type")
+	}
+
+	urlPath := strings.TrimPrefix(parsedURL.Path, "/")
+	parts := strings.Split(urlPath, "/")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid registry URL format: expected registry://resource-type/source/publisher/name[@version]")
+	}
+
+	source := parts[0]
+	if source == "" {
+		return nil, fmt.Errorf("invalid registry URL: missing source")
+	}
+
+	publisher := parts[1]
+	if publisher == "" {
+		return nil, fmt.Errorf("invalid registry URL: missing publisher")
+	}
+
+	nameAndVersion := parts[2]
+	nameVersionParts := strings.Split(nameAndVersion, "@")
+	if len(nameVersionParts) > 2 {
+		return nil, fmt.Errorf("invalid registry URL format: expected registry://resource-type/source/publisher/name[@version]")
+	}
+
+	encodedName := nameVersionParts[0]
+	if encodedName == "" {
+		return nil, fmt.Errorf("invalid registry URL: missing name")
+	}
+
+	name, err := decodeArtifactNamePart(encodedName)
+	if err != nil {
+		return nil, fmt.Errorf("invalid registry URL: failed to decode name: %w", err)
+	}
+
+	var version *semver.Version
+	if len(nameVersionParts) == 2 {
+		versionStr := nameVersionParts[1]
+		if versionStr == "" {
+			return nil, fmt.Errorf("invalid registry URL: missing version")
+		}
+		
+		if versionStr != "latest" {
+			version, err = parseVersion(versionStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid registry URL: invalid version %q: %w", versionStr, err)
+			}
+		}
+	}
+
+	return &URLInfo{
+		resourceType: resourceType,
+		source:       source,
+		publisher:    publisher,
+		name:         name,
+		version:      version,
+	}, nil
+}
+
+func (u *URLInfo) String() string {
+	encodedName := encodeArtifactNamePart(u.Name())
+
+	if u.Version() == nil {
+		return fmt.Sprintf("registry://%s/%s/%s/%s",
+			u.ResourceType(), u.Source(), u.Publisher(), encodedName)
+	}
+	return fmt.Sprintf("registry://%s/%s/%s/%s@%s",
+		u.ResourceType(), u.Source(), u.Publisher(), encodedName, u.Version().String())
+}
+
+func ParseRegistryURLOrPartial(registryURL string, defaultResourceType string) (*URLInfo, error) {
+	if IsRegistryURL(registryURL) {
+		return ParseRegistryURL(registryURL)
+	}
+	return parsePartialRegistryURL(registryURL, defaultResourceType)
+}
+
+func parsePartialRegistryURL(registryURL string, defaultResourceType string) (*URLInfo, error) {
+	var version *semver.Version
+	nameSpec := registryURL
+	if idx := strings.LastIndex(registryURL, "@"); idx != -1 {
+		versionStr := registryURL[idx+1:]
+		if versionStr == "" {
+			return nil, fmt.Errorf("invalid registry URL: missing version after @")
+		}
+		if versionStr != "latest" {
+			var err error
+			version, err = parseVersion(versionStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid registry URL: invalid version %q: %w", versionStr, err)
+			}
+		}
+		nameSpec = registryURL[:idx]
+	}
+	
+	parts := strings.Split(nameSpec, "/")
+	var source, publisher, name string
+	switch len(parts) {
+	case 1:
+		name = parts[0]
+	case 2:
+		publisher = parts[0]
+		name = parts[1]
+	case 3:
+		source = parts[0]
+		publisher = parts[1]
+		name = parts[2]
+	default:
+		return nil, fmt.Errorf("invalid registry URL format: expected [source/]publisher/name[@version] or name[@version]")
+	}
+	
+	if name == "" {
+		return nil, fmt.Errorf("invalid registry URL: missing name")
+	}
+	
+	return &URLInfo{
+		resourceType: defaultResourceType,
+		source:       source,
+		publisher:    publisher,
+		name:         name,
+		version:      version,
+	}, nil
+}
+
+func IsRegistryURL(input string) bool {
+	return strings.HasPrefix(input, RegistryURLScheme+"://")
+}
+
+func parseVersion(versionStr string) (*semver.Version, error) {
+	version, err := semver.Parse(versionStr)
+	if err != nil {
+		return nil, err
+	}
+	return &version, nil
+}
+
+func decodeArtifactNamePart(encoded string) (string, error) {
+	decodedOnce, err := url.QueryUnescape(encoded)
+	if err != nil {
+		return "", fmt.Errorf("failed first decode: %w", err)
+	}
+	
+	decodedTwice, err := url.QueryUnescape(decodedOnce)
+	if err != nil {
+		return decodedOnce, nil
+	}
+	
+	return decodedTwice, nil
+}
+
+func encodeArtifactNamePart(name string) string {
+	return url.QueryEscape(url.QueryEscape(name))
+}

--- a/sdk/go/common/registry/urls_test.go
+++ b/sdk/go/common/registry/urls_test.go
@@ -1,0 +1,483 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustParseVersion(v string) *semver.Version {
+	version, err := semver.Parse(v)
+	if err != nil {
+		panic(err)
+	}
+	return &version
+}
+
+func TestParseRegistryURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		url         string
+		expected    *URLInfo
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "valid registry URL with version",
+			url:  "registry://templates/test-source/test-publisher/test-template@1.0.0",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "test-source",
+				publisher:    "test-publisher",
+				name:         "test-template",
+				version:      mustParseVersion("1.0.0"),
+			},
+			expectError: false,
+		},
+		{
+			name: "valid registry URL without version",
+			url:  "registry://templates/test-source/test-publisher/test-template",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "test-source",
+				publisher:    "test-publisher",
+				name:         "test-template",
+				version:      nil,
+			},
+			expectError: false,
+		},
+		{
+			name: "valid registry URL with latest version",
+			url:  "registry://templates/test-source/test-publisher/test-template@latest",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "test-source",
+				publisher:    "test-publisher",
+				name:         "test-template",
+				version:      nil, // latest is treated as nil version
+			},
+			expectError: false,
+		},
+		{
+			name: "valid registry URL with complex version",
+			url:  "registry://templates/my-source/my-publisher/my-template@2.1.0-beta.1",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "my-source",
+				publisher:    "my-publisher",
+				name:         "my-template",
+				version:      mustParseVersion("2.1.0-beta.1"),
+			},
+			expectError: false,
+		},
+		{
+			name: "valid registry URL with double-encoded name",
+			url:  "registry://templates/test-source/test-publisher/test%252Ftemplate@1.0.0",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "test-source",
+				publisher:    "test-publisher",
+				name:         "test/template",
+				version:      mustParseVersion("1.0.0"),
+			},
+			expectError: false,
+		},
+		{
+			name: "valid registry URL with packages resource type",
+			url:  "registry://packages/test-source/test-publisher/test-package@1.0.0",
+			expected: &URLInfo{
+				resourceType: "packages",
+				source:       "test-source",
+				publisher:    "test-publisher",
+				name:         "test-package",
+				version:      mustParseVersion("1.0.0"),
+			},
+			expectError: false,
+		},
+		{
+			name:        "invalid URL format",
+			url:         "not-a-valid-url",
+			expectError: true,
+			errorMsg:    "invalid registry URL",
+		},
+		{
+			name:        "wrong scheme",
+			url:         "https://test-host/templates/test-source/test-publisher/test-template@1.0.0",
+			expectError: true,
+			errorMsg:    "invalid registry URL scheme",
+		},
+		{
+			name:        "missing resource type",
+			url:         "registry:////test-source/test-publisher/test-template@1.0.0",
+			expectError: true,
+			errorMsg:    "invalid registry URL: missing resource type",
+		},
+		{
+			name:        "missing source",
+			url:         "registry://templates//test-publisher/test-template@1.0.0",
+			expectError: true,
+			errorMsg:    "invalid registry URL: missing source",
+		},
+		{
+			name:        "missing publisher",
+			url:         "registry://templates/test-source//test-template@1.0.0",
+			expectError: true,
+			errorMsg:    "invalid registry URL: missing publisher",
+		},
+		{
+			name:        "missing name",
+			url:         "registry://templates/test-source/test-publisher/@1.0.0",
+			expectError: true,
+			errorMsg:    "invalid registry URL: missing name",
+		},
+		{
+			name:        "missing version",
+			url:         "registry://templates/test-source/test-publisher/test-template@",
+			expectError: true,
+			errorMsg:    "invalid registry URL: missing version",
+		},
+		{
+			name:        "too many path segments",
+			url:         "registry://templates/test-source/test-publisher/test-template/extra@1.0.0",
+			expectError: true,
+			errorMsg:    "invalid registry URL format",
+		},
+		{
+			name:        "too few path segments",
+			url:         "registry://templates/test-template@1.0.0",
+			expectError: true,
+			errorMsg:    "invalid registry URL format",
+		},
+		{
+			name:        "multiple @ symbols",
+			url:         "registry://templates/test-source/test-publisher/test-template@1.0.0@extra",
+			expectError: true,
+			errorMsg:    "invalid registry URL format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseRegistryURL(tt.url)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorMsg != "" {
+					assert.Contains(t, err.Error(), tt.errorMsg)
+				}
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, tt.expected.ResourceType(), result.ResourceType())
+				assert.Equal(t, tt.expected.Source(), result.Source())
+				assert.Equal(t, tt.expected.Publisher(), result.Publisher())
+				assert.Equal(t, tt.expected.Name(), result.Name())
+				if tt.expected.Version() == nil {
+					assert.Nil(t, result.Version())
+				} else {
+					require.NotNil(t, result.Version())
+					assert.True(t, tt.expected.Version().Equals(*result.Version()))
+				}
+			}
+		})
+	}
+}
+
+func TestURLInfoString(t *testing.T) {
+	t.Run("with version", func(t *testing.T) {
+		info := &URLInfo{
+			resourceType: "templates",
+			source:       "test-source",
+			publisher:    "test-publisher",
+			name:         "test-template",
+			version:      mustParseVersion("1.0.0"),
+		}
+
+		expected := "registry://templates/test-source/test-publisher/test-template@1.0.0"
+		assert.Equal(t, expected, info.String())
+	})
+
+	t.Run("without version", func(t *testing.T) {
+		info := &URLInfo{
+			resourceType: "templates",
+			source:       "test-source",
+			publisher:    "test-publisher",
+			name:         "test-template",
+			version:      nil,
+		}
+
+		expected := "registry://templates/test-source/test-publisher/test-template"
+		assert.Equal(t, expected, info.String())
+	})
+}
+
+func TestRegistryURL_RoundTrip(t *testing.T) {
+	t.Run("with version", func(t *testing.T) {
+		originalURL := "registry://templates/test-source/test-publisher/test-template@1.0.0"
+
+		info, err := ParseRegistryURL(originalURL)
+		require.NoError(t, err)
+
+		roundTripURL := info.String()
+
+		assert.Equal(t, originalURL, roundTripURL)
+	})
+
+	t.Run("without version", func(t *testing.T) {
+		originalURL := "registry://templates/test-source/test-publisher/test-template"
+
+		info, err := ParseRegistryURL(originalURL)
+		require.NoError(t, err)
+
+		roundTripURL := info.String()
+
+		assert.Equal(t, originalURL, roundTripURL)
+	})
+
+	t.Run("with latest version", func(t *testing.T) {
+		originalURL := "registry://templates/test-source/test-publisher/test-template@latest"
+
+		info, err := ParseRegistryURL(originalURL)
+		require.NoError(t, err)
+
+		roundTripURL := info.String()
+
+		// latest should be omitted in round-trip (becomes empty version)
+		assert.Equal(t, "registry://templates/test-source/test-publisher/test-template", roundTripURL)
+	})
+
+	t.Run("with encoded name", func(t *testing.T) {
+		info := &URLInfo{
+			resourceType: "templates",
+			source:       "test-source",
+			publisher:    "test-publisher",
+			name:         "test/template",
+			version:      nil,
+		}
+
+		result := info.String()
+		assert.Equal(t, "registry://templates/test-source/test-publisher/test%252Ftemplate", result)
+	})
+
+	t.Run("double-encoded name round-trip", func(t *testing.T) {
+		info := &URLInfo{
+			resourceType: "templates",
+			source:       "test-source",
+			publisher:    "test-publisher",
+			name:         "test/template",
+			version:      nil,
+		}
+
+		urlString := info.String()
+		assert.Equal(t, "registry://templates/test-source/test-publisher/test%252Ftemplate", urlString)
+
+		parsed, err := ParseRegistryURL(urlString)
+		require.NoError(t, err)
+		assert.Equal(t, info.ResourceType(), parsed.ResourceType())
+		assert.Equal(t, info.Source(), parsed.Source())
+		assert.Equal(t, info.Publisher(), parsed.Publisher())
+		assert.Equal(t, info.Name(), parsed.Name())
+		assert.Equal(t, info.Version(), parsed.Version())
+	})
+}
+
+func TestParseRegistryURLOrPartial(t *testing.T) {
+	tests := []struct {
+		name        string
+		registryURL string
+		expected    *URLInfo
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "bare template name",
+			registryURL: "csharp-documented",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "",
+				publisher:    "",
+				name:         "csharp-documented",
+				version:      nil,
+			},
+		},
+		{
+			name:        "bare template name with version",
+			registryURL: "csharp-documented@1.1.0",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "",
+				publisher:    "",
+				name:         "csharp-documented",
+				version:      mustParseVersion("1.1.0"),
+			},
+		},
+		{
+			name:        "bare template name with latest version",
+			registryURL: "csharp-documented@latest",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "",
+				publisher:    "",
+				name:         "csharp-documented",
+				version:      nil, // latest becomes nil
+			},
+		},
+		{
+			name:        "publisher/name format",
+			registryURL: "pulumi_local/csharp-documented",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "",
+				publisher:    "pulumi_local",
+				name:         "csharp-documented",
+				version:      nil,
+			},
+		},
+		{
+			name:        "publisher/name with version",
+			registryURL: "pulumi_local/csharp-documented@1.1.0",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "",
+				publisher:    "pulumi_local",
+				name:         "csharp-documented",
+				version:      mustParseVersion("1.1.0"),
+			},
+		},
+		{
+			name:        "source/publisher/name format",
+			registryURL: "private/pulumi_local/csharp-documented",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "private",
+				publisher:    "pulumi_local",
+				name:         "csharp-documented",
+				version:      nil,
+			},
+		},
+		{
+			name:        "source/publisher/name with version",
+			registryURL: "private/pulumi_local/csharp-documented@1.1.0",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "private",
+				publisher:    "pulumi_local",
+				name:         "csharp-documented",
+				version:      mustParseVersion("1.1.0"),
+			},
+		},
+		{
+			name:        "full registry URL",
+			registryURL: "registry://templates/private/pulumi_local/csharp-documented@1.1.0",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "private",
+				publisher:    "pulumi_local",
+				name:         "csharp-documented",
+				version:      mustParseVersion("1.1.0"),
+			},
+		},
+		{
+			name:        "full registry URL with encoding",
+			registryURL: "registry://templates/private/pulumi_local/csharp%252Ddocumented",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "private",
+				publisher:    "pulumi_local",
+				name:         "csharp-documented",
+				version:      nil,
+			},
+		},
+		{
+			name:        "too many path segments",
+			registryURL: "a/b/c/d/e",
+			expectError: true,
+			errorMsg:    "invalid registry URL format",
+		},
+		{
+			name:        "empty",
+			registryURL: "",
+			expectError: true,
+			errorMsg:    "missing name",
+		},
+		{
+			name:        "empty version",
+			registryURL: "template@",
+			expectError: true,
+			errorMsg:    "missing version after @",
+		},
+		{
+			name:        "empty name with version",
+			registryURL: "@1.0.0",
+			expectError: true,
+			errorMsg:    "missing name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseRegistryURLOrPartial(tt.registryURL, "templates")
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorMsg != "" {
+					assert.Contains(t, err.Error(), tt.errorMsg)
+				}
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, tt.expected.ResourceType(), result.ResourceType())
+				assert.Equal(t, tt.expected.Source(), result.Source())
+				assert.Equal(t, tt.expected.Publisher(), result.Publisher())
+				assert.Equal(t, tt.expected.Name(), result.Name())
+				if tt.expected.Version() == nil {
+					assert.Nil(t, result.Version())
+				} else {
+					require.NotNil(t, result.Version())
+					assert.True(t, tt.expected.Version().Equals(*result.Version()))
+				}
+			}
+		})
+	}
+}
+
+func TestIsRegistryURL(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"registry://templates/private/pulumi_local/template@latest", true},
+		{"registry://templates/private/pulumi_local/template@1.0.0", true},
+		{"registry://templates/private/pulumi_local/template", true},
+		{"registry://packages/github/pulumi/aws", true},
+		{"https://github.com/pulumi/templates", false},
+		{"template-name", false},
+		{"private/pulumi_local/template", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := IsRegistryURL(tt.input)
+			assert.Equal(t, tt.expected, result, "IsRegistryURL(%q) should return %v", tt.input, tt.expected)
+		})
+	}
+}

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -29,6 +29,7 @@ import (
 	"github.com/texttheater/golang-levenshtein/levenshtein"
 	"gopkg.in/yaml.v3"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -268,6 +269,11 @@ func cleanupLegacyTemplateDir(templateKind TemplateKind) error {
 
 // IsTemplateURL returns true if templateNamePathOrURL starts with "https://" (SSL) or "git@" (SSH).
 func IsTemplateURL(templateNamePathOrURL string) bool {
+	// Registry URLs should be handled as template names, not URLs
+	if registry.IsRegistryURL(templateNamePathOrURL) {
+		return false
+	}
+	
 	// Normalize the provided URL so we can check its scheme. This will
 	// correctly return false in the case where the URL doesn't parse cleanly.
 	url, _, _ := gitutil.ParseGitRepoURL(templateNamePathOrURL)


### PR DESCRIPTION
Enables `pulumi new` to accept registry URLs and qualified template names:

 ```sh
 PULUMI_EXPERIMENTAL=1 pulumi new private/pulumi_local/csharp-documented
 (successfully finds template)

 PULUMI_EXPERIMENTAL=1 pulumi new private/pulumi_local/csharp-documented@latest
 (successfully finds template)

 PULUMI_EXPERIMENTAL=1 pulumi new pulumi_local/csharp-documented@latest
 (successfully finds template)

 PULUMI_EXPERIMENTAL=1 pulumi new registry://templates/private/pulumi_local/csharp-documented@latest
 (successfully finds template)

 PULUMI_EXPERIMENTAL=0 pulumi new private/pulumi_local/csharp-documented
 error: template 'private/pulumi_local/csharp-documented' not found

 PULUMI_EXPERIMENTAL=0 pulumi new random-typescript
 This command will walk you through creating a new Pulumi project.

 PULUMI_EXPERIMENTAL=1 pulumi new random-typescript
 This command will walk you through creating a new Pulumi project.
 ```

Note that `version` is currently ignored and only the latest version is considered.

Previously only bare names like `csharp-documented` worked. Now supports:

- Full registry URLs: `registry://templates/source/publisher/name[@version]`
- Partial formats: `source/publisher/name[@version]` and `publisher/name[@version]`
- Maintains backward compatibility with bare template names
- Uses exact field matching for registry URLs, falls back to name matching