### PR TITLE
Fix flake in TestNodejsPromiseMessage

### DIFF
--- a/tests/integration/nodejs/promise-message/index.js
+++ b/tests/integration/nodejs/promise-message/index.js
@@ -12,7 +12,7 @@ function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-sleep(2000).then(() => {
+sleep(60000).then(() => {
     new Named("res");
 })
 


### PR DESCRIPTION
I saw this flake. I assume what’s happening is that it took too long to go through our exit handlers on an overloaded CI run.
