### PR TITLE
Log stack trace when interrupted when using verbose logging

### DIFF
--- a/changelog/pending/20250821--cli--log-stack-trace-when-interrupted-when-using-verbose-logging.yaml
+++ b/changelog/pending/20250821--cli--log-stack-trace-when-interrupted-when-using-verbose-logging.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli
+  description: Log stack trace when interrupted when using verbose logging


### PR DESCRIPTION
When logging at level 9 and above, grab a stack trace for all goroutines when we get interrupted. This can be helpful when debugging a hang.

For example this snippet is from a run that has a transform that's hanging:
```
I0821 20:19:32.155779   91857 cancellation_scope.go:79] github.com/pulumi/pulumi/pkg/v3/resource/deploy.(*resmon).wrapTransformCallback.func1({0x10737e420, 0x140006b4d50}, {0x106bca008, 0x1}, {0x14001f00240, 0x15}, 0x1, {0x14001c5e8c0, 0x37}, 0x140006b4ea0, ...)
I0821 20:19:32.155782   91857 cancellation_scope.go:79] 	/Users/julien/Projects/pulumi/pulumi/pkg/resource/deploy/source_eval.go:1496 +0x3e4
I0821 20:19:32.155788   91857 cancellation_scope.go:79] github.com/pulumi/pulumi/pkg/v3/resource/deploy.(*resmon).RegisterResource(0x140021021e0, {0x10737e420, 0x140006b4d50}, 0x140021865a0)
I0821 20:19:32.155790   91857 cancellation_scope.go:79] 	/Users/julien/Projects/pulumi/pulumi/pkg/resource/deploy/source_eval.go:2162 +0x1250
```