### PR TITLE
[PCL] Simplify range value types when it is derived from object of objects and warn on unknown properties

### DIFF
--- a/changelog/pending/20250820--programgen--simplify-range-value-types-when-it-is-derived-from-object-of-objects-and-warn-on-unknown-properties.yaml
+++ b/changelog/pending/20250820--programgen--simplify-range-value-types-when-it-is-derived-from-object-of-objects-and-warn-on-unknown-properties.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Simplify range value types when it is derived from object of objects and warn on unknown properties

--- a/pkg/codegen/hcl2/model/type_collection.go
+++ b/pkg/codegen/hcl2/model/type_collection.go
@@ -119,7 +119,7 @@ func GetCollectionTypes(collectionType Type, rng hcl.Range, strict bool) (Type, 
 			}
 		}
 
-		if valueTypesAreObjects {
+		if valueTypesAreObjects && len(collectionType.ElementTypes) > 0 {
 			objectTypes := make([]*ObjectType, 0, len(collectionType.ElementTypes))
 			for _, t := range collectionType.ElementTypes {
 				if objType, ok := t.(*ObjectType); ok {
@@ -150,7 +150,7 @@ func GetCollectionTypes(collectionType Type, rng hcl.Range, strict bool) (Type, 
 			}
 		}
 
-		if valueTypesAreObjects {
+		if valueTypesAreObjects && len(types) > 0 {
 			objectTypes := make([]*ObjectType, 0, len(types))
 			for _, t := range types {
 				if objType, ok := t.(*ObjectType); ok {

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -602,7 +602,6 @@ func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 					strictCollectionType := !b.options.skipRangeTypecheck
 					rk, rv, diags := model.GetCollectionTypes(typ, rng.Range(), strictCollectionType)
 					rangeKey, rangeValue, diagnostics = rk, rv, append(diagnostics, diags...)
-
 					iterationExpr := &model.ForExpression{
 						ValueVariable: &model.Variable{
 							Name:         "_",
@@ -624,6 +623,12 @@ func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 	// Bind the resource's body.
 	scopes := newResourceScopes(b.root, node, rangeKey, rangeValue)
 	block, blockDiags := model.BindBlock(node.syntax, scopes, b.tokens, b.options.modelOptions()...)
+	for _, diag := range blockDiags {
+		if b.options.skipResourceTypecheck && diag.Severity == hcl.DiagError {
+			// If we are skipping resource type-checking, convert errors to warnings.
+			diag.Severity = hcl.DiagWarning
+		}
+	}
 	diagnostics = append(diagnostics, blockDiags...)
 
 	var options *model.Block

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -1076,7 +1076,7 @@ func TestInferVariableNameForDeferredOutputVariables(t *testing.T) {
 	assert.Equal(t, "componentFirstValue", variableName)
 }
 
-func TestSimplifyingObjectTypesForTraversal(t *testing.T) {
+func TestRangeTraversalFromObjectOfObjectsDoesNotError(t *testing.T) {
 	t.Parallel()
 	source := `
 accounts = {
@@ -1103,6 +1103,10 @@ resource "name" "random:index/randomString:RandomString" {
 
 	program, diags, err := ParseAndBindProgram(t, source, "program.pp", pcl.NonStrictBindOptions()...)
 	require.NoError(t, err)
-	assert.False(t, diags.HasErrors(), "There are no error or warning diagnostics")
+	require.False(t, diags.HasErrors(), "There are no error diagnostics")
 	require.NotNil(t, program)
+	require.Equal(t, 1, len(diags), "There is one diagnostic")
+	require.Equal(t, diags[0].Severity, hcl.DiagWarning, "The diagnostic is a warning")
+	require.Contains(t, diags[0].Summary, "unknown property 'aws_region' among [awsRegion something]",
+		"The diagnostic contains the correct message about the unknown property")
 }


### PR DESCRIPTION
Fixes the type-checking issue of https://github.com/pulumi/pulumi-converter-terraform/issues/373 making CLI more resilient when encountering programs of that try to traverse an object of objects and then indexing a non-existent key 😓 

Part of the problem is that when traversing an object of objects shaped like this 
```
accounts = {
  "us-east-1" = {
    awsRegion = "us-east-1"
    something = 10
  }
  "us-west-2" = {
    awsRegion = "us-west-2"
    something = 20
  }
  "eu-west-1" = {
    awsRegion = "eu-west-1"
    something = 30
  }
}
```
When such object is used in a `range` expression of a resource, then we try to extract the `rangeKey` and `rangeValue` types of the collection being iterated. In the case of the above the `rangeValue` is computed to be a union of all the objects types in the map `union(object1, object2, ...., objectN)` 

This PR simplifies this process by instead making `rangeValue` a single object where all the properties are unified instead.

Also treat unknown property errors into warnings during resource binding if we are binding in non-strict mode