### PR TITLE
Remove Stringify from Sink interface

### DIFF
--- a/pkg/resource/deploy/deploytest/sink.go
+++ b/pkg/resource/deploy/deploytest/sink.go
@@ -39,9 +39,3 @@ func (s *NoopSink) Infoerrf(diag *diag.Diag, args ...interface{}) {}
 func (s *NoopSink) Errorf(diag *diag.Diag, args ...interface{}) {}
 
 func (s *NoopSink) Warningf(diag *diag.Diag, args ...interface{}) {}
-
-func (s *NoopSink) Stringify(
-	sev diag.Severity, diag *diag.Diag, args ...interface{},
-) (string, string) {
-	return "", ""
-}

--- a/sdk/go/common/diag/sink.go
+++ b/sdk/go/common/diag/sink.go
@@ -39,9 +39,6 @@ type Sink interface {
 	Errorf(diag *Diag, args ...interface{})
 	// Warningf issues a new warning diagnostic.
 	Warningf(diag *Diag, args ...interface{})
-
-	// Stringify stringifies a diagnostic into a prefix and message that is appropriate for printing.
-	Stringify(sev Severity, diag *Diag, args ...interface{}) (string, string)
 }
 
 // Severity dictates the kind of diagnostic.

--- a/sdk/go/common/diag/sink_test.go
+++ b/sdk/go/common/diag/sink_test.go
@@ -59,7 +59,7 @@ func TestCounts(t *testing.T) {
 func TestEscape(t *testing.T) {
 	t.Parallel()
 
-	sink := discardSink()
+	sink := discardSink().(*defaultSink)
 
 	// Passing % chars in the argument should not yield %!(MISSING)s.
 	p, s := sink.Stringify(Error, Message("", "%s"), "lots of %v %s %d chars")


### PR DESCRIPTION
While the Stringify function is used, and both real implementations of Sink have a Stringify function, there wasn't anything that made use of the fact that it was on the interface. 

Remove it from the interface so we now have a simpler interface that will be easier to write a mock type around. As opposed to the old TestSink which had to embed the defaultSink in it just to get access to Stringify.