### PR TITLE
Fix `make` for Node.js

### DIFF
--- a/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
@@ -35,6 +35,11 @@ describe("Analyzer", function () {
         execa.sync("yarn", ["link", "@pulumi/pulumi", "--no-default-rc", "--non-interactive"], { cwd: dir });
     });
 
+    after(() => {
+        const dir = path.join(__dirname, "testdata");
+        execa.sync("yarn", ["unlink", "@pulumi/pulumi", "--no-default-rc", "--non-interactive"], { cwd: dir });
+    });
+
     it("infers simple types", async function () {
         const dir = path.join(__dirname, "testdata", "simple-types");
         const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));

--- a/sdk/nodejs/tests/provider/experimental/testdata/package.json
+++ b/sdk/nodejs/tests/provider/experimental/testdata/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "testdata",
+    "version": "1.0.0",
+    "description": "testadata is a Node.js package so we can `yarn link` @pulumi/pulumi into it.",
+    "peerDependencies": {
+        "@pulumi/pulumi": "*"
+    }
+}


### PR DESCRIPTION
When running `make` multiple times in `sdks/nodejs`, we’d end up with an error when coping the compiled TS files to `$PULUMI_HOME/node_modules/@pulumi/pulumi` because we had `yarn link`ed the package within itself.