### PR TITLE
Fix race when reading plugin stdout

### DIFF
--- a/changelog/pending/20250808--engine--fix-race-when-reading-plugin-stdout.yaml
+++ b/changelog/pending/20250808--engine--fix-race-when-reading-plugin-stdout.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix race when reading plugin stdout


### PR DESCRIPTION
When running a binary plugin we use `cmd.Stdout/StderrPipe` to get the output from the binary. These pipes have internal goroutines that copy the data around, and when the process exits, the pipes are closed. An important caveat when using these pipes is that you must read all the data from the pipe before `cmd.Wait()` is called, otherwise you will miss data.

From the documentation https://pkg.go.dev/os/exec#Cmd.StdoutPipe:

> It is thus incorrect to call Wait before all reads from the pipe have completed

However, ExecPlugin returns an already started plugin and runs a goroutine that waits for the plugin to exit:

```go
	go func() {
		err := cmd.Wait()
		if err != nil {
			wait.Reject(err)
		} else {
			wait.Fulfill(struct{}{})
		}
	}()
```

If a plugin exits very quickly, this can lead to us trying to read from an already closed pipe.

This happens in the test `TestNonZeroExitcode`, where we see an error:

```
Error "could not read plugin [/tmp/TestNonZeroExitcode36998759/001/test-plugin-exit]: read |0: file already closed" does not contain "test-plugin-exit]: exit status 1"
```

We can fix this by using `io.Pipe`. These pipes are synchronous and writes from the plugin while block until we set up a reader.

Fixes https://github.com/pulumi/pulumi/issues/20240
