### PR TITLE
Log version and CLI metadata

### DIFF
--- a/changelog/pending/20250820--cli--log-version-and-cli-metadata.yaml
+++ b/changelog/pending/20250820--cli--log-version-and-cli-metadata.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli
+  description: Log version and CLI metadata

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -283,6 +283,15 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 			loggingWriter := &loggingWriter{}
 			log.SetOutput(loggingWriter)
 
+			ver, err := semver.ParseTolerant(version.Version)
+			if err != nil {
+				logging.V(3).Infof("error parsing current version: %s", err)
+			} else {
+				logging.V(3).Info("Pulumi " + ver.String())
+			}
+			metadata := getCLIMetadata(cmd, os.Environ())
+			logging.V(9).Infof("CLI Metadata: %v", metadata)
+
 			if profiling != "" {
 				if err := cmdutil.InitProfiling(profiling, memProfileRate); err != nil {
 					logging.Warningf("could not initialize profiling: %v", err)
@@ -295,7 +304,6 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 				// Run the version check in parallel so that it doesn't block executing the command.
 				// If there is a new version to report, we will do so after the command has finished.
 				waitForUpdateCheck = true
-				metadata := getCLIMetadata(cmd, os.Environ())
 				go func() {
 					updateCheckResult <- checkForUpdate(ctx, httpstate.PulumiCloudURL, metadata)
 					close(updateCheckResult)


### PR DESCRIPTION
When looking through logs, it is useful to know which version of the CLI was used, or which command was run. To help with this, when running with verbose logging, we now output the version of the CLI and metadata about the command being run, such as the command & flags, as well as any `PULUMI_` env variables. This does not include any potentially sensitive information like flag or env variable values, only their names.

Example output:
```
I0820 10:18:09.751839   99698 pulumi.go:290] Pulumi 3.191.0-dev.0
I0820 10:18:09.753023   99698 pulumi.go:293] CLI Metadata: map[Command:pulumi up Environment:PULUMI_TEST_ORG PULUMI_CONFIG_PASSPHRASE Flags:--diff --refresh --run-program --skip-preview --verbose
```
