### PR TITLE
Fix registry template downloads by not passing custom headers

### DIFF
--- a/changelog/pending/20250724--cli--stop-passing-accept-application-x-tar-to-registry-template-download-urls-to-avoid-signature-mismatch.yaml
+++ b/changelog/pending/20250724--cli--stop-passing-accept-application-x-tar-to-registry-template-download-urls-to-avoid-signature-mismatch.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: "Stop passing Accept: application/x-tar to registry template download URLs to avoid signature mismatch"

--- a/pkg/backend/httpstate/client/client_template_test.go
+++ b/pkg/backend/httpstate/client/client_template_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -483,6 +484,139 @@ func (r *testCloudRegistry) PublishTemplate(ctx context.Context, op templatePubl
 	}
 
 	return nil
+}
+
+func TestDownloadTemplate(t *testing.T) {
+	t.Parallel()
+
+	testTarData := []byte("fake-tar-data")
+
+	t.Run("SuccessfulDownloadFromClientURL", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method)
+			assert.Equal(t, "/api/template/download", r.URL.Path)
+			assert.Equal(t, "application/x-tar", r.Header.Get("Accept"))
+			w.Header().Set("Content-Type", "application/x-tar")
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write(testTarData)
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		downloadURL := server.URL + "/api/template/download"
+
+		result, err := client.DownloadTemplate(context.Background(), downloadURL)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		defer result.Close()
+
+		data, err := io.ReadAll(result)
+		require.NoError(t, err)
+		assert.Equal(t, testTarData, data)
+	})
+
+	t.Run("SuccessfulDownloadFromPresignedURL", func(t *testing.T) {
+		t.Parallel()
+
+		presignedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method)
+			// For presigned URLs, we should NOT have any custom headers
+			assert.Empty(t, r.Header.Get("Accept"))
+			w.Header().Set("Content-Type", "application/x-tar")
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write(testTarData)
+			require.NoError(t, err)
+		}))
+		defer presignedServer.Close()
+
+		client := newMockClient(httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("Should not call client server for presigned URLs")
+		})))
+
+		presignedURL := presignedServer.URL + "/file.tar.gz?X-Amz-Expires=3600&X-Amz-Signature=abc123"
+
+		result, err := client.DownloadTemplate(context.Background(), presignedURL)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		defer result.Close()
+
+		data, err := io.ReadAll(result)
+		require.NoError(t, err)
+		assert.Equal(t, testTarData, data)
+	})
+
+	t.Run("SuccessfulDownloadFromForeignURL", func(t *testing.T) {
+		t.Parallel()
+
+		foreignServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method)
+			// For non-presigned foreign URLs, we should still set Accept header
+			assert.Equal(t, "application/x-tar", r.Header.Get("Accept"))
+			w.Header().Set("Content-Type", "application/x-tar")
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write(testTarData)
+			require.NoError(t, err)
+		}))
+		defer foreignServer.Close()
+
+		clientServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("Should not call client server for foreign URLs")
+		}))
+		defer clientServer.Close()
+
+		client := newMockClient(clientServer)
+
+		result, err := client.DownloadTemplate(context.Background(), foreignServer.URL)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		defer result.Close()
+
+		data, err := io.ReadAll(result)
+		require.NoError(t, err)
+		assert.Equal(t, testTarData, data)
+	})
+
+	t.Run("ErrorResponse", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, err := w.Write([]byte("Template not found"))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		downloadURL := server.URL + "/api/template/download"
+
+		_, err := client.DownloadTemplate(context.Background(), downloadURL)
+		require.Error(t, err)
+	})
+
+	t.Run("ErrorResponseFromPresignedURL", func(t *testing.T) {
+		t.Parallel()
+
+		presignedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			_, err := w.Write([]byte("Access denied"))
+			require.NoError(t, err)
+		}))
+		defer presignedServer.Close()
+
+		client := newMockClient(httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("Should not call client server for presigned URLs")
+		})))
+
+		presignedURL := presignedServer.URL + "/file.tar.gz?X-Amz-Expires=3600&X-Amz-Signature=abc123"
+
+		_, err := client.DownloadTemplate(context.Background(), presignedURL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "HTTP 403")
+		assert.Contains(t, err.Error(), "Access denied")
+	})
 }
 
 func TestListTemplates(t *testing.T) {

--- a/pkg/backend/httpstate/client/client_template_test.go
+++ b/pkg/backend/httpstate/client/client_template_test.go
@@ -617,6 +617,32 @@ func TestDownloadTemplate(t *testing.T) {
 		assert.Contains(t, err.Error(), "HTTP 403")
 		assert.Contains(t, err.Error(), "Access denied")
 	})
+
+	t.Run("NetworkErrorFromPresignedURL", func(t *testing.T) {
+		t.Parallel()
+
+		client := newMockClient(httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("Should not call client server for presigned URLs")
+		})))
+
+		presignedURL := "http://127.0.0.1:1/invalid?X-Amz-Expires=3600&X-Amz-Signature=abc123"
+
+		_, err := client.DownloadTemplate(context.Background(), presignedURL)
+		require.Error(t, err)
+	})
+
+	t.Run("InvalidPresignedURL", func(t *testing.T) {
+		t.Parallel()
+
+		client := newMockClient(httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("Should not call client server for presigned URLs")
+		})))
+
+		presignedURL := "://invalid-url?X-Amz-Expires=3600&X-Amz-Signature=abc123"
+
+		_, err := client.DownloadTemplate(context.Background(), presignedURL)
+		require.Error(t, err)
+	})
 }
 
 func TestListTemplates(t *testing.T) {


### PR DESCRIPTION
Stop passing `Accept: application/x-tar` and other headers to registry template download URLs to avoid signature mismatch.

Example error this fixes:

```
 ~/Development/cli-deployment-test λ PULUMI_EXPERIMENTAL=1 ~/go/src/github.com/pulumi/pulumi/bin/pulumi new csharp-documented
error: failed to download from "https://blobs-fnune-review.review-stacks.pulumi-dev.io/private-registry/templates/d5c13739-d452-46d5-a978-1bd79b022439/archive.tar.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=reviewStacksSecretRootUser%2F20250721%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250721T152124Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=50cf2d9cf4e2a5164122c07b4bb7085a3314d58b59987c482a9fbde9a0ffd27d": [403] <?xml version="1.0" encoding="UTF-8"?>
<Error><Code>SignatureDoesNotMatch</Code><Message>The request signature we calculated does not match the signature you provided. Check your key and signing method.</Message><Key>templates/d5c13739-d452-46d5-a978-1bd79b022439/archive.tar.gz</Key><BucketName>private-registry</BucketName><Resource>/private-registry/templates/d5c13739-d452-46d5-a978-1bd79b022439/archive.tar.gz</Resource><RequestId>18544D6CF90F1BBF</RequestId><HostId>dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8</HostId></Error>
```

Fixing this in `pulumi-service` is not wanted because template download URLs should work e.g. in browsers or clients that don't know to pass custom headers.