### PR TITLE
Add `json` option to preview in Python `pulumi.automation`.

### DIFF
--- a/changelog/pending/20250807--auto-python--add-json-option-to-preview-in-python-pulumi-automation-add-flag-to-obtain-json-output-when-running-preview-using-python-automation-bindings.yaml
+++ b/changelog/pending/20250807--auto-python--add-json-option-to-preview-in-python-pulumi-automation-add-flag-to-obtain-json-output-when-running-preview-using-python-automation-bindings.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/python
+  description: Surface `json` option to `pulumi preview` calls in Python when using the `pulumi.automation` package.

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -436,6 +436,7 @@ class Stack:
         refresh: Optional[bool] = None,
         config_file: Optional[str] = None,
         run_program: Optional[bool] = None,
+        json: Optional[bool] = None,
     ) -> PreviewResult:
         """
         Performs a dry-run update to a stack, returning pending changes.
@@ -470,6 +471,7 @@ class Stack:
         :param attach_debugger: Run the process under a debugger, and pause until a debugger is attached
         :param refresh: Refresh the state of the stack's resources against the cloud provider before running preview.
         :param config_file: Path to a Pulumi config file to use for this update.
+        :param json: Output the preview in JSON format.
         :returns: PreviewResult
         """
         program = program or self.workspace.program
@@ -521,6 +523,9 @@ class Stack:
         log_file, temp_dir = _create_log_file("preview")
         args.extend(["--event-log", log_file])
         summary_events: List[SummaryEvent] = []
+
+        if json:
+            args.extend(["--json"])
 
         def on_event_callback(event: EngineEvent) -> None:
             if event.summary_event:

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -953,6 +953,27 @@ class TestLocalWorkspace(unittest.TestCase):
         finally:
             stack.workspace.remove_stack(stack_name)
 
+    def test_preview_with_json(self):
+        project_name = "inline_python"
+        stack_name = stack_namer(project_name)
+        stack = create_or_select_stack(
+            stack_name, program=pulumi_program_with_resource, project_name=project_name
+        )
+        
+        try:
+            # pulumi up
+            stack.up()
+            
+            # pulumi preview
+            preview_res = stack.preview(json=True)
+
+            result = json.loads(preview_res.stdout)
+
+            # Check that the JSON output could be parsed.
+            assert result is not None
+        finally:
+            stack.workspace.remove_stack(stack_name)
+
     def test_stack_lifecycle_inline_program_remove_without_destroy(self):
         project_name = "inline_python"
         stack_name = stack_namer(project_name)

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -971,6 +971,11 @@ class TestLocalWorkspace(unittest.TestCase):
 
             # Check that the JSON output could be parsed.
             assert result is not None
+
+            # pulumi destroy to clean up
+            destroy_res = stack.destroy()
+            self.assertEqual(destroy_res.summary.kind, "destroy")
+            self.assertEqual(destroy_res.summary.result, "succeeded")
         finally:
             stack.workspace.remove_stack(stack_name)
 

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -959,11 +959,11 @@ class TestLocalWorkspace(unittest.TestCase):
         stack = create_or_select_stack(
             stack_name, program=pulumi_program_with_resource, project_name=project_name
         )
-        
+
         try:
             # pulumi up
             stack.up()
-            
+
             # pulumi preview
             preview_res = stack.preview(json=True)
 


### PR DESCRIPTION
Add flag to obtain JSON output when running preview using Python automation bindings.