### PR TITLE
add support for chained inheritance on component resource

### DIFF
--- a/sdk/nodejs/provider/experimental/analyzer.ts
+++ b/sdk/nodejs/provider/experimental/analyzer.ts
@@ -333,11 +333,11 @@ Please ensure these components are properly imported to your package's entry poi
          */
         for (const type of this.getOrderedInheritanceChain(node)) {
 
-            const symbol = type.getSymbol();
-
-            if (symbol?.escapedName === "ComponentResource") {
+            if (this.isTypeComponentResource(type)) {
                 break;
             }
+
+            const symbol = type.getSymbol();
 
             if (symbol?.members) {
                 outputs = { 
@@ -367,20 +367,18 @@ Please ensure these components are properly imported to your package's entry poi
     }
 
     private isPulumiComponent(node: typescript.ClassDeclaration): boolean {
+        return this.getOrderedInheritanceChain(node).some(this.isTypeComponentResource);
+    }
 
-        return this.getOrderedInheritanceChain(node).some((type) => {
+    private isTypeComponentResource(type: typescript.Type): boolean {
+        const symbol = type.getSymbol();
 
-            const symbol = type.getSymbol();
+        const matchesName = symbol?.escapedName === "ComponentResource";
+        const sourceFile = symbol?.declarations?.[0].getSourceFile();
+        const matchesSourceFile =
+            sourceFile?.fileName.endsWith("resource.ts") || sourceFile?.fileName.endsWith("resource.d.ts");
 
-            const matchesName = symbol?.escapedName === "ComponentResource";
-            const sourceFile = symbol?.declarations?.[0].getSourceFile();
-            const matchesSourceFile =
-                sourceFile?.fileName.endsWith("resource.ts") || sourceFile?.fileName.endsWith("resource.d.ts");
-
-            return matchesName && matchesSourceFile;
-
-        });
-
+        return matchesName && matchesSourceFile!;
     }
 
     private getOrderedInheritanceChain(node: typescript.ClassDeclaration): typescript.Type[] {

--- a/sdk/nodejs/provider/experimental/analyzer.ts
+++ b/sdk/nodejs/provider/experimental/analyzer.ts
@@ -327,14 +327,29 @@ Please ensure these components are properly imported to your package's entry poi
         }
 
         let outputs: Record<string, PropertyDefinition> = {};
-        const classType = this.checker.getTypeAtLocation(node);
-        const classSymbol = classType.getSymbol();
-        if (classSymbol?.members) {
-            outputs = this.analyzeSymbols(
-                { component: componentName, inputOutput: InputOutput.Output },
-                symbolTableToSymbols(classSymbol.members),
-                node,
-            );
+
+        /**
+         * We need to walk up the inheritance chain to find all the outputs
+         */
+        for (const type of this.getOrderedInheritanceChain(node)) {
+
+            const symbol = type.getSymbol();
+
+            if (symbol?.escapedName === "ComponentResource") {
+                break;
+            }
+
+            if (symbol?.members) {
+                outputs = { 
+                    ...outputs, 
+                    ...this.analyzeSymbols(
+                        { component: componentName, inputOutput: InputOutput.Output },
+                        symbolTableToSymbols(symbol.members),
+                        node,
+                    )
+                };
+            }
+
         }
 
         const definition: ComponentDefinition = {
@@ -352,21 +367,34 @@ Please ensure these components are properly imported to your package's entry poi
     }
 
     private isPulumiComponent(node: typescript.ClassDeclaration): boolean {
-        if (!node.heritageClauses) {
-            return false;
+
+        return this.getOrderedInheritanceChain(node).some((type) => {
+
+            const symbol = type.getSymbol();
+
+            const matchesName = symbol?.escapedName === "ComponentResource";
+            const sourceFile = symbol?.declarations?.[0].getSourceFile();
+            const matchesSourceFile =
+                sourceFile?.fileName.endsWith("resource.ts") || sourceFile?.fileName.endsWith("resource.d.ts");
+
+            return matchesName && matchesSourceFile;
+
+        });
+
+    }
+
+    private getOrderedInheritanceChain(node: typescript.ClassDeclaration): typescript.Type[] {
+        const chain: typescript.Type[] = [];
+
+        let type: typescript.Type | undefined = this.checker.getTypeAtLocation(node);
+
+        while (type) {
+            chain.push(type);
+            const bases = type.getBaseTypes();
+            type = bases?.[0];
         }
 
-        return node.heritageClauses.some((clause) => {
-            return clause.types.some((clauseNode) => {
-                const type = this.checker.getTypeAtLocation(clauseNode);
-                const symbol = type.getSymbol();
-                const matchesName = symbol?.escapedName === "ComponentResource";
-                const sourceFile = symbol?.declarations?.[0].getSourceFile();
-                const matchesSourceFile =
-                    sourceFile?.fileName.endsWith("resource.ts") || sourceFile?.fileName.endsWith("resource.d.ts");
-                return matchesName && matchesSourceFile;
-            });
-        });
+        return chain;
     }
 
     private analyzeSymbols(

--- a/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
@@ -62,6 +62,36 @@ describe("Analyzer", function () {
         });
     });
 
+    it("infers chained inheritance", async function () {
+        const dir = path.join(__dirname, "testdata", "chained-inheritance");
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent", "MyInheritingComponent"]));
+        const { components } = analyzer.analyze();
+
+        assert.deepStrictEqual(components, {
+            MyComponent: {
+                name: "MyComponent",
+                inputs: {
+                    aNumber: { type: "number" },
+                    aString: { type: "string" },
+                },
+                outputs: {
+                    outNumber: { type: "number" },
+                },
+            },
+            MyInheritingComponent: {
+                name: "MyInheritingComponent",
+                inputs: {
+                    aNumber: { type: "number" },
+                    aString: { type: "string" },
+                },
+                outputs: {
+                    outString: { type: "string" },
+                    outNumber: { type: "number" },
+                },
+            },
+        });
+    });
+
     it("infers optional types", async function () {
         const dir = path.join(__dirname, "testdata", "optional-types");
         const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));

--- a/sdk/nodejs/tests/provider/experimental/testdata/chained-inheritance/index.ts
+++ b/sdk/nodejs/tests/provider/experimental/testdata/chained-inheritance/index.ts
@@ -1,0 +1,22 @@
+import * as pulumi from "@pulumi/pulumi";
+
+export interface MyComponentArgs {
+    aNumber: pulumi.Input<number>;
+    aString: pulumi.Input<string>;
+}
+
+export class MyComponent extends pulumi.ComponentResource {
+    outNumber: pulumi.Output<number>;
+
+    constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions, type: string = "provider:index:MyComponent") {
+        super(type, name, args, opts);
+    }
+}
+
+export class MyInheritingComponent extends MyComponent {
+    outString: pulumi.Output<string>;
+
+    constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super(name, args, opts, "provider:index:MyInheritingComponent");
+    }
+}


### PR DESCRIPTION
Adds support for chained inheritance on `pulumi.ComponentResource`

Linked to this issue:
https://github.com/pulumi/pulumi/issues/20071

The example I've tested with exposes the components name in the constructor of the first level component. It may be fine but feedback welcome

Solution:

1. Introduced a new function for walking through the inheritance chain
2. Used the walk to validate if the class is at some point inherited from `pulumi.ComponentResource`
3. Used the walk to gather the outputs from all levels