### PR TITLE
[sdk/go] Source position tweaks

### DIFF
--- a/changelog/pending/20250821--sdk-go--fix-source-position-information.yaml
+++ b/changelog/pending/20250821--sdk-go--fix-source-position-information.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fix source position information


### PR DESCRIPTION
- Per the docs, `Frame.File` is always `/`-separated. Split it
  correctly.
- The `Uri` property of each reported source position should have the
  `file` scheme, not the `project` scheme. The engine will perform the
  `file`->`project` mapping.
- Pull the frame -> position mapping out into its own function
