### PR TITLE
use the testify framework more in lifecycletests

### DIFF
--- a/pkg/engine/lifecycletest/framework/framework.go
+++ b/pkg/engine/lifecycletest/framework/framework.go
@@ -350,10 +350,7 @@ func (op TestOp) runWithContext(
 // checking the events properly.
 func compareEvents(t TB, expected, actual []engine.Event) {
 	encountered := make(map[int]struct{})
-	if len(expected) != len(actual) {
-		t.Logf("expected %d events, got %d", len(expected), len(actual))
-		t.Fail()
-	}
+	require.Len(t, actual, len(expected), "expected and actual event counts differ")
 	for _, e := range expected {
 		found := false
 		for i, a := range actual {
@@ -366,16 +363,13 @@ func compareEvents(t TB, expected, actual []engine.Event) {
 				break
 			}
 		}
-		if !found {
-			t.Logf("expected event %v not found", e)
-			t.Fail()
-		}
+		assert.True(t, found, "expected event %v not found in actual events", e)
 	}
 	for i, e := range actual {
 		if _, ok := encountered[i]; ok {
 			continue
 		}
-		t.Logf("did not expect event %v", e)
+		assert.Fail(t, "unexpected event %v found in actual events", e)
 	}
 }
 


### PR DESCRIPTION
I ran into this while working on https://github.com/pulumi/pulumi/pull/20174. Testify returns the whole stack trace rather than just showing the log, which is often useful to see what actually failed.  Use that framework here consistently, so we get better test output.

There's also a bug here, where we don't fail if we encounter an event we don't expect, so fix that as well.