### PR TITLE
Fix TestDestroyTargetWithChildren to run with grpc

### DIFF
--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -1823,7 +1823,7 @@ func destroySpecificTargetsWithChildren(
 					return plugin.DiffResult{}, nil
 				},
 			}, nil
-		}),
+		}, deploytest.WithGrpc),
 	}
 
 	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, loaders...)
@@ -1876,6 +1876,9 @@ func newResource(urn, parent resource.URN, id resource.ID, provider string, depe
 	inputs := resource.PropertyMap{}
 	for k := range propertyDeps {
 		inputs[k] = resource.NewStringProperty("foo")
+	}
+	if outputs == nil {
+		outputs = resource.PropertyMap{}
 	}
 
 	return &resource.State{


### PR DESCRIPTION
Small fixup that `outputs` need to be non-nil in the state.