### PR TITLE
Support writing v4 checkpoints/deployments

### DIFF
--- a/changelog/pending/20250716--cli--support-for-writing-v4-checkpoints-deployments.yaml
+++ b/changelog/pending/20250716--cli--support-for-writing-v4-checkpoints-deployments.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Support for writing v4 checkpoints/deployments

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -179,7 +179,10 @@ func TestGzip(t *testing.T) {
 	// PATCH /checkpoint
 	err = client.PatchUpdateCheckpoint(context.Background(), UpdateIdentifier{
 		StackIdentifier: identifier,
-	}, nil, tok)
+	}, &apitype.UntypedDeployment{
+		Version:    3,
+		Deployment: json.RawMessage("{}"),
+	}, tok)
 	require.NoError(t, err)
 
 	// POST /events/batch
@@ -240,7 +243,7 @@ func TestPatchUpdateCheckpointVerbatimIndents(t *testing.T) {
 			StackIdentifier: StackIdentifier{
 				Stack: tokens.MustParseStackName("stack"),
 			},
-		}, sequenceNumber, indented, updateTokenStaticSource("token"))
+		}, sequenceNumber, indented, 3, updateTokenStaticSource("token"))
 	require.NoError(t, err)
 
 	compacted := func(raw json.RawMessage) string {

--- a/pkg/backend/httpstate/snapshot.go
+++ b/pkg/backend/httpstate/snapshot.go
@@ -45,6 +45,8 @@ func (persister *cloudSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
 			return fmt.Errorf("serializing deployment: %w", err)
 		}
 
+		persister.backend.downgradeUntypedDeploymentVersionIfNeeded(ctx, untypedDeployment)
+
 		// Continue with how deployments were saved before diff.
 		return persister.backend.client.PatchUpdateCheckpoint(
 			persister.context, persister.update, untypedDeployment, persister.tokenSource)
@@ -54,6 +56,8 @@ func (persister *cloudSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
 	if err != nil {
 		return fmt.Errorf("serializing deployment: %w", err)
 	}
+
+	version, features = persister.backend.downgradeDeploymentVersionIfNeeded(ctx, version, features)
 
 	differ := persister.deploymentDiffState
 

--- a/pkg/backend/httpstate/snapshot.go
+++ b/pkg/backend/httpstate/snapshot.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,28 +38,33 @@ type cloudSnapshotPersister struct {
 func (persister *cloudSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
 	ctx := persister.context
 
-	deploymentV3, err := stack.SerializeDeployment(ctx, snapshot, false /* showSecrets */)
+	// Diff capability can be nil because of feature flagging.
+	if persister.deploymentDiffState == nil {
+		untypedDeployment, err := stack.SerializeUntypedDeployment(ctx, snapshot, nil /*opts*/)
+		if err != nil {
+			return fmt.Errorf("serializing deployment: %w", err)
+		}
+
+		// Continue with how deployments were saved before diff.
+		return persister.backend.client.PatchUpdateCheckpoint(
+			persister.context, persister.update, untypedDeployment, persister.tokenSource)
+	}
+
+	deploymentV3, version, features, err := stack.SerializeDeploymentWithMetadata(ctx, snapshot, false /*showSecrets*/)
 	if err != nil {
 		return fmt.Errorf("serializing deployment: %w", err)
 	}
 
-	// Diff capability can be nil because of feature flagging.
-	if persister.deploymentDiffState == nil {
-		// Continue with how deployments were saved before diff.
-		return persister.backend.client.PatchUpdateCheckpoint(
-			persister.context, persister.update, deploymentV3, persister.tokenSource)
-	}
-
 	differ := persister.deploymentDiffState
 
-	deployment, err := differ.MarshalDeployment(deploymentV3)
+	deployment, err := differ.MarshalDeployment(deploymentV3, version, features)
 	if err != nil {
 		return err
 	}
 
 	// If there is no baseline to diff against, or diff is predicted to be inefficient, use saveFull.
 	if !differ.ShouldDiff(deployment) {
-		if err := persister.saveFullVerbatim(ctx, differ, deployment.raw, persister.tokenSource); err != nil {
+		if err := persister.saveFullVerbatim(ctx, differ, deployment.raw, version, persister.tokenSource); err != nil {
 			return err
 		}
 	} else { // Otherwise can use saveDiff.
@@ -67,13 +72,14 @@ func (persister *cloudSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
 		if err != nil {
 			return err
 		}
-		if err := persister.saveDiff(ctx, diff, persister.tokenSource); err != nil {
+		if err := persister.saveDiff(ctx, diff, version, persister.tokenSource); err != nil {
 			if logging.V(3) {
 				logging.V(3).Infof("ignoring error saving checkpoint "+
 					"with PatchUpdateCheckpointDelta, falling back to "+
 					"PatchUpdateCheckpoint: %v", err)
 			}
-			if err := persister.saveFullVerbatim(ctx, differ, deployment.raw, persister.tokenSource); err != nil {
+			if err := persister.saveFullVerbatim(
+				ctx, differ, deployment.raw, version, persister.tokenSource); err != nil {
 				return err
 			}
 		}
@@ -83,19 +89,19 @@ func (persister *cloudSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
 }
 
 func (persister *cloudSnapshotPersister) saveDiff(ctx context.Context,
-	diff deploymentDiff, token client.UpdateTokenSource,
+	diff deploymentDiff, deploymentVersion int, token client.UpdateTokenSource,
 ) error {
 	return persister.backend.client.PatchUpdateCheckpointDelta(
 		persister.context, persister.update,
-		diff.sequenceNumber, diff.checkpointHash, diff.deploymentDelta, token)
+		diff.sequenceNumber, diff.checkpointHash, diff.deploymentDelta, deploymentVersion, token)
 }
 
 func (persister *cloudSnapshotPersister) saveFullVerbatim(ctx context.Context,
-	differ *deploymentDiffState, deployment json.RawMessage, token client.UpdateTokenSource,
+	differ *deploymentDiffState, deployment json.RawMessage, deploymentVersion int, token client.UpdateTokenSource,
 ) error {
 	return persister.backend.client.PatchUpdateCheckpointVerbatim(
 		persister.context, persister.update, differ.SequenceNumber(),
-		deployment, token)
+		deployment, deploymentVersion, token)
 }
 
 var _ backend.SnapshotPersister = (*cloudSnapshotPersister)(nil)

--- a/pkg/backend/httpstate/testdata/snapshot_test.json
+++ b/pkg/backend/httpstate/testdata/snapshot_test.json
@@ -3,5 +3,7 @@
   "req2": "[{\"Span\":{\"uri\":\"\",\"start\":{\"line\":1,\"column\":1,\"offset\":121},\"end\":{\"line\":1,\"column\":1,\"offset\":161}},\"NewText\":\"{\\\"urn\\\":\\\"urn-1\\\",\\\"custom\\\":false,\\\"type\\\":\\\"\\\"},{\\\"urn\\\":\\\"urn-2\\\",\\\"custom\\\":false,\\\"type\\\":\\\"\\\"}\"}]",
   "req2.hash": "5ffa59a4628983b155933e87fd91ef1f5e76cb2dfdd413eefc3bedb52a7ce1c4",
   "req3": "[{\"Span\":{\"uri\":\"\",\"start\":{\"line\":1,\"column\":1,\"offset\":121},\"end\":{\"line\":1,\"column\":1,\"offset\":202}},\"NewText\":\"{\\\"urn\\\":\\\"urn-1\\\",\\\"custom\\\":false,\\\"type\\\":\\\"\\\"}\"}]",
-  "req3.hash": "fa39495cd65a25d850d69388092ae6efcdb5e999ca72b378384236bc77e098a4"
+  "req3.hash": "fa39495cd65a25d850d69388092ae6efcdb5e999ca72b378384236bc77e098a4",
+  "req4": "[{\"Span\":{\"uri\":\"\",\"start\":{\"line\":1,\"column\":1,\"offset\":0},\"end\":{\"line\":1,\"column\":1,\"offset\":161}},\"NewText\":\"{\\\"version\\\":4,\\\"features\\\":[\\\"refreshBeforeUpdate\\\"],\\\"deployment\\\":{\\\"manifest\\\":{\\\"time\\\":\\\"0001-01-01T00:00:00Z\\\",\\\"magic\\\":\\\"\\\",\\\"version\\\":\\\"\\\"},\\\"metadata\\\":{},\\\"resources\\\":[{\\\"urn\\\":\\\"urn-1\\\",\\\"custom\\\":false,\\\"type\\\":\\\"\\\",\\\"refreshBeforeUpdate\\\":true}\"}]",
+  "req4.hash": "5e927ea2f899447a4b917769e32d921f96dd19c637c593eb936563380f2be3a3"
 }

--- a/pkg/resource/stack/checkpoint_test.go
+++ b/pkg/resource/stack/checkpoint_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,8 +30,10 @@ func TestLoadV0Checkpoint(t *testing.T) {
 	bytes, err := os.ReadFile("testdata/checkpoint-v0.json")
 	require.NoError(t, err)
 
-	chk, err := UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
+	chk, version, features, err := UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
 	require.NoError(t, err)
+	require.Equal(t, 3, version)
+	require.Empty(t, features)
 	require.NotNil(t, chk.Latest)
 	require.Len(t, chk.Latest.Resources, 30)
 }
@@ -40,8 +44,10 @@ func TestLoadV1Checkpoint(t *testing.T) {
 	bytes, err := os.ReadFile("testdata/checkpoint-v1.json")
 	require.NoError(t, err)
 
-	chk, err := UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
+	chk, version, features, err := UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
 	require.NoError(t, err)
+	require.Equal(t, 3, version)
+	require.Empty(t, features)
 	require.NotNil(t, chk.Latest)
 	require.Len(t, chk.Latest.Resources, 30)
 }
@@ -52,8 +58,10 @@ func TestLoadV3Checkpoint(t *testing.T) {
 	bytes, err := os.ReadFile("testdata/checkpoint-v3.json")
 	require.NoError(t, err)
 
-	chk, err := UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
+	chk, version, features, err := UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
 	require.NoError(t, err)
+	require.Equal(t, 3, version)
+	require.Empty(t, features)
 	require.NotNil(t, chk.Latest)
 	require.Len(t, chk.Latest.Resources, 30)
 }
@@ -64,8 +72,10 @@ func TestLoadV4Checkpoint(t *testing.T) {
 	bytes, err := os.ReadFile("testdata/checkpoint-v4.json")
 	require.NoError(t, err)
 
-	chk, err := UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
+	chk, version, features, err := UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
 	require.NoError(t, err)
+	require.Equal(t, 4, version)
+	require.Equal(t, []string{"refreshBeforeUpdate"}, features)
 	require.NotNil(t, chk.Latest)
 	require.Len(t, chk.Latest.Resources, 30)
 }
@@ -76,9 +86,88 @@ func TestLoadV4CheckpointUnsupportedFeature(t *testing.T) {
 	bytes, err := os.ReadFile("testdata/checkpoint-v4-unsupported-feature.json")
 	require.NoError(t, err)
 
-	chk, err := UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
+	chk, version, features, err := UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
 	require.Nil(t, chk)
+	require.Equal(t, 0, version)
+	require.Nil(t, features)
 	var expectedErr *ErrDeploymentUnsupportedFeatures
 	require.ErrorAs(t, err, &expectedErr)
 	require.Equal(t, []string{"unsupported-feature"}, expectedErr.Features)
+}
+
+// TestSerializeCheckpoint tests that the appropriate version and features are used when
+// serializing a checkpoint.
+func TestSerializeCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		resources        []*resource.State
+		expectedVersion  int
+		expectedFeatures []string
+	}{
+		{
+			name: "v3 deployment with no features",
+			resources: []*resource.State{
+				{
+					URN: "urn1",
+				},
+			},
+			expectedVersion:  3,
+			expectedFeatures: nil,
+		},
+		{
+			name: "v4 deployment with refreshBeforeUpdate",
+			resources: []*resource.State{
+				{
+					URN:                 "urn1",
+					RefreshBeforeUpdate: true,
+				},
+			},
+			expectedVersion:  4,
+			expectedFeatures: []string{"refreshBeforeUpdate"},
+		},
+		{
+			name: "v4 deployment with views",
+			resources: []*resource.State{
+				{
+					URN: "urn1",
+				},
+				{
+					URN:    "urn2",
+					Parent: "urn1",
+					ViewOf: "urn1",
+				},
+			},
+			expectedVersion:  4,
+			expectedFeatures: []string{"views"},
+		},
+		{
+			name: "v4 deployment with hooks",
+			resources: []*resource.State{
+				{
+					URN: "urn1",
+					ResourceHooks: map[resource.HookType][]string{
+						resource.AfterCreate: {"hook1"},
+					},
+				},
+			},
+			expectedVersion:  4,
+			expectedFeatures: []string{"hooks"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			snap := &deploy.Snapshot{
+				Resources: tt.resources,
+			}
+			checkpoint, err := SerializeCheckpoint("stack", snap, false /*showSecrets*/)
+			require.NoError(t, err)
+			require.NotNil(t, checkpoint)
+			require.Equal(t, tt.expectedVersion, checkpoint.Version)
+			require.Equal(t, tt.expectedFeatures, checkpoint.Features)
+		})
+	}
 }

--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,12 +39,20 @@ const (
 
 	// Indicates whether the service supports the Copilot explainer.
 	CopilotExplainPreview APICapability = "copilot-explain-preview"
+
+	// Indicates the maximum deployment schema version that the service supports.
+	DeploymentSchemaVersion APICapability = "deployment-schema-version"
 )
 
 type DeltaCheckpointUploadsConfigV2 struct {
 	// CheckpointCutoffSizeBytes defines the size of a checkpoint file, in bytes,
 	// at which the CLI should cutover to using delta checkpoint uploads.
 	CheckpointCutoffSizeBytes int `json:"checkpointCutoffSizeBytes"`
+}
+
+type DeploymentSchemaVersionConfig struct {
+	// Version is the maximum version of the deployment schema that the service supports.
+	Version int `json:"version"`
 }
 
 // APICapabilityConfig captures a service backend capability and any associated
@@ -75,6 +83,9 @@ type Capabilities struct {
 
 	// Indicates whether the service supports the Copilot explainer.
 	CopilotExplainPreviewV1 bool
+
+	// Indicates the maximum deployment schema version that the service supports.
+	DeploymentSchemaVersion int
 }
 
 // Parse decodes the CapabilitiesResponse into a Capabilities struct for ease of use.
@@ -105,6 +116,14 @@ func (r CapabilitiesResponse) Parse() (Capabilities, error) {
 		case CopilotExplainPreview:
 			if entry.Version == 1 {
 				parsed.CopilotExplainPreviewV1 = true
+			}
+		case DeploymentSchemaVersion:
+			if entry.Version == 1 {
+				var versionConfig DeploymentSchemaVersionConfig
+				if err := json.Unmarshal(entry.Configuration, &versionConfig); err != nil {
+					return Capabilities{}, fmt.Errorf("decoding DeploymentSchemaVersionConfig returned %w", err)
+				}
+				parsed.DeploymentSchemaVersion = versionConfig.Version
 			}
 		default:
 			continue

--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -50,6 +50,7 @@ type DeltaCheckpointUploadsConfigV2 struct {
 	CheckpointCutoffSizeBytes int `json:"checkpointCutoffSizeBytes"`
 }
 
+// DeploymentSchemaVersionConfig is the configuration for the deployment-schema-version capability.
 type DeploymentSchemaVersionConfig struct {
 	// Version is the maximum version of the deployment schema that the service supports.
 	Version int `json:"version"`

--- a/sdk/go/common/apitype/service_test.go
+++ b/sdk/go/common/apitype/service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -138,5 +138,23 @@ func TestCapabilities(t *testing.T) {
 		actual, err := response.Parse()
 		require.NoError(t, err)
 		assert.Equal(t, Capabilities{}, actual)
+	})
+
+	t.Run("parse deployment schema v4", func(t *testing.T) {
+		t.Parallel()
+		response := CapabilitiesResponse{
+			Capabilities: []APICapabilityConfig{
+				{
+					Capability:    DeploymentSchemaVersion,
+					Version:       1,
+					Configuration: json.RawMessage(`{"version": 4}`),
+				},
+			},
+		}
+		actual, err := response.Parse()
+		require.NoError(t, err)
+		assert.Equal(t, Capabilities{
+			DeploymentSchemaVersion: 4,
+		}, actual)
 	})
 }


### PR DESCRIPTION
This change adds support for writing checkpoints/deployments with a schema version of 4 when the following features are used: refreshBeforeUpdate, views, or hooks. Otherwise, version 3 will continue to be used.

If the service doesn't support v4 deployment schemas, v3 will continue to be used.

Fixes https://github.com/pulumi/pulumi/issues/19705