### PR TITLE
introduce a validating persister that validates the snapshot

### DIFF
--- a/pkg/backend/validating_persister.go
+++ b/pkg/backend/validating_persister.go
@@ -1,0 +1,58 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+var _ = SnapshotPersister((*ValidatingPersister)(nil))
+
+type ValidatingPersister struct {
+	Snap      *deploy.Snapshot
+	ErrorFunc func(error)
+}
+
+func (p *ValidatingPersister) Save(snap *deploy.Snapshot) error {
+	result := &deploy.Snapshot{
+		Manifest:          snap.Manifest,
+		SecretsManager:    snap.SecretsManager,
+		Resources:         make([]*resource.State, len(snap.Resources)),
+		PendingOperations: make([]resource.Operation, len(snap.PendingOperations)),
+	}
+
+	for i, res := range snap.Resources {
+		res.Lock.Lock()
+		result.Resources[i] = res.Copy()
+		res.Lock.Unlock()
+	}
+
+	for i, op := range snap.PendingOperations {
+		op.Resource.Lock.Lock()
+		result.PendingOperations[i] = resource.Operation{
+			Type:     op.Type,
+			Resource: op.Resource.Copy(),
+		}
+		op.Resource.Lock.Unlock()
+	}
+
+	if p.ErrorFunc != nil {
+		p.ErrorFunc(result.VerifyIntegrity())
+	}
+
+	p.Snap = result
+	return nil
+}


### PR DESCRIPTION
Introduce a validating persister, that validates the snapshot each time it is persisted, iow, when `Save` is called.  It works using a callback that can collect the errors and do with them as the caller desires.

The idea is to use this for the journaling code to verify the snapshot after each step. Introduce it here in a separate PR to keep https://github.com/pulumi/pulumi/pull/19862 from growing too much.