### PR TITLE
Bump TypeScript target to ES2020 for plugins and policy packs

### DIFF
--- a/changelog/pending/20250725--sdk-nodejs--bump-typescript-target-to-es2020-for-plugins-and-policy-packs.yaml
+++ b/changelog/pending/20250725--sdk-nodejs--bump-typescript-target-to-es2020-for-plugins-and-policy-packs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/nodejs
+  description: Bump TypeScript target to ES2020 for plugins and policy packs

--- a/sdk/nodejs/cmd/run-plugin/run.ts
+++ b/sdk/nodejs/cmd/run-plugin/run.ts
@@ -177,7 +177,7 @@ export function run(opts: RunOpts): Promise<Record<string, any> | undefined> | P
             skipProject: skipProject,
             compiler: typescriptRequire,
             compilerOptions: {
-                target: "es6",
+                target: "ES2020", // TypeScript 3.8 supports this
                 module: "commonjs",
                 moduleResolution: "node",
                 sourceMap: "true",

--- a/sdk/nodejs/cmd/run-policy-pack/run.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/run.ts
@@ -174,7 +174,7 @@ export function run(opts: RunOpts): Promise<Record<string, any> | undefined> | P
             skipProject: skipProject,
             compiler: typescriptRequire,
             compilerOptions: {
-                target: "es6",
+                target: "ES2020", // TypeScript 3.8 supports this
                 module: "commonjs",
                 moduleResolution: "node",
                 sourceMap: "true",


### PR DESCRIPTION
We updated this for the program entrypoint in https://github.com/pulumi/pulumi/pull/19980/files#diff-56150bcb0a988cc1b28983a197010bbca7a34e91910a23c5062aee074e8164b6R366

The minimum version of TypeScript we support (and ship a vendored version of) is 3.8, which supports ES 2020.
