### PR TITLE
propagate context through cancellationScopeSource

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -354,7 +354,7 @@ type CancellationScope interface {
 // CancellationScopeSource provides a source for cancellation scopes.
 type CancellationScopeSource interface {
 	// NewScope creates a new cancellation scope.
-	NewScope(events chan<- engine.Event, isPreview bool) CancellationScope
+	NewScope(ctx context.Context, events chan<- engine.Event, isPreview bool) CancellationScope
 }
 
 // NewBackendClient returns a deploy.BackendClient that wraps the given Backend.

--- a/pkg/backend/cancellation_scope.go
+++ b/pkg/backend/cancellation_scope.go
@@ -49,8 +49,10 @@ type cancellationScopeSource int
 
 var CancellationScopes = CancellationScopeSource(cancellationScopeSource(0))
 
-func (cancellationScopeSource) NewScope(events chan<- engine.Event, isPreview bool) CancellationScope {
-	cancelContext, cancelSource := cancel.NewContext(context.Background())
+func (cancellationScopeSource) NewScope(
+	ctx context.Context, events chan<- engine.Event, isPreview bool,
+) CancellationScope {
+	cancelContext, cancelSource := cancel.NewContext(ctx)
 
 	c := &cancellationScope{
 		context: cancelContext,

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1179,7 +1179,7 @@ func (b *diyBackend) apply(
 	// Create a separate event channel for engine events that we'll pipe to both listening streams.
 	engineEvents := make(chan engine.Event)
 
-	scope := op.Scopes.NewScope(engineEvents, opts.DryRun)
+	scope := op.Scopes.NewScope(ctx, engineEvents, opts.DryRun)
 	eventsDone := make(chan bool)
 	go func() {
 		// Pull in all events from the engine and send them to the two listeners.

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1657,7 +1657,7 @@ func (b *cloudBackend) runEngineAction(
 
 	// Depending on the action, kick off the relevant engine activity.  Note that we don't immediately check and
 	// return error conditions, because we will do so below after waiting for the display channels to close.
-	cancellationScope := op.Scopes.NewScope(engineEvents, dryRun)
+	cancellationScope := op.Scopes.NewScope(ctx, engineEvents, dryRun)
 	engineCtx := &engine.Context{
 		Cancel:          cancellationScope.Context(),
 		Events:          engineEvents,


### PR DESCRIPTION
WE have a `cancellationScopeSource` that we use for terminating the program using `SIGINT`. Currently we generate a new context for this purpose. However I think it makes more sense to pass in a context, so the cancelation scope is also canceled if the parent context is canceled.

Note that if we call `cancel` on the `cancelContext` inside the cancellation source, the parent context will not be canceled, so there's no change in behaviour there.

I looked into this because of the conversation here: https://github.com/pulumi/pulumi/pull/20397#discussion_r2301734743.  