### PR TITLE
update latest Go release to 1.25.x

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -138,7 +138,7 @@ ALL_PLATFORMS = ["ubuntu-latest", "windows-latest", "macos-latest"]
 
 ALL_VERSION_SET = {
     "dotnet": ["8", "9"],
-    "go": ["1.23.x", "1.24.x"],
+    "go": ["1.23.x", "1.24.x", "1.25.x"],
     "nodejs": ["20.x", "22.x", "23.x", "24.x"],
     # When updating the minimum Python version here, also update `pyproject.toml`, including the
     # `mypy` and `ruff` sections.


### PR DESCRIPTION
Update the latest Go release to 1.25.x, which means we also build the CLI with that latest version. This in turn means this should fix https://github.com/pulumi/pulumi/issues/19537.

Leaving 1.23.x in place here, as I don't think we have a real reason to not use it anymore yet.