### PR TITLE
Calculate PluginInfo.Size on demand

### DIFF
--- a/changelog/pending/20250808--sdk-go--calculate-plugininfo-size-on-demand.yaml
+++ b/changelog/pending/20250808--sdk-go--calculate-plugininfo-size-on-demand.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Calculate PluginInfo.Size on demand

--- a/pkg/cmd/pulumi/plugin/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin/plugin_ls.go
@@ -110,7 +110,7 @@ func formatPluginsJSON(plugins []workspace.PluginInfo) error {
 			Name:    plugin.Name,
 			Kind:    string(plugin.Kind),
 			Version: version,
-			Size:    plugin.Size,
+			Size:    plugin.Size(),
 		}
 
 		if !plugin.InstallTime.IsZero() {
@@ -136,10 +136,10 @@ func formatPluginConsole(plugins []workspace.PluginInfo) error {
 			version = plugin.Version.String()
 		}
 		var bytes string
-		if plugin.Size == 0 {
+		if plugin.Size() == 0 {
 			bytes = naString
 		} else {
-			bytes = humanize.Bytes(plugin.Size)
+			bytes = humanize.Bytes(plugin.Size())
 		}
 		var installTime string
 		if plugin.InstallTime.IsZero() {
@@ -158,7 +158,7 @@ func formatPluginConsole(plugins []workspace.PluginInfo) error {
 			Columns: []string{plugin.Name, string(plugin.Kind), version, bytes, installTime, lastUsedTime},
 		})
 
-		totalSize += plugin.Size
+		totalSize += plugin.Size()
 	}
 
 	ui.PrintTable(cmdutil.Table{

--- a/sdk/go/auto/example_test.go
+++ b/sdk/go/auto/example_test.go
@@ -425,7 +425,7 @@ func ExampleLocalWorkspace_ListPlugins() {
 	// create a workspace from a local project
 	w, _ := NewLocalWorkspace(ctx, WorkDir(filepath.Join(".", "program")))
 	ps, _ := w.ListPlugins(ctx)
-	fmt.Println(ps[0].Size)
+	fmt.Println(ps[0].Size())
 }
 
 func ExampleLocalWorkspace_ListStacks() {

--- a/sdk/go/common/workspace/plugins_install_test.go
+++ b/sdk/go/common/workspace/plugins_install_test.go
@@ -116,8 +116,7 @@ func assertPluginInstalled(t *testing.T, dir string, plugin PluginSpec) PluginIn
 	require.NoError(t, err)
 	assert.True(t, has)
 
-	skipMetadata := true
-	plugins, err := getPlugins(dir, skipMetadata)
+	plugins, err := getPlugins(dir)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(plugins))
 	assert.Equal(t, plugin.Name, plugins[0].Name)
@@ -313,8 +312,7 @@ func TestGetPluginsSkipsPartial(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, has)
 
-	skipMetadata := true
-	plugins, err := getPlugins(dir, skipMetadata)
+	plugins, err := getPlugins(dir)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(plugins))
 }

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1744,7 +1744,7 @@ func TestPluginInfoShimless(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, pluginPath, info.Path)
-	assert.Equal(t, uint64(23), info.Size)
+	assert.Equal(t, uint64(23), info.Size())
 	assert.Equal(t, stat.ModTime(), info.InstallTime)
 	assert.Equal(t, stat.ModTime(), info.SchemaTime)
 	// schemaPaths are odd, they're one directory up from the plugin directory

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1879,3 +1879,22 @@ func TestRunningViaCLIWrapper(t *testing.T) {
 			" Output so far: %s", timeout.String(), output.String())
 	}
 }
+
+func TestPluginLs(t *testing.T) {
+	t.Parallel()
+	e := ptesting.NewEnvironment(t)
+	e.Env = append(e.Env, "PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=false")
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.RunCommand("pulumi", "plugin", "install", "resource", "random")
+
+	stdout, _ := e.RunCommand("pulumi", "plugin", "ls", "--json")
+	plugins := []map[string]any{}
+	err := json.Unmarshal([]byte(stdout), &plugins)
+
+	require.NoError(t, err)
+	require.Len(t, plugins, 1)
+	random := plugins[0]
+	require.Equal(t, "random", random["name"].(string))
+	require.Equal(t, "resource", random["kind"].(string))
+	require.Greater(t, random["size"].(float64), 0.0)
+}


### PR DESCRIPTION
This can be somewhat slow for when there’s for example large node_modules folders in the plugins. In practice we never care about the size, except when displaying it in `pulumi plugin ls`.

This is a breaking API change in `sdk/go/common`. I checked https://github.com/pulumi/pulumi-terraform-bridge and it compiles fine with this change, it never uses `PluginInfo.Size`.
