### PR TITLE
Don’t create empty maps for language specific overrides

### DIFF
--- a/changelog/pending/20250807--sdkgen--dont-create-empty-maps-for-language-specific-overrides.yaml
+++ b/changelog/pending/20250807--sdkgen--dont-create-empty-maps-for-language-specific-overrides.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdkgen
+  description: Don’t create empty maps for language specific overrides

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -2092,7 +2092,6 @@ func TestFunctionToFunctionSpecTurnaround(t *testing.T) {
 				Token:            "token",
 				ReturnType:       IntType,
 				ReturnTypePlain:  true,
-				Language:         map[string]interface{}{},
 			},
 			fspec: FunctionSpec{
 				ReturnType: &ReturnTypeSpec{


### PR DESCRIPTION
When dealing with very large schemas, such as AWS, the memory usage for these empty map objects adds up.

To test this, I ran the following command (in a Python project) 3 times:

```
/usr/bin/time -l pulumi package add --profiling ./prof/trim-props https://github.com/pulumi-pequod/component-microservice@v1.0.1
```

This provider has a component with outputs that are types from AWS and AWSX.

With the current master branch:

| Max Mem [GB] | Duration [s] |
|--------------|--------------|
| 17.2         | 84           |
| 17.1         | 80           |
| 17.5         | 82           |

With this PR:

| Max Mem [GB] | Duration [s] |
|--------------|--------------|
| 15.6         | 80           |
| 14.9        | 79           |
| 15.5        | 78           |
