### PR TITLE
Add getRootDirectory to root pulumi module

### DIFF
--- a/changelog/pending/20250730--sdk-nodejs--copy-getrootdirectory-to-the-pulumi-module.yaml
+++ b/changelog/pending/20250730--sdk-nodejs--copy-getrootdirectory-to-the-pulumi-module.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description:  Copy `getRootDirectory` to the pulumi module

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -658,7 +658,7 @@ func (g *generator) genCan(w io.Writer, expr *model.FunctionCallExpression) {
 }
 
 func (g *generator) genRootDirectory(w io.Writer) {
-	g.Fgen(w, "pulumi.runtime.getRootDirectory()")
+	g.Fgen(w, "pulumi.getRootDirectory()")
 }
 
 func (g *generator) GenIndexExpression(w io.Writer, expr *model.IndexExpression) {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-builtin-project-root/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l1-builtin-project-root/index.ts
@@ -1,3 +1,3 @@
 import * as pulumi from "@pulumi/pulumi";
 
-export const rootDirectoryOutput = pulumi.runtime.getRootDirectory();
+export const rootDirectoryOutput = pulumi.getRootDirectory();

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-builtin-project-root/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l1-builtin-project-root/index.ts
@@ -1,3 +1,3 @@
 import * as pulumi from "@pulumi/pulumi";
 
-export const rootDirectoryOutput = pulumi.runtime.getRootDirectory();
+export const rootDirectoryOutput = pulumi.getRootDirectory();

--- a/sdk/nodejs/metadata.ts
+++ b/sdk/nodejs/metadata.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,4 +33,10 @@ export function getProject(): string {
  */
 export function getStack(): string {
     return settings.getStack();
+}
+/**
+ * Returns the root directory of the current Pulumi project.
+ */
+export function getRootDirectory(): string {
+    return settings.getRootDirectory();
 }


### PR DESCRIPTION
Same fix as https://github.com/pulumi/pulumi/pull/20172 but for nodejs.

This got added back in https://github.com/pulumi/pulumi/pull/18595 but you had to use it via `pulumi.runtime.getRootDirectory()`. There isn't really anything else that we expect users to look at in the runtime module, so this copies it to the root pulumi module so it's now just `pulumi.getRootDirectory()`.