### PR TITLE
Add get_root_directory to root pulumi module

### DIFF
--- a/changelog/pending/20250730--sdk-python--copy-get_root_directory-to-the-pulumi-module.yaml
+++ b/changelog/pending/20250730--sdk-python--copy-get_root_directory-to-the-pulumi-module.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Copy `get_root_directory` to the pulumi module

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -562,7 +562,7 @@ func (g *generator) genCan(w io.Writer, args []model.Expression) {
 }
 
 func (g *generator) genRootDirectory(w io.Writer) {
-	g.Fgen(w, "pulumi.runtime.get_root_directory()")
+	g.Fgen(w, "pulumi.get_root_directory()")
 }
 
 func (g *generator) GenIndexExpression(w io.Writer, expr *model.IndexExpression) {

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-builtin-project-root/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/projects/l1-builtin-project-root/__main__.py
@@ -1,3 +1,3 @@
 import pulumi
 
-pulumi.export("rootDirectoryOutput", pulumi.runtime.get_root_directory())
+pulumi.export("rootDirectoryOutput", pulumi.get_root_directory())

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-builtin-project-root/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-builtin-project-root/__main__.py
@@ -1,3 +1,3 @@
 import pulumi
 
-pulumi.export("rootDirectoryOutput", pulumi.runtime.get_root_directory())
+pulumi.export("rootDirectoryOutput", pulumi.get_root_directory())

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-builtin-project-root/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-builtin-project-root/__main__.py
@@ -1,3 +1,3 @@
 import pulumi
 
-pulumi.export("rootDirectoryOutput", pulumi.runtime.get_root_directory())
+pulumi.export("rootDirectoryOutput", pulumi.get_root_directory())

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -59,6 +59,7 @@ from .metadata import (
     get_organization,
     get_project,
     get_stack,
+    get_root_directory,
 )
 
 from .resource import (
@@ -155,6 +156,7 @@ __all__ = [
     "get_organization",
     "get_project",
     "get_stack",
+    "get_root_directory",
     # resource
     "Alias",
     "Resource",

--- a/sdk/python/lib/pulumi/metadata.py
+++ b/sdk/python/lib/pulumi/metadata.py
@@ -12,27 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .runtime.settings import get_organization as runtime_go
-from .runtime.settings import get_project as runtime_gp
-from .runtime.settings import get_stack as runtime_gs
+from .runtime import settings
 
 
 def get_organization() -> str:
     """
     Returns the current organization name.
     """
-    return runtime_go()
+    return settings.get_organization()
 
 
 def get_project() -> str:
     """
     Returns the current project name.
     """
-    return runtime_gp()
+    return settings.get_project()
 
 
 def get_stack() -> str:
     """
     Returns the current stack name.
     """
-    return runtime_gs()
+    return settings.get_stack()
+
+
+def get_root_directory() -> str:
+    """
+    Returns the current root directory.
+    """
+    return settings.get_root_directory()


### PR DESCRIPTION
This got added back in https://github.com/pulumi/pulumi/pull/18595 but you had to use it via `pulumi.runtime.get_root_directory()`. There isn't really anything else that we expect users to look at in the runtime module, so this copies it to the root pulumi module so it's now just `pulumi.get_root_directory()`.