### PR TITLE
Enable `pulumi import` to always `--generate-resources`

### DIFF
--- a/changelog/pending/20250731--cli-import--enable-pulumi-import-to-always-generate-resources-when-converting-from-state-files.yaml
+++ b/changelog/pending/20250731--cli-import--enable-pulumi-import-to-always-generate-resources-when-converting-from-state-files.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/import
+  description: Enable `pulumi import` to always `--generate-resources` when converting `--from` state files


### PR DESCRIPTION
When using `pulumi import` to import resources `--from` a converted state file, Pulumi will write out a JSON-encoded set of resources if things go wrong so that the user can then try to fix things up and try again using the `--file` option instead. There are cases however where the JSON-encoded set of resources is useful even when an import succeeds. This change adds the `--generate-resources <path>` option to `pulumi import` so that users can force the generation of resources JSON regardless of whether the import succeeds or fails. It also fixes a small double-`%s` error in one of our diagnostic messages, since that's the kind of bonus content we live for.