### PR TITLE
Fix concurrent read/write during plugin downloads

### DIFF
--- a/changelog/pending/20250806--cli--fix-concurrent-read-write-during-plugin-downloads.yaml
+++ b/changelog/pending/20250806--cli--fix-concurrent-read-write-during-plugin-downloads.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix concurrent read/write during plugin downloads

--- a/pkg/backend/display/tree.go
+++ b/pkg/backend/display/tree.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
-	"golang.org/x/exp/maps"
 )
 
 type treeRenderer struct {
@@ -195,17 +194,23 @@ func (r *treeRenderer) render(termWidth int) {
 		r.systemMessages = append(r.systemMessages, splitIntoDisplayableLines(msg)...)
 	}
 
-	if len(r.systemMessages) == 0 && len(r.display.progressEventPayloads) > 0 {
+	keys := []string{}
+	if r.display.progressEventPayloads != nil {
+		r.display.progressEventPayloads.Range(func(key string, value engine.ProgressEventPayload) bool {
+			keys = append(keys, key)
+			return true
+		})
+	}
+	if len(r.systemMessages) == 0 && len(keys) > 0 {
 		// If we don't have system messages, but we do have progress events, show
 		// the progress. For the most part, we shouldn't have both at the same time,
 		// since the most common system messages refer to cancellation/SIGINT
 		// handling, at which point the program will be terminating. That said, if
 		// we do, we'll give the system messages priority.
-		keys := maps.Keys(r.display.progressEventPayloads)
 		slices.Sort(keys)
 
 		for _, key := range keys {
-			payload := r.display.progressEventPayloads[key]
+			payload, _ := r.display.progressEventPayloads.Load(key)
 			r.systemMessages = append(r.systemMessages, renderProgress(
 				renderUnicodeProgressBar,
 				termWidth-4,


### PR DESCRIPTION
It’s possible that we insert a new progressEventPayload while iterating over the map, oops.

Fixes https://github.com/pulumi/pulumi/issues/20213
