### PR TITLE
Disambiguate duplicate resource names by their types when importing

### DIFF
--- a/changelog/pending/20250820--cli-import--disambiguate-duplicate-resource-names-by-their-types-when-importing.yaml
+++ b/changelog/pending/20250820--cli-import--disambiguate-duplicate-resource-names-by-their-types-when-importing.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/import
+  description: Disambiguate duplicate resource names by their types when importing

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -393,9 +393,23 @@ func parseImportFile(
 			}
 			urnMapping[spec.Name] = urn
 			takenURNs[urn] = struct{}{}
-			// This might clash with earlier entries in the name table (unique urn, but duplicate name) that's
-			// fine and the code generators should deal with it.
-			names[urn] = spec.Name
+
+			nameExists := false
+			for _, n := range names {
+				if n == spec.Name {
+					nameExists = true
+					break
+				}
+			}
+
+			if nameExists {
+				// disambiguate the name by resource type
+				resourceType := urn.Type().Name().String()
+				names[urn] = fmt.Sprintf("%s_%s", spec.Name, resourceType)
+			} else {
+				names[urn] = spec.Name
+			}
+
 			// Mark this resource as done
 			dones[i] = true
 		}


### PR DESCRIPTION
I think this fixes #20318 because code generation in PCL does not handle declaring multiple nodes (in this case resources) of the same name. 

This PR tries to disambiguate the names of the resources to be generated in the `NamesTable` using their resource type.

```
{
	Name: "thing",
	ID:   "thing",
	Type: "pkg:module/Baz:First",
},
{
	Name: "thing",
	ID:   "thing",
	Type: "pkg:module/Quux:Second",
},
```
generates this `NamesTable`
```go
importer.NameTable{
	"urn:pulumi:stack::proj::pkg:module/Baz:First::thing":   "thing",
	"urn:pulumi:stack::proj::pkg:module/Quux:Second::thing": "thing_Second",
}
```
which is then used in generated PCL.

It is possible that there are multiple resources of the same name & type from a different module or package that this code doesn't handle but that seems unlikely 