### PR TITLE
Go SDK: Fix running against old CLI versions without SignalAndWaitForShutdown

### DIFF
--- a/changelog/pending/20250805--sdk-go--fix-running-against-old-cli-versions-without-signalandwaitforshutdown.yaml
+++ b/changelog/pending/20250805--sdk-go--fix-running-against-old-cli-versions-without-signalandwaitforshutdown.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fix running against old CLI versions without SignalAndWaitForShutdown

--- a/sdk/go/pulumi/mocks.go
+++ b/sdk/go/pulumi/mocks.go
@@ -57,6 +57,15 @@ type mockResourceMonitorWithRegisterResourceOutput interface {
 	RegisterResourceOutputs() (*emptypb.Empty, error)
 }
 
+// mockResourceMonitorWithSignalAndWaitForShutdown is a mock resource monitor
+// that also implements the SignalAndWaitForShutdown method. A new resource
+// monitor interface is created to avoid needing to implement additional methods
+// for existing implementations of MockResourceMonitor.
+type mockResourceMonitorWithSignalAndWaitForShutdown interface {
+	MockResourceMonitor
+	SignalAndWaitForShutdown() (*emptypb.Empty, error)
+}
+
 func WithMocks(project, stack string, mocks MockResourceMonitor) RunOption {
 	return func(info *RunInfo) {
 		info.Project, info.Stack, info.Mocks = project, stack, mocks
@@ -366,6 +375,10 @@ func (m *mockMonitor) RegisterPackage(ctx context.Context, in *pulumirpc.Registe
 func (m *mockMonitor) SignalAndWaitForShutdown(ctx context.Context, req *emptypb.Empty,
 	opts ...grpc.CallOption,
 ) (*emptypb.Empty, error) {
+	if m, ok := m.mocks.(mockResourceMonitorWithSignalAndWaitForShutdown); ok {
+		return m.SignalAndWaitForShutdown()
+	}
+
 	return &emptypb.Empty{}, nil
 }
 

--- a/sdk/go/pulumi/run.go
+++ b/sdk/go/pulumi/run.go
@@ -104,7 +104,7 @@ func runErrInner(body RunFunc, logError func(*Context, error), opts ...RunOption
 		logError(ctx, err)
 	} else {
 		if _, signalErr := ctx.state.monitor.SignalAndWaitForShutdown(ctx.ctx, &pbempty.Empty{}); signalErr != nil {
-			status, ok := status.FromError(err)
+			status, ok := status.FromError(signalErr)
 			if ok && status.Code() != codes.Unimplemented {
 				// If we are running against an older version of the CLI,
 				// SignalAndWaitForShutdown might not be implemented. This is
@@ -112,7 +112,9 @@ func runErrInner(body RunFunc, logError func(*Context, error), opts ...RunOption
 				// we check if the CLI supports the `resourceHook` feature when
 				// registering hooks, it's fine to ignore the `UNIMPLEMENTED`
 				// error here.
-				return fmt.Errorf("error waiting for shutdown: %v", signalErr)
+				err := fmt.Errorf("error waiting for shutdown: %v", signalErr)
+				logError(ctx, err)
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
In the Go SSDK, a typo caused us to not gracefully handle old CLIs that would return `Unimplemented` for `SignalAndWaitForShutdown`. This lead to operations returning with an error code, but no error being displayed to the user.

Fixes https://github.com/pulumi/pulumi/issues/20198
Fixes https://github.com/pulumi/pulumi/issues/20103
