### PR TITLE
Fix parallel map write panic

### DIFF
--- a/changelog/pending/20250820--engine--fix-a-panic-with-refresh-run-program.yaml
+++ b/changelog/pending/20250820--engine--fix-a-panic-with-refresh-run-program.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix a panic with `refresh --run-program`

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -708,8 +708,8 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, boo
 				// This mutates depGraph but this in a goroutine so might race other Alias calls so we need to lock around this.
 				sg.refreshAliasLock.Lock()
 				sg.deployment.depGraph.Alias(state, old)
-				sg.refreshAliasLock.Unlock()
 				sg.refreshStates[old] = state
+				sg.refreshAliasLock.Unlock()
 			}
 			contract.AssertNoErrorf(err, "expected a result from refresh step")
 			sg.events <- &continueResourceRefreshEvent{


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/20331.

The write to the refreshStates map needs to be protected by the refreshAliasLock, its fine to reuse the lock for alias here as it's protecting the same thing. That is writing mutable data inside the refresh continuation.