### PR TITLE
use ErrorWithStderr for `go mod tidy` errors

### DIFF
--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -1126,7 +1126,7 @@ func (host *goLanguageHost) InstallDependencies(
 	cmd.Stdout, cmd.Stderr = stdout, stderr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("`go mod tidy` failed to install dependencies: %w", err)
+		return errutil.ErrorWithStderr(err, "`go mod tidy` failed to install dependencies: %w")
 	}
 
 	stdout.Write([]byte("Finished installing dependencies\n\n"))


### PR DESCRIPTION
Noticed this error in CI somewhere today.  I suspect it's because of network errors, but hard to tell without more information.  Using `errutil.ErrorWithStderr` should help with making this easier to read in the future.