### PR TITLE
update mise guide to show enabling experimental mode

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -39,7 +39,7 @@ which you can do as follows:
    top-level `.mise.toml` file. After this, you should find that the tools you
    need are now available in your `$PATH`.
 5. Run `mise settings experimental=true` or use the `MISE_EXPERIMENTAL` environment variable. 
-   This is currently required to enable the Go backend.
+   This is currently required to enable the [Go backend](https://mise.jdx.dev/dev-tools/backends/go.html#go-backend).
 6. Run `mise install` to ensure all tools are up to date. You may need to re-run
    this if the tool list changes.
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -38,7 +38,9 @@ which you can do as follows:
    repository to specify the required tools, all of which are listed in the
    top-level `.mise.toml` file. After this, you should find that the tools you
    need are now available in your `$PATH`.
-5. Run `mise install` to ensure all tools are up to date. You may need to re-run
+5. Run `mise settings experimental=true` or use the `MISE_EXPERIMENTAL` environment variable. 
+   This is currently required to enable the Go backend.
+6. Run `mise install` to ensure all tools are up to date. You may need to re-run
    this if the tool list changes.
 
 When using Mise `$PULUMI_ROOT` is set to `$REPO/.root`. This is convenient for


### PR DESCRIPTION
The mise configuration uses Go package installation, this is still experimental and requires a flag to be enabled:
https://mise.jdx.dev/dev-tools/backends/go.html

I've updated the documentation to show how to enable it either with a setting or an environment variable. I'll keep an eye on if this changes and remove it later. 

Question: 
Happy with me not linking the reference here?