### PR TITLE
Move ID="" logic from grpc layer to refresh step

### DIFF
--- a/pkg/engine/lifecycletest/continue_on_error_test.go
+++ b/pkg/engine/lifecycletest/continue_on_error_test.go
@@ -392,6 +392,16 @@ func TestUpContinueOnErrorUpdateWithRefresh(t *testing.T) {
 				UpdateF: func(context.Context, plugin.UpdateRequest) (plugin.UpdateResponse, error) {
 					return plugin.UpdateResponse{Status: resource.StatusOK}, errors.New("intentionally failed update")
 				},
+				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					return plugin.ReadResponse{
+						ReadResult: plugin.ReadResult{
+							ID:      req.ID,
+							Inputs:  resource.PropertyMap{},
+							Outputs: resource.PropertyMap{},
+						},
+						Status: resource.StatusOK,
+					}, nil
+				},
 			}, nil
 		}, deploytest.WithoutGrpc),
 	}

--- a/pkg/engine/lifecycletest/golang_sdk_test.go
+++ b/pkg/engine/lifecycletest/golang_sdk_test.go
@@ -75,6 +75,7 @@ func TestSingleResourceDefaultProviderGolangLifecycle(t *testing.T) {
 				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
 					return plugin.ReadResponse{
 						ReadResult: plugin.ReadResult{
+							ID:      req.ID,
 							Inputs:  req.Inputs,
 							Outputs: req.State,
 						},

--- a/pkg/engine/lifecycletest/refresh_legacy_diff_test.go
+++ b/pkg/engine/lifecycletest/refresh_legacy_diff_test.go
@@ -131,6 +131,7 @@ func validateRefreshBasicsWithLegacyDiffCombination(
 				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
 					new, hasNewState := newStates[req.ID]
 					assert.True(t, hasNewState)
+					new.ID = req.ID
 					return plugin.ReadResponse{
 						ReadResult: new,
 						Status:     resource.StatusOK,

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -420,7 +420,10 @@ func TestRefreshDeletePropertyDependencies(t *testing.T) {
 					}
 
 					return plugin.ReadResponse{
-						ReadResult: plugin.ReadResult{Outputs: resource.PropertyMap{}},
+						ReadResult: plugin.ReadResult{
+							ID:      req.ID,
+							Outputs: resource.PropertyMap{},
+						},
 					}, nil
 				},
 			}, nil
@@ -481,8 +484,11 @@ func TestRefreshDeleteDeletedWith(t *testing.T) {
 					}
 
 					return plugin.ReadResponse{
-						ReadResult: plugin.ReadResult{Outputs: resource.PropertyMap{}},
-						Status:     resource.StatusOK,
+						ReadResult: plugin.ReadResult{
+							ID:      req.ID,
+							Outputs: resource.PropertyMap{},
+						},
+						Status: resource.StatusOK,
 					}, nil
 				},
 			}, nil
@@ -599,6 +605,7 @@ func validateRefreshDeleteCombination(t *testing.T, names []string, targets []st
 					default:
 						return plugin.ReadResponse{
 							ReadResult: plugin.ReadResult{
+								ID:      req.ID,
 								Inputs:  req.Inputs,
 								Outputs: req.State,
 							},
@@ -785,6 +792,7 @@ func validateRefreshBasicsCombination(t *testing.T, names []string, targets []st
 				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
 					new, hasNewState := newStates[req.ID]
 					assert.True(t, hasNewState)
+					new.ID = req.ID
 					return plugin.ReadResponse{
 						ReadResult: new,
 						Status:     resource.StatusOK,
@@ -964,6 +972,7 @@ func TestCanceledRefresh(t *testing.T) {
 					<-cancelled
 
 					new, hasNewState := newStates[req.ID]
+					new.ID = req.ID
 					assert.True(t, hasNewState)
 					return plugin.ReadResponse{
 						ReadResult: new,

--- a/pkg/engine/lifecycletest/resource_reference_test.go
+++ b/pkg/engine/lifecycletest/resource_reference_test.go
@@ -63,6 +63,7 @@ func TestResourceReferences(t *testing.T) {
 				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
 					return plugin.ReadResponse{
 						ReadResult: plugin.ReadResult{
+							ID:      req.ID,
 							Inputs:  req.Inputs,
 							Outputs: req.State,
 						},
@@ -146,6 +147,7 @@ func TestResourceReferences_DownlevelSDK(t *testing.T) {
 				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
 					return plugin.ReadResponse{
 						ReadResult: plugin.ReadResult{
+							ID:      req.ID,
 							Inputs:  req.Inputs,
 							Outputs: req.State,
 						},
@@ -224,6 +226,7 @@ func TestResourceReferences_DownlevelEngine(t *testing.T) {
 				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
 					return plugin.ReadResponse{
 						ReadResult: plugin.ReadResult{
+							ID:      req.ID,
 							Inputs:  req.Inputs,
 							Outputs: req.State,
 						},
@@ -302,6 +305,7 @@ func TestResourceReferences_GetResource(t *testing.T) {
 				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
 					return plugin.ReadResponse{
 						ReadResult: plugin.ReadResult{
+							ID:      req.ID,
 							Inputs:  req.Inputs,
 							Outputs: req.State,
 						},

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -58,6 +58,7 @@ func TestRefreshTargetChildren(t *testing.T) {
 
 					return plugin.ReadResponse{
 						ReadResult: plugin.ReadResult{
+							ID: req.ID,
 							Outputs: resource.PropertyMap{
 								"count": resource.NewNumberProperty(float64(count)),
 							},
@@ -498,6 +499,7 @@ func TestRefreshExcludeTarget(t *testing.T) {
 
 					return plugin.ReadResponse{
 						ReadResult: plugin.ReadResult{
+							ID: req.ID,
 							Outputs: resource.PropertyMap{
 								"count": resource.NewNumberProperty(float64(count)),
 							},
@@ -577,6 +579,7 @@ func TestRefreshExcludeChildren(t *testing.T) {
 
 					return plugin.ReadResponse{
 						ReadResult: plugin.ReadResult{
+							ID: req.ID,
 							Outputs: resource.PropertyMap{
 								"count": resource.NewNumberProperty(callCount),
 							},

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -225,6 +225,7 @@ func (p *builtinProvider) Read(_ context.Context, req plugin.ReadRequest) (plugi
 
 	return plugin.ReadResponse{
 		ReadResult: plugin.ReadResult{
+			ID:      req.ID,
 			Inputs:  req.Inputs,
 			Outputs: outputs,
 		},

--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -185,10 +185,20 @@ func (prov *Provider) Read(ctx context.Context, req plugin.ReadRequest) (plugin.
 	contract.Assertf(req.URN != "", "Read URN was empty")
 	contract.Assertf(req.ID != "", "Read ID was empty")
 	if prov.ReadF == nil {
+		state := req.State
+		if state == nil {
+			state = resource.PropertyMap{}
+		}
+		inputs := req.Inputs
+		if inputs == nil {
+			inputs = resource.PropertyMap{}
+		}
+
 		return plugin.ReadResponse{
 			ReadResult: plugin.ReadResult{
-				Outputs: resource.PropertyMap{},
-				Inputs:  resource.PropertyMap{},
+				ID:      req.ID,
+				Outputs: state,
+				Inputs:  inputs,
 			},
 			Status: resource.StatusUnknown,
 		}, nil

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -1313,8 +1313,8 @@ func (s *RefreshStep) Apply() (resource.Status, StepCompleteFunc, error) {
 		}
 	}
 
-	logging.V(10).Infof("Refreshed resource ID: %q, Inputs: %v, Outputs: %v",
-		refreshed.ID, refreshed.Inputs, refreshed.Outputs)
+	logging.V(10).Infof("Refreshed resource ID: %q, Inputs: #%d, Outputs: #%d",
+		refreshed.ID, len(refreshed.Inputs), len(refreshed.Outputs))
 
 	// If the ID is blank treat this as a delete, and leave outputs blank.
 	var outputs resource.PropertyMap

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -1480,11 +1480,6 @@ func (p *provider) Read(ctx context.Context, req ReadRequest) (ReadResponse, err
 		refreshBeforeUpdate = resp.GetRefreshBeforeUpdate()
 	}
 
-	// If the resource was missing, simply return a nil property map.
-	if string(readID) == "" {
-		return ReadResponse{Status: resourceStatus}, nil
-	}
-
 	// Finally, unmarshal the resulting state properties and return them.
 	newState, err := UnmarshalProperties(liveObject, MarshalOptions{
 		Label:          label + ".outputs",


### PR DESCRIPTION
Prompted by https://github.com/pulumi/pulumi/issues/20186

The logic that `ID=""` should be treated as a delete was squeezed into the grpc layer by setting outputs to nil if ID was blank.

This PR moves that logic up to the refresh step, so it's consistent across all lifecycle tests. A number of tests and the builtin provider needed updating for this.