### PR TITLE
Fix delete hooks in inline automation API programs

### DIFF
--- a/changelog/pending/20250725--sdk-nodejs--fix-delete-hooks-in-inline-automation-api-programs.yaml
+++ b/changelog/pending/20250725--sdk-nodejs--fix-delete-hooks-in-inline-automation-api-programs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix delete hooks in inline automation API programs

--- a/sdk/nodejs/automation/server.ts
+++ b/sdk/nodejs/automation/server.ts
@@ -99,11 +99,11 @@ export class LanguageServer<T> implements grpc.UntypedServiceImplementation {
 
                 try {
                     await stack.runInPulumiStack(this.program);
-                    await settings.disconnect();
+                    await settings.disconnect(true /* signalShutdown */);
                     process.off("uncaughtException", uncaughtHandler);
                     process.off("unhandledRejection", uncaughtHandler);
                 } catch (e) {
-                    await settings.disconnect();
+                    await settings.disconnect(false /* signalShutdown */);
                     process.off("uncaughtException", uncaughtHandler);
                     process.off("unhandledRejection", uncaughtHandler);
 

--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -143,23 +143,8 @@ async function beforeExitHandler(code: number) {
         return;
     }
     hasSignaled = true;
-    settings.getMonitor()?.signalAndWaitForShutdown(new emptyproto.Empty(), (err, _) => {
-        if (err) {
-            // If we are running against an older version of the CLI,
-            // SignalAndWaitForShutdown might not be implemented. This is
-            // mostly fine, but means that delete hooks do not work. Since
-            // we check if the CLI supports the `resourceHook` feature when
-            // registering hooks, it's fine to ignore the `UNIMPLEMENTED`
-            // error here.
-            // If we get `UNAVAILABLE`, the monitor was already shutdown, likely
-            // due to an error, and we can ignore the GRPC error here, since
-            // Pulumi will have notified the user.
-            if (err && (err.code === grpc.status.UNIMPLEMENTED || err.code === grpc.status.UNAVAILABLE)) {
-                return;
-            }
-            console.error(`Error while signaling shutdown: ${err}`);
-        }
-        return;
+    settings.signalAndWaitForShutdown().catch((err) => {
+        console.error(`Error while signaling shutdown: ${err}`);
     });
 }
 

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -539,15 +539,25 @@ function options(): Options {
  * Permanently disconnects from the server, closing the connections. It waits
  * for the existing RPC queue to drain.  If any RPCs come in afterwards,
  * however, they will crash the process.
+ *
+ * If `signalShutdown` is true, signal to the monitor that we're ready to
+ * shutdown. This will wait until the monitor has completed all steps,
+ * including deletion steps.
  */
-export function disconnect(): Promise<void> {
-    return waitForRPCs(/*disconnectFromServers*/ true);
+export async function disconnect(signalShutdown = false): Promise<void> {
+    await waitForRPCs();
+    if (signalShutdown) {
+        await signalAndWaitForShutdown();
+    }
+    disconnectSync();
 }
 
 /**
+ * Waits for the existing RPC queue to drain.
+ *
  * @internal
  */
-export function waitForRPCs(disconnectFromServers = false): Promise<void> {
+export function waitForRPCs(): Promise<void> {
     const localStore = getStore();
     let done: Promise<any> | undefined;
     const closeCallback: () => Promise<void> = async () => {
@@ -556,12 +566,42 @@ export function waitForRPCs(disconnectFromServers = false): Promise<void> {
             done = localStore.settings.rpcDone;
             return debuggablePromise(done.then(closeCallback), "disconnect");
         }
-        if (disconnectFromServers) {
-            disconnectSync();
-        }
         return Promise.resolve();
     };
     return closeCallback();
+}
+
+/**
+ * Signals to the monitor that we're ready to shutdown. This will wait until the
+ * monitor has completed all steps, including deletion steps.
+ *
+ * @internal
+ */
+export function signalAndWaitForShutdown(): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const monitorRef = getMonitor();
+        if (!monitorRef) {
+            return resolve();
+        }
+        monitorRef.signalAndWaitForShutdown(new emptyproto.Empty(), (err, _) => {
+            if (err) {
+                // If we are running against an older version of the CLI,
+                // SignalAndWaitForShutdown might not be implemented. This is
+                // mostly fine, but means that delete hooks do not work. Since
+                // we check if the CLI supports the `resourceHook` feature when
+                // registering hooks, it's fine to ignore the `UNIMPLEMENTED`
+                // error here.
+                // If we get `UNAVAILABLE`, the monitor was already shutdown, likely
+                // due to an error, and we can ignore the GRPC error here, since
+                // Pulumi will have notified the user.
+                if (err && (err.code === grpc.status.UNIMPLEMENTED || err.code === grpc.status.UNAVAILABLE)) {
+                    return resolve();
+                }
+                return reject(new Error(`Error while signaling shutdown: ${err}`));
+            }
+            return resolve();
+        });
+    });
 }
 
 /**


### PR DESCRIPTION
The inline automation API language runtime needs to call `SignalAndWaitForShutdown` when the program completes.

Note that for inline programs the lifetime of the program is tied to the program function execution. When the program function returns, we wait for any queued work and then shutdown. Work that gets queued later will not be executed (or might if it manages to race the shutdown), see https://github.com/pulumi/pulumi/issues/20114. This is different from "normal" Pulumi programs, where the lifetime is that of the Node.js process. This is *not* a change in this PR, but we do rely on this existing behaviour for delete hooks.