### PR TITLE
Add `previewDestroy` to the NodeJS SDK

### DIFF
--- a/changelog/pending/20250822--sdk-nodejs--add-previewdestroy-to-allow-dry-runs-of-destroy-commands.yaml
+++ b/changelog/pending/20250822--sdk-nodejs--add-previewdestroy-to-allow-dry-runs-of-destroy-commands.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Add `previewDestroy` to allow dry-runs of `destroy` commands

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -830,6 +830,99 @@ Event: ${line}\n${e.toString()}`);
     }
 
     /**
+     * Performs a dry-run destroy of the stack, returning pending changes.
+     *
+     * @param opts
+     *  Options to customize the behavior of the destroy.
+     */
+    async previewDestroy(opts?: DestroyOptions): Promise<PreviewResult> {
+        const args = ["destroy", "--preview-only"];
+        args.push(...this.remoteArgs());
+
+        if (opts) {
+            if (opts.message) {
+                args.push("--message", opts.message);
+            }
+            if (opts.exclude) {
+                for (const eURN of opts.exclude) {
+                    args.push("--exclude", eURN);
+                }
+            }
+            if (opts.target) {
+                for (const tURN of opts.target) {
+                    args.push("--target", tURN);
+                }
+            }
+            if (opts.excludeDependents) {
+                args.push("--exclude-dependents");
+            }
+            if (opts.targetDependents) {
+                args.push("--target-dependents");
+            }
+            if (opts.excludeProtected) {
+                args.push("--exclude-protected");
+            }
+            if (opts.continueOnError) {
+                args.push("--continue-on-error");
+            }
+            if (opts.parallel) {
+                args.push("--parallel", opts.parallel.toString());
+            }
+            if (opts.userAgent) {
+                args.push("--exec-agent", opts.userAgent);
+            }
+            if (opts.refresh) {
+                args.push("--refresh");
+            }
+            if (opts.runProgram !== undefined) {
+                if (opts.runProgram) {
+                    args.push("--run-program=true");
+                } else {
+                    args.push("--run-program=false");
+                }
+            }
+            applyGlobalOpts(opts, args);
+        }
+
+        args.push("--exec-kind", execKind.local);
+
+        const logFile = createLogFile("destroy");
+        args.push("--event-log", logFile);
+
+        let summaryEvent: SummaryEvent | undefined;
+        const logPromise = this.readLines(logFile, (event) => {
+            if (event.summaryEvent) {
+                summaryEvent = event.summaryEvent;
+            }
+            if (opts?.onEvent) {
+                const onEvent = opts.onEvent;
+                onEvent(event);
+            }
+        });
+
+        let previewResult: CommandResult;
+        try {
+            previewResult = await this.runPulumiCmd(args, opts?.onOutput, opts?.onError, opts?.signal);
+        } catch (e) {
+            throw e;
+        } finally {
+            await cleanUp(logFile, await logPromise);
+        }
+
+        if (!summaryEvent) {
+            log.warn(
+                "Failed to parse summary event, but preview succeeded. PreviewResult `changeSummary` will be empty.",
+            );
+        }
+
+        return {
+            stdout: previewResult.stdout,
+            stderr: previewResult.stderr,
+            changeSummary: summaryEvent?.resourceChanges || {},
+        };
+    }
+
+    /**
      * Rename an existing stack
      */
     async rename(options: RenameOptions): Promise<RenameResult> {
@@ -1945,6 +2038,7 @@ export interface DestroyOptions extends GlobalOpts {
 
     /**
      * Only show a preview of the destroy, but don't perform the destroy itself.
+     * @deprecated Use `previewDestroy` instead.
      */
     previewOnly?: boolean;
 

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -684,9 +684,14 @@ describe("LocalWorkspace", () => {
         assert.strictEqual(upRes.summary.kind, "update");
         assert.strictEqual(upRes.summary.result, "succeeded");
 
+        // pulumi destroy --preview-only
+        const previewDestroyRes = await stack.previewDestroy({ userAgent });
+        assert.deepStrictEqual(previewDestroyRes.changeSummary, { delete: 1 });
+
         // pulumi destroy
-        const destroyRes = await stack.destroy({ userAgent, previewOnly: true });
-        assert.strictEqual(destroyRes.summary.kind, "update");
+        const destroyRes = await stack.destroy({ userAgent });
+        assert.deepStrictEqual(destroyRes.summary.resourceChanges, { delete: 1 });
+        assert.strictEqual(destroyRes.summary.kind, "destroy");
         assert.strictEqual(destroyRes.summary.result, "succeeded");
 
         await stack.workspace.removeStack(stackName);


### PR DESCRIPTION
Continuing in the steps of #19900, #19948, and so on, this PR adds the `previewDestroy` command and deprecates the `--preview-only` flag in the `destroy` command. The reason is that `destroy` (like `refresh`) uses the event log to figure out what was affected by a change. However, preview commands don't generate event logs, so you instead get the results of whatever the _previous_ change was. This PR special-cases this preview behaviour to avoid the bug.