### PR TITLE
Improve types for handle_grpc_error

### DIFF
--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -494,7 +494,6 @@ def call(
                     return monitor.Call(req)
                 except grpc.RpcError as exn:
                     handle_grpc_error(exn)
-                    return None
 
             resp = await asyncio.get_event_loop().run_in_executor(None, do_rpc_call)
             if resp is None:

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -568,7 +568,6 @@ def get_resource(
                     return monitor.Invoke(req)
                 except grpc.RpcError as exn:
                     handle_grpc_error(exn)
-                    return None
 
             resp = await asyncio.get_event_loop().run_in_executor(None, do_invoke)
 
@@ -820,7 +819,6 @@ def read_resource(
                     return monitor.ReadResource(req)
                 except grpc.RpcError as exn:
                     handle_grpc_error(exn)
-                    return None
 
             resp = await asyncio.get_event_loop().run_in_executor(None, do_rpc_call)
 
@@ -1059,7 +1057,6 @@ def register_resource(
                     return monitor.RegisterResource(req)
                 except grpc.RpcError as exn:
                     handle_grpc_error(exn)
-                    return None
 
             resp = await asyncio.get_event_loop().run_in_executor(None, do_rpc_call)
         except Exception as exn:
@@ -1162,7 +1159,6 @@ def register_resource_outputs(
                 return monitor.RegisterResourceOutputs(req)
             except grpc.RpcError as exn:
                 handle_grpc_error(exn)
-                return None
 
         await asyncio.get_event_loop().run_in_executor(None, do_rpc_call)
         log.debug(

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -23,7 +23,7 @@ import os
 import threading
 from collections import deque
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, NoReturn, Optional, Union
 
 import grpc
 
@@ -320,7 +320,7 @@ def grpc_error_to_exception(exn: grpc.RpcError) -> Exception:
     return Exception(details)
 
 
-def handle_grpc_error(exn: grpc.RpcError) -> None:
+def handle_grpc_error(exn: grpc.RpcError) -> NoReturn:
     raise grpc_error_to_exception(exn)
 
 


### PR DESCRIPTION
This always raises an exception, so the correct return type is `NoReturn`.

Edit: `Never` was added in 3.11, use `NoReturn` instead, which is equivalent but more idiomatic for function returns https://typing.python.org/en/latest/spec/special-types.html#never