### PR TITLE
Add "list" alias to `pulumi policy ls`

### DIFF
--- a/changelog/pending/20250805--cli-plugin--add-list-alias-to-pulumi-policy-ls.yaml
+++ b/changelog/pending/20250805--cli-plugin--add-list-alias-to-pulumi-policy-ls.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/plugin
+  description: Add "list" alias to `pulumi policy ls`.

--- a/pkg/cmd/pulumi/policy/policy_ls.go
+++ b/pkg/cmd/pulumi/policy/policy_ls.go
@@ -35,10 +35,11 @@ func newPolicyLsCmd() *cobra.Command {
 	var jsonOut bool
 
 	cmd := &cobra.Command{
-		Use:   "ls [org-name]",
-		Args:  cmdutil.MaximumNArgs(1),
-		Short: "List all Policy Packs for a Pulumi organization",
-		Long:  "List all Policy Packs for a Pulumi organization",
+		Use:     "ls [org-name]",
+		Aliases: []string{"list"},
+		Args:    cmdutil.MaximumNArgs(1),
+		Short:   "List all Policy Packs for a Pulumi organization",
+		Long:    "List all Policy Packs for a Pulumi organization",
 		RunE: func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := cmd.Context()
 


### PR DESCRIPTION
While working with policies on my repo, I tried to run `pulumi policy list` and I discover that it was not a valid command. On this PR, I'm aliasing `list` to `ls` to enable using it that way.