### PR TITLE
Fix TestResourceHookComponent to work with grpc

### DIFF
--- a/changelog/pending/20250826--engine--fix-a-bug-causing-hooks-to-never-pass-correctly-to-remote-go-components.yaml
+++ b/changelog/pending/20250826--engine--fix-a-bug-causing-hooks-to-never-pass-correctly-to-remote-go-components.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix a bug causing hooks to never pass correctly to remote Go components

--- a/sdk/go/common/resource/plugin/provider_server.go
+++ b/sdk/go/common/resource/plugin/provider_server.go
@@ -818,7 +818,7 @@ func (p *providerServer) Construct(ctx context.Context,
 	var hooks map[resource.HookType][]string
 	binding := req.GetResourceHooks()
 	if binding != nil {
-		hooks := make(map[resource.HookType][]string)
+		hooks = make(map[resource.HookType][]string)
 		hooks[resource.BeforeCreate] = binding.GetBeforeCreate()
 		hooks[resource.AfterCreate] = binding.GetAfterCreate()
 		hooks[resource.BeforeUpdate] = binding.GetBeforeUpdate()


### PR DESCRIPTION
There was a bug in the provider server logic for Construct that set the parsed hooks to an inner variable that was never used, so the actual request options passed onwards never had any hooks.