### PR TITLE
Fix TestImportOption to work with grpc

### DIFF
--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -49,7 +49,8 @@ func TestImportOption(t *testing.T) {
 
 	// For imports we expect inputs and state to be nil, but when we change to do a read they should both be set to the
 	// resource inputs.
-	var expectedInputs, expectedState resource.PropertyMap
+	expectedInputs := resource.PropertyMap{}
+	expectedState := resource.PropertyMap{}
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return &deploytest.Provider{
@@ -97,7 +98,7 @@ func TestImportOption(t *testing.T) {
 					}, nil
 				},
 			}, nil
-		}),
+		}, deploytest.WithGrpc),
 	}
 
 	readID, importID, inputs := resource.ID(""), resource.ID("id"), resource.PropertyMap{}
@@ -344,7 +345,7 @@ func TestImportOption(t *testing.T) {
 
 	// Now have the program import the resource. We should see an import-replace and a read-discard.
 	readID, importID = "", readID
-	expectedInputs, expectedState = nil, nil
+	expectedInputs, expectedState = resource.PropertyMap{}, resource.PropertyMap{}
 	_, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, entries JournalEntries, _ []Event, err error) error {
 			for _, entry := range entries {


### PR DESCRIPTION
Grpc doesn't send nil maps, just empties, so a couple of expected values needed fixing in this test when running on grpc.