### PR TITLE
Support parsing object types in `Pulumi.yaml`

### DIFF
--- a/changelog/pending/20250724--yaml--config-values-can-now-be-parsed-with-type-object.yaml
+++ b/changelog/pending/20250724--yaml--config-values-can-now-be-parsed-with-type-object.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: yaml
-  description: Config values can now be parsed with type `object`
+  description: Allow config values to be parsed with type `object`

--- a/changelog/pending/20250724--yaml--config-values-can-now-be-parsed-with-type-object.yaml
+++ b/changelog/pending/20250724--yaml--config-values-can-now-be-parsed-with-type-object.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: yaml
+  description: Config values can now be parsed with type `object`

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -51,6 +51,7 @@ const (
 	integerTypeName = "integer"
 	stringTypeName  = "string"
 	booleanTypeName = "boolean"
+	objectTypeName  = "object"
 )
 
 //go:embed project.json
@@ -724,6 +725,12 @@ func ValidateConfigValue(typeName string, itemsType *ProjectConfigItemsType, val
 		}
 
 		_, ok = value.(bool)
+		return ok
+	}
+
+	if typeName == objectTypeName {
+		// validate that the item is a map
+		_, ok := value.(map[string]interface{})
 		return ok
 	}
 

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -95,7 +95,7 @@ func TestProjectValidationSucceedsForObjectConfigType(t *testing.T) {
 
 	project.Config = config
 	err := project.Validate()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestProjectValidationFailsForIncorrectDefaultValueType(t *testing.T) {

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -83,6 +83,21 @@ func TestProjectValidationForNameAndRuntime(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestProjectValidationSucceedsForObjectConfigType(t *testing.T) {
+	t.Parallel()
+	project := Project{Name: "test", Runtime: NewProjectRuntimeInfo("dotnet", nil)}
+	config := make(map[string]ProjectConfigType)
+	objectType := "object"
+	config["example"] = ProjectConfigType{
+		Type:    &objectType,
+		Default: map[string]interface{}{"hello": "world"},
+	}
+
+	project.Config = config
+	err := project.Validate()
+	assert.NoError(t, err)
+}
+
 func TestProjectValidationFailsForIncorrectDefaultValueType(t *testing.T) {
 	t.Parallel()
 	project := Project{Name: "test", Runtime: NewProjectRuntimeInfo("dotnet", nil)}


### PR DESCRIPTION
In #20129, we added `object` as a type that may be used for `config` in `Pulumi.yaml`. This PR ensures that we are able to parse objects into this new type.