### PR TITLE
Rename Journal to TestJournal

### DIFF
--- a/pkg/engine/deployment_test.go
+++ b/pkg/engine/deployment_test.go
@@ -47,14 +47,14 @@ type testContext struct {
 	Context
 	wg      sync.WaitGroup
 	events  chan Event
-	journal *Journal
+	journal *TestJournal
 
 	firedEvents []Event
 }
 
 func makeTestContext(t testing.TB, cancelCtx *cancel.Context) *testContext {
 	events := make(chan Event)
-	journal := NewJournal()
+	journal := NewTestJournal()
 
 	ctx := &testContext{
 		Context: Context{

--- a/pkg/engine/lifecycletest/framework/framework.go
+++ b/pkg/engine/lifecycletest/framework/framework.go
@@ -244,7 +244,7 @@ func (op TestOp) runWithContext(
 	}()
 
 	events := make(chan engine.Event)
-	journal := engine.NewJournal()
+	journal := engine.NewTestJournal()
 	persister := &backend.InMemoryPersister{}
 	secretsManager := b64.NewBase64SecretsManager()
 	snapshotManager := backend.NewSnapshotManager(persister, secretsManager, target.Snapshot)


### PR DESCRIPTION
This journal is only used internally for testing.  Rename it to TestJournal to make it clear that this is only used for testing.

This will also help disambiguate this test journal from the journaling changes that are going to be implemented in https://github.com/pulumi/pulumi/pull/19862