### PR TITLE
Fix flaky TestNodejsPromiseMessage (again)

### DIFF
--- a/tests/integration/nodejs/promise-message/index.js
+++ b/tests/integration/nodejs/promise-message/index.js
@@ -1,19 +1,11 @@
 // Copyright 2025, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "@pulumi/pulumi";
-
-class Named extends pulumi.CustomResource {
-    constructor(name, resourceName) {
-        super("testprovider:index:Named", name, { name: resourceName });
-    }
-}
+import * as debuggable from "@pulumi/pulumi/runtime/debuggable.js";
 
 function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-sleep(60000).then(() => {
-    new Named("res");
-})
+debuggable.debuggablePromise(sleep(5 * 60 * 1000), "sleep")
 
 process.exit(0);


### PR DESCRIPTION
I attempted to fix this in https://github.com/pulumi/pulumi/pull/20144, but misunderstood how promise leak detection works. We need a pending `debuggablePromise` when the process exits to trigger the message.

Something like `sleep(60000).then(() => { new Named("res”); })` will not create a `debuggablePromise` until we hit the resource constructor.

The reason the test passed previously was that it would usually, but not always, hit `process.exit` while debug logs (which uses `debuggablePromise`, since it's an RPC) were being sent.