### PR TITLE
Fix swapped stderr/stdout comments in PreviewOptions interface

### DIFF
--- a/changelog/pending/20250810--sdk-nodejs--fix-swapped-stderr-stdout-callback-comments-in-previewoptions-interface.yaml
+++ b/changelog/pending/20250810--sdk-nodejs--fix-swapped-stderr-stdout-callback-comments-in-previewoptions-interface.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/nodejs
+  description: Fix swapped stderr/stdout callback comments in PreviewOptions interface

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -1749,12 +1749,12 @@ export interface PreviewOptions extends GlobalOpts {
     program?: PulumiFn;
 
     /**
-     * A callback to be executed when the operation produces stderr output.
+     * A callback to be executed when the operation produces stdout output.
      */
     onOutput?: (out: string) => void;
 
     /**
-     * A callback to be executed when the operation produces stdout output.
+     * A callback to be executed when the operation produces stderr output.
      */
     onError?: (err: string) => void;
 


### PR DESCRIPTION
Fixes #20246

This PR corrects the swapped documentation comments for `onOutput` and `onError` callbacks in the `PreviewOptions` interface.