### PR TITLE
Warn on refs of the form "#/resources/pulumi:providers:<pkg>"

### DIFF
--- a/changelog/pending/20250801--sdkgen--warn-about-refs-of-the-form-resources-pulumi-providers-pkg.yaml
+++ b/changelog/pending/20250801--sdkgen--warn-about-refs-of-the-form-resources-pulumi-providers-pkg.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen
+  description: "Warn about refs of the form \"#/resources/pulumi:providers:<pkg>\""


### PR DESCRIPTION
Part of fixing https://github.com/pulumi/pulumi/issues/20029

This makes schema binding warn when finding references of the form "#/resources/pulumi:providers:<pkg>", instructing that the user should rewrite them to the form "#/provider".