### PR TITLE
Fix template publish with relative paths other than '.'

### DIFF
--- a/changelog/pending/20250815--cli--fix-pulumi-template-publish-failing-with-relative-paths-by-normalizing-to-absolute-paths-before-archive-creation.yaml
+++ b/changelog/pending/20250815--cli--fix-pulumi-template-publish-failing-with-relative-paths-by-normalizing-to-absolute-paths-before-archive-creation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix `pulumi template publish` failing with relative paths by normalizing to absolute paths before archive creation

--- a/pkg/cmd/pulumi/templatecmd/template_publish.go
+++ b/pkg/cmd/pulumi/templatecmd/template_publish.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -86,6 +87,11 @@ func (tplCmd *templatePublishCmd) Run(
 		return fmt.Errorf("template directory does not exist: %s", templateDir)
 	}
 
+	absTemplateDir, err := filepath.Abs(templateDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve absolute path for template directory: %w", err)
+	}
+
 	version, err := semver.ParseTolerant(args.version)
 	if err != nil {
 		return fmt.Errorf("invalid version format: %w", err)
@@ -125,7 +131,7 @@ func (tplCmd *templatePublishCmd) Run(
 	}
 
 	fmt.Fprintf(cmd.ErrOrStderr(), "Creating archive from directory: %s\n", templateDir)
-	archiveBytes, err := archive.TGZ(templateDir, "", true /*useDefaultExcludes*/)
+	archiveBytes, err := archive.TGZ(absTemplateDir, "", true /*useDefaultExcludes*/)
 	if err != nil {
 		return fmt.Errorf("failed to create archive: %w", err)
 	}


### PR DESCRIPTION
When using relative paths other than `.`, like `./template-dir`, the archive creation would nest files under the directory name (e.g., `template-dir/Pulumi.yaml`) instead of at the archive root. The backend expects `Pulumi.yaml` at the root level, causing publish to fail with "archive is missing Pulumi.yaml file".

Resolve this by converting the template directory path to an absolute path before creating the archive, ensuring consistent archive structure regardless of whether relative or absolute paths are used.

Example failure output:

```sh
     ~/Development λ pulumi template publish ./registry-backed-templates-demo --name registry-backed-templates-demo --version 0.0.0
    Creating archive from directory: ./registry-backed-templates-demo
    Publishing template pulumi_local/registry-backed-templates-demo@0.0.0...
    error: failed to publish template: failed to publish template: failed to complete template publish: failed to complete template publishing operation "5e85d7eb-8393-4d2e-a2d0-57d73a6d8927": [400] Bad Request: archive is missing Pulumi.yaml file
     ~/Development λ cd registry-backed-templates-demo
     ~/Development/registry-backed-templates-demo λ ls -la
    drwxrwxr-x   - fausto  8 Aug 17:26  .git
    .rw-rw-r-- 132 fausto  8 Aug 17:26  index.ts
    .rw-rw-r-- 221 fausto  8 Aug 17:26  package.json
    .rw-rw-r-- 140 fausto  8 Aug 17:26  Pulumi.yaml
    .rw-rw-r-- 438 fausto  8 Aug 17:26  tsconfig.json
```