### PR TITLE
Limit @types packages used during local SDK generation

### DIFF
--- a/changelog/pending/20250826--sdkgen-nodejs--limit-attypes-packages-used-during-local-sdk-generation.yaml
+++ b/changelog/pending/20250826--sdkgen-nodejs--limit-attypes-packages-used-during-local-sdk-generation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/nodejs
+  description: Limit @types packages used during local SDK generation

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -2565,13 +2565,22 @@ func genNPMPackageMetadata(
 // local SDKs declare typescript as a dependencies. When the script is run via a
 // package manager, the package manager will add `node_modules/.bin` to the
 // path, ensuring we run the intended version of `tsc`.
+// We also limit the `@types` packages that are used to those the SDK itself
+// depends on. Otherwise typescript will use all `@types` packages in the
+// project, which can lead to it trying to use type packages that are not
+// compatible with the SDK's typescript version.
 func genPostInstallScript() []byte {
 	return []byte(`const fs = require("node:fs");
 const path = require("node:path");
 const process = require("node:process");
 const { execSync } = require('node:child_process');
+// We want to run "tsc --types node --types something-else ..." for each @types package.
+const packageJSON = JSON.parse(fs.readFileSync("package.json") ?? "{}");
+const deps = Object.keys(packageJSON.dependencies ?? []).concat(Object.keys(packageJSON.devDependencies ?? []));
+const types = deps.filter(d => d.startsWith("@types/")).map(d => d.slice("@types/".length)).join(",");
+const typesFlag = types.length > 0 ? " --types " + types : "";
 try {
-  execSync("tsc");
+  execSync("tsc"+typesFlag);
 } catch (error) {
   console.error("Failed to run 'tsc'", {
     stdout: error.stdout.toString(),

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -3098,6 +3098,21 @@ func TestNodePackageAddTSC(t *testing.T) {
 	}
 }
 
+// Test that `tsc` does not pick up the project's @types packages when compiling the local SDK
+func TestNodePackageAddTypes(t *testing.T) {
+	t.Parallel()
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+	e.ImportDirectory("packageadd-types")
+	provider := filepath.Join(e.RootPath, "provider")
+	program := filepath.Join(e.RootPath, "program")
+	e.CWD = provider
+	installNodejsProviderDependencies(t, provider)
+	e.CWD = program
+	e.RunCommand("pulumi", "install")
+	e.RunCommand("pulumi", "package", "add", provider)
+}
+
 // Regression test for https://github.com/pulumi/pulumi/issues/20068
 //
 //nolint:paralleltest // ProgramTest calls t.Parallel()

--- a/tests/integration/packageadd-types/program/Pulumi.yaml
+++ b/tests/integration/packageadd-types/program/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: program
+runtime:
+  name: nodejs
+  options:
+    packagemanager: npm

--- a/tests/integration/packageadd-types/program/index.ts
+++ b/tests/integration/packageadd-types/program/index.ts
@@ -1,0 +1,4 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as provider from "@pulumi/provider";
+
+new provider.MyComponent("comp")

--- a/tests/integration/packageadd-types/program/package.json
+++ b/tests/integration/packageadd-types/program/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "program",
+    "version": "0.0.1",
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@types/jest": "^30"
+    },
+    "//": "@types/jest@30 is not compatible with the tsconfig of the generated provider SDK"
+}

--- a/tests/integration/packageadd-types/provider/PulumiPlugin.yaml
+++ b/tests/integration/packageadd-types/provider/PulumiPlugin.yaml
@@ -1,0 +1,1 @@
+runtime: nodejs

--- a/tests/integration/packageadd-types/provider/index.ts
+++ b/tests/integration/packageadd-types/provider/index.ts
@@ -1,0 +1,12 @@
+// Copyright 2025 Pulumi Corporation.
+
+import * as pulumi from "@pulumi/pulumi"
+
+export interface MyComponentArgs {
+}
+
+export class MyComponent extends pulumi.ComponentResource {
+    constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("provider:index:MyComponent", name, args, opts);
+    }
+}

--- a/tests/integration/packageadd-types/provider/package.json
+++ b/tests/integration/packageadd-types/provider/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "provider",
+    "version": "0.0.1",
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}


### PR DESCRIPTION
Generated local SDKs depend directly on typescript because we require the ts compiler to build the package in a postinstall script. The dependency ensures that the compiler is present and at a version that is guaranteed to work for the local SDK.

By default typescript will include any `@types/…` packages. When the project that uses the local SDK includes a `@types/…` package that uses features requiring a more recent typescript compiler, the postinstall script will fail. An example is `@types/jest@30`, which requires typescript 5.2, but local SDKs use 4.3.

To fix this we can pass the `--types` flag to `tsc` to select which `@types/…` packages are included in the compilation and limit it to only those the local SDK depends on, not those of the project.

Fixes https://github.com/pulumi/pulumi/issues/20386
