### PR TITLE
Remove experimental label & unhide save-plan

### DIFF
--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -579,7 +579,7 @@ func NewPreviewCmd() *cobra.Command {
 		"Config keys contain a path to a property in a map or list to set")
 	cmd.PersistentFlags().StringVar(
 		&planFilePath, "save-plan", "",
-		"Save the operations proposed by the preview to a plan file at the given path")
+		"[PREVIEW] Save the operations proposed by the preview to a plan file at the given path")
 	cmd.Flags().BoolVarP(
 		&showSecrets, "show-secrets", "", false,
 		"Show secrets in plaintext in the CLI output,"+

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -579,16 +579,12 @@ func NewPreviewCmd() *cobra.Command {
 		"Config keys contain a path to a property in a map or list to set")
 	cmd.PersistentFlags().StringVar(
 		&planFilePath, "save-plan", "",
-		"[EXPERIMENTAL] Save the operations proposed by the preview to a plan file at the given path")
+		"Save the operations proposed by the preview to a plan file at the given path")
 	cmd.Flags().BoolVarP(
 		&showSecrets, "show-secrets", "", false,
 		"Show secrets in plaintext in the CLI output,"+
 			" if used with --save-plan the secrets will also be shown in the plan file. Defaults to `false`")
 
-	if !env.Experimental.Value() {
-		contract.AssertNoErrorf(cmd.PersistentFlags().MarkHidden("save-plan"),
-			`Could not mark "save-plan" as hidden`)
-	}
 	cmd.PersistentFlags().StringVar(
 		&importFilePath, "import-file", "",
 		"Save any creates seen during the preview into an import file to use with 'pulumi import'")


### PR DESCRIPTION
Per https://github.com/pulumi/docs/pull/15698 and [the GA blog post](https://www.pulumi.com/blog/announcing-public-preview-update-plans/) `save-plan` is no longer experimental. The label can be removed and flag unhidden.