### PR TITLE
Remove experimental flag requirement for registry operations

### DIFF
--- a/changelog/pending/20250821--cli--registry-operations-no-longer-experimental.yaml
+++ b/changelog/pending/20250821--cli--registry-operations-no-longer-experimental.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli
+  description: Registry operations (`pulumi template publish`, `pulumi package publish`, registry-based template resolution in `pulumi new`) no longer require `PULUMI_EXPERIMENTAL` flag and use stable endpoints, while registry-backed template resolution in `pulumi new` may still be disabled using `PULUMI_DISABLE_REGISTRY_RESOLVE=true pulumi new`

--- a/changelog/pending/20250821--cli--registry-operations-no-longer-experimental.yaml
+++ b/changelog/pending/20250821--cli--registry-operations-no-longer-experimental.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: chore
   scope: cli
-  description: Registry operations (`pulumi template publish`, `pulumi package publish`, registry-based template resolution in `pulumi new`) no longer require `PULUMI_EXPERIMENTAL` flag and use stable endpoints, while registry-backed template resolution in `pulumi new` may still be disabled using `PULUMI_DISABLE_REGISTRY_RESOLVE=true pulumi new`
+  description: No longer require the `PULUMI_EXPERIMENTAL` flag for Private Registry operations (`pulumi template publish`, `pulumi package publish`, registry-based template resolution in `pulumi new`), while registry-backed template resolution in `pulumi new` may still be disabled using `PULUMI_DISABLE_REGISTRY_RESOLVE=true pulumi new`

--- a/pkg/backend/httpstate/client/api_endpoints.go
+++ b/pkg/backend/httpstate/client/api_endpoints.go
@@ -125,10 +125,10 @@ func init() {
 	addEndpoint("GET", "/api/orgs/{orgName}/search/resources/parse", "getSearchResourcesParse")
 
 	// APIs for interacting with the Package Registry
-	addEndpoint("POST", "/api/preview/registry/packages/{source}/{publisher}/{name}/versions", "publishPackage")
-	addEndpoint("POST", "/api/preview/registry/packages/{source}/{publisher}/{name}/versions/{version}/complete", "completePackagePublish")
+	addEndpoint("POST", "/api/registry/packages/{source}/{publisher}/{name}/versions", "publishPackage")
+	addEndpoint("POST", "/api/registry/packages/{source}/{publisher}/{name}/versions/{version}/complete", "completePackagePublish")
 
 	// APIs for interacting with the Template Registry
-	addEndpoint("POST", "/api/preview/registry/templates/{source}/{publisher}/{name}/versions", "publishTemplate")
-	addEndpoint("POST", "/api/preview/registry/templates/{source}/{publisher}/{name}/versions/{version}/complete", "completeTemplatePublish")
+	addEndpoint("POST", "/api/registry/templates/{source}/{publisher}/{name}/versions", "publishTemplate")
+	addEndpoint("POST", "/api/registry/templates/{source}/{publisher}/{name}/versions/{version}/complete", "completeTemplatePublish")
 }

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -261,19 +261,19 @@ func getUpdatePath(update UpdateIdentifier, components ...string) string {
 }
 
 func publishPackagePath(source, publisher, name string) string {
-	return fmt.Sprintf("/api/preview/registry/packages/%s/%s/%s/versions", source, publisher, name)
+	return fmt.Sprintf("/api/registry/packages/%s/%s/%s/versions", source, publisher, name)
 }
 
 func completePackagePublishPath(source, publisher, name, version string) string {
-	return fmt.Sprintf("/api/preview/registry/packages/%s/%s/%s/versions/%s/complete", source, publisher, name, version)
+	return fmt.Sprintf("/api/registry/packages/%s/%s/%s/versions/%s/complete", source, publisher, name, version)
 }
 
 func publishTemplatePath(source, publisher, name string) string {
-	return fmt.Sprintf("/api/preview/registry/templates/%s/%s/%s/versions", source, publisher, name)
+	return fmt.Sprintf("/api/registry/templates/%s/%s/%s/versions", source, publisher, name)
 }
 
 func completeTemplatePublishPath(source, publisher, name string, version semver.Version) string {
-	return fmt.Sprintf("/api/preview/registry/templates/%s/%s/%s/versions/%s/complete", source, publisher, name, version)
+	return fmt.Sprintf("/api/registry/templates/%s/%s/%s/versions/%s/complete", source, publisher, name, version)
 }
 
 // Copied from https://github.com/pulumi/pulumi-service/blob/master/pkg/apitype/users.go#L7-L16
@@ -1673,7 +1673,7 @@ func (pc *Client) GetPackage(
 	if version != nil {
 		v = version.String()
 	}
-	url := fmt.Sprintf("/api/preview/registry/packages/%s/%s/%s/versions/%s", source, publisher, name, v)
+	url := fmt.Sprintf("/api/registry/packages/%s/%s/%s/versions/%s", source, publisher, name, v)
 	var resp apitype.PackageMetadata
 	err := pc.restCall(ctx, "GET", url, nil, nil, &resp)
 	return resp, err
@@ -1688,7 +1688,7 @@ func (pc *Client) GetTemplate(
 	if version != nil {
 		v = version.String()
 	}
-	url := fmt.Sprintf("/api/preview/registry/templates/%s/%s/%s/versions/%s", source, publisher, name, v)
+	url := fmt.Sprintf("/api/registry/templates/%s/%s/%s/versions/%s", source, publisher, name, v)
 	var resp apitype.TemplateMetadata
 	err := pc.restCall(ctx, "GET", url, nil, nil, &resp)
 	return resp, err
@@ -1749,7 +1749,7 @@ func (pc *Client) downloadWithRawClient(ctx context.Context, downloadURL string)
 }
 
 func (pc *Client) ListPackages(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
-	url := "/api/preview/registry/packages?limit=499"
+	url := "/api/registry/packages?limit=499"
 	if name != nil {
 		url += "&name=" + *name
 	}
@@ -1783,7 +1783,7 @@ func (pc *Client) ListPackages(ctx context.Context, name *string) iter.Seq2[apit
 // ListTemplates is a preview API, and should not be used without an approved EOL plan for
 // deprecation.
 func (pc *Client) ListTemplates(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
-	url := "/api/preview/registry/templates?limit=499"
+	url := "/api/registry/templates?limit=499"
 	if name != nil {
 		url += "&name=" + *name
 	}

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1679,8 +1679,6 @@ func (pc *Client) GetPackage(
 	return resp, err
 }
 
-// GetTemplate is a preview API, and should not be used without an approved EOL plan for
-// deprecation.
 func (pc *Client) GetTemplate(
 	ctx context.Context, source, publisher, name string, version *semver.Version,
 ) (apitype.TemplateMetadata, error) {
@@ -1780,8 +1778,6 @@ func (pc *Client) ListPackages(ctx context.Context, name *string) iter.Seq2[apit
 	}
 }
 
-// ListTemplates is a preview API, and should not be used without an approved EOL plan for
-// deprecation.
 func (pc *Client) ListTemplates(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
 	url := "/api/registry/templates?limit=499"
 	if name != nil {

--- a/pkg/backend/httpstate/client/client_package_test.go
+++ b/pkg/backend/httpstate/client/client_package_test.go
@@ -68,7 +68,7 @@ func TestPublishPackage(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
@@ -83,7 +83,7 @@ func TestPublishPackage(t *testing.T) {
 						}
 						require.NoError(t, json.NewEncoder(w).Encode(response))
 
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions/1.0.0/complete":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions/1.0.0/complete":
 						w.WriteHeader(http.StatusCreated)
 					}
 				}))
@@ -98,7 +98,7 @@ func TestPublishPackage(t *testing.T) {
 			},
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if r.URL.Path == "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions" {
+					if r.URL.Path == "/api/registry/packages/pulumi/test-publisher/test-package/versions" {
 						w.WriteHeader(http.StatusInternalServerError)
 						_, err := w.Write([]byte("Internal Server Error"))
 						require.NoError(t, err)
@@ -121,7 +121,7 @@ func TestPublishPackage(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
@@ -154,7 +154,7 @@ func TestPublishPackage(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
@@ -187,7 +187,7 @@ func TestPublishPackage(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
@@ -216,7 +216,7 @@ func TestPublishPackage(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
@@ -230,7 +230,7 @@ func TestPublishPackage(t *testing.T) {
 							},
 						}
 						require.NoError(t, json.NewEncoder(w).Encode(response))
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions/1.0.0/complete":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions/1.0.0/complete":
 						w.WriteHeader(http.StatusInternalServerError)
 						_, err := w.Write([]byte("Failed to complete"))
 						require.NoError(t, err)
@@ -254,7 +254,7 @@ func TestPublishPackage(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
@@ -269,7 +269,7 @@ func TestPublishPackage(t *testing.T) {
 						}
 						require.NoError(t, json.NewEncoder(w).Encode(response))
 
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions/1.0.0/complete":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions/1.0.0/complete":
 						w.WriteHeader(http.StatusCreated)
 					}
 				}))
@@ -302,7 +302,7 @@ func TestPublishPackage(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
@@ -343,7 +343,7 @@ func TestPublishPackage(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",

--- a/pkg/backend/httpstate/client/client_template_test.go
+++ b/pkg/backend/httpstate/client/client_template_test.go
@@ -62,7 +62,7 @@ func TestStartTemplatePublish(t *testing.T) {
 			name: "SuccessfulStartPublish",
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if r.URL.Path == "/api/preview/registry/templates/private/test-publisher/test-template/versions" {
+					if r.URL.Path == "/api/registry/templates/private/test-publisher/test-template/versions" {
 						w.WriteHeader(http.StatusAccepted)
 						response := StartTemplatePublishResponse{
 							OperationID: "test-operation-id",
@@ -153,7 +153,7 @@ func TestCompleteTemplatePublish(t *testing.T) {
 			name: "SuccessfulCompletePublish",
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if r.URL.Path == "/api/preview/registry/templates/private/test-publisher/test-template/versions/1.0.0/complete" {
+					if r.URL.Path == "/api/registry/templates/private/test-publisher/test-template/versions/1.0.0/complete" {
 						w.WriteHeader(http.StatusCreated)
 						response := PublishTemplateVersionCompleteResponse{}
 						require.NoError(t, json.NewEncoder(w).Encode(response))
@@ -236,7 +236,7 @@ func TestPublishTemplate_Integration(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/templates/private/test-publisher/test-template/versions":
+					case "/api/registry/templates/private/test-publisher/test-template/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := StartTemplatePublishResponse{
 							OperationID: "test-operation-id",
@@ -246,7 +246,7 @@ func TestPublishTemplate_Integration(t *testing.T) {
 						}
 						require.NoError(t, json.NewEncoder(w).Encode(response))
 
-					case "/api/preview/registry/templates/private/test-publisher/test-template/versions/1.0.0/complete":
+					case "/api/registry/templates/private/test-publisher/test-template/versions/1.0.0/complete":
 						w.WriteHeader(http.StatusCreated)
 					}
 				}))
@@ -266,7 +266,7 @@ func TestPublishTemplate_Integration(t *testing.T) {
 			},
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if r.URL.Path == "/api/preview/registry/templates/private/test-publisher/test-template/versions" {
+					if r.URL.Path == "/api/registry/templates/private/test-publisher/test-template/versions" {
 						w.WriteHeader(http.StatusInternalServerError)
 						_, err := w.Write([]byte("Internal Server Error"))
 						require.NoError(t, err)
@@ -294,7 +294,7 @@ func TestPublishTemplate_Integration(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/templates/private/test-publisher/test-template/versions":
+					case "/api/registry/templates/private/test-publisher/test-template/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := StartTemplatePublishResponse{
 							OperationID: "test-operation-id",
@@ -323,7 +323,7 @@ func TestPublishTemplate_Integration(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/templates/private/test-publisher/test-template/versions":
+					case "/api/registry/templates/private/test-publisher/test-template/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := StartTemplatePublishResponse{
 							OperationID: "test-operation-id",
@@ -332,7 +332,7 @@ func TestPublishTemplate_Integration(t *testing.T) {
 							},
 						}
 						require.NoError(t, json.NewEncoder(w).Encode(response))
-					case "/api/preview/registry/templates/private/test-publisher/test-template/versions/1.0.0/complete":
+					case "/api/registry/templates/private/test-publisher/test-template/versions/1.0.0/complete":
 						w.WriteHeader(http.StatusInternalServerError)
 						_, err := w.Write([]byte("Failed to complete"))
 						require.NoError(t, err)
@@ -363,7 +363,7 @@ func TestPublishTemplate_Integration(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/templates/private/test-publisher/test-template/versions":
+					case "/api/registry/templates/private/test-publisher/test-template/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := StartTemplatePublishResponse{
 							OperationID: "test-operation-id",
@@ -679,7 +679,7 @@ func TestListTemplates(t *testing.T) {
 
 		// Set up mock server
 		mockServer := newMockServerRequestProcessor(200, func(req *http.Request) string {
-			assert.Contains(t, req.URL.String(), "/api/preview/registry/templates?limit=499")
+			assert.Contains(t, req.URL.String(), "/api/registry/templates?limit=499")
 			assert.Equal(t, "GET", req.Method)
 
 			data, err := json.Marshal(mockResponse)
@@ -752,7 +752,7 @@ func TestListTemplates(t *testing.T) {
 
 			switch requestCount {
 			case 0:
-				assert.Equal(t, "/api/preview/registry/templates?limit=499&name=my-template", req.URL.String())
+				assert.Equal(t, "/api/registry/templates?limit=499&name=my-template", req.URL.String())
 				assert.NotContains(t, "continuationToken", req.URL.String())
 
 				responseData, err = json.Marshal(apitype.ListTemplatesResponse{
@@ -762,7 +762,7 @@ func TestListTemplates(t *testing.T) {
 				require.NoError(t, err)
 			case 1:
 				assert.Equal(t,
-					"/api/preview/registry/templates?limit=499&name=my-template&continuationToken=next-page-token-1",
+					"/api/registry/templates?limit=499&name=my-template&continuationToken=next-page-token-1",
 					req.URL.String())
 
 				responseData, err = json.Marshal(apitype.ListTemplatesResponse{
@@ -772,7 +772,7 @@ func TestListTemplates(t *testing.T) {
 				require.NoError(t, err)
 			case 2:
 				assert.Equal(t,
-					"/api/preview/registry/templates?limit=499&name=my-template&continuationToken=next-page-token-2",
+					"/api/registry/templates?limit=499&name=my-template&continuationToken=next-page-token-2",
 					req.URL.String())
 
 				responseData, err = json.Marshal(apitype.ListTemplatesResponse{

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -602,7 +602,7 @@ func TestListPackages(t *testing.T) {
 
 		// Set up mock server
 		mockServer := newMockServerRequestProcessor(200, func(req *http.Request) string {
-			assert.Contains(t, req.URL.String(), "/api/preview/registry/packages?limit=499")
+			assert.Contains(t, req.URL.String(), "/api/registry/packages?limit=499")
 			assert.Equal(t, "GET", req.Method)
 
 			data, err := json.Marshal(mockResponse)
@@ -672,7 +672,7 @@ func TestListPackages(t *testing.T) {
 
 			switch requestCount {
 			case 0:
-				assert.Equal(t, "/api/preview/registry/packages?limit=499&name=my-package", req.URL.String())
+				assert.Equal(t, "/api/registry/packages?limit=499&name=my-package", req.URL.String())
 				assert.NotContains(t, "continuationToken", req.URL.String())
 
 				responseData, err = json.Marshal(apitype.ListPackagesResponse{
@@ -682,7 +682,7 @@ func TestListPackages(t *testing.T) {
 				require.NoError(t, err)
 			case 1:
 				assert.Equal(t,
-					"/api/preview/registry/packages?limit=499&name=my-package&continuationToken=next-page-token-1",
+					"/api/registry/packages?limit=499&name=my-package&continuationToken=next-page-token-1",
 					req.URL.String())
 
 				responseData, err = json.Marshal(apitype.ListPackagesResponse{
@@ -692,7 +692,7 @@ func TestListPackages(t *testing.T) {
 				require.NoError(t, err)
 			case 2:
 				assert.Equal(t,
-					"/api/preview/registry/packages?limit=499&name=my-package&continuationToken=next-page-token-2",
+					"/api/registry/packages?limit=499&name=my-package&continuationToken=next-page-token-2",
 					req.URL.String())
 
 				responseData, err = json.Marshal(apitype.ListPackagesResponse{

--- a/pkg/cmd/pulumi/newcmd/new_ai_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_ai_test.go
@@ -16,12 +16,15 @@ package newcmd
 
 import (
 	"context"
+	"iter"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/util/testutil"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,8 +37,7 @@ func TestErrorsOnNonHTTPBackend(t *testing.T) {
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return name == projectName, nil
 		},
-		SupportsTemplatesF: func() bool { return false },
-		NameF:              func() string { return "mock" },
+		NameF: func() string { return "mock" },
 	})
 
 	testNewArgs := newArgs{
@@ -58,12 +60,29 @@ func TestGeneratingProjectWithAIPromptSucceeds(t *testing.T) {
 	tempdir := tempProjectDir(t)
 	chdir(t, tempdir)
 
+	listTemplates := func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+		assert.Nil(t, name)
+		return func(yield func(apitype.TemplateMetadata, error) bool) {
+			if !yield(apitype.TemplateMetadata{
+				Name:      "name1",
+				Publisher: "publisher1",
+				Source:    "source1",
+			}, nil) {
+				return
+			}
+		}
+	}
+
 	testutil.MockBackendInstance(t, &backend.MockBackend{
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return true, nil
 		},
-		SupportsTemplatesF: func() bool { return false },
-		NameF:              func() string { return "mock" },
+		NameF: func() string { return "mock" },
+		GetReadOnlyCloudRegistryF: func() registry.Registry {
+			return &backend.MockCloudRegistry{
+				ListTemplatesF: listTemplates,
+			}
+		},
 	})
 
 	// Generate-only command is not creating any stacks, so don't bother with with the name uniqueness check.

--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -919,10 +919,7 @@ func ProviderFromSource(
 		pctx.Base(),
 		reg,
 		pluginSpec,
-		packageresolution.Options{
-			DisableRegistryResolve: env.DisableRegistryResolve.Value(),
-			Experimental:           env.Experimental.Value(),
-		},
+		packageresolution.Options{DisableRegistryResolve: env.DisableRegistryResolve.Value()},
 		pctx.Root,
 	)
 	if err != nil {

--- a/pkg/cmd/pulumi/packageresolution/package_resolution.go
+++ b/pkg/cmd/pulumi/packageresolution/package_resolution.go
@@ -67,7 +67,6 @@ func (e PackageNotFoundError) Suggestions() []apitype.PackageMetadata {
 
 type Options struct {
 	DisableRegistryResolve bool
-	Experimental           bool
 }
 
 type Result interface {
@@ -117,7 +116,7 @@ func Resolve(
 	var registryNotFoundErr error
 	var registryQueryErr error
 
-	if !options.DisableRegistryResolve && options.Experimental {
+	if !options.DisableRegistryResolve {
 		metadata, err := registry.ResolvePackageFromName(ctx, reg, pluginSpec.Name, pluginSpec.Version)
 		if err == nil {
 			return RegistryResult{Metadata: metadata}, nil

--- a/pkg/cmd/pulumi/packageresolution/package_resolution_test.go
+++ b/pkg/cmd/pulumi/packageresolution/package_resolution_test.go
@@ -164,7 +164,7 @@ packages:
 		// Environment combination tests for pre-registry packages
 		{
 			name:       "pre-registry package with registry disabled",
-			env:        &Options{DisableRegistryResolve: true, Experimental: false},
+			env:        &Options{DisableRegistryResolve: true},
 			pluginSpec: workspace.PluginSpec{Name: "aws"},
 			registryResponse: func() (*backend.MockCloudRegistry, error) {
 				return &backend.MockCloudRegistry{
@@ -177,7 +177,7 @@ packages:
 		},
 		{
 			name:       "registry disabled ignores available registry package",
-			env:        &Options{DisableRegistryResolve: true, Experimental: true},
+			env:        &Options{DisableRegistryResolve: true},
 			pluginSpec: workspace.PluginSpec{Name: "aws"},
 			registryResponse: func() (*backend.MockCloudRegistry, error) {
 				return &backend.MockCloudRegistry{
@@ -192,7 +192,7 @@ packages:
 		// Environment combination tests for unknown packages
 		{
 			name:       "unknown package with registry disabled",
-			env:        &Options{DisableRegistryResolve: true, Experimental: false},
+			env:        &Options{DisableRegistryResolve: true},
 			pluginSpec: workspace.PluginSpec{Name: "unknown-package"},
 			registryResponse: func() (*backend.MockCloudRegistry, error) {
 				return &backend.MockCloudRegistry{
@@ -245,10 +245,7 @@ packages:
 			reg, expectedErr := tt.registryResponse()
 			require.NoError(t, expectedErr)
 
-			env := Options{
-				DisableRegistryResolve: false,
-				Experimental:           true,
-			}
+			env := Options{DisableRegistryResolve: false}
 			if tt.env != nil {
 				env = *tt.env
 			}
@@ -320,10 +317,7 @@ func TestResolvePackage_WithVersion(t *testing.T) {
 		context.Background(),
 		reg,
 		pluginSpec,
-		Options{
-			DisableRegistryResolve: false,
-			Experimental:           true,
-		},
+		Options{DisableRegistryResolve: false},
 		t.TempDir(),
 	)
 	require.NoError(t, err)
@@ -359,10 +353,7 @@ packages:
 		context.Background(),
 		reg,
 		pluginSpec, // This is both pre-registry AND defined locally
-		Options{
-			DisableRegistryResolve: true,
-			Experimental:           false,
-		},
+		Options{DisableRegistryResolve: true},
 		tmpDir,
 	)
 	require.NoError(t, err)

--- a/pkg/cmd/pulumi/packageresolution/package_resolution_test.go
+++ b/pkg/cmd/pulumi/packageresolution/package_resolution_test.go
@@ -204,19 +204,6 @@ packages:
 			expectedErr: &PackageNotFoundError{Package: "unknown-package"},
 		},
 		{
-			name:       "unknown package with experimental off",
-			env:        &Options{DisableRegistryResolve: false, Experimental: false},
-			pluginSpec: workspace.PluginSpec{Name: "unknown-package"},
-			registryResponse: func() (*backend.MockCloudRegistry, error) {
-				return &backend.MockCloudRegistry{
-					ListPackagesF: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
-						return func(yield func(apitype.PackageMetadata, error) bool) {} // empty
-					},
-				}, nil
-			},
-			expectedErr: &PackageNotFoundError{Package: "unknown-package"},
-		},
-		{
 			name:       "project source takes precedence over plugin name",
 			pluginSpec: workspace.PluginSpec{Name: "my-local-pkg", PluginDownloadURL: "git://github.com/should-not-use/this"},
 			registryResponse: func() (*backend.MockCloudRegistry, error) {

--- a/pkg/cmd/pulumi/plugin/plugin.go
+++ b/pkg/cmd/pulumi/plugin/plugin.go
@@ -48,10 +48,7 @@ func NewPluginCmd() *cobra.Command {
 		Args: cmdutil.NoArgs,
 	}
 
-	packageResolutionOptions := packageresolution.Options{
-		DisableRegistryResolve: env.DisableRegistryResolve.Value(),
-		Experimental:           env.Experimental.Value(),
-	}
+	packageResolutionOptions := packageresolution.Options{DisableRegistryResolve: env.DisableRegistryResolve.Value()}
 	cmd.AddCommand(newPluginInstallCmd(packageResolutionOptions))
 	cmd.AddCommand(newPluginLsCmd())
 	cmd.AddCommand(newPluginRmCmd())

--- a/pkg/cmd/pulumi/plugin/plugin_install_test.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install_test.go
@@ -129,11 +129,8 @@ func TestGetPluginDownloadURLFromRegistry(t *testing.T) {
 	}()
 
 	cmd := &pluginInstallCmd{
-		diag: diagtest.LogSink(t),
-		packageResolutionOptions: packageresolution.Options{
-			DisableRegistryResolve: false,
-			Experimental:           true,
-		},
+		diag:                     diagtest.LogSink(t),
+		packageResolutionOptions: packageresolution.Options{DisableRegistryResolve: false},
 		pluginGetLatestVersion: func(ps workspace.PluginSpec, ctx context.Context) (*semver.Version, error) {
 			assert.Fail(t, "GetLatestVersion should not have been called")
 			return nil, nil
@@ -244,11 +241,8 @@ func TestGetPluginDownloadForMissingPackage(t *testing.T) {
 		t.Parallel()
 
 		cmd := &pluginInstallCmd{
-			diag: diagtest.LogSink(t),
-			packageResolutionOptions: packageresolution.Options{
-				DisableRegistryResolve: false,
-				Experimental:           true,
-			},
+			diag:                     diagtest.LogSink(t),
+			packageResolutionOptions: packageresolution.Options{DisableRegistryResolve: false},
 			pluginGetLatestVersion: func(ps workspace.PluginSpec, ctx context.Context) (*semver.Version, error) {
 				assert.Fail(t, "GetLatestVersion should not have been called")
 				return nil, nil
@@ -271,11 +265,8 @@ func TestGetPluginDownloadForMissingPackage(t *testing.T) {
 		t.Parallel()
 
 		cmd := &pluginInstallCmd{
-			diag: diagtest.LogSink(t),
-			packageResolutionOptions: packageresolution.Options{
-				DisableRegistryResolve: false,
-				Experimental:           true,
-			},
+			diag:                     diagtest.LogSink(t),
+			packageResolutionOptions: packageresolution.Options{DisableRegistryResolve: false},
 			pluginGetLatestVersion: func(ps workspace.PluginSpec, ctx context.Context) (*semver.Version, error) {
 				assert.Fail(t, "GetLatestVersion should not have been called")
 				return nil, nil
@@ -387,11 +378,8 @@ func TestSuggestedPackagesDisplay(t *testing.T) {
 	sink := diagtest.MockSink(&stdout, &stderr)
 
 	cmd := &pluginInstallCmd{
-		diag: sink,
-		packageResolutionOptions: packageresolution.Options{
-			DisableRegistryResolve: false,
-			Experimental:           true,
-		},
+		diag:                     sink,
+		packageResolutionOptions: packageresolution.Options{DisableRegistryResolve: false},
 		pluginGetLatestVersion: func(ps workspace.PluginSpec, ctx context.Context) (*semver.Version, error) {
 			assert.Fail(t, "GetLatestVersion should not have been called")
 			return nil, nil

--- a/pkg/cmd/pulumi/templatecmd/template.go
+++ b/pkg/cmd/pulumi/templatecmd/template.go
@@ -15,7 +15,6 @@
 package templatecmd
 
 import (
-	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -24,15 +23,10 @@ func NewTemplateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "template",
 		Short: "Work with Pulumi templates",
-		Long: `[EXPERIMENTAL] Work with Pulumi templates
+		Long: `Work with Pulumi templates
 
 Publish and manage Pulumi templates.`,
-		// NB: the `pulumi template` namespace depends on pulumi-service APIs that
-		// are currently behind `/preview`. The `pulumi template` namespace should
-		// not be made generally available before those APIs are stabilized out of
-		// `/preview`.
-		Hidden: !env.Experimental.Value(),
-		Args:   cmdutil.NoArgs,
+		Args: cmdutil.NoArgs,
 	}
 	cmd.AddCommand(
 		newTemplatePublishCmd(),

--- a/pkg/cmd/pulumi/templates/cloud.go
+++ b/pkg/cmd/pulumi/templates/cloud.go
@@ -124,7 +124,7 @@ func (s *Source) getCloudTemplates(
 	ctx context.Context, templateName string,
 	wg *sync.WaitGroup, e env.Env,
 ) {
-	if !e.GetBool(env.DisableRegistryResolve) && e.GetBool(env.Experimental) {
+	if !e.GetBool(env.DisableRegistryResolve) {
 		s.getRegistryTemplates(ctx, e, templateName)
 		return
 	}

--- a/pkg/cmd/pulumi/templates/cloud.go
+++ b/pkg/cmd/pulumi/templates/cloud.go
@@ -146,6 +146,9 @@ func (s *Source) getRegistryTemplates(ctx context.Context, e env.Env, templateNa
 		return
 	}
 
+	// n.b. name filter is intentionally nil since the template names displayed here differ from the
+	// template names returned from the ListTemplates for VCS backed templates. We fetch all templates
+	// and filter manually.
 	var nameFilter *string
 	for template, err := range r.ListTemplates(ctx, nameFilter) {
 		if err != nil {

--- a/pkg/cmd/pulumi/templates/templates_test.go
+++ b/pkg/cmd/pulumi/templates/templates_test.go
@@ -157,7 +157,6 @@ func TestFilterOnName(t *testing.T) {
 		})
 		testFilterOnName(t, env.MapStore{
 			"PULUMI_DISABLE_REGISTRY_RESOLVE": "false",
-			"PULUMI_EXPERIMENTAL":             "true",
 		})
 	})
 }

--- a/sdk/go/common/registry/registry.go
+++ b/sdk/go/common/registry/registry.go
@@ -50,16 +50,22 @@ type Registry interface {
 	// there are no matching packages in the Registry.
 	ListPackages(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error]
 
-	// GetTemplate is a preview API, and should not be used without an approved EOL
-	// plan for deprecation. The safest way to do this is to flag functionality behind
-	// `PULUMI_EXPERIMENTAL`, which removes any backwards comparability requirements.
+	// Retrieve metadata about a specific template.
+	//
+	// {source}/{publisher}/{name} should form the identifier that describes the
+	// desired package.
+	//
+	// Implementations of GetTemplate should return `apitype.TemplateMetadata{}, err`
+	// such that `errors.Is(err, ErrNotFound{})` returns true when the arguments to
+	// GetTemplate do not point to a package.
 	GetTemplate(
 		ctx context.Context, source, publisher, name string, version *semver.Version,
 	) (apitype.TemplateMetadata, error)
 
-	// ListTemplates is a preview API, and should not be used without an approved EOL
-	// plan for deprecation. The safest way to do this is to flag functionality behind
-	// `PULUMI_EXPERIMENTAL`, which removes any backwards comparability requirements.
+	// Retrieve a list of templates.
+	//
+	// If name is non-nil, it will filte to accessible templates that exactly match
+	// */*/{name}.
 	ListTemplates(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error]
 
 	// DownloadTemplate downloads a template given the value of

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -1355,7 +1355,7 @@ func TestPackageAddGoParameterized(t *testing.T) {
 	yamlString := string(yamlContent)
 	require.Contains(t, yamlString, "packages:")
 	require.Contains(t, yamlString, "netapp-cloudmanager:")
-	require.Contains(t, yamlString, "source: pulumi/pulumi/terraform-provider")
+	require.Contains(t, yamlString, "source: terraform-provider")
 	require.Contains(t, yamlString, "version: "+terraformProviderVersion)
 	require.Contains(t, yamlString, "parameters:")
 	require.Contains(t, yamlString, "- NetApp/netapp-cloudmanager")

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -1355,7 +1355,7 @@ func TestPackageAddGoParameterized(t *testing.T) {
 	yamlString := string(yamlContent)
 	require.Contains(t, yamlString, "packages:")
 	require.Contains(t, yamlString, "netapp-cloudmanager:")
-	require.Contains(t, yamlString, "source: terraform-provider")
+	require.Contains(t, yamlString, "source: pulumi/pulumi/terraform-provider")
 	require.Contains(t, yamlString, "version: "+terraformProviderVersion)
 	require.Contains(t, yamlString, "parameters:")
 	require.Contains(t, yamlString, "- NetApp/netapp-cloudmanager")

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1604,14 +1604,13 @@ func TestPulumiInstallInstallsPackagesIntoTheCorrectDirectory(t *testing.T) {
 	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview")
 }
 
-func TestPulumiInstallInstallsPackagesWithExperimentalRegistry(t *testing.T) {
+func TestPulumiInstallInstallsPackagesFromLocalProjectFile(t *testing.T) {
 	t.Parallel()
 	e := ptesting.NewEnvironment(t)
 
 	e.ImportDirectory("packageadd-remote")
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 	e.Env = append(e.Env, "PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=false")
-	e.Env = append(e.Env, "PULUMI_EXPERIMENTAL=true")
 	e.RunCommand("pulumi", "stack", "select", "organization/packageadd-remote", "--create")
 
 	// Manually modify Pulumi.yaml to include a GitHub URL in packages section


### PR DESCRIPTION
- Make `pulumi template` and `pulumi template publish` commands generally available
- Make `pulumi package publish` command generally available
- Enable registry-based package resolution by default
- Enable registry-based template resolution by default in `pulumi new`
- Update API endpoints from `/api/preview/registry/*` to `/api/registry/*`
- Update tests to match new endpoint URLs

If registry services are or not working as expected, set `PULUMI_DISABLE_REGISTRY_RESOLVE=true` to make `pulumi new` fall back to the previous public and organization-based template resolution mechanism.