### PR TITLE
Handle `-v` flag passed to policy packs

### DIFF
--- a/changelog/pending/20250822--sdk-python--handle-v-flag-passed-to-policy-packs.yaml
+++ b/changelog/pending/20250822--sdk-python--handle-v-flag-passed-to-policy-packs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Handle `-v` flag passed to policy packs

--- a/sdk/python/lib/pulumi/policy/__main__.py
+++ b/sdk/python/lib/pulumi/policy/__main__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020, Pulumi Corporation.
+# Copyright 2016-2025, Pulumi Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,9 @@ def main():
     parser.add_argument("--tracing", required=False, nargs=1, metavar="TRACING_FILE")
     parser.add_argument("--logtostderr", required=False, action="store_true")
     parser.add_argument("--logflow", required=False, action="store_true")
-    args = parser.parse_args()
+    parser.add_argument("-v", "--verbose", required=False, type=int, default=0)
+    # Parse the args, ignoring unknown args.
+    args, _ = parser.parse_known_args()
     program = args.program
 
     # If any config variables are present, parse and set them, so subsequent accesses are fast.

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1386,6 +1386,7 @@ func TestMultiplePolicyPacks(t *testing.T) {
 }
 
 // regression test for https://github.com/pulumi/pulumi/issues/11092
+// and https://github.com/pulumi/pulumi/issues/20367
 func TestPolicyPluginExtraArguments(t *testing.T) {
 	t.Parallel()
 
@@ -1424,7 +1425,7 @@ func TestPolicyPluginExtraArguments(t *testing.T) {
 
 	// Run with extra arguments
 	_, _, err = e.GetCommandResults("pulumi", "--logflow", "preview", "--logtostderr",
-		"--policy-pack", "python_policy_pack", "--tracing", "file:/trace.log")
+		"-v9", "--policy-pack", "python_policy_pack", "--tracing", "file:/trace.log")
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
This change allows the `-v` command line flag to be used with policy packs written in Python, e.g. `pulumi preview --policy-pack ./pypp --logflow -v9`.