### PR TITLE
Fix TestDeletedWithOptionInheritanceMLC to pass with grpc providers

### DIFF
--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -1719,7 +1719,7 @@ func TestDeletedWithOptionInheritanceMLC(t *testing.T) {
 					}, nil
 				},
 			}, nil
-		}),
+		}, deploytest.WithGrpc),
 	}
 
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)

--- a/sdk/go/common/resource/plugin/provider_server.go
+++ b/sdk/go/common/resource/plugin/provider_server.go
@@ -834,6 +834,7 @@ func (p *providerServer) Construct(ctx context.Context,
 		Providers:            req.GetProviders(),
 		PropertyDependencies: propertyDependencies,
 		ResourceHooks:        hooks,
+		DeletedWith:          resource.URN(req.DeletedWith),
 	}
 
 	resp, err := p.provider.Construct(ctx, ConstructRequest{


### PR DESCRIPTION
This was missing the propogation of the DeletedWith option on the server side.