### PR TITLE
Set ThreadPoolExecutor max_workers to parallelism * 4

### DIFF
--- a/changelog/pending/20250821--sdk-python--set-threadpoolexecutor-max_workers-to-parallelism-4.yaml
+++ b/changelog/pending/20250821--sdk-python--set-threadpoolexecutor-max_workers-to-parallelism-4.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Set ThreadPoolExecutor max_workers to parallelism * 4

--- a/sdk/python/cmd/pulumi-language-python-exec
+++ b/sdk/python/cmd/pulumi-language-python-exec
@@ -63,7 +63,7 @@ def _set_default_executor(loop, parallelism: Optional[int]):
     """configure this event loop to respect the settings provided."""
     if parallelism is None:
         return
-    parallelism = max(parallelism, 1)
+    parallelism = max(parallelism, 1) * 4
     exec = ThreadPoolExecutor(max_workers=parallelism)
     loop.set_default_executor(exec)
     return exec

--- a/sdk/python/lib/pulumi/automation/_server.py
+++ b/sdk/python/lib/pulumi/automation/_server.py
@@ -79,7 +79,7 @@ class LanguageServer(LanguageRuntimeServicer):
             result = language_pb2.RunResponse()
             loop = asyncio.new_event_loop()
             if request.parallel is not None:
-                request.parallel = max(request.parallel, 1)
+                request.parallel = max(request.parallel, 1) * 4
                 loop.set_default_executor(
                     ThreadPoolExecutor(max_workers=request.parallel)
                 )


### PR DESCRIPTION
The GRPC monitor client uses blocking operations, so we run them in a ThreadPool. This was configured to use the value of the `--parallel` flag, which controls the engine parallelism. However other operation than just resource registrations can occupy slots in the threadpool, and reduce the number of calls the SDK could make.

This could also lead to deadlocks when `--parallel` was set to a low value and a transform would call for example an invoke. In this case a resource registration would block until the transform finishes, but the transform would block waiting to get a thread to run the invoke. Neither of the threads get freed up, and we are blocked.

Set the max_workers for the pool to parallelism * 4 to give us more head room here.
