### PR TITLE
try to unflake TestResourceRefsGetResourceNode test

### DIFF
--- a/tests/integration/resource_refs_get_resource/nodejs/index.ts
+++ b/tests/integration/resource_refs_get_resource/nodejs/index.ts
@@ -29,27 +29,27 @@ class Container extends pulumi.ComponentResource {
 }
 
 async function waitForContainer(container: Container): Promise<void> {
-    // Wait for a maximum of 500ms for the resource outputs to be registered.
-    const end = Date.now() + 500;
+    // Wait for a maximum of 5s for the resource outputs to be registered.
+    const end = Date.now() + 5000;
     for (let i = 0; ; i++) {
-	let foundURN = false;
-	let success = new Promise((resolve, reject) => {
-	    container.urn.apply(urn => {
-		const roundTrippedContainer = new Container("mycontainer", undefined, { urn })
-		roundTrippedContainer.child.apply(c => {
-		    if (c != undefined) {
-			foundURN = true;
-		    }
-		    resolve();
-		});
-	    });
-	});
-	await success;
-	if (foundURN) {
-	    break;
-	} else if (Date.now() > end) {
-	    throw new Error("resource outputs not registered correctly");
-	}
+        let foundURN = false;
+        let success = new Promise((resolve, reject) => {
+            container.urn.apply(urn => {
+                const roundTrippedContainer = new Container("mycontainer", undefined, { urn })
+                roundTrippedContainer.child.apply(c => {
+                    if (c != undefined) {
+                        foundURN = true;
+                    }
+                    resolve();
+                });
+            });
+        });
+        await success;
+        if (foundURN) {
+            break;
+        } else if (Date.now() > end) {
+            throw new Error("resource outputs not registered correctly");
+        }
     }
 }
 
@@ -81,14 +81,14 @@ waitForContainer(container).then(() => {
     console.log(child, container);
 
     pulumi.all([child.urn, container.urn]).apply(([childUrn, urn]) => {
-	const roundTrippedContainer = new Container("mycontainer", undefined, { urn })
-	const roundTrippedContainerChildUrn = roundTrippedContainer.child.apply(c => c.urn);
-	const roundTrippedContainerChildMessage = roundTrippedContainer.child.apply(c => c.message);
-	return pulumi.all([childUrn, roundTrippedContainerChildUrn, roundTrippedContainerChildMessage])
-	    .apply(([expectedUrn, actualUrn, actualMessage]) => {
-		assert.strictEqual(actualUrn, expectedUrn);
-		assert.strictEqual(actualMessage, "hello world!");
-		return expectedUrn;
-	    });
+        const roundTrippedContainer = new Container("mycontainer", undefined, { urn })
+        const roundTrippedContainerChildUrn = roundTrippedContainer.child.apply(c => c.urn);
+        const roundTrippedContainerChildMessage = roundTrippedContainer.child.apply(c => c.message);
+        return pulumi.all([childUrn, roundTrippedContainerChildUrn, roundTrippedContainerChildMessage])
+            .apply(([expectedUrn, actualUrn, actualMessage]) => {
+                assert.strictEqual(actualUrn, expectedUrn);
+                assert.strictEqual(actualMessage, "hello world!");
+                return expectedUrn;
+            });
     });
 });


### PR DESCRIPTION
This test was re-enabled in
https://github.com/pulumi/pulumi/pull/16903, but is still flaky.  CI can be very slow sometimes, so let's increase the time we're waiting for outputs, in hopes that that unflakes the test.

While there also fix up tabs vs. spaces, as my original PR introduced a bunch of tabs where the indentation should be with spaces.

Fixes https://github.com/pulumi/pulumi/issues/20349