### PR TITLE
Fix TestInitErrorsStep to run with grpc

### DIFF
--- a/pkg/engine/lifecycletest/step_generator_test.go
+++ b/pkg/engine/lifecycletest/step_generator_test.go
@@ -328,11 +328,13 @@ func TestInitErrorsStep(t *testing.T) {
 	lt.NewTestBuilder(t, &deploy.Snapshot{
 		Resources: []*resource.State{
 			{
-				Type:   "pulumi:providers:pkgA",
-				URN:    "urn:pulumi:test::test::pulumi:providers:pkgA::default",
-				Custom: true,
-				Delete: false,
-				ID:     "935b2216-aec5-4810-96fd-5f6eae57ac88",
+				Type:    "pulumi:providers:pkgA",
+				URN:     "urn:pulumi:test::test::pulumi:providers:pkgA::default",
+				Custom:  true,
+				Delete:  false,
+				ID:      "935b2216-aec5-4810-96fd-5f6eae57ac88",
+				Outputs: resource.PropertyMap{},
+				Inputs:  resource.PropertyMap{},
 			},
 			{
 				Type:     "pkgA:m:typA",
@@ -343,6 +345,8 @@ func TestInitErrorsStep(t *testing.T) {
 				InitErrors: []string{
 					`errors should yield an empty update to "continue" awaiting initialization.`,
 				},
+				Outputs: resource.PropertyMap{},
+				Inputs:  resource.PropertyMap{},
 			},
 		},
 	}).


### PR DESCRIPTION
The grpc layer asserts that input and output maps are non-nil, so our initial state needs to have empty, not nil, maps.