### PR TITLE
Emit warnings instead of erros in non-strict mode when binding resource blocks

### DIFF
--- a/changelog/pending/20250820--programgen--emit-warnings-instead-of-erros-in-non-strict-mode-when-binding-resource-blocks.yaml
+++ b/changelog/pending/20250820--programgen--emit-warnings-instead-of-erros-in-non-strict-mode-when-binding-resource-blocks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Emit warnings instead of erros in non-strict mode when binding resource blocks

--- a/changelog/pending/20250820--programgen--emit-warnings-instead-of-erros-in-non-strict-mode-when-binding-resource-blocks.yaml
+++ b/changelog/pending/20250820--programgen--emit-warnings-instead-of-erros-in-non-strict-mode-when-binding-resource-blocks.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: programgen
-  description: Emit warnings instead of erros in non-strict mode when binding resource blocks
+  description: Emit warnings instead of errors in non-strict mode when binding resource blocks

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -624,6 +624,12 @@ func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 	// Bind the resource's body.
 	scopes := newResourceScopes(b.root, node, rangeKey, rangeValue)
 	block, blockDiags := model.BindBlock(node.syntax, scopes, b.tokens, b.options.modelOptions()...)
+	for _, diag := range blockDiags {
+		if b.options.skipResourceTypecheck && diag.Severity == hcl.DiagError {
+			// If we are skipping resource type-checking, convert errors to warnings.
+			diag.Severity = hcl.DiagWarning
+		}
+	}
 	diagnostics = append(diagnostics, blockDiags...)
 
 	var options *model.Block


### PR DESCRIPTION
Separate PR for https://github.com/pulumi/pulumi/pull/20345 specifically for turning errors into warnings in non-strict mode