### PR TITLE
Add `--remove-backups` flag to `pulumi stack rm`

### DIFF
--- a/changelog/pending/20250805--cli--add-remove-backups-flag-to-pulumi-stack-rm-for-diy-backends.yaml
+++ b/changelog/pending/20250805--cli--add-remove-backups-flag-to-pulumi-stack-rm-for-diy-backends.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `--remove-backups` flag to `pulumi stack rm` for DIY backends

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -167,8 +167,9 @@ type Backend interface {
 
 	// RemoveStack removes a stack with the given name.  If force is true, the stack will be removed even if it
 	// still contains resources.  Otherwise, if the stack contains resources, a non-nil error is returned, and the
-	// first boolean return value will be set to true.
-	RemoveStack(ctx context.Context, stack Stack, force bool) (bool, error)
+	// first boolean return value will be set to true. If removeBackups is true, any backups associated with the
+	// the stack will also be removed if the backend supports it.
+	RemoveStack(ctx context.Context, stack Stack, force, removeBackups bool) (bool, error)
 	// ListStacks returns a list of stack summaries for all known stacks in the target backend.
 	ListStacks(ctx context.Context, filter ListStacksFilter, inContToken ContinuationToken) (
 		[]StackSummary, ContinuationToken, error)

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -899,7 +899,7 @@ func (b *diyBackend) ListStackNames(
 	return filteredStacks, nil, nil
 }
 
-func (b *diyBackend) RemoveStack(ctx context.Context, stack backend.Stack, force bool) (bool, error) {
+func (b *diyBackend) RemoveStack(ctx context.Context, stack backend.Stack, force, removeBackups bool) (bool, error) {
 	diyStackRef, err := b.getReference(stack.Ref())
 	if err != nil {
 		return false, err
@@ -924,7 +924,7 @@ func (b *diyBackend) RemoveStack(ctx context.Context, stack backend.Stack, force
 		}
 	}
 
-	return false, b.removeStack(ctx, diyStackRef)
+	return false, b.removeStack(ctx, diyStackRef, removeBackups)
 }
 
 func (b *diyBackend) RenameStack(ctx context.Context, stack backend.Stack,

--- a/pkg/backend/diy/backend_legacy_test.go
+++ b/pkg/backend/diy/backend_legacy_test.go
@@ -56,7 +56,7 @@ func TestListStacksWithMultiplePassphrases_legacy(t *testing.T) {
 	require.NotNil(t, aStack)
 	defer func() {
 		t.Setenv("PULUMI_CONFIG_PASSPHRASE", "abc123")
-		_, err := b.RemoveStack(ctx, aStack, true)
+		_, err := b.RemoveStack(ctx, aStack, true /*force*/, false /*removeBackups*/)
 		require.NoError(t, err)
 	}()
 	deployment, err := makeUntypedDeployment("a", "abc123",
@@ -74,7 +74,7 @@ func TestListStacksWithMultiplePassphrases_legacy(t *testing.T) {
 	require.NotNil(t, bStack)
 	defer func() {
 		t.Setenv("PULUMI_CONFIG_PASSPHRASE", "123abc")
-		_, err := b.RemoveStack(ctx, bStack, true)
+		_, err := b.RemoveStack(ctx, bStack, true /*force*/, false /*removeBackups*/)
 		require.NoError(t, err)
 	}()
 	deployment, err = makeUntypedDeployment("b", "123abc",
@@ -208,7 +208,7 @@ func TestRemoveMakesBackups_legacy(t *testing.T) {
 	assert.False(t, backupFileExists)
 
 	// Now remove the stack
-	removed, err := b.RemoveStack(ctx, aStack, false)
+	removed, err := b.RemoveStack(ctx, aStack, false /*force*/, false /*removeBackups*/)
 	require.NoError(t, err)
 	assert.False(t, removed)
 

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1098,11 +1098,13 @@ func (b *cloudBackend) ListStackNames(
 	return stackRefs, outContToken, nil
 }
 
-func (b *cloudBackend) RemoveStack(ctx context.Context, stack backend.Stack, force bool) (bool, error) {
+func (b *cloudBackend) RemoveStack(ctx context.Context, stack backend.Stack, force, removeBackups bool) (bool, error) {
 	stackID, err := b.getCloudStackIdentifier(stack.Ref())
 	if err != nil {
 		return false, err
 	}
+
+	// Note: removeBackups is currently unused in the cloud backend.
 
 	return b.client.DeleteStack(ctx, stackID, force)
 }

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -69,7 +69,7 @@ func TestEnabledFullyQualifiedStackNames(t *testing.T) {
 	s, err := b.CreateStack(ctx, ref, "", nil, nil)
 	require.NoError(t, err)
 	defer func() {
-		_, err := b.RemoveStack(ctx, s, true)
+		_, err := b.RemoveStack(ctx, s, true /*force*/, false /*removeBackups*/)
 		require.NoError(t, err)
 	}()
 
@@ -129,7 +129,7 @@ func TestDisabledFullyQualifiedStackNames(t *testing.T) {
 	s, err := b.CreateStack(ctx, ref, "", nil, nil)
 	require.NoError(t, err)
 	defer func() {
-		_, err := b.RemoveStack(ctx, s, true)
+		_, err := b.RemoveStack(ctx, s, true /*force*/, false /*removeBackups*/)
 		require.NoError(t, err)
 	}()
 
@@ -288,7 +288,7 @@ func TestDisableIntegrityChecking(t *testing.T) {
 	s, err := b.CreateStack(ctx, ref, "", nil, nil)
 	require.NoError(t, err)
 	defer func() {
-		_, err := b.RemoveStack(ctx, s, true)
+		_, err := b.RemoveStack(ctx, s, true /*force*/, false /*removeBackups*/)
 		require.NoError(t, err)
 	}()
 
@@ -455,7 +455,7 @@ func TestListStackNames(t *testing.T) {
 	// Cleanup stacks
 	defer func() {
 		for _, s := range stacks {
-			_, err := b.RemoveStack(ctx, s, true)
+			_, err := b.RemoveStack(ctx, s, true /*force*/, false /*removeBackups*/)
 			require.NoError(t, err)
 		}
 	}()
@@ -559,7 +559,7 @@ func TestListStackNamesVsListStacks(t *testing.T) {
 	s, err := b.CreateStack(ctx, ref, "", nil, nil)
 	require.NoError(t, err)
 	defer func() {
-		_, err := b.RemoveStack(ctx, s, true)
+		_, err := b.RemoveStack(ctx, s, true /*force*/, false /*removeBackups*/)
 		require.NoError(t, err)
 	}()
 

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -65,7 +65,7 @@ type MockBackend struct {
 		*apitype.UntypedDeployment,
 		*CreateStackOptions,
 	) (Stack, error)
-	RemoveStackF func(context.Context, Stack, bool) (bool, error)
+	RemoveStackF func(context.Context, Stack, bool, bool) (bool, error)
 	ListStacksF  func(context.Context, ListStacksFilter, ContinuationToken) (
 		[]StackSummary, ContinuationToken, error)
 	ListStackNamesF func(context.Context, ListStackNamesFilter, ContinuationToken) (
@@ -258,9 +258,9 @@ func (be *MockBackend) CreateStack(
 	panic("not implemented")
 }
 
-func (be *MockBackend) RemoveStack(ctx context.Context, stack Stack, force bool) (bool, error) {
+func (be *MockBackend) RemoveStack(ctx context.Context, stack Stack, force, removeBackups bool) (bool, error) {
 	if be.RemoveStackF != nil {
-		return be.RemoveStackF(ctx, stack, force)
+		return be.RemoveStackF(ctx, stack, force, removeBackups)
 	}
 	panic("not implemented")
 }

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -61,8 +61,8 @@ type Stack interface {
 }
 
 // RemoveStack returns the stack, or returns an error if it cannot.
-func RemoveStack(ctx context.Context, s Stack, force bool) (bool, error) {
-	return s.Backend().RemoveStack(ctx, s, force)
+func RemoveStack(ctx context.Context, s Stack, force, removeBackups bool) (bool, error) {
+	return s.Backend().RemoveStack(ctx, s, force, removeBackups)
 }
 
 // RenameStack renames the stack, or returns an error if it cannot.

--- a/pkg/cmd/pulumi/newcmd/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_acceptance_test.go
@@ -294,7 +294,7 @@ func removeStack(t *testing.T, dir, name string) {
 	require.NoError(t, err)
 	stack, err := b.GetStack(context.Background(), ref)
 	require.NoError(t, err)
-	_, err = b.RemoveStack(context.Background(), stack, false)
+	_, err = b.RemoveStack(context.Background(), stack, false /*force*/, false /*removeBackups*/)
 	require.NoError(t, err)
 }
 

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -332,7 +332,7 @@ func NewDestroyCmd() *cobra.Command {
 						"associated with the stack are still maintained. \nIf you want to remove the stack "+
 						"completely, run `pulumi stack rm %s`.\n", s.Ref())
 				} else if remove {
-					_, err = backend.RemoveStack(ctx, s, false)
+					_, err = backend.RemoveStack(ctx, s, false /*force*/, false /*removeBackups*/)
 					if err != nil {
 						return err
 					}

--- a/pkg/cmd/pulumi/stack/stack_rm.go
+++ b/pkg/cmd/pulumi/stack/stack_rm.go
@@ -42,6 +42,7 @@ func newStackRmCmd() *cobra.Command {
 	var yes bool
 	var force bool
 	var preserveConfig bool
+	var removeBackups bool
 	cmd := &cobra.Command{
 		Use:   "rm [<stack-name>]",
 		Args:  cmdutil.MaximumNArgs(1),
@@ -91,7 +92,7 @@ func newStackRmCmd() *cobra.Command {
 				return result.FprintBailf(os.Stdout, "confirmation declined")
 			}
 
-			hasResources, err := backend.RemoveStack(ctx, s, force)
+			hasResources, err := backend.RemoveStack(ctx, s, force, removeBackups)
 			if err != nil {
 				if hasResources {
 					return fmt.Errorf(
@@ -137,6 +138,9 @@ func newStackRmCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&preserveConfig, "preserve-config", false,
 		"Do not delete the corresponding Pulumi.<stack-name>.yaml configuration file for the stack")
+	cmd.PersistentFlags().BoolVar(
+		&removeBackups, "remove-backups", false,
+		"Additionally remove backups of the stack, if using the DIY backend")
 
 	return cmd
 }

--- a/tests/integration/backend/diy/backend_postgres_test.go
+++ b/tests/integration/backend/diy/backend_postgres_test.go
@@ -388,12 +388,12 @@ func TestPostgresBackend(t *testing.T) {
 	t.Log("Testing stack removal and cleanup")
 
 	// Test stack removal (backend level)
-	removed1, err := b.RemoveStack(ctx, stack1, true)
+	removed1, err := b.RemoveStack(ctx, stack1, true /*force*/, false /*removeBackups*/)
 	require.NoError(t, err, "Failed to remove stack 1")
 	assert.False(t, removed1, "Stack 1 should be removed without confirmation")
 
 	// Test stack removal (stack level)
-	removed2, err := backend.RemoveStack(ctx, stack2, true)
+	removed2, err := backend.RemoveStack(ctx, stack2, true /*force*/, false /*removeBackups*/)
 	require.NoError(t, err, "Failed to remove stack 2")
 	assert.False(t, removed2, "Stack 2 should be removed without confirmation")
 
@@ -472,9 +472,9 @@ func TestPostgresBackendMultipleTables(t *testing.T) {
 	require.Len(t, stacks2, 1)
 
 	// Clean up
-	_, err = backend1.RemoveStack(ctx, stack1, true)
+	_, err = backend1.RemoveStack(ctx, stack1, true /*force*/, false /*removeBackups*/)
 	require.NoError(t, err)
-	_, err = backend2.RemoveStack(ctx, stack2, true)
+	_, err = backend2.RemoveStack(ctx, stack2, true /*force*/, false /*removeBackups*/)
 	require.NoError(t, err)
 }
 
@@ -536,7 +536,7 @@ func TestPostgresBackendConcurrency(t *testing.T) {
 
 	// Clean up all stacks
 	for i := 0; i < numConcurrentOperations; i++ {
-		removed, err := backends[i].RemoveStack(ctx, stacks[i], true)
+		removed, err := backends[i].RemoveStack(ctx, stacks[i], true /*force*/, false /*removeBackups*/)
 		require.NoError(t, err, "Failed to remove stack %d", i)
 		assert.False(t, removed, "Stack %d should be removed without confirmation", i)
 	}


### PR DESCRIPTION
This change adds a new `--remove-backups` flag to the `pulumi stack rm` command. This flag will remove any backups of the stack if using the DIY backend. It is a no-op if using the cloud backend.

Fixes #9474

Question: Assuming we're happy with exposing this via this new flag, do we also want to expose it from Automation API (my default assumption is "yes")?