### PR TITLE
Print the location of the log file when running with the verbose flag

### DIFF
--- a/changelog/pending/20250821--cli--print-the-location-of-the-log-file-when-running-with-the-verbose-flag.yaml
+++ b/changelog/pending/20250821--cli--print-the-location-of-the-log-file-when-running-with-the-verbose-flag.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli
+  description: Print the location of the log file when running with the verbose flag

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -192,6 +192,16 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 		logging.Flush()
 		cmdutil.CloseTracing()
 
+		if logging.Verbose > 0 && !logging.LogToStderr {
+			logFile, err := logging.GetLogfilePath()
+			if err != nil {
+				logging.Warningf("could not find the log file: %s", err)
+				logging.Flush()
+			} else {
+				fmt.Printf("The log file for this run is at %s\n", logFile)
+			}
+		}
+
 		if profiling != "" {
 			if err := cmdutil.CloseProfiling(profiling); err != nil {
 				logging.Warningf("could not close profiling: %v", err)

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -24,6 +24,7 @@ package logging
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"strconv"
@@ -130,6 +131,17 @@ func InitLogging(logToStderr bool, verbose int, logFlow bool) {
 	if verbose > 0 {
 		maybeSetFlag("v", strconv.Itoa(verbose))
 	}
+}
+
+func GetLogfilePath() (string, error) {
+	logFiles, err := glog.Names("INFO")
+	if err != nil {
+		return "", err
+	}
+	if len(logFiles) == 0 {
+		return "", errors.New("no log files found")
+	}
+	return logFiles[0], nil
 }
 
 func assertNoError(err error) {


### PR DESCRIPTION
Make it easier to find the log file when running with `-vN` by printing the path at the end of the command run.