### PR TITLE
make ErrorEventPayload a string

### DIFF
--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -218,7 +218,7 @@ func ConvertEngineEvent(e engine.Event, showSecrets bool) (apitype.EngineEvent, 
 			return apiEvent, eventTypePayloadMismatch
 		}
 		apiEvent.ErrorEvent = &apitype.ErrorEvent{
-			Error: p.Error.Error(),
+			Error: p.Error,
 		}
 
 	default:

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -274,7 +274,7 @@ type ResourcePreEventPayload struct {
 }
 
 type ErrorEventPayload struct {
-	Error error
+	Error string
 }
 
 // StepEventMetadata contains the metadata associated with a step the engine is performing.


### PR DESCRIPTION
We deepcopy engine events when creating them, but our deepcopy code doesn't support errors.  ErrorEvents would thus always end up empty. Fix this by making the payload a string instead.

Noticed this while testing the journaling code.