### PR TITLE
Restore terminal mode on panic

### DIFF
--- a/changelog/pending/20250806--cli--restore-terminal-mode-on-panic.yaml
+++ b/changelog/pending/20250806--cli--restore-terminal-mode-on-panic.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Restore terminal mode on panic

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -271,7 +271,11 @@ func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.Stack
 		opStopwatch:           newOpStopwatch(),
 		permalink:             permalink,
 	}
-	defer contract.IgnoreClose(display.renderer)
+	defer func() {
+		contract.IgnoreClose(display.renderer)
+		// let our caller know we're done.
+		close(done)
+	}()
 	renderer.initializeDisplay(display)
 
 	ticker := time.NewTicker(1 * time.Second)
@@ -280,9 +284,6 @@ func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.Stack
 	}
 	display.processEvents(ticker, events)
 	ticker.Stop()
-
-	// let our caller know we're done.
-	close(done)
 }
 
 // RenderProgressEvents renders the engine events as if to a terminal, providing a simple interface

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -271,6 +271,7 @@ func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.Stack
 		opStopwatch:           newOpStopwatch(),
 		permalink:             permalink,
 	}
+	defer contract.IgnoreClose(display.renderer)
 	renderer.initializeDisplay(display)
 
 	ticker := time.NewTicker(1 * time.Second)
@@ -278,7 +279,6 @@ func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.Stack
 		ticker.Stop()
 	}
 	display.processEvents(ticker, events)
-	contract.IgnoreClose(display.renderer)
 	ticker.Stop()
 
 	// let our caller know we're done.


### PR DESCRIPTION
Pulumi sets the terminal to raw mode, and on exit restores the terminal to its previous state. However when we crash due to a panic, we don’t restore the state.

By deferring the `Close` call, we’ll call the terminal’s `Close` method when we panic.

This only works if the panic comes from the same goroutine as the display code. If we panic in another goroutine, we won’t call the deferred method, and we still won't restore the state.
