### PR TITLE
WIP: Check tests when using bun

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -220,6 +220,8 @@ jobs:
           node-version: ${{ fromJson(inputs.version-set).nodejs }}
           cache: yarn
           cache-dependency-path: sdk/nodejs/yarn.lock
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
       - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -66,18 +66,18 @@ install_plugin:: build
 
 install:: install_package install_plugin
 
+# FIXME: bun
 unit_tests:: $(TEST_ALL_DEPS)
 	yarn run nyc --no-clean -s mocha --timeout 120000 \
 		--exclude 'bin/tests/automation/**/*.spec.js' \
-		--exclude 'bin/tests/runtime/closure-integration-tests.js' \
 		'bin/tests/**/*.spec.js'
 	yarn run nyc --no-clean -s mocha 'bin/tests_with_mocks/**/*.spec.js'
 
 test_auto:: $(TEST_ALL_DEPS)
 	yarn run nyc --no-clean -s mocha --timeout 300000 'bin/tests/automation/**/*.spec.js'
 
+# FIXME: bun
 test_integration:: $(TEST_ALL_DEPS)
-	node 'bin/tests/runtime/closure-integration-tests.js'
 	node 'bin/tests/runtime/install-package-tests.js'
 
 TSC_SUPPORTED_VERSIONS = ~3.8.3 ^3 ^4

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -691,7 +691,8 @@ func (host *nodeLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 	}
 	defer pipes.shutdown()
 
-	nodeBin, err := exec.LookPath("node")
+	// FIXME: bun
+	nodeBin, err := exec.LookPath("bun")
 	if err != nil {
 		return &pulumirpc.RunResponse{Error: "could not find node on the $PATH: " + err.Error()}, nil
 	}
@@ -1164,7 +1165,8 @@ func (host *nodeLanguageHost) About(ctx context.Context,
 		return ex, strings.TrimSpace(string(out)), nil
 	}
 
-	node, version, err := getResponse("node", "--version")
+	// FIXME: bun
+	node, version, err := getResponse("bun", "--version")
 	if err != nil {
 		return nil, err
 	}
@@ -1485,7 +1487,8 @@ func (host *nodeLanguageHost) RunPlugin(
 	// best effort close, but we try an explicit close and error check at the end as well
 	defer closer.Close()
 
-	nodeBin, err := exec.LookPath("node")
+	// FIXME: bun
+	nodeBin, err := exec.LookPath("bun")
 	if err != nil {
 		return err
 	}

--- a/sdk/nodejs/cmd/run-plugin/index.ts
+++ b/sdk/nodejs/cmd/run-plugin/index.ts
@@ -78,7 +78,9 @@ process.on("exit", (code: number) => {
 // fact.  For example, we want to keep track of ScriptId->FileNames so that we can appropriately
 // report errors for Functions we cannot serialize.  This can only be done (up to Node11 at least)
 // by register to hear about scripts being parsed.
-import * as v8Hooks from "../../runtime/closure/v8Hooks";
+//
+// FIXME: Bun uses the WebKit Inspector Protocol, not the v8 one.
+// import * as v8Hooks from "../../runtime/closure/v8Hooks";
 
 // This is the entrypoint for running a Node.js program with minimal scaffolding.
 import minimist from "minimist";
@@ -101,8 +103,10 @@ function main(args: string[]): void {
         return printUsageAndExit();
     }
 
+    // FIXME: Bun uses the WebKit Inspector Protocol, not the v8 one.
     // Ensure that our v8 hooks have been initialized.  Then actually load and run the user program.
-    v8Hooks.isInitializedAsync().then(() => {
+    const ready = process.versions.bun ? Promise.resolve() : import("../../runtime/closure/v8Hooks").then((v8Hooks) => v8Hooks.isInitializedAsync());
+    ready.then(() => {
         const promise: Promise<void> = require("./run").run({
             argv,
             programStarted: () => {

--- a/sdk/nodejs/cmd/run-policy-pack/index.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/index.ts
@@ -78,7 +78,10 @@ process.on("exit", (code: number) => {
 // fact.  For example, we want to keep track of ScriptId->FileNames so that we can appropriately
 // report errors for Functions we cannot serialize.  This can only be done (up to Node11 at least)
 // by register to hear about scripts being parsed.
-import * as v8Hooks from "../../runtime/closure/v8Hooks";
+//
+// FIXME: Bun uses the WebKit Inspector Protocol, not the v8 one.
+// import * as v8Hooks from "../../runtime/closure/v8Hooks";
+// import * as v8Hooks from "../../runtime/closure/v8Hooks";
 
 // This is the entrypoint for running a Node.js program with minimal scaffolding.
 import minimist from "minimist";
@@ -104,8 +107,10 @@ function main(args: string[]): void {
     // Remove <engine-address> so we simply execute the program.
     argv._.shift();
 
+    // FIXME: Bun uses the WebKit Inspector Protocol, not the v8 one.
     // Ensure that our v8 hooks have been initialized.  Then actually load and run the user program.
-    v8Hooks.isInitializedAsync().then(() => {
+    const ready = process.versions.bun ? Promise.resolve() : import("../../runtime/closure/v8Hooks").then((v8Hooks) => v8Hooks.isInitializedAsync());
+    ready.then(() => {
         const promise: Promise<void> = require("./run").run({
             argv,
             programStarted: () => {

--- a/sdk/nodejs/dist/pulumi-analyzer-policy
+++ b/sdk/nodejs/dist/pulumi-analyzer-policy
@@ -1,5 +1,7 @@
 #!/bin/sh
-PULUMI_RUN_SCRIPT_PATH=$(node -e "try { console.log(require.resolve('@pulumi/pulumi/cmd/run-policy-pack')) } catch (e) { console.error(e.message) }")
+# FIXME: bun
+PULUMI_RUN_SCRIPT_PATH=$(bun -e "try { console.log(require.resolve('@pulumi/pulumi/cmd/run-policy-pack')) } catch (e) { console.error(e.message) }")
 if [ ! -z "$PULUMI_RUN_SCRIPT_PATH" ]; then
-    node "$PULUMI_RUN_SCRIPT_PATH" $@
+    # FIXME: bun
+    bun "$PULUMI_RUN_SCRIPT_PATH" $@
 fi

--- a/sdk/nodejs/dist/pulumi-analyzer-policy.cmd
+++ b/sdk/nodejs/dist/pulumi-analyzer-policy.cmd
@@ -1,6 +1,8 @@
 @echo off
 setlocal
-for /f "delims=" %%i in ('node -e "console.log(require.resolve('@pulumi/pulumi/cmd/run-policy-pack'))"') do set PULUMI_RUN_SCRIPT_PATH=%%i
+REM FIXME: bun
+for /f "delims=" %%i in ('bun -e "console.log(require.resolve('@pulumi/pulumi/cmd/run-policy-pack'))"') do set PULUMI_RUN_SCRIPT_PATH=%%i
 if DEFINED PULUMI_RUN_SCRIPT_PATH (
-   @node "%PULUMI_RUN_SCRIPT_PATH%" %*
+   REM FIXME: bun
+   @bun "%PULUMI_RUN_SCRIPT_PATH%" %*
 )

--- a/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs
+++ b/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs
@@ -1,5 +1,7 @@
 #!/bin/sh
-PULUMI_DYNAMIC_PROVIDER_SCRIPT_PATH=$(node -e "console.log(require.resolve('@pulumi/pulumi/cmd/dynamic-provider'))")
+# FIXME: bun
+PULUMI_DYNAMIC_PROVIDER_SCRIPT_PATH=$(bun -e "console.log(require.resolve('@pulumi/pulumi/cmd/dynamic-provider'))")
 if [ ! -z "$PULUMI_DYNAMIC_PROVIDER_SCRIPT_PATH" ]; then
-    node "$PULUMI_DYNAMIC_PROVIDER_SCRIPT_PATH" $@
+    # FIXME: bun
+    bun "$PULUMI_DYNAMIC_PROVIDER_SCRIPT_PATH" $@
 fi

--- a/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs.cmd
+++ b/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs.cmd
@@ -1,6 +1,8 @@
 @echo off
 setlocal
-for /f "delims=" %%i in ('node -e "console.log(require.resolve('@pulumi/pulumi/cmd/dynamic-provider'))"') do set PULUMI_DYNAMIC_PROVIDER_SCRIPT_PATH=%%i
+REM FIXME: bun
+for /f "delims=" %%i in ('bun -e "console.log(require.resolve('@pulumi/pulumi/cmd/dynamic-provider'))"') do set PULUMI_DYNAMIC_PROVIDER_SCRIPT_PATH=%%i
 if DEFINED PULUMI_DYNAMIC_PROVIDER_SCRIPT_PATH (
-   @node "%PULUMI_DYNAMIC_PROVIDER_SCRIPT_PATH%" %*
+   REM FIXME: bun
+   @bun "%PULUMI_DYNAMIC_PROVIDER_SCRIPT_PATH%" %*
 )

--- a/sdk/nodejs/runtime/index.ts
+++ b/sdk/nodejs/runtime/index.ts
@@ -13,11 +13,25 @@
 // limitations under the License.
 
 export {
-    serializeFunctionAsync,
-    serializeFunction,
+    // serializeFunctionAsync,
+    // serializeFunction,
     SerializedFunction,
     SerializeFunctionArgs,
 } from "./closure/serializeClosure";
+
+export const serializeFunctionAsync = async (args: any) => {
+    // FIXME: Bun uses the WebKit Inspector Protocol, not the v8 one.
+    // lazy import, since this will end up pulling in the v8 module.
+    const serializeClosure = await import("./closure/serializeClosure");
+    return serializeClosure.serializeFunctionAsync(args);
+}
+
+export const serializeFunction = async (args: any) => {
+    // FIXME: Bun uses the WebKit Inspector Protocol, not the v8 one.
+    // lazy import, since this will end up pulling in the v8 module.
+    const serializeClosure = await import("./closure/serializeClosure");
+    return serializeClosure.serializeFunction(args);
+}
 
 export { CodePathOptions, computeCodePaths } from "./closure/codePaths";
 export { Mocks, setMocks, MockResourceArgs, MockResourceResult, MockCallArgs, MockCallResult } from "./mocks";


### PR DESCRIPTION
Check which tests break when running with bun as typescript runtime.

Anything releated to closure serialization won’t work (“magic” functions like `Bucket.onObjectCreated`, dynamic providers).

Tests that use certain Node.js flags, like `--loader` will likely fail. Probably anything running through `ts-node` also, so the vast majority of TypeScript tests.

Related to https://github.com/pulumi/pulumi/issues/13904
