### PR TITLE
Add lock around depGraph.Alias

### DIFF
--- a/changelog/pending/20250805--engine--fix-panic-in-refreshes-due-to-concurrent-map-writes.yaml
+++ b/changelog/pending/20250805--engine--fix-panic-in-refreshes-due-to-concurrent-map-writes.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix panic in refreshes due to concurrent map writes


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/20194

This code is called in a goroutine, potentially in parallel with other calls. Lock around it to prevent `fatal error: concurrent map writes` errors from happening.