### PR TITLE
Default lifecycle Read methods to be StatusOK

### DIFF
--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -200,7 +200,7 @@ func (prov *Provider) Read(ctx context.Context, req plugin.ReadRequest) (plugin.
 				Outputs: state,
 				Inputs:  inputs,
 			},
-			Status: resource.StatusUnknown,
+			Status: resource.StatusOK,
 		}, nil
 	}
 


### PR DESCRIPTION
We're filling in all the inputs and outputs as if nothings changed, which will be fine for most of the tests. As such we can just. return OK here instead of Unknown, I don't think any test is affected by this yet but I could see subtle changes causing Unknown to start causing issues.