### PR TITLE
Add support for qualified registry template names in `pulumi new`

### DIFF
--- a/changelog/pending/20250724--cli-new--add-support-for-qualified-registry-template-names.yaml
+++ b/changelog/pending/20250724--cli-new--add-support-for-qualified-registry-template-names.yaml
@@ -1,0 +1,5 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add support for qualified registry template names in `pulumi new`
+

--- a/pkg/cmd/pulumi/templates/cloud.go
+++ b/pkg/cmd/pulumi/templates/cloud.go
@@ -41,6 +41,83 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+type TemplateMatchable interface {
+	GetRegistryName() string
+	GetTemplateName() string
+	GetSource() string
+	GetPublisher() string
+}
+
+func NewTemplateMatcher(templateName string) (func(TemplateMatchable) bool, error) {
+	if templateName == "" {
+		return func(TemplateMatchable) bool { return true }, nil
+	}
+
+	var urlInfo *registry.URLInfo
+	var err error
+
+	// 1. Try parsing as a strict registry:// URL
+	if registry.IsRegistryURL(templateName) {
+		urlInfo, err = registry.ParseRegistryURL(templateName)
+		if err != nil {
+			var invalidRegistryURL *registry.InvalidRegistryURLError
+			if errors.As(err, &invalidRegistryURL) {
+				// Wrap this particular error reason because formats other than the
+				// full registry:// URL format are supported by `pulumi new`.
+				if strings.Contains(invalidRegistryURL.Reason, "expected format") {
+					return nil, errors.New("Expected: registry://templates/source/publisher/name[@version], " +
+						"source/publisher/name[@version], publisher/name[@version], or name[@version]")
+				}
+			}
+			return nil, err
+		}
+		if urlInfo.ResourceType() != "templates" {
+			return nil, fmt.Errorf("resource type '%s' is not valid for templates", urlInfo.ResourceType())
+		}
+	} else {
+		// 2. Try parsing as a partial registry URL
+		urlInfo, err = registry.ParsePartialRegistryURL(templateName, "templates")
+		if err != nil {
+			var missingVersion *registry.MissingVersionAfterAtSignError
+			if errors.As(err, &missingVersion) {
+				return nil, err
+			}
+
+			// Structural errors: fall back to name matching
+			urlInfo = nil
+		}
+	}
+
+	// Validation: versions other than "latest" are not yet supported because the
+	// list endpoint used by `pulumi new` only returns the latest version.
+	if urlInfo != nil && urlInfo.Version() != nil {
+		return nil, &registry.UnsupportedVersionError{Version: urlInfo.Version().String()}
+	}
+
+	return matcherFromURLInfo(urlInfo, templateName), nil
+}
+
+func matcherFromURLInfo(urlInfo *registry.URLInfo, templateName string) func(TemplateMatchable) bool {
+	if urlInfo == nil {
+		return func(t TemplateMatchable) bool {
+			return t.GetRegistryName() == templateName || t.GetTemplateName() == templateName
+		}
+	}
+
+	return func(t TemplateMatchable) bool {
+		if urlInfo.Source() != "" && t.GetSource() != urlInfo.Source() {
+			return false
+		}
+		if urlInfo.Publisher() != "" && t.GetPublisher() != urlInfo.Publisher() {
+			return false
+		}
+		if urlInfo.Name() != "" {
+			return t.GetRegistryName() == urlInfo.Name() || t.GetTemplateName() == urlInfo.Name()
+		}
+		return true
+	}
+}
+
 func (s *Source) getCloudTemplates(
 	ctx context.Context, templateName string,
 	wg *sync.WaitGroup, e env.Env,
@@ -61,11 +138,13 @@ func (s *Source) getCloudTemplates(
 func (s *Source) getRegistryTemplates(ctx context.Context, e env.Env, templateName string) {
 	r := cmdCmd.NewDefaultRegistry(ctx, pkgWorkspace.Instance, nil, cmdutil.Diag(), e)
 
-	// Since the templates names displayed here differ from the template names
-	// returned from ListTemplates for VCS backed templates, we need to fetch
-	// all templates and then filter manually.
-	var nameFilter *string
+	matches, err := NewTemplateMatcher(templateName)
+	if err != nil {
+		s.addError(err)
+		return
+	}
 
+	var nameFilter *string
 	for template, err := range r.ListTemplates(ctx, nameFilter) {
 		if err != nil {
 			s.addError(fmt.Errorf("could not get template: %w", err))
@@ -79,7 +158,7 @@ func (s *Source) getRegistryTemplates(ctx context.Context, e env.Env, templateNa
 		}
 
 		t := registryTemplate{template, r, s}
-		if templateName != "" && t.Name() != templateName {
+		if !matches(t) {
 			continue
 		}
 
@@ -135,6 +214,11 @@ func (r registryTemplate) Download(ctx context.Context) (workspace.Template, err
 	template, err := workspace.LoadTemplate(templateDir)
 	return template, err
 }
+
+func (r registryTemplate) GetRegistryName() string { return r.t.Name }
+func (r registryTemplate) GetTemplateName() string { return r.Name() }
+func (r registryTemplate) GetSource() string       { return r.t.Source }
+func (r registryTemplate) GetPublisher() string    { return r.t.Publisher }
 
 func (s *Source) getOrgTemplates(
 	ctx context.Context, templateName string,

--- a/pkg/cmd/pulumi/templates/templates.go
+++ b/pkg/cmd/pulumi/templates/templates.go
@@ -183,7 +183,7 @@ func newImpl(
 }
 
 func isTemplateName(templateNamePathOrURL string) bool {
-	return !workspace.IsTemplateURL(templateNamePathOrURL) &&
+	return !workspace.IsGitRepoTemplateURL(templateNamePathOrURL) &&
 		!isTemplatePath(templateNamePathOrURL)
 }
 

--- a/pkg/cmd/pulumi/templates/templates_test.go
+++ b/pkg/cmd/pulumi/templates/templates_test.go
@@ -39,6 +39,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const expectedRegistryFormatError = "Expected: registry://templates/source/publisher/name[@version], " +
+	"source/publisher/name[@version], publisher/name[@version], or name[@version]"
+
 //nolint:paralleltest // replaces global backend instance
 func TestFilterOnName(t *testing.T) {
 	template1 := &apitype.PulumiTemplateRemote{
@@ -714,3 +717,178 @@ func testContext(t *testing.T) context.Context {
 }
 
 func ref[T any](v T) *T { return &v }
+
+//nolint:paralleltest // replaces global backend instance
+func TestRegistryTemplateResolution(t *testing.T) {
+	ctx := testContext(t)
+
+	mockRegistry := &backend.MockCloudRegistry{
+		ListTemplatesF: func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+			return func(yield func(apitype.TemplateMetadata, error) bool) {
+				yield(apitype.TemplateMetadata{
+					Name:        "csharp-documented",
+					Source:      "private",
+					Publisher:   "pulumi_local",
+					Description: ref("A C# template"),
+				}, nil)
+				yield(apitype.TemplateMetadata{
+					Name:      "csharp-documented",
+					Source:    "github",
+					Publisher: "different-org",
+				}, nil)
+				yield(apitype.TemplateMetadata{
+					Name:      "gh-org/repo/target",
+					Source:    "github",
+					Publisher: "pulumi-org",
+				}, nil)
+				yield(apitype.TemplateMetadata{
+					Name:        "whatever-template",
+					Source:      "private",
+					Publisher:   "test-org",
+					Description: ref("A template with special chars"),
+				}, nil)
+			}
+		},
+	}
+	mockBackend := &backend.MockBackend{
+		GetReadOnlyCloudRegistryF: func() registry.Registry { return mockRegistry },
+	}
+	testutil.MockBackendInstance(t, mockBackend)
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{ /* panic on use */ })
+
+	testCases := []struct {
+		name                string
+		templateURL         string
+		shouldMatch         bool
+		expectedName        string
+		description         string
+		expectSpecificError string
+	}{
+		{
+			name:         "registry URL full format",
+			templateURL:  "registry://templates/private/pulumi_local/csharp-documented",
+			shouldMatch:  true,
+			expectedName: "csharp-documented",
+			description:  "A C# template",
+		},
+		{
+			name:         "registry URL with version",
+			templateURL:  "registry://templates/private/pulumi_local/csharp-documented@latest",
+			shouldMatch:  true,
+			expectedName: "csharp-documented",
+			description:  "A C# template",
+		},
+		{
+			name:         "partial URL format",
+			templateURL:  "private/pulumi_local/csharp-documented",
+			shouldMatch:  true,
+			expectedName: "csharp-documented",
+			description:  "A C# template",
+		},
+		{
+			name:         "partial URL with version",
+			templateURL:  "private/pulumi_local/csharp-documented@latest",
+			shouldMatch:  true,
+			expectedName: "csharp-documented",
+			description:  "A C# template",
+		},
+		{
+			name:         "VCS template display name matching",
+			templateURL:  "target",
+			shouldMatch:  true,
+			expectedName: "target",
+		},
+		{
+			name:                "wrong resource type does not match",
+			templateURL:         "registry://packages/private/pulumi_local/csharp-documented",
+			shouldMatch:         false,
+			expectSpecificError: "resource type 'packages' is not valid for templates",
+		},
+		{
+			name:         "parsing failure falls back to exact name match",
+			templateURL:  "whatever-template",
+			shouldMatch:  true,
+			expectedName: "whatever-template",
+			description:  "A template with special chars",
+		},
+		{
+			name:        "nonexistent template returns not found",
+			templateURL: "nonexistent/template/name",
+			shouldMatch: false,
+		},
+		{
+			name:                "malformed URL with no match",
+			templateURL:         "registry://templates/a/b/c/d/e",
+			shouldMatch:         false,
+			expectSpecificError: expectedRegistryFormatError,
+		},
+		{
+			name:        "git repo URL should not trigger registry errors",
+			templateURL: "https://github.com/user/repo",
+			shouldMatch: false,
+		},
+		{
+			name:        "ssh git URL should not trigger registry errors",
+			templateURL: "git@github.com:user/repo.git",
+			shouldMatch: false,
+		},
+		{
+			name:        "git repo URL with path should not trigger registry errors",
+			templateURL: "https://github.com/user/repo/tree/main/templates/example",
+			shouldMatch: false,
+		},
+		{
+			name:                "wrong resource type - unknown resource type",
+			templateURL:         "registry://unknown/private/publisher/name",
+			shouldMatch:         false,
+			expectSpecificError: "resource type 'unknown' is not valid for templates",
+		},
+		{
+			name:                "malformed registry URL - missing parts",
+			templateURL:         "registry://templates/private",
+			shouldMatch:         false,
+			expectSpecificError: expectedRegistryFormatError,
+		},
+		{
+			name:        "malformed partial URL - too many parts",
+			templateURL: "a/b/c/d/e",
+			shouldMatch: false,
+			// This should fall back to name matching (structural error), not show specific error
+		},
+		{
+			name:                "malformed registry URL - empty version",
+			templateURL:         "registry://templates/private/publisher/name@",
+			shouldMatch:         false,
+			expectSpecificError: "missing version",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			source := newImpl(ctx, tc.templateURL, ScopeAll, workspace.TemplateKindPulumiProject,
+				templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+				env.NewEnv(env.MapStore{
+					"PULUMI_DISABLE_REGISTRY_RESOLVE": "false",
+					"PULUMI_EXPERIMENTAL":             "true",
+				}))
+
+			templates, err := source.Templates()
+			if tc.shouldMatch {
+				require.NoError(t, err)
+				require.Len(t, templates, 1)
+				assert.Equal(t, tc.expectedName, templates[0].Name())
+				if tc.description != "" {
+					assert.Equal(t, tc.description, templates[0].ProjectDescription())
+				}
+			} else {
+				require.Error(t, err)
+				if tc.expectSpecificError != "" {
+					assert.Contains(t, err.Error(), tc.expectSpecificError)
+				} else {
+					var templateNotFound workspace.TemplateNotFoundError
+					assert.ErrorAs(t, err, &templateNotFound)
+				}
+			}
+		})
+	}
+}

--- a/sdk/go/common/registry/urls.go
+++ b/sdk/go/common/registry/urls.go
@@ -1,0 +1,293 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/blang/semver"
+)
+
+const RegistryURLScheme = "registry"
+
+type URLInfo struct {
+	resourceType string
+	source       string
+	publisher    string
+	name         string
+	version      *semver.Version // optional
+}
+
+type WrongResourceTypeError struct {
+	Got      string
+	Expected string
+}
+
+func (e *WrongResourceTypeError) Error() string {
+	return fmt.Sprintf("resource type '%s' is not valid for %s", e.Got, e.Expected)
+}
+
+type MalformedRegistryURLError struct {
+	URL    string
+	Reason string
+}
+
+func (e *MalformedRegistryURLError) Error() string {
+	return fmt.Sprintf("malformed registry URL '%s': %s", e.URL, e.Reason)
+}
+
+type UnsupportedVersionError struct {
+	Version string
+}
+
+func (e *UnsupportedVersionError) Error() string {
+	return fmt.Sprintf("version '%s' is not supported; only 'latest' is supported", e.Version)
+}
+
+type MissingVersionAfterAtSignError struct {
+	URL string
+}
+
+func (e *MissingVersionAfterAtSignError) Error() string {
+	return "missing version after @"
+}
+
+type StructuralError struct {
+	Reason string
+}
+
+func (e *StructuralError) Error() string {
+	return e.Reason
+}
+
+type InvalidRegistryURLError struct {
+	URL    string
+	Reason string
+}
+
+func (e *InvalidRegistryURLError) Error() string {
+	return fmt.Sprintf("invalid registry URL '%s': %s", e.URL, e.Reason)
+}
+
+func (u *URLInfo) ResourceType() string {
+	return u.resourceType
+}
+
+func (u *URLInfo) Source() string {
+	return u.source
+}
+
+func (u *URLInfo) Publisher() string {
+	return u.publisher
+}
+
+func (u *URLInfo) Name() string {
+	return u.name
+}
+
+func (u *URLInfo) Version() *semver.Version {
+	return u.version
+}
+
+func ParseRegistryURL(registryURL string) (*URLInfo, error) {
+	parsedURL, err := url.Parse(registryURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid registry URL: %w", err)
+	}
+
+	if parsedURL.Scheme != RegistryURLScheme {
+		return nil, fmt.Errorf("invalid registry URL scheme: expected %s, got %s", RegistryURLScheme, parsedURL.Scheme)
+	}
+
+	resourceType := parsedURL.Host
+	if resourceType == "" {
+		return nil, errors.New("invalid registry URL: missing resource type")
+	}
+
+	urlPath := strings.TrimPrefix(parsedURL.Path, "/")
+	parts := strings.Split(urlPath, "/")
+	if len(parts) != 3 {
+		return nil, &InvalidRegistryURLError{
+			URL:    registryURL,
+			Reason: fmt.Sprintf("expected format: registry://%s/source/publisher/name[@version]", resourceType),
+		}
+	}
+
+	source := parts[0]
+	if source == "" {
+		return nil, &InvalidRegistryURLError{
+			URL:    registryURL,
+			Reason: "missing source",
+		}
+	}
+
+	publisher := parts[1]
+	if publisher == "" {
+		return nil, &InvalidRegistryURLError{
+			URL:    registryURL,
+			Reason: "missing publisher",
+		}
+	}
+
+	nameAndVersion := parts[2]
+	nameVersionParts := strings.Split(nameAndVersion, "@")
+	if len(nameVersionParts) > 2 {
+		return nil, &InvalidRegistryURLError{
+			URL:    registryURL,
+			Reason: fmt.Sprintf("expected format: registry://%s/source/publisher/name[@version]", resourceType),
+		}
+	}
+
+	encodedName := nameVersionParts[0]
+	if encodedName == "" {
+		return nil, &InvalidRegistryURLError{
+			URL:    registryURL,
+			Reason: "missing name",
+		}
+	}
+
+	name, err := decodeArtifactNamePart(encodedName)
+	if err != nil {
+		return nil, &InvalidRegistryURLError{
+			URL:    registryURL,
+			Reason: fmt.Sprintf("failed to decode name: %v", err),
+		}
+	}
+
+	var version *semver.Version
+	if len(nameVersionParts) == 2 {
+		versionStr := nameVersionParts[1]
+		if versionStr == "" {
+			return nil, &InvalidRegistryURLError{
+				URL:    registryURL,
+				Reason: "missing version",
+			}
+		}
+
+		if versionStr != "latest" {
+			version, err = parseVersion(versionStr)
+			if err != nil {
+				return nil, &InvalidRegistryURLError{
+					URL:    registryURL,
+					Reason: fmt.Sprintf("invalid version %q: %v", versionStr, err),
+				}
+			}
+		}
+	}
+
+	return &URLInfo{
+		resourceType: resourceType,
+		source:       source,
+		publisher:    publisher,
+		name:         name,
+		version:      version,
+	}, nil
+}
+
+func (u *URLInfo) String() string {
+	encodedName := encodeArtifactNamePart(u.Name())
+
+	if u.Version() == nil {
+		return fmt.Sprintf("registry://%s/%s/%s/%s",
+			u.ResourceType(), u.Source(), u.Publisher(), encodedName)
+	}
+	return fmt.Sprintf("registry://%s/%s/%s/%s@%s",
+		u.ResourceType(), u.Source(), u.Publisher(), encodedName, u.Version().String())
+}
+
+func ParsePartialRegistryURL(registryURL string, assumedResourceType string) (*URLInfo, error) {
+	var version *semver.Version
+	nameSpec := registryURL
+	if idx := strings.LastIndex(registryURL, "@"); idx != -1 {
+		versionStr := registryURL[idx+1:]
+		if versionStr == "" {
+			return nil, &MissingVersionAfterAtSignError{URL: registryURL}
+		}
+		if versionStr != "latest" {
+			var err error
+			version, err = parseVersion(versionStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid version %q: %w", versionStr, err)
+			}
+		}
+		nameSpec = registryURL[:idx]
+	}
+
+	parts := strings.Split(nameSpec, "/")
+	var source, publisher, name string
+	switch len(parts) {
+	case 1:
+		name = parts[0]
+	case 2:
+		publisher = parts[0]
+		name = parts[1]
+	case 3:
+		source = parts[0]
+		publisher = parts[1]
+		name = parts[2]
+	default:
+		return nil, &StructuralError{Reason: "too many path segments"}
+	}
+
+	if name == "" {
+		return nil, &StructuralError{Reason: "missing name"}
+	}
+
+	decodedName, err := decodeArtifactNamePart(name)
+	if err != nil {
+		return nil, &StructuralError{Reason: fmt.Sprintf("failed to decode name: %v", err)}
+	}
+
+	return &URLInfo{
+		resourceType: assumedResourceType,
+		source:       source,
+		publisher:    publisher,
+		name:         decodedName,
+		version:      version,
+	}, nil
+}
+
+func IsRegistryURL(input string) bool {
+	return strings.HasPrefix(input, RegistryURLScheme+"://")
+}
+
+func parseVersion(versionStr string) (*semver.Version, error) {
+	version, err := semver.Parse(versionStr)
+	if err != nil {
+		return nil, err
+	}
+	return &version, nil
+}
+
+func decodeArtifactNamePart(encoded string) (string, error) {
+	decodedOnce, err := url.QueryUnescape(encoded)
+	if err != nil {
+		return "", fmt.Errorf("failed first decode: %w", err)
+	}
+
+	decodedTwice, err := url.QueryUnescape(decodedOnce)
+	if err != nil {
+		return decodedOnce, nil
+	}
+
+	return decodedTwice, nil
+}
+
+func encodeArtifactNamePart(name string) string {
+	return url.QueryEscape(url.QueryEscape(name))
+}

--- a/sdk/go/common/registry/urls_test.go
+++ b/sdk/go/common/registry/urls_test.go
@@ -1,0 +1,511 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustParseVersion(v string) *semver.Version {
+	version, err := semver.Parse(v)
+	if err != nil {
+		panic(err)
+	}
+	return &version
+}
+
+func TestParseRegistryURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		url         string
+		expected    *URLInfo
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "valid registry URL with version",
+			url:  "registry://templates/test-source/test-publisher/test-template@1.0.0",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "test-source",
+				publisher:    "test-publisher",
+				name:         "test-template",
+				version:      mustParseVersion("1.0.0"),
+			},
+			expectError: false,
+		},
+		{
+			name: "valid registry URL without version",
+			url:  "registry://templates/test-source/test-publisher/test-template",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "test-source",
+				publisher:    "test-publisher",
+				name:         "test-template",
+				version:      nil,
+			},
+			expectError: false,
+		},
+		{
+			name: "valid registry URL with latest version",
+			url:  "registry://templates/test-source/test-publisher/test-template@latest",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "test-source",
+				publisher:    "test-publisher",
+				name:         "test-template",
+				version:      nil, // latest is treated as nil version
+			},
+			expectError: false,
+		},
+		{
+			name: "valid registry URL with complex version",
+			url:  "registry://templates/my-source/my-publisher/my-template@2.1.0-beta.1",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "my-source",
+				publisher:    "my-publisher",
+				name:         "my-template",
+				version:      mustParseVersion("2.1.0-beta.1"),
+			},
+			expectError: false,
+		},
+		{
+			name: "valid registry URL with double-encoded name",
+			url:  "registry://templates/test-source/test-publisher/test%252Ftemplate@1.0.0",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "test-source",
+				publisher:    "test-publisher",
+				name:         "test/template",
+				version:      mustParseVersion("1.0.0"),
+			},
+			expectError: false,
+		},
+		{
+			name: "valid registry URL with packages resource type",
+			url:  "registry://packages/test-source/test-publisher/test-package@1.0.0",
+			expected: &URLInfo{
+				resourceType: "packages",
+				source:       "test-source",
+				publisher:    "test-publisher",
+				name:         "test-package",
+				version:      mustParseVersion("1.0.0"),
+			},
+			expectError: false,
+		},
+		{
+			name:        "invalid URL format",
+			url:         "not-a-valid-url",
+			expectError: true,
+			errorMsg:    "invalid registry URL",
+		},
+		{
+			name:        "wrong scheme",
+			url:         "https://test-host/templates/test-source/test-publisher/test-template@1.0.0",
+			expectError: true,
+			errorMsg:    "invalid registry URL scheme",
+		},
+		{
+			name:        "missing resource type",
+			url:         "registry:////test-source/test-publisher/test-template@1.0.0",
+			expectError: true,
+			errorMsg:    "invalid registry URL: missing resource type",
+		},
+		{
+			name:        "missing source",
+			url:         "registry://templates//test-publisher/test-template@1.0.0",
+			expectError: true,
+			errorMsg:    "missing source",
+		},
+		{
+			name:        "missing publisher",
+			url:         "registry://templates/test-source//test-template@1.0.0",
+			expectError: true,
+			errorMsg:    "missing publisher",
+		},
+		{
+			name:        "missing name",
+			url:         "registry://templates/test-source/test-publisher/@1.0.0",
+			expectError: true,
+			errorMsg:    "missing name",
+		},
+		{
+			name:        "missing version",
+			url:         "registry://templates/test-source/test-publisher/test-template@",
+			expectError: true,
+			errorMsg:    "missing version",
+		},
+		{
+			name:        "too many path segments",
+			url:         "registry://templates/test-source/test-publisher/test-template/extra@1.0.0",
+			expectError: true,
+			errorMsg:    "expected format: registry://templates/source/publisher/name[@version]",
+		},
+		{
+			name:        "too few path segments",
+			url:         "registry://templates/test-template@1.0.0",
+			expectError: true,
+			errorMsg:    "expected format: registry://templates/source/publisher/name[@version]",
+		},
+		{
+			name:        "multiple @ symbols",
+			url:         "registry://templates/test-source/test-publisher/test-template@1.0.0@extra",
+			expectError: true,
+			errorMsg:    "expected format: registry://templates/source/publisher/name[@version]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := ParseRegistryURL(tt.url)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorMsg != "" {
+					assert.Contains(t, err.Error(), tt.errorMsg)
+				}
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				assert.Equal(t, tt.expected.ResourceType(), result.ResourceType())
+				assert.Equal(t, tt.expected.Source(), result.Source())
+				assert.Equal(t, tt.expected.Publisher(), result.Publisher())
+				assert.Equal(t, tt.expected.Name(), result.Name())
+				if tt.expected.Version() == nil {
+					assert.Nil(t, result.Version())
+				} else {
+					require.NotNil(t, result.Version())
+					assert.True(t, tt.expected.Version().Equals(*result.Version()))
+				}
+			}
+		})
+	}
+}
+
+func TestURLInfoString(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with version", func(t *testing.T) {
+		t.Parallel()
+
+		info := &URLInfo{
+			resourceType: "templates",
+			source:       "test-source",
+			publisher:    "test-publisher",
+			name:         "test-template",
+			version:      mustParseVersion("1.0.0"),
+		}
+
+		expected := "registry://templates/test-source/test-publisher/test-template@1.0.0"
+		assert.Equal(t, expected, info.String())
+	})
+
+	t.Run("without version", func(t *testing.T) {
+		t.Parallel()
+
+		info := &URLInfo{
+			resourceType: "templates",
+			source:       "test-source",
+			publisher:    "test-publisher",
+			name:         "test-template",
+			version:      nil,
+		}
+
+		expected := "registry://templates/test-source/test-publisher/test-template"
+		assert.Equal(t, expected, info.String())
+	})
+}
+
+func TestRegistryURL_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with version", func(t *testing.T) {
+		t.Parallel()
+		originalURL := "registry://templates/test-source/test-publisher/test-template@1.0.0"
+
+		info, err := ParseRegistryURL(originalURL)
+		require.NoError(t, err)
+
+		roundTripURL := info.String()
+
+		assert.Equal(t, originalURL, roundTripURL)
+	})
+
+	t.Run("without version", func(t *testing.T) {
+		t.Parallel()
+
+		originalURL := "registry://templates/test-source/test-publisher/test-template"
+
+		info, err := ParseRegistryURL(originalURL)
+		require.NoError(t, err)
+
+		roundTripURL := info.String()
+
+		assert.Equal(t, originalURL, roundTripURL)
+	})
+
+	t.Run("with latest version", func(t *testing.T) {
+		t.Parallel()
+
+		originalURL := "registry://templates/test-source/test-publisher/test-template@latest"
+
+		info, err := ParseRegistryURL(originalURL)
+		require.NoError(t, err)
+
+		roundTripURL := info.String()
+
+		// latest should be omitted in round-trip (becomes empty version)
+		assert.Equal(t, "registry://templates/test-source/test-publisher/test-template", roundTripURL)
+	})
+
+	t.Run("with encoded name", func(t *testing.T) {
+		t.Parallel()
+
+		info := &URLInfo{
+			resourceType: "templates",
+			source:       "test-source",
+			publisher:    "test-publisher",
+			name:         "test/template",
+			version:      nil,
+		}
+
+		result := info.String()
+		assert.Equal(t, "registry://templates/test-source/test-publisher/test%252Ftemplate", result)
+	})
+
+	t.Run("double-encoded name round-trip", func(t *testing.T) {
+		t.Parallel()
+
+		info := &URLInfo{
+			resourceType: "templates",
+			source:       "test-source",
+			publisher:    "test-publisher",
+			name:         "test/template",
+			version:      nil,
+		}
+
+		urlString := info.String()
+		assert.Equal(t, "registry://templates/test-source/test-publisher/test%252Ftemplate", urlString)
+
+		parsed, err := ParseRegistryURL(urlString)
+		require.NoError(t, err)
+		assert.Equal(t, info.ResourceType(), parsed.ResourceType())
+		assert.Equal(t, info.Source(), parsed.Source())
+		assert.Equal(t, info.Publisher(), parsed.Publisher())
+		assert.Equal(t, info.Name(), parsed.Name())
+		assert.Equal(t, info.Version(), parsed.Version())
+	})
+}
+
+func TestParsePartialRegistryURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		registryURL string
+		expected    *URLInfo
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "bare template name",
+			registryURL: "csharp-documented",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "",
+				publisher:    "",
+				name:         "csharp-documented",
+				version:      nil,
+			},
+		},
+		{
+			name:        "bare template name with version",
+			registryURL: "csharp-documented@1.1.0",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "",
+				publisher:    "",
+				name:         "csharp-documented",
+				version:      mustParseVersion("1.1.0"),
+			},
+		},
+		{
+			name:        "bare template name with latest version",
+			registryURL: "csharp-documented@latest",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "",
+				publisher:    "",
+				name:         "csharp-documented",
+				version:      nil, // latest becomes nil
+			},
+		},
+		{
+			name:        "publisher/name format",
+			registryURL: "pulumi_local/csharp-documented",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "",
+				publisher:    "pulumi_local",
+				name:         "csharp-documented",
+				version:      nil,
+			},
+		},
+		{
+			name:        "publisher/name with version",
+			registryURL: "pulumi_local/csharp-documented@1.1.0",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "",
+				publisher:    "pulumi_local",
+				name:         "csharp-documented",
+				version:      mustParseVersion("1.1.0"),
+			},
+		},
+		{
+			name:        "source/publisher/name format",
+			registryURL: "private/pulumi_local/csharp-documented",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "private",
+				publisher:    "pulumi_local",
+				name:         "csharp-documented",
+				version:      nil,
+			},
+		},
+		{
+			name:        "source/publisher/name with version",
+			registryURL: "private/pulumi_local/csharp-documented@1.1.0",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "private",
+				publisher:    "pulumi_local",
+				name:         "csharp-documented",
+				version:      mustParseVersion("1.1.0"),
+			},
+		},
+		{
+			name:        "partial URL with double-encoded name",
+			registryURL: "private/pulumi_local/csharp%252Ddocumented",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "private",
+				publisher:    "pulumi_local",
+				name:         "csharp-documented",
+				version:      nil,
+			},
+		},
+		{
+			name:        "bare template name with encoding",
+			registryURL: "test%252Ftemplate",
+			expected: &URLInfo{
+				resourceType: "templates",
+				source:       "",
+				publisher:    "",
+				name:         "test/template",
+				version:      nil,
+			},
+		},
+		{
+			name:        "too many path segments",
+			registryURL: "a/b/c/d/e",
+			expectError: true,
+			errorMsg:    "too many path segments",
+		},
+		{
+			name:        "empty",
+			registryURL: "",
+			expectError: true,
+			errorMsg:    "missing name",
+		},
+		{
+			name:        "empty version",
+			registryURL: "template@",
+			expectError: true,
+			errorMsg:    "missing version after @",
+		},
+		{
+			name:        "empty name with version",
+			registryURL: "@1.0.0",
+			expectError: true,
+			errorMsg:    "missing name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := ParsePartialRegistryURL(tt.registryURL, "templates")
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorMsg != "" {
+					assert.Contains(t, err.Error(), tt.errorMsg)
+				}
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				assert.Equal(t, tt.expected.ResourceType(), result.ResourceType())
+				assert.Equal(t, tt.expected.Source(), result.Source())
+				assert.Equal(t, tt.expected.Publisher(), result.Publisher())
+				assert.Equal(t, tt.expected.Name(), result.Name())
+				if tt.expected.Version() == nil {
+					assert.Nil(t, result.Version())
+				} else {
+					require.NotNil(t, result.Version())
+					assert.True(t, tt.expected.Version().Equals(*result.Version()))
+				}
+			}
+		})
+	}
+}
+
+func TestIsRegistryURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"registry://templates/private/pulumi_local/template@latest", true},
+		{"registry://templates/private/pulumi_local/template@1.0.0", true},
+		{"registry://templates/private/pulumi_local/template", true},
+		{"registry://packages/github/pulumi/aws", true},
+		{"https://github.com/pulumi/templates", false},
+		{"template-name", false},
+		{"private/pulumi_local/template", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			result := IsRegistryURL(tt.input)
+			assert.Equal(t, tt.expected, result, "IsRegistryURL(%q) should return %v", tt.input, tt.expected)
+		})
+	}
+}

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -266,8 +266,8 @@ func cleanupLegacyTemplateDir(templateKind TemplateKind) error {
 	return nil
 }
 
-// IsTemplateURL returns true if templateNamePathOrURL starts with "https://" (SSL) or "git@" (SSH).
-func IsTemplateURL(templateNamePathOrURL string) bool {
+// IsGitRepoTemplateURL returns true if templateNamePathOrURL is a git repository URL (https:// or ssh://).
+func IsGitRepoTemplateURL(templateNamePathOrURL string) bool {
 	// Normalize the provided URL so we can check its scheme. This will
 	// correctly return false in the case where the URL doesn't parse cleanly.
 	url, _, _ := gitutil.ParseGitRepoURL(templateNamePathOrURL)
@@ -287,7 +287,7 @@ func RetrieveTemplates(ctx context.Context, templateNamePathOrURL string, offlin
 	if isZIPTemplateURL(templateNamePathOrURL) {
 		return RetrieveZIPTemplates(templateNamePathOrURL)
 	}
-	if IsTemplateURL(templateNamePathOrURL) {
+	if IsGitRepoTemplateURL(templateNamePathOrURL) {
 		return retrieveURLTemplates(ctx, templateNamePathOrURL, offline)
 	}
 	if isTemplateFileOrDirectory(templateNamePathOrURL) {


### PR DESCRIPTION
Previously, `pulumi new` only supported bare template names like `csharp-documented`.
This refactoring adds support for qualified registry template names,
both as full registry URLs as well as partial ones (see examples below).

New template name formats supported:

- Full registry URLs: `registry://templates/source/publisher/name[@version]`
- Partial formats: `source/publisher/name[@version]` and `publisher/name[@version]`
- Maintains backward compatibility with bare template names

Examples:

```sh
PULUMI_EXPERIMENTAL=1 pulumi new private/pulumi_local/csharp-documented
PULUMI_EXPERIMENTAL=1 pulumi new pulumi_local/csharp-documented@latest
PULUMI_EXPERIMENTAL=1 pulumi new registry://templates/private/pulumi_local/csharp-documented
```

Error handling:
- Version errors (unsupported versions) are shown to users
- Structural parsing errors fall back gracefully to name matching only for partial URLs
- Complete registry:// URLs with structural errors show specific error messages
- Clear, helpful error messages for malformed registry URLs
