### PR TITLE
Remove unused config block from conformance test

### DIFF
--- a/cmd/pulumi-test-language/tests/l1_builtin_project_root.go
+++ b/cmd/pulumi-test-language/tests/l1_builtin_project_root.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,9 +26,6 @@ func init() {
 	LanguageTests["l1-builtin-project-root"] = LanguageTest{
 		Runs: []TestRun{
 			{
-				Config: config.Map{
-					config.MustMakeKey("l1-builtin-project-root", "object"): config.NewObjectValue("{}"),
-				},
 				Assert: func(l *L,
 					projectDirectory string, err error,
 					snap *deploy.Snapshot, changes display.ResourceChanges,


### PR DESCRIPTION
I think this was left in from copy paste from another test, it's not used in this test.