### PR TITLE
fix flaky TestRangeTraversalFromObjectOfObjectsDoesNotError

### DIFF
--- a/pkg/codegen/hcl2/model/diagnostics.go
+++ b/pkg/codegen/hcl2/model/diagnostics.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
@@ -104,6 +105,7 @@ func tupleIndexOutOfRange(tupleLen int, indexRange hcl.Range) *hcl.Diagnostic {
 }
 
 func unknownObjectProperty(name string, indexRange hcl.Range, props []string) *hcl.Diagnostic {
+	slices.Sort(props)
 	return errorf(indexRange, "unknown property '%s' among %v", name, props)
 }
 


### PR DESCRIPTION
This test is sometimes flaky because the array of unknown properties is not sorted, and can appear in different orders.

The test fails with:

```
        	Error:      	"unknown property 'aws_region' among [something awsRegion]" does not contain "unknown property 'aws_region' among [awsRegion something]"
```

We go for the simple fix here, just sorting that array, as it should always be cheap enough to do so, and is the best way to fix the test.

noticed in https://github.com/pulumi/pulumi/actions/runs/17270052509/job/49012394297?pr=20403.

Fixes https://github.com/pulumi/pulumi/issues/20406