### PR TITLE
Fix component providers when using pnpm

### DIFF
--- a/changelog/pending/20250811--sdk-nodejs--fix-component-providers-when-using-pnpm.yaml
+++ b/changelog/pending/20250811--sdk-nodejs--fix-component-providers-when-using-pnpm.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix component providers when using pnpm

--- a/sdk/nodejs/provider/experimental/analyzer.ts
+++ b/sdk/nodejs/provider/experimental/analyzer.ts
@@ -699,8 +699,12 @@ Please ensure these components are properly imported to your package's entry poi
         // Extract the package name and pulumi type from the __pulumiType property.
         const packageName = pulumiType.split(":")[0];
 
-        // Extract package name from the path.
-        const packageMatch = implPath.match(/node_modules\/((@[^/]+\/)?[^/]+)/);
+        // Extract package name from the path. There might be multiple levels of
+        // `node_modules`, we want the right most one.
+        // The optional non-capturing group `(?:.*\/node_modules\/)?` will
+        // greedily match anything until `node_modules`, leaving anything after
+        // that for us to grab.
+        const packageMatch = implPath.match(/node_modules\/(?:.*\/node_modules\/)?((@[^/]+\/)?[^/]+)/);
         if (!packageMatch || packageMatch.length < 2) {
             throw new Error(
                 `Cannot determine resource type: package name not found for '${symbol.name}' for ${this.formatErrorContext(context)}`,

--- a/tests/integration/component_provider/nodejs/component-provider-host/nodejs-npm/Pulumi.yaml
+++ b/tests/integration/component_provider/nodejs/component-provider-host/nodejs-npm/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: nodejs-component-provider-pnpm
+description: Using a component provider written in TypeScript from TypeScript, using npm as package manager
+runtime:
+  name: nodejs
+  options:
+    packagemanager: npm

--- a/tests/integration/component_provider/nodejs/component-provider-host/nodejs-npm/index.ts
+++ b/tests/integration/component_provider/nodejs/component-provider-host/nodejs-npm/index.ts
@@ -1,0 +1,32 @@
+// Copyright 2025-2025, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as provider from "@pulumi/nodejs-component-provider";
+// TODO: https://github.com/pulumi/pulumi/issues/20252
+// For the resource reference to `random.RandomPet` to work, we need to ensure
+// the `@pulumi/random` package is imported. As a side effect of the import, we
+// call `registerResourceModule`, which is needed for the deserialization code
+// to lookup the constructor for given URN.
+import * as random from "@pulumi/random"
+import * as assert from "node:assert";
+assert(random);
+
+let comp = new provider.MyComponent("comp", {
+    aNumber: 123,
+    anOptionalString: "Bonnie",
+    aBooleanInput: pulumi.Output.create(true),
+    aComplexTypeInput: {
+        aNumber: 7,
+        nestedComplexType: {
+            aNumber: 9,
+        }
+    }
+})
+
+export const urn = comp.urn;
+export const aNumberOutput = comp.aNumberOutput;
+export const anOptionalStringOutput = comp.anOptionalStringOutput;
+export const aBooleanOutput = comp.aBooleanOutput;
+export const aComplexTypeOutput = comp.aComplexTypeOutput;
+export const aResourceOutputUrn = comp.aResourceOutput.urn;
+export const aString = comp.aString;

--- a/tests/integration/component_provider/nodejs/component-provider-host/nodejs-npm/package.json
+++ b/tests/integration/component_provider/nodejs/component-provider-host/nodejs-npm/package.json
@@ -1,0 +1,11 @@
+{
+    "main": "index.ts",
+    "dependencies": {
+        "@pulumi/pulumi": "latest"
+    },
+    "devDependencies": {
+        "@types/node": "^18",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.0"
+    }
+}

--- a/tests/integration/component_provider/nodejs/component-provider-host/nodejs-npm/tsconfig.json
+++ b/tests/integration/component_provider/nodejs/component-provider-host/nodejs-npm/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/integration/component_provider/nodejs/component-provider-host/nodejs-pnpm/Pulumi.yaml
+++ b/tests/integration/component_provider/nodejs/component-provider-host/nodejs-pnpm/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: nodejs-component-provider-pnpm
+description: Using a component provider written in TypeScript from TypeScript, using pnpm as package manager
+runtime:
+  name: nodejs
+  options:
+    packagemanager: pnpm

--- a/tests/integration/component_provider/nodejs/component-provider-host/nodejs-pnpm/index.ts
+++ b/tests/integration/component_provider/nodejs/component-provider-host/nodejs-pnpm/index.ts
@@ -1,0 +1,32 @@
+// Copyright 2025-2025, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as provider from "@pulumi/nodejs-component-provider";
+// TODO: https://github.com/pulumi/pulumi/issues/20252
+// For the resource reference to `random.RandomPet` to work, we need to ensure
+// the `@pulumi/random` package is imported. As a side effect of the import, we
+// call `registerResourceModule`, which is needed for the deserialization code
+// to lookup the constructor for given URN.
+import * as random from "@pulumi/random"
+import * as assert from "node:assert";
+assert(random);
+
+let comp = new provider.MyComponent("comp", {
+    aNumber: 123,
+    anOptionalString: "Bonnie",
+    aBooleanInput: pulumi.Output.create(true),
+    aComplexTypeInput: {
+        aNumber: 7,
+        nestedComplexType: {
+            aNumber: 9,
+        }
+    }
+})
+
+export const urn = comp.urn;
+export const aNumberOutput = comp.aNumberOutput;
+export const anOptionalStringOutput = comp.anOptionalStringOutput;
+export const aBooleanOutput = comp.aBooleanOutput;
+export const aComplexTypeOutput = comp.aComplexTypeOutput;
+export const aResourceOutputUrn = comp.aResourceOutput.urn;
+export const aString = comp.aString;

--- a/tests/integration/component_provider/nodejs/component-provider-host/nodejs-pnpm/package.json
+++ b/tests/integration/component_provider/nodejs/component-provider-host/nodejs-pnpm/package.json
@@ -1,0 +1,12 @@
+{
+    "main": "index.ts",
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/random": "latest"
+    },
+    "devDependencies": {
+        "@types/node": "^18",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.0"
+    }
+}

--- a/tests/integration/component_provider/nodejs/component-provider-host/nodejs-pnpm/tsconfig.json
+++ b/tests/integration/component_provider/nodejs/component-provider-host/nodejs-pnpm/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/integration/component_provider/nodejs/component-provider-host/python/Pulumi.yaml
+++ b/tests/integration/component_provider/nodejs/component-provider-host/python/Pulumi.yaml
@@ -5,5 +5,3 @@ runtime:
   options:
     toolchain: pip
     virtualenv: venv
-packages:
-  provider: ../provider

--- a/tests/integration/component_provider/nodejs/component-provider-host/python/requirements.txt
+++ b/tests/integration/component_provider/nodejs/component-provider-host/python/requirements.txt
@@ -1,1 +1,0 @@
-sdks/nodejs-component-provider

--- a/tests/integration/component_provider/nodejs/component-provider-host/yaml/Pulumi.yaml
+++ b/tests/integration/component_provider/nodejs/component-provider-host/yaml/Pulumi.yaml
@@ -1,8 +1,6 @@
 name: nodejs-component-provider-yaml
 description: Using a component provider written in Node.js from YAML
 runtime: yaml
-packages:
-  provider: ../provider
 resources:
   comp:
     type: nodejs-component-provider:index:MyComponent

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2944,7 +2944,7 @@ func TestNodejsComponentProviderGetSchema(t *testing.T) {
 
 // Tests that we can run a Node.js component provider using component_provider_host
 func TestNodejsComponentProviderRun(t *testing.T) {
-	for _, runtime := range []string{"yaml", "python"} {
+	for _, runtime := range []string{"yaml", "python", "nodejs-pnpm", "nodejs-npm"} {
 		t.Run(runtime, func(t *testing.T) {
 			// This uses the random plugin so needs to be able to download it
 			t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
@@ -2954,6 +2954,14 @@ func TestNodejsComponentProviderRun(t *testing.T) {
 				PrepareProject: func(info *engine.Projinfo) error {
 					providerPath := filepath.Join(info.Root, "..", "provider")
 					installNodejsProviderDependencies(t, providerPath)
+
+					if runtime != "yaml" {
+						cmd := exec.Command("pulumi", "install")
+						cmd.Dir = info.Root
+						out, err := cmd.CombinedOutput()
+						require.NoError(t, err, "%s failed with: %s", cmd.String(), string(out))
+					}
+
 					cmd := exec.Command("pulumi", "package", "add", providerPath)
 					cmd.Dir = info.Root
 					out, err := cmd.CombinedOutput()


### PR DESCRIPTION
During schema analysis, we need to determine the package name for resource references. To do this, we look at the import path for a given module, and attempt to extract the name from there. The regex assumed the simple case of `node_modules/@org/name` or `node_modules/name`, but `node_modules` can be nested. The right most package name is the one we’re looking for.

Once that was fixed, we ran into a 2nd issue. pnpm will not run postinstall scripts by default, so `pulumi package add ...` would not compile the generated TypeScript to JavaScript. Using the `--allow-build <package>` fixes this.

Fixes https://github.com/pulumi/pulumi/issues/20244
