### PR TITLE
[chore] Add bun as a .mise.toml dependency.

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -18,6 +18,7 @@ node = "20"
 "npm:typescript" = "latest"
 "npm:typescript-language-server" = "latest"
 "npm:yarn" = "latest"
+bun = "latest"
 python = '3.11'
 uv = "0.6.16"
 "go:github.com/mitranim/gow" = "latest"


### PR DESCRIPTION
While running `make` on the project, some of the tests on `sdk/nodejs/npm/manager_test.go` started failing as `bun` was not installed on my system.

I considered introducing go test tags to gate whether these tests should run or not based on `bun` being present. However, I could not find whether we are using that mechanism for anywhere else. Hence, I decided to simply add the dependency to the latest version of `bun` to `.mise.toml`.