### PR TITLE
Fix a bug with `destroy --exclude-protected --remove` and empty stacks

### DIFF
--- a/changelog/pending/20250813--cli--fix-destroy-exclude-protected-remove-returning-an-error-for-empty-stacks-that-could-safely-be-removed.yaml
+++ b/changelog/pending/20250813--cli--fix-destroy-exclude-protected-remove-returning-an-error-for-empty-stacks-that-could-safely-be-removed.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix `destroy --exclude-protected --remove` returning an error for empty stacks that could safely be removed

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -286,10 +286,12 @@ func NewDestroyCmd() *cobra.Command {
 						fmt.Printf("There were no unprotected resources to destroy. There are still %d"+
 							" protected resources associated with this stack.\n", protectedCount)
 					}
-					// We need to return now. Otherwise the update will conclude
-					// we tried to destroy everything and error for trying to
-					// destroy a protected resource.
-					return nil
+					// We need to return now. Otherwise the update will conclude we tried to destroy
+					// everything and error for trying to destroy a protected resource. _Unless_ there are no
+					// resources in which case we can do a no-op destroy and remove the stack (if requested).
+					if protectedCount != 0 {
+						return nil
+					}
 				}
 			}
 

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -1139,3 +1139,19 @@ example = airbyte.Provider("provider")`)
 
 	e.RunCommand("pulumi", "up", "--yes", "--expect-no-changes")
 }
+
+// Test that `destroy --exclude-protected --remove` removes the stack if the stack is empty.
+func TestDestroyProtectedEmpty(t *testing.T) {
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.RunCommand("pulumi", "new", "python", "--force", "--yes")
+	// Init a new empty stack
+	e.RunCommand("pulumi", "stack", "init", "empty-test-stack")
+	// Then immediatly destroy it
+	e.RunCommand("pulumi", "destroy", "--yes", "--exclude-protected", "--remove")
+	// It should be removed
+	stdout, _ := e.RunCommand("pulumi", "stack", "ls")
+	assert.NotContains(t, stdout, "empty-test-stack")
+}


### PR DESCRIPTION
When destroying an empty stack with `--exclude-protected --remove` you would expect it to do a no-op destroy and then remove the stack, instead you would get an error:

```
There were no unprotected resources to destroy. There are still 0
protected resources associated with this stack
```

This fixes the command to just carry on for empty stacks and do the destroy and stack removal.