### PR TITLE
Add "remove backups" option to automation API

### DIFF
--- a/changelog/pending/20250805--auto-go-nodejs-python--add-remove-backups-option-to-remove-stack.yaml
+++ b/changelog/pending/20250805--auto-go-nodejs-python--add-remove-backups-option-to-remove-stack.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go,nodejs,python
+  description: Add "remove backups" option to remove stack

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -620,6 +620,13 @@ func (l *LocalWorkspace) RemoveStack(ctx context.Context, stackName string, opts
 
 	if optRemoveOpts.Force {
 		args = append(args, "--force")
+	}
+	if optRemoveOpts.RemoveBackups {
+		// Pulumi 3.188.0 introduced the `--remove-backups` flag.
+		if l.pulumiCommand.Version().LT(semver.Version{Major: 3, Minor: 188}) {
+			return errors.New("RemoveBackups requires Pulumi CLI version >= 3.188.0")
+		}
+		args = append(args, "--remove-backups")
 	}
 
 	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, args...)

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -245,6 +245,29 @@ func TestRemoveWithForce(t *testing.T) {
 	}
 
 	// to make sure stack was removed
+	err = s.Workspace().SelectStack(ctx, s.Name())
+	assert.ErrorContains(t, err, "no stack named")
+}
+
+func TestRemoveWithRemoveBackups(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	sName := ptesting.RandomStackName()
+	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
+
+	s, err := NewStackInlineSource(ctx, stackName, pName, func(ctx *pulumi.Context) error {
+		return nil
+	})
+	require.NoError(t, err, "failed to initialize stack")
+
+	_, err = s.Up(ctx)
+	require.NoError(t, err, "up failed")
+
+	err = s.Workspace().RemoveStack(ctx, stackName, optremove.RemoveBackups())
+	require.NoError(t, err, "remove stack with remove backups failed")
+
+	// make sure stack was removed
 	err = s.Workspace().SelectStack(ctx, s.Name())
 	assert.ErrorContains(t, err, "no stack named")
 }

--- a/sdk/go/auto/optremove/optremove.go
+++ b/sdk/go/auto/optremove/optremove.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,13 @@ func Force() Option {
 	})
 }
 
+// RemoveBackups indicates whether to remove backups of the stack, if using the DIY backend.
+func RemoveBackups() Option {
+	return optionFunc(func(opts *Options) {
+		opts.RemoveBackups = true
+	})
+}
+
 // Option is a parameter to be applied to a Stack.Remove() operation
 type Option interface {
 	ApplyOption(*Options)
@@ -34,6 +41,9 @@ type Option interface {
 type Options struct {
 	// forces a stack to be deleted
 	Force bool
+
+	// RemoveBackups indicates whether to remove backups of the stack, if using the DIY backend.
+	RemoveBackups bool
 }
 
 type optionFunc func(*Options)

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -562,6 +562,16 @@ export class LocalWorkspace implements Workspace {
 
         if (opts?.preserveConfig) {
             args.push("--preserve-config");
+        }
+
+        if (opts?.removeBackups) {
+            const ver = this._pulumiVersion ?? semver.parse("3.0.0")!;
+            if (ver.compare("3.188.0") < 0) {
+                // Pulumi 3.188.0 introduced the `--remove-backups` flag.
+                // https://github.com/pulumi/pulumi/releases/tag/v3.188.0
+                throw new Error(`removeBackups requires Pulumi version >= 3.188.0`);
+            }
+            args.push("--remove-backups");
         }
 
         args.push(stackName);
@@ -1401,4 +1411,9 @@ export interface RemoveOptions {
      * Do not delete the corresponding Pulumi.<stack-name>.yaml configuration file for the stack
      */
     preserveConfig?: boolean;
+
+    /**
+     * Remove backups of the stack, if using the DIY backend
+     */
+    removeBackups?: boolean;
 }

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -894,6 +894,25 @@ describe("LocalWorkspace", () => {
         assert.rejects(stack.workspace.removeStack(stackName));
 
         await stack.workspace.removeStack(stackName, { force: true });
+
+        // we shouldn't be able to select the stack after it's been removed
+        // we expect this error
+        assert.rejects(stack.workspace.selectStack(stackName));
+    });
+    it(`runs through the stack lifecycle with an inline program, testing removing with removeBackups`, async () => {
+        const program = async () => {
+            return {};
+        };
+        const projectName = "inline_node";
+        const stackName = fullyQualifiedStackName(getTestOrg(), projectName, `int_test${getTestSuffix()}`);
+        const stack = await LocalWorkspace.createStack(
+            { stackName, projectName, program },
+            withTestBackend({}, "inline_node"),
+        );
+
+        await stack.up({ userAgent });
+
+        await stack.workspace.removeStack(stackName, { removeBackups: true });
 
         // we shouldn't be able to select the stack after it's been removed
         // we expect this error

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023, Pulumi Corporation.
+# Copyright 2016-2025, Pulumi Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -460,12 +460,27 @@ class LocalWorkspace(Workspace):
         stack_name: str,
         force: Optional[bool] = None,
         preserve_config: Optional[bool] = None,
+        remove_backups: Optional[bool] = None,
     ) -> None:
         args = ["stack", "rm", "--yes"]
         if force:
             args.append("--force")
         if preserve_config:
             args.append("--preserve-config")
+        if remove_backups:
+            ver = VersionInfo(3)
+            if self.pulumi_command.version is not None:
+                ver = self.pulumi_command.version
+            if ver >= VersionInfo(3, 188):
+                # Pulumi 3.188.0 introduced the `--remove-backups` flag.
+                # https://github.com/pulumi/pulumi/releases/tag/v3.188.0
+                args.append("--remove-backups")
+            else:
+                raise InvalidVersionError(
+                    "The installed version of the CLI does not support remove_backups. Please "
+                    "upgrade to at least version 3.188.0."
+                )
+            args.append("--remove-backups")
         args.append(stack_name)
         self._run_pulumi_cmd_sync(args)
 

--- a/sdk/python/lib/pulumi/automation/_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_workspace.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021, Pulumi Corporation.
+# Copyright 2016-2025, Pulumi Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -414,11 +414,16 @@ class Workspace(ABC):
         stack_name: str,
         force: Optional[bool] = None,
         preserve_config: Optional[bool] = None,
+        remove_backups: Optional[bool] = None,
     ) -> None:
         """
         Deletes the stack and all associated configuration and history.
 
         :param stack_name: The name of the stack to remove
+        :param force: If True, forces deletion of the stack, leaving behind any resources managed by the stack
+        :param preserve_config: If True, do not delete the corresponding Pulumi.<stack-name>.yaml configuration file for
+            the stack
+        :param remove_backups: If True, remove backups of the stack, if using the DIY backend
         """
 
     @abstractmethod

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021, Pulumi Corporation.
+# Copyright 2016-2025, Pulumi Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -968,6 +968,22 @@ class TestLocalWorkspace(unittest.TestCase):
             stack.workspace.remove_stack(stack_name)
 
         stack.workspace.remove_stack(stack_name, force=True)
+
+        # we shouldn't be able to select the stack after it's been removed
+        # we expect this error
+        with self.assertRaises(StackNotFoundError):
+            stack.workspace.select_stack(stack_name)
+
+    def test_stack_remove_with_remove_backups(self):
+        project_name = "inline_python"
+        stack_name = stack_namer(project_name)
+        stack = create_stack(
+            stack_name, program=pulumi_program, project_name=project_name
+        )
+
+        stack.up()
+
+        stack.workspace.remove_stack(stack_name, remove_backups=True)
 
         # we shouldn't be able to select the stack after it's been removed
         # we expect this error


### PR DESCRIPTION
This change exposes the `pulumi stack rm --remove-backups` flag in Go, Node.js, and Python automation APIs.

Part of #9474
Follow-up of #20203