### PR TITLE
Handle missing cases in `ConvertJSONEvent`

### DIFF
--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -433,6 +433,12 @@ func ConvertJSONEvent(apiEvent apitype.EngineEvent) (engine.Event, error) {
 	case apiEvent.PolicyLoadEvent != nil:
 		event = engine.NewEvent(engine.PolicyLoadEventPayload{})
 
+	case apiEvent.StartDebuggingEvent != nil:
+		p := apiEvent.StartDebuggingEvent
+		event = engine.NewEvent(engine.StartDebuggingEventPayload{
+			Config: p.Config,
+		})
+
 	case apiEvent.ProgressEvent != nil:
 		p := apiEvent.ProgressEvent
 		event = engine.NewEvent(engine.ProgressEventPayload{
@@ -442,6 +448,12 @@ func ConvertJSONEvent(apiEvent apitype.EngineEvent) (engine.Event, error) {
 			Completed: p.Completed,
 			Total:     p.Total,
 			Done:      p.Done,
+		})
+
+	case apiEvent.ErrorEvent != nil:
+		p := apiEvent.ErrorEvent
+		event = engine.NewEvent(engine.ErrorEventPayload{
+			Error: p.Error,
 		})
 
 	default:

--- a/pkg/backend/display/events_test.go
+++ b/pkg/backend/display/events_test.go
@@ -18,9 +18,11 @@ package display
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -63,4 +65,30 @@ func TestEmptyDetailedDiff(t *testing.T) {
 	jsonEvent, err := json.Marshal(res)
 	require.NoError(t, err, "unable to marshal to json")
 	assert.Equal(t, expected, string(jsonEvent))
+}
+
+// TestConvertJSONEventExhaustive tests that all fields of the EngineEvent type are handled by ConvertJSONEvent.
+func TestConvertJSONEventExhaustive(t *testing.T) {
+	t.Parallel()
+
+	rt := reflect.TypeOf(apitype.EngineEvent{})
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		// Only consider exported pointer-to-struct fields.
+		if f.PkgPath != "" || f.Type.Kind() != reflect.Ptr || f.Type.Elem().Kind() != reflect.Struct {
+			continue
+		}
+
+		t.Run(f.Name, func(t *testing.T) {
+			t.Parallel()
+
+			// Build an event with exactly this field set non-nil.
+			var v apitype.EngineEvent
+			rv := reflect.ValueOf(&v).Elem()
+			rv.Field(i).Set(reflect.New(f.Type.Elem())) // zero value pointer, but non-nil
+
+			_, err := ConvertJSONEvent(v)
+			require.NoError(t, err, "field %s is not handled by ConvertJSONEvent", f.Name)
+		})
+	}
 }


### PR DESCRIPTION
`ConvertJSONEvent` is used when running a remote deployment via automation API (via the CLI), to convert the engine events being produced by the remote deployment into engine events that can be displayed locally.

I was looking at the recent change that added `ErrorEvent` and noticed it wasn't being handled here. It's not a problem yet since the CLI is not producing this event yet, but could turn into a problem when it does. This change handles `ErrorEvent` and adds a test that ensures we're exhaustively handling all possible cases on `apitype.EngineEvent`, since we can't lean on a linter in this case.

The test found that we're also not handling `StartDebuggingEvent`. It's arguable if we even need to handle this internal event here, but it is a field on `apitype.EngineEvent` and we are handling the ephemeral `ProgressEvent` event, (and it's simple enough to handle), so I've chosen to do so.

As a possible follow-up, we may want to reconsider whether we should have internal/ephemeral events on `apitype.EngineEvent`.