### PR TITLE
Fix dependency installation in uv workspaces

### DIFF
--- a/changelog/pending/20250806--sdk-python--fix-dependency-installation-in-uv-workspaces.yaml
+++ b/changelog/pending/20250806--sdk-python--fix-dependency-installation-in-uv-workspaces.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix dependency installation in uv workspaces

--- a/sdk/python/toolchain/uv.go
+++ b/sdk/python/toolchain/uv.go
@@ -278,7 +278,9 @@ func (u *uv) Command(ctx context.Context, args ...string) (*exec.Cmd, error) {
 		}
 	}
 	if pyprojectTomlDir != "" {
-		venvCmd := u.uvCommand(ctx, u.root, false, nil, nil, "sync")
+		// uv run does an "inexact" sync, that is it leaves extraneous
+		// dependencies alone and does not remove them.
+		venvCmd := u.uvCommand(ctx, u.root, false, nil, nil, "sync", "--inexact")
 		if err := venvCmd.Run(); err != nil {
 			return nil, errutil.ErrorWithStderr(err, "error creating virtual environment")
 		}

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -438,7 +438,7 @@ func TestUv(t *testing.T) {
 		{
 			template:     "uv-workspace",
 			cwd:          "infra/projects/some-project",
-			expectedVenv: "infra/.venv", // The virtualenv is relative to workspace root'spyproject.toml
+			expectedVenv: "infra/.venv", // The virtualenv is relative to workspace root's pyproject.toml
 			prepareProject: func(e *ptesting.Environment) error {
 				oldCWD := e.CWD
 				e.CWD = filepath.Join(e.RootPath, "infra")

--- a/tests/integration/python/uv-workspace/infra/projects/some-project/Pulumi.yaml
+++ b/tests/integration/python/uv-workspace/infra/projects/some-project/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: some-project
+description: A Python project inside a uv workspace
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/python/uv-workspace/infra/projects/some-project/__main__.py
+++ b/tests/integration/python/uv-workspace/infra/projects/some-project/__main__.py
@@ -1,0 +1,6 @@
+# Copyright 2025, Pulumi Corporation.  All rights reserved.
+
+import pulumi
+import some_package
+
+pulumi.export("foo", some_package.double(3))

--- a/tests/integration/python/uv-workspace/infra/projects/some-project/pyproject.toml
+++ b/tests/integration/python/uv-workspace/infra/projects/some-project/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "some-project"
+version = "0.1.0"
+description = "A Python project inside a uv workspace"
+requires-python = ">=3.9"
+dependencies = []

--- a/tests/integration/python/uv-workspace/infra/pyproject.toml
+++ b/tests/integration/python/uv-workspace/infra/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "infra-workspace"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = ["some-package", "pulumi"]
+
+[tool.uv.workspace]
+members = ["projects/*"]
+
+[tool.uv.sources]
+# Reference an external project, this should be available in our Pulumi programs
+some-package = { path = "../packages/some-package", editable = true }

--- a/tests/integration/python/uv-workspace/packages/some-package/pyproject.toml
+++ b/tests/integration/python/uv-workspace/packages/some-package/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "some-package"
+version = "0.1.0"
+description = "A Python package"
+requires-python = ">=3.9"
+dependencies = []
+
+[build-system]
+requires = ["uv_build>=0.8.5,<0.9.0"]
+build-backend = "uv_build"

--- a/tests/integration/python/uv-workspace/packages/some-package/src/some_package/__init__.py
+++ b/tests/integration/python/uv-workspace/packages/some-package/src/some_package/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2025, Pulumi Corporation.  All rights reserved.
+
+
+def double(a: int) -> int:
+    return a * 2


### PR DESCRIPTION
Since https://github.com/pulumi/pulumi/pull/20117 we run `uv sync` for any Python command to get closer to the behaviour of  `uv run python`. However `uv run` does an inexact sync by deafult, so we need to run with the `--inexact` flag.

This could lead to dependencies being removed from the virtualenv if they were assumed to be implicitly available via the workspace.

Fixes https://github.com/pulumi/pulumi/issues/20185
