### PR TITLE
use control-close event to interrupt childeren

### DIFF
--- a/sdk/go/common/util/cmdutil/child_windows.go
+++ b/sdk/go/common/util/cmdutil/child_windows.go
@@ -119,6 +119,6 @@ func RegisterProcessGroup(cmd *exec.Cmd) {
 }
 
 func InterruptChildren(pid int) {
-	_, _, err := generateConsoleCtrlEvent.Call(syscall.CTRL_BREAK_EVENT, uintptr(pid))
+	_, _, err := generateConsoleCtrlEvent.Call(syscall.CTRL_CLOSE_EVENT, uintptr(pid))
 	contract.IgnoreError(err)
 }


### PR DESCRIPTION
Wondering if this could be a sneaky way to fix https://github.com/pulumi/pulumi/issues/20136 without having to translate all the scripts to `.ps1` scripts.