### PR TITLE
rename JournalEntry to TestJournalEntry in test_journal.go

### DIFF
--- a/pkg/engine/lifecycletest/alias_test.go
+++ b/pkg/engine/lifecycletest/alias_test.go
@@ -210,12 +210,12 @@ func createUpdateProgramWithResourceFuncForAliasTests(
 								continue
 							}
 							switch entry.Kind {
-							case JournalEntrySuccess:
+							case TestJournalEntrySuccess:
 								assert.Subset(t, allowedOps, []display.StepOp{entry.Step.Op()})
-							case JournalEntryFailure:
+							case TestJournalEntryFailure:
 								assert.Fail(t, "unexpected failure in journal")
-							case JournalEntryBegin:
-							case JournalEntryOutputs:
+							case TestJournalEntryBegin:
+							case TestJournalEntryOutputs:
 							}
 						}
 

--- a/pkg/engine/lifecycletest/delete_before_replace_test.go
+++ b/pkg/engine/lifecycletest/delete_before_replace_test.go
@@ -774,14 +774,14 @@ func TestDBRReplaceOnChanges(t *testing.T) {
 		resADeleted := false
 		resBDeleted := false
 		for _, entry := range entries {
-			if entry.Kind == engine.JournalEntrySuccess && entry.Step.URN().Name() == "resA" {
+			if entry.Kind == engine.TestJournalEntrySuccess && entry.Step.URN().Name() == "resA" {
 				switch entry.Step.Op() {
 				case deploy.OpDeleteReplaced:
 					resADeleted = true
 				}
 			}
 
-			if entry.Kind == engine.JournalEntrySuccess && entry.Step.URN().Name() == "resB" {
+			if entry.Kind == engine.TestJournalEntrySuccess && entry.Step.URN().Name() == "resB" {
 				switch entry.Step.Op() {
 				case deploy.OpDeleteReplaced:
 					assert.False(t, resADeleted, "resA should not have been deleted yet")

--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -143,10 +143,10 @@ func TestImportOption(t *testing.T) {
 				case resURN:
 					if seenImport {
 						assert.Equal(t, deploy.OpUpdate, entry.Step.Op())
-						seenUpdate = entry.Kind == JournalEntrySuccess
+						seenUpdate = entry.Kind == TestJournalEntrySuccess
 					} else {
 						assert.Equal(t, deploy.OpImport, entry.Step.Op())
-						seenImport = entry.Kind == JournalEntrySuccess
+						seenImport = entry.Kind == TestJournalEntrySuccess
 					}
 				default:
 					t.Fatalf("unexpected resource %v", urn)
@@ -1511,10 +1511,10 @@ func TestImportWithFailedUpdate(t *testing.T) {
 				case resURN:
 					if seenImport {
 						assert.Equal(t, deploy.OpUpdate, entry.Step.Op())
-						seenUpdate = entry.Kind == JournalEntryFailure
+						seenUpdate = entry.Kind == TestJournalEntryFailure
 					} else {
 						assert.Equal(t, deploy.OpImport, entry.Step.Op())
-						seenImport = entry.Kind == JournalEntrySuccess
+						seenImport = entry.Kind == TestJournalEntrySuccess
 					}
 				default:
 					t.Fatalf("unexpected resource %v", urn)

--- a/pkg/engine/lifecycletest/pending_delete_test.go
+++ b/pkg/engine/lifecycletest/pending_delete_test.go
@@ -83,7 +83,7 @@ func TestDestroyWithPendingDelete(t *testing.T) {
 			deletedID0, deletedID1 := false, false
 			for _, entry := range entries {
 				// Ignore non-terminal steps and steps that affect the injected default provider.
-				if entry.Kind != JournalEntrySuccess || entry.Step.URN() != resURN ||
+				if entry.Kind != TestJournalEntrySuccess || entry.Step.URN() != resURN ||
 					(entry.Step.Op() != deploy.OpDelete && entry.Step.Op() != deploy.OpDeleteReplaced) {
 					continue
 				}
@@ -160,7 +160,7 @@ func TestUpdateWithPendingDelete(t *testing.T) {
 			deletedID0, deletedID1 := false, false
 			for _, entry := range entries {
 				// Ignore non-terminal steps and steps that affect the injected default provider.
-				if entry.Kind != JournalEntrySuccess || entry.Step.URN() != resURN ||
+				if entry.Kind != TestJournalEntrySuccess || entry.Step.URN() != resURN ||
 					(entry.Step.Op() != deploy.OpDelete && entry.Step.Op() != deploy.OpDeleteReplaced) {
 					continue
 				}

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -260,7 +260,7 @@ func TestSingleResourceDefaultProviderReplace(t *testing.T) {
 			// Look for replace steps on the provider and the resource.
 			replacedProvider, replacedResource := false, false
 			for _, entry := range entries {
-				if entry.Kind != JournalEntrySuccess || entry.Step.Op() != deploy.OpDeleteReplaced {
+				if entry.Kind != TestJournalEntrySuccess || entry.Step.Op() != deploy.OpDeleteReplaced {
 					continue
 				}
 
@@ -352,7 +352,7 @@ func TestSingleResourceExplicitProviderReplace(t *testing.T) {
 			// Look for replace steps on the provider and the resource.
 			replacedProvider, replacedResource := false, false
 			for _, entry := range entries {
-				if entry.Kind != JournalEntrySuccess || entry.Step.Op() != deploy.OpDeleteReplaced {
+				if entry.Kind != TestJournalEntrySuccess || entry.Step.Op() != deploy.OpDeleteReplaced {
 					continue
 				}
 
@@ -622,7 +622,7 @@ func TestSingleResourceExplicitProviderAliasReplace(t *testing.T) {
 					}
 				}
 
-				if entry.Kind != JournalEntrySuccess || op != deploy.OpDeleteReplaced {
+				if entry.Kind != TestJournalEntrySuccess || op != deploy.OpDeleteReplaced {
 					continue
 				}
 
@@ -726,7 +726,7 @@ func TestSingleResourceExplicitProviderDeleteBeforeReplace(t *testing.T) {
 			createdProvider, createdResource := false, false
 			deletedProvider, deletedResource := false, false
 			for _, entry := range entries {
-				if entry.Kind != JournalEntrySuccess {
+				if entry.Kind != TestJournalEntrySuccess {
 					continue
 				}
 
@@ -818,7 +818,7 @@ func TestDefaultProviderDiff(t *testing.T) {
 						events []Event, err error,
 					) error {
 						for _, entry := range entries {
-							if entry.Kind != JournalEntrySuccess {
+							if entry.Kind != TestJournalEntrySuccess {
 								continue
 							}
 
@@ -946,7 +946,7 @@ func TestDefaultProviderDiffReplacement(t *testing.T) {
 						events []Event, err error,
 					) error {
 						for _, entry := range entries {
-							if entry.Kind != JournalEntrySuccess {
+							if entry.Kind != TestJournalEntrySuccess {
 								continue
 							}
 
@@ -1065,7 +1065,7 @@ func TestExplicitProviderDiffReplacement(t *testing.T) {
 						events []Event, err error,
 					) error {
 						for _, entry := range entries {
-							if entry.Kind != JournalEntrySuccess {
+							if entry.Kind != TestJournalEntrySuccess {
 								continue
 							}
 

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -61,7 +61,7 @@ import (
 func SuccessfulSteps(entries JournalEntries) []deploy.Step {
 	var steps []deploy.Step
 	for _, entry := range entries {
-		if entry.Kind == JournalEntrySuccess {
+		if entry.Kind == TestJournalEntrySuccess {
 			steps = append(steps, entry.Step)
 		}
 	}
@@ -1002,9 +1002,9 @@ func TestUpdatePartialFailure(t *testing.T) {
 					assert.Equal(t, deploy.OpUpdate, entry.Step.Op())
 					//nolint:exhaustive // default case signifies testing failure
 					switch entry.Kind {
-					case JournalEntryBegin:
+					case TestJournalEntryBegin:
 						continue
-					case JournalEntrySuccess:
+					case TestJournalEntrySuccess:
 						inputs := entry.Step.New().Inputs
 						outputs := entry.Step.New().Outputs
 						require.Len(t, inputs, 1)
@@ -2054,7 +2054,7 @@ func TestProviderDiffMissingOldOutputs(t *testing.T) {
 			// Look for replace steps on the provider and the resource.
 			replacedProvider, replacedResource := false, false
 			for _, entry := range entries {
-				if entry.Kind != JournalEntrySuccess || entry.Step.Op() != deploy.OpDeleteReplaced {
+				if entry.Kind != TestJournalEntrySuccess || entry.Step.Op() != deploy.OpDeleteReplaced {
 					continue
 				}
 


### PR DESCRIPTION
In #20199 we refactored the test journal to be named like that, but we didn't rename the internal names of constants and structs and types. Do that now, to avoid conflicts in subsequent refactorings. (In particular for https://github.com/pulumi/pulumi/pull/19862#discussion_r2257736913)