### PR TITLE
Target ES2020 for generated SDKs

### DIFF
--- a/changelog/pending/20250812--sdkgen-nodejs--target-es2020-for-generated-sdks.yaml
+++ b/changelog/pending/20250812--sdkgen-nodejs--target-es2020-for-generated-sdks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdkgen/nodejs
+  description: Target ES2020 for generated SDKs

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -2572,7 +2572,7 @@ func genTypeScriptProjectFile(info NodePackageInfo, files codegen.Fs) string {
 	fmt.Fprintf(w, `{
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/any-type-function-15.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/any-type-function-15.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/asset-archive-5.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/asset-archive-5.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/byepackage-2.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/byepackage-2.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/call-15.7.9/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/call-15.7.9/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/camelNames-19.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/camelNames-19.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/component-13.3.7/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/component-13.3.7/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/component-property-deps-1.33.7/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/component-property-deps-1.33.7/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/config-9.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/config-9.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/config-grpc-1.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/config-grpc-1.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/fail_on_create-4.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/fail_on_create-4.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/goodbye-2.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/goodbye-2.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/hipackage-2.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/hipackage-2.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/keywords-20.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/keywords-20.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/large-4.3.2/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/large-4.3.2/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/namespaced-16.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/namespaced-16.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/plain-13.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/plain-13.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/primitive-7.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/primitive-7.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/primitive-ref-11.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/primitive-ref-11.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/ref-ref-12.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/ref-ref-12.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/secret-14.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/secret-14.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/simple-2.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/simple-2.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/simple-invoke-10.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/simple-invoke-10.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/simple-invoke-with-scalar-return-17.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/simple-invoke-with-scalar-return-17.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/subpackage-2.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/subpackage-2.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/union-18.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/sdks/union-18.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/any-type-function-15.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/any-type-function-15.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/asset-archive-5.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/asset-archive-5.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/byepackage-2.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/byepackage-2.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/call-15.7.9/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/call-15.7.9/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/camelNames-19.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/camelNames-19.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/component-13.3.7/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/component-13.3.7/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/component-property-deps-1.33.7/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/component-property-deps-1.33.7/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/config-9.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/config-9.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/config-grpc-1.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/config-grpc-1.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/fail_on_create-4.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/fail_on_create-4.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/goodbye-2.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/goodbye-2.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/hipackage-2.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/hipackage-2.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/keywords-20.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/keywords-20.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/large-4.3.2/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/large-4.3.2/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/namespaced-16.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/namespaced-16.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/plain-13.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/plain-13.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/primitive-7.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/primitive-7.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/primitive-ref-11.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/primitive-ref-11.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/ref-ref-12.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/ref-ref-12.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/secret-14.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/secret-14.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/simple-2.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/simple-2.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/simple-invoke-10.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/simple-invoke-10.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/simple-invoke-with-scalar-return-17.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/simple-invoke-with-scalar-return-17.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/subpackage-2.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/subpackage-2.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/union-18.0.0/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/sdks/union-18.0.0/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/assets-and-archives/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/assets-and-archives/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/azure-native-nested-types/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/azure-native-nested-types/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/config-variables/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/config-variables/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/cyclic-types/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/cyclic-types/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/dash-named-schema/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/dash-named-schema/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/dashed-import-schema/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/dashed-import-schema/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/different-enum/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/different-enum/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/embedded-crd-types/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/embedded-crd-types/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/enum-reference/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/enum-reference/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/external-enum/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/external-enum/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/external-node-compatibility/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/external-node-compatibility/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/external-resource-schema/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/external-resource-schema/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/functions-secrets/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/functions-secrets/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/hyphen-url/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/hyphen-url/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/kubernetes20/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/kubernetes20/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/legacy-names/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/legacy-names/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/methods-return-plain-resource/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/methods-return-plain-resource/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/naming-collisions/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/naming-collisions/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/nested-module-thirdparty/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/nested-module-thirdparty/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/nested-module/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/nested-module/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/output-funcs-edgeorder/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/output-funcs-edgeorder/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/output-funcs-tfbridge20/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/output-funcs/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/output-funcs/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/plain-and-default/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/plain-and-default/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/plain-object-defaults/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/plain-object-defaults/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/plain-object-disable-defaults/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/plain-object-disable-defaults/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/plain-schema-gh6957/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/plain-schema-gh6957/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/provider-config-schema/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/provider-config-schema/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/provider-type-schema/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/provider-type-schema/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/regress-8403/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/regress-8403/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/regress-node-8110/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/regress-node-8110/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/replace-on-change/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/replace-on-change/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/resource-args-python/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/resource-args-python/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/resource-property-overlap/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/resource-property-overlap/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/secrets/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/secrets/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/simple-enum-schema/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/simple-enum-schema/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/simple-methods-schema/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/simple-methods-schema/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/simple-plain-schema/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/simple-plain-schema/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/simple-resource-schema/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/simple-resource-schema/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/simple-resource-with-aliases/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/simple-resource-with-aliases/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/simple-yaml-schema/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/simple-yaml-schema/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/simplified-invokes/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/simplified-invokes/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/unions-inline/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/unions-inline/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/unions-inside-arrays/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/unions-inside-arrays/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/urn-id-properties/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/urn-id-properties/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/testdata/codegen/using-shared-types-in-config/nodejs/tsconfig.json
+++ b/tests/testdata/codegen/using-shared-types-in-config/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es2016",
+        "target": "ES2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,


### PR DESCRIPTION
The types of the `@pulumi/pulumi` SDK are built with TypeScript >= 3.8.3, so any project consuming the cofe SDK will have to be using TypeScript >= 3.8.3 too.

The latest target supported by that version is ES2020.