### PR TITLE
Unignore wrapper scripts

### DIFF
--- a/sdk/nodejs/.gitignore
+++ b/sdk/nodejs/.gitignore
@@ -7,3 +7,7 @@
 .nyc_output/
 !yarn.lock
 !vendor
+!dist/pulumi-analyzer-policy
+!dist/pulumi-analyzer-policy.cmd
+!dist/pulumi-resource-pulumi-nodejs
+!dist/pulumi-resource-pulumi-nodejs.cmd

--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -8,3 +8,7 @@ venv/
 .coverage
 build/
 !cmd/pulumi-language-python-exec
+!dist/pulumi-analyzer-policy-python
+!dist/pulumi-analyzer-policy-python.cmd
+!dist/pulumi-resource-pulumi-python
+!dist/pulumi-resource-pulumi-python.cmd


### PR DESCRIPTION
These are ignored in the top-level .gitingore, supposedly for Goreleaser. Unignore them inside the SDK specific .gitignore files.