### PR TITLE
Mark interface implementations for update & previewActions

### DIFF
--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -579,6 +579,11 @@ func abbreviateFilePath(path string) string {
 	return path
 }
 
+var (
+	_ = deploy.StepExecutorEvents(&updateActions{})
+	_ = runActions(&updateActions{})
+)
+
 // updateActions pretty-prints the plan application process as it goes.
 type updateActions struct {
 	Context *Context
@@ -763,6 +768,11 @@ func (acts *updateActions) MaybeCorrupt() bool {
 func (acts *updateActions) Changes() display.ResourceChanges {
 	return display.ResourceChanges(acts.Ops)
 }
+
+var (
+	_ = deploy.StepExecutorEvents(&previewActions{})
+	_ = runActions(&previewActions{})
+)
 
 type previewActions struct {
 	Ops     map[display.StepOp]int


### PR DESCRIPTION
While trying to piece together how we manage snapshots, I found it helpful to explicitly mark what interacts the `updateActions` struct implements. I generally like implicit interface implementation, but sometimes it's useful to have an explicit marker. 

We can close this PR if we feel that's not the style we want though.