### PR TITLE
update versions of language providers

### DIFF
--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -381,4 +381,4 @@ const (
 )
 
 // PulumiDotnetSDKVersion is the version of the Pulumi .NET SDK to use in program-gen tests
-const PulumiDotnetSDKVersion = "3.85.1"
+const PulumiDotnetSDKVersion = "3.86.0"

--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -28,7 +28,7 @@ download_release() {
 # * When updating .Net, you should also update PulumiDotnetSDKVersion in pulumi/pkg/codegen/testing/test/helpers.go
 #
 # shellcheck disable=SC2043
-for i in "github.com/pulumi/pulumi-java java v1.16.0" "github.com/pulumi/pulumi-yaml yaml v1.21.3" "github.com/pulumi/pulumi-dotnet dotnet v3.85.1"; do
+for i in "github.com/pulumi/pulumi-java java v1.16.1" "github.com/pulumi/pulumi-yaml yaml v1.21.4" "github.com/pulumi/pulumi-dotnet dotnet v3.86.0"; do
   set -- $i # treat strings in loop as args
   REPO="$1"
   PULUMI_LANG="$2"


### PR DESCRIPTION
In preparation for the 3.187.0 release.

(https://github.com/pulumi/pulumi-dotnet/pull/678 still needs to merge before we can do this)