### PR TITLE
Don't prompt for ai or template when passing --yes

### DIFF
--- a/changelog/pending/20250811--cli-new--dont-prompt-for-ai-or-template-when-passing-yes.yaml
+++ b/changelog/pending/20250811--cli-new--dont-prompt-for-ai-or-template-when-passing-yes.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Don't prompt for ai or template when passing --yes

--- a/pkg/cmd/pulumi/newcmd/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_acceptance_test.go
@@ -240,6 +240,47 @@ func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 	assert.Equal(t, backendURL, b.URL())
 }
 
+//nolint:paralleltest // changes directory for process
+func TestRunNewYesNoTemplate(t *testing.T) {
+	tempdir := tempProjectDir(t)
+	chdir(t, tempdir)
+
+	args := newArgs{
+		yes:               true,
+		interactive:       false,
+		templateNameOrURL: "", // empty
+		prompt:            ui.PromptForValue,
+		chooseTemplate:    ChooseTemplate,
+		secretsProvider:   "default",
+		stack:             stackName,
+		generateOnly:      true,
+	}
+
+	err := runNew(context.Background(), args)
+	require.ErrorContains(t, err, "template or url is required when running in non-interactive mode")
+}
+
+//nolint:paralleltest // changes directory for process
+func TestRunNewYesWithTemplate(t *testing.T) {
+	tempdir := tempProjectDir(t)
+	chdir(t, tempdir)
+
+	args := newArgs{
+		yes:               true,
+		interactive:       false,
+		templateNameOrURL: "yaml",
+		prompt:            ui.PromptForValue,
+		secretsProvider:   "default",
+		stack:             stackName,
+		generateOnly:      true,
+	}
+
+	err := runNew(context.Background(), args)
+	require.NoError(t, err)
+	proj := loadProject(t, args.dir)
+	require.Equal(t, "yaml", proj.Runtime.Name())
+}
+
 const (
 	projectName = "test_project"
 	stackName   = "test_stack"

--- a/pkg/cmd/pulumi/newcmd/new_ai.go
+++ b/pkg/cmd/pulumi/newcmd/new_ai.go
@@ -48,7 +48,9 @@ func shouldPromptForAIOrTemplate(args newArgs, userBackend backend.Backend) bool
 	return args.aiPrompt == "" &&
 		args.aiLanguage == "" &&
 		!args.templateMode &&
-		isHTTPBackend
+		isHTTPBackend &&
+		!args.yes &&
+		args.interactive
 }
 
 // Iteratively prompt the user for input, sending their input as a prompt tp Pulumi AI

--- a/pkg/cmd/pulumi/newcmd/new_ai.go
+++ b/pkg/cmd/pulumi/newcmd/new_ai.go
@@ -49,8 +49,7 @@ func shouldPromptForAIOrTemplate(args newArgs, userBackend backend.Backend) bool
 		args.aiLanguage == "" &&
 		!args.templateMode &&
 		isHTTPBackend &&
-		!args.yes &&
-		args.interactive
+		!args.yes
 }
 
 // Iteratively prompt the user for input, sending their input as a prompt tp Pulumi AI

--- a/pkg/cmd/pulumi/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_test.go
@@ -1158,3 +1158,29 @@ func assertTemplateContains(t *testing.T, actual, expected string) {
 		assert.Contains(t, actualP, e)
 	}
 }
+
+//nolint:paralleltest // changes directory for process, mocks backendInstance
+func TestNoPromptWithYesAndNonInteractive(t *testing.T) {
+	args := newArgs{
+		interactive: false,
+		yes:         true,
+	}
+
+	// Mock backend
+	mockBackend := &backend.MockBackend{
+		SupportsTemplatesF: func() bool { return false },
+		NameF:              func() string { return "mock" },
+	}
+
+	// Verify that deriveAIOrTemplate returns "template" without prompting
+	result := deriveAIOrTemplate(args)
+	if result != "template" {
+		t.Errorf("Expected deriveAIOrTemplate to return 'template' with --yes and --non-interactive, got %s", result)
+	}
+
+	// Verify that shouldPromptForAIOrTemplate returns false
+	shouldPrompt := shouldPromptForAIOrTemplate(args, mockBackend)
+	if shouldPrompt {
+		t.Error("Expected shouldPromptForAIOrTemplate to return false with --yes and --non-interactive")
+	}
+}

--- a/pkg/cmd/pulumi/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_test.go
@@ -453,7 +453,7 @@ func TestInvalidTemplateName(t *testing.T) {
 		}
 
 		err := runNew(context.Background(), args)
-		assert.ErrorContains(t, err, "no template selected")
+		assert.ErrorContains(t, err, "template or url is required when running in non-interactive mode")
 	})
 
 	t.Run("RemoteTemplateNotFound", func(t *testing.T) {

--- a/pkg/cmd/pulumi/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_test.go
@@ -1159,28 +1159,21 @@ func assertTemplateContains(t *testing.T, actual, expected string) {
 	}
 }
 
-//nolint:paralleltest // changes directory for process, mocks backendInstance
-func TestNoPromptWithYesAndNonInteractive(t *testing.T) {
-	args := newArgs{
-		interactive: false,
-		yes:         true,
-	}
+//nolint:paralleltest // mocks backendInstance
+func TestNoPromptWithYes(t *testing.T) {
+	for _, interactive := range []bool{true, false} {
+		t.Run(fmt.Sprintf("interactive=%t", interactive), func(t *testing.T) {
+			args := newArgs{
+				interactive: interactive,
+				yes:         true,
+			}
 
-	// Mock backend
-	mockBackend := &backend.MockBackend{
-		SupportsTemplatesF: func() bool { return false },
-		NameF:              func() string { return "mock" },
-	}
+			mockBackend := &backend.MockBackend{
+				SupportsTemplatesF: func() bool { return false },
+				NameF:              func() string { return "mock" },
+			}
 
-	// Verify that deriveAIOrTemplate returns "template" without prompting
-	result := deriveAIOrTemplate(args)
-	if result != "template" {
-		t.Errorf("Expected deriveAIOrTemplate to return 'template' with --yes and --non-interactive, got %s", result)
-	}
-
-	// Verify that shouldPromptForAIOrTemplate returns false
-	shouldPrompt := shouldPromptForAIOrTemplate(args, mockBackend)
-	if shouldPrompt {
-		t.Error("Expected shouldPromptForAIOrTemplate to return false with --yes and --non-interactive")
+			require.False(t, shouldPromptForAIOrTemplate(args, mockBackend))
+		})
 	}
 }

--- a/pkg/cmd/pulumi/newcmd/template.go
+++ b/pkg/cmd/pulumi/newcmd/template.go
@@ -37,9 +37,8 @@ const (
 
 // ChooseTemplate will prompt the user to choose amongst the available templates.
 func ChooseTemplate(templates []cmdTemplates.Template, opts display.Options) (cmdTemplates.Template, error) {
-	const chooseTemplateErr = "no template selected; please use `pulumi new` to choose one"
 	if !opts.IsInteractive {
-		return nil, errors.New(chooseTemplateErr)
+		return nil, errors.New("template or url is required when running in non-interactive mode")
 	}
 
 	// Customize the prompt a little bit (and disable color since it doesn't match our scheme).
@@ -57,7 +56,7 @@ func ChooseTemplate(templates []cmdTemplates.Template, opts display.Options) (cm
 		Options:  options,
 		PageSize: pageSize,
 	}, &option, ui.SurveyIcons(opts.Color)); err != nil {
-		return nil, errors.New(chooseTemplateErr)
+		return nil, errors.New("no template selected; please use `pulumi new` to choose one")
 	}
 
 	return optionToTemplateMap[option], nil


### PR DESCRIPTION
Picks up the work in https://github.com/pulumi/pulumi/pull/19414 

Default to picking a template over ai mode when running `pulumi new --yes`.

This also tweaks the error message when new template name or url is provided when running in non-interactive mode.

Fixes https://github.com/pulumi/pulumi/issues/19378