### PR TITLE
[chore] Use `resource.NewProperty`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -78,6 +78,8 @@ linters:
           msg: Use require.NotNil instead
         - pattern: ^assert.Len$
           msg: Use require.Len instead
+        - pattern: ^resource.New(String|Bool|Number|Array|Asset|Archive|Object|Computed|Output|Secret|ResourceReference)Property$
+          msg: Use resource.NewProperty instead
   exclusions:
     generated: lax
     presets:

--- a/cmd/pulumi-test-language/providers/any_type_function_provider.go
+++ b/cmd/pulumi-test-language/providers/any_type_function_provider.go
@@ -192,8 +192,8 @@ func (p *AnyTypeFunctionProvider) Invoke(
 
 		return plugin.InvokeResponse{
 			Properties: resource.PropertyMap{
-				"result": resource.NewObjectProperty(resource.PropertyMap{
-					"resultProperty": resource.NewStringProperty("resultValue"),
+				"result": resource.NewProperty(resource.PropertyMap{
+					"resultProperty": resource.NewProperty("resultValue"),
 				}),
 			},
 		}, nil

--- a/cmd/pulumi-test-language/providers/camel_names_provider.go
+++ b/cmd/pulumi-test-language/providers/camel_names_provider.go
@@ -244,10 +244,10 @@ func (p *CamelNamesProvider) Read(ctx context.Context, req plugin.ReadRequest) (
 		ReadResult: plugin.ReadResult{
 			ID: req.ID,
 			Inputs: resource.PropertyMap{
-				"theInput": resource.NewBoolProperty(true),
+				"theInput": resource.NewProperty(true),
 			},
 			Outputs: resource.PropertyMap{
-				"theOutput": resource.NewBoolProperty(true),
+				"theOutput": resource.NewProperty(true),
 			},
 		},
 		Status: resource.StatusOK,

--- a/cmd/pulumi-test-language/providers/component_property_deps_provider.go
+++ b/cmd/pulumi-test-language/providers/component_property_deps_provider.go
@@ -427,7 +427,7 @@ func (p *ComponentPropertyDepsProvider) convertMapToObjectProperty(
 	for key, urns := range m {
 		fields[string(key)] = urns
 	}
-	return resource.NewObjectProperty(resource.NewPropertyMapFromMap(fields))
+	return resource.NewProperty(resource.NewPropertyMapFromMap(fields))
 }
 
 func (p *ComponentPropertyDepsProvider) convertMapToStruct(

--- a/cmd/pulumi-test-language/providers/component_provider.go
+++ b/cmd/pulumi-test-language/providers/component_provider.go
@@ -399,9 +399,9 @@ func (p *ComponentProvider) constructComponentCustomRefOutput(
 
 	// Create a resource reference to the child, that we'll register as an output of the component and return as part of
 	// our ConstructResponse.
-	refPropVal := resource.NewResourceReferenceProperty(resource.ResourceReference{
+	refPropVal := resource.NewProperty(resource.ResourceReference{
 		URN: resource.URN(child.Urn),
-		ID:  resource.NewStringProperty(child.Id),
+		ID:  resource.NewProperty(child.Id),
 	})
 	refStruct, err := plugin.MarshalPropertyValue("ref", refPropVal, plugin.MarshalOptions{
 		KeepResources: true,
@@ -490,7 +490,7 @@ func (p *ComponentProvider) constructComponentCustomRefInputOutput(
 	}
 
 	// Create resource references for the inputRef and outputRef component outputs.
-	inputRefPropVal := resource.NewResourceReferenceProperty(inputRef)
+	inputRefPropVal := resource.NewProperty(inputRef)
 	inputRefStruct, err := plugin.MarshalPropertyValue("inputRef", inputRefPropVal, plugin.MarshalOptions{
 		KeepResources: true,
 		KeepSecrets:   true,
@@ -499,9 +499,9 @@ func (p *ComponentProvider) constructComponentCustomRefInputOutput(
 		return plugin.ConstructResponse{}, fmt.Errorf("marshal input ref: %w", err)
 	}
 
-	outputRefPropVal := resource.NewResourceReferenceProperty(resource.ResourceReference{
+	outputRefPropVal := resource.NewProperty(resource.ResourceReference{
 		URN: resource.URN(child.Urn),
-		ID:  resource.NewStringProperty(child.Id),
+		ID:  resource.NewProperty(child.Id),
 	})
 	outputRefStruct, err := plugin.MarshalPropertyValue("outputRef", outputRefPropVal, plugin.MarshalOptions{
 		KeepResources: true,

--- a/cmd/pulumi-test-language/providers/config_grpc_provider.go
+++ b/cmd/pulumi-test-language/providers/config_grpc_provider.go
@@ -279,7 +279,7 @@ func (p *ConfigGrpcProvider) Create(
 		return plugin.CreateResponse{
 			ID: resource.ID(id),
 			Properties: resource.PropertyMap{
-				"config": resource.NewStringProperty(string(requestsJSON)),
+				"config": resource.NewProperty(string(requestsJSON)),
 			},
 			Status: resource.StatusOK,
 		}, nil

--- a/cmd/pulumi-test-language/providers/config_provider.go
+++ b/cmd/pulumi-test-language/providers/config_provider.go
@@ -222,7 +222,7 @@ func (p *ConfigProvider) Create(
 	text := req.Properties["text"].StringValue()
 
 	props := resource.PropertyMap{
-		"text": resource.NewStringProperty(p.prefix + ": " + text),
+		"text": resource.NewProperty(p.prefix + ": " + text),
 	}
 
 	return plugin.CreateResponse{

--- a/cmd/pulumi-test-language/providers/large_provider.go
+++ b/cmd/pulumi-test-language/providers/large_provider.go
@@ -160,7 +160,7 @@ func (p *LargeProvider) Create(
 	// aim for 100mb of data (400mb is the size limit we normally set, but nodejs is far more limited)
 	repeat := (100 * 1024 * 1024) / len(value.StringValue())
 	result := resource.PropertyMap{
-		"value": resource.NewStringProperty(
+		"value": resource.NewProperty(
 			strings.Repeat(value.StringValue(), repeat)),
 	}
 	return plugin.CreateResponse{

--- a/cmd/pulumi-test-language/providers/parameterized_provider.go
+++ b/cmd/pulumi-test-language/providers/parameterized_provider.go
@@ -256,7 +256,7 @@ func (p *ParameterizedProvider) Construct(
 	return plugin.ConstructResponse{
 		URN: urn,
 		Outputs: resource.PropertyMap{
-			"parameterValue": resource.NewStringProperty(string(p.parameterValue) + "Component"),
+			"parameterValue": resource.NewProperty(string(p.parameterValue) + "Component"),
 		},
 	}, nil
 }

--- a/cmd/pulumi-test-language/providers/simple_invoke_provider.go
+++ b/cmd/pulumi-test-language/providers/simple_invoke_provider.go
@@ -230,7 +230,7 @@ func (p *SimpleInvokeProvider) Invoke(
 
 		return plugin.InvokeResponse{
 			Properties: resource.PropertyMap{
-				"result": resource.NewStringProperty(value.StringValue() + " world"),
+				"result": resource.NewProperty(value.StringValue() + " world"),
 			},
 		}, nil
 	case "simple-invoke:index:myInvokeScalar":
@@ -260,7 +260,7 @@ func (p *SimpleInvokeProvider) Invoke(
 		// invoke implementations.
 		return plugin.InvokeResponse{
 			Properties: resource.PropertyMap{
-				"result": resource.NewBoolProperty(true),
+				"result": resource.NewProperty(true),
 			},
 		}, nil
 	case "simple-invoke:index:unit":
@@ -272,7 +272,7 @@ func (p *SimpleInvokeProvider) Invoke(
 
 		return plugin.InvokeResponse{
 			Properties: resource.PropertyMap{
-				"result": resource.NewStringProperty("Hello world"),
+				"result": resource.NewProperty("Hello world"),
 			},
 		}, nil
 	case "simple-invoke:index:secretInvoke":
@@ -309,7 +309,7 @@ func (p *SimpleInvokeProvider) Invoke(
 		}
 
 		// if the secretResponse is true, wrap the response as a secret
-		response := resource.NewStringProperty(value.StringValue() + " world")
+		response := resource.NewProperty(value.StringValue() + " world")
 		if secretResponse.BoolValue() {
 			response = resource.MakeSecret(response)
 		}
@@ -358,7 +358,7 @@ func (p *SimpleInvokeProvider) Create(
 	return plugin.CreateResponse{
 		ID: resource.ID(id),
 		Properties: resource.PropertyMap{
-			"text": resource.NewStringProperty("Goodbye"),
+			"text": resource.NewProperty("Goodbye"),
 		},
 		Status: resource.StatusOK,
 	}, nil

--- a/cmd/pulumi-test-language/providers/simple_invoke_with_scalar_return_provider.go
+++ b/cmd/pulumi-test-language/providers/simple_invoke_with_scalar_return_provider.go
@@ -168,7 +168,7 @@ func (p *SimpleInvokeWithScalarReturnProvider) Invoke(
 		// invoke implementations.
 		return plugin.InvokeResponse{
 			Properties: resource.PropertyMap{
-				"result": resource.NewBoolProperty(true),
+				"result": resource.NewProperty(true),
 			},
 		}, nil
 	}
@@ -211,7 +211,7 @@ func (p *SimpleInvokeWithScalarReturnProvider) Create(
 	return plugin.CreateResponse{
 		ID: resource.ID(id),
 		Properties: resource.PropertyMap{
-			"text": resource.NewStringProperty("Goodbye"),
+			"text": resource.NewProperty("Goodbye"),
 		},
 		Status: resource.StatusOK,
 	}, nil

--- a/cmd/pulumi-test-language/providers/simple_provider.go
+++ b/cmd/pulumi-test-language/providers/simple_provider.go
@@ -238,10 +238,10 @@ func (p *SimpleProvider) Read(ctx context.Context, req plugin.ReadRequest) (plug
 		ReadResult: plugin.ReadResult{
 			ID: req.ID,
 			Inputs: resource.PropertyMap{
-				"value": resource.NewBoolProperty(true),
+				"value": resource.NewProperty(true),
 			},
 			Outputs: resource.PropertyMap{
-				"value": resource.NewBoolProperty(true),
+				"value": resource.NewProperty(true),
 			},
 		},
 		Status: resource.StatusOK,

--- a/cmd/pulumi-test-language/tests/l1_builtin_can.go
+++ b/cmd/pulumi-test-language/tests/l1_builtin_can.go
@@ -43,8 +43,8 @@ func init() {
 					outputs := stack.Outputs
 
 					require.Len(l, outputs, 10, "expected 10 outputs")
-					AssertPropertyMapMember(l, outputs, "plainTrySuccess", resource.NewBoolProperty(true))
-					AssertPropertyMapMember(l, outputs, "plainTryFailure", resource.NewBoolProperty(false))
+					AssertPropertyMapMember(l, outputs, "plainTrySuccess", resource.NewProperty(true))
+					AssertPropertyMapMember(l, outputs, "plainTryFailure", resource.NewProperty(false))
 
 					// The output failure variants may or may not be secret, depending on the language. We allow either.
 					assertPropertyMapMember := func(
@@ -70,19 +70,19 @@ func init() {
 					}
 
 					AssertPropertyMapMember(l, outputs, "outputTrySuccess",
-						resource.MakeSecret(resource.NewBoolProperty(true)))
+						resource.MakeSecret(resource.NewProperty(true)))
 					assertPropertyMapMember(outputs, "outputTryFailure",
-						resource.NewBoolProperty(false))
+						resource.NewProperty(false))
 					AssertPropertyMapMember(l, outputs, "dynamicTrySuccess",
-						resource.NewBoolProperty(true))
+						resource.NewProperty(true))
 					assertPropertyMapMember(outputs, "dynamicTryFailure",
-						resource.NewBoolProperty(false))
+						resource.NewProperty(false))
 					AssertPropertyMapMember(l, outputs, "outputDynamicTrySuccess",
-						resource.MakeSecret(resource.NewBoolProperty(true)))
+						resource.MakeSecret(resource.NewProperty(true)))
 					assertPropertyMapMember(outputs, "outputDynamicTryFailure",
-						resource.NewBoolProperty(false))
-					AssertPropertyMapMember(l, outputs, "plainTryNull", resource.NewBoolProperty(true))
-					assertPropertyMapMember(outputs, "outputTryNull", resource.NewBoolProperty(true))
+						resource.NewProperty(false))
+					AssertPropertyMapMember(l, outputs, "plainTryNull", resource.NewProperty(true))
+					assertPropertyMapMember(outputs, "outputTryNull", resource.NewProperty(true))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l1_builtin_info.go
+++ b/cmd/pulumi-test-language/tests/l1_builtin_info.go
@@ -37,9 +37,9 @@ func init() {
 					outputs := stack.Outputs
 
 					require.Len(l, outputs, 3, "expected 3 outputs")
-					AssertPropertyMapMember(l, outputs, "stackOutput", resource.NewStringProperty("test"))
-					AssertPropertyMapMember(l, outputs, "projectOutput", resource.NewStringProperty("l1-builtin-info"))
-					AssertPropertyMapMember(l, outputs, "organizationOutput", resource.NewStringProperty("organization"))
+					AssertPropertyMapMember(l, outputs, "stackOutput", resource.NewProperty("test"))
+					AssertPropertyMapMember(l, outputs, "projectOutput", resource.NewProperty("l1-builtin-info"))
+					AssertPropertyMapMember(l, outputs, "organizationOutput", resource.NewProperty("organization"))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l1_builtin_project_root.go
+++ b/cmd/pulumi-test-language/tests/l1_builtin_project_root.go
@@ -37,7 +37,7 @@ func init() {
 					outputs := stack.Outputs
 
 					require.Len(l, outputs, 1, "expected 1 outputs")
-					AssertPropertyMapMember(l, outputs, "rootDirectoryOutput", resource.NewStringProperty(projectDirectory))
+					AssertPropertyMapMember(l, outputs, "rootDirectoryOutput", resource.NewProperty(projectDirectory))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l1_builtin_try.go
+++ b/cmd/pulumi-test-language/tests/l1_builtin_try.go
@@ -44,8 +44,8 @@ func init() {
 					outputs := stack.Outputs
 
 					require.Len(l, outputs, 10, "expected 10 outputs")
-					AssertPropertyMapMember(l, outputs, "plainTrySuccess", resource.NewStringProperty("MOK"))
-					AssertPropertyMapMember(l, outputs, "plainTryFailure", resource.NewStringProperty("fallback"))
+					AssertPropertyMapMember(l, outputs, "plainTrySuccess", resource.NewProperty("MOK"))
+					AssertPropertyMapMember(l, outputs, "plainTryFailure", resource.NewProperty("fallback"))
 
 					// The output failure variants may or may not be secret, depending on the language. We allow either.
 					assertPropertyMapMember := func(
@@ -71,19 +71,19 @@ func init() {
 					}
 
 					AssertPropertyMapMember(l, outputs, "outputTrySuccess",
-						resource.MakeSecret(resource.NewStringProperty("MOK")))
+						resource.MakeSecret(resource.NewProperty("MOK")))
 					assertPropertyMapMember(outputs, "outputTryFailure",
-						resource.NewStringProperty("fallback"))
+						resource.NewProperty("fallback"))
 					AssertPropertyMapMember(l, outputs, "dynamicTrySuccess",
-						resource.NewStringProperty("OOK"))
+						resource.NewProperty("OOK"))
 					assertPropertyMapMember(outputs, "dynamicTryFailure",
-						resource.NewStringProperty("fallback"))
+						resource.NewProperty("fallback"))
 					AssertPropertyMapMember(l, outputs, "outputDynamicTrySuccess",
-						resource.MakeSecret(resource.NewStringProperty("OOK")))
+						resource.MakeSecret(resource.NewProperty("OOK")))
 					assertPropertyMapMember(outputs, "outputDynamicTryFailure",
-						resource.NewStringProperty("fallback"))
+						resource.NewProperty("fallback"))
 					AssertPropertyMapMember(l, outputs, "plainTryNull",
-						resource.NewArrayProperty([]resource.PropertyValue{resource.NewNullProperty()}))
+						resource.NewProperty([]resource.PropertyValue{resource.NewNullProperty()}))
 
 					// This may be secret at the list level, or the element level, or none
 					got, ok := outputs["outputTryNull"]
@@ -92,9 +92,9 @@ func init() {
 
 						ok := false
 						for _, want := range []resource.PropertyValue{
-							resource.NewArrayProperty([]resource.PropertyValue{resource.NewNullProperty()}),
-							resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{resource.NewNullProperty()})),
-							resource.NewArrayProperty([]resource.PropertyValue{resource.MakeSecret(resource.NewNullProperty())}),
+							resource.NewProperty([]resource.PropertyValue{resource.NewNullProperty()}),
+							resource.MakeSecret(resource.NewProperty([]resource.PropertyValue{resource.NewNullProperty()})),
+							resource.NewProperty([]resource.PropertyValue{resource.MakeSecret(resource.NewNullProperty())}),
 						} {
 							if got.DeepEquals(want) {
 								ok = true

--- a/cmd/pulumi-test-language/tests/l1_config_types.go
+++ b/cmd/pulumi-test-language/tests/l1_config_types.go
@@ -45,14 +45,14 @@ func init() {
 					outputs := stack.Outputs
 
 					require.Len(l, outputs, 5, "expected 5 outputs")
-					AssertPropertyMapMember(l, outputs, "theNumber", resource.NewNumberProperty(4.75))
-					AssertPropertyMapMember(l, outputs, "theString", resource.NewStringProperty("Hello World"))
-					AssertPropertyMapMember(l, outputs, "theMap", resource.NewObjectProperty(resource.PropertyMap{
-						"a": resource.NewNumberProperty(2),
-						"b": resource.NewNumberProperty(3),
+					AssertPropertyMapMember(l, outputs, "theNumber", resource.NewProperty(4.75))
+					AssertPropertyMapMember(l, outputs, "theString", resource.NewProperty("Hello World"))
+					AssertPropertyMapMember(l, outputs, "theMap", resource.NewProperty(resource.PropertyMap{
+						"a": resource.NewProperty(2.0),
+						"b": resource.NewProperty(3.0),
 					}))
-					AssertPropertyMapMember(l, outputs, "theObject", resource.NewBoolProperty(true))
-					AssertPropertyMapMember(l, outputs, "theThing", resource.NewNumberProperty(30))
+					AssertPropertyMapMember(l, outputs, "theObject", resource.NewProperty(true))
+					AssertPropertyMapMember(l, outputs, "theThing", resource.NewProperty(30.0))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l1_keyword_overlap.go
+++ b/cmd/pulumi-test-language/tests/l1_keyword_overlap.go
@@ -35,15 +35,15 @@ func init() {
 
 					outputs := stack.Outputs
 
-					AssertPropertyMapMember(l, outputs, "class", resource.NewStringProperty("class_output_string"))
-					AssertPropertyMapMember(l, outputs, "export", resource.NewStringProperty("export_output_string"))
-					AssertPropertyMapMember(l, outputs, "import", resource.NewStringProperty("import_output_string"))
-					AssertPropertyMapMember(l, outputs, "mod", resource.NewStringProperty("mod_output_string"))
+					AssertPropertyMapMember(l, outputs, "class", resource.NewProperty("class_output_string"))
+					AssertPropertyMapMember(l, outputs, "export", resource.NewProperty("export_output_string"))
+					AssertPropertyMapMember(l, outputs, "import", resource.NewProperty("import_output_string"))
+					AssertPropertyMapMember(l, outputs, "mod", resource.NewProperty("mod_output_string"))
 					AssertPropertyMapMember(l, outputs, "object",
-						resource.NewObjectProperty(resource.PropertyMap{"object": resource.NewStringProperty("object_output_string")}),
+						resource.NewProperty(resource.PropertyMap{"object": resource.NewProperty("object_output_string")}),
 					)
-					AssertPropertyMapMember(l, outputs, "self", resource.NewStringProperty("self_output_string"))
-					AssertPropertyMapMember(l, outputs, "this", resource.NewStringProperty("this_output_string"))
+					AssertPropertyMapMember(l, outputs, "self", resource.NewProperty("self_output_string"))
+					AssertPropertyMapMember(l, outputs, "this", resource.NewProperty("this_output_string"))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l1_main.go
+++ b/cmd/pulumi-test-language/tests/l1_main.go
@@ -38,7 +38,7 @@ func init() {
 
 					outputs := stack.Outputs
 
-					AssertPropertyMapMember(l, outputs, "output_true", resource.NewBoolProperty(true))
+					AssertPropertyMapMember(l, outputs, "output_true", resource.NewProperty(true))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l1_output_array.go
+++ b/cmd/pulumi-test-language/tests/l1_output_array.go
@@ -37,32 +37,32 @@ func init() {
 					outputs := stack.Outputs
 
 					require.Len(l, outputs, 5, "expected 5 outputs")
-					AssertPropertyMapMember(l, outputs, "empty", resource.NewArrayProperty([]resource.PropertyValue{}))
-					AssertPropertyMapMember(l, outputs, "small", resource.NewArrayProperty([]resource.PropertyValue{
-						resource.NewStringProperty("Hello"),
-						resource.NewStringProperty("World"),
+					AssertPropertyMapMember(l, outputs, "empty", resource.NewProperty([]resource.PropertyValue{}))
+					AssertPropertyMapMember(l, outputs, "small", resource.NewProperty([]resource.PropertyValue{
+						resource.NewProperty("Hello"),
+						resource.NewProperty("World"),
 					}))
-					AssertPropertyMapMember(l, outputs, "numbers", resource.NewArrayProperty([]resource.PropertyValue{
-						resource.NewNumberProperty(0), resource.NewNumberProperty(1), resource.NewNumberProperty(2),
-						resource.NewNumberProperty(3), resource.NewNumberProperty(4), resource.NewNumberProperty(5),
+					AssertPropertyMapMember(l, outputs, "numbers", resource.NewProperty([]resource.PropertyValue{
+						resource.NewProperty(0.0), resource.NewProperty(1.0), resource.NewProperty(2.0),
+						resource.NewProperty(3.0), resource.NewProperty(4.0), resource.NewProperty(5.0),
 					}))
-					AssertPropertyMapMember(l, outputs, "nested", resource.NewArrayProperty([]resource.PropertyValue{
-						resource.NewArrayProperty([]resource.PropertyValue{
-							resource.NewNumberProperty(1), resource.NewNumberProperty(2), resource.NewNumberProperty(3),
+					AssertPropertyMapMember(l, outputs, "nested", resource.NewProperty([]resource.PropertyValue{
+						resource.NewProperty([]resource.PropertyValue{
+							resource.NewProperty(1.0), resource.NewProperty(2.0), resource.NewProperty(3.0),
 						}),
-						resource.NewArrayProperty([]resource.PropertyValue{
-							resource.NewNumberProperty(4), resource.NewNumberProperty(5), resource.NewNumberProperty(6),
+						resource.NewProperty([]resource.PropertyValue{
+							resource.NewProperty(4.0), resource.NewProperty(5.0), resource.NewProperty(6.0),
 						}),
-						resource.NewArrayProperty([]resource.PropertyValue{
-							resource.NewNumberProperty(7), resource.NewNumberProperty(8), resource.NewNumberProperty(9),
+						resource.NewProperty([]resource.PropertyValue{
+							resource.NewProperty(7.0), resource.NewProperty(8.0), resource.NewProperty(9.0),
 						}),
 					}))
 
 					large := []resource.PropertyValue{}
 					for i := 0; i < 150; i++ {
-						large = append(large, resource.NewStringProperty(lorem))
+						large = append(large, resource.NewProperty(lorem))
 					}
-					AssertPropertyMapMember(l, outputs, "large", resource.NewArrayProperty(large))
+					AssertPropertyMapMember(l, outputs, "large", resource.NewProperty(large))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l1_output_bool.go
+++ b/cmd/pulumi-test-language/tests/l1_output_bool.go
@@ -37,8 +37,8 @@ func init() {
 
 					outputs := stack.Outputs
 
-					AssertPropertyMapMember(l, outputs, "output_true", resource.NewBoolProperty(true))
-					AssertPropertyMapMember(l, outputs, "output_false", resource.NewBoolProperty(false))
+					AssertPropertyMapMember(l, outputs, "output_true", resource.NewProperty(true))
+					AssertPropertyMapMember(l, outputs, "output_false", resource.NewProperty(false))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l1_output_map.go
+++ b/cmd/pulumi-test-language/tests/l1_output_map.go
@@ -37,22 +37,22 @@ func init() {
 					outputs := stack.Outputs
 
 					require.Len(l, outputs, 4, "expected 4 outputs")
-					AssertPropertyMapMember(l, outputs, "empty", resource.NewObjectProperty(resource.PropertyMap{}))
-					AssertPropertyMapMember(l, outputs, "strings", resource.NewObjectProperty(resource.PropertyMap{
-						"greeting": resource.NewStringProperty("Hello, world!"),
-						"farewell": resource.NewStringProperty("Goodbye, world!"),
+					AssertPropertyMapMember(l, outputs, "empty", resource.NewProperty(resource.PropertyMap{}))
+					AssertPropertyMapMember(l, outputs, "strings", resource.NewProperty(resource.PropertyMap{
+						"greeting": resource.NewProperty("Hello, world!"),
+						"farewell": resource.NewProperty("Goodbye, world!"),
 					}))
-					AssertPropertyMapMember(l, outputs, "numbers", resource.NewObjectProperty(resource.PropertyMap{
-						"1": resource.NewNumberProperty(1),
-						"2": resource.NewNumberProperty(2),
+					AssertPropertyMapMember(l, outputs, "numbers", resource.NewProperty(resource.PropertyMap{
+						"1": resource.NewProperty(1.0),
+						"2": resource.NewProperty(2.0),
 					}))
-					AssertPropertyMapMember(l, outputs, "keys", resource.NewObjectProperty(resource.PropertyMap{
-						"my.key": resource.NewNumberProperty(1),
-						"my-key": resource.NewNumberProperty(2),
-						"my_key": resource.NewNumberProperty(3),
-						"MY_KEY": resource.NewNumberProperty(4),
-						"mykey":  resource.NewNumberProperty(5),
-						"MYKEY":  resource.NewNumberProperty(6),
+					AssertPropertyMapMember(l, outputs, "keys", resource.NewProperty(resource.PropertyMap{
+						"my.key": resource.NewProperty(1.0),
+						"my-key": resource.NewProperty(2.0),
+						"my_key": resource.NewProperty(3.0),
+						"MY_KEY": resource.NewProperty(4.0),
+						"mykey":  resource.NewProperty(5.0),
+						"MYKEY":  resource.NewProperty(6.0),
 					}))
 				},
 			},

--- a/cmd/pulumi-test-language/tests/l1_output_null.go
+++ b/cmd/pulumi-test-language/tests/l1_output_null.go
@@ -44,10 +44,10 @@ func init() {
 
 					// These lines are commented out to show what _should_ be here, but isn't because of the issue above.
 					// AssertPropertyMapMember(l, outputs, "null", resource.NewNullProperty())
-					AssertPropertyMapMember(l, outputs, "array", resource.NewArrayProperty([]resource.PropertyValue{
+					AssertPropertyMapMember(l, outputs, "array", resource.NewProperty([]resource.PropertyValue{
 						resource.NewNullProperty(),
 					}))
-					//AssertPropertyMapMember(l, outputs, "map", resource.NewObjectProperty(resource.PropertyMap{
+					//AssertPropertyMapMember(l, outputs, "map", resource.NewProperty(resource.PropertyMap{
 					//	"key": resource.NewNullProperty(),
 					//}))
 				},

--- a/cmd/pulumi-test-language/tests/l1_output_number.go
+++ b/cmd/pulumi-test-language/tests/l1_output_number.go
@@ -39,12 +39,12 @@ func init() {
 					outputs := stack.Outputs
 
 					require.Len(l, outputs, 6, "expected 6 outputs")
-					AssertPropertyMapMember(l, outputs, "zero", resource.NewNumberProperty(0))
-					AssertPropertyMapMember(l, outputs, "one", resource.NewNumberProperty(1))
-					AssertPropertyMapMember(l, outputs, "e", resource.NewNumberProperty(2.718))
-					AssertPropertyMapMember(l, outputs, "minInt32", resource.NewNumberProperty(math.MinInt32))
-					AssertPropertyMapMember(l, outputs, "max", resource.NewNumberProperty(math.MaxFloat64))
-					AssertPropertyMapMember(l, outputs, "min", resource.NewNumberProperty(math.SmallestNonzeroFloat64))
+					AssertPropertyMapMember(l, outputs, "zero", resource.NewProperty(0.0))
+					AssertPropertyMapMember(l, outputs, "one", resource.NewProperty(1.0))
+					AssertPropertyMapMember(l, outputs, "e", resource.NewProperty(2.718))
+					AssertPropertyMapMember(l, outputs, "minInt32", resource.NewProperty(float64(math.MinInt32)))
+					AssertPropertyMapMember(l, outputs, "max", resource.NewProperty(math.MaxFloat64))
+					AssertPropertyMapMember(l, outputs, "min", resource.NewProperty(math.SmallestNonzeroFloat64))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l1_output_string.go
+++ b/cmd/pulumi-test-language/tests/l1_output_string.go
@@ -39,18 +39,18 @@ func init() {
 					outputs := stack.Outputs
 
 					require.Len(l, outputs, 6, "expected 6 outputs")
-					AssertPropertyMapMember(l, outputs, "empty", resource.NewStringProperty(""))
-					AssertPropertyMapMember(l, outputs, "small", resource.NewStringProperty("Hello world!"))
-					AssertPropertyMapMember(l, outputs, "emoji", resource.NewStringProperty("👋 \"Hello \U0001019b!\" 😊"))
-					AssertPropertyMapMember(l, outputs, "escape", resource.NewStringProperty(
+					AssertPropertyMapMember(l, outputs, "empty", resource.NewProperty(""))
+					AssertPropertyMapMember(l, outputs, "small", resource.NewProperty("Hello world!"))
+					AssertPropertyMapMember(l, outputs, "emoji", resource.NewProperty("👋 \"Hello \U0001019b!\" 😊"))
+					AssertPropertyMapMember(l, outputs, "escape", resource.NewProperty(
 						"Some ${common} \"characters\" 'that' need escaping: "+
 							"\\ (backslash), \t (tab), \u001b (escape), \u0007 (bell), \u0000 (null), \U000e0021 (tag space)"))
-					AssertPropertyMapMember(l, outputs, "escapeNewline", resource.NewStringProperty(
+					AssertPropertyMapMember(l, outputs, "escapeNewline", resource.NewProperty(
 						"Some ${common} \"characters\" 'that' need escaping: "+
 							"\\ (backslash), \n (newline), \t (tab), \u001b (escape), \u0007 (bell), \u0000 (null), \U000e0021 (tag space)"))
 
 					large := strings.Repeat(lorem+"\n", 150)
-					AssertPropertyMapMember(l, outputs, "large", resource.NewStringProperty(large))
+					AssertPropertyMapMember(l, outputs, "large", resource.NewProperty(large))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l1_proxy_index.go
+++ b/cmd/pulumi-test-language/tests/l1_proxy_index.go
@@ -42,11 +42,11 @@ func init() {
 					outputs := stack.Outputs
 
 					require.Len(l, outputs, 5, "expected 5 outputs")
-					AssertPropertyMapMember(l, outputs, "l", resource.MakeSecret(resource.NewNumberProperty(1)))
-					AssertPropertyMapMember(l, outputs, "m", resource.MakeSecret(resource.NewBoolProperty(true)))
-					AssertPropertyMapMember(l, outputs, "c", resource.MakeSecret(resource.NewStringProperty("config")))
-					AssertPropertyMapMember(l, outputs, "o", resource.MakeSecret(resource.NewStringProperty("value")))
-					AssertPropertyMapMember(l, outputs, "a", resource.MakeSecret(resource.NewStringProperty("dynamic")))
+					AssertPropertyMapMember(l, outputs, "l", resource.MakeSecret(resource.NewProperty(1.0)))
+					AssertPropertyMapMember(l, outputs, "m", resource.MakeSecret(resource.NewProperty(true)))
+					AssertPropertyMapMember(l, outputs, "c", resource.MakeSecret(resource.NewProperty("config")))
+					AssertPropertyMapMember(l, outputs, "o", resource.MakeSecret(resource.NewProperty("value")))
+					AssertPropertyMapMember(l, outputs, "a", resource.MakeSecret(resource.NewProperty("dynamic")))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l1_stack_reference.go
+++ b/cmd/pulumi-test-language/tests/l1_stack_reference.go
@@ -26,8 +26,8 @@ func init() {
 	LanguageTests["l1-stack-reference"] = LanguageTest{
 		StackReferences: map[string]resource.PropertyMap{
 			"organization/other/dev": {
-				"plain":  resource.NewStringProperty("plain"),
-				"secret": resource.MakeSecret(resource.NewStringProperty("secret")),
+				"plain":  resource.NewProperty("plain"),
+				"secret": resource.MakeSecret(resource.NewProperty("secret")),
 			},
 		},
 		Runs: []TestRun{
@@ -47,8 +47,8 @@ func init() {
 					outputs := stack.Outputs
 
 					require.Len(l, outputs, 2, "expected 2 outputs")
-					AssertPropertyMapMember(l, outputs, "plain", resource.NewStringProperty("plain"))
-					AssertPropertyMapMember(l, outputs, "secret", resource.MakeSecret(resource.NewStringProperty("secret")))
+					AssertPropertyMapMember(l, outputs, "plain", resource.NewProperty("plain"))
+					AssertPropertyMapMember(l, outputs, "secret", resource.MakeSecret(resource.NewProperty("secret")))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l2_camel_names.go
+++ b/cmd/pulumi-test-language/tests/l2_camel_names.go
@@ -46,13 +46,13 @@ func init() {
 					second := RequireSingleNamedResource(l, snap.Resources, "secondResource")
 
 					wantInputs := resource.NewPropertyMapFromMap(map[string]any{
-						"theInput": resource.NewBoolProperty(true),
+						"theInput": resource.NewProperty(true),
 					})
 					assert.Equal(l, wantInputs, first.Inputs, "expected inputs to be %v", wantInputs)
 					assert.Equal(l, wantInputs, second.Inputs, "expected inputs to be %v", wantInputs)
 
 					wantOutputs := resource.NewPropertyMapFromMap(map[string]any{
-						"theOutput": resource.NewBoolProperty(true),
+						"theOutput": resource.NewProperty(true),
 					})
 					assert.Equal(l, wantOutputs, first.Outputs, "expected outputs to be %v", wantOutputs)
 					assert.Equal(l, wantOutputs, second.Outputs, "expected outputs to be %v", wantOutputs)

--- a/cmd/pulumi-test-language/tests/l2_component_call_simple.go
+++ b/cmd/pulumi-test-language/tests/l2_component_call_simple.go
@@ -78,8 +78,8 @@ func init() {
 					// * from_prefixed, whose value should be the value output of component1, prefixed with "foo-".
 					outputs := stack.Outputs
 					require.Len(l, outputs, 2, "expected 2 outputs")
-					AssertPropertyMapMember(l, outputs, "from_identity", resource.NewStringProperty("bar"))
-					AssertPropertyMapMember(l, outputs, "from_prefixed", resource.NewStringProperty("foo-bar"))
+					AssertPropertyMapMember(l, outputs, "from_identity", resource.NewProperty("bar"))
+					AssertPropertyMapMember(l, outputs, "from_prefixed", resource.NewProperty("foo-bar"))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l2_explicit_parameterized_provider.go
+++ b/cmd/pulumi-test-language/tests/l2_explicit_parameterized_provider.go
@@ -44,7 +44,7 @@ func init() {
 
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 					require.Equal(l,
-						resource.NewStringProperty("Goodbye World"),
+						resource.NewProperty("Goodbye World"),
 						stack.Outputs["parameterValue"],
 						"parameter value and provider config should be correct")
 

--- a/cmd/pulumi-test-language/tests/l2_invoke_options.go
+++ b/cmd/pulumi-test-language/tests/l2_invoke_options.go
@@ -54,7 +54,7 @@ func init() {
 
 					require.NotNil(l, stack, "expected a stack resource")
 					outputs := stack.Outputs
-					AssertPropertyMapMember(l, outputs, "hello", resource.NewStringProperty("hello world"))
+					AssertPropertyMapMember(l, outputs, "hello", resource.NewProperty("hello world"))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l2_invoke_options_depends_on.go
+++ b/cmd/pulumi-test-language/tests/l2_invoke_options_depends_on.go
@@ -54,7 +54,7 @@ func init() {
 
 					require.NotNil(l, stack, "expected a stack resource")
 					outputs := stack.Outputs
-					AssertPropertyMapMember(l, outputs, "hello", resource.NewStringProperty("hello world"))
+					AssertPropertyMapMember(l, outputs, "hello", resource.NewProperty("hello world"))
 
 					var first *resource.State
 					var second *resource.State

--- a/cmd/pulumi-test-language/tests/l2_invoke_scalar.go
+++ b/cmd/pulumi-test-language/tests/l2_invoke_scalar.go
@@ -46,7 +46,7 @@ func init() {
 
 					outputs := stack.Outputs
 
-					AssertPropertyMapMember(l, outputs, "scalar", resource.NewBoolProperty(true))
+					AssertPropertyMapMember(l, outputs, "scalar", resource.NewProperty(true))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l2_invoke_secrets.go
+++ b/cmd/pulumi-test-language/tests/l2_invoke_secrets.go
@@ -50,11 +50,11 @@ func init() {
 
 					outputs := stack.Outputs
 					AssertPropertyMapMember(l, outputs, "nonSecret",
-						resource.NewStringProperty("hello world"))
+						resource.NewProperty("hello world"))
 					AssertPropertyMapMember(l, outputs, "firstSecret",
-						resource.MakeSecret(resource.NewStringProperty("hello world")))
+						resource.MakeSecret(resource.NewProperty("hello world")))
 					AssertPropertyMapMember(l, outputs, "secondSecret",
-						resource.MakeSecret(resource.NewStringProperty("goodbye world")))
+						resource.MakeSecret(resource.NewProperty("goodbye world")))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l2_invoke_simple.go
+++ b/cmd/pulumi-test-language/tests/l2_invoke_simple.go
@@ -46,8 +46,8 @@ func init() {
 
 					outputs := stack.Outputs
 
-					AssertPropertyMapMember(l, outputs, "hello", resource.NewStringProperty("hello world"))
-					AssertPropertyMapMember(l, outputs, "goodbye", resource.NewStringProperty("goodbye world"))
+					AssertPropertyMapMember(l, outputs, "hello", resource.NewProperty("hello world"))
+					AssertPropertyMapMember(l, outputs, "goodbye", resource.NewProperty("goodbye world"))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l2_invoke_variants.go
+++ b/cmd/pulumi-test-language/tests/l2_invoke_variants.go
@@ -57,8 +57,8 @@ func init() {
 
 					outputs := stack.Outputs
 
-					AssertPropertyMapMember(l, outputs, "outputInput", resource.NewStringProperty("Goodbye world"))
-					AssertPropertyMapMember(l, outputs, "unit", resource.NewStringProperty("Hello world"))
+					AssertPropertyMapMember(l, outputs, "outputInput", resource.NewProperty("Goodbye world"))
+					AssertPropertyMapMember(l, outputs, "unit", resource.NewProperty("Hello world"))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l2_large_string.go
+++ b/cmd/pulumi-test-language/tests/l2_large_string.go
@@ -42,10 +42,10 @@ func init() {
 					require.Len(l, snap.Resources, 3, "expected 3 resources in snapshot")
 
 					// Check that the large string is in the snapshot
-					largeString := resource.NewStringProperty(strings.Repeat("hello world", 9532509))
+					largeString := resource.NewProperty(strings.Repeat("hello world", 9532509))
 					large := RequireSingleResource(l, snap.Resources, "large:index:String")
 					require.Equal(l,
-						resource.NewStringProperty("hello world"),
+						resource.NewProperty("hello world"),
 						large.Inputs["value"],
 					)
 					require.Equal(l,

--- a/cmd/pulumi-test-language/tests/l2_namespaced_provider.go
+++ b/cmd/pulumi-test-language/tests/l2_namespaced_provider.go
@@ -52,9 +52,9 @@ func init() {
 					//nolint:lll // Breaking the URN up makes it harder to read
 					want := resource.NewPropertyMapFromMap(map[string]any{
 						"value": true,
-						"resourceRef": resource.NewResourceReferenceProperty(resource.ResourceReference{
+						"resourceRef": resource.NewProperty(resource.ResourceReference{
 							URN: "urn:pulumi:test::l2-namespaced-provider::component:index:ComponentCustomRefOutput$component:index:Custom::componentRes-child",
-							ID:  resource.NewStringProperty("id-foo-bar-baz"),
+							ID:  resource.NewProperty("id-foo-bar-baz"),
 						}),
 					})
 					require.Equal(l, want, namespaced.Inputs)

--- a/cmd/pulumi-test-language/tests/l2_parameterized_resource.go
+++ b/cmd/pulumi-test-language/tests/l2_parameterized_resource.go
@@ -39,11 +39,11 @@ func init() {
 					RequireStackResource(l, err, changes)
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 					require.Equal(l,
-						resource.NewStringProperty("HelloWorld"),
+						resource.NewProperty("HelloWorld"),
 						stack.Outputs["parameterValue"],
 						"parameter value should be correct")
 					require.Equal(l,
-						resource.NewStringProperty("HelloWorldComponent"),
+						resource.NewProperty("HelloWorldComponent"),
 						stack.Outputs["parameterValueFromComponent"],
 						"parameter value from component should be correct")
 				},

--- a/cmd/pulumi-test-language/tests/l2_parameterized_resource_twice.go
+++ b/cmd/pulumi-test-language/tests/l2_parameterized_resource_twice.go
@@ -39,19 +39,19 @@ func init() {
 					RequireStackResource(l, err, changes)
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 					require.Equal(l,
-						resource.NewStringProperty("HelloWorld"),
+						resource.NewProperty("HelloWorld"),
 						stack.Outputs["parameterValue1"],
 						"first parameter value should be correct")
 					require.Equal(l,
-						resource.NewStringProperty("HelloWorldComponent"),
+						resource.NewProperty("HelloWorldComponent"),
 						stack.Outputs["parameterValueFromComponent1"],
 						"first parameter value from component should be correct")
 					require.Equal(l,
-						resource.NewStringProperty("GoodbyeWorld"),
+						resource.NewProperty("GoodbyeWorld"),
 						stack.Outputs["parameterValue2"],
 						"second parameter value should be correct")
 					require.Equal(l,
-						resource.NewStringProperty("GoodbyeWorldComponent"),
+						resource.NewProperty("GoodbyeWorldComponent"),
 						stack.Outputs["parameterValueFromComponent2"],
 						"second parameter value from component should be correct")
 				},

--- a/cmd/pulumi-test-language/tests/l2_provider_call.go
+++ b/cmd/pulumi-test-language/tests/l2_provider_call.go
@@ -73,7 +73,7 @@ func init() {
 					require.Len(l, outputs, 1, "expected 1 output")
 					AssertPropertyMapMember(
 						l, outputs,
-						"defaultProviderValue", resource.NewStringProperty("defaultProvValuedefaultValue"),
+						"defaultProviderValue", resource.NewProperty("defaultProvValuedefaultValue"),
 					)
 				},
 			},

--- a/cmd/pulumi-test-language/tests/l2_provider_call_explicit.go
+++ b/cmd/pulumi-test-language/tests/l2_provider_call_explicit.go
@@ -72,15 +72,15 @@ func init() {
 					require.Len(l, outputs, 3, "expected 3 outputs")
 					AssertPropertyMapMember(
 						l, outputs,
-						"explicitProviderValue", resource.NewStringProperty("explicitProvValueexplicitValue"),
+						"explicitProviderValue", resource.NewProperty("explicitProvValueexplicitValue"),
 					)
 					AssertPropertyMapMember(
 						l, outputs,
-						"explicitProvFromIdentity", resource.NewStringProperty("explicitProvValue"),
+						"explicitProvFromIdentity", resource.NewProperty("explicitProvValue"),
 					)
 					AssertPropertyMapMember(
 						l, outputs,
-						"explicitProvFromPrefixed", resource.NewStringProperty("call-prefix-explicitProvValue"),
+						"explicitProvFromPrefixed", resource.NewProperty("call-prefix-explicitProvValue"),
 					)
 				},
 			},

--- a/cmd/pulumi-test-language/tests/l2_proxy_index.go
+++ b/cmd/pulumi-test-language/tests/l2_proxy_index.go
@@ -42,10 +42,10 @@ func init() {
 					outputs := stack.Outputs
 
 					require.Len(l, outputs, 4, "expected 4 outputs")
-					AssertPropertyMapMember(l, outputs, "bool", resource.NewBoolProperty(true))
-					AssertPropertyMapMember(l, outputs, "array", resource.NewBoolProperty(true))
-					AssertPropertyMapMember(l, outputs, "map", resource.NewStringProperty("100"))
-					AssertPropertyMapMember(l, outputs, "nested", resource.NewStringProperty("french hens"))
+					AssertPropertyMapMember(l, outputs, "bool", resource.NewProperty(true))
+					AssertPropertyMapMember(l, outputs, "array", resource.NewProperty(true))
+					AssertPropertyMapMember(l, outputs, "map", resource.NewProperty("100"))
+					AssertPropertyMapMember(l, outputs, "nested", resource.NewProperty("french hens"))
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l2_resource_config.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_config.go
@@ -53,7 +53,7 @@ func init() {
 					})
 					expectedInputs := deepcopy.Copy(expectedOutputs).(resource.PropertyMap)
 					// inputs should also have the __internal key
-					expectedInputs[resource.PropertyKey("__internal")] = resource.NewObjectProperty(
+					expectedInputs[resource.PropertyKey("__internal")] = resource.NewProperty(
 						resource.NewPropertyMapFromMap(map[string]interface{}{
 							"pluginDownloadURL": "http://example.com",
 						}))
@@ -68,7 +68,7 @@ func init() {
 					})
 					expectedInputs = deepcopy.Copy(expectedOutputs).(resource.PropertyMap)
 					// inputs should also have the __internal key
-					expectedInputs[resource.PropertyKey("__internal")] = resource.NewObjectProperty(
+					expectedInputs[resource.PropertyKey("__internal")] = resource.NewProperty(
 						resource.NewPropertyMapFromMap(map[string]interface{}{
 							"pluginDownloadURL": "http://example.com",
 						}))

--- a/cmd/pulumi-test-language/tests/l2_resource_invoke_dynamic_function.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_invoke_dynamic_function.go
@@ -46,9 +46,9 @@ func init() {
 						l,
 						r.Outputs,
 						"dynamic",
-						resource.NewObjectProperty(
+						resource.NewProperty(
 							resource.NewPropertyMapFromMap(
-								map[string]any{"resultProperty": resource.NewStringProperty("resultValue")},
+								map[string]any{"resultProperty": resource.NewProperty("resultValue")},
 							),
 						),
 					)

--- a/cmd/pulumi-test-language/tests/l2_resource_secret.go
+++ b/cmd/pulumi-test-language/tests/l2_resource_secret.go
@@ -47,7 +47,7 @@ func init() {
 
 					want := resource.NewPropertyMapFromMap(map[string]any{
 						"public":  "open",
-						"private": resource.MakeSecret(resource.NewStringProperty("closed")),
+						"private": resource.MakeSecret(resource.NewProperty("closed")),
 						"publicData": map[string]interface{}{
 							"public": "open",
 							// TODO https://github.com/pulumi/pulumi/issues/10319: This should be a secret,
@@ -55,7 +55,7 @@ func init() {
 							// fix it. We should fix the engine to ensure this ends up as secret as well.
 							"private": "closed",
 						},
-						"privateData": resource.MakeSecret(resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]any{
+						"privateData": resource.MakeSecret(resource.NewProperty(resource.NewPropertyMapFromMap(map[string]any{
 							"public":  "open",
 							"private": "closed",
 						}))),

--- a/cmd/pulumi-test-language/tests/l2_rtti.go
+++ b/cmd/pulumi-test-language/tests/l2_rtti.go
@@ -53,8 +53,8 @@ func init() {
 					require.NotNil(l, stack)
 					assert.Equal(l, "pulumi:pulumi:Stack", stack.Type.String(), "expected stack resource")
 					// Check we have to two expected outputs name and type
-					assert.Equal(l, resource.NewStringProperty("res"), stack.Outputs["name"])
-					assert.Equal(l, resource.NewStringProperty("simple:index:Resource"), stack.Outputs["type"])
+					assert.Equal(l, resource.NewProperty("res"), stack.Outputs["name"])
+					assert.Equal(l, resource.NewProperty("simple:index:Resource"), stack.Outputs["type"])
 				},
 			},
 		},

--- a/cmd/pulumi-test-language/tests/l2_union.go
+++ b/cmd/pulumi-test-language/tests/l2_union.go
@@ -45,9 +45,9 @@ func init() {
 
 				mmu := RequireSingleNamedResource(l, snapshot.Resources, "mapMapUnionExample")
 
-				expected := resource.NewObjectProperty(resource.PropertyMap{
-					"key1": resource.NewObjectProperty(resource.PropertyMap{
-						"key1a": resource.NewStringProperty("value1a"),
+				expected := resource.NewProperty(resource.PropertyMap{
+					"key1": resource.NewProperty(resource.PropertyMap{
+						"key1a": resource.NewProperty("value1a"),
 					}),
 				})
 
@@ -59,10 +59,10 @@ func init() {
 				si1 := RequireSingleNamedResource(l, snapshot.Resources, "stringOrIntegerExample1")
 				si2 := RequireSingleNamedResource(l, snapshot.Resources, "stringOrIntegerExample2")
 
-				require.Equal(l, resource.NewNumberProperty(42),
+				require.Equal(l, resource.NewProperty(42.0),
 					si1.Outputs["stringOrIntegerProperty"])
 
-				require.Equal(l, resource.NewStringProperty("forty two"),
+				require.Equal(l, resource.NewProperty("forty two"),
 					si2.Outputs["stringOrIntegerProperty"])
 			},
 		}},

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -427,10 +427,10 @@ func (c *backendClient) GetStackResourceOutputs(
 		}
 
 		resc := resource.PropertyMap{
-			resource.PropertyKey("type"):    resource.NewStringProperty(string(r.Type)),
-			resource.PropertyKey("outputs"): resource.NewObjectProperty(r.Outputs),
+			resource.PropertyKey("type"):    resource.NewProperty(string(r.Type)),
+			resource.PropertyKey("outputs"): resource.NewProperty(r.Outputs),
 		}
-		pm[resource.PropertyKey(r.URN)] = resource.NewObjectProperty(resc)
+		pm[resource.PropertyKey(r.URN)] = resource.NewProperty(resc)
 	}
 	return pm, nil
 }

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -36,16 +36,16 @@ func TestGetStackResourceOutputs(t *testing.T) {
 	typ := "some:invalid:type1"
 
 	resc1 := liveState(typ, "resc1", resource.PropertyMap{
-		resource.PropertyKey("prop1"): resource.NewStringProperty("val1"),
+		resource.PropertyKey("prop1"): resource.NewProperty("val1"),
 	})
 	resc2 := liveState(typ, "resc2", resource.PropertyMap{
-		resource.PropertyKey("prop2"): resource.NewStringProperty("val2"),
+		resource.PropertyKey("prop2"): resource.NewProperty("val2"),
 	})
 
 	// `deleted` will be ignored by `GetStackResourceOutputs`.
 	deletedName := "resc3"
 	deleted := deleteState("deletedType", "resc3", resource.PropertyMap{
-		resource.PropertyKey("deleted"): resource.NewStringProperty("deleted"),
+		resource.PropertyKey("deleted"): resource.NewProperty("deleted"),
 	})
 
 	// Mock backend that implements just enough methods to service `GetStackResourceOutputs`.

--- a/pkg/backend/display/json.go
+++ b/pkg/backend/display/json.go
@@ -41,17 +41,17 @@ func massagePropertyValue(v resource.PropertyValue, showSecrets bool) resource.P
 		for i, e := range v.ArrayValue() {
 			new[i] = massagePropertyValue(e, showSecrets)
 		}
-		return resource.NewArrayProperty(new)
+		return resource.NewProperty(new)
 	case v.IsObject():
 		new := make(resource.PropertyMap, len(v.ObjectValue()))
 		for k, e := range v.ObjectValue() {
 			new[k] = massagePropertyValue(e, showSecrets)
 		}
-		return resource.NewObjectProperty(new)
+		return resource.NewProperty(new)
 	case v.IsSecret() && showSecrets:
 		return massagePropertyValue(v.SecretValue().Element, showSecrets)
 	case v.IsSecret():
-		return resource.NewStringProperty("[secret]")
+		return resource.NewProperty("[secret]")
 	default:
 		return v
 	}

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -287,7 +287,7 @@ func massageStackPreviewAdd(p resource.PropertyValue) resource.PropertyValue {
 		for i, v := range p.ArrayValue() {
 			arr[i] = massageStackPreviewAdd(v)
 		}
-		return resource.NewArrayProperty(arr)
+		return resource.NewProperty(arr)
 	case p.IsObject():
 		obj := resource.PropertyMap{}
 		for k, v := range p.ObjectValue() {
@@ -295,7 +295,7 @@ func massageStackPreviewAdd(p resource.PropertyValue) resource.PropertyValue {
 				obj[k] = massageStackPreviewAdd(v)
 			}
 		}
-		return resource.NewObjectProperty(obj)
+		return resource.NewProperty(obj)
 	default:
 		return p
 	}
@@ -655,9 +655,9 @@ func (p *propertyPrinter) printAssetOrArchive(v interface{}, name string) {
 func assetOrArchiveToPropertyValue(v interface{}) resource.PropertyValue {
 	switch t := v.(type) {
 	case *asset.Asset:
-		return resource.NewAssetProperty(t)
+		return resource.NewProperty(t)
 	case *archive.Archive:
-		return resource.NewArchiveProperty(t)
+		return resource.NewProperty(t)
 	default:
 		contract.Failf("Unexpected archive element '%v'", reflect.TypeOf(t))
 		return resource.PropertyValue{V: nil}

--- a/pkg/backend/display/object_diff_test.go
+++ b/pkg/backend/display/object_diff_test.go
@@ -132,10 +132,10 @@ func Test_PrintObject(t *testing.T) {
 		{
 			"secret_noshow",
 			resource.NewPropertyMapFromMap(map[string]interface{}{
-				"secret": resource.NewSecretProperty(&resource.Secret{Element: resource.NewStringProperty("secrets")}),
+				"secret": resource.NewProperty(&resource.Secret{Element: resource.NewProperty("secrets")}),
 				"nested_secret": resource.NewPropertyMapFromMap(map[string]interface{}{
-					"super_secret": resource.NewSecretProperty(&resource.Secret{
-						Element: resource.NewStringProperty("super_secret"),
+					"super_secret": resource.NewProperty(&resource.Secret{
+						Element: resource.NewProperty("super_secret"),
 					}),
 				}),
 			}),
@@ -149,10 +149,10 @@ func Test_PrintObject(t *testing.T) {
 		{
 			"secrets_show",
 			resource.NewPropertyMapFromMap(map[string]interface{}{
-				"secret": resource.NewSecretProperty(&resource.Secret{Element: resource.NewStringProperty("my_secret")}),
+				"secret": resource.NewProperty(&resource.Secret{Element: resource.NewProperty("my_secret")}),
 				"nested_secret": resource.NewPropertyMapFromMap(map[string]interface{}{
-					"super_secret": resource.NewSecretProperty(&resource.Secret{
-						Element: resource.NewStringProperty("my_super_secret"),
+					"super_secret": resource.NewProperty(&resource.Secret{
+						Element: resource.NewProperty("my_super_secret"),
 					}),
 				}),
 			}),
@@ -299,17 +299,17 @@ func TestGetResourceOutputsPropertiesString(t *testing.T) {
 				URN:  "urn:pulumi:test::stack::pulumi:pulumi:Stack::test-stack",
 				Type: "pulumi:pulumi:Stack",
 				Outputs: resource.NewPropertyMapFromMap(map[string]any{
-					"secret": resource.MakeSecret(resource.NewStringProperty("shhhh")),
+					"secret": resource.MakeSecret(resource.NewProperty("shhhh")),
 				}),
 			},
 			newState: engine.StepEventStateMetadata{
 				URN:  "urn:pulumi:test::stack::pulumi:pulumi:Stack::test-stack",
 				Type: "pulumi:pulumi:Stack",
 				Outputs: resource.NewPropertyMapFromMap(map[string]any{
-					"secret": resource.MakeSecret(resource.NewStringProperty("shhhh")),
+					"secret": resource.MakeSecret(resource.NewProperty("shhhh")),
 					"secretObj": resource.MakeSecret(
-						resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]any{
-							"a": resource.NewStringProperty("1"),
+						resource.NewProperty(resource.NewPropertyMapFromMap(map[string]any{
+							"a": resource.NewProperty("1"),
 						}))),
 				}),
 			},
@@ -330,17 +330,17 @@ func TestGetResourceOutputsPropertiesString(t *testing.T) {
 				URN:  "urn:pulumi:test::stack::pulumi:pulumi:Stack::test-stack",
 				Type: "pulumi:pulumi:Stack",
 				Outputs: resource.NewPropertyMapFromMap(map[string]any{
-					"secret": resource.MakeSecret(resource.NewStringProperty("shhhh")),
+					"secret": resource.MakeSecret(resource.NewProperty("shhhh")),
 				}),
 			},
 			newState: engine.StepEventStateMetadata{
 				URN:  "urn:pulumi:test::stack::pulumi:pulumi:Stack::test-stack",
 				Type: "pulumi:pulumi:Stack",
 				Outputs: resource.NewPropertyMapFromMap(map[string]any{
-					"secret": resource.MakeSecret(resource.NewStringProperty("shhhh")),
+					"secret": resource.MakeSecret(resource.NewProperty("shhhh")),
 					"secretObj": resource.MakeSecret(
-						resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]any{
-							"a": resource.NewStringProperty("1"),
+						resource.NewProperty(resource.NewPropertyMapFromMap(map[string]any{
+							"a": resource.NewProperty("1"),
 						}))),
 				}),
 			},

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -461,11 +461,11 @@ func getDiffInfo(step engine.StepEventMetadata, action apitype.UpdateKind) strin
 		}
 
 		recordMetadataDiff("provider",
-			resource.NewStringProperty(step.Old.Provider), resource.NewStringProperty(step.New.Provider))
+			resource.NewProperty(step.Old.Provider), resource.NewProperty(step.New.Provider))
 		recordMetadataDiff("protect",
-			resource.NewBoolProperty(step.Old.Protect), resource.NewBoolProperty(step.New.Protect))
+			resource.NewProperty(step.Old.Protect), resource.NewProperty(step.New.Protect))
 		recordMetadataDiff(colors.Red+"taint"+colors.Reset,
-			resource.NewBoolProperty(step.Old.Taint), resource.NewBoolProperty(step.New.Taint))
+			resource.NewProperty(step.Old.Taint), resource.NewProperty(step.New.Taint))
 
 		writeShortDiff(changesBuf, diff, step.Diffs)
 	}

--- a/pkg/backend/diy/backend_legacy_test.go
+++ b/pkg/backend/diy/backend_legacy_test.go
@@ -301,7 +301,7 @@ func TestHtmlEscaping_legacy(t *testing.T) {
 			URN:  resource.NewURN("a", "proj", "d:e:f", "a:b:c", "name"),
 			Type: "a:b:c",
 			Inputs: resource.PropertyMap{
-				resource.PropertyKey("html"): resource.NewStringProperty("<html@tags>"),
+				resource.PropertyKey("html"): resource.NewProperty("<html@tags>"),
 			},
 		},
 	}

--- a/pkg/backend/diy/backend_test.go
+++ b/pkg/backend/diy/backend_test.go
@@ -243,7 +243,7 @@ func makeUntypedDeploymentTimestamp(
 			URN:  resource.NewURN("a", "proj", "d:e:f", "a:b:c", name),
 			Type: "a:b:c",
 			Inputs: resource.PropertyMap{
-				resource.PropertyKey("secret"): resource.MakeSecret(resource.NewStringProperty("s3cr3t")),
+				resource.PropertyKey("secret"): resource.MakeSecret(resource.NewProperty("s3cr3t")),
 			},
 			Created:  created,
 			Modified: modified,
@@ -615,7 +615,7 @@ func TestRenamePreservesIntegrity(t *testing.T) {
 		URN:  resource.NewURN("a", "proj", "d:e:f", "a:b:c", "base"),
 		Type: "a:b:c",
 		Inputs: resource.PropertyMap{
-			resource.PropertyKey("p"): resource.NewStringProperty("v"),
+			resource.PropertyKey("p"): resource.NewProperty("v"),
 		},
 	}
 
@@ -623,7 +623,7 @@ func TestRenamePreservesIntegrity(t *testing.T) {
 		URN:  resource.NewURN("a", "proj", "d:e:f", "a:b:c", "dependency"),
 		Type: "a:b:c",
 		Inputs: resource.PropertyMap{
-			resource.PropertyKey("p"): resource.NewStringProperty("v"),
+			resource.PropertyKey("p"): resource.NewProperty("v"),
 		},
 		Dependencies: []resource.URN{rBase.URN},
 	}
@@ -632,7 +632,7 @@ func TestRenamePreservesIntegrity(t *testing.T) {
 		URN:  resource.NewURN("a", "proj", "d:e:f", "a:b:c", "property-dependency"),
 		Type: "a:b:c",
 		Inputs: resource.PropertyMap{
-			resource.PropertyKey("p"): resource.NewStringProperty("v"),
+			resource.PropertyKey("p"): resource.NewProperty("v"),
 		},
 		PropertyDependencies: map[resource.PropertyKey][]resource.URN{
 			resource.PropertyKey("p"): {rBase.URN},
@@ -643,7 +643,7 @@ func TestRenamePreservesIntegrity(t *testing.T) {
 		URN:  resource.NewURN("a", "proj", "d:e:f", "a:b:c", "deleted-with"),
 		Type: "a:b:c",
 		Inputs: resource.PropertyMap{
-			resource.PropertyKey("p"): resource.NewStringProperty("v"),
+			resource.PropertyKey("p"): resource.NewProperty("v"),
 		},
 		DeletedWith: rBase.URN,
 	}
@@ -652,7 +652,7 @@ func TestRenamePreservesIntegrity(t *testing.T) {
 		URN:  resource.NewURN("a", "proj", "d:e:f", "a:b:c", "parent"),
 		Type: "a:b:c",
 		Inputs: resource.PropertyMap{
-			resource.PropertyKey("p"): resource.NewStringProperty("v"),
+			resource.PropertyKey("p"): resource.NewProperty("v"),
 		},
 		Parent: rBase.URN,
 	}
@@ -780,7 +780,7 @@ func TestHtmlEscaping(t *testing.T) {
 			URN:  resource.NewURN("a", "proj", "d:e:f", "a:b:c", "name"),
 			Type: "a:b:c",
 			Inputs: resource.PropertyMap{
-				resource.PropertyKey("html"): resource.NewStringProperty("<html@tags>"),
+				resource.PropertyKey("html"): resource.NewProperty("<html@tags>"),
 			},
 		},
 	}

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -342,7 +342,7 @@ func TestSamesWithOtherMeaningfulChanges(t *testing.T) {
 
 	// Change the resource outputs.
 	changes = append(changes, NewResource(resourceA.URN))
-	changes[3].Outputs = resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
+	changes[3].Outputs = resource.PropertyMap{"foo": resource.NewProperty("bar")}
 
 	snap := NewSnapshot([]*resource.State{
 		provider,
@@ -724,9 +724,9 @@ func TestRecordingUpdateSuccess(t *testing.T) {
 	t.Parallel()
 
 	resourceA := NewResource("a")
-	resourceA.Inputs["key"] = resource.NewStringProperty("old")
+	resourceA.Inputs["key"] = resource.NewProperty("old")
 	resourceANew := NewResource("a")
-	resourceANew.Inputs["key"] = resource.NewStringProperty("new")
+	resourceANew.Inputs["key"] = resource.NewProperty("new")
 	snap := NewSnapshot([]*resource.State{
 		resourceA,
 	})
@@ -743,7 +743,7 @@ func TestRecordingUpdateSuccess(t *testing.T) {
 	require.Len(t, snap.PendingOperations, 1)
 	assert.Equal(t, resourceA.URN, snap.PendingOperations[0].Resource.URN)
 	assert.Equal(t, resource.OperationTypeUpdating, snap.PendingOperations[0].Type)
-	assert.Equal(t, resource.NewStringProperty("new"), snap.PendingOperations[0].Resource.Inputs["key"])
+	assert.Equal(t, resource.NewProperty("new"), snap.PendingOperations[0].Resource.Inputs["key"])
 
 	err = mutation.End(step, true /* successful */)
 	require.NoError(t, err)
@@ -754,16 +754,16 @@ func TestRecordingUpdateSuccess(t *testing.T) {
 	require.Len(t, snap.Resources, 1)
 	require.Len(t, snap.PendingOperations, 0)
 	assert.Equal(t, resourceA.URN, snap.Resources[0].URN)
-	assert.Equal(t, resource.NewStringProperty("new"), snap.Resources[0].Inputs["key"])
+	assert.Equal(t, resource.NewProperty("new"), snap.Resources[0].Inputs["key"])
 }
 
 func TestRecordingUpdateFailure(t *testing.T) {
 	t.Parallel()
 
 	resourceA := NewResource("a")
-	resourceA.Inputs["key"] = resource.NewStringProperty("old")
+	resourceA.Inputs["key"] = resource.NewProperty("old")
 	resourceANew := NewResource("a")
-	resourceANew.Inputs["key"] = resource.NewStringProperty("new")
+	resourceANew.Inputs["key"] = resource.NewProperty("new")
 	snap := NewSnapshot([]*resource.State{
 		resourceA,
 	})
@@ -780,7 +780,7 @@ func TestRecordingUpdateFailure(t *testing.T) {
 	require.Len(t, snap.PendingOperations, 1)
 	assert.Equal(t, resourceA.URN, snap.PendingOperations[0].Resource.URN)
 	assert.Equal(t, resource.OperationTypeUpdating, snap.PendingOperations[0].Type)
-	assert.Equal(t, resource.NewStringProperty("new"), snap.PendingOperations[0].Resource.Inputs["key"])
+	assert.Equal(t, resource.NewProperty("new"), snap.PendingOperations[0].Resource.Inputs["key"])
 
 	err = mutation.End(step, false /* successful */)
 	require.NoError(t, err)
@@ -791,7 +791,7 @@ func TestRecordingUpdateFailure(t *testing.T) {
 	require.Len(t, snap.Resources, 1)
 	require.Len(t, snap.PendingOperations, 0)
 	assert.Equal(t, resourceA.URN, snap.Resources[0].URN)
-	assert.Equal(t, resource.NewStringProperty("old"), snap.Resources[0].Inputs["key"])
+	assert.Equal(t, resource.NewProperty("old"), snap.Resources[0].Inputs["key"])
 }
 
 func TestRecordingDeleteSuccess(t *testing.T) {
@@ -887,12 +887,12 @@ func TestRecordingReadSuccessPreviousResource(t *testing.T) {
 	resourceA.ID = "some-c"
 	resourceA.External = true
 	resourceA.Custom = true
-	resourceA.Inputs["key"] = resource.NewStringProperty("old")
+	resourceA.Inputs["key"] = resource.NewProperty("old")
 	resourceANew := NewResource("c")
 	resourceANew.ID = "some-other-c"
 	resourceANew.External = true
 	resourceANew.Custom = true
-	resourceANew.Inputs["key"] = resource.NewStringProperty("new")
+	resourceANew.Inputs["key"] = resource.NewProperty("new")
 
 	snap := NewSnapshot([]*resource.State{
 		resourceA,
@@ -909,9 +909,9 @@ func TestRecordingReadSuccessPreviousResource(t *testing.T) {
 	require.Len(t, snap.PendingOperations, 1)
 	assert.Equal(t, resourceA.URN, snap.PendingOperations[0].Resource.URN)
 	assert.Equal(t, resource.OperationTypeReading, snap.PendingOperations[0].Type)
-	assert.Equal(t, resource.NewStringProperty("new"), snap.PendingOperations[0].Resource.Inputs["key"])
+	assert.Equal(t, resource.NewProperty("new"), snap.PendingOperations[0].Resource.Inputs["key"])
 	assert.Equal(t, resourceA.URN, snap.Resources[0].URN)
-	assert.Equal(t, resource.NewStringProperty("old"), snap.Resources[0].Inputs["key"])
+	assert.Equal(t, resource.NewProperty("old"), snap.Resources[0].Inputs["key"])
 	err = mutation.End(step, true /* successful */)
 	require.NoError(t, err)
 
@@ -920,7 +920,7 @@ func TestRecordingReadSuccessPreviousResource(t *testing.T) {
 	require.Len(t, snap.Resources, 1)
 	require.Len(t, snap.PendingOperations, 0)
 	assert.Equal(t, resourceA.URN, snap.Resources[0].URN)
-	assert.Equal(t, resource.NewStringProperty("new"), snap.Resources[0].Inputs["key"])
+	assert.Equal(t, resource.NewProperty("new"), snap.Resources[0].Inputs["key"])
 }
 
 func TestRecordingReadFailureNoPreviousResource(t *testing.T) {
@@ -958,12 +958,12 @@ func TestRecordingReadFailurePreviousResource(t *testing.T) {
 	resourceA.ID = "some-e"
 	resourceA.External = true
 	resourceA.Custom = true
-	resourceA.Inputs["key"] = resource.NewStringProperty("old")
+	resourceA.Inputs["key"] = resource.NewProperty("old")
 	resourceANew := NewResource("e")
 	resourceANew.ID = "some-new-e"
 	resourceANew.External = true
 	resourceANew.Custom = true
-	resourceANew.Inputs["key"] = resource.NewStringProperty("new")
+	resourceANew.Inputs["key"] = resource.NewProperty("new")
 
 	snap := NewSnapshot([]*resource.State{
 		resourceA,
@@ -980,9 +980,9 @@ func TestRecordingReadFailurePreviousResource(t *testing.T) {
 	require.Len(t, snap.PendingOperations, 1)
 	assert.Equal(t, resourceA.URN, snap.PendingOperations[0].Resource.URN)
 	assert.Equal(t, resource.OperationTypeReading, snap.PendingOperations[0].Type)
-	assert.Equal(t, resource.NewStringProperty("new"), snap.PendingOperations[0].Resource.Inputs["key"])
+	assert.Equal(t, resource.NewProperty("new"), snap.PendingOperations[0].Resource.Inputs["key"])
 	assert.Equal(t, resourceA.URN, snap.Resources[0].URN)
-	assert.Equal(t, resource.NewStringProperty("old"), snap.Resources[0].Inputs["key"])
+	assert.Equal(t, resource.NewProperty("old"), snap.Resources[0].Inputs["key"])
 	err = mutation.End(step, false /* successful */)
 	require.NoError(t, err)
 
@@ -992,7 +992,7 @@ func TestRecordingReadFailurePreviousResource(t *testing.T) {
 	require.Len(t, snap.Resources, 1)
 	require.Len(t, snap.PendingOperations, 0)
 	assert.Equal(t, resourceA.URN, snap.Resources[0].URN)
-	assert.Equal(t, resource.NewStringProperty("old"), snap.Resources[0].Inputs["key"])
+	assert.Equal(t, resource.NewProperty("old"), snap.Resources[0].Inputs["key"])
 }
 
 func TestRegisterOutputs(t *testing.T) {
@@ -1017,7 +1017,7 @@ func TestRegisterOutputs(t *testing.T) {
 
 	// Now, change the outputs and issue another RRO.
 	resourceA2 := NewResource("a")
-	resourceA2.Outputs = resource.PropertyMap{"hello": resource.NewStringProperty("world")}
+	resourceA2.Outputs = resource.PropertyMap{"hello": resource.NewProperty("world")}
 	step = deploy.NewSameStep(nil, nil, resourceA, resourceA2)
 	err = manager.RegisterResourceOutputs(step)
 	require.NoError(t, err)

--- a/pkg/cmd/pulumi/config/config_env_init.go
+++ b/pkg/cmd/pulumi/config/config_env_init.go
@@ -272,7 +272,7 @@ func (cmd *configEnvInitCmd) renderEnvironmentDefinition(
 	enc.SetIndent(2)
 	err := enc.Encode(map[string]any{
 		"values": map[string]any{
-			"pulumiConfig": cmd.render(resource.NewObjectProperty(config)),
+			"pulumiConfig": cmd.render(resource.NewProperty(config)),
 		},
 	})
 	if err != nil {

--- a/pkg/cmd/pulumi/stack/stack_change_secrets_provider_test.go
+++ b/pkg/cmd/pulumi/stack/stack_change_secrets_provider_test.go
@@ -188,7 +188,7 @@ func TestChangeSecretsProvider_WithSecrets(t *testing.T) {
 				URN:  resource.NewURN("testStack", "testProject", "", resource.RootStackType, "testStack"),
 				Type: resource.RootStackType,
 				Outputs: resource.PropertyMap{
-					"foo": resource.MakeSecret(resource.NewStringProperty("bar")),
+					"foo": resource.MakeSecret(resource.NewProperty("bar")),
 				},
 			},
 		},
@@ -270,7 +270,7 @@ runtime: mock
 	// Check that the snapshot still records the secret value with the same value
 	foo := snapshot.Resources[0].Outputs["foo"]
 	assert.True(t, foo.IsSecret())
-	assert.Equal(t, resource.NewStringProperty("bar"), foo.SecretValue().Element)
+	assert.Equal(t, resource.NewProperty("bar"), foo.SecretValue().Element)
 	// Check the config has been updated to the new secret
 	project, err := workspace.LoadProject("Pulumi.yaml")
 	require.NoError(t, err)

--- a/pkg/cmd/pulumi/stack/stack_output_test.go
+++ b/pkg/cmd/pulumi/stack/stack_output_test.go
@@ -40,9 +40,9 @@ func TestStackOutputCmd_plainText(t *testing.T) {
 	t.Parallel()
 
 	outputsWithSecret := resource.PropertyMap{
-		"bucketName": resource.NewStringProperty("mybucket-1234"),
-		"password": resource.NewSecretProperty(&resource.Secret{
-			Element: resource.NewStringProperty("hunter2"),
+		"bucketName": resource.NewProperty("mybucket-1234"),
+		"password": resource.NewProperty(&resource.Secret{
+			Element: resource.NewProperty("hunter2"),
 		}),
 	}
 
@@ -149,9 +149,9 @@ func TestStackOutputCmd_json(t *testing.T) {
 	t.Parallel()
 
 	outputsWithSecret := resource.PropertyMap{
-		"bucketName": resource.NewStringProperty("mybucket-1234"),
-		"password": resource.NewSecretProperty(&resource.Secret{
-			Element: resource.NewStringProperty("hunter2"),
+		"bucketName": resource.NewProperty("mybucket-1234"),
+		"password": resource.NewProperty(&resource.Secret{
+			Element: resource.NewProperty("hunter2"),
 		}),
 	}
 
@@ -258,9 +258,9 @@ func TestStackOutputCmd_shell(t *testing.T) {
 	t.Parallel()
 
 	outputsWithSecret := resource.PropertyMap{
-		"bucketName": resource.NewStringProperty("mybucket-1234"),
-		"password": resource.NewSecretProperty(&resource.Secret{
-			Element: resource.NewStringProperty("hunter2"),
+		"bucketName": resource.NewProperty("mybucket-1234"),
+		"password": resource.NewProperty(&resource.Secret{
+			Element: resource.NewProperty("hunter2"),
 		}),
 	}
 

--- a/pkg/cmd/pulumi/state/state_edit_test.go
+++ b/pkg/cmd/pulumi/state/state_edit_test.go
@@ -38,7 +38,7 @@ func TestSnapshotFrontendRoundTrip(t *testing.T) {
 				URN:  resource.URN("urn:pulumi:dev::random::pulumi:pulumi:Stack::random-dev"),
 				Type: "pulumi:pulumi:Stack",
 				Outputs: resource.PropertyMap{
-					resource.PropertyKey("name"): resource.NewStringProperty("fancy-pig"),
+					resource.PropertyKey("name"): resource.NewProperty("fancy-pig"),
 				},
 			},
 			{
@@ -47,11 +47,11 @@ func TestSnapshotFrontendRoundTrip(t *testing.T) {
 				Custom: true,
 				ID:     resource.ID("ed72fad1-9a82-49d7-b09f-1659b7a3c7db"),
 				Inputs: resource.PropertyMap{
-					resource.PropertyKey("version"): resource.NewStringProperty("4.13.2"),
+					resource.PropertyKey("version"): resource.NewProperty("4.13.2"),
 				},
 				Outputs: resource.PropertyMap{
-					resource.PropertyKey("aversion"): resource.NewStringProperty("4.13.2"),
-					resource.PropertyKey("version"):  resource.NewStringProperty("4.13.2"),
+					resource.PropertyKey("aversion"): resource.NewProperty("4.13.2"),
+					resource.PropertyKey("version"):  resource.NewProperty("4.13.2"),
 				},
 			},
 			{
@@ -60,9 +60,9 @@ func TestSnapshotFrontendRoundTrip(t *testing.T) {
 				Custom: true,
 				ID:     resource.ID("wondrous-doe"),
 				Outputs: resource.PropertyMap{
-					resource.PropertyKey("id"):        resource.NewStringProperty("wondrous-doe"),
-					resource.PropertyKey("length"):    resource.NewNumberProperty(2),
-					resource.PropertyKey("separator"): resource.NewStringProperty("-"),
+					resource.PropertyKey("id"):        resource.NewProperty("wondrous-doe"),
+					resource.PropertyKey("length"):    resource.NewProperty(2.0),
+					resource.PropertyKey("separator"): resource.NewProperty("-"),
 				},
 				Parent:   resource.URN("urn:pulumi:dev::random::pulumi:pulumi:Stack::random-dev"),
 				Provider: "urn:pulumi:dev::random::pulumi:providers:random::default_4_13_2::ed72fad1-9a82-49d7-b09f-1659b7a3c7db",

--- a/pkg/cmd/pulumi/state/state_move_test.go
+++ b/pkg/cmd/pulumi/state/state_move_test.go
@@ -353,7 +353,7 @@ func TestMoveWithExistingProvider(t *testing.T) {
 			ID:     "provider_id",
 			Custom: true,
 			Inputs: resource.PropertyMap{
-				"key": resource.NewStringProperty("value"),
+				"key": resource.NewProperty("value"),
 			},
 		},
 		{
@@ -370,7 +370,7 @@ func TestMoveWithExistingProvider(t *testing.T) {
 			ID:     "other_provider_id",
 			Custom: true,
 			Inputs: resource.PropertyMap{
-				"key": resource.NewStringProperty("different value"),
+				"key": resource.NewProperty("different value"),
 			},
 		},
 	}
@@ -959,7 +959,7 @@ func TestMoveSecret(t *testing.T) {
 			Type:     "a:b:c",
 			Provider: string(providerURN) + "::provider_id",
 			Parent:   resource.DefaultRootStackURN("sourceStack", "test"),
-			Outputs:  resource.PropertyMap{"secret": resource.MakeSecret(resource.NewStringProperty("secret"))},
+			Outputs:  resource.PropertyMap{"secret": resource.MakeSecret(resource.NewProperty("secret"))},
 		},
 	}
 
@@ -1058,7 +1058,7 @@ func TestMoveSecretOutsideOfProjectDir(t *testing.T) {
 			Type:     "a:b:c",
 			Provider: string(providerURN) + "::provider_id",
 			Parent:   resource.DefaultRootStackURN("sourceStack", "test"),
-			Outputs:  resource.PropertyMap{"secret": resource.MakeSecret(resource.NewStringProperty("secret"))},
+			Outputs:  resource.PropertyMap{"secret": resource.MakeSecret(resource.NewProperty("secret"))},
 		},
 	}
 
@@ -1131,7 +1131,7 @@ func TestMoveSecretNotInDestProjectDir(t *testing.T) {
 			Type:     "a:b:c",
 			Provider: string(providerURN) + "::provider_id",
 			Parent:   resource.DefaultRootStackURN("sourceStack", "test"),
-			Outputs:  resource.PropertyMap{"secret": resource.MakeSecret(resource.NewStringProperty("secret"))},
+			Outputs:  resource.PropertyMap{"secret": resource.MakeSecret(resource.NewProperty("secret"))},
 		},
 	}
 
@@ -1206,7 +1206,7 @@ func TestMoveProviderWithSameInputs(t *testing.T) {
 			ID:     "provider_id",
 			Custom: true,
 			Inputs: resource.PropertyMap{
-				"key": resource.NewStringProperty("value"),
+				"key": resource.NewProperty("value"),
 			},
 		},
 		{
@@ -1224,7 +1224,7 @@ func TestMoveProviderWithSameInputs(t *testing.T) {
 			ID:     "another_provider_id",
 			Custom: true,
 			Inputs: resource.PropertyMap{
-				"key": resource.NewStringProperty("value"),
+				"key": resource.NewProperty("value"),
 			},
 		},
 	}

--- a/pkg/engine/detailedDiff.go
+++ b/pkg/engine/detailedDiff.go
@@ -159,14 +159,14 @@ func TranslateDetailedDiff(step *StepEventMetadata, refresh bool) *resource.Obje
 			elements = []interface{}{path}
 		}
 
-		olds := resource.NewObjectProperty(step.Old.Outputs)
+		olds := resource.NewProperty(step.Old.Outputs)
 		if pdiff.InputDiff {
-			olds = resource.NewObjectProperty(step.Old.Inputs)
+			olds = resource.NewProperty(step.Old.Inputs)
 		}
 
-		news := resource.NewObjectProperty(step.New.Inputs)
+		news := resource.NewProperty(step.New.Inputs)
 		if refresh {
-			news = resource.NewObjectProperty(step.New.Outputs)
+			news = resource.NewProperty(step.New.Outputs)
 		}
 
 		addDiff(elements, pdiff.Kind, &diff, olds, news)

--- a/pkg/engine/detailedDiff_test.go
+++ b/pkg/engine/detailedDiff_test.go
@@ -55,8 +55,8 @@ func TestTranslateDetailedDiff(t *testing.T) {
 				Sames:   resource.PropertyMap{},
 				Updates: map[resource.PropertyKey]resource.ValueDiff{
 					"foo": {
-						Old: resource.NewNumberProperty(42),
-						New: resource.NewNumberProperty(24),
+						Old: resource.NewProperty(42.0),
+						New: resource.NewProperty(24.0),
 					},
 				},
 			},
@@ -77,8 +77,8 @@ func TestTranslateDetailedDiff(t *testing.T) {
 				Sames:   resource.PropertyMap{},
 				Updates: map[resource.PropertyKey]resource.ValueDiff{
 					"foo": {
-						Old: resource.NewNumberProperty(42),
-						New: resource.NewNumberProperty(42),
+						Old: resource.NewProperty(42.0),
+						New: resource.NewProperty(42.0),
 					},
 				},
 			},
@@ -101,8 +101,8 @@ func TestTranslateDetailedDiff(t *testing.T) {
 				Sames:   resource.PropertyMap{},
 				Updates: map[resource.PropertyKey]resource.ValueDiff{
 					"foo": {
-						Old: resource.NewNumberProperty(42),
-						New: resource.NewNumberProperty(24),
+						Old: resource.NewProperty(42.0),
+						New: resource.NewProperty(24.0),
 					},
 				},
 			},
@@ -125,8 +125,8 @@ func TestTranslateDetailedDiff(t *testing.T) {
 				Sames:   resource.PropertyMap{},
 				Updates: map[resource.PropertyKey]resource.ValueDiff{
 					"foo": {
-						Old: resource.NewNumberProperty(42),
-						New: resource.NewNumberProperty(24),
+						Old: resource.NewProperty(42.0),
+						New: resource.NewProperty(24.0),
 					},
 				},
 			},
@@ -141,7 +141,7 @@ func TestTranslateDetailedDiff(t *testing.T) {
 			},
 			expected: &resource.ObjectDiff{
 				Adds: resource.PropertyMap{
-					"foo": resource.NewNumberProperty(24),
+					"foo": resource.NewProperty(24.0),
 				},
 				Deletes: resource.PropertyMap{},
 				Sames:   resource.PropertyMap{},
@@ -159,7 +159,7 @@ func TestTranslateDetailedDiff(t *testing.T) {
 			expected: &resource.ObjectDiff{
 				Adds: resource.PropertyMap{},
 				Deletes: resource.PropertyMap{
-					"foo": resource.NewNumberProperty(24),
+					"foo": resource.NewProperty(24.0),
 				},
 				Sames:   resource.PropertyMap{},
 				Updates: map[resource.PropertyKey]resource.ValueDiff{},
@@ -182,7 +182,7 @@ func TestTranslateDetailedDiff(t *testing.T) {
 			expected: &resource.ObjectDiff{
 				Adds: resource.PropertyMap{},
 				Deletes: resource.PropertyMap{
-					"foo": resource.NewNumberProperty(42),
+					"foo": resource.NewProperty(42.0),
 				},
 				Sames:   resource.PropertyMap{},
 				Updates: map[resource.PropertyKey]resource.ValueDiff{},
@@ -216,8 +216,8 @@ func TestTranslateDetailedDiff(t *testing.T) {
 							Sames:   map[int]resource.PropertyValue{},
 							Updates: map[int]resource.ValueDiff{
 								1: {
-									Old: resource.NewStringProperty("baz"),
-									New: resource.NewStringProperty("qux"),
+									Old: resource.NewProperty("baz"),
+									New: resource.NewProperty("qux"),
 								},
 							},
 						},
@@ -263,8 +263,8 @@ func TestTranslateDetailedDiff(t *testing.T) {
 							},
 							Updates: map[int]resource.ValueDiff{
 								1: {
-									Old: resource.NewStringProperty("baz"),
-									New: resource.NewStringProperty("qux"),
+									Old: resource.NewProperty("baz"),
+									New: resource.NewProperty("qux"),
 								},
 							},
 						},
@@ -296,7 +296,7 @@ func TestTranslateDetailedDiff(t *testing.T) {
 					"foo": {
 						Array: &resource.ArrayDiff{
 							Adds: map[int]resource.PropertyValue{
-								1: resource.NewStringProperty("baz"),
+								1: resource.NewProperty("baz"),
 							},
 							Deletes: map[int]resource.PropertyValue{},
 							Sames:   map[int]resource.PropertyValue{},
@@ -330,7 +330,7 @@ func TestTranslateDetailedDiff(t *testing.T) {
 						Array: &resource.ArrayDiff{
 							Adds: map[int]resource.PropertyValue{},
 							Deletes: map[int]resource.PropertyValue{
-								1: resource.NewStringProperty("baz"),
+								1: resource.NewProperty("baz"),
 							},
 							Sames:   map[int]resource.PropertyValue{},
 							Updates: map[int]resource.ValueDiff{},
@@ -445,8 +445,8 @@ func TestTranslateDetailedDiff(t *testing.T) {
 						Array: &resource.ArrayDiff{
 							Adds: map[int]resource.PropertyValue{},
 							Deletes: map[int]resource.PropertyValue{
-								0: resource.NewObjectProperty(resource.PropertyMap{
-									"baz": resource.NewNumberProperty(42),
+								0: resource.NewProperty(resource.PropertyMap{
+									"baz": resource.NewProperty(42.0),
 								}),
 							},
 							Sames:   map[int]resource.PropertyValue{},
@@ -484,8 +484,8 @@ func TestTranslateDetailedDiff(t *testing.T) {
 							Sames:   resource.PropertyMap{},
 							Updates: map[resource.PropertyKey]resource.ValueDiff{
 								"qux": {
-									Old: resource.NewStringProperty("zed"),
-									New: resource.NewStringProperty("alpha"),
+									Old: resource.NewProperty("zed"),
+									New: resource.NewProperty("alpha"),
 								},
 							},
 						},
@@ -531,8 +531,8 @@ func TestTranslateDetailedDiff(t *testing.T) {
 							},
 							Updates: map[resource.PropertyKey]resource.ValueDiff{
 								"qux": {
-									Old: resource.NewStringProperty("zed"),
-									New: resource.NewStringProperty("alpha"),
+									Old: resource.NewProperty("zed"),
+									New: resource.NewProperty("alpha"),
 								},
 							},
 						},
@@ -563,7 +563,7 @@ func TestTranslateDetailedDiff(t *testing.T) {
 					"foo": {
 						Object: &resource.ObjectDiff{
 							Adds: resource.PropertyMap{
-								"qux": resource.NewStringProperty("alpha"),
+								"qux": resource.NewProperty("alpha"),
 							},
 							Deletes: resource.PropertyMap{},
 							Sames:   resource.PropertyMap{},
@@ -597,7 +597,7 @@ func TestTranslateDetailedDiff(t *testing.T) {
 						Object: &resource.ObjectDiff{
 							Adds: resource.PropertyMap{},
 							Deletes: resource.PropertyMap{
-								"qux": resource.NewStringProperty("zed"),
+								"qux": resource.NewProperty("zed"),
 							},
 							Sames:   resource.PropertyMap{},
 							Updates: map[resource.PropertyKey]resource.ValueDiff{},
@@ -712,8 +712,8 @@ func TestTranslateDetailedDiff(t *testing.T) {
 						Array: &resource.ArrayDiff{
 							Adds: map[int]resource.PropertyValue{},
 							Deletes: map[int]resource.PropertyValue{
-								0: resource.NewObjectProperty(resource.PropertyMap{
-									"baz": resource.NewNumberProperty(42),
+								0: resource.NewProperty(resource.PropertyMap{
+									"baz": resource.NewProperty(42.0),
 								}),
 							},
 							Sames:   map[int]resource.PropertyValue{},

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -698,7 +698,7 @@ func (e *eventEmitter) startDebugging(info plugin.DebuggingInfo) {
 }
 
 func filterResourceProperties(m resource.PropertyMap, debug bool, showSecrets bool) resource.PropertyMap {
-	return filterPropertyValue(resource.NewObjectProperty(m), debug, showSecrets).ObjectValue()
+	return filterPropertyValue(resource.NewProperty(m), debug, showSecrets).ObjectValue()
 }
 
 func filterPropertyValue(v resource.PropertyValue, debug bool, showSecrets bool) resource.PropertyValue {
@@ -707,34 +707,34 @@ func filterPropertyValue(v resource.PropertyValue, debug bool, showSecrets bool)
 		return v
 	case v.IsString():
 		// have to ensure we filter out secrets.
-		return resource.NewStringProperty(logging.FilterString(v.StringValue()))
+		return resource.NewProperty(logging.FilterString(v.StringValue()))
 	case v.IsAsset():
-		return resource.NewAssetProperty(filterAsset(v.AssetValue(), debug))
+		return resource.NewProperty(filterAsset(v.AssetValue(), debug))
 	case v.IsArchive():
-		return resource.NewArchiveProperty(filterArchive(v.ArchiveValue(), debug))
+		return resource.NewProperty(filterArchive(v.ArchiveValue(), debug))
 	case v.IsArray():
 		arr := make([]resource.PropertyValue, len(v.ArrayValue()))
 		for i, v := range v.ArrayValue() {
 			arr[i] = filterPropertyValue(v, debug, showSecrets)
 		}
-		return resource.NewArrayProperty(arr)
+		return resource.NewProperty(arr)
 	case v.IsObject():
 		obj := make(resource.PropertyMap, len(v.ObjectValue()))
 		for k, v := range v.ObjectValue() {
 			obj[k] = filterPropertyValue(v, debug, showSecrets)
 		}
-		return resource.NewObjectProperty(obj)
+		return resource.NewProperty(obj)
 	case v.IsComputed():
 		return resource.MakeComputed(filterPropertyValue(v.Input().Element, debug, showSecrets))
 	case v.IsOutput():
 		return resource.MakeComputed(filterPropertyValue(v.OutputValue().Element, debug, showSecrets))
 	case v.IsSecret() && showSecrets:
-		return resource.NewSecretProperty(v.SecretValue())
+		return resource.NewProperty(v.SecretValue())
 	case v.IsSecret():
-		return resource.MakeSecret(resource.NewStringProperty("[secret]"))
+		return resource.MakeSecret(resource.NewProperty("[secret]"))
 	case v.IsResourceReference():
 		ref := v.ResourceReferenceValue()
-		return resource.NewResourceReferenceProperty(resource.ResourceReference{
+		return resource.NewProperty(resource.ResourceReference{
 			URN:            resource.URN(logging.FilterString(string(ref.URN))),
 			ID:             filterPropertyValue(ref.ID, debug, showSecrets),
 			PackageVersion: logging.FilterString(ref.PackageVersion),

--- a/pkg/engine/lifecycletest/alias_test.go
+++ b/pkg/engine/lifecycletest/alias_test.go
@@ -339,7 +339,7 @@ func TestAliases(t *testing.T) {
 		t:    "pkgA:index:t4",
 		name: "n2",
 		props: resource.PropertyMap{
-			resource.PropertyKey("x"): resource.NewNumberProperty(42),
+			resource.PropertyKey("x"): resource.NewProperty(42.0),
 		},
 		aliases: []resource.Alias{
 			{Type: "pkgA:othermod:t3", Name: "n1"},
@@ -351,7 +351,7 @@ func TestAliases(t *testing.T) {
 		t:    "pkgA:index:t5",
 		name: "n3",
 		props: resource.PropertyMap{
-			resource.PropertyKey("x"): resource.NewNumberProperty(1000),
+			resource.PropertyKey("x"): resource.NewProperty(1000.0),
 		},
 		aliases: []resource.Alias{
 			{Type: "pkgA:index:t4", Name: "n2"},
@@ -363,7 +363,7 @@ func TestAliases(t *testing.T) {
 		t:    "pkgA:index:t6",
 		name: "n4",
 		props: resource.PropertyMap{
-			resource.PropertyKey("forcesReplacement"): resource.NewNumberProperty(1000),
+			resource.PropertyKey("forcesReplacement"): resource.NewProperty(1000.0),
 		},
 		aliases: []resource.Alias{
 			{Type: "pkgA:index:t5", Name: "n3"},
@@ -376,7 +376,7 @@ func TestAliases(t *testing.T) {
 		t:    "pkgA:index:t7",
 		name: "n5",
 		props: resource.PropertyMap{
-			resource.PropertyKey("forcesReplacement"): resource.NewNumberProperty(999),
+			resource.PropertyKey("forcesReplacement"): resource.NewProperty(999.0),
 		},
 		deleteBeforeReplace: true,
 		aliases: []resource.Alias{
@@ -389,7 +389,7 @@ func TestAliases(t *testing.T) {
 		t:    "pkgA:index:t1",
 		name: "n1",
 		props: resource.PropertyMap{
-			resource.PropertyKey("forcesReplacement"): resource.NewNumberProperty(1),
+			resource.PropertyKey("forcesReplacement"): resource.NewProperty(1.0),
 		},
 		deleteBeforeReplace: true,
 	}, {
@@ -402,7 +402,7 @@ func TestAliases(t *testing.T) {
 		t:    "pkgA:index:t1-new",
 		name: "n1-new",
 		props: resource.PropertyMap{
-			resource.PropertyKey("forcesReplacement"): resource.NewNumberProperty(2),
+			resource.PropertyKey("forcesReplacement"): resource.NewProperty(2.0),
 		},
 		deleteBeforeReplace: true,
 		aliases: []resource.Alias{
@@ -423,7 +423,7 @@ func TestAliases(t *testing.T) {
 		t:    "pkgA:index:t1",
 		name: "n1",
 		props: resource.PropertyMap{
-			resource.PropertyKey("forcesReplacement"): resource.NewNumberProperty(1),
+			resource.PropertyKey("forcesReplacement"): resource.NewProperty(1.0),
 		},
 		deleteBeforeReplace: true,
 	}, {
@@ -436,7 +436,7 @@ func TestAliases(t *testing.T) {
 		t:    "pkgA:index:t1-new",
 		name: "n1-new",
 		props: resource.PropertyMap{
-			resource.PropertyKey("forcesReplacement"): resource.NewNumberProperty(2),
+			resource.PropertyKey("forcesReplacement"): resource.NewProperty(2.0),
 		},
 		deleteBeforeReplace: true,
 		aliases: []resource.Alias{
@@ -880,7 +880,7 @@ func TestAliasURNs(t *testing.T) {
 		t:    "pkgA:index:t4",
 		name: "n2",
 		props: resource.PropertyMap{
-			resource.PropertyKey("x"): resource.NewNumberProperty(42),
+			resource.PropertyKey("x"): resource.NewProperty(42.0),
 		},
 		aliasURNs: []resource.URN{
 			"urn:pulumi:test::test::pkgA:othermod:t3::n1",
@@ -892,7 +892,7 @@ func TestAliasURNs(t *testing.T) {
 		t:    "pkgA:index:t5",
 		name: "n3",
 		props: resource.PropertyMap{
-			resource.PropertyKey("x"): resource.NewNumberProperty(1000),
+			resource.PropertyKey("x"): resource.NewProperty(1000.0),
 		},
 		aliasURNs: []resource.URN{
 			"urn:pulumi:test::test::pkgA:index:t4::n2",
@@ -904,7 +904,7 @@ func TestAliasURNs(t *testing.T) {
 		t:    "pkgA:index:t6",
 		name: "n4",
 		props: resource.PropertyMap{
-			resource.PropertyKey("forcesReplacement"): resource.NewNumberProperty(1000),
+			resource.PropertyKey("forcesReplacement"): resource.NewProperty(1000.0),
 		},
 		aliasURNs: []resource.URN{
 			"urn:pulumi:test::test::pkgA:index:t5::n3",
@@ -917,7 +917,7 @@ func TestAliasURNs(t *testing.T) {
 		t:    "pkgA:index:t7",
 		name: "n5",
 		props: resource.PropertyMap{
-			resource.PropertyKey("forcesReplacement"): resource.NewNumberProperty(999),
+			resource.PropertyKey("forcesReplacement"): resource.NewProperty(999.0),
 		},
 		deleteBeforeReplace: true,
 		aliasURNs: []resource.URN{
@@ -930,7 +930,7 @@ func TestAliasURNs(t *testing.T) {
 		t:    "pkgA:index:t1",
 		name: "n1",
 		props: resource.PropertyMap{
-			resource.PropertyKey("forcesReplacement"): resource.NewNumberProperty(1),
+			resource.PropertyKey("forcesReplacement"): resource.NewProperty(1.0),
 		},
 		deleteBeforeReplace: true,
 	}, {
@@ -943,7 +943,7 @@ func TestAliasURNs(t *testing.T) {
 		t:    "pkgA:index:t1-new",
 		name: "n1-new",
 		props: resource.PropertyMap{
-			resource.PropertyKey("forcesReplacement"): resource.NewNumberProperty(2),
+			resource.PropertyKey("forcesReplacement"): resource.NewProperty(2.0),
 		},
 		deleteBeforeReplace: true,
 		aliasURNs: []resource.URN{
@@ -964,7 +964,7 @@ func TestAliasURNs(t *testing.T) {
 		t:    "pkgA:index:t1",
 		name: "n1",
 		props: resource.PropertyMap{
-			resource.PropertyKey("forcesReplacement"): resource.NewNumberProperty(1),
+			resource.PropertyKey("forcesReplacement"): resource.NewProperty(1.0),
 		},
 		deleteBeforeReplace: true,
 	}, {
@@ -977,7 +977,7 @@ func TestAliasURNs(t *testing.T) {
 		t:    "pkgA:index:t1-new",
 		name: "n1-new",
 		props: resource.PropertyMap{
-			resource.PropertyKey("forcesReplacement"): resource.NewNumberProperty(2),
+			resource.PropertyKey("forcesReplacement"): resource.NewProperty(2.0),
 		},
 		deleteBeforeReplace: true,
 		aliasURNs: []resource.URN{

--- a/pkg/engine/lifecycletest/analyzer_test.go
+++ b/pkg/engine/lifecycletest/analyzer_test.go
@@ -229,8 +229,8 @@ func TestResourceRemediation(t *testing.T) {
 							PolicyPackVersion: "1.0.0",
 							Description:       "a remediation that gets ignored because it runs first",
 							Properties: resource.PropertyMap{
-								"a":   resource.NewStringProperty("nope"),
-								"ggg": resource.NewBoolProperty(true),
+								"a":   resource.NewProperty("nope"),
+								"ggg": resource.NewProperty(true),
 							},
 						},
 						{
@@ -239,9 +239,9 @@ func TestResourceRemediation(t *testing.T) {
 							PolicyPackVersion: "1.0.0",
 							Description:       "a remediation that actually gets applied because it runs last",
 							Properties: resource.PropertyMap{
-								"a":   resource.NewStringProperty("foo"),
-								"fff": resource.NewBoolProperty(true),
-								"z":   resource.NewStringProperty("bar"),
+								"a":   resource.NewProperty("foo"),
+								"fff": resource.NewProperty(true),
+								"z":   resource.NewProperty("bar"),
 							},
 						},
 					}, nil

--- a/pkg/engine/lifecycletest/components_test.go
+++ b/pkg/engine/lifecycletest/components_test.go
@@ -56,7 +56,7 @@ func TestSingleComponentDefaultProviderLifecycle(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				outs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
+				outs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
 				err = monitor.RegisterResourceOutputs(resp.URN, outs)
 				require.NoError(t, err)
 
@@ -78,7 +78,7 @@ func TestSingleComponentDefaultProviderLifecycle(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Equal(t, resource.PropertyMap{
-			"foo": resource.NewStringProperty("bar"),
+			"foo": resource.NewProperty("bar"),
 		}, resp.Outputs)
 		return nil
 	})
@@ -309,8 +309,8 @@ func TestConstructCallSecretsUnknowns(t *testing.T) {
 
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		inputs := resource.PropertyMap{
-			"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-			"bar": resource.MakeComputed(resource.NewStringProperty("")),
+			"foo": resource.MakeSecret(resource.NewProperty("foo")),
+			"bar": resource.MakeComputed(resource.NewProperty("")),
 		}
 
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", false, deploytest.ResourceOptions{
@@ -378,8 +378,8 @@ func TestConstructCallReturnDependencies(t *testing.T) {
 						return plugin.ConstructResponse{
 							URN: resp.URN,
 							Outputs: resource.PropertyMap{
-								"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-								"bar": resource.MakeComputed(resource.NewStringProperty("")),
+								"foo": resource.MakeSecret(resource.NewProperty("foo")),
+								"bar": resource.MakeComputed(resource.NewProperty("")),
 							},
 							OutputDependencies: map[resource.PropertyKey][]resource.URN{
 								"foo": deps,
@@ -403,8 +403,8 @@ func TestConstructCallReturnDependencies(t *testing.T) {
 
 						return plugin.CallResponse{
 							Return: resource.PropertyMap{
-								"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-								"bar": resource.MakeComputed(resource.NewStringProperty("")),
+								"foo": resource.MakeSecret(resource.NewProperty("foo")),
+								"bar": resource.MakeComputed(resource.NewProperty("")),
 							},
 							ReturnDependencies: map[resource.PropertyKey][]resource.URN{
 								"foo": deps,
@@ -428,8 +428,8 @@ func TestConstructCallReturnDependencies(t *testing.T) {
 			// Assert that the outputs are received as just plain values because SDKs don't yet support output
 			// values returned from RegisterResource.
 			assert.Equal(t, resource.PropertyMap{
-				"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-				"bar": resource.MakeComputed(resource.NewStringProperty("")),
+				"foo": resource.MakeSecret(resource.NewProperty("foo")),
+				"bar": resource.MakeComputed(resource.NewProperty("")),
 			}, resp.Outputs)
 			assert.Equal(t, map[resource.PropertyKey][]resource.URN{
 				"foo": {urn},
@@ -438,7 +438,7 @@ func TestConstructCallReturnDependencies(t *testing.T) {
 
 			result, deps, _, err := monitor.Call("pkgA:m:typA", resource.PropertyMap{
 				// Send this as an output value using the dependencies returned.
-				"arg": resource.NewOutputProperty(resource.Output{
+				"arg": resource.NewProperty(resource.Output{
 					Element:      resp.Outputs["foo"].SecretValue().Element,
 					Known:        true,
 					Secret:       true,
@@ -450,8 +450,8 @@ func TestConstructCallReturnDependencies(t *testing.T) {
 			// Assert that the outputs are received as just plain values because SDKs don't yet support output
 			// values returned from Call.
 			assert.Equal(t, resource.PropertyMap{
-				"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-				"bar": resource.MakeComputed(resource.NewStringProperty("")),
+				"foo": resource.MakeSecret(resource.NewProperty("foo")),
+				"bar": resource.MakeComputed(resource.NewProperty("")),
 			}, result)
 			assert.Equal(t, map[resource.PropertyKey][]resource.URN{
 				"foo": {urn},
@@ -524,13 +524,13 @@ func TestConstructCallReturnOutputs(t *testing.T) {
 						return plugin.ConstructResponse{
 							URN: resp.URN,
 							Outputs: resource.PropertyMap{
-								"foo": resource.NewOutputProperty(resource.Output{
-									Element:      resource.NewStringProperty("foo"),
+								"foo": resource.NewProperty(resource.Output{
+									Element:      resource.NewProperty("foo"),
 									Known:        true,
 									Secret:       true,
 									Dependencies: deps,
 								}),
-								"bar": resource.NewOutputProperty(resource.Output{
+								"bar": resource.NewProperty(resource.Output{
 									Dependencies: deps,
 								}),
 							},
@@ -553,13 +553,13 @@ func TestConstructCallReturnOutputs(t *testing.T) {
 
 						return plugin.CallResponse{
 							Return: resource.PropertyMap{
-								"foo": resource.NewOutputProperty(resource.Output{
-									Element:      resource.NewStringProperty("foo"),
+								"foo": resource.NewProperty(resource.Output{
+									Element:      resource.NewProperty("foo"),
 									Known:        true,
 									Secret:       true,
 									Dependencies: deps,
 								}),
-								"bar": resource.NewOutputProperty(resource.Output{
+								"bar": resource.NewProperty(resource.Output{
 									Dependencies: deps,
 								}),
 							},
@@ -582,8 +582,8 @@ func TestConstructCallReturnOutputs(t *testing.T) {
 			// Assert that the outputs are received as just plain values because SDKs don't yet support output
 			// values returned from RegisterResource.
 			assert.Equal(t, resource.PropertyMap{
-				"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-				"bar": resource.MakeComputed(resource.NewStringProperty("")),
+				"foo": resource.MakeSecret(resource.NewProperty("foo")),
+				"bar": resource.MakeComputed(resource.NewProperty("")),
 			}, resp.Outputs)
 			assert.Equal(t, map[resource.PropertyKey][]resource.URN{
 				"foo": {urn},
@@ -592,7 +592,7 @@ func TestConstructCallReturnOutputs(t *testing.T) {
 
 			result, deps, _, err := monitor.Call("pkgA:m:typA", resource.PropertyMap{
 				// Send this as an output value using the dependencies returned.
-				"arg": resource.NewOutputProperty(resource.Output{
+				"arg": resource.NewProperty(resource.Output{
 					Element:      resp.Outputs["foo"].SecretValue().Element,
 					Known:        true,
 					Secret:       true,
@@ -604,8 +604,8 @@ func TestConstructCallReturnOutputs(t *testing.T) {
 			// Assert that the outputs are received as just plain values because SDKs don't yet support output
 			// values returned from Call.
 			assert.Equal(t, resource.PropertyMap{
-				"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-				"bar": resource.MakeComputed(resource.NewStringProperty("")),
+				"foo": resource.MakeSecret(resource.NewProperty("foo")),
+				"bar": resource.MakeComputed(resource.NewProperty("")),
 			}, result)
 			assert.Equal(t, map[resource.PropertyKey][]resource.URN{
 				"foo": {urn},
@@ -682,8 +682,8 @@ func TestConstructCallSendDependencies(t *testing.T) {
 						return plugin.ConstructResponse{
 							URN: resp.URN,
 							Outputs: resource.PropertyMap{
-								"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-								"bar": resource.MakeComputed(resource.NewStringProperty("")),
+								"foo": resource.MakeSecret(resource.NewProperty("foo")),
+								"bar": resource.MakeComputed(resource.NewProperty("")),
 							},
 							OutputDependencies: map[resource.PropertyKey][]resource.URN{
 								"foo": deps,
@@ -707,8 +707,8 @@ func TestConstructCallSendDependencies(t *testing.T) {
 
 						return plugin.CallResponse{
 							Return: resource.PropertyMap{
-								"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-								"bar": resource.MakeComputed(resource.NewStringProperty("")),
+								"foo": resource.MakeSecret(resource.NewProperty("foo")),
+								"bar": resource.MakeComputed(resource.NewProperty("")),
 							},
 							ReturnDependencies: map[resource.PropertyKey][]resource.URN{
 								"foo": deps,
@@ -723,7 +723,7 @@ func TestConstructCallSendDependencies(t *testing.T) {
 		programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 			respC, err := monitor.RegisterResource("pkgA:m:typC", "resC", false, deploytest.ResourceOptions{
 				Inputs: resource.PropertyMap{
-					"arg": resource.NewNumberProperty(1),
+					"arg": resource.NewProperty(1.0),
 				},
 			})
 			require.NoError(t, err)
@@ -731,7 +731,7 @@ func TestConstructCallSendDependencies(t *testing.T) {
 			resp, err := monitor.RegisterResource("pkgA:m:typA", "resA", false, deploytest.ResourceOptions{
 				Remote: true,
 				Inputs: resource.PropertyMap{
-					"arg": resource.NewOutputProperty(resource.Output{
+					"arg": resource.NewProperty(resource.Output{
 						Element:      respC.Outputs["arg"],
 						Known:        true,
 						Dependencies: []resource.URN{respC.URN},
@@ -746,8 +746,8 @@ func TestConstructCallSendDependencies(t *testing.T) {
 			// Assert that the outputs are received as just plain values because SDKs don't yet support output
 			// values returned from RegisterResource.
 			assert.Equal(t, resource.PropertyMap{
-				"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-				"bar": resource.MakeComputed(resource.NewStringProperty("")),
+				"foo": resource.MakeSecret(resource.NewProperty("foo")),
+				"bar": resource.MakeComputed(resource.NewProperty("")),
 			}, resp.Outputs)
 			assert.Equal(t, map[resource.PropertyKey][]resource.URN{
 				"foo": {urn},
@@ -756,7 +756,7 @@ func TestConstructCallSendDependencies(t *testing.T) {
 
 			result, deps, _, err := monitor.Call("pkgA:m:typA", resource.PropertyMap{
 				// Send this as an output value using the dependencies returned.
-				"arg": resource.NewOutputProperty(resource.Output{
+				"arg": resource.NewProperty(resource.Output{
 					Element:      resp.Outputs["foo"].SecretValue().Element,
 					Known:        true,
 					Secret:       true,
@@ -768,8 +768,8 @@ func TestConstructCallSendDependencies(t *testing.T) {
 			// Assert that the outputs are received as just plain values because SDKs don't yet support output
 			// values returned from Call.
 			assert.Equal(t, resource.PropertyMap{
-				"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-				"bar": resource.MakeComputed(resource.NewStringProperty("")),
+				"foo": resource.MakeSecret(resource.NewProperty("foo")),
+				"bar": resource.MakeComputed(resource.NewProperty("")),
 			}, result)
 			assert.Equal(t, map[resource.PropertyKey][]resource.URN{
 				"foo": {urn},
@@ -847,8 +847,8 @@ func TestConstructCallDependencyDedeuplication(t *testing.T) {
 						return plugin.ConstructResponse{
 							URN: resp.URN,
 							Outputs: resource.PropertyMap{
-								"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-								"bar": resource.MakeComputed(resource.NewStringProperty("")),
+								"foo": resource.MakeSecret(resource.NewProperty("foo")),
+								"bar": resource.MakeComputed(resource.NewProperty("")),
 							},
 							OutputDependencies: map[resource.PropertyKey][]resource.URN{
 								"foo": deps,
@@ -872,8 +872,8 @@ func TestConstructCallDependencyDedeuplication(t *testing.T) {
 
 						return plugin.CallResponse{
 							Return: resource.PropertyMap{
-								"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-								"bar": resource.MakeComputed(resource.NewStringProperty("")),
+								"foo": resource.MakeSecret(resource.NewProperty("foo")),
+								"bar": resource.MakeComputed(resource.NewProperty("")),
 							},
 							ReturnDependencies: map[resource.PropertyKey][]resource.URN{
 								"foo": deps,
@@ -888,7 +888,7 @@ func TestConstructCallDependencyDedeuplication(t *testing.T) {
 		programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 			respC, err := monitor.RegisterResource("pkgA:m:typC", "resC", false, deploytest.ResourceOptions{
 				Inputs: resource.PropertyMap{
-					"arg": resource.NewNumberProperty(1),
+					"arg": resource.NewProperty(1.0),
 				},
 			})
 			require.NoError(t, err)
@@ -896,7 +896,7 @@ func TestConstructCallDependencyDedeuplication(t *testing.T) {
 			resp, err := monitor.RegisterResource("pkgA:m:typA", "resA", false, deploytest.ResourceOptions{
 				Remote: true,
 				Inputs: resource.PropertyMap{
-					"arg": resource.NewOutputProperty(resource.Output{
+					"arg": resource.NewProperty(resource.Output{
 						Element:      respC.Outputs["arg"],
 						Known:        true,
 						Dependencies: []resource.URN{respC.URN},
@@ -914,8 +914,8 @@ func TestConstructCallDependencyDedeuplication(t *testing.T) {
 			// Assert that the outputs are received as just plain values because SDKs don't yet support output
 			// values returned from RegisterResource.
 			assert.Equal(t, resource.PropertyMap{
-				"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-				"bar": resource.MakeComputed(resource.NewStringProperty("")),
+				"foo": resource.MakeSecret(resource.NewProperty("foo")),
+				"bar": resource.MakeComputed(resource.NewProperty("")),
 			}, resp.Outputs)
 			assert.Equal(t, map[resource.PropertyKey][]resource.URN{
 				"foo": {urn},
@@ -924,7 +924,7 @@ func TestConstructCallDependencyDedeuplication(t *testing.T) {
 
 			result, deps, _, err := monitor.Call("pkgA:m:typA", resource.PropertyMap{
 				// Send this as an output value using the dependencies returned.
-				"arg": resource.NewOutputProperty(resource.Output{
+				"arg": resource.NewProperty(resource.Output{
 					Element:      resp.Outputs["foo"].SecretValue().Element,
 					Known:        true,
 					Secret:       true,
@@ -938,8 +938,8 @@ func TestConstructCallDependencyDedeuplication(t *testing.T) {
 			// Assert that the outputs are received as just plain values because SDKs don't yet support output
 			// values returned from Call.
 			assert.Equal(t, resource.PropertyMap{
-				"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-				"bar": resource.MakeComputed(resource.NewStringProperty("")),
+				"foo": resource.MakeSecret(resource.NewProperty("foo")),
+				"bar": resource.MakeComputed(resource.NewProperty("")),
 			}, result)
 			assert.Equal(t, map[resource.PropertyKey][]resource.URN{
 				"foo": {urn},
@@ -995,7 +995,7 @@ func TestSingleComponentMethodResourceDefaultProviderLifecycle(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				outs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
+				outs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
 				err = monitor.RegisterResourceOutputs(resp.URN, outs)
 				require.NoError(t, err)
 
@@ -1031,7 +1031,7 @@ func TestSingleComponentMethodResourceDefaultProviderLifecycle(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Equal(t, resource.PropertyMap{
-			"foo": resource.NewStringProperty("bar"),
+			"foo": resource.NewProperty("bar"),
 		}, resp.Outputs)
 
 		_, _, _, err = monitor.Call("pkgA:m:typA/methodA", resource.PropertyMap{}, nil, "", "", "")
@@ -1076,7 +1076,7 @@ func TestSingleComponentMethodDefaultProviderLifecycle(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				outs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
+				outs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
 				err = monitor.RegisterResourceOutputs(urn, outs)
 				require.NoError(t, err)
 
@@ -1092,12 +1092,12 @@ func TestSingleComponentMethodDefaultProviderLifecycle(t *testing.T) {
 				monitor *deploytest.ResourceMonitor,
 			) (plugin.CallResponse, error) {
 				assert.Equal(t, resource.PropertyMap{
-					"name": resource.NewStringProperty("Alice"),
+					"name": resource.NewProperty("Alice"),
 				}, req.Args)
 				name := req.Args["name"].StringValue()
 
 				result, _, err := monitor.Invoke("pulumi:pulumi:getResource", resource.PropertyMap{
-					"urn": resource.NewStringProperty(string(urn)),
+					"urn": resource.NewProperty(string(urn)),
 				}, "", "", "")
 				require.NoError(t, err)
 				state := result["state"]
@@ -1106,7 +1106,7 @@ func TestSingleComponentMethodDefaultProviderLifecycle(t *testing.T) {
 				message := fmt.Sprintf("%s, %s!", name, foo)
 				return plugin.CallResponse{
 					Return: resource.PropertyMap{
-						"message": resource.NewStringProperty(message),
+						"message": resource.NewProperty(message),
 					},
 				}, nil
 			}
@@ -1124,15 +1124,15 @@ func TestSingleComponentMethodDefaultProviderLifecycle(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Equal(t, resource.PropertyMap{
-			"foo": resource.NewStringProperty("bar"),
+			"foo": resource.NewProperty("bar"),
 		}, resp.Outputs)
 
 		outs, _, _, err := monitor.Call("pkgA:m:typA/methodA", resource.PropertyMap{
-			"name": resource.NewStringProperty("Alice"),
+			"name": resource.NewProperty("Alice"),
 		}, nil, "", "", "")
 		require.NoError(t, err)
 		assert.Equal(t, resource.PropertyMap{
-			"message": resource.NewStringProperty("Alice, bar!"),
+			"message": resource.NewProperty("Alice, bar!"),
 		}, outs)
 
 		return nil
@@ -1189,7 +1189,7 @@ func TestComponentRegisteredResourceOutputCanBeHydratedByProgram(t *testing.T) {
 						custom, err := rm.RegisterResource("pkgA:index:Custom", "custom", true, deploytest.ResourceOptions{
 							Parent: component.URN,
 							Inputs: resource.PropertyMap{
-								"foo": resource.NewStringProperty("bar"),
+								"foo": resource.NewProperty("bar"),
 							},
 						})
 						require.NoError(t, err)
@@ -1219,7 +1219,7 @@ func TestComponentRegisteredResourceOutputCanBeHydratedByProgram(t *testing.T) {
 		state, _, err := monitor.Invoke(
 			"pulumi:pulumi:getResource",
 			resource.PropertyMap{
-				"urn": resource.NewStringProperty(string(customResRef.URN)),
+				"urn": resource.NewProperty(string(customResRef.URN)),
 			},
 			"", /*provider*/
 			"", /*version*/
@@ -1237,10 +1237,10 @@ func TestComponentRegisteredResourceOutputCanBeHydratedByProgram(t *testing.T) {
 		require.Equal(
 			t,
 			resource.PropertyMap{
-				"urn": resource.NewStringProperty(string(customResRef.URN)),
-				"id":  resource.NewStringProperty(customResRef.ID.StringValue()),
-				"state": resource.NewObjectProperty(resource.PropertyMap{
-					"foo": resource.NewStringProperty("bar"),
+				"urn": resource.NewProperty(string(customResRef.URN)),
+				"id":  resource.NewProperty(customResRef.ID.StringValue()),
+				"state": resource.NewProperty(resource.PropertyMap{
+					"foo": resource.NewProperty("bar"),
 				}),
 			},
 			state,
@@ -1302,7 +1302,7 @@ func TestComponentRegisteredResourceOutputCanBeHydratedByComponent(t *testing.T)
 						custom, err := rm.RegisterResource("pkgA:index:Custom", "custom", true, deploytest.ResourceOptions{
 							Parent: component.URN,
 							Inputs: resource.PropertyMap{
-								"foo": resource.NewStringProperty("bar"),
+								"foo": resource.NewProperty("bar"),
 							},
 						})
 						require.NoError(t, err)
@@ -1326,7 +1326,7 @@ func TestComponentRegisteredResourceOutputCanBeHydratedByComponent(t *testing.T)
 						state, _, err := rm.Invoke(
 							"pulumi:pulumi:getResource",
 							resource.PropertyMap{
-								"urn": resource.NewStringProperty(string(customResRef.URN)),
+								"urn": resource.NewProperty(string(customResRef.URN)),
 							},
 							"", /*provider*/
 							"", /*version*/
@@ -1344,10 +1344,10 @@ func TestComponentRegisteredResourceOutputCanBeHydratedByComponent(t *testing.T)
 						require.Equal(
 							t,
 							resource.PropertyMap{
-								"urn": resource.NewStringProperty(string(customResRef.URN)),
-								"id":  resource.NewStringProperty(customResRef.ID.StringValue()),
-								"state": resource.NewObjectProperty(resource.PropertyMap{
-									"foo": resource.NewStringProperty("bar"),
+								"urn": resource.NewProperty(string(customResRef.URN)),
+								"id":  resource.NewProperty(customResRef.ID.StringValue()),
+								"state": resource.NewProperty(resource.PropertyMap{
+									"foo": resource.NewProperty("bar"),
 								}),
 							},
 							state,
@@ -1440,7 +1440,7 @@ func TestComponentReadResourceOutputCanBeHydratedByProgram(t *testing.T) {
 							customID,
 							component.URN, /*parent*/
 							resource.PropertyMap{
-								"foo": resource.NewStringProperty("bar"),
+								"foo": resource.NewProperty("bar"),
 							},
 							"", /*provider*/
 							"", /*version*/
@@ -1474,7 +1474,7 @@ func TestComponentReadResourceOutputCanBeHydratedByProgram(t *testing.T) {
 		state, _, err := monitor.Invoke(
 			"pulumi:pulumi:getResource",
 			resource.PropertyMap{
-				"urn": resource.NewStringProperty(string(customResRef.URN)),
+				"urn": resource.NewProperty(string(customResRef.URN)),
 			},
 			"", /*provider*/
 			"", /*version*/
@@ -1492,10 +1492,10 @@ func TestComponentReadResourceOutputCanBeHydratedByProgram(t *testing.T) {
 		require.Equal(
 			t,
 			resource.PropertyMap{
-				"urn": resource.NewStringProperty(string(customResRef.URN)),
-				"id":  resource.NewStringProperty(customResRef.ID.StringValue()),
-				"state": resource.NewObjectProperty(resource.PropertyMap{
-					"foo": resource.NewStringProperty("bar"),
+				"urn": resource.NewProperty(string(customResRef.URN)),
+				"id":  resource.NewProperty(customResRef.ID.StringValue()),
+				"state": resource.NewProperty(resource.PropertyMap{
+					"foo": resource.NewProperty("bar"),
 				}),
 			},
 			state,
@@ -1563,7 +1563,7 @@ func TestComponentReadResourceOutputCanBeHydratedByComponent(t *testing.T) {
 							customID,
 							component.URN, /*parent*/
 							resource.PropertyMap{
-								"foo": resource.NewStringProperty("bar"),
+								"foo": resource.NewProperty("bar"),
 							},
 							"", /*provider*/
 							"", /*version*/
@@ -1591,7 +1591,7 @@ func TestComponentReadResourceOutputCanBeHydratedByComponent(t *testing.T) {
 						state, _, err := rm.Invoke(
 							"pulumi:pulumi:getResource",
 							resource.PropertyMap{
-								"urn": resource.NewStringProperty(string(customResRef.URN)),
+								"urn": resource.NewProperty(string(customResRef.URN)),
 							},
 							"", /*provider*/
 							"", /*version*/
@@ -1609,10 +1609,10 @@ func TestComponentReadResourceOutputCanBeHydratedByComponent(t *testing.T) {
 						require.Equal(
 							t,
 							resource.PropertyMap{
-								"urn": resource.NewStringProperty(string(customResRef.URN)),
-								"id":  resource.NewStringProperty(customResRef.ID.StringValue()),
-								"state": resource.NewObjectProperty(resource.PropertyMap{
-									"foo": resource.NewStringProperty("bar"),
+								"urn": resource.NewProperty(string(customResRef.URN)),
+								"id":  resource.NewProperty(customResRef.ID.StringValue()),
+								"state": resource.NewProperty(resource.PropertyMap{
+									"foo": resource.NewProperty("bar"),
 								}),
 							},
 							state,

--- a/pkg/engine/lifecycletest/continue_on_error_test.go
+++ b/pkg/engine/lifecycletest/continue_on_error_test.go
@@ -375,7 +375,7 @@ func TestUpContinueOnErrorUpdate(t *testing.T) {
 
 		switch urn {
 		case "urn:pulumi:test::test::pkgB:m:typB::failing", "urn:pulumi:test::test::pkgB:m:typB::failing2":
-			assert.Equal(t, resource.NewStringProperty("bar"), snap.Resources[idx].Inputs["foo"])
+			assert.Equal(t, resource.NewProperty("bar"), snap.Resources[idx].Inputs["foo"])
 		}
 	}
 }
@@ -658,7 +658,7 @@ func TestUpContinueOnErrorUpdateNoSDKSupport(t *testing.T) {
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::independent2"), snap.Resources[3].URN)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::independent3"), snap.Resources[4].URN)
 	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgB:m:typB::failing"), snap.Resources[5].URN)
-	assert.Equal(t, resource.NewStringProperty("bar"), snap.Resources[5].Inputs["foo"])
+	assert.Equal(t, resource.NewProperty("bar"), snap.Resources[5].Inputs["foo"])
 }
 
 func TestDestroyContinueOnErrorDeleteAfterFailedUp(t *testing.T) {

--- a/pkg/engine/lifecycletest/delete_before_replace_test.go
+++ b/pkg/engine/lifecycletest/delete_before_replace_test.go
@@ -75,12 +75,12 @@ func generateComplexTestDependencyGraph(
 
 	old := &deploy.Snapshot{
 		Resources: []*resource.State{
-			newResource(urnA, "0", "", nil, nil, resource.PropertyMap{"A": resource.NewStringProperty("foo")}),
+			newResource(urnA, "0", "", nil, nil, resource.PropertyMap{"A": resource.NewProperty("foo")}),
 			newResource(urnB, "1", string(urnA)+"::0", nil, nil, nil),
 			newResource(urnC, "2", "",
 				[]resource.URN{urnA},
 				propertyDependencies{"A": []resource.URN{urnA}},
-				resource.PropertyMap{"A": resource.NewStringProperty("bar")}),
+				resource.PropertyMap{"A": resource.NewProperty("bar")}),
 			newResource(urnD, "3", "",
 				[]resource.URN{urnA},
 				propertyDependencies{"B": []resource.URN{urnA}}, nil),
@@ -118,7 +118,7 @@ func generateComplexTestDependencyGraph(
 			return resp.ID
 		}
 
-		idA := register(urnA, "", resource.PropertyMap{"A": resource.NewStringProperty("bar")})
+		idA := register(urnA, "", resource.PropertyMap{"A": resource.NewProperty("bar")})
 		register(urnB, string(urnA)+"::"+string(idA), nil)
 		idC := register(urnC, "", nil)
 		idD := register(urnD, "", nil)
@@ -254,12 +254,12 @@ func TestPropertyDependenciesAdapter(t *testing.T) {
 		urnA = register("A", nil, nil, nil)
 		urnB = register("B", nil, nil, nil)
 		urnC = register("C", resource.PropertyMap{
-			"A": resource.NewStringProperty("foo"),
-			"B": resource.NewStringProperty("bar"),
+			"A": resource.NewProperty("foo"),
+			"B": resource.NewProperty("bar"),
 		}, nil, []resource.URN{urnA, urnB})
 		urnD = register("D", resource.PropertyMap{
-			"A": resource.NewStringProperty("foo"),
-			"B": resource.NewStringProperty("bar"),
+			"A": resource.NewProperty("foo"),
+			"B": resource.NewProperty("bar"),
 		}, propertyDependencies{
 			"A": []resource.URN{urnB},
 			"B": []resource.URN{urnA, urnC},
@@ -358,7 +358,7 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 	snap := p.Run(t, nil)
 
 	// Change the value of resA.A. Only resA should be replaced, and the replacement should be create-before-delete.
-	inputsA["A"] = resource.NewStringProperty("bar")
+	inputsA["A"] = resource.NewProperty("bar")
 	p.Steps = []lt.TestStep{{
 		Op: Update,
 
@@ -382,7 +382,7 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 
 	// Change the registration of resA such that it requires delete-before-replace and change the value of resA.A. Both
 	// resA and resB should be replaced, and the replacements should be delete-before-replace.
-	dbrA, inputsA["A"] = &dbrValue, resource.NewStringProperty("baz")
+	dbrA, inputsA["A"] = &dbrValue, resource.NewProperty("baz")
 	p.Steps = []lt.TestStep{{
 		Op: Update,
 
@@ -407,7 +407,7 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 	snap = p.Run(t, snap)
 
 	// Change the value of resB.A. Only resB should be replaced, and the replacement should be create-before-delete.
-	inputsB["A"] = resource.NewStringProperty("qux")
+	inputsB["A"] = resource.NewProperty("qux")
 	p.Steps = []lt.TestStep{{
 		Op: Update,
 
@@ -431,7 +431,7 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 
 	// Change the registration of resA such that it no longer requires delete-before-replace and change the value of
 	// resA.A. Only resA should be replaced, and the replacement should be create-before-delete.
-	dbrA, inputsA["A"] = nil, resource.NewStringProperty("zam")
+	dbrA, inputsA["A"] = nil, resource.NewProperty("zam")
 	p.Steps = []lt.TestStep{{
 		Op: Update,
 
@@ -455,7 +455,7 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 
 	// Change the diff of resA such that it requires delete-before-replace and change the value of resA.A. Both
 	// resA and resB should be replaced, and the replacements should be delete-before-replace.
-	dbrDiff, inputsA["A"] = true, resource.NewStringProperty("foo")
+	dbrDiff, inputsA["A"] = true, resource.NewProperty("foo")
 	p.Steps = []lt.TestStep{{
 		Op: Update,
 
@@ -481,7 +481,7 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 
 	// Change the registration of resA such that it disables delete-before-replace and change the value of
 	// resA.A. Only resA should be replaced, and the replacement should be create-before-delete.
-	dbrA, dbrValue, inputsA["A"] = &dbrValue, false, resource.NewStringProperty("bar")
+	dbrA, dbrValue, inputsA["A"] = &dbrValue, false, resource.NewProperty("bar")
 	p.Steps = []lt.TestStep{{
 		Op: Update,
 
@@ -567,7 +567,7 @@ func TestDependencyChangeDBR(t *testing.T) {
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
 
-	inputsA["A"] = resource.NewStringProperty("bar")
+	inputsA["A"] = resource.NewProperty("bar")
 	programF = deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		resp, err := monitor.RegisterResource(resType, "resB", true, deploytest.ResourceOptions{
 			Inputs: inputsB,
@@ -687,7 +687,7 @@ func TestDBRProtect(t *testing.T) {
 	require.Len(t, snap.Resources, 3)
 
 	// Update A to trigger a replace this should error because of the protect flag on B.
-	inputsA["A"] = resource.NewStringProperty("bar")
+	inputsA["A"] = resource.NewProperty("bar")
 	_, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), options, false, p.BackendClient, nil, "1")
 	assert.ErrorContains(t, err, "unable to replace resource \"urn:pulumi:test::test::pkgA:index:typ::resB\""+
 		" as part of replacing \"urn:pulumi:test::test::pkgA:index:typ::resA\" as it is currently marked for protection.")
@@ -730,7 +730,7 @@ func TestDBRReplaceOnChanges(t *testing.T) {
 	}
 
 	inputsA := resource.PropertyMap{
-		"value": resource.NewStringProperty("foo"),
+		"value": resource.NewProperty("foo"),
 	}
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		respA, err := monitor.RegisterResource("pkgA:index:typA", "resA", true, deploytest.ResourceOptions{
@@ -764,7 +764,7 @@ func TestDBRReplaceOnChanges(t *testing.T) {
 	require.Len(t, snap.Resources, 3)
 
 	// Update value to trigger a replace this should also replace resB because of the replaceOnChanges.
-	inputsA["value"] = resource.NewStringProperty("bar")
+	inputsA["value"] = resource.NewProperty("bar")
 	validate := func(
 		project workspace.Project, target deploy.Target, entries engine.JournalEntries,
 		events []engine.Event, err error,

--- a/pkg/engine/lifecycletest/destroy_test.go
+++ b/pkg/engine/lifecycletest/destroy_test.go
@@ -40,9 +40,9 @@ import (
 func TestDestroyWithProgram(t *testing.T) {
 	t.Parallel()
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("baz")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createOutputs := resource.PropertyMap{"foo": resource.NewProperty("baz")}
 
 	var deleteCalled int32
 	loaders := []*deploytest.ProviderLoader{
@@ -131,7 +131,7 @@ func TestDestroyWithProgram(t *testing.T) {
 	assert.Equal(t, createOutputs, snap.Resources[2].Outputs)
 
 	// Change the program inputs to check we don't send changed inputs to the provider
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	// Run a destroy
 	snap, err = lt.TestOp(DestroyV2).
 		RunStep(p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
@@ -148,9 +148,9 @@ func TestDestroyWithProgram(t *testing.T) {
 func TestTargetedDestroyWithProgram(t *testing.T) {
 	t.Parallel()
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("baz")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createOutputs := resource.PropertyMap{"foo": resource.NewProperty("baz")}
 
 	deleteCalled := 0
 	loaders := []*deploytest.ProviderLoader{
@@ -239,7 +239,7 @@ func TestTargetedDestroyWithProgram(t *testing.T) {
 	assert.Equal(t, createOutputs, snap.Resources[2].Outputs)
 
 	// Change the program inputs to check we don't send changed inputs to the provider
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	// Run a targeted destroy against resA
 	p.Options.Targets = deploy.NewUrnTargetsFromUrns([]resource.URN{snap.Resources[1].URN})
 	snap, err = lt.TestOp(DestroyV2).
@@ -258,9 +258,9 @@ func TestTargetedDestroyWithProgram(t *testing.T) {
 func TestProviderUpdateDestroyWithProgram(t *testing.T) {
 	t.Parallel()
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("baz")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createOutputs := resource.PropertyMap{"foo": resource.NewProperty("baz")}
 
 	var deleteCalled int32
 	loaders := []*deploytest.ProviderLoader{
@@ -370,7 +370,7 @@ func TestProviderUpdateDestroyWithProgram(t *testing.T) {
 	assert.Equal(t, createOutputs, snap.Resources[2].Outputs)
 
 	// Change the program inputs to check we don't send changed inputs to the provider
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	// Run a destroy with the new provider version
 	pkgVersion = "2.0.0"
 	snap, err = lt.TestOp(DestroyV2).
@@ -389,9 +389,9 @@ func TestProviderUpdateDestroyWithProgram(t *testing.T) {
 func TestExplicitProviderUpdateDestroyWithProgram(t *testing.T) {
 	t.Parallel()
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("baz")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createOutputs := resource.PropertyMap{"foo": resource.NewProperty("baz")}
 
 	var deleteCalled int32
 	loaders := []*deploytest.ProviderLoader{
@@ -496,7 +496,7 @@ func TestExplicitProviderUpdateDestroyWithProgram(t *testing.T) {
 	assert.Equal(t, createOutputs, snap.Resources[2].Outputs)
 
 	// Change the program inputs to check we don't send changed inputs to the provider
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	// Run a destroy with the new provider version
 	pkgVersion = "2.0.0"
 	snap, err = lt.TestOp(DestroyV2).
@@ -514,9 +514,9 @@ func TestExplicitProviderUpdateDestroyWithProgram(t *testing.T) {
 func TestDestroyWithProgramWithComponents(t *testing.T) {
 	t.Parallel()
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("baz")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createOutputs := resource.PropertyMap{"foo": resource.NewProperty("baz")}
 
 	deleteCalled := 0
 	loaders := []*deploytest.ProviderLoader{
@@ -597,7 +597,7 @@ func TestDestroyWithProgramWithComponents(t *testing.T) {
 	assert.Equal(t, createOutputs, snap.Resources[2].Outputs)
 
 	// Change the program inputs to check we don't send changed inputs to the provider
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	// Run a destroy
 	snap, err = lt.TestOp(DestroyV2).
 		RunStep(p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
@@ -615,9 +615,9 @@ func TestDestroyWithProgramWithComponents(t *testing.T) {
 func TestDestroyWithProgramWithSkippedComponents(t *testing.T) {
 	t.Parallel()
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("baz")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createOutputs := resource.PropertyMap{"foo": resource.NewProperty("baz")}
 
 	deleteCalled := 0
 	loaders := []*deploytest.ProviderLoader{
@@ -712,7 +712,7 @@ func TestDestroyWithProgramWithSkippedComponents(t *testing.T) {
 	assert.Equal(t, createOutputs, snap.Resources[1].Outputs)
 
 	// Change the program inputs to check we don't send changed inputs to the provider
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	// Run a destroy
 	snap, err = lt.TestOp(DestroyV2).
 		RunStep(p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
@@ -730,9 +730,9 @@ func TestDestroyWithProgramWithSkippedComponents(t *testing.T) {
 func TestDestroyWithProgramWithSkippedAlias(t *testing.T) {
 	t.Parallel()
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("baz")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createOutputs := resource.PropertyMap{"foo": resource.NewProperty("baz")}
 
 	deleteCalled := 0
 	loaders := []*deploytest.ProviderLoader{
@@ -831,7 +831,7 @@ func TestDestroyWithProgramWithSkippedAlias(t *testing.T) {
 	assert.Equal(t, createOutputs, snap.Resources[1].Outputs)
 
 	// Change the program inputs to check we don't send changed inputs to the provider
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	// Run a destroy
 	snap, err = lt.TestOp(DestroyV2).
 		RunStep(p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
@@ -849,12 +849,12 @@ func TestDestroyWithProgramWithSkippedAlias(t *testing.T) {
 func TestDestroyWithProgramResourceRead(t *testing.T) {
 	t.Parallel()
 
-	readInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	readOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
+	readInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	readOutputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("baz")}
-	createInputs := resource.PropertyMap{"foo": resource.NewStringProperty("baz")}
-	createOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("baz")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("baz")}
+	createInputs := resource.PropertyMap{"foo": resource.NewProperty("baz")}
+	createOutputs := resource.PropertyMap{"foo": resource.NewProperty("baz")}
 
 	deleteCalled := 0
 	loaders := []*deploytest.ProviderLoader{
@@ -950,7 +950,7 @@ func TestDestroyWithProgramResourceRead(t *testing.T) {
 	assert.Equal(t, createOutputs, snap.Resources[2].Outputs)
 
 	// Change the program inputs to check we don't send changed inputs to the provider
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	// Run a destroy
 	snap, err = lt.TestOp(DestroyV2).
 		RunStep(p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")

--- a/pkg/engine/lifecycletest/fuzzing/reprogen.go
+++ b/pkg/engine/lifecycletest/fuzzing/reprogen.go
@@ -601,7 +601,7 @@ func writeSnapshotStatements(t require.TestingT, snapSpec *SnapshotSpec) func(g 
 						g.writeBlock(
 							"Inputs: resource.PropertyMap{",
 							func(g *generator) {
-								g.writeLinef("\"__id\": resource.NewStringProperty(\"%s\"),", r.ID.String())
+								g.writeLinef("\"__id\": resource.NewProperty(\"%s\"),", r.ID.String())
 							},
 							"},",
 						)

--- a/pkg/engine/lifecycletest/fuzzing/resource.go
+++ b/pkg/engine/lifecycletest/fuzzing/resource.go
@@ -191,7 +191,7 @@ func (r *ResourceSpec) AsResource() *resource.State {
 	// we'll set the ResourceSpec's ID field as an input property.
 	if !providers.IsProviderType(r.Type) {
 		s.Inputs = resource.PropertyMap{
-			"__id": resource.NewStringProperty(r.ID.String()),
+			"__id": resource.NewProperty(r.ID.String()),
 		}
 	}
 

--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -40,11 +40,11 @@ func TestImportOption(t *testing.T) {
 	t.Parallel()
 
 	readInputs := resource.PropertyMap{
-		"foo": resource.NewStringProperty("bar"),
+		"foo": resource.NewProperty("bar"),
 	}
 	readOutputs := resource.PropertyMap{
-		"foo": resource.NewStringProperty("bar"),
-		"out": resource.NewNumberProperty(41),
+		"foo": resource.NewProperty("bar"),
+		"out": resource.NewProperty(41.0),
 	}
 
 	// For imports we expect inputs and state to be nil, but when we change to do a read they should both be set to the
@@ -163,7 +163,7 @@ func TestImportOption(t *testing.T) {
 
 	// Run another update (from zero starting snapshot) after matching the inputs to the cloud. The import
 	// should succeed, and just import the resource (i.e. we don't bother Same'ing it).
-	inputs["foo"] = resource.NewStringProperty("bar")
+	inputs["foo"] = resource.NewProperty("bar")
 	expectedOutputs = readOutputs
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, entries JournalEntries, _ []Event, err error) error {
@@ -206,7 +206,7 @@ func TestImportOption(t *testing.T) {
 	assert.Equal(t, resource.ID("imported-id"), snap.Resources[1].ID)
 
 	// Change a property value and run a third update. The update should succeed.
-	inputs["foo"] = resource.NewStringProperty("rab")
+	inputs["foo"] = resource.NewProperty("rab")
 	expectedOutputs = inputs
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, entries JournalEntries, _ []Event, err error) error {
@@ -230,7 +230,7 @@ func TestImportOption(t *testing.T) {
 	assert.Equal(t, resource.ID("imported-id"), snap.Resources[1].ID)
 
 	// Change the property value s.t. the resource requires replacement. The update should fail.
-	inputs["foo"] = resource.NewStringProperty("replace")
+	inputs["foo"] = resource.NewProperty("replace")
 	_, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "4")
 	assert.ErrorContains(t, err, "previously-imported resources that still specify an ID may not be replaced")
 
@@ -250,7 +250,7 @@ func TestImportOption(t *testing.T) {
 	require.NoError(t, err)
 
 	// Now clear the ID to import and run an initial update to create a resource that we will import-replace.
-	importID, inputs["foo"] = "", resource.NewStringProperty("bar")
+	importID, inputs["foo"] = "", resource.NewProperty("bar")
 	expectedID = resource.ID("created-id")
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, entries JournalEntries, _ []Event, err error) error {
@@ -403,10 +403,10 @@ func TestImportWithDifferingImportIdentifierFormat(t *testing.T) {
 							// This ID is deliberately not the same as the ID used to import.
 							ID: "id",
 							Inputs: resource.PropertyMap{
-								"foo": resource.NewStringProperty("bar"),
+								"foo": resource.NewProperty("bar"),
 							},
 							Outputs: resource.PropertyMap{
-								"foo": resource.NewStringProperty("bar"),
+								"foo": resource.NewProperty("bar"),
 							},
 						},
 						Status: resource.StatusOK,
@@ -419,7 +419,7 @@ func TestImportWithDifferingImportIdentifierFormat(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: resource.PropertyMap{
-				"foo": resource.NewStringProperty("bar"),
+				"foo": resource.NewProperty("bar"),
 			},
 			// The import ID is deliberately not the same as the ID returned from Read.
 			ImportID: resource.ID("import-id"),
@@ -592,11 +592,11 @@ func TestImportPlan(t *testing.T) {
 	t.Parallel()
 
 	readInputs := resource.PropertyMap{
-		"foo": resource.NewStringProperty("bar"),
+		"foo": resource.NewProperty("bar"),
 	}
 	readOutputs := resource.PropertyMap{
-		"foo":  resource.NewStringProperty("bar"),
-		"frob": resource.NewNumberProperty(1),
+		"foo":  resource.NewProperty("bar"),
+		"frob": resource.NewProperty(1.0),
 	}
 
 	loaders := []*deploytest.ProviderLoader{
@@ -683,12 +683,12 @@ func TestImportIgnoreChanges(t *testing.T) {
 					return plugin.ReadResponse{
 						ReadResult: plugin.ReadResult{
 							Inputs: resource.PropertyMap{
-								"foo":  resource.NewStringProperty("bar"),
-								"frob": resource.NewNumberProperty(1),
+								"foo":  resource.NewProperty("bar"),
+								"frob": resource.NewProperty(1.0),
 							},
 							Outputs: resource.PropertyMap{
-								"foo":  resource.NewStringProperty("bar"),
-								"frob": resource.NewNumberProperty(1),
+								"foo":  resource.NewProperty("bar"),
+								"frob": resource.NewProperty(1.0),
 							},
 						},
 						Status: resource.StatusOK,
@@ -701,8 +701,8 @@ func TestImportIgnoreChanges(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: resource.PropertyMap{
-				"foo":  resource.NewStringProperty("foo"),
-				"frob": resource.NewNumberProperty(1),
+				"foo":  resource.NewProperty("foo"),
+				"frob": resource.NewProperty(1.0),
 			},
 			ImportID:      "import-id",
 			IgnoreChanges: []string{"foo"},
@@ -721,7 +721,7 @@ func TestImportIgnoreChanges(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, snap.Resources, 2)
-	assert.Equal(t, resource.NewStringProperty("bar"), snap.Resources[1].Outputs["foo"])
+	assert.Equal(t, resource.NewProperty("bar"), snap.Resources[1].Outputs["foo"])
 }
 
 func TestImportPlanExistingImport(t *testing.T) {
@@ -745,12 +745,12 @@ func TestImportPlanExistingImport(t *testing.T) {
 					return plugin.ReadResponse{
 						ReadResult: plugin.ReadResult{
 							Inputs: resource.PropertyMap{
-								"foo":  resource.NewStringProperty("bar"),
-								"frob": resource.NewNumberProperty(1),
+								"foo":  resource.NewProperty("bar"),
+								"frob": resource.NewProperty(1.0),
 							},
 							Outputs: resource.PropertyMap{
-								"foo":  resource.NewStringProperty("bar"),
-								"frob": resource.NewNumberProperty(1),
+								"foo":  resource.NewProperty("bar"),
+								"frob": resource.NewProperty(1.0),
 							},
 						},
 						Status: resource.StatusOK,
@@ -766,8 +766,8 @@ func TestImportPlanExistingImport(t *testing.T) {
 
 		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: resource.PropertyMap{
-				"foo":  resource.NewStringProperty("bar"),
-				"frob": resource.NewNumberProperty(1),
+				"foo":  resource.NewProperty("bar"),
+				"frob": resource.NewProperty(1.0),
 			},
 			ImportID: "imported-id",
 			Parent:   resp.URN,
@@ -835,12 +835,12 @@ func TestImportPlanEmptyState(t *testing.T) {
 					return plugin.ReadResponse{
 						ReadResult: plugin.ReadResult{
 							Inputs: resource.PropertyMap{
-								"foo":  resource.NewStringProperty("bar"),
-								"frob": resource.NewNumberProperty(1),
+								"foo":  resource.NewProperty("bar"),
+								"frob": resource.NewProperty(1.0),
 							},
 							Outputs: resource.PropertyMap{
-								"foo":  resource.NewStringProperty("bar"),
-								"frob": resource.NewNumberProperty(1),
+								"foo":  resource.NewProperty("bar"),
+								"frob": resource.NewProperty(1.0),
 							},
 						},
 						Status: resource.StatusOK,
@@ -889,12 +889,12 @@ func TestImportPlanSpecificProvider(t *testing.T) {
 					return plugin.ReadResponse{
 						ReadResult: plugin.ReadResult{
 							Inputs: resource.PropertyMap{
-								"foo":  resource.NewStringProperty("bar"),
-								"frob": resource.NewNumberProperty(1),
+								"foo":  resource.NewProperty("bar"),
+								"frob": resource.NewProperty(1.0),
 							},
 							Outputs: resource.PropertyMap{
-								"foo":  resource.NewStringProperty("bar"),
-								"frob": resource.NewNumberProperty(1),
+								"foo":  resource.NewProperty("bar"),
+								"frob": resource.NewProperty(1.0),
 							},
 						},
 						Status: resource.StatusOK,
@@ -952,14 +952,14 @@ func TestImportPlanSpecificProperties(t *testing.T) {
 					return plugin.ReadResponse{
 						ReadResult: plugin.ReadResult{
 							Inputs: resource.PropertyMap{
-								"foo":  resource.NewStringProperty("bar"),
-								"frob": resource.NewNumberProperty(1),
-								"baz":  resource.NewNumberProperty(2),
+								"foo":  resource.NewProperty("bar"),
+								"frob": resource.NewProperty(1.0),
+								"baz":  resource.NewProperty(2.0),
 							},
 							Outputs: resource.PropertyMap{
-								"foo":  resource.NewStringProperty("bar"),
-								"frob": resource.NewNumberProperty(1),
-								"baz":  resource.NewNumberProperty(2),
+								"foo":  resource.NewProperty("bar"),
+								"frob": resource.NewProperty(1.0),
+								"baz":  resource.NewProperty(2.0),
 							},
 						},
 						Status: resource.StatusOK,
@@ -1014,7 +1014,7 @@ func TestImportPlanSpecificProperties(t *testing.T) {
 	require.Len(t, snap.Resources, 3)
 
 	// We should still have the baz output but will be missing its input
-	assert.Equal(t, resource.NewNumberProperty(2), snap.Resources[2].Outputs["baz"])
+	assert.Equal(t, resource.NewProperty(2.0), snap.Resources[2].Outputs["baz"])
 	assert.NotContains(t, snap.Resources[2].Inputs, "baz")
 }
 
@@ -1039,12 +1039,12 @@ func TestImportIntoParent(t *testing.T) {
 					return plugin.ReadResponse{
 						ReadResult: plugin.ReadResult{
 							Inputs: resource.PropertyMap{
-								"foo":  resource.NewStringProperty("bar"),
-								"frob": resource.NewNumberProperty(1),
+								"foo":  resource.NewProperty("bar"),
+								"frob": resource.NewProperty(1.0),
 							},
 							Outputs: resource.PropertyMap{
-								"foo":  resource.NewStringProperty("bar"),
-								"frob": resource.NewNumberProperty(1),
+								"foo":  resource.NewProperty("bar"),
+								"frob": resource.NewProperty(1.0),
 							},
 						},
 						Status: resource.StatusOK,
@@ -1097,12 +1097,12 @@ func TestImportComponent(t *testing.T) {
 					return plugin.ReadResponse{
 						ReadResult: plugin.ReadResult{
 							Inputs: resource.PropertyMap{
-								"foo":  resource.NewStringProperty("bar"),
-								"frob": resource.NewNumberProperty(1),
+								"foo":  resource.NewProperty("bar"),
+								"frob": resource.NewProperty(1.0),
 							},
 							Outputs: resource.PropertyMap{
-								"foo":  resource.NewStringProperty("bar"),
-								"frob": resource.NewNumberProperty(1),
+								"foo":  resource.NewProperty("bar"),
+								"frob": resource.NewProperty(1.0),
 							},
 						},
 						Status: resource.StatusOK,
@@ -1170,12 +1170,12 @@ func TestImportRemoteComponent(t *testing.T) {
 					return plugin.ReadResponse{
 						ReadResult: plugin.ReadResult{
 							Inputs: resource.PropertyMap{
-								"foo":  resource.NewStringProperty("bar"),
-								"frob": resource.NewNumberProperty(1),
+								"foo":  resource.NewProperty("bar"),
+								"frob": resource.NewProperty(1.0),
 							},
 							Outputs: resource.PropertyMap{
-								"foo":  resource.NewStringProperty("bar"),
-								"frob": resource.NewNumberProperty(1),
+								"foo":  resource.NewProperty("bar"),
+								"frob": resource.NewProperty(1.0),
 							},
 						},
 						Status: resource.StatusOK,
@@ -1230,14 +1230,14 @@ func TestImportInputDiff(t *testing.T) {
 	t.Parallel()
 
 	upInputs := resource.PropertyMap{
-		"foo": resource.NewStringProperty("barz"),
+		"foo": resource.NewProperty("barz"),
 	}
 	readInputs := resource.PropertyMap{
-		"foo": resource.NewStringProperty("bar"),
+		"foo": resource.NewProperty("bar"),
 	}
 	readOutputs := resource.PropertyMap{
-		"foo":  resource.NewStringProperty("bar"),
-		"frob": resource.NewNumberProperty(1),
+		"foo":  resource.NewProperty("bar"),
+		"frob": resource.NewProperty(1.0),
 	}
 
 	loaders := []*deploytest.ProviderLoader{
@@ -1323,11 +1323,11 @@ func TestImportDefaultProvider(t *testing.T) {
 	t.Parallel()
 
 	readInputs := resource.PropertyMap{
-		"foo": resource.NewStringProperty("bar"),
+		"foo": resource.NewProperty("bar"),
 	}
 	readOutputs := resource.PropertyMap{
-		"foo":  resource.NewStringProperty("bar"),
-		"frob": resource.NewNumberProperty(1),
+		"foo":  resource.NewProperty("bar"),
+		"frob": resource.NewProperty(1.0),
 	}
 
 	pkgAVersion := semver.MustParse("1.0.0")
@@ -1434,11 +1434,11 @@ func TestImportWithFailedUpdate(t *testing.T) {
 	t.Parallel()
 
 	readInputs := resource.PropertyMap{
-		"foo": resource.NewStringProperty("bar"),
+		"foo": resource.NewProperty("bar"),
 	}
 	readOutputs := resource.PropertyMap{
-		"foo": resource.NewStringProperty("bar"),
-		"out": resource.NewNumberProperty(41),
+		"foo": resource.NewProperty("bar"),
+		"out": resource.NewProperty(41.0),
 	}
 
 	// For imports we expect inputs and state to be nil, but when we change to do a read they should both be set to the
@@ -1481,7 +1481,7 @@ func TestImportWithFailedUpdate(t *testing.T) {
 	}
 
 	importID, inputs := resource.ID("id"), resource.PropertyMap{
-		"foo": resource.NewStringProperty("baz"),
+		"foo": resource.NewProperty("baz"),
 	}
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, _ = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{ //nolint:errcheck

--- a/pkg/engine/lifecycletest/parameterized_test.go
+++ b/pkg/engine/lifecycletest/parameterized_test.go
@@ -161,11 +161,11 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 				},
 				InvokeF: func(_ context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					assert.Equal(t, "pkgExt:index:func", req.Tok.String())
-					assert.Equal(t, resource.NewStringProperty("in"), req.Args["input"])
+					assert.Equal(t, resource.NewProperty("in"), req.Args["input"])
 
 					return plugin.InvokeResponse{
 						Properties: resource.PropertyMap{
-							"output": resource.NewStringProperty("in " + param),
+							"output": resource.NewProperty("in " + param),
 						},
 					}, nil
 				},
@@ -187,14 +187,14 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 				},
 				CallF: func(_ context.Context, req plugin.CallRequest, _ *deploytest.ResourceMonitor) (plugin.CallResponse, error) {
 					assert.Equal(t, "pkgExt:index:call", req.Tok.String())
-					assert.Equal(t, resource.NewStringProperty("in"), req.Args["input"])
+					assert.Equal(t, resource.NewProperty("in"), req.Args["input"])
 					assert.Equal(t, map[resource.PropertyKey][]resource.URN{
 						"input": {"urn:pulumi:stack::m::typA::resB"},
 					}, req.Options.ArgDependencies)
 
 					return plugin.CallResponse{
 						Return: resource.PropertyMap{
-							"output": resource.NewStringProperty("output"),
+							"output": resource.NewProperty("output"),
 						},
 						ReturnDependencies: map[resource.PropertyKey][]resource.URN{
 							"output": {"urn:pulumi:stack::m::typA::resB"},
@@ -218,7 +218,7 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 					return plugin.ConstructResponse{
 						URN: resource.NewURN("", "", "", req.Type, req.Name),
 						Outputs: resource.PropertyMap{
-							"output": resource.NewStringProperty("output"),
+							"output": resource.NewProperty("output"),
 						},
 						OutputDependencies: map[resource.PropertyKey][]resource.URN{
 							"output": {"urn:pulumi:stack::m::typA::resB"},
@@ -247,7 +247,7 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "mlcA", mlcA.URN.Name())
 		assert.Equal(t, resource.PropertyMap{
-			"output": resource.NewStringProperty("output"),
+			"output": resource.NewProperty("output"),
 		}, mlcA.Outputs)
 		assert.Equal(t, map[resource.PropertyKey][]resource.URN{
 			"output": {"urn:pulumi:stack::m::typA::resB"},
@@ -275,7 +275,7 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "mlcB", mlcB.URN.Name())
 		assert.Equal(t, resource.PropertyMap{
-			"output": resource.NewStringProperty("output"),
+			"output": resource.NewProperty("output"),
 		}, mlcB.Outputs)
 		assert.Equal(t, map[resource.PropertyKey][]resource.URN{
 			"output": {"urn:pulumi:stack::m::typA::resB"},
@@ -283,11 +283,11 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 
 		// Test invoking a function on the replacement provider
 		result, _, err := monitor.Invoke("pkgExt:index:func", resource.PropertyMap{
-			"input": resource.NewStringProperty("in"),
+			"input": resource.NewProperty("in"),
 		}, "", "", extRef)
 		require.NoError(t, err)
 		assert.Equal(t, resource.PropertyMap{
-			"output": resource.NewStringProperty("in replacement"),
+			"output": resource.NewProperty("in replacement"),
 		}, result)
 
 		// Test reading a resource on the replacement provider
@@ -298,7 +298,7 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 		callOuts, callDeps, callFailures, err := monitor.Call(
 			"pkgExt:index:call",
 			resource.PropertyMap{
-				"input": resource.NewStringProperty("in"),
+				"input": resource.NewProperty("in"),
 			},
 			map[resource.PropertyKey][]resource.URN{
 				"input": {"urn:pulumi:stack::m::typA::resB"},
@@ -309,7 +309,7 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 		)
 		require.NoError(t, err)
 		assert.Equal(t, resource.PropertyMap{
-			"output": resource.NewStringProperty("output"),
+			"output": resource.NewProperty("output"),
 		}, callOuts)
 		assert.Equal(t, map[resource.PropertyKey][]resource.URN{
 			"output": {"urn:pulumi:stack::m::typA::resB"},
@@ -536,10 +536,10 @@ func TestReplacementParameterizedProviderImport(t *testing.T) {
 						ReadResult: plugin.ReadResult{
 							ID: req.ID,
 							Inputs: resource.PropertyMap{
-								"input": resource.NewStringProperty("input"),
+								"input": resource.NewProperty("input"),
 							},
 							Outputs: resource.PropertyMap{
-								"output": resource.NewStringProperty("output"),
+								"output": resource.NewProperty("output"),
 							},
 						},
 						Status: resource.StatusOK,
@@ -558,7 +558,7 @@ func TestReplacementParameterizedProviderImport(t *testing.T) {
 			PackageRef: pkgRef,
 			ImportID:   "idA",
 			Inputs: resource.PropertyMap{
-				"input": resource.NewStringProperty("input"),
+				"input": resource.NewProperty("input"),
 			},
 		})
 		require.NoError(t, err)
@@ -576,7 +576,7 @@ func TestReplacementParameterizedProviderImport(t *testing.T) {
 			PackageRef: extRef,
 			ImportID:   "idB",
 			Inputs: resource.PropertyMap{
-				"input": resource.NewStringProperty("input"),
+				"input": resource.NewProperty("input"),
 			},
 		})
 		require.NoError(t, err)
@@ -594,7 +594,7 @@ func TestReplacementParameterizedProviderImport(t *testing.T) {
 			Provider: provRef.String(),
 			ImportID: "idB",
 			Inputs: resource.PropertyMap{
-				"input": resource.NewStringProperty("input"),
+				"input": resource.NewProperty("input"),
 			},
 		})
 		require.NoError(t, err)
@@ -634,29 +634,29 @@ func TestReplacementParameterizedProviderImport(t *testing.T) {
 	assert.Equal(t, tokens.Type("pkgA:m:typA"), resA.Type)
 	assert.Equal(t, "resA", resA.URN.Name())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("input"),
+		"input": resource.NewProperty("input"),
 	}, resA.Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"output": resource.NewStringProperty("output"),
+		"output": resource.NewProperty("output"),
 	}, resA.Outputs)
 
 	resB := snap.Resources[3]
 	assert.Equal(t, tokens.Type("pkgExt:m:typA"), resB.Type)
 	assert.Equal(t, "resB", resB.URN.Name())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("input"),
+		"input": resource.NewProperty("input"),
 	}, resB.Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"output": resource.NewStringProperty("output"),
+		"output": resource.NewProperty("output"),
 	}, resB.Outputs)
 
 	resC := snap.Resources[5]
 	assert.Equal(t, tokens.Type("pkgExt:m:typA"), resC.Type)
 	assert.Equal(t, "resC", resC.URN.Name())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("input"),
+		"input": resource.NewProperty("input"),
 	}, resC.Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"output": resource.NewStringProperty("output"),
+		"output": resource.NewProperty("output"),
 	}, resC.Outputs)
 }

--- a/pkg/engine/lifecycletest/preview_test.go
+++ b/pkg/engine/lifecycletest/preview_test.go
@@ -36,10 +36,10 @@ import (
 func TestPreviewRefreshWithProgram(t *testing.T) {
 	t.Parallel()
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	updateOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("qux")}
-	readOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("baz")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createOutputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	updateOutputs := resource.PropertyMap{"foo": resource.NewProperty("qux")}
+	readOutputs := resource.PropertyMap{"foo": resource.NewProperty("baz")}
 
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
@@ -150,7 +150,7 @@ func TestPreviewRefreshWithProgram(t *testing.T) {
 	assert.Equal(t, createOutputs, snap.Resources[1].Outputs)
 
 	// Change the program inputs to check we don't send changed inputs to the provider for refresh
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	// Run a preview with refresh
 	p.Options.Refresh = true
 	p.Options.RefreshProgram = true
@@ -187,21 +187,21 @@ func TestPreviewStackOutputs(t *testing.T) {
 		switch step {
 		case 0:
 			outputs = resource.PropertyMap{
-				"first":  resource.NewStringProperty("abc"),
-				"second": resource.NewStringProperty("def"),
+				"first":  resource.NewProperty("abc"),
+				"second": resource.NewProperty("def"),
 			}
 		case 1:
 			// Changes to "first" should be shown in the preview.
 			// Changes to "second" should not be shown in the preview, as it is not changed.
 			outputs = resource.PropertyMap{
-				"first":  resource.NewStringProperty("step 1"),
-				"second": resource.NewStringProperty("def"),
+				"first":  resource.NewProperty("step 1"),
+				"second": resource.NewProperty("def"),
 			}
 		case 2:
 			// We're changing "first" to an unknown, so it should not be shown in the preview.
 			outputs = resource.PropertyMap{
-				"first":  resource.NewComputedProperty(resource.Computed{}),
-				"second": resource.NewStringProperty("def"),
+				"first":  resource.NewProperty(resource.Computed{}),
+				"second": resource.NewProperty("def"),
 			}
 		}
 

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -310,7 +310,7 @@ func TestSingleResourceExplicitProviderReplace(t *testing.T) {
 	}
 
 	providerInputs := resource.PropertyMap{
-		resource.PropertyKey("foo"): resource.NewStringProperty("bar"),
+		resource.PropertyKey("foo"): resource.NewProperty("bar"),
 	}
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		resp, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true,
@@ -341,7 +341,7 @@ func TestSingleResourceExplicitProviderReplace(t *testing.T) {
 	snap := p.Run(t, nil)
 
 	// Change the config and run an update. We expect everything to require replacement.
-	providerInputs[resource.PropertyKey("foo")] = resource.NewStringProperty("baz")
+	providerInputs[resource.PropertyKey("foo")] = resource.NewProperty("baz")
 	p.Steps = []lt.TestStep{{
 		Op: Update,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
@@ -446,7 +446,7 @@ func TestSingleResourceExplicitProviderAliasUpdateDelete(t *testing.T) {
 	}
 
 	providerInputs := resource.PropertyMap{
-		resource.PropertyKey("id"): resource.NewStringProperty("first"),
+		resource.PropertyKey("id"): resource.NewProperty("first"),
 	}
 	providerName := "provA"
 	aliases := []resource.URN{}
@@ -493,7 +493,7 @@ func TestSingleResourceExplicitProviderAliasUpdateDelete(t *testing.T) {
 	// Change the provider name and configuration and remove the resource. This will cause an Update for the provider
 	// and a Delete for the resource. The updated provider instance should be used to perform the delete.
 	providerName = "provB"
-	providerInputs[resource.PropertyKey("id")] = resource.NewStringProperty("second")
+	providerInputs[resource.PropertyKey("id")] = resource.NewProperty("second")
 	registerResource = false
 
 	p.Steps = []lt.TestStep{{Op: Update}}
@@ -539,7 +539,7 @@ func TestSingleResourceExplicitProviderAliasReplace(t *testing.T) {
 	}
 
 	providerInputs := resource.PropertyMap{
-		resource.PropertyKey("id"): resource.NewStringProperty("first"),
+		resource.PropertyKey("id"): resource.NewProperty("first"),
 	}
 	providerName := "provA"
 	aliases := []resource.URN{}
@@ -597,7 +597,7 @@ func TestSingleResourceExplicitProviderAliasReplace(t *testing.T) {
 	snap = p.Run(t, snap)
 
 	// Change the config and run an update maintaining the alias. We expect everything to require replacement.
-	providerInputs[resource.PropertyKey("id")] = resource.NewStringProperty("second")
+	providerInputs[resource.PropertyKey("id")] = resource.NewProperty("second")
 	p.Steps = []lt.TestStep{{
 		Op: Update,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
@@ -683,7 +683,7 @@ func TestSingleResourceExplicitProviderDeleteBeforeReplace(t *testing.T) {
 	}
 
 	providerInputs := resource.PropertyMap{
-		resource.PropertyKey("foo"): resource.NewStringProperty("bar"),
+		resource.PropertyKey("foo"): resource.NewProperty("bar"),
 	}
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		resp, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true,
@@ -714,7 +714,7 @@ func TestSingleResourceExplicitProviderDeleteBeforeReplace(t *testing.T) {
 	snap := p.Run(t, nil)
 
 	// Change the config and run an update. We expect everything to require replacement.
-	providerInputs[resource.PropertyKey("foo")] = resource.NewStringProperty("baz")
+	providerInputs[resource.PropertyKey("foo")] = resource.NewProperty("baz")
 	p.Steps = []lt.TestStep{{
 		Op: Update,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
@@ -1215,7 +1215,7 @@ func TestProviderVersionInput(t *testing.T) {
 		resp, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true,
 			deploytest.ResourceOptions{
 				Inputs: resource.PropertyMap{
-					"version": resource.NewStringProperty("1.0.0"),
+					"version": resource.NewProperty("1.0.0"),
 				},
 			})
 		require.NoError(t, err)
@@ -1260,7 +1260,7 @@ func TestProviderVersionInputAndOption(t *testing.T) {
 		resp, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true,
 			deploytest.ResourceOptions{
 				Inputs: resource.PropertyMap{
-					"version": resource.NewStringProperty("1.5.0"),
+					"version": resource.NewProperty("1.5.0"),
 				},
 				Version: "1.0.0",
 			})
@@ -1852,7 +1852,7 @@ func TestRefreshLegacyState(t *testing.T) {
 				URN:  p.NewURN("providers:pulumi:pkgA", "prov", ""),
 				Inputs: map[resource.PropertyKey]resource.PropertyValue{
 					"version":           resource.NewPropertyValue("1.3.0"),
-					"pluginDownloadURL": resource.NewStringProperty("http://example.com"),
+					"pluginDownloadURL": resource.NewProperty("http://example.com"),
 				},
 			},
 		},
@@ -1973,7 +1973,7 @@ func TestInternalFiltered(t *testing.T) {
 func TestProviderSameStep(t *testing.T) {
 	t.Parallel()
 
-	providerConfigValue := resource.NewStringProperty("100")
+	providerConfigValue := resource.NewProperty("100")
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkg", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return &deploytest.Provider{
@@ -2016,7 +2016,7 @@ func TestProviderSameStep(t *testing.T) {
 
 	// Run another update where we send a new value for the provider config, but diff reports no diff so we
 	// should same step
-	providerConfigValue = resource.NewStringProperty("200")
+	providerConfigValue = resource.NewProperty("200")
 	snap, err = lt.TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil)
 	require.NoError(t, err)
 
@@ -2104,7 +2104,7 @@ func TestMissingIDRefresh(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		resp, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: resource.PropertyMap{
-				"foo": resource.NewStringProperty("bar"),
+				"foo": resource.NewProperty("bar"),
 			},
 		})
 		require.NoError(t, err)
@@ -2206,7 +2206,7 @@ func TestChangedVersion(t *testing.T) {
 			return &deploytest.Provider{
 				CheckConfigF: func(_ context.Context, req plugin.CheckConfigRequest) (plugin.CheckConfigResponse, error) {
 					news := req.News.Copy()
-					news["version"] = resource.NewStringProperty("2.0.0")
+					news["version"] = resource.NewProperty("2.0.0")
 					return plugin.CheckConfigResponse{
 						Properties: news,
 					}, nil
@@ -2247,7 +2247,7 @@ func TestInternalKey(t *testing.T) {
 			return &deploytest.Provider{
 				CheckConfigF: func(_ context.Context, req plugin.CheckConfigRequest) (plugin.CheckConfigResponse, error) {
 					news := req.News.Copy()
-					news["__internal"] = resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+					news["__internal"] = resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 						"some": "internal data",
 					}))
 					return plugin.CheckConfigResponse{
@@ -2288,7 +2288,7 @@ func TestInternalKey(t *testing.T) {
 	require.True(t, ok, "expected '__internal' to be present in provider inputs")
 	require.True(t, internal.IsObject(), "expected '__internal' to be an object")
 	assert.Equal(t, resource.PropertyMap{
-		"pluginDownloadURL": resource.NewStringProperty("http://example.com"),
+		"pluginDownloadURL": resource.NewProperty("http://example.com"),
 	}, internal.ObjectValue())
 	// assert we got the warning message
 	warns := sink.Messages[diag.Warning]

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -219,7 +219,7 @@ func TestSingleResourceDiffUnavailable(t *testing.T) {
 
 	// Now run a preview. Expect a warning because the diff is unavailable.
 	inputs = resource.PropertyMap{
-		"input": resource.MakeComputed(resource.NewStringProperty("")),
+		"input": resource.MakeComputed(resource.NewProperty("")),
 	}
 	_, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, true, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, _ JournalEntries,
@@ -1024,9 +1024,9 @@ func TestUpdatePartialFailure(t *testing.T) {
 						require.Len(t, inputs, 1)
 						require.Len(t, outputs, 1)
 						assert.Equal(t,
-							resource.NewStringProperty("old inputs"), inputs[resource.PropertyKey("input_prop")])
+							resource.NewProperty("old inputs"), inputs[resource.PropertyKey("input_prop")])
 						assert.Equal(t,
-							resource.NewNumberProperty(42), outputs[resource.PropertyKey("output_prop")])
+							resource.NewProperty(42.0), outputs[resource.PropertyKey("output_prop")])
 					default:
 						t.Fatalf("unexpected journal operation: %d", entry.Kind)
 					}
@@ -1566,19 +1566,19 @@ func TestSingleResourceIgnoreChanges(t *testing.T) {
 
 	// Check that ignoring a secret value works, first update to make foo, bar secret
 	snap = updateProgramWithProps(snap, resource.PropertyMap{
-		"a": resource.NewNumberProperty(3),
-		"b": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("foo"),
-			resource.NewStringProperty("bar"),
+		"a": resource.NewProperty(3.0),
+		"b": resource.MakeSecret(resource.NewProperty([]resource.PropertyValue{
+			resource.NewProperty("foo"),
+			resource.NewProperty("bar"),
 		})),
 	}, nil, []display.StepOp{deploy.OpUpdate}, "ignore-secret")
 
 	// Now check that changing a value (but not secretness) can be ignored
 	_ = updateProgramWithProps(snap, resource.PropertyMap{
-		"a": resource.NewNumberProperty(3),
-		"b": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("foo"),
-			resource.NewStringProperty("baz"),
+		"a": resource.NewProperty(3.0),
+		"b": resource.MakeSecret(resource.NewProperty([]resource.PropertyValue{
+			resource.NewProperty("foo"),
+			resource.NewProperty("baz"),
 		})),
 	}, []string{"b[1]"}, []display.StepOp{deploy.OpSame}, "change-value-not-secretness")
 }
@@ -1595,11 +1595,11 @@ func TestIgnoreChangesInvalidPaths(t *testing.T) {
 	program := func(monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: resource.PropertyMap{
-				"foo": resource.NewObjectProperty(resource.PropertyMap{
-					"bar": resource.NewStringProperty("baz"),
+				"foo": resource.NewProperty(resource.PropertyMap{
+					"bar": resource.NewProperty("baz"),
 				}),
-				"qux": resource.NewArrayProperty([]resource.PropertyValue{
-					resource.NewStringProperty("zed"),
+				"qux": resource.NewProperty([]resource.PropertyValue{
+					resource.NewProperty("zed"),
 				}),
 			},
 		})
@@ -1636,13 +1636,13 @@ func TestIgnoreChangesInvalidPaths(t *testing.T) {
 	program = func(monitor *deploytest.ResourceMonitor) error {
 		resp, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: resource.PropertyMap{
-				"qux": resource.NewArrayProperty([]resource.PropertyValue{}),
+				"qux": resource.NewProperty([]resource.PropertyValue{}),
 			},
 			IgnoreChanges: []string{"qux[0]"},
 		})
 		require.NoError(t, err)
 		assert.Equal(t, resource.PropertyMap{
-			"qux": resource.NewArrayProperty([]resource.PropertyValue{}),
+			"qux": resource.NewProperty([]resource.PropertyValue{}),
 		}, resp.Outputs)
 		return nil
 	}
@@ -1666,18 +1666,18 @@ func TestIgnoreChangesInvalidPaths(t *testing.T) {
 	program = func(monitor *deploytest.ResourceMonitor) error {
 		resp, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: resource.PropertyMap{
-				"qux": resource.NewArrayProperty([]resource.PropertyValue{
-					resource.NewStringProperty("zed"),
-					resource.NewStringProperty("zob"),
+				"qux": resource.NewProperty([]resource.PropertyValue{
+					resource.NewProperty("zed"),
+					resource.NewProperty("zob"),
 				}),
 			},
 			IgnoreChanges: []string{"qux[1]"},
 		})
 		require.NoError(t, err)
 		assert.Equal(t, resource.PropertyMap{
-			"qux": resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewStringProperty("zed"),
-				resource.NewStringProperty("zob"),
+			"qux": resource.NewProperty([]resource.PropertyValue{
+				resource.NewProperty("zed"),
+				resource.NewProperty("zob"),
 			}),
 		}, resp.Outputs)
 		return nil
@@ -1811,7 +1811,7 @@ func TestReplaceOnChanges(t *testing.T) {
 			// we treat 42 as an OpSame. We use this to check that the right diff function is being
 			// used.
 			for k, v := range req.NewInputs {
-				if v == resource.NewNumberProperty(42) {
+				if v == resource.NewProperty(42.0) {
 					req.NewInputs[k] = req.OldOutputs[k]
 				}
 			}
@@ -2164,7 +2164,7 @@ func TestProviderPreview(t *testing.T) {
 
 	preview := true
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		computed := interface{}(resource.Computed{Element: resource.NewStringProperty("")})
+		computed := interface{}(resource.Computed{Element: resource.NewProperty("")})
 		if !preview {
 			computed = "alpha"
 		}
@@ -2254,7 +2254,7 @@ func TestProviderPreviewGrpc(t *testing.T) {
 
 	preview := true
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		computed := interface{}(resource.Computed{Element: resource.NewStringProperty("")})
+		computed := interface{}(resource.Computed{Element: resource.NewProperty("")})
 		if !preview {
 			computed = "alpha"
 		}
@@ -2410,7 +2410,7 @@ func TestProviderPreviewUnknowns(t *testing.T) {
 
 	preview := true
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		computed := interface{}(resource.Computed{Element: resource.NewStringProperty("")})
+		computed := interface{}(resource.Computed{Element: resource.NewProperty("")})
 		if !preview {
 			computed = "alpha"
 		}
@@ -2461,7 +2461,7 @@ func TestProviderPreviewUnknowns(t *testing.T) {
 		} else {
 			require.NoError(t, err)
 			assert.True(t, respC.Outputs.DeepEquals(resource.PropertyMap{
-				"foo": resource.NewStringProperty("bar"),
+				"foo": resource.NewProperty("bar"),
 			}))
 		}
 
@@ -2482,7 +2482,7 @@ func TestProviderPreviewUnknowns(t *testing.T) {
 			assert.True(t, outs.DeepEquals(resource.PropertyMap{}), "outs was %v", outs)
 		} else {
 			assert.True(t, outs.DeepEquals(resource.PropertyMap{
-				"message": resource.NewStringProperty("Hello, bar!"),
+				"message": resource.NewProperty("Hello, bar!"),
 			}), "outs was %v", outs)
 		}
 
@@ -2500,7 +2500,7 @@ func TestProviderPreviewUnknowns(t *testing.T) {
 			assert.True(t, outs.DeepEquals(resource.PropertyMap{}), "outs was %v", outs)
 		} else {
 			assert.True(t, outs.DeepEquals(resource.PropertyMap{
-				"message": resource.NewStringProperty("Hello, bar!"),
+				"message": resource.NewProperty("Hello, bar!"),
 			}), "outs was %v", outs)
 		}
 
@@ -2710,7 +2710,7 @@ func TestComponentOutputs(t *testing.T) {
 		assert.Equal(t, resource.PropertyMap{}, resp.Outputs)
 
 		err = monitor.RegisterResourceOutputs(resp.URN, resource.PropertyMap{
-			"foo": resource.NewStringProperty("bar"),
+			"foo": resource.NewProperty("bar"),
 		})
 		require.NoError(t, err)
 		return nil
@@ -3079,10 +3079,10 @@ func TestEventSecrets(t *testing.T) {
 	}
 
 	inputs = resource.PropertyMap{
-		"webhooks": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewObjectProperty(resource.PropertyMap{
-				"clientConfig": resource.NewObjectProperty(resource.PropertyMap{
-					"service": resource.NewStringProperty("foo"),
+		"webhooks": resource.MakeSecret(resource.NewProperty([]resource.PropertyValue{
+			resource.NewProperty(resource.PropertyMap{
+				"clientConfig": resource.NewProperty(resource.PropertyMap{
+					"service": resource.NewProperty("foo"),
 				}),
 			}),
 		})),
@@ -3090,10 +3090,10 @@ func TestEventSecrets(t *testing.T) {
 	snap := p.Run(t, nil)
 
 	inputs = resource.PropertyMap{
-		"webhooks": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewObjectProperty(resource.PropertyMap{
-				"clientConfig": resource.NewObjectProperty(resource.PropertyMap{
-					"service": resource.NewStringProperty("bar"),
+		"webhooks": resource.MakeSecret(resource.NewProperty([]resource.PropertyValue{
+			resource.NewProperty(resource.PropertyMap{
+				"clientConfig": resource.NewProperty(resource.PropertyMap{
+					"service": resource.NewProperty("bar"),
 				}),
 			}),
 		})),
@@ -3162,9 +3162,9 @@ func TestAdditionalSecretOutputs(t *testing.T) {
 	project := p.GetProject()
 
 	inputs = resource.PropertyMap{
-		"a": resource.NewStringProperty("testA"),
+		"a": resource.NewProperty("testA"),
 		// b is missing
-		"c": resource.MakeSecret(resource.NewStringProperty("testC")),
+		"c": resource.MakeSecret(resource.NewProperty("testC")),
 	}
 
 	// Run an update to create the resource and check we warn about b
@@ -3735,7 +3735,7 @@ func TestOldCheckedInputsAreSent(t *testing.T) {
 					for k, v := range req.News {
 						results[k] = v
 					}
-					results["default"] = resource.NewStringProperty("default")
+					results["default"] = resource.NewProperty("default")
 
 					return plugin.CheckResponse{Properties: results}, nil
 				},
@@ -3773,11 +3773,11 @@ func TestOldCheckedInputsAreSent(t *testing.T) {
 						results[k] = v
 					}
 					// Add a computed property
-					results["computed"] = resource.MakeComputed(resource.NewStringProperty(""))
+					results["computed"] = resource.MakeComputed(resource.NewProperty(""))
 
 					if !req.Preview {
 						id = resource.ID("1")
-						results["computed"] = resource.NewStringProperty("computed")
+						results["computed"] = resource.NewProperty("computed")
 					}
 					return plugin.CreateResponse{
 						ID:         id,
@@ -3806,10 +3806,10 @@ func TestOldCheckedInputsAreSent(t *testing.T) {
 						results[k] = v
 					}
 					// Add a computed property
-					results["computed"] = resource.MakeComputed(resource.NewStringProperty(""))
+					results["computed"] = resource.MakeComputed(resource.NewProperty(""))
 
 					if !req.Preview {
-						results["computed"] = resource.NewStringProperty("computed")
+						results["computed"] = resource.NewProperty("computed")
 					}
 
 					return plugin.UpdateResponse{
@@ -4200,7 +4200,7 @@ func TestAutomaticDiff(t *testing.T) {
 	}
 
 	inputs := resource.PropertyMap{
-		"foo": resource.NewNumberProperty(1),
+		"foo": resource.NewProperty(1.0),
 	}
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
@@ -4223,7 +4223,7 @@ func TestAutomaticDiff(t *testing.T) {
 
 	// Change the inputs and run again
 	inputs = resource.PropertyMap{
-		"foo": resource.NewNumberProperty(2),
+		"foo": resource.NewProperty(2.0),
 	}
 	_, err = lt.TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, true, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, _ JournalEntries,

--- a/pkg/engine/lifecycletest/refresh_before_update_test.go
+++ b/pkg/engine/lifecycletest/refresh_before_update_test.go
@@ -96,7 +96,7 @@ func TestRefreshBeforeUpdate(t *testing.T) {
 	}
 
 	inputs := resource.PropertyMap{
-		"input": resource.NewStringProperty("value-1"),
+		"input": resource.NewProperty("value-1"),
 	}
 
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
@@ -137,7 +137,7 @@ func TestRefreshBeforeUpdate(t *testing.T) {
 
 	// Second update.
 	inputs = resource.PropertyMap{
-		"input": resource.NewStringProperty("value-2"),
+		"input": resource.NewProperty("value-2"),
 	}
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap = p.Run(t, snap)

--- a/pkg/engine/lifecycletest/refresh_legacy_diff_test.go
+++ b/pkg/engine/lifecycletest/refresh_legacy_diff_test.go
@@ -110,10 +110,10 @@ func validateRefreshBasicsWithLegacyDiffCombination(
 		"3": {Outputs: resource.PropertyMap{}, Inputs: resource.PropertyMap{}},
 
 		// B::1 and A::4 will have changes. The latter will also have input changes.
-		"1": {Outputs: resource.PropertyMap{"foo": resource.NewStringProperty("bar")}, Inputs: resource.PropertyMap{}},
+		"1": {Outputs: resource.PropertyMap{"foo": resource.NewProperty("bar")}, Inputs: resource.PropertyMap{}},
 		"4": {
-			Outputs: resource.PropertyMap{"baz": resource.NewStringProperty("qux")},
-			Inputs:  resource.PropertyMap{"oof": resource.NewStringProperty("zab")},
+			Outputs: resource.PropertyMap{"baz": resource.NewProperty("qux")},
+			Inputs:  resource.PropertyMap{"oof": resource.NewProperty("zab")},
 		},
 
 		// C::2 and C::5 will be deleted.

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -167,7 +167,7 @@ func TestExternalRefreshDoesNotCallDiff(t *testing.T) {
 					return plugin.ReadResponse{
 						ReadResult: plugin.ReadResult{
 							Outputs: resource.PropertyMap{
-								"o1": resource.NewNumberProperty(float64(readCall)),
+								"o1": resource.NewProperty(float64(readCall)),
 							},
 						},
 						Status: resource.StatusOK,
@@ -217,7 +217,7 @@ func TestRefreshInitFailure(t *testing.T) {
 	resURN := p.NewURN("pkgA:m:typA", "resA", "")
 	res2URN := p.NewURN("pkgA:m:typA", "resB", "")
 
-	res2Outputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
+	res2Outputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
 
 	//
 	// Refresh will persist any initialization errors that are returned by `Read`. This provider
@@ -779,16 +779,16 @@ func validateRefreshBasicsCombination(t *testing.T, names []string, targets []st
 		"3": {Outputs: resource.PropertyMap{}, Inputs: resource.PropertyMap{}},
 
 		// B::1 has output-only changes which will not be reported as a refresh diff.
-		"1": {Outputs: resource.PropertyMap{"foo": resource.NewStringProperty("bar")}, Inputs: resource.PropertyMap{}},
+		"1": {Outputs: resource.PropertyMap{"foo": resource.NewProperty("bar")}, Inputs: resource.PropertyMap{}},
 
 		// A::4 will have input and output changes. The changes that impact the inputs will be reported
 		// as a refresh diff.
 		"4": {
 			Outputs: resource.PropertyMap{
-				"baz": resource.NewStringProperty("qux"),
-				"oof": resource.NewStringProperty("zab"),
+				"baz": resource.NewProperty("qux"),
+				"oof": resource.NewProperty("zab"),
 			},
-			Inputs: resource.PropertyMap{"oof": resource.NewStringProperty("zab")},
+			Inputs: resource.PropertyMap{"oof": resource.NewProperty("zab")},
 		},
 
 		// C::2 and C::5 will be deleted.
@@ -953,12 +953,12 @@ func TestCanceledRefresh(t *testing.T) {
 		// A::0 will have input and output changes. The changes that impact the inputs will be reported
 		// as a refresh diff.
 		"0": {
-			Outputs: resource.PropertyMap{"foo": resource.NewStringProperty("bar")},
-			Inputs:  resource.PropertyMap{"oof": resource.NewStringProperty("rab")},
+			Outputs: resource.PropertyMap{"foo": resource.NewProperty("bar")},
+			Inputs:  resource.PropertyMap{"oof": resource.NewProperty("rab")},
 		},
 		// B::1 will have output changes.
 		"1": {
-			Outputs: resource.PropertyMap{"baz": resource.NewStringProperty("qux")},
+			Outputs: resource.PropertyMap{"baz": resource.NewProperty("qux")},
 		},
 		// C::2 will be deleted.
 		"2": {},
@@ -1110,7 +1110,7 @@ func TestRefreshStepWillPersistUpdatedIDs(t *testing.T) {
 	resURN := p.NewURN("pkgA:m:typA", "resA", "")
 	idBefore := resource.ID("myid")
 	idAfter := resource.ID("mynewid")
-	outputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
+	outputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
 
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
@@ -1220,9 +1220,9 @@ func TestRefreshUpdateWithDeletedResource(t *testing.T) {
 func TestRefreshWithProgram(t *testing.T) {
 	t.Parallel()
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	readOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("baz")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createOutputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	readOutputs := resource.PropertyMap{"foo": resource.NewProperty("baz")}
 
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
@@ -1313,7 +1313,7 @@ func TestRefreshWithProgram(t *testing.T) {
 	assert.Equal(t, createOutputs, snap.Resources[1].Outputs)
 
 	// Change the program inputs to check we don't changed inputs to the provider
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	// Run a refresh
 	snap, err = lt.TestOp(RefreshV2).
 		RunStep(p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
@@ -1330,11 +1330,11 @@ func TestRefreshWithProgram(t *testing.T) {
 func TestRefreshWithProgramUpdateExplicitProvider(t *testing.T) {
 	t.Parallel()
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	readOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("baz")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createOutputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	readOutputs := resource.PropertyMap{"foo": resource.NewProperty("baz")}
 
-	expectedAuth := resource.NewStringProperty("upauth")
+	expectedAuth := resource.NewProperty("upauth")
 
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
@@ -1448,10 +1448,10 @@ func TestRefreshWithProgramUpdateExplicitProvider(t *testing.T) {
 	assert.Equal(t, createOutputs, snap.Resources[1].Outputs)
 
 	// Change the program inputs to check we don't changed inputs to the provider
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	// And update the expected auth required for the provider, if we loaded the provider just from state we
 	// wouldn't pick this up.
-	expectedAuth = resource.NewStringProperty("refreshauth")
+	expectedAuth = resource.NewProperty("refreshauth")
 	// Run a refresh
 	snap, err = lt.TestOp(RefreshV2).
 		RunStep(p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
@@ -1468,11 +1468,11 @@ func TestRefreshWithProgramUpdateExplicitProvider(t *testing.T) {
 func TestRefreshWithProgramUpdateDefaultProvider(t *testing.T) {
 	t.Parallel()
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	readOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("baz")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createOutputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	readOutputs := resource.PropertyMap{"foo": resource.NewProperty("baz")}
 
-	expectedAuth := resource.NewStringProperty("upauth")
+	expectedAuth := resource.NewProperty("upauth")
 
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
@@ -1580,10 +1580,10 @@ func TestRefreshWithProgramUpdateDefaultProvider(t *testing.T) {
 	assert.Equal(t, createOutputs, snap.Resources[1].Outputs)
 
 	// Change the program inputs to check we don't changed inputs to the provider
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	// And update the expected auth required for the provider, if we loaded the provider just from state we
 	// wouldn't pick this up.
-	expectedAuth = resource.NewStringProperty("refreshauth")
+	expectedAuth = resource.NewProperty("refreshauth")
 	p.Config = config.Map{
 		config.MustParseKey("pkgA:config:auth"): config.NewValue("refreshauth"),
 	}
@@ -1603,11 +1603,11 @@ func TestRefreshWithProgramUpdateDefaultProvider(t *testing.T) {
 func TestRefreshWithProgramUpdateDefaultProviderWithoutRegistration(t *testing.T) {
 	t.Parallel()
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	readOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("baz")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createOutputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	readOutputs := resource.PropertyMap{"foo": resource.NewProperty("baz")}
 
-	expectedAuth := resource.NewStringProperty("upauth")
+	expectedAuth := resource.NewProperty("upauth")
 
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
@@ -1714,7 +1714,7 @@ func TestRefreshWithProgramUpdateDefaultProviderWithoutRegistration(t *testing.T
 	assert.Equal(t, createOutputs, snap.Resources[1].Outputs)
 
 	// Change the program inputs to check we don't changed inputs to the provider
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	// We can't change the 'expectedauth' in this case because we're re-loading the provider
 	// from state. We change config here to show that's the case.
 	p.Config = config.Map{
@@ -1735,9 +1735,9 @@ func TestRefreshWithProgramUpdateDefaultProviderWithoutRegistration(t *testing.T
 func TestRefreshWithProgramWithDeletedResource(t *testing.T) {
 	t.Parallel()
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	readOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("baz")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createOutputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	readOutputs := resource.PropertyMap{"foo": resource.NewProperty("baz")}
 
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
@@ -1852,7 +1852,7 @@ func TestRefreshWithProgramWithDeletedResource(t *testing.T) {
 	require.Len(t, snap.Resources, 3)
 
 	// Change the program inputs to check we don't changed inputs to the provider
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	// Run a refresh
 	snap, err = lt.TestOp(RefreshV2).
 		RunStep(p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
@@ -1868,9 +1868,9 @@ func TestRefreshWithProgramWithDeletedResource(t *testing.T) {
 func TestRefreshWithBigProgram(t *testing.T) {
 	t.Parallel()
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	readOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("baz")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createOutputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	readOutputs := resource.PropertyMap{"foo": resource.NewProperty("baz")}
 
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
@@ -1969,7 +1969,7 @@ func TestRefreshWithBigProgram(t *testing.T) {
 	assert.Equal(t, createOutputs, snap.Resources[1].Outputs)
 
 	// Change the program inputs to check we don't changed inputs to the provider
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	// Run a refresh
 	snap, err = lt.TestOp(RefreshV2).
 		RunStep(p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
@@ -1986,9 +1986,9 @@ func TestRefreshWithBigProgram(t *testing.T) {
 func TestRefreshWithAlias(t *testing.T) {
 	t.Parallel()
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	readOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("baz")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createOutputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	readOutputs := resource.PropertyMap{"foo": resource.NewProperty("baz")}
 
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
@@ -2092,7 +2092,7 @@ func TestRefreshWithAlias(t *testing.T) {
 	assert.Equal(t, createOutputs, snap.Resources[1].Outputs)
 
 	// Change the program inputs to check we don't changed inputs to the provider
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	// Run a refresh
 	snap, err = lt.TestOp(RefreshV2).
 		RunStep(p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
@@ -2108,8 +2108,8 @@ func TestRefreshWithAlias(t *testing.T) {
 func TestRefreshRunProgramDeletedResource(t *testing.T) {
 	t.Parallel()
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createOutputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
 
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
@@ -2191,7 +2191,7 @@ func TestRefreshRunProgramDeletedResource(t *testing.T) {
 	firstID := snap.Resources[1].ID
 
 	// Change the program inputs to check we don't changed inputs to the provider
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	p.Options.Refresh = true
 	p.Options.RefreshProgram = true
 	// Run a refresh update
@@ -2210,8 +2210,8 @@ func TestRefreshRunProgramDeletedResource(t *testing.T) {
 func TestRefreshRunProgramDBRReplacedResource(t *testing.T) {
 	t.Parallel()
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	createOutputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	createOutputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
 
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
@@ -2313,7 +2313,7 @@ func TestRefreshRunProgramDBRReplacedResource(t *testing.T) {
 	require.Len(t, snap.Resources, 3)
 	firstID := snap.Resources[1].ID
 
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	p.Options.Refresh = true
 	p.Options.RefreshProgram = true
 	// Run a refresh update
@@ -2332,8 +2332,8 @@ func TestRefreshRunProgramDBRReplacedResource(t *testing.T) {
 func TestRefreshRunProgramReplacedResource(t *testing.T) {
 	t.Parallel()
 
-	programInputs := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
-	initialProperties := resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
+	programInputs := resource.PropertyMap{"foo": resource.NewProperty("bar")}
+	initialProperties := resource.PropertyMap{"foo": resource.NewProperty("bar")}
 
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
@@ -2427,7 +2427,7 @@ func TestRefreshRunProgramReplacedResource(t *testing.T) {
 	require.Len(t, snap.Resources, 2)
 	firstID := snap.Resources[1].ID
 
-	programInputs["foo"] = resource.NewStringProperty("qux")
+	programInputs["foo"] = resource.NewProperty("qux")
 	p.Options.Refresh = true
 	p.Options.RefreshProgram = true
 	// Run a refresh update

--- a/pkg/engine/lifecycletest/resource_reference_test.go
+++ b/pkg/engine/lifecycletest/resource_reference_test.go
@@ -176,9 +176,9 @@ func TestResourceReferences_DownlevelSDK(t *testing.T) {
 		respC, err := monitor.RegisterResource("pkgA:m:typA", "resC", true, opts)
 		require.NoError(t, err)
 
-		assert.Equal(t, resource.NewStringProperty(string(urnA)), respC.Outputs["resA"])
+		assert.Equal(t, resource.NewProperty(string(urnA)), respC.Outputs["resA"])
 		if idB != "" {
-			assert.Equal(t, resource.NewStringProperty(string(idB)), respC.Outputs["resB"])
+			assert.Equal(t, resource.NewProperty(string(idB)), respC.Outputs["resB"])
 		} else {
 			assert.True(t, respC.Outputs["resB"].IsComputed())
 		}
@@ -213,7 +213,7 @@ func TestResourceReferences_DownlevelEngine(t *testing.T) {
 
 					// If we have resource references here, the engine has not properly disabled them.
 					if req.URN.Name() == "resC" {
-						assert.Equal(t, resource.NewStringProperty(string(urnA)), req.Properties["resA"])
+						assert.Equal(t, resource.NewProperty(string(urnA)), req.Properties["resA"])
 						assert.Equal(t, refB.ResourceReferenceValue().ID, req.Properties["resB"])
 					}
 
@@ -259,7 +259,7 @@ func TestResourceReferences_DownlevelEngine(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		assert.Equal(t, resource.NewStringProperty(string(urnA)), resp.Outputs["resA"])
+		assert.Equal(t, resource.NewProperty(string(urnA)), resp.Outputs["resA"])
 		if refB.ResourceReferenceValue().ID.IsComputed() {
 			assert.True(t, resp.Outputs["resB"].IsComputed())
 		} else {
@@ -333,12 +333,12 @@ func TestResourceReferences_GetResource(t *testing.T) {
 		// Expect the `child` property from `resContainer`'s state to come back from 'pulumi:pulumi:getResource'
 		// as a resource reference.
 		result, failures, err := monitor.Invoke("pulumi:pulumi:getResource", resource.PropertyMap{
-			"urn": resource.NewStringProperty(string(resp.URN)),
+			"urn": resource.NewProperty(string(resp.URN)),
 		}, "", "", "")
 		require.NoError(t, err)
 		assert.Empty(t, failures)
-		assert.Equal(t, resource.NewStringProperty(string(resp.URN)), result["urn"])
-		assert.Equal(t, resource.NewStringProperty(string(resp.ID)), result["id"])
+		assert.Equal(t, resource.NewProperty(string(resp.URN)), result["urn"])
+		assert.Equal(t, resource.NewProperty(string(resp.ID)), result["id"])
 		state := result["state"].ObjectValue()
 		assert.Equal(t, refChild, state["child"])
 

--- a/pkg/engine/lifecycletest/step_generator_test.go
+++ b/pkg/engine/lifecycletest/step_generator_test.go
@@ -121,7 +121,7 @@ func TestSecretMasked(t *testing.T) {
 					return plugin.CreateResponse{
 						ID: "id",
 						Properties: resource.PropertyMap{
-							"shouldBeSecret": resource.NewStringProperty("bar"),
+							"shouldBeSecret": resource.NewProperty("bar"),
 						},
 						Status: resource.StatusOK,
 					}, nil
@@ -133,7 +133,7 @@ func TestSecretMasked(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: resource.PropertyMap{
-				"shouldBeSecret": resource.MakeSecret(resource.NewStringProperty("bar")),
+				"shouldBeSecret": resource.MakeSecret(resource.NewProperty("bar")),
 			},
 		})
 		require.NoError(t, err)

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -60,7 +60,7 @@ func TestRefreshTargetChildren(t *testing.T) {
 						ReadResult: plugin.ReadResult{
 							ID: req.ID,
 							Outputs: resource.PropertyMap{
-								"count": resource.NewNumberProperty(float64(count)),
+								"count": resource.NewProperty(float64(count)),
 							},
 						},
 						Status: resource.StatusOK,
@@ -501,7 +501,7 @@ func TestRefreshExcludeTarget(t *testing.T) {
 						ReadResult: plugin.ReadResult{
 							ID: req.ID,
 							Outputs: resource.PropertyMap{
-								"count": resource.NewNumberProperty(float64(count)),
+								"count": resource.NewProperty(float64(count)),
 							},
 						},
 						Status: resource.StatusOK,
@@ -581,7 +581,7 @@ func TestRefreshExcludeChildren(t *testing.T) {
 						ReadResult: plugin.ReadResult{
 							ID: req.ID,
 							Outputs: resource.PropertyMap{
-								"count": resource.NewNumberProperty(callCount),
+								"count": resource.NewProperty(callCount),
 							},
 						},
 						Status: resource.StatusOK,
@@ -632,7 +632,7 @@ func TestRefreshExcludeChildren(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, snap.Resources, 5)
-	assert.Equal(t, snap.Resources[1].Outputs["count"], resource.NewNumberProperty(1.0))
+	assert.Equal(t, snap.Resources[1].Outputs["count"], resource.NewProperty(1.0))
 	assert.Equal(t, snap.Resources[2].Outputs["count"], null)
 	assert.Equal(t, snap.Resources[3].Outputs["count"], null)
 	assert.Equal(t, snap.Resources[4].Outputs["count"], null)
@@ -1875,7 +1875,7 @@ func newResource(urn, parent resource.URN, id resource.ID, provider string, depe
 ) *resource.State {
 	inputs := resource.PropertyMap{}
 	for k := range propertyDeps {
-		inputs[k] = resource.NewStringProperty("foo")
+		inputs[k] = resource.NewProperty("foo")
 	}
 	if outputs == nil {
 		outputs = resource.PropertyMap{}
@@ -1967,7 +1967,7 @@ func TestEnsureUntargetedSame(t *testing.T) {
 					req plugin.CheckRequest,
 				) (plugin.CheckResponse, error) {
 					// Pulumi GCP provider alters inputs during Check.
-					req.News["__defaults"] = resource.NewStringProperty("exists")
+					req.News["__defaults"] = resource.NewProperty("exists")
 					return plugin.CheckResponse{Properties: req.News}, nil
 				},
 			}, nil
@@ -1981,14 +1981,14 @@ func TestEnsureUntargetedSame(t *testing.T) {
 
 		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: resource.PropertyMap{
-				"foo": resource.NewStringProperty("foo"),
+				"foo": resource.NewProperty("foo"),
 			},
 		})
 		require.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgA:m:typA", "resB", true, deploytest.ResourceOptions{
 			Inputs: resource.PropertyMap{
-				"foo": resource.NewStringProperty("bar"),
+				"foo": resource.NewProperty("bar"),
 			},
 		})
 		require.NoError(t, err)
@@ -2056,7 +2056,7 @@ func TestReplaceSpecificTargetsPlan(t *testing.T) {
 
 		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: resource.PropertyMap{
-				"foo": resource.NewStringProperty(fooVal),
+				"foo": resource.NewProperty(fooVal),
 			},
 			ReplaceOnChanges: []string{"foo"},
 		})
@@ -2066,14 +2066,14 @@ func TestReplaceSpecificTargetsPlan(t *testing.T) {
 			// Now try to create resB which is not targeted and should show up in the plan.
 			_, err := monitor.RegisterResource("pkgA:m:typA", "resB", true, deploytest.ResourceOptions{
 				Inputs: resource.PropertyMap{
-					"foo": resource.NewStringProperty(fooVal),
+					"foo": resource.NewProperty(fooVal),
 				},
 			})
 			require.NoError(t, err)
 		}
 
 		err = monitor.RegisterResourceOutputs(resp.URN, resource.PropertyMap{
-			"foo": resource.NewStringProperty(fooVal),
+			"foo": resource.NewProperty(fooVal),
 		})
 
 		require.NoError(t, err)
@@ -2512,7 +2512,7 @@ func TestTargetUntargetedParent(t *testing.T) {
 		// Run an update to target the child. This works because we don't need to create the parent so can just
 		// SameStep it using the data currently in state.
 		inputs = resource.PropertyMap{
-			"foo": resource.NewStringProperty("bar"),
+			"foo": resource.NewProperty("bar"),
 		}
 		snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
 			T:     t,
@@ -2983,7 +2983,7 @@ func TestDependencyUnreleatedToTargetUpdatedSucceeds(t *testing.T) {
 
 	// Run an update to target the target, and make sure the unrelated dependency isn't changed
 	inputs = resource.PropertyMap{
-		"foo": resource.NewStringProperty("bar"),
+		"foo": resource.NewProperty("bar"),
 	}
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
 		T:     t,
@@ -3082,7 +3082,7 @@ func TestTargetUntargetedParentWithUpdatedDependency(t *testing.T) {
 		// Run an update to target the child. This works because we don't need to create the parent so can just
 		// SameStep it using the data currently in state.
 		inputs = resource.PropertyMap{
-			"foo": resource.NewStringProperty("bar"),
+			"foo": resource.NewProperty("bar"),
 		}
 		snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
 			T:     t,
@@ -3181,7 +3181,7 @@ func TestTargetChangeProviderVersion(t *testing.T) {
 	providerVersion = "2.0.0"
 	expectError = true
 	inputs = resource.PropertyMap{
-		"foo": resource.NewStringProperty("bar"),
+		"foo": resource.NewProperty("bar"),
 	}
 	options.UpdateOptions = UpdateOptions{
 		Targets: deploy.NewUrnTargets([]string{
@@ -3252,7 +3252,7 @@ func TestTargetChangeAndSameProviderVersion(t *testing.T) {
 	// Run an update to target the target, that also happens to change the unrelated provider version.
 	providerVersion = "2.0.0"
 	inputs = resource.PropertyMap{
-		"foo": resource.NewStringProperty("bar"),
+		"foo": resource.NewProperty("bar"),
 	}
 	options.UpdateOptions = UpdateOptions{
 		Targets: deploy.NewUrnTargets([]string{
@@ -4410,7 +4410,7 @@ func TestUntargetedProviderChange(t *testing.T) {
 	expectError = true
 	explicitProvider = false
 	inputs = resource.PropertyMap{
-		"foo": resource.NewStringProperty("bar"),
+		"foo": resource.NewProperty("bar"),
 	}
 	options.UpdateOptions = UpdateOptions{
 		Targets: deploy.NewUrnTargets([]string{

--- a/pkg/engine/lifecycletest/update_plan_test.go
+++ b/pkg/engine/lifecycletest/update_plan_test.go
@@ -78,7 +78,7 @@ func TestPlannedUpdate(t *testing.T) {
 	project := p.GetProject()
 
 	// Generate a plan.
-	computed := interface{}(resource.Computed{Element: resource.NewStringProperty("")})
+	computed := interface{}(resource.Computed{Element: resource.NewProperty("")})
 	ins = resource.NewPropertyMapFromMap(map[string]interface{}{
 		"foo": "bar",
 		"baz": map[string]interface{}{
@@ -693,7 +693,7 @@ func TestResoucesWithSames(t *testing.T) {
 	// Generate a plan to create A
 	createA = true
 	createB = false
-	computed := interface{}(resource.Computed{Element: resource.NewStringProperty("")})
+	computed := interface{}(resource.Computed{Element: resource.NewProperty("")})
 	ins = resource.NewPropertyMapFromMap(map[string]interface{}{
 		"foo": "bar",
 		"zed": computed,
@@ -786,7 +786,7 @@ func TestPlannedPreviews(t *testing.T) {
 	project := p.GetProject()
 
 	// Generate a plan.
-	computed := interface{}(resource.Computed{Element: resource.NewStringProperty("")})
+	computed := interface{}(resource.Computed{Element: resource.NewProperty("")})
 	ins = resource.NewPropertyMapFromMap(map[string]interface{}{
 		"foo": "bar",
 		"baz": map[string]interface{}{
@@ -1212,7 +1212,7 @@ func TestComputedCanBeDropped(t *testing.T) {
 	project := p.GetProject()
 
 	// The three property sets we'll use in this test
-	computed := interface{}(resource.Computed{Element: resource.NewStringProperty("")})
+	computed := interface{}(resource.Computed{Element: resource.NewProperty("")})
 	computedPropertySet := resource.NewPropertyMapFromMap(map[string]interface{}{
 		"foo": "bar",
 		"baz": map[string]interface{}{
@@ -1326,7 +1326,7 @@ func TestPlannedUpdateWithNondeterministicCheck(t *testing.T) {
 					require.NoError(t, err)
 
 					result := req.News.Copy()
-					result["name"] = resource.NewStringProperty(name)
+					result["name"] = resource.NewProperty(name)
 					return plugin.CheckResponse{Properties: result}, nil
 				},
 			}, nil
@@ -1368,7 +1368,7 @@ func TestPlannedUpdateWithNondeterministicCheck(t *testing.T) {
 	project := p.GetProject()
 
 	// Generate a plan.
-	computed := interface{}(resource.Computed{Element: resource.NewStringProperty("")})
+	computed := interface{}(resource.Computed{Element: resource.NewProperty("")})
 	ins = resource.NewPropertyMapFromMap(map[string]interface{}{
 		"foo": "bar",
 		"zed": computed,
@@ -1545,7 +1545,7 @@ func TestProviderDeterministicPreview(t *testing.T) {
 						} else {
 							name, err := resource.NewUniqueName(req.RandomSeed, req.URN.Name(), -1, -1, nil)
 							require.NoError(t, err)
-							generatedName = resource.NewStringProperty(name)
+							generatedName = resource.NewProperty(name)
 							req.News["name"] = generatedName
 						}
 					}
@@ -1736,7 +1736,7 @@ func TestResourcesTargeted(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs: resource.PropertyMap{
-				"foo": resource.NewStringProperty("bar"),
+				"foo": resource.NewProperty("bar"),
 			},
 		})
 		if expectError {
@@ -1747,7 +1747,7 @@ func TestResourcesTargeted(t *testing.T) {
 
 		_, _ = monitor.RegisterResource("pkgA:m:typA", "resB", true, deploytest.ResourceOptions{
 			Inputs: resource.PropertyMap{
-				"foo": resource.NewStringProperty("bar"),
+				"foo": resource.NewProperty("bar"),
 			},
 		})
 
@@ -1828,7 +1828,7 @@ func TestStackOutputsWithTargetedPlan(t *testing.T) {
 		require.NoError(t, err)
 
 		err = monitor.RegisterResourceOutputs(resp.URN, resource.PropertyMap{
-			"foo": resource.NewStringProperty("bar"),
+			"foo": resource.NewProperty("bar"),
 		})
 
 		require.NoError(t, err)

--- a/pkg/engine/lifecycletest/views_test.go
+++ b/pkg/engine/lifecycletest/views_test.go
@@ -88,10 +88,10 @@ func TestViewsBasic(t *testing.T) {
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
 							Inputs: resource.PropertyMap{
-								"input": resource.NewStringProperty("bar"),
+								"input": resource.NewProperty("bar"),
 							},
 							Outputs: resource.PropertyMap{
-								"result": resource.NewStringProperty("bar"),
+								"result": resource.NewProperty("bar"),
 							},
 						},
 					}, req.OldViews)
@@ -137,10 +137,10 @@ func TestViewsBasic(t *testing.T) {
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
 							Inputs: resource.PropertyMap{
-								"input": resource.NewStringProperty("baz"),
+								"input": resource.NewProperty("baz"),
 							},
 							Outputs: resource.PropertyMap{
-								"result": resource.NewStringProperty("baz"),
+								"result": resource.NewProperty("baz"),
 							},
 						},
 					}, req.OldViews)
@@ -223,10 +223,10 @@ func TestViewsBasic(t *testing.T) {
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
 	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[2].URN.Type())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("bar"),
+		"input": resource.NewProperty("bar"),
 	}, snap.Resources[2].Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"result": resource.NewStringProperty("bar"),
+		"result": resource.NewProperty("bar"),
 	}, snap.Resources[2].Outputs)
 
 	// Run a second update, should be same.
@@ -242,10 +242,10 @@ func TestViewsBasic(t *testing.T) {
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
 	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[2].URN.Type())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("bar"),
+		"input": resource.NewProperty("bar"),
 	}, snap.Resources[2].Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"result": resource.NewStringProperty("bar"),
+		"result": resource.NewProperty("bar"),
 	}, snap.Resources[2].Outputs)
 
 	// Run a third update with a change, should update.
@@ -264,10 +264,10 @@ func TestViewsBasic(t *testing.T) {
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
 	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[2].URN.Type())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("baz"),
+		"input": resource.NewProperty("baz"),
 	}, snap.Resources[2].Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"result": resource.NewStringProperty("baz"),
+		"result": resource.NewProperty("baz"),
 	}, snap.Resources[2].Outputs)
 
 	// Run a fourth update, this time deleting the resource and its view.
@@ -332,10 +332,10 @@ func TestViewsUpdateError(t *testing.T) {
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
 							Inputs: resource.PropertyMap{
-								"input": resource.NewStringProperty("bar"),
+								"input": resource.NewProperty("bar"),
 							},
 							Outputs: resource.PropertyMap{
-								"result": resource.NewStringProperty("bar"),
+								"result": resource.NewProperty("bar"),
 							},
 						},
 					}, req.OldViews)
@@ -428,10 +428,10 @@ func TestViewsUpdateError(t *testing.T) {
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
 	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[2].URN.Type())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("bar"),
+		"input": resource.NewProperty("bar"),
 	}, snap.Resources[2].Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"result": resource.NewStringProperty("bar"),
+		"result": resource.NewProperty("bar"),
 	}, snap.Resources[2].Outputs)
 
 	// Run a second update, we should get an error for the view.
@@ -494,10 +494,10 @@ func TestViewsUpdateDelete(t *testing.T) {
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
 							Inputs: resource.PropertyMap{
-								"input": resource.NewStringProperty("bar"),
+								"input": resource.NewProperty("bar"),
 							},
 							Outputs: resource.PropertyMap{
-								"result": resource.NewStringProperty("bar"),
+								"result": resource.NewProperty("bar"),
 							},
 						},
 					}, req.OldViews)
@@ -581,10 +581,10 @@ func TestViewsUpdateDelete(t *testing.T) {
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
 	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[2].URN.Type())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("bar"),
+		"input": resource.NewProperty("bar"),
 	}, snap.Resources[2].Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"result": resource.NewStringProperty("bar"),
+		"result": resource.NewProperty("bar"),
 	}, snap.Resources[2].Outputs)
 
 	// Run an update that will delete the view.
@@ -645,10 +645,10 @@ func TestViewsRefreshSame(t *testing.T) {
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
 							Inputs: resource.PropertyMap{
-								"input": resource.NewStringProperty("bar"),
+								"input": resource.NewProperty("bar"),
 							},
 							Outputs: resource.PropertyMap{
-								"result": resource.NewStringProperty("bar"),
+								"result": resource.NewProperty("bar"),
 							},
 						},
 					}, req.OldViews)
@@ -713,10 +713,10 @@ func TestViewsRefreshSame(t *testing.T) {
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
 	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[2].URN.Type())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("bar"),
+		"input": resource.NewProperty("bar"),
 	}, snap.Resources[2].Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"result": resource.NewStringProperty("bar"),
+		"result": resource.NewProperty("bar"),
 	}, snap.Resources[2].Outputs)
 
 	p.Steps = []lt.TestStep{{Op: Refresh}}
@@ -728,10 +728,10 @@ func TestViewsRefreshSame(t *testing.T) {
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
 	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[2].URN.Type())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("bar"),
+		"input": resource.NewProperty("bar"),
 	}, snap.Resources[2].Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"result": resource.NewStringProperty("bar"),
+		"result": resource.NewProperty("bar"),
 	}, snap.Resources[2].Outputs)
 }
 
@@ -913,10 +913,10 @@ func TestViewsRefreshUpdate(t *testing.T) {
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
 							Inputs: resource.PropertyMap{
-								"input": resource.NewStringProperty("bar"),
+								"input": resource.NewProperty("bar"),
 							},
 							Outputs: resource.PropertyMap{
-								"result": resource.NewStringProperty("bar"),
+								"result": resource.NewProperty("bar"),
 							},
 						},
 					}, req.OldViews)
@@ -985,10 +985,10 @@ func TestViewsRefreshUpdate(t *testing.T) {
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
 	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[2].URN.Type())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("bar"),
+		"input": resource.NewProperty("bar"),
 	}, snap.Resources[2].Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"result": resource.NewStringProperty("bar"),
+		"result": resource.NewProperty("bar"),
 	}, snap.Resources[2].Outputs)
 
 	p.Steps = []lt.TestStep{{Op: Refresh}}
@@ -1000,10 +1000,10 @@ func TestViewsRefreshUpdate(t *testing.T) {
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
 	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[2].URN.Type())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("baz"),
+		"input": resource.NewProperty("baz"),
 	}, snap.Resources[2].Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"result": resource.NewStringProperty("baz"),
+		"result": resource.NewProperty("baz"),
 	}, snap.Resources[2].Outputs)
 }
 
@@ -1190,10 +1190,10 @@ func TestViewsRefreshDelete(t *testing.T) {
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
 							Inputs: resource.PropertyMap{
-								"input": resource.NewStringProperty("bar"),
+								"input": resource.NewProperty("bar"),
 							},
 							Outputs: resource.PropertyMap{
-								"result": resource.NewStringProperty("bar"),
+								"result": resource.NewProperty("bar"),
 							},
 						},
 					}, req.OldViews)
@@ -1252,10 +1252,10 @@ func TestViewsRefreshDelete(t *testing.T) {
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
 	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[2].URN.Type())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("bar"),
+		"input": resource.NewProperty("bar"),
 	}, snap.Resources[2].Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"result": resource.NewStringProperty("bar"),
+		"result": resource.NewProperty("bar"),
 	}, snap.Resources[2].Outputs)
 
 	p.Steps = []lt.TestStep{{Op: Refresh}}
@@ -1453,10 +1453,10 @@ func TestViewsImport(t *testing.T) {
 	assert.Equal(t, "resA-child", snap.Resources[3].URN.Name())
 	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[3].URN.Type())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("bar"),
+		"input": resource.NewProperty("bar"),
 	}, snap.Resources[3].Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"result": resource.NewStringProperty("bar"),
+		"result": resource.NewProperty("bar"),
 	}, snap.Resources[3].Outputs)
 
 	// Import.
@@ -1473,10 +1473,10 @@ func TestViewsImport(t *testing.T) {
 	assert.Equal(t, "resA-child", snap.Resources[3].URN.Name())
 	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[3].URN.Type())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("bar"),
+		"input": resource.NewProperty("bar"),
 	}, snap.Resources[3].Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"result": resource.NewStringProperty("bar"),
+		"result": resource.NewProperty("bar"),
 	}, snap.Resources[3].Outputs)
 	assert.Equal(t, "imported-id", snap.Resources[4].ID.String())
 }
@@ -1532,10 +1532,10 @@ func TestViewsDeleteBeforeReplace(t *testing.T) {
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
 							Inputs: resource.PropertyMap{
-								"input": resource.NewStringProperty("bar"),
+								"input": resource.NewProperty("bar"),
 							},
 							Outputs: resource.PropertyMap{
-								"result": resource.NewStringProperty("bar"),
+								"result": resource.NewProperty("bar"),
 							},
 						},
 					}, req.OldViews)
@@ -1653,10 +1653,10 @@ func TestViewsDeleteBeforeReplace(t *testing.T) {
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
 	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[2].URN.Type())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("bar"),
+		"input": resource.NewProperty("bar"),
 	}, snap.Resources[2].Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"result": resource.NewStringProperty("bar"),
+		"result": resource.NewProperty("bar"),
 	}, snap.Resources[2].Outputs)
 
 	// Run another update, with a change, should update.
@@ -1676,10 +1676,10 @@ func TestViewsDeleteBeforeReplace(t *testing.T) {
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
 	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[2].URN.Type())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("baz"),
+		"input": resource.NewProperty("baz"),
 	}, snap.Resources[2].Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"result": resource.NewStringProperty("baz"),
+		"result": resource.NewProperty("baz"),
 	}, snap.Resources[2].Outputs)
 }
 
@@ -1734,10 +1734,10 @@ func TestViewsCreateBeforeReplace(t *testing.T) {
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
 							Inputs: resource.PropertyMap{
-								"input": resource.NewStringProperty("bar"),
+								"input": resource.NewProperty("bar"),
 							},
 							Outputs: resource.PropertyMap{
-								"result": resource.NewStringProperty("bar"),
+								"result": resource.NewProperty("bar"),
 							},
 						},
 					}, req.OldViews)
@@ -1861,10 +1861,10 @@ func TestViewsCreateBeforeReplace(t *testing.T) {
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
 	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[2].URN.Type())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("bar"),
+		"input": resource.NewProperty("bar"),
 	}, snap.Resources[2].Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"result": resource.NewStringProperty("bar"),
+		"result": resource.NewProperty("bar"),
 	}, snap.Resources[2].Outputs)
 
 	// Run another update, with a change, should update.
@@ -1884,10 +1884,10 @@ func TestViewsCreateBeforeReplace(t *testing.T) {
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
 	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[2].URN.Type())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("baz"),
+		"input": resource.NewProperty("baz"),
 	}, snap.Resources[2].Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"result": resource.NewStringProperty("baz"),
+		"result": resource.NewProperty("baz"),
 	}, snap.Resources[2].Outputs)
 }
 
@@ -2464,10 +2464,10 @@ func TestViewsDestroyPreview(t *testing.T) {
 	assert.Equal(t, "resA-child", snap.Resources[2].URN.Name())
 	assert.Equal(t, tokens.Type("pkgA:m:typAView"), snap.Resources[2].URN.Type())
 	assert.Equal(t, resource.PropertyMap{
-		"input": resource.NewStringProperty("bar"),
+		"input": resource.NewProperty("bar"),
 	}, snap.Resources[2].Inputs)
 	assert.Equal(t, resource.PropertyMap{
-		"result": resource.NewStringProperty("bar"),
+		"result": resource.NewProperty("bar"),
 	}, snap.Resources[2].Outputs)
 
 	// Run a destroy preview and ensure we got a delete event for the view.

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -533,15 +533,15 @@ func zeroValue(t schema.Type) model.Expression {
 	}
 	switch t {
 	case schema.BoolType:
-		x, err := generateValue(t, resource.NewBoolProperty(false), emptyImportState, onReferenceAdded)
+		x, err := generateValue(t, resource.NewProperty(false), emptyImportState, onReferenceAdded)
 		contract.IgnoreError(err)
 		return x
 	case schema.IntType, schema.NumberType:
-		x, err := generateValue(t, resource.NewNumberProperty(0), emptyImportState, onReferenceAdded)
+		x, err := generateValue(t, resource.NewProperty(0.0), emptyImportState, onReferenceAdded)
 		contract.IgnoreError(err)
 		return x
 	case schema.StringType:
-		x, err := generateValue(t, resource.NewStringProperty(""), emptyImportState, onReferenceAdded)
+		x, err := generateValue(t, resource.NewProperty(""), emptyImportState, onReferenceAdded)
 		contract.IgnoreError(err)
 		return x
 	case schema.ArchiveType, schema.AssetType:

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -305,7 +305,7 @@ func (p *builtinProvider) readStackReference(inputs resource.PropertyMap) (resou
 	secretOutputs := make([]resource.PropertyValue, 0)
 	for k, v := range outputs {
 		if v.ContainsSecrets() {
-			secretOutputs = append(secretOutputs, resource.NewStringProperty(string(k)))
+			secretOutputs = append(secretOutputs, resource.NewProperty(string(k)))
 		}
 	}
 
@@ -316,8 +316,8 @@ func (p *builtinProvider) readStackReference(inputs resource.PropertyMap) (resou
 
 	return resource.PropertyMap{
 		"name":              name,
-		"outputs":           resource.NewObjectProperty(outputs),
-		"secretOutputNames": resource.NewArrayProperty(secretOutputs),
+		"outputs":           resource.NewProperty(outputs),
+		"secretOutputNames": resource.NewProperty(secretOutputs),
 	}, nil
 }
 
@@ -337,7 +337,7 @@ func (p *builtinProvider) readStackResourceOutputs(inputs resource.PropertyMap) 
 
 	return resource.PropertyMap{
 		"name":    name,
-		"outputs": resource.NewObjectProperty(outputs),
+		"outputs": resource.NewProperty(outputs),
 	}, nil
 }
 
@@ -363,8 +363,8 @@ func (p *builtinProvider) getResource(inputs resource.PropertyMap) (resource.Pro
 
 	return resource.PropertyMap{
 		"urn":      urnInput,
-		"id":       resource.NewStringProperty(string(state.ID)),
-		"provider": resource.NewStringProperty(state.Provider),
-		"state":    resource.NewObjectProperty(state.Outputs),
+		"id":       resource.NewProperty(string(state.ID)),
+		"provider": resource.NewProperty(state.Provider),
+		"state":    resource.NewProperty(state.Outputs),
 	}, nil
 }

--- a/pkg/resource/deploy/builtins_test.go
+++ b/pkg/resource/deploy/builtins_test.go
@@ -104,7 +104,7 @@ func TestBuiltinProvider(t *testing.T) {
 				URN:  resource.CreateURN("foo", stackReferenceType, "", "proj", "stack"),
 				Olds: resource.PropertyMap{},
 				News: resource.PropertyMap{
-					"name": resource.NewNumberProperty(10),
+					"name": resource.NewProperty(10.0),
 				},
 				AllowUnknowns: true,
 			})
@@ -124,14 +124,14 @@ func TestBuiltinProvider(t *testing.T) {
 			resp, err := p.Check(context.Background(), plugin.CheckRequest{
 				URN: resource.CreateURN("foo", stackReferenceType, "", "proj", "stack"),
 				News: resource.PropertyMap{
-					"name": resource.NewStringProperty("res-name"),
+					"name": resource.NewProperty("res-name"),
 				},
 				AllowUnknowns: true,
 			})
 			assert.Nil(t, resp.Failures)
 			require.NoError(t, err)
 			assert.Equal(t, resource.PropertyMap{
-				"name": resource.NewStringProperty("res-name"),
+				"name": resource.NewProperty("res-name"),
 			}, resp.Properties)
 		})
 	})
@@ -140,7 +140,7 @@ func TestBuiltinProvider(t *testing.T) {
 		assert.Panics(t, func() {
 			p := &builtinProvider{}
 
-			oldOutputs := resource.PropertyMap{"cookie": resource.NewStringProperty("yum")}
+			oldOutputs := resource.PropertyMap{"cookie": resource.NewProperty("yum")}
 			_, err := p.Update(context.Background(), plugin.UpdateRequest{
 				URN:        resource.CreateURN("foo", "not-stack-reference-type", "", "proj", "stack"),
 				ID:         "some-id",
@@ -167,7 +167,7 @@ func TestBuiltinProvider(t *testing.T) {
 				_, err := p.Invoke(context.Background(), plugin.InvokeRequest{
 					Tok: readStackOutputs,
 					Args: resource.PropertyMap{
-						"name": resource.NewStringProperty("res-name"),
+						"name": resource.NewProperty("res-name"),
 					},
 				})
 				assert.ErrorContains(t, err, "no backend client is available")
@@ -180,8 +180,8 @@ func TestBuiltinProvider(t *testing.T) {
 						GetStackOutputsF: func(ctx context.Context, name string, _ func(error) error) (resource.PropertyMap, error) {
 							called = true
 							return resource.PropertyMap{
-								"normal": resource.NewStringProperty("foo"),
-								"secret": resource.MakeSecret(resource.NewStringProperty("bar")),
+								"normal": resource.NewProperty("foo"),
+								"secret": resource.MakeSecret(resource.NewProperty("bar")),
 							}, nil
 						},
 					},
@@ -189,7 +189,7 @@ func TestBuiltinProvider(t *testing.T) {
 				resp, err := p.Invoke(context.Background(), plugin.InvokeRequest{
 					Tok: readStackOutputs,
 					Args: resource.PropertyMap{
-						"name": resource.NewStringProperty("res-name"),
+						"name": resource.NewProperty("res-name"),
 					},
 				})
 				require.NoError(t, err)
@@ -210,7 +210,7 @@ func TestBuiltinProvider(t *testing.T) {
 				_, err := p.Invoke(context.Background(), plugin.InvokeRequest{
 					Tok: readStackResourceOutputs,
 					Args: resource.PropertyMap{
-						"stackName": resource.NewStringProperty("res-name"),
+						"stackName": resource.NewProperty("res-name"),
 					},
 				})
 				assert.ErrorContains(t, err, "no backend client is available")
@@ -229,7 +229,7 @@ func TestBuiltinProvider(t *testing.T) {
 				_, err := p.Invoke(context.Background(), plugin.InvokeRequest{
 					Tok: readStackResourceOutputs,
 					Args: resource.PropertyMap{
-						"stackName": resource.NewStringProperty("res-name"),
+						"stackName": resource.NewProperty("res-name"),
 					},
 				})
 				require.NoError(t, err)
@@ -249,7 +249,7 @@ func TestBuiltinProvider(t *testing.T) {
 
 				expected := &resource.State{
 					Outputs: resource.PropertyMap{
-						"foo": resource.NewStringProperty("bar"),
+						"foo": resource.NewProperty("bar"),
 					},
 				}
 
@@ -258,7 +258,7 @@ func TestBuiltinProvider(t *testing.T) {
 				actual, err := p.Invoke(context.Background(), plugin.InvokeRequest{
 					Tok: getResource,
 					Args: resource.PropertyMap{
-						"urn": resource.NewStringProperty("res-name"),
+						"urn": resource.NewProperty("res-name"),
 					},
 				})
 
@@ -276,7 +276,7 @@ func TestBuiltinProvider(t *testing.T) {
 
 				expected := &resource.State{
 					Outputs: resource.PropertyMap{
-						"foo": resource.NewStringProperty("bar"),
+						"foo": resource.NewProperty("bar"),
 					},
 				}
 
@@ -285,7 +285,7 @@ func TestBuiltinProvider(t *testing.T) {
 				actual, err := p.Invoke(context.Background(), plugin.InvokeRequest{
 					Tok: getResource,
 					Args: resource.PropertyMap{
-						"urn": resource.NewStringProperty("res-name"),
+						"urn": resource.NewProperty("res-name"),
 					},
 				})
 
@@ -302,7 +302,7 @@ func TestBuiltinProvider(t *testing.T) {
 				_, err := p.Invoke(context.Background(), plugin.InvokeRequest{
 					Tok: getResource,
 					Args: resource.PropertyMap{
-						"urn": resource.NewStringProperty("res-name"),
+						"urn": resource.NewProperty("res-name"),
 					},
 				})
 				assert.ErrorContains(t, err, "unknown resource")

--- a/pkg/resource/deploy/deploytest/provider_test.go
+++ b/pkg/resource/deploy/deploytest/provider_test.go
@@ -112,8 +112,8 @@ func TestProvider(t *testing.T) {
 					req plugin.CheckConfigRequest,
 				) (plugin.CheckConfigResponse, error) {
 					assert.Equal(t, resource.URN("expected-urn"), req.URN)
-					assert.Equal(t, resource.NewStringProperty("old-value"), req.Olds["old"])
-					assert.Equal(t, resource.NewStringProperty("new-value"), req.News["new"])
+					assert.Equal(t, resource.NewProperty("old-value"), req.Olds["old"])
+					assert.Equal(t, resource.NewProperty("new-value"), req.News["new"])
 					called = true
 					return plugin.CheckConfigResponse{}, expectedErr
 				},
@@ -121,10 +121,10 @@ func TestProvider(t *testing.T) {
 			_, err := prov.CheckConfig(context.Background(), plugin.CheckConfigRequest{
 				URN: resource.URN("expected-urn"),
 				Olds: resource.PropertyMap{
-					"old": resource.NewStringProperty("old-value"),
+					"old": resource.NewProperty("old-value"),
 				},
 				News: resource.PropertyMap{
-					"new": resource.NewStringProperty("new-value"),
+					"new": resource.NewProperty("new-value"),
 				},
 				AllowUnknowns: true,
 			})
@@ -136,14 +136,14 @@ func TestProvider(t *testing.T) {
 			prov := &Provider{}
 			resp, err := prov.CheckConfig(context.Background(), plugin.CheckConfigRequest{
 				News: resource.PropertyMap{
-					"expected": resource.NewStringProperty("expected-value"),
+					"expected": resource.NewProperty("expected-value"),
 				},
 				AllowUnknowns: true,
 			})
 			require.NoError(t, err)
 			assert.Empty(t, resp.Failures)
 			// Should return the news.
-			assert.Equal(t, resource.NewStringProperty("expected-value"), resp.Properties["expected"])
+			assert.Equal(t, resource.NewProperty("expected-value"), resp.Properties["expected"])
 		})
 	})
 	t.Run("Construct", func(t *testing.T) {
@@ -257,7 +257,7 @@ func TestProvider(t *testing.T) {
 		t.Run("has InvokeF", func(t *testing.T) {
 			t.Parallel()
 			expectedPropertyMap := resource.PropertyMap{
-				"key": resource.NewStringProperty("expected-value"),
+				"key": resource.NewProperty("expected-value"),
 			}
 			var called bool
 			prov := &Provider{

--- a/pkg/resource/deploy/plan_test.go
+++ b/pkg/resource/deploy/plan_test.go
@@ -60,7 +60,7 @@ func TestPlan(t *testing.T) {
 					resource.PropertyKey("foo"),
 				},
 			}
-			val := resource.NewStringProperty("val")
+			val := resource.NewProperty("val")
 			errStr := p.MakeError(resource.PropertyKey("foo"), "", &val)
 			assert.True(t, strings.HasPrefix(errStr, "-"))
 		})
@@ -564,7 +564,7 @@ func TestCheckDiff(t *testing.T) {
 				err := checkDiff(
 					resource.PropertyMap{},
 					resource.PropertyMap{
-						resource.PropertyKey("should-delete"): resource.NewStringProperty("test"),
+						resource.PropertyKey("should-delete"): resource.NewProperty("test"),
 					},
 					PlanDiff{
 						Deletes: []resource.PropertyKey{
@@ -577,10 +577,10 @@ func TestCheckDiff(t *testing.T) {
 				t.Parallel()
 				err := checkDiff(
 					resource.PropertyMap{
-						resource.PropertyKey("should-delete"): resource.NewStringProperty("test"),
+						resource.PropertyKey("should-delete"): resource.NewProperty("test"),
 					},
 					resource.PropertyMap{
-						resource.PropertyKey("should-delete"): resource.NewStringProperty("new-test"),
+						resource.PropertyKey("should-delete"): resource.NewProperty("new-test"),
 					},
 					PlanDiff{
 						Deletes: []resource.PropertyKey{
@@ -602,11 +602,11 @@ func TestCheckDiff(t *testing.T) {
 			err := checkDiff(
 				resource.PropertyMap{},
 				resource.PropertyMap{
-					resource.PropertyKey("should-update"): resource.NewStringProperty("new-test"),
+					resource.PropertyKey("should-update"): resource.NewProperty("new-test"),
 				},
 				PlanDiff{
 					Adds: resource.PropertyMap{
-						resource.PropertyKey("should-update"): resource.NewStringProperty("new-test"),
+						resource.PropertyKey("should-update"): resource.NewProperty("new-test"),
 					},
 				})
 			require.NoError(t, err)
@@ -622,14 +622,14 @@ func TestCheckDiff(t *testing.T) {
 			t.Parallel()
 			err := checkDiff(
 				resource.PropertyMap{
-					resource.PropertyKey("should-update"): resource.NewStringProperty("old-test"),
+					resource.PropertyKey("should-update"): resource.NewProperty("old-test"),
 				},
 				resource.PropertyMap{
-					resource.PropertyKey("should-update"): resource.NewStringProperty("new-test"),
+					resource.PropertyKey("should-update"): resource.NewProperty("new-test"),
 				},
 				PlanDiff{
 					Updates: resource.PropertyMap{
-						resource.PropertyKey("should-update"): resource.NewStringProperty("new-test"),
+						resource.PropertyKey("should-update"): resource.NewProperty("new-test"),
 					},
 				})
 			require.NoError(t, err)
@@ -638,14 +638,14 @@ func TestCheckDiff(t *testing.T) {
 			t.Parallel()
 			err := checkDiff(
 				resource.PropertyMap{
-					resource.PropertyKey("should-update"): resource.NewStringProperty("new-test"),
+					resource.PropertyKey("should-update"): resource.NewProperty("new-test"),
 				},
 				resource.PropertyMap{
-					resource.PropertyKey("should-update"): resource.NewStringProperty("new-test"),
+					resource.PropertyKey("should-update"): resource.NewProperty("new-test"),
 				},
 				PlanDiff{
 					Updates: resource.PropertyMap{
-						resource.PropertyKey("should-update"): resource.NewStringProperty("new-test"),
+						resource.PropertyKey("should-update"): resource.NewProperty("new-test"),
 					},
 				})
 			require.NoError(t, err)
@@ -657,11 +657,11 @@ func TestCheckDiff(t *testing.T) {
 				err := checkDiff(
 					resource.PropertyMap{},
 					resource.PropertyMap{
-						resource.PropertyKey("should-update"): resource.NewStringProperty("new-test"),
+						resource.PropertyKey("should-update"): resource.NewProperty("new-test"),
 					},
 					PlanDiff{
 						Updates: resource.PropertyMap{
-							resource.PropertyKey("should-update"): resource.NewStringProperty("new-test"),
+							resource.PropertyKey("should-update"): resource.NewProperty("new-test"),
 						},
 					})
 				assert.ErrorContains(t, err,
@@ -671,14 +671,14 @@ func TestCheckDiff(t *testing.T) {
 				t.Parallel()
 				err := checkDiff(
 					resource.PropertyMap{
-						resource.PropertyKey("should-update"): resource.NewStringProperty("new-test"),
+						resource.PropertyKey("should-update"): resource.NewProperty("new-test"),
 					},
 					resource.PropertyMap{
-						resource.PropertyKey("should-update"): resource.NewStringProperty("new-test"),
+						resource.PropertyKey("should-update"): resource.NewProperty("new-test"),
 					},
 					PlanDiff{
 						Updates: resource.PropertyMap{
-							resource.PropertyKey("should-update"): resource.NewStringProperty("new-new-test"),
+							resource.PropertyKey("should-update"): resource.NewProperty("new-new-test"),
 						},
 					})
 				assert.ErrorContains(t, err, "properties changed: ~=should-update[{new-new-test}!={new-test}]")
@@ -689,12 +689,12 @@ func TestCheckDiff(t *testing.T) {
 					t.Parallel()
 					err := checkDiff(
 						resource.PropertyMap{
-							resource.PropertyKey("should-update"): resource.NewStringProperty("new-test"),
+							resource.PropertyKey("should-update"): resource.NewProperty("new-test"),
 						},
 						resource.PropertyMap{},
 						PlanDiff{
 							Updates: resource.PropertyMap{
-								resource.PropertyKey("should-update"): resource.NewStringProperty("new-new-test"),
+								resource.PropertyKey("should-update"): resource.NewProperty("new-new-test"),
 							},
 						})
 					assert.ErrorContains(t, err,
@@ -704,12 +704,12 @@ func TestCheckDiff(t *testing.T) {
 					t.Parallel()
 					err := checkDiff(
 						resource.PropertyMap{
-							resource.PropertyKey("should-update"): resource.NewStringProperty("new-test"),
+							resource.PropertyKey("should-update"): resource.NewProperty("new-test"),
 						},
 						resource.PropertyMap{},
 						PlanDiff{
 							Updates: resource.PropertyMap{
-								resource.PropertyKey("should-update"): resource.MakeComputed(resource.NewStringProperty("new-new-test")),
+								resource.PropertyKey("should-update"): resource.MakeComputed(resource.NewProperty("new-new-test")),
 							},
 						})
 					require.NoError(t, err)

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -58,7 +58,7 @@ func addOrGetInternal(inputs resource.PropertyMap) resource.PropertyMap {
 	internalInputs := inputs[internalKey]
 	if !internalInputs.IsObject() {
 		newMap := resource.PropertyMap{}
-		internalInputs = resource.NewObjectProperty(newMap)
+		internalInputs = resource.NewProperty(newMap)
 		inputs[internalKey] = internalInputs
 		return newMap
 	}
@@ -85,10 +85,10 @@ func SetProviderChecksums(inputs resource.PropertyMap, value map[string][]byte) 
 	propMap := make(resource.PropertyMap)
 	for key, checksum := range value {
 		hex := hex.EncodeToString(checksum)
-		propMap[resource.PropertyKey(key)] = resource.NewStringProperty(hex)
+		propMap[resource.PropertyKey(key)] = resource.NewProperty(hex)
 	}
 
-	internalInputs[pluginChecksumsKey] = resource.NewObjectProperty(propMap)
+	internalInputs[pluginChecksumsKey] = resource.NewProperty(propMap)
 }
 
 // GetProviderChecksums fetches a provider plugin checksums from the given property map.
@@ -121,7 +121,7 @@ func GetProviderChecksums(inputs resource.PropertyMap) (map[string][]byte, error
 // SetProviderURL sets the provider plugin download server URL in the given property map.
 func SetProviderURL(inputs resource.PropertyMap, value string) {
 	internalInputs := addOrGetInternal(inputs)
-	internalInputs[pluginDownloadKey] = resource.NewStringProperty(value)
+	internalInputs[pluginDownloadKey] = resource.NewProperty(value)
 }
 
 // GetProviderDownloadURL fetches a provider plugin download server URL from the given property map.
@@ -148,7 +148,7 @@ func SetProviderVersion(inputs resource.PropertyMap, value *semver.Version) {
 	// __internal, and don't try and look up the key from the root config where a provider may just have a config key
 	// itself of the same text.
 	addOrGetInternal(inputs)
-	inputs[versionKey] = resource.NewStringProperty(value.String())
+	inputs[versionKey] = resource.NewProperty(value.String())
 }
 
 // GetProviderVersion fetches and parses a provider version from the given property map. If the
@@ -184,7 +184,7 @@ func GetProviderVersion(inputs resource.PropertyMap) (*semver.Version, error) {
 // Sets the provider name in the given property map.
 func SetProviderName(inputs resource.PropertyMap, name tokens.Package) {
 	internalInputs := addOrGetInternal(inputs)
-	internalInputs[nameKey] = resource.NewStringProperty(name.String())
+	internalInputs[nameKey] = resource.NewProperty(name.String())
 }
 
 // GetProviderName fetches and parses a provider name from the given property map. If the
@@ -219,9 +219,9 @@ func SetProviderParameterization(inputs resource.PropertyMap, value *workspace.P
 	// SetVersion will have written the base plugin version to inputs["version"], if we're parameterized we need to move
 	// it, and replace it with our package version.
 	internalInputs[versionKey] = inputs[versionKey]
-	inputs[versionKey] = resource.NewStringProperty(value.Version.String())
+	inputs[versionKey] = resource.NewProperty(value.Version.String())
 	// We don't write name here because we can reconstruct that from the providers type token
-	internalInputs[parameterizationKey] = resource.NewStringProperty(
+	internalInputs[parameterizationKey] = resource.NewProperty(
 		base64.StdEncoding.EncodeToString(value.Value))
 }
 

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -299,7 +299,7 @@ func TestNewRegistryOldState(t *testing.T) {
 		newProviderState("pkgC", "a", "id2", true, nil),
 		// One provider from package D with a version
 		newProviderState("pkgD", "a", "id1", false, resource.PropertyMap{
-			"version": resource.NewStringProperty("1.0.0"),
+			"version": resource.NewProperty("1.0.0"),
 		}),
 	}
 	loaders := []*providerLoader{
@@ -737,7 +737,7 @@ func TestCRUDWrongVersion(t *testing.T) {
 
 	typ := MakeProviderType("pkgA")
 	urn := resource.NewURN("test", "test", "", typ, "b")
-	olds, news := resource.PropertyMap{}, resource.PropertyMap{"version": resource.NewStringProperty("1.0.0")}
+	olds, news := resource.PropertyMap{}, resource.PropertyMap{"version": resource.NewProperty("1.0.0")}
 
 	// Check
 	check, err := r.Check(context.Background(), plugin.CheckRequest{
@@ -763,7 +763,7 @@ func TestCRUDBadVersionNotString(t *testing.T) {
 
 	typ := MakeProviderType("pkgA")
 	urn := resource.NewURN("test", "test", "", typ, "b")
-	olds, news := resource.PropertyMap{}, resource.PropertyMap{"version": resource.NewBoolProperty(true)}
+	olds, news := resource.PropertyMap{}, resource.PropertyMap{"version": resource.NewProperty(true)}
 
 	// Check
 	check, err := r.Check(context.Background(), plugin.CheckRequest{
@@ -790,7 +790,7 @@ func TestCRUDBadVersion(t *testing.T) {
 
 	typ := MakeProviderType("pkgA")
 	urn := resource.NewURN("test", "test", "", typ, "b")
-	olds, news := resource.PropertyMap{}, resource.PropertyMap{"version": resource.NewStringProperty("foo")}
+	olds, news := resource.PropertyMap{}, resource.PropertyMap{"version": resource.NewProperty("foo")}
 
 	// Check
 	check, err := r.Check(context.Background(), plugin.CheckRequest{
@@ -883,7 +883,7 @@ func TestConcurrentRegistryUsage(t *testing.T) {
 			}
 
 			// Now check that we can get the provider back.
-			olds, news := resource.PropertyMap{}, resource.PropertyMap{"version": resource.NewBoolProperty(true)}
+			olds, news := resource.PropertyMap{}, resource.PropertyMap{"version": resource.NewProperty(true)}
 
 			// Check
 			check, err := r.Check(context.Background(), plugin.CheckRequest{

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -1956,7 +1956,7 @@ func errorToMessage(err error, inputs resource.PropertyMap) string {
 			message = fmt.Sprintf("%v: %v", message, e.Cause().Message())
 		}
 		if len(e.InputPropertiesErrors()) > 0 {
-			props := resource.NewObjectProperty(inputs)
+			props := resource.NewProperty(inputs)
 			for _, err := range e.InputPropertiesErrors() {
 				propertyPath, e := resource.ParsePropertyPath(err.PropertyPath)
 				if e == nil {
@@ -2913,7 +2913,7 @@ func downgradeOutputValues(v resource.PropertyMap) resource.PropertyMap {
 			if output.Known {
 				result = downgradeOutputPropertyValue(output.Element)
 			} else {
-				result = resource.MakeComputed(resource.NewStringProperty(""))
+				result = resource.MakeComputed(resource.NewProperty(""))
 			}
 			if output.Secret {
 				result = resource.MakeSecret(result)
@@ -2921,21 +2921,21 @@ func downgradeOutputValues(v resource.PropertyMap) resource.PropertyMap {
 			return result
 		}
 		if v.IsObject() {
-			return resource.NewObjectProperty(downgradeOutputValues(v.ObjectValue()))
+			return resource.NewProperty(downgradeOutputValues(v.ObjectValue()))
 		}
 		if v.IsArray() {
 			result := make([]resource.PropertyValue, len(v.ArrayValue()))
 			for i, elem := range v.ArrayValue() {
 				result[i] = downgradeOutputPropertyValue(elem)
 			}
-			return resource.NewArrayProperty(result)
+			return resource.NewProperty(result)
 		}
 		if v.IsSecret() {
 			return resource.MakeSecret(downgradeOutputPropertyValue(v.SecretValue().Element))
 		}
 		if v.IsResourceReference() {
 			ref := v.ResourceReferenceValue()
-			return resource.NewResourceReferenceProperty(
+			return resource.NewProperty(
 				resource.ResourceReference{
 					URN:            ref.URN,
 					ID:             downgradeOutputPropertyValue(ref.ID),
@@ -2984,7 +2984,7 @@ func upgradeOutputValues(
 				currentDeps = currentDeps.Union(deps)
 
 				output.Dependencies = currentDeps.ToSlice()
-				result[k] = resource.NewOutputProperty(output)
+				result[k] = resource.NewProperty(output)
 			}
 		} else {
 			// no deps just copy across

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -2353,7 +2353,7 @@ func TestDefaultProviders(t *testing.T) {
 					config: &configSourceMock{
 						GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
 							return resource.PropertyMap{
-								"disable-default-providers": resource.NewNumberProperty(100),
+								"disable-default-providers": resource.NewProperty(100.0),
 							}, nil
 						},
 					},
@@ -2367,7 +2367,7 @@ func TestDefaultProviders(t *testing.T) {
 					config: &configSourceMock{
 						GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
 							return resource.PropertyMap{
-								"disable-default-providers": resource.NewStringProperty(""),
+								"disable-default-providers": resource.NewProperty(""),
 							}, nil
 						},
 					},
@@ -2383,7 +2383,7 @@ func TestDefaultProviders(t *testing.T) {
 						config: &configSourceMock{
 							GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
 								return resource.PropertyMap{
-									"disable-default-providers": resource.NewStringProperty("[[["),
+									"disable-default-providers": resource.NewProperty("[[["),
 								}, nil
 							},
 						},
@@ -2398,7 +2398,7 @@ func TestDefaultProviders(t *testing.T) {
 						config: &configSourceMock{
 							GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
 								return resource.PropertyMap{
-									"disable-default-providers": resource.NewStringProperty(`["foo", 2, 3]`),
+									"disable-default-providers": resource.NewProperty(`["foo", 2, 3]`),
 								}, nil
 							},
 						},
@@ -2707,7 +2707,7 @@ func TestCall(t *testing.T) {
 				) (plugin.CallResponse, error) {
 					assert.Equal(t,
 						resource.PropertyMap{
-							"test": resource.NewStringProperty("test-value"),
+							"test": resource.NewProperty("test-value"),
 						},
 						req.Args)
 					require.Equal(t, 1, len(req.Options.ArgDependencies))
@@ -2740,7 +2740,7 @@ func TestCall(t *testing.T) {
 		}()
 
 		args, err := plugin.MarshalProperties(resource.PropertyMap{
-			"test": resource.NewStringProperty("test-value"),
+			"test": resource.NewProperty("test-value"),
 		}, plugin.MarshalOptions{})
 		require.NoError(t, err)
 
@@ -2809,7 +2809,7 @@ func TestCall(t *testing.T) {
 		require.NoError(t, err)
 
 		args, err := plugin.MarshalProperties(resource.PropertyMap{
-			"test": resource.NewStringProperty("test-value"),
+			"test": resource.NewProperty("test-value"),
 		}, plugin.MarshalOptions{})
 		require.NoError(t, err)
 
@@ -2868,7 +2868,7 @@ func TestCall(t *testing.T) {
 				CallF: func(context.Context, plugin.CallRequest, *deploytest.ResourceMonitor) (plugin.CallResponse, error) {
 					return plugin.CallResponse{
 						Return: resource.PropertyMap{
-							"result": resource.NewNumberProperty(100),
+							"result": resource.NewProperty(100.0),
 						},
 						ReturnDependencies: map[resource.PropertyKey][]resource.URN{
 							"prop": {
@@ -2890,7 +2890,7 @@ func TestCall(t *testing.T) {
 		require.NoError(t, err)
 
 		args, err := plugin.MarshalProperties(resource.PropertyMap{
-			"test": resource.NewStringProperty("test-value"),
+			"test": resource.NewProperty("test-value"),
 		}, plugin.MarshalOptions{})
 		require.NoError(t, err)
 
@@ -3582,7 +3582,7 @@ func TestValidationFailures(t *testing.T) {
 
 		props := resource.PropertyMap{
 			"testproperty": resource.NewPropertyValue("testvalue"),
-			"nested": resource.NewArrayProperty(
+			"nested": resource.NewProperty(
 				[]resource.PropertyValue{resource.NewPropertyValue("nestedvalue")},
 			),
 		}
@@ -3615,69 +3615,69 @@ func TestDowngradeOutputValues(t *testing.T) {
 		{
 			"plain",
 			resource.PropertyMap{
-				"foo": resource.NewStringProperty("hello"),
-				"bar": resource.NewNumberProperty(42),
+				"foo": resource.NewProperty("hello"),
+				"bar": resource.NewProperty(42.0),
 			},
 			resource.PropertyMap{
-				"foo": resource.NewStringProperty("hello"),
-				"bar": resource.NewNumberProperty(42),
+				"foo": resource.NewProperty("hello"),
+				"bar": resource.NewProperty(42.0),
 			},
 		},
 		{
 			"secret",
 			resource.PropertyMap{
-				"foo": resource.MakeSecret(resource.NewStringProperty("hello")),
+				"foo": resource.MakeSecret(resource.NewProperty("hello")),
 			},
 			resource.PropertyMap{
-				"foo": resource.MakeSecret(resource.NewStringProperty("hello")),
+				"foo": resource.MakeSecret(resource.NewProperty("hello")),
 			},
 		},
 		{
 			"output",
 			resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewStringProperty("hello"),
+				"foo": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("hello"),
 					Known:   true,
 				}),
 			},
 			resource.PropertyMap{
-				"foo": resource.NewStringProperty("hello"),
+				"foo": resource.NewProperty("hello"),
 			},
 		},
 		{
 			"secret output",
 			resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewStringProperty("hello"),
+				"foo": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("hello"),
 					Known:   true,
 					Secret:  true,
 				}),
 			},
 			resource.PropertyMap{
-				"foo": resource.MakeSecret(resource.NewStringProperty("hello")),
+				"foo": resource.MakeSecret(resource.NewProperty("hello")),
 			},
 		},
 		{
 			"unknown output",
 			resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{}),
+				"foo": resource.NewProperty(resource.Output{}),
 			},
 			resource.PropertyMap{
-				"foo": resource.MakeComputed(resource.NewStringProperty("")),
+				"foo": resource.MakeComputed(resource.NewProperty("")),
 			},
 		},
 		{
 			"unknown resource reference",
 			resource.PropertyMap{
-				"foo": resource.NewResourceReferenceProperty(resource.ResourceReference{
+				"foo": resource.NewProperty(resource.ResourceReference{
 					URN: "urn:pulumi:stack::project::package:module:resource::name",
-					ID:  resource.NewOutputProperty(resource.Output{}),
+					ID:  resource.NewProperty(resource.Output{}),
 				}),
 			},
 			resource.PropertyMap{
-				"foo": resource.NewResourceReferenceProperty(resource.ResourceReference{
+				"foo": resource.NewProperty(resource.ResourceReference{
 					URN: "urn:pulumi:stack::project::package:module:resource::name",
-					ID:  resource.MakeComputed(resource.NewStringProperty("")),
+					ID:  resource.MakeComputed(resource.NewProperty("")),
 				}),
 			},
 		},

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -2861,7 +2861,7 @@ func (sg *stepGenerator) calculateDependentReplacements(root *resource.State) ([
 			for _, propertyDep := range r.PropertyDependencies[pk] {
 				if replaceSet[propertyDep] {
 					hasDependencyInReplaceSet = true
-					pv = resource.MakeComputed(resource.NewStringProperty("<unknown>"))
+					pv = resource.MakeComputed(resource.NewProperty("<unknown>"))
 				}
 			}
 			inputsForDiff[pk] = pv

--- a/pkg/resource/deploy/step_generator_test.go
+++ b/pkg/resource/deploy/step_generator_test.go
@@ -327,7 +327,7 @@ func TestEngineDiff(t *testing.T) {
 				"val0": resource.NewPropertyValue(3.14),
 			}),
 			newInputs: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"val1": resource.NewNumberProperty(42),
+				"val1": resource.NewProperty(42.0),
 				"val2": resource.NewPropertyValue("world"),
 			}),
 			expected:        []resource.PropertyKey{"val0", "val1", "val2"},
@@ -339,7 +339,7 @@ func TestEngineDiff(t *testing.T) {
 				"val1": resource.NewPropertyValue(42),
 			}),
 			newInputs: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"val1": resource.NewNumberProperty(42),
+				"val1": resource.NewProperty(42.0),
 				"val2": resource.NewPropertyValue("world"),
 			}),
 			expected:        []resource.PropertyKey{"val2"},

--- a/pkg/resource/deploy/step_test.go
+++ b/pkg/resource/deploy/step_test.go
@@ -456,7 +456,7 @@ func TestUpdateStep(t *testing.T) {
 					UpdateF: func(context.Context, plugin.UpdateRequest) (plugin.UpdateResponse, error) {
 						return plugin.UpdateResponse{
 								Properties: resource.PropertyMap{
-									"key": resource.NewStringProperty("expected-value"),
+									"key": resource.NewProperty("expected-value"),
 								},
 								Status: resource.StatusPartialFailure,
 							}, &plugin.InitError{
@@ -474,7 +474,7 @@ func TestUpdateStep(t *testing.T) {
 			// News should be updated.
 			require.Len(t, s.new.InitErrors, 1)
 			assert.Equal(t, resource.PropertyMap{
-				"key": resource.NewStringProperty("expected-value"),
+				"key": resource.NewProperty("expected-value"),
 			}, s.new.Outputs)
 		})
 	})
@@ -562,10 +562,10 @@ func TestReadStep(t *testing.T) {
 								ReadResult: plugin.ReadResult{
 									ID: "new-id",
 									Inputs: resource.PropertyMap{
-										"inputs-key": resource.NewStringProperty("expected-value"),
+										"inputs-key": resource.NewProperty("expected-value"),
 									},
 									Outputs: resource.PropertyMap{
-										"outputs-key": resource.NewStringProperty("expected-value"),
+										"outputs-key": resource.NewProperty("expected-value"),
 									},
 								},
 								Status: resource.StatusPartialFailure,
@@ -585,7 +585,7 @@ func TestReadStep(t *testing.T) {
 			require.Len(t, s.new.InitErrors, 1)
 			assert.Equal(t, (resource.PropertyMap)(nil), s.new.Inputs)
 			assert.Equal(t, resource.PropertyMap{
-				"outputs-key": resource.NewStringProperty("expected-value"),
+				"outputs-key": resource.NewProperty("expected-value"),
 			}, s.new.Outputs)
 			assert.Equal(t, resource.ID("new-id"), s.new.ID)
 		})
@@ -632,11 +632,11 @@ func TestRefreshStepPatterns(t *testing.T) {
 			name:   "tfbridge 'computed' property changed",
 			inputs: resource.PropertyMap{},
 			outputs: resource.PropertyMap{
-				"etag": resource.NewStringProperty("abc"),
+				"etag": resource.NewProperty("abc"),
 			},
 			readInputs: resource.PropertyMap{},
 			readOutputs: resource.PropertyMap{
-				"etag": resource.NewStringProperty("def"),
+				"etag": resource.NewProperty("def"),
 			},
 			diffResult: plugin.DiffResult{
 				// Diff newInputs, newOutputs, oldInputs
@@ -650,16 +650,16 @@ func TestRefreshStepPatterns(t *testing.T) {
 			// really shouldn't change, but this is common in TF providers.
 			name: "tfbridge 'required' property changed",
 			inputs: resource.PropertyMap{
-				"title": resource.NewStringProperty("test"),
+				"title": resource.NewProperty("test"),
 			},
 			outputs: resource.PropertyMap{
-				"title": resource.NewStringProperty("test"),
+				"title": resource.NewProperty("test"),
 			},
 			readInputs: resource.PropertyMap{
-				"title": resource.NewStringProperty("testtesttest"),
+				"title": resource.NewProperty("testtesttest"),
 			},
 			readOutputs: resource.PropertyMap{
-				"title": resource.NewStringProperty("testtesttest"),
+				"title": resource.NewProperty("testtesttest"),
 			},
 			diffResult: plugin.DiffResult{
 				// Diff newInputs, newOutputs, oldInputs
@@ -678,16 +678,16 @@ func TestRefreshStepPatterns(t *testing.T) {
 			name:          "tfbridge 'required' property changed w/ ignoreChanges",
 			ignoreChanges: []string{"title"},
 			inputs: resource.PropertyMap{
-				"title": resource.NewStringProperty("test"),
+				"title": resource.NewProperty("test"),
 			},
 			outputs: resource.PropertyMap{
-				"title": resource.NewStringProperty("test"),
+				"title": resource.NewProperty("test"),
 			},
 			readInputs: resource.PropertyMap{
-				"title": resource.NewStringProperty("testtesttest"),
+				"title": resource.NewProperty("testtesttest"),
 			},
 			readOutputs: resource.PropertyMap{
-				"title": resource.NewStringProperty("testtesttest"),
+				"title": resource.NewProperty("testtesttest"),
 			},
 			diffResult: plugin.DiffResult{
 				// Diff newInputs, newOutputs, oldInputs
@@ -702,7 +702,7 @@ func TestRefreshStepPatterns(t *testing.T) {
 			name:   "tfbridge 'optional' property changed",
 			inputs: resource.PropertyMap{},
 			outputs: resource.PropertyMap{
-				"body": resource.NewStringProperty(""),
+				"body": resource.NewProperty(""),
 			},
 			readInputs: resource.PropertyMap{
 				// Pretty sure its a bug in tfbridge that it doesn't populate the new value
@@ -710,7 +710,7 @@ func TestRefreshStepPatterns(t *testing.T) {
 				// testing against the current behaviour.
 			},
 			readOutputs: resource.PropertyMap{
-				"body": resource.NewStringProperty("bodybodybody"),
+				"body": resource.NewProperty("bodybodybody"),
 			},
 			diffResult: plugin.DiffResult{
 				// Diff newInputs, newOutputs, oldInputs
@@ -730,7 +730,7 @@ func TestRefreshStepPatterns(t *testing.T) {
 			ignoreChanges: []string{"body"},
 			inputs:        resource.PropertyMap{},
 			outputs: resource.PropertyMap{
-				"body": resource.NewStringProperty(""),
+				"body": resource.NewProperty(""),
 			},
 			readInputs: resource.PropertyMap{
 				// Pretty sure its a bug in tfbridge that it doesn't populate the new value
@@ -738,7 +738,7 @@ func TestRefreshStepPatterns(t *testing.T) {
 				// testing against the current behaviour.
 			},
 			readOutputs: resource.PropertyMap{
-				"body": resource.NewStringProperty("bodybodybody"),
+				"body": resource.NewProperty("bodybodybody"),
 			},
 			diffResult: plugin.DiffResult{
 				// Diff newInputs, newOutputs, oldInputs
@@ -751,12 +751,12 @@ func TestRefreshStepPatterns(t *testing.T) {
 			name:   "tfbridge 'optional+computed' property element added",
 			inputs: resource.PropertyMap{},
 			outputs: resource.PropertyMap{
-				"tags": resource.NewObjectProperty(resource.PropertyMap{}),
+				"tags": resource.NewProperty(resource.PropertyMap{}),
 			},
 			readInputs: resource.PropertyMap{},
 			readOutputs: resource.PropertyMap{
-				"tags": resource.NewObjectProperty((resource.PropertyMap{
-					"foo": resource.NewStringProperty("bar"),
+				"tags": resource.NewProperty((resource.PropertyMap{
+					"foo": resource.NewProperty("bar"),
 				})),
 			},
 			diffResult: plugin.DiffResult{
@@ -775,23 +775,23 @@ func TestRefreshStepPatterns(t *testing.T) {
 		{
 			name: "tfbridge 'optional+computed' property element changed",
 			inputs: resource.PropertyMap{
-				"tags": resource.NewObjectProperty(resource.PropertyMap{
-					"foo": resource.NewStringProperty("bar"),
+				"tags": resource.NewProperty(resource.PropertyMap{
+					"foo": resource.NewProperty("bar"),
 				}),
 			},
 			outputs: resource.PropertyMap{
-				"tags": resource.NewObjectProperty(resource.PropertyMap{
-					"foo": resource.NewStringProperty("bar"),
+				"tags": resource.NewProperty(resource.PropertyMap{
+					"foo": resource.NewProperty("bar"),
 				}),
 			},
 			readInputs: resource.PropertyMap{
-				"tags": resource.NewObjectProperty((resource.PropertyMap{
-					"foo": resource.NewStringProperty("baz"),
+				"tags": resource.NewProperty((resource.PropertyMap{
+					"foo": resource.NewProperty("baz"),
 				})),
 			},
 			readOutputs: resource.PropertyMap{
-				"tags": resource.NewObjectProperty((resource.PropertyMap{
-					"foo": resource.NewStringProperty("baz"),
+				"tags": resource.NewProperty((resource.PropertyMap{
+					"foo": resource.NewProperty("baz"),
 				})),
 			},
 			diffResult: plugin.DiffResult{
@@ -917,10 +917,10 @@ func TestRefreshStep(t *testing.T) {
 							ReadResult: plugin.ReadResult{
 								ID: "new-id",
 								Inputs: resource.PropertyMap{
-									"inputs-key": resource.NewStringProperty("expected-value"),
+									"inputs-key": resource.NewProperty("expected-value"),
 								},
 								Outputs: resource.PropertyMap{
-									"outputs-key": resource.NewStringProperty("expected-value"),
+									"outputs-key": resource.NewProperty("expected-value"),
 								},
 							},
 							Status: resource.StatusPartialFailure,
@@ -938,7 +938,7 @@ func TestRefreshStep(t *testing.T) {
 			// News should be updated.
 			require.Len(t, s.new.InitErrors, 1)
 			assert.Equal(t, resource.PropertyMap{
-				"outputs-key": resource.NewStringProperty("expected-value"),
+				"outputs-key": resource.NewProperty("expected-value"),
 			}, s.new.Outputs)
 			assert.Equal(t, resource.ID("new-id"), s.new.ID)
 		})

--- a/pkg/resource/deploy/target.go
+++ b/pkg/resource/deploy/target.go
@@ -60,7 +60,7 @@ func (t *Target) GetPackageConfig(pkg tokens.Package) (resource.PropertyMap, err
 			return nil, err
 		}
 
-		propertyValue := resource.NewStringProperty(v)
+		propertyValue := resource.NewProperty(v)
 		if c.Secure() {
 			propertyValue = resource.MakeSecret(propertyValue)
 		}

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -718,14 +718,14 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter,
 	if v != nil {
 		switch w := v.(type) {
 		case bool:
-			return resource.NewBoolProperty(w), nil
+			return resource.NewProperty(w), nil
 		case float64:
-			return resource.NewNumberProperty(w), nil
+			return resource.NewProperty(w), nil
 		case string:
 			if w == computedValuePlaceholder {
-				return resource.MakeComputed(resource.NewStringProperty("")), nil
+				return resource.MakeComputed(resource.NewProperty("")), nil
 			}
-			return resource.NewStringProperty(w), nil
+			return resource.NewProperty(w), nil
 		case []interface{}:
 			arr := make([]resource.PropertyValue, len(w))
 			for i, elem := range w {
@@ -735,7 +735,7 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter,
 				}
 				arr[i] = ev
 			}
-			return resource.NewArrayProperty(arr), nil
+			return resource.NewProperty(arr), nil
 		case map[string]interface{}:
 			obj, err := DeserializeProperties(w, dec)
 			if err != nil {
@@ -752,14 +752,14 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter,
 						return resource.PropertyValue{}, err
 					}
 					contract.Assertf(isasset, "resource with asset signature is not an asset")
-					return resource.NewAssetProperty(asset), nil
+					return resource.NewProperty(asset), nil
 				case archive.ArchiveSig:
 					archive, isarchive, err := archive.Deserialize(objmap)
 					if err != nil {
 						return resource.PropertyValue{}, err
 					}
 					contract.Assertf(isarchive, "resource with archive signature is not an archive")
-					return resource.NewArchiveProperty(archive), nil
+					return resource.NewProperty(archive), nil
 				case resource.SecretSig:
 					prop := resource.MakeSecret(resource.NewNullProperty())
 					secret := prop.SecretValue()
@@ -856,7 +856,7 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter,
 			}
 
 			// Otherwise, it's just a weakly typed object map.
-			return resource.NewObjectProperty(obj), nil
+			return resource.NewProperty(obj), nil
 		default:
 			contract.Failf("Unrecognized property type %T: %v", v, reflect.ValueOf(v))
 		}

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -451,7 +451,7 @@ func TestCustomSerialization(t *testing.T) {
 	textAsset, err := rasset.FromText("alpha beta gamma")
 	require.NoError(t, err)
 
-	strProp := resource.NewStringProperty("strProp")
+	strProp := resource.NewProperty("strProp")
 
 	computed := resource.Computed{Element: strProp}
 	output := resource.Output{Element: strProp}
@@ -727,12 +727,12 @@ func TestSerializePropertyValue_ShowSecrets(t *testing.T) {
 	ctx := context.Background()
 	crypter := config.NewPanicCrypter()
 
-	secret := resource.MakeSecret(resource.NewStringProperty("secret"))
+	secret := resource.MakeSecret(resource.NewProperty("secret"))
 	_, err := SerializePropertyValue(ctx, secret, crypter, true)
 	require.NoError(t, err)
 
-	secret = resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
-		resource.MakeSecret(resource.NewStringProperty("secret")),
+	secret = resource.MakeSecret(resource.NewProperty([]resource.PropertyValue{
+		resource.MakeSecret(resource.NewProperty("secret")),
 	}))
 	_, err = SerializePropertyValue(ctx, secret, crypter, true)
 	require.NoError(t, err)
@@ -800,7 +800,7 @@ func replaceOutputsWithComputed(v resource.PropertyValue) resource.PropertyValue
 			o[k] = replaceOutputsWithComputed(v)
 		}
 	case v.IsOutput():
-		return resource.MakeComputed(resource.NewStringProperty(""))
+		return resource.MakeComputed(resource.NewProperty(""))
 	case v.IsSecret():
 		v.SecretValue().Element = replaceOutputsWithComputed(v.SecretValue().Element)
 	}

--- a/pkg/resource/stack/secrets_test.go
+++ b/pkg/resource/stack/secrets_test.go
@@ -118,9 +118,9 @@ func TestCachingSecretsManager(t *testing.T) {
 	sm := &testSecretsManager{}
 	csm := NewBatchingCachingSecretsManager(sm)
 
-	foo1 := resource.MakeSecret(resource.NewStringProperty("foo"))
-	foo2 := resource.MakeSecret(resource.NewStringProperty("foo"))
-	bar := resource.MakeSecret(resource.NewStringProperty("bar"))
+	foo1 := resource.MakeSecret(resource.NewProperty("foo"))
+	foo2 := resource.MakeSecret(resource.NewProperty("foo"))
+	bar := resource.MakeSecret(resource.NewProperty("bar"))
 
 	// Serialize the first copy of "foo". Encrypt should be called once, as this value has not yet been encrypted.
 	enc, completeEnc := csm.BeginBatchEncryption()
@@ -478,7 +478,7 @@ func TestBatchDecrypter(t *testing.T) {
 		require.NoError(t, dec.Enqueue(ctx, "1-1:\"plaintext\"", secret), "enqueue")
 		require.NoError(t, complete(ctx), "complete")
 
-		assert.Equal(t, resource.MakeSecret(resource.NewStringProperty("plaintext")).SecretValue(), secret)
+		assert.Equal(t, resource.MakeSecret(resource.NewProperty("plaintext")).SecretValue(), secret)
 		assert.Equal(t, 1, sm.batchDecryptCalls)
 	})
 
@@ -493,10 +493,10 @@ func TestBatchDecrypter(t *testing.T) {
 		require.NoError(t, dec.Enqueue(ctx, "1-1:\"plaintext1\"", secret1), "enqueue 1")
 		require.NoError(t, dec.Enqueue(ctx, "2-1:\"plaintext2\"", secret2), "enqueue 2")
 		assert.Equal(t, 1, sm.batchDecryptCalls, "first batch auto-sent on limit reached")
-		assert.Equal(t, resource.MakeSecret(resource.NewStringProperty("plaintext1")).SecretValue(), secret1)
+		assert.Equal(t, resource.MakeSecret(resource.NewProperty("plaintext1")).SecretValue(), secret1)
 
 		require.NoError(t, complete(ctx), "complete")
-		assert.Equal(t, resource.MakeSecret(resource.NewStringProperty("plaintext2")).SecretValue(), secret2)
+		assert.Equal(t, resource.MakeSecret(resource.NewProperty("plaintext2")).SecretValue(), secret2)
 		assert.Equal(t, 2, sm.batchDecryptCalls)
 	})
 
@@ -513,7 +513,7 @@ func TestBatchDecrypter(t *testing.T) {
 		require.NoError(t, dec.Enqueue(ctx, ciphertext, secret), "enqueue")
 
 		require.NoError(t, complete(ctx), "complete")
-		assert.Equal(t, resource.MakeSecret(resource.NewStringProperty("plaintext")).SecretValue(), secret)
+		assert.Equal(t, resource.MakeSecret(resource.NewProperty("plaintext")).SecretValue(), secret)
 		assert.Equal(t, 0, sm.batchDecryptCalls)
 	})
 
@@ -533,8 +533,8 @@ func TestBatchDecrypter(t *testing.T) {
 		require.NoError(t, dec.Enqueue(ctx, ciphertext2, secret2), "enqueue 2")
 
 		require.NoError(t, complete(ctx), "complete")
-		assert.Equal(t, resource.MakeSecret(resource.NewStringProperty("plaintext 1")).SecretValue(), secret1)
-		assert.Equal(t, resource.MakeSecret(resource.NewStringProperty("plaintext 2")).SecretValue(), secret2)
+		assert.Equal(t, resource.MakeSecret(resource.NewProperty("plaintext 1")).SecretValue(), secret1)
+		assert.Equal(t, resource.MakeSecret(resource.NewProperty("plaintext 2")).SecretValue(), secret2)
 		assert.Equal(t, 1, sm.batchDecryptCalls)
 	})
 

--- a/sdk/go/common/resource/config/map_test.go
+++ b/sdk/go/common/resource/config/map_test.go
@@ -1453,7 +1453,7 @@ func TestPropertyMap(t *testing.T) {
 				MustMakeKey("my", "testKey"): NewValue("testValue"),
 			},
 			Expected: resource.PropertyMap{
-				"my:testKey": resource.NewStringProperty("testValue"),
+				"my:testKey": resource.NewProperty("testValue"),
 			},
 		},
 		{
@@ -1461,7 +1461,7 @@ func TestPropertyMap(t *testing.T) {
 				MustMakeKey("my", "testKey"): NewValue("1"),
 			},
 			Expected: resource.PropertyMap{
-				"my:testKey": resource.NewNumberProperty(1.0),
+				"my:testKey": resource.NewProperty(1.0),
 			},
 		},
 		{
@@ -1469,7 +1469,7 @@ func TestPropertyMap(t *testing.T) {
 				MustMakeKey("my", "testKey"): NewValue("18446744073709551615"),
 			},
 			Expected: resource.PropertyMap{
-				"my:testKey": resource.NewNumberProperty(1.8446744073709552e+19),
+				"my:testKey": resource.NewProperty(1.8446744073709552e+19),
 			},
 		},
 		{
@@ -1477,7 +1477,7 @@ func TestPropertyMap(t *testing.T) {
 				MustMakeKey("my", "testKey"): NewValue("true"),
 			},
 			Expected: resource.PropertyMap{
-				"my:testKey": resource.NewBoolProperty(true),
+				"my:testKey": resource.NewProperty(true),
 			},
 		},
 		{
@@ -1485,7 +1485,7 @@ func TestPropertyMap(t *testing.T) {
 				MustMakeKey("my", "testKey"): NewSecureValue("stackAsecurevalue"),
 			},
 			Expected: resource.PropertyMap{
-				"my:testKey": resource.MakeSecret(resource.NewStringProperty("stackAsecurevalue")),
+				"my:testKey": resource.MakeSecret(resource.NewProperty("stackAsecurevalue")),
 			},
 		},
 		{
@@ -1493,8 +1493,8 @@ func TestPropertyMap(t *testing.T) {
 				MustMakeKey("my", "testKey"): NewObjectValue(`{"inner":"value"}`),
 			},
 			Expected: resource.PropertyMap{
-				"my:testKey": resource.NewObjectProperty(resource.PropertyMap{
-					"inner": resource.NewStringProperty("value"),
+				"my:testKey": resource.NewProperty(resource.PropertyMap{
+					"inner": resource.NewProperty("value"),
 				}),
 			},
 		},
@@ -1505,11 +1505,11 @@ func TestPropertyMap(t *testing.T) {
 			},
 			Expected: resource.PropertyMap{
 				//nolint:lll
-				"my:testKey": resource.NewArrayProperty([]resource.PropertyValue{
-					resource.NewObjectProperty(resource.PropertyMap{
-						"inner": resource.MakeSecret(resource.NewStringProperty("stackAsecurevalue")),
+				"my:testKey": resource.NewProperty([]resource.PropertyValue{
+					resource.NewProperty(resource.PropertyMap{
+						"inner": resource.MakeSecret(resource.NewProperty("stackAsecurevalue")),
 					}),
-					resource.MakeSecret(resource.NewStringProperty("stackAsecurevalue2")),
+					resource.MakeSecret(resource.NewProperty("stackAsecurevalue2")),
 				}),
 			},
 		},
@@ -1518,7 +1518,7 @@ func TestPropertyMap(t *testing.T) {
 				MustMakeKey("my", "test.Key"): NewValue("testValue"),
 			},
 			Expected: resource.PropertyMap{
-				"my:test.Key": resource.NewStringProperty("testValue"),
+				"my:test.Key": resource.NewProperty("testValue"),
 			},
 		},
 		{
@@ -1526,9 +1526,9 @@ func TestPropertyMap(t *testing.T) {
 				MustMakeKey("my", "name"): NewObjectValue(`[["value"]]`),
 			},
 			Expected: resource.PropertyMap{
-				"my:name": resource.NewArrayProperty([]resource.PropertyValue{
-					resource.NewArrayProperty([]resource.PropertyValue{
-						resource.NewStringProperty("value"),
+				"my:name": resource.NewProperty([]resource.PropertyValue{
+					resource.NewProperty([]resource.PropertyValue{
+						resource.NewProperty("value"),
 					}),
 				}),
 			},

--- a/sdk/go/common/resource/config/plaintext.go
+++ b/sdk/go/common/resource/config/plaintext.go
@@ -109,27 +109,27 @@ func (c Plaintext) PropertyValue() resource.PropertyValue {
 	var prop resource.PropertyValue
 	switch v := c.Value().(type) {
 	case bool:
-		prop = resource.NewBoolProperty(v)
+		prop = resource.NewProperty(v)
 	case int64:
-		prop = resource.NewNumberProperty(float64(v))
+		prop = resource.NewProperty(float64(v))
 	case uint64:
-		prop = resource.NewNumberProperty(float64(v))
+		prop = resource.NewProperty(float64(v))
 	case float64:
-		prop = resource.NewNumberProperty(v)
+		prop = resource.NewProperty(v)
 	case string:
-		prop = resource.NewStringProperty(v)
+		prop = resource.NewProperty(v)
 	case []Plaintext:
 		vs := make([]resource.PropertyValue, len(v))
 		for i, v := range v {
 			vs[i] = v.PropertyValue()
 		}
-		prop = resource.NewArrayProperty(vs)
+		prop = resource.NewProperty(vs)
 	case map[string]Plaintext:
-		vs := make(map[resource.PropertyKey]resource.PropertyValue, len(v))
+		vs := make(resource.PropertyMap, len(v))
 		for k, v := range v {
 			vs[resource.PropertyKey(k)] = v.PropertyValue()
 		}
-		prop = resource.NewObjectProperty(vs)
+		prop = resource.NewProperty(vs)
 	case nil:
 		prop = resource.NewNullProperty()
 	default:

--- a/sdk/go/common/resource/plugin/provider_plugin_test.go
+++ b/sdk/go/common/resource/plugin/provider_plugin_test.go
@@ -44,44 +44,44 @@ func TestAnnotateSecrets(t *testing.T) {
 	t.Parallel()
 
 	from := resource.PropertyMap{
-		"stringValue": resource.MakeSecret(resource.NewStringProperty("hello")),
-		"numberValue": resource.MakeSecret(resource.NewNumberProperty(1.00)),
-		"boolValue":   resource.MakeSecret(resource.NewBoolProperty(true)),
-		"secretArrayValue": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("a"),
-			resource.NewStringProperty("b"),
-			resource.NewStringProperty("c"),
+		"stringValue": resource.MakeSecret(resource.NewProperty("hello")),
+		"numberValue": resource.MakeSecret(resource.NewProperty(1.00)),
+		"boolValue":   resource.MakeSecret(resource.NewProperty(true)),
+		"secretArrayValue": resource.MakeSecret(resource.NewProperty([]resource.PropertyValue{
+			resource.NewProperty("a"),
+			resource.NewProperty("b"),
+			resource.NewProperty("c"),
 		})),
-		"secretObjectValue": resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
-			"a": resource.NewStringProperty("aValue"),
-			"b": resource.NewStringProperty("bValue"),
-			"c": resource.NewStringProperty("cValue"),
+		"secretObjectValue": resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+			"a": resource.NewProperty("aValue"),
+			"b": resource.NewProperty("bValue"),
+			"c": resource.NewProperty("cValue"),
 		})),
-		"objectWithSecretValue": resource.NewObjectProperty(resource.PropertyMap{
-			"a": resource.NewStringProperty("aValue"),
-			"b": resource.MakeSecret(resource.NewStringProperty("bValue")),
-			"c": resource.NewStringProperty("cValue"),
+		"objectWithSecretValue": resource.NewProperty(resource.PropertyMap{
+			"a": resource.NewProperty("aValue"),
+			"b": resource.MakeSecret(resource.NewProperty("bValue")),
+			"c": resource.NewProperty("cValue"),
 		}),
 	}
 
 	to := resource.PropertyMap{
-		"stringValue": resource.NewStringProperty("hello"),
-		"numberValue": resource.NewNumberProperty(1.00),
-		"boolValue":   resource.NewBoolProperty(true),
-		"secretArrayValue": resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("a"),
-			resource.NewStringProperty("b"),
-			resource.NewStringProperty("c"),
+		"stringValue": resource.NewProperty("hello"),
+		"numberValue": resource.NewProperty(1.00),
+		"boolValue":   resource.NewProperty(true),
+		"secretArrayValue": resource.NewProperty([]resource.PropertyValue{
+			resource.NewProperty("a"),
+			resource.NewProperty("b"),
+			resource.NewProperty("c"),
 		}),
-		"secretObjectValue": resource.NewObjectProperty(resource.PropertyMap{
-			"a": resource.NewStringProperty("aValue"),
-			"b": resource.NewStringProperty("bValue"),
-			"c": resource.NewStringProperty("cValue"),
+		"secretObjectValue": resource.NewProperty(resource.PropertyMap{
+			"a": resource.NewProperty("aValue"),
+			"b": resource.NewProperty("bValue"),
+			"c": resource.NewProperty("cValue"),
 		}),
-		"objectWithSecretValue": resource.NewObjectProperty(resource.PropertyMap{
-			"a": resource.NewStringProperty("aValue"),
-			"b": resource.NewStringProperty("bValue"),
-			"c": resource.NewStringProperty("cValue"),
+		"objectWithSecretValue": resource.NewProperty(resource.PropertyMap{
+			"a": resource.NewProperty("aValue"),
+			"b": resource.NewProperty("bValue"),
+			"c": resource.NewProperty("cValue"),
 		}),
 	}
 
@@ -97,37 +97,37 @@ func TestAnnotateSecretsDifferentProperties(t *testing.T) {
 	// are not present in from stay in to, but any secretness is propigated for shared keys.
 
 	from := resource.PropertyMap{
-		"stringValue": resource.MakeSecret(resource.NewStringProperty("hello")),
-		"numberValue": resource.MakeSecret(resource.NewNumberProperty(1.00)),
-		"boolValue":   resource.MakeSecret(resource.NewBoolProperty(true)),
-		"secretObjectValue": resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
-			"a": resource.NewStringProperty("aValue"),
-			"b": resource.NewStringProperty("bValue"),
-			"c": resource.NewStringProperty("cValue"),
+		"stringValue": resource.MakeSecret(resource.NewProperty("hello")),
+		"numberValue": resource.MakeSecret(resource.NewProperty(1.00)),
+		"boolValue":   resource.MakeSecret(resource.NewProperty(true)),
+		"secretObjectValue": resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+			"a": resource.NewProperty("aValue"),
+			"b": resource.NewProperty("bValue"),
+			"c": resource.NewProperty("cValue"),
 		})),
-		"objectWithSecretValue": resource.NewObjectProperty(resource.PropertyMap{
-			"a": resource.NewStringProperty("aValue"),
-			"b": resource.MakeSecret(resource.NewStringProperty("bValue")),
-			"c": resource.NewStringProperty("cValue"),
+		"objectWithSecretValue": resource.NewProperty(resource.PropertyMap{
+			"a": resource.NewProperty("aValue"),
+			"b": resource.MakeSecret(resource.NewProperty("bValue")),
+			"c": resource.NewProperty("cValue"),
 		}),
-		"extraFromValue": resource.NewStringProperty("extraFromValue"),
+		"extraFromValue": resource.NewProperty("extraFromValue"),
 	}
 
 	to := resource.PropertyMap{
-		"stringValue": resource.NewStringProperty("hello"),
-		"numberValue": resource.NewNumberProperty(1.00),
-		"boolValue":   resource.NewBoolProperty(true),
-		"secretObjectValue": resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
-			"a": resource.NewStringProperty("aValue"),
-			"b": resource.NewStringProperty("bValue"),
-			"c": resource.NewStringProperty("cValue"),
+		"stringValue": resource.NewProperty("hello"),
+		"numberValue": resource.NewProperty(1.00),
+		"boolValue":   resource.NewProperty(true),
+		"secretObjectValue": resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+			"a": resource.NewProperty("aValue"),
+			"b": resource.NewProperty("bValue"),
+			"c": resource.NewProperty("cValue"),
 		})),
-		"objectWithSecretValue": resource.NewObjectProperty(resource.PropertyMap{
-			"a": resource.NewStringProperty("aValue"),
-			"b": resource.NewStringProperty("bValue"),
-			"c": resource.NewStringProperty("cValue"),
+		"objectWithSecretValue": resource.NewProperty(resource.PropertyMap{
+			"a": resource.NewProperty("aValue"),
+			"b": resource.NewProperty("bValue"),
+			"c": resource.NewProperty("cValue"),
 		}),
-		"extraToValue": resource.NewStringProperty("extraToValue"),
+		"extraToValue": resource.NewProperty("extraToValue"),
 	}
 
 	annotateSecrets(to, from)
@@ -152,41 +152,41 @@ func TestAnnotateSecretsArrays(t *testing.T) {
 	t.Parallel()
 
 	from := resource.PropertyMap{
-		"secretArray": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("a"),
-			resource.NewStringProperty("b"),
-			resource.NewStringProperty("c"),
+		"secretArray": resource.MakeSecret(resource.NewProperty([]resource.PropertyValue{
+			resource.NewProperty("a"),
+			resource.NewProperty("b"),
+			resource.NewProperty("c"),
 		})),
-		"arrayWithSecrets": resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("a"),
-			resource.MakeSecret(resource.NewStringProperty("b")),
-			resource.NewStringProperty("c"),
+		"arrayWithSecrets": resource.NewProperty([]resource.PropertyValue{
+			resource.NewProperty("a"),
+			resource.MakeSecret(resource.NewProperty("b")),
+			resource.NewProperty("c"),
 		}),
 	}
 
 	to := resource.PropertyMap{
-		"secretArray": resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("a"),
-			resource.NewStringProperty("b"),
-			resource.NewStringProperty("c"),
+		"secretArray": resource.NewProperty([]resource.PropertyValue{
+			resource.NewProperty("a"),
+			resource.NewProperty("b"),
+			resource.NewProperty("c"),
 		}),
-		"arrayWithSecrets": resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("a"),
-			resource.NewStringProperty("c"),
-			resource.NewStringProperty("b"),
+		"arrayWithSecrets": resource.NewProperty([]resource.PropertyValue{
+			resource.NewProperty("a"),
+			resource.NewProperty("c"),
+			resource.NewProperty("b"),
 		}),
 	}
 
 	expected := resource.PropertyMap{
-		"secretArray": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("a"),
-			resource.NewStringProperty("b"),
-			resource.NewStringProperty("c"),
+		"secretArray": resource.MakeSecret(resource.NewProperty([]resource.PropertyValue{
+			resource.NewProperty("a"),
+			resource.NewProperty("b"),
+			resource.NewProperty("c"),
 		})),
-		"arrayWithSecrets": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("a"),
-			resource.NewStringProperty("c"),
-			resource.NewStringProperty("b"),
+		"arrayWithSecrets": resource.MakeSecret(resource.NewProperty([]resource.PropertyValue{
+			resource.NewProperty("a"),
+			resource.NewProperty("c"),
+			resource.NewProperty("b"),
 		})),
 	}
 
@@ -199,59 +199,59 @@ func TestNestedSecret(t *testing.T) {
 	t.Parallel()
 
 	from := resource.PropertyMap{
-		"secretString": resource.MakeSecret(resource.NewStringProperty("shh")),
-		"secretArray": resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("hello"),
-			resource.MakeSecret(resource.NewStringProperty("shh")),
-			resource.NewStringProperty("goodbye"),
+		"secretString": resource.MakeSecret(resource.NewProperty("shh")),
+		"secretArray": resource.NewProperty([]resource.PropertyValue{
+			resource.NewProperty("hello"),
+			resource.MakeSecret(resource.NewProperty("shh")),
+			resource.NewProperty("goodbye"),
 		}),
-		"secretMap": resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
-			"a": resource.NewStringProperty("a"),
-			"b": resource.NewStringProperty("b"),
+		"secretMap": resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+			"a": resource.NewProperty("a"),
+			"b": resource.NewProperty("b"),
 		})),
-		"deepSecretMap": resource.NewObjectProperty(resource.PropertyMap{
-			"a": resource.NewStringProperty("a"),
-			"b": resource.MakeSecret(resource.NewStringProperty("b")),
+		"deepSecretMap": resource.NewProperty(resource.PropertyMap{
+			"a": resource.NewProperty("a"),
+			"b": resource.MakeSecret(resource.NewProperty("b")),
 		}),
 	}
 
 	to := resource.PropertyMap{
-		"secretString": resource.NewStringProperty("shh"),
-		"secretArray": resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("shh"),
-			resource.NewStringProperty("hello"),
-			resource.NewStringProperty("goodbye"),
+		"secretString": resource.NewProperty("shh"),
+		"secretArray": resource.NewProperty([]resource.PropertyValue{
+			resource.NewProperty("shh"),
+			resource.NewProperty("hello"),
+			resource.NewProperty("goodbye"),
 		}),
-		"secretMap": resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
-			"a": resource.NewStringProperty("a"),
-			"b": resource.NewStringProperty("b"),
+		"secretMap": resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+			"a": resource.NewProperty("a"),
+			"b": resource.NewProperty("b"),
 		})),
-		"deepSecretMap": resource.NewObjectProperty(resource.PropertyMap{
-			"a": resource.NewStringProperty("a"),
-			"b": resource.NewStringProperty("b"),
+		"deepSecretMap": resource.NewProperty(resource.PropertyMap{
+			"a": resource.NewProperty("a"),
+			"b": resource.NewProperty("b"),
 			// Note the additional property here, which we expect to be kept when annotating.
-			"c": resource.NewStringProperty("c"),
+			"c": resource.NewProperty("c"),
 		}),
 	}
 
 	expected := resource.PropertyMap{
-		"secretString": resource.MakeSecret(resource.NewStringProperty("shh")),
+		"secretString": resource.MakeSecret(resource.NewProperty("shh")),
 		// The entire array has been marked a secret because it contained a secret member in from. Since arrays
 		// are often used for sets, we didn't try to apply the secretness to a specific member of the array, like
 		// we would have with maps (where we can use the keys to correlate related properties)
-		"secretArray": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("shh"),
-			resource.NewStringProperty("hello"),
-			resource.NewStringProperty("goodbye"),
+		"secretArray": resource.MakeSecret(resource.NewProperty([]resource.PropertyValue{
+			resource.NewProperty("shh"),
+			resource.NewProperty("hello"),
+			resource.NewProperty("goodbye"),
 		})),
-		"secretMap": resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
-			"a": resource.NewStringProperty("a"),
-			"b": resource.NewStringProperty("b"),
+		"secretMap": resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+			"a": resource.NewProperty("a"),
+			"b": resource.NewProperty("b"),
 		})),
-		"deepSecretMap": resource.NewObjectProperty(resource.PropertyMap{
-			"a": resource.NewStringProperty("a"),
-			"b": resource.MakeSecret(resource.NewStringProperty("b")),
-			"c": resource.NewStringProperty("c"),
+		"deepSecretMap": resource.NewProperty(resource.PropertyMap{
+			"a": resource.NewProperty("a"),
+			"b": resource.MakeSecret(resource.NewProperty("b")),
+			"c": resource.NewProperty("c"),
 		}),
 	}
 
@@ -265,23 +265,23 @@ func TestRestoreElidedAssetContents(t *testing.T) {
 	textAsset := func(text string) resource.PropertyValue {
 		asset, err := asset.FromText(text)
 		require.NoError(t, err)
-		return resource.NewAssetProperty(asset)
+		return resource.NewProperty(asset)
 	}
 
 	original := resource.PropertyMap{
 		"source": textAsset("Hello world"),
-		"nested": resource.NewObjectProperty(resource.PropertyMap{
+		"nested": resource.NewProperty(resource.PropertyMap{
 			"another":      textAsset("Another"),
 			"doubleNested": textAsset("Double nested"),
-			"tripleNested": resource.NewObjectProperty(resource.PropertyMap{
+			"tripleNested": resource.NewProperty(resource.PropertyMap{
 				"secret": resource.MakeSecret(textAsset("Secret content")),
 			}),
 		}),
-		"insideArray": resource.NewArrayProperty([]resource.PropertyValue{
+		"insideArray": resource.NewProperty([]resource.PropertyValue{
 			textAsset("First"),
 			textAsset("Second"),
-			resource.NewObjectProperty(resource.PropertyMap{
-				"nestedArray": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewProperty(resource.PropertyMap{
+				"nestedArray": resource.NewProperty([]resource.PropertyValue{
 					textAsset("Nested array"),
 					resource.MakeSecret(textAsset("another secret content")),
 				}),
@@ -347,7 +347,7 @@ func TestProvider_DeleteRequests(t *testing.T) {
 				ID:  id,
 				URN: urn,
 				Inputs: resource.PropertyMap{
-					"foo": resource.NewStringProperty("bar"),
+					"foo": resource.NewProperty("bar"),
 				},
 			},
 			want: &pulumirpc.DeleteRequest{
@@ -369,7 +369,7 @@ func TestProvider_DeleteRequests(t *testing.T) {
 				ID:  id,
 				URN: urn,
 				Outputs: resource.PropertyMap{
-					"baz": resource.NewStringProperty("quux"),
+					"baz": resource.NewProperty("quux"),
 				},
 			},
 			want: &pulumirpc.DeleteRequest{
@@ -408,10 +408,10 @@ func TestProvider_DeleteRequests(t *testing.T) {
 				ID:  id,
 				URN: urn,
 				Inputs: resource.PropertyMap{
-					"foo": resource.NewStringProperty("bar"),
+					"foo": resource.NewProperty("bar"),
 				},
 				Outputs: resource.PropertyMap{
-					"baz": resource.NewStringProperty("quux"),
+					"baz": resource.NewProperty("quux"),
 				},
 				Timeout: 30,
 			},
@@ -735,8 +735,8 @@ func TestProvider_ConfigureDeleteRace(t *testing.T) {
 	p := NewProviderWithClient(newTestContext(t), "foo", client, false /* disablePreview */)
 
 	props := resource.PropertyMap{
-		"foo": resource.NewSecretProperty(&resource.Secret{
-			Element: resource.NewStringProperty("bar"),
+		"foo": resource.NewProperty(&resource.Secret{
+			Element: resource.NewProperty("bar"),
 		}),
 	}
 

--- a/sdk/go/common/resource/plugin/provider_server_test.go
+++ b/sdk/go/common/resource/plugin/provider_server_test.go
@@ -98,8 +98,8 @@ func TestProviderServer_Read_respects_ID(t *testing.T) {
 			return ReadResult{
 				ID: resource.ID("none"),
 				Outputs: resource.NewPropertyMapFromMap(map[string]interface{}{
-					"result": resource.NewSecretProperty(&resource.Secret{
-						Element: resource.NewStringProperty(string(id)),
+					"result": resource.NewProperty(&resource.Secret{
+						Element: resource.NewProperty(string(id)),
 					}),
 				}),
 			}, resource.StatusOK, nil

--- a/sdk/go/common/resource/plugin/provider_test.go
+++ b/sdk/go/common/resource/plugin/provider_test.go
@@ -173,9 +173,9 @@ func TestNewDetailedDiffFromObjectDiff(t *testing.T) {
 		"nested update": {
 			diff: &resource.ObjectDiff{
 				Updates: map[resource.PropertyKey]resource.ValueDiff{
-					"a": *resource.NewObjectProperty(resource.PropertyMap{
+					"a": *resource.NewProperty(resource.PropertyMap{
 						"b": resource.NewPropertyValue(1),
-					}).Diff(resource.NewObjectProperty(resource.PropertyMap{
+					}).Diff(resource.NewProperty(resource.PropertyMap{
 						"b": resource.NewPropertyValue(2),
 					})),
 				},
@@ -190,10 +190,10 @@ func TestNewDetailedDiffFromObjectDiff(t *testing.T) {
 		"nested update with quoted keys": {
 			diff: &resource.ObjectDiff{
 				Updates: map[resource.PropertyKey]resource.ValueDiff{
-					"a": *resource.NewObjectProperty(resource.PropertyMap{
+					"a": *resource.NewProperty(resource.PropertyMap{
 						"b.c":          resource.NewPropertyValue(1),
 						`"quoted key"`: resource.NewPropertyValue(2),
-					}).Diff(resource.NewObjectProperty(resource.PropertyMap{
+					}).Diff(resource.NewProperty(resource.PropertyMap{
 						"b.c":          resource.NewPropertyValue(2),
 						`"quoted key"`: resource.NewPropertyValue(3),
 					})),

--- a/sdk/go/common/resource/plugin/rpc.go
+++ b/sdk/go/common/resource/plugin/rpc.go
@@ -150,8 +150,8 @@ func MarshalPropertyValue(key resource.PropertyKey, v resource.PropertyValue,
 			return nil, fmt.Errorf("unexpected unknown property value for %q", key)
 		} else if opts.KeepUnknowns {
 			if opts.KeepOutputValues && opts.UpgradeToOutputValues {
-				output := resource.NewObjectProperty(resource.PropertyMap{
-					resource.SigKey: resource.NewStringProperty(resource.OutputValueSig),
+				output := resource.NewProperty(resource.PropertyMap{
+					resource.SigKey: resource.NewProperty(resource.OutputValueSig),
 				})
 				return MarshalPropertyValue(key, output, opts)
 			}
@@ -163,7 +163,7 @@ func MarshalPropertyValue(key resource.PropertyKey, v resource.PropertyValue,
 			result := v.OutputValue().Element
 			if !v.OutputValue().Known {
 				// Unknown outputs are marshaled the same as Computed.
-				result = resource.MakeComputed(resource.NewStringProperty(""))
+				result = resource.MakeComputed(resource.NewProperty(""))
 			}
 			if v.OutputValue().Secret {
 				result = resource.MakeSecret(result)
@@ -171,22 +171,22 @@ func MarshalPropertyValue(key resource.PropertyKey, v resource.PropertyValue,
 			return MarshalPropertyValue(key, result, opts)
 		}
 		obj := resource.PropertyMap{
-			resource.SigKey: resource.NewStringProperty(resource.OutputValueSig),
+			resource.SigKey: resource.NewProperty(resource.OutputValueSig),
 		}
 		if v.OutputValue().Known {
 			obj["value"] = v.OutputValue().Element
 		}
 		if v.OutputValue().Secret {
-			obj["secret"] = resource.NewBoolProperty(v.OutputValue().Secret)
+			obj["secret"] = resource.NewProperty(v.OutputValue().Secret)
 		}
 		if len(v.OutputValue().Dependencies) > 0 {
 			deps := make([]resource.PropertyValue, len(v.OutputValue().Dependencies))
 			for i, dep := range v.OutputValue().Dependencies {
-				deps[i] = resource.NewStringProperty(string(dep))
+				deps[i] = resource.NewProperty(string(dep))
 			}
-			obj["dependencies"] = resource.NewArrayProperty(deps)
+			obj["dependencies"] = resource.NewProperty(deps)
 		}
-		output := resource.NewObjectProperty(obj)
+		output := resource.NewProperty(obj)
 		return MarshalPropertyValue(key, output, opts)
 	} else if v.IsSecret() {
 		if !opts.KeepSecrets {
@@ -194,15 +194,15 @@ func MarshalPropertyValue(key resource.PropertyKey, v resource.PropertyValue,
 			return MarshalPropertyValue(key, v.SecretValue().Element, opts)
 		}
 		if opts.KeepOutputValues && opts.UpgradeToOutputValues {
-			output := resource.NewObjectProperty(resource.PropertyMap{
-				resource.SigKey: resource.NewStringProperty(resource.OutputValueSig),
-				"secret":        resource.NewBoolProperty(true),
+			output := resource.NewProperty(resource.PropertyMap{
+				resource.SigKey: resource.NewProperty(resource.OutputValueSig),
+				"secret":        resource.NewProperty(true),
 				"value":         v.SecretValue().Element,
 			})
 			return MarshalPropertyValue(key, output, opts)
 		}
-		secret := resource.NewObjectProperty(resource.PropertyMap{
-			resource.SigKey: resource.NewStringProperty(resource.SecretSig),
+		secret := resource.NewProperty(resource.PropertyMap{
+			resource.SigKey: resource.NewProperty(resource.SecretSig),
 			"value":         v.SecretValue().Element,
 		})
 		return MarshalPropertyValue(key, secret, opts)
@@ -217,16 +217,16 @@ func MarshalPropertyValue(key resource.PropertyKey, v resource.PropertyValue,
 			return MarshalString(val, opts), nil
 		}
 		m := resource.PropertyMap{
-			resource.SigKey: resource.NewStringProperty(resource.ResourceReferenceSig),
-			"urn":           resource.NewStringProperty(string(ref.URN)),
+			resource.SigKey: resource.NewProperty(resource.ResourceReferenceSig),
+			"urn":           resource.NewProperty(string(ref.URN)),
 		}
 		if id, hasID := ref.IDString(); hasID {
-			m["id"] = resource.NewStringProperty(id)
+			m["id"] = resource.NewProperty(id)
 		}
 		if ref.PackageVersion != "" {
-			m["packageVersion"] = resource.NewStringProperty(ref.PackageVersion)
+			m["packageVersion"] = resource.NewProperty(ref.PackageVersion)
 		}
-		return MarshalPropertyValue(key, resource.NewObjectProperty(m), opts)
+		return MarshalPropertyValue(key, resource.NewProperty(m), opts)
 	}
 
 	contract.Failf("Unrecognized property value in RPC[%s] for %q: %v (type=%v)",
@@ -314,10 +314,10 @@ func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 		m := resource.NewNullProperty()
 		return &m, nil
 	case *structpb.Value_BoolValue:
-		m := resource.NewBoolProperty(v.GetBoolValue())
+		m := resource.NewProperty(v.GetBoolValue())
 		return &m, nil
 	case *structpb.Value_NumberValue:
-		m := resource.NewNumberProperty(v.GetNumberValue())
+		m := resource.NewProperty(v.GetNumberValue())
 		return &m, nil
 	case *structpb.Value_StringValue:
 		// If it's a string, it could be an unknown property, or just a regular string.
@@ -330,7 +330,7 @@ func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 			}
 			return nil, nil
 		}
-		m := resource.NewStringProperty(s)
+		m := resource.NewProperty(s)
 		return &m, nil
 	case *structpb.Value_ListValue:
 		lst := v.GetListValue()
@@ -347,7 +347,7 @@ func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 				}
 			}
 		}
-		m := resource.NewArrayProperty(elems)
+		m := resource.NewProperty(elems)
 		return &m, nil
 	case *structpb.Value_StructValue:
 		// Start by unmarshaling.
@@ -361,7 +361,7 @@ func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 		sig, hasSig := objmap[string(resource.SigKey)]
 		if !hasSig {
 			// This is a weakly-typed object map.
-			m := resource.NewObjectProperty(obj)
+			m := resource.NewProperty(obj)
 			return &m, nil
 		}
 
@@ -388,7 +388,7 @@ func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 					}
 				}
 			}
-			m := resource.NewAssetProperty(asset)
+			m := resource.NewProperty(asset)
 			return &m, nil
 		case archive.ArchiveSig:
 			if opts.RejectAssets {
@@ -412,7 +412,7 @@ func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 					}
 				}
 			}
-			m := resource.NewArchiveProperty(archive)
+			m := resource.NewProperty(archive)
 			return &m, nil
 		case resource.SecretSig:
 			value, ok := obj["value"]
@@ -469,7 +469,7 @@ func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 					}
 					value = id
 				}
-				r := resource.NewStringProperty(value)
+				r := resource.NewProperty(value)
 				return &r, nil
 			}
 
@@ -522,7 +522,7 @@ func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 				}
 			}
 
-			output := resource.NewOutputProperty(resource.Output{
+			output := resource.NewProperty(resource.Output{
 				Element:      value,
 				Known:        known,
 				Secret:       secret,
@@ -544,28 +544,28 @@ func unmarshalUnknownPropertyValue(s string, opts MarshalOptions) (resource.Prop
 	var unknown bool
 	switch s {
 	case UnknownBoolValue:
-		elem, unknown = resource.NewBoolProperty(false), true
+		elem, unknown = resource.NewProperty(false), true
 	case UnknownNumberValue:
-		elem, unknown = resource.NewNumberProperty(0), true
+		elem, unknown = resource.NewProperty(0.0), true
 	case UnknownStringValue:
-		elem, unknown = resource.NewStringProperty(""), true
+		elem, unknown = resource.NewProperty(""), true
 	case UnknownArrayValue:
-		elem, unknown = resource.NewArrayProperty([]resource.PropertyValue{}), true
+		elem, unknown = resource.NewProperty([]resource.PropertyValue{}), true
 	case UnknownAssetValue:
-		elem, unknown = resource.NewAssetProperty(&asset.Asset{}), true
+		elem, unknown = resource.NewProperty(&asset.Asset{}), true
 	case UnknownArchiveValue:
-		elem, unknown = resource.NewArchiveProperty(&archive.Archive{}), true
+		elem, unknown = resource.NewProperty(&archive.Archive{}), true
 	case UnknownObjectValue:
-		elem, unknown = resource.NewObjectProperty(make(resource.PropertyMap)), true
+		elem, unknown = resource.NewProperty(make(resource.PropertyMap)), true
 	}
 	if unknown {
 		if opts.KeepOutputValues && opts.UpgradeToOutputValues {
-			return resource.NewOutputProperty(resource.Output{
+			return resource.NewProperty(resource.Output{
 				Element: elem,
 			}), true
 		}
 		comp := resource.Computed{Element: elem}
-		return resource.NewComputedProperty(comp), true
+		return resource.NewProperty(comp), true
 	}
 	return resource.PropertyValue{}, false
 }
@@ -577,7 +577,7 @@ func unmarshalSecretPropertyValue(v resource.PropertyValue, opts MarshalOptions)
 	}
 	var s resource.PropertyValue
 	if opts.KeepOutputValues && opts.UpgradeToOutputValues {
-		s = resource.NewOutputProperty(resource.Output{
+		s = resource.NewProperty(resource.Output{
 			Element: v,
 			Secret:  true,
 			Known:   true,
@@ -640,7 +640,7 @@ func MarshalAsset(v *asset.Asset, opts MarshalOptions) (*structpb.Value, error) 
 	sera := v.Serialize()
 	serap := resource.NewPropertyMapFromMap(sera)
 	pk := resource.PropertyKey(v.URI)
-	return MarshalPropertyValue(pk, resource.NewObjectProperty(serap), opts)
+	return MarshalPropertyValue(pk, resource.NewProperty(serap), opts)
 }
 
 // MarshalArchive marshals an archive into its wire form for resource provider plugins.
@@ -668,5 +668,5 @@ func MarshalArchive(v *archive.Archive, opts MarshalOptions) (*structpb.Value, e
 	sera := v.Serialize()
 	serap := resource.NewPropertyMapFromMap(sera)
 	pk := resource.PropertyKey(v.URI)
-	return MarshalPropertyValue(pk, resource.NewObjectProperty(serap), opts)
+	return MarshalPropertyValue(pk, resource.NewProperty(serap), opts)
 }

--- a/sdk/go/common/resource/plugin/rpc_test.go
+++ b/sdk/go/common/resource/plugin/rpc_test.go
@@ -45,7 +45,7 @@ func TestAssetSerialize(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, text, anAsset.Text)
 	assert.Equal(t, "e34c74529110661faae4e121e57165ff4cb4dbdde1ef9770098aa3695e6b6704", anAsset.Hash)
-	assetProps, err := MarshalPropertyValue(pk, resource.NewAssetProperty(anAsset), MarshalOptions{})
+	assetProps, err := MarshalPropertyValue(pk, resource.NewProperty(anAsset), MarshalOptions{})
 	require.NoError(t, err)
 	t.Logf("%v", assetProps)
 	assetValue, err := UnmarshalPropertyValue("", assetProps, MarshalOptions{})
@@ -86,7 +86,7 @@ func TestAssetSerialize(t *testing.T) {
 		// Go 1.10 introduced breaking changes to archive/zip and archive/tar headers
 		assert.Equal(t, "27ab4a14a617df10cff3e1cf4e30cf510302afe56bf4cc91f84041c9f7b62fd8", arch.Hash)
 	}
-	archProps, err := MarshalPropertyValue(pk, resource.NewArchiveProperty(arch), MarshalOptions{})
+	archProps, err := MarshalPropertyValue(pk, resource.NewProperty(arch), MarshalOptions{})
 	require.NoError(t, err)
 	archValue, err := UnmarshalPropertyValue("", archProps, MarshalOptions{})
 	require.NoError(t, err)
@@ -134,8 +134,8 @@ func TestComputedSerialize(t *testing.T) {
 	pk := resource.PropertyKey("pk")
 	{
 		cprop, err := MarshalPropertyValue(pk,
-			resource.NewComputedProperty(
-				resource.Computed{Element: resource.NewStringProperty("")}), opts)
+			resource.NewProperty(
+				resource.Computed{Element: resource.NewProperty("")}), opts)
 		require.NoError(t, err)
 		cpropU, err := UnmarshalPropertyValue(pk, cprop, opts)
 		require.NoError(t, err)
@@ -144,8 +144,8 @@ func TestComputedSerialize(t *testing.T) {
 	}
 	{
 		cprop, err := MarshalPropertyValue(pk,
-			resource.NewComputedProperty(
-				resource.Computed{Element: resource.NewNumberProperty(0)}), opts)
+			resource.NewProperty(
+				resource.Computed{Element: resource.NewProperty(0.0)}), opts)
 		require.NoError(t, err)
 		cpropU, err := UnmarshalPropertyValue(pk, cprop, opts)
 		require.NoError(t, err)
@@ -162,15 +162,15 @@ func TestComputedSkip(t *testing.T) {
 	pk := resource.PropertyKey("pk")
 	{
 		cprop, err := MarshalPropertyValue(pk,
-			resource.NewComputedProperty(
-				resource.Computed{Element: resource.NewStringProperty("")}), opts)
+			resource.NewProperty(
+				resource.Computed{Element: resource.NewProperty("")}), opts)
 		require.NoError(t, err)
 		assert.Nil(t, cprop)
 	}
 	{
 		cprop, err := MarshalPropertyValue(pk,
-			resource.NewComputedProperty(
-				resource.Computed{Element: resource.NewNumberProperty(0)}), opts)
+			resource.NewProperty(
+				resource.Computed{Element: resource.NewProperty(0.0)}), opts)
 		require.NoError(t, err)
 		assert.Nil(t, cprop)
 	}
@@ -184,15 +184,15 @@ func TestComputedReject(t *testing.T) {
 	pk := resource.PropertyKey("pk")
 	{
 		cprop, err := MarshalPropertyValue(pk,
-			resource.NewComputedProperty(
-				resource.Computed{Element: resource.NewStringProperty("")}), opts)
+			resource.NewProperty(
+				resource.Computed{Element: resource.NewProperty("")}), opts)
 		assert.EqualError(t, err, "unexpected unknown property value for \"pk\"")
 		assert.Nil(t, cprop)
 	}
 	{
 		cprop, err := MarshalPropertyValue(pk,
-			resource.NewComputedProperty(
-				resource.Computed{Element: resource.NewStringProperty("")}), MarshalOptions{KeepUnknowns: true})
+			resource.NewProperty(
+				resource.Computed{Element: resource.NewProperty("")}), MarshalOptions{KeepUnknowns: true})
 		require.NoError(t, err)
 		cpropU, err := UnmarshalPropertyValue(pk, cprop, opts)
 		assert.EqualError(t, err, "unexpected unknown property value for \"pk\"")
@@ -212,12 +212,12 @@ func TestAssetReject(t *testing.T) {
 	asset, err := asset.FromText(text)
 	require.NoError(t, err)
 	{
-		assetProps, err := MarshalPropertyValue(pk, resource.NewAssetProperty(asset), opts)
+		assetProps, err := MarshalPropertyValue(pk, resource.NewProperty(asset), opts)
 		assert.EqualError(t, err, "unexpected Asset property value for \"an asset URI\"")
 		assert.Nil(t, assetProps)
 	}
 	{
-		assetProps, err := MarshalPropertyValue(pk, resource.NewAssetProperty(asset), MarshalOptions{})
+		assetProps, err := MarshalPropertyValue(pk, resource.NewProperty(asset), MarshalOptions{})
 		require.NoError(t, err)
 		assetPropU, err := UnmarshalPropertyValue(pk, assetProps, opts)
 		assert.EqualError(t, err, "unexpected Asset property value for \"an asset URI\"")
@@ -227,12 +227,12 @@ func TestAssetReject(t *testing.T) {
 	arch, err := archive.FromAssets(map[string]interface{}{"foo": asset})
 	require.NoError(t, err)
 	{
-		archProps, err := MarshalPropertyValue(pk, resource.NewArchiveProperty(arch), opts)
+		archProps, err := MarshalPropertyValue(pk, resource.NewProperty(arch), opts)
 		assert.EqualError(t, err, "unexpected Asset Archive property value for \"an asset URI\"")
 		assert.Nil(t, archProps)
 	}
 	{
-		archProps, err := MarshalPropertyValue(pk, resource.NewArchiveProperty(arch), MarshalOptions{})
+		archProps, err := MarshalPropertyValue(pk, resource.NewProperty(arch), MarshalOptions{})
 		require.NoError(t, err)
 		archValue, err := UnmarshalPropertyValue(pk, archProps, opts)
 		assert.EqualError(t, err, "unexpected Asset property value for \"foo\"")
@@ -243,7 +243,7 @@ func TestAssetReject(t *testing.T) {
 func TestUnsupportedSecret(t *testing.T) {
 	t.Parallel()
 
-	rawProp := resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+	rawProp := resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 		resource.SigKey: resource.SecretSig,
 		"value":         "foo",
 	}))
@@ -260,7 +260,7 @@ func TestUnsupportedSecret(t *testing.T) {
 func TestSupportedSecret(t *testing.T) {
 	t.Parallel()
 
-	rawProp := resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+	rawProp := resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 		resource.SigKey: resource.SecretSig,
 		"value":         "foo",
 	}))
@@ -278,7 +278,7 @@ func TestSupportedSecret(t *testing.T) {
 func TestUnknownSig(t *testing.T) {
 	t.Parallel()
 
-	rawProp := resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+	rawProp := resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 		resource.SigKey: "foobar",
 	}))
 	pk := resource.PropertyKey("pk")
@@ -327,7 +327,7 @@ func TestMarshalProperties(t *testing.T) {
 		{
 			name: "empty (default)",
 			props: resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{}),
+				"foo": resource.NewProperty(resource.Output{}),
 			},
 			expected: &structpb.Struct{
 				Fields: map[string]*structpb.Value{},
@@ -336,7 +336,7 @@ func TestMarshalProperties(t *testing.T) {
 		{
 			name: "unknown (default)",
 			props: resource.PropertyMap{
-				"foo": resource.MakeOutput(resource.NewStringProperty("")),
+				"foo": resource.MakeOutput(resource.NewProperty("")),
 			},
 			expected: &structpb.Struct{
 				Fields: map[string]*structpb.Value{},
@@ -345,8 +345,8 @@ func TestMarshalProperties(t *testing.T) {
 		{
 			name: "unknown with deps (default)",
 			props: resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{
-					Element:      resource.NewStringProperty(""),
+				"foo": resource.NewProperty(resource.Output{
+					Element:      resource.NewProperty(""),
 					Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
 				}),
 			},
@@ -357,8 +357,8 @@ func TestMarshalProperties(t *testing.T) {
 		{
 			name: "known (default)",
 			props: resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewStringProperty("hello"),
+				"foo": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("hello"),
 					Known:   true,
 				}),
 			},
@@ -375,8 +375,8 @@ func TestMarshalProperties(t *testing.T) {
 		{
 			name: "known with deps (default)",
 			props: resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{
-					Element:      resource.NewStringProperty("hello"),
+				"foo": resource.NewProperty(resource.Output{
+					Element:      resource.NewProperty("hello"),
 					Known:        true,
 					Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
 				}),
@@ -394,8 +394,8 @@ func TestMarshalProperties(t *testing.T) {
 		{
 			name: "secret (default)",
 			props: resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewStringProperty("hello"),
+				"foo": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("hello"),
 					Known:   true,
 					Secret:  true,
 				}),
@@ -413,8 +413,8 @@ func TestMarshalProperties(t *testing.T) {
 		{
 			name: "secret with deps (default)",
 			props: resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{
-					Element:      resource.NewStringProperty("hello"),
+				"foo": resource.NewProperty(resource.Output{
+					Element:      resource.NewProperty("hello"),
 					Known:        true,
 					Secret:       true,
 					Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
@@ -433,8 +433,8 @@ func TestMarshalProperties(t *testing.T) {
 		{
 			name: "unknown secret (default)",
 			props: resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewStringProperty("shhh"),
+				"foo": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("shhh"),
 					Secret:  true,
 				}),
 			},
@@ -445,8 +445,8 @@ func TestMarshalProperties(t *testing.T) {
 		{
 			name: "unknown secret with deps (default)",
 			props: resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{
-					Element:      resource.NewStringProperty("shhh"),
+				"foo": resource.NewProperty(resource.Output{
+					Element:      resource.NewProperty("shhh"),
 					Secret:       true,
 					Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
 				}),
@@ -459,7 +459,7 @@ func TestMarshalProperties(t *testing.T) {
 			name: "empty (KeepOutputValues)",
 			opts: MarshalOptions{KeepOutputValues: true},
 			props: resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{}),
+				"foo": resource.NewProperty(resource.Output{}),
 			},
 			expected: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
@@ -481,7 +481,7 @@ func TestMarshalProperties(t *testing.T) {
 			name: "unknown (KeepOutputValues)",
 			opts: MarshalOptions{KeepOutputValues: true},
 			props: resource.PropertyMap{
-				"foo": resource.MakeOutput(resource.NewStringProperty("")),
+				"foo": resource.MakeOutput(resource.NewProperty("")),
 			},
 			expected: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
@@ -503,8 +503,8 @@ func TestMarshalProperties(t *testing.T) {
 			name: "unknown with deps (KeepOutputValues)",
 			opts: MarshalOptions{KeepOutputValues: true},
 			props: resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{
-					Element:      resource.NewStringProperty(""),
+				"foo": resource.NewProperty(resource.Output{
+					Element:      resource.NewProperty(""),
 					Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
 				}),
 			},
@@ -538,8 +538,8 @@ func TestMarshalProperties(t *testing.T) {
 			name: "known (KeepOutputValues)",
 			opts: MarshalOptions{KeepOutputValues: true},
 			props: resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewStringProperty("hello"),
+				"foo": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("hello"),
 					Known:   true,
 				}),
 			},
@@ -566,8 +566,8 @@ func TestMarshalProperties(t *testing.T) {
 			name: "known with deps (KeepOutputValues)",
 			opts: MarshalOptions{KeepOutputValues: true},
 			props: resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{
-					Element:      resource.NewStringProperty("hello"),
+				"foo": resource.NewProperty(resource.Output{
+					Element:      resource.NewProperty("hello"),
 					Known:        true,
 					Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
 				}),
@@ -605,8 +605,8 @@ func TestMarshalProperties(t *testing.T) {
 			name: "secret (KeepOutputValues)",
 			opts: MarshalOptions{KeepOutputValues: true},
 			props: resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewStringProperty("shhh"),
+				"foo": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("shhh"),
 					Known:   true,
 					Secret:  true,
 				}),
@@ -637,8 +637,8 @@ func TestMarshalProperties(t *testing.T) {
 			name: "secret with deps (KeepOutputValues)",
 			opts: MarshalOptions{KeepOutputValues: true},
 			props: resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{
-					Element:      resource.NewStringProperty("shhh"),
+				"foo": resource.NewProperty(resource.Output{
+					Element:      resource.NewProperty("shhh"),
 					Known:        true,
 					Secret:       true,
 					Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
@@ -680,8 +680,8 @@ func TestMarshalProperties(t *testing.T) {
 			name: "unknown secret (KeepOutputValues)",
 			opts: MarshalOptions{KeepOutputValues: true},
 			props: resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewStringProperty("shhh"),
+				"foo": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("shhh"),
 					Secret:  true,
 				}),
 			},
@@ -708,8 +708,8 @@ func TestMarshalProperties(t *testing.T) {
 			name: "unknown secret with deps (KeepOutputValues)",
 			opts: MarshalOptions{KeepOutputValues: true},
 			props: resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{
-					Element:      resource.NewStringProperty("shhh"),
+				"foo": resource.NewProperty(resource.Output{
+					Element:      resource.NewProperty("shhh"),
 					Secret:       true,
 					Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
 				}),
@@ -773,7 +773,7 @@ func TestResourceReference(t *testing.T) {
 	opts.KeepResources = false
 	actual, err = UnmarshalPropertyValue(pk, prop, opts)
 	require.NoError(t, err)
-	assert.Equal(t, resource.NewStringProperty(rawProp.ResourceReferenceValue().ID.StringValue()), *actual)
+	assert.Equal(t, resource.NewProperty(rawProp.ResourceReferenceValue().ID.StringValue()), *actual)
 
 	// Test marshaling as an ID
 	prop, err = MarshalPropertyValue(pk, rawProp, opts)
@@ -781,7 +781,7 @@ func TestResourceReference(t *testing.T) {
 	opts.KeepResources = true
 	actual, err = UnmarshalPropertyValue(pk, prop, opts)
 	require.NoError(t, err)
-	assert.Equal(t, resource.NewStringProperty(rawProp.ResourceReferenceValue().ID.StringValue()), *actual)
+	assert.Equal(t, resource.NewProperty(rawProp.ResourceReferenceValue().ID.StringValue()), *actual)
 
 	// Test unmarshaling as a URN
 	rawProp = resource.MakeComponentResourceReference("fakeURN", "fakeVersion")
@@ -790,7 +790,7 @@ func TestResourceReference(t *testing.T) {
 	opts.KeepResources = false
 	actual, err = UnmarshalPropertyValue(pk, prop, opts)
 	require.NoError(t, err)
-	assert.Equal(t, resource.NewStringProperty(string(rawProp.ResourceReferenceValue().URN)), *actual)
+	assert.Equal(t, resource.NewProperty(string(rawProp.ResourceReferenceValue().URN)), *actual)
 
 	// Test marshaling as a URN
 	prop, err = MarshalPropertyValue(pk, rawProp, opts)
@@ -798,7 +798,7 @@ func TestResourceReference(t *testing.T) {
 	opts.KeepResources = true
 	actual, err = UnmarshalPropertyValue(pk, prop, opts)
 	require.NoError(t, err)
-	assert.Equal(t, resource.NewStringProperty(string(rawProp.ResourceReferenceValue().URN)), *actual)
+	assert.Equal(t, resource.NewProperty(string(rawProp.ResourceReferenceValue().URN)), *actual)
 }
 
 func TestOutputValueRoundTrip(t *testing.T) {
@@ -810,41 +810,41 @@ func TestOutputValueRoundTrip(t *testing.T) {
 	}{
 		{
 			name: "unknown",
-			raw:  resource.NewOutputProperty(resource.Output{}),
+			raw:  resource.NewProperty(resource.Output{}),
 		},
 		{
 			name: "unknown with deps",
-			raw: resource.NewOutputProperty(resource.Output{
+			raw: resource.NewProperty(resource.Output{
 				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
 			}),
 		},
 		{
 			name: "known",
-			raw: resource.NewOutputProperty(resource.Output{
-				Element: resource.NewStringProperty("hello"),
+			raw: resource.NewProperty(resource.Output{
+				Element: resource.NewProperty("hello"),
 				Known:   true,
 			}),
 		},
 		{
 			name: "known with deps",
-			raw: resource.NewOutputProperty(resource.Output{
-				Element:      resource.NewStringProperty("hello"),
+			raw: resource.NewProperty(resource.Output{
+				Element:      resource.NewProperty("hello"),
 				Known:        true,
 				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
 			}),
 		},
 		{
 			name: "secret",
-			raw: resource.NewOutputProperty(resource.Output{
-				Element: resource.NewStringProperty("secret"),
+			raw: resource.NewProperty(resource.Output{
+				Element: resource.NewProperty("secret"),
 				Known:   true,
 				Secret:  true,
 			}),
 		},
 		{
 			name: "secret with deps",
-			raw: resource.NewOutputProperty(resource.Output{
-				Element:      resource.NewStringProperty("secret"),
+			raw: resource.NewProperty(resource.Output{
+				Element:      resource.NewProperty("secret"),
 				Known:        true,
 				Secret:       true,
 				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
@@ -852,13 +852,13 @@ func TestOutputValueRoundTrip(t *testing.T) {
 		},
 		{
 			name: "unknown secret",
-			raw: resource.NewOutputProperty(resource.Output{
+			raw: resource.NewProperty(resource.Output{
 				Secret: true,
 			}),
 		},
 		{
 			name: "unknown secret with deps",
-			raw: resource.NewOutputProperty(resource.Output{
+			raw: resource.NewProperty(resource.Output{
 				Secret:       true,
 				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
 			}),
@@ -890,26 +890,26 @@ func TestOutputValueMarshaling(t *testing.T) {
 	}{
 		{
 			name:     "empty (default)",
-			raw:      resource.NewOutputProperty(resource.Output{}),
+			raw:      resource.NewProperty(resource.Output{}),
 			expected: nil,
 		},
 		{
 			name:     "unknown (default)",
-			raw:      resource.MakeOutput(resource.NewStringProperty("")),
+			raw:      resource.MakeOutput(resource.NewProperty("")),
 			expected: nil,
 		},
 		{
 			name: "unknown with deps (default)",
-			raw: resource.NewOutputProperty(resource.Output{
-				Element:      resource.NewStringProperty("hello"),
+			raw: resource.NewProperty(resource.Output{
+				Element:      resource.NewProperty("hello"),
 				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
 			}),
 			expected: nil,
 		},
 		{
 			name: "known (default)",
-			raw: resource.NewOutputProperty(resource.Output{
-				Element: resource.NewStringProperty("hello"),
+			raw: resource.NewProperty(resource.Output{
+				Element: resource.NewProperty("hello"),
 				Known:   true,
 			}),
 			expected: &structpb.Value{
@@ -918,8 +918,8 @@ func TestOutputValueMarshaling(t *testing.T) {
 		},
 		{
 			name: "known with deps (default)",
-			raw: resource.NewOutputProperty(resource.Output{
-				Element:      resource.NewStringProperty("hello"),
+			raw: resource.NewProperty(resource.Output{
+				Element:      resource.NewProperty("hello"),
 				Known:        true,
 				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
 			}),
@@ -929,8 +929,8 @@ func TestOutputValueMarshaling(t *testing.T) {
 		},
 		{
 			name: "secret (default)",
-			raw: resource.NewOutputProperty(resource.Output{
-				Element: resource.NewStringProperty("shhh"),
+			raw: resource.NewProperty(resource.Output{
+				Element: resource.NewProperty("shhh"),
 				Known:   true,
 				Secret:  true,
 			}),
@@ -940,8 +940,8 @@ func TestOutputValueMarshaling(t *testing.T) {
 		},
 		{
 			name: "secret with deps (default)",
-			raw: resource.NewOutputProperty(resource.Output{
-				Element:      resource.NewStringProperty("shhh"),
+			raw: resource.NewProperty(resource.Output{
+				Element:      resource.NewProperty("shhh"),
 				Known:        true,
 				Secret:       true,
 				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
@@ -952,16 +952,16 @@ func TestOutputValueMarshaling(t *testing.T) {
 		},
 		{
 			name: "unknown secret (default)",
-			raw: resource.NewOutputProperty(resource.Output{
-				Element: resource.NewStringProperty("shhh"),
+			raw: resource.NewProperty(resource.Output{
+				Element: resource.NewProperty("shhh"),
 				Secret:  true,
 			}),
 			expected: nil,
 		},
 		{
 			name: "unknown secret with deps (default)",
-			raw: resource.NewOutputProperty(resource.Output{
-				Element:      resource.NewStringProperty("shhh"),
+			raw: resource.NewProperty(resource.Output{
+				Element:      resource.NewProperty("shhh"),
 				Secret:       true,
 				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
 			}),
@@ -970,7 +970,7 @@ func TestOutputValueMarshaling(t *testing.T) {
 		{
 			name: "empty (KeepUnknowns)",
 			opts: MarshalOptions{KeepUnknowns: true},
-			raw:  resource.NewOutputProperty(resource.Output{}),
+			raw:  resource.NewProperty(resource.Output{}),
 			expected: &structpb.Value{
 				Kind: &structpb.Value_StringValue{StringValue: UnknownStringValue},
 			},
@@ -978,7 +978,7 @@ func TestOutputValueMarshaling(t *testing.T) {
 		{
 			name: "unknown (KeepUnknowns)",
 			opts: MarshalOptions{KeepUnknowns: true},
-			raw:  resource.MakeOutput(resource.NewStringProperty("")),
+			raw:  resource.MakeOutput(resource.NewProperty("")),
 			expected: &structpb.Value{
 				Kind: &structpb.Value_StringValue{StringValue: UnknownStringValue},
 			},
@@ -986,8 +986,8 @@ func TestOutputValueMarshaling(t *testing.T) {
 		{
 			name: "unknown with deps (KeepUnknowns)",
 			opts: MarshalOptions{KeepUnknowns: true},
-			raw: resource.NewOutputProperty(resource.Output{
-				Element:      resource.NewStringProperty("hello"),
+			raw: resource.NewProperty(resource.Output{
+				Element:      resource.NewProperty("hello"),
 				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
 			}),
 			expected: &structpb.Value{
@@ -997,8 +997,8 @@ func TestOutputValueMarshaling(t *testing.T) {
 		{
 			name: "unknown secret (KeepUnknowns)",
 			opts: MarshalOptions{KeepUnknowns: true},
-			raw: resource.NewOutputProperty(resource.Output{
-				Element: resource.NewStringProperty("shhh"),
+			raw: resource.NewProperty(resource.Output{
+				Element: resource.NewProperty("shhh"),
 				Secret:  true,
 			}),
 			expected: &structpb.Value{
@@ -1008,8 +1008,8 @@ func TestOutputValueMarshaling(t *testing.T) {
 		{
 			name: "unknown secret with deps (KeepUnknowns)",
 			opts: MarshalOptions{KeepUnknowns: true},
-			raw: resource.NewOutputProperty(resource.Output{
-				Element:      resource.NewStringProperty("shhh"),
+			raw: resource.NewProperty(resource.Output{
+				Element:      resource.NewProperty("shhh"),
 				Secret:       true,
 				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
 			}),
@@ -1020,8 +1020,8 @@ func TestOutputValueMarshaling(t *testing.T) {
 		{
 			name: "secret (KeepUnknowns)",
 			opts: MarshalOptions{KeepUnknowns: true},
-			raw: resource.NewOutputProperty(resource.Output{
-				Element: resource.NewStringProperty("shhh"),
+			raw: resource.NewProperty(resource.Output{
+				Element: resource.NewProperty("shhh"),
 				Known:   true,
 				Secret:  true,
 			}),
@@ -1032,8 +1032,8 @@ func TestOutputValueMarshaling(t *testing.T) {
 		{
 			name: "secret with deps (KeepUnknowns)",
 			opts: MarshalOptions{KeepUnknowns: true},
-			raw: resource.NewOutputProperty(resource.Output{
-				Element:      resource.NewStringProperty("shhh"),
+			raw: resource.NewProperty(resource.Output{
+				Element:      resource.NewProperty("shhh"),
 				Known:        true,
 				Secret:       true,
 				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
@@ -1045,8 +1045,8 @@ func TestOutputValueMarshaling(t *testing.T) {
 		{
 			name: "secret (KeepSecrets)",
 			opts: MarshalOptions{KeepSecrets: true},
-			raw: resource.NewOutputProperty(resource.Output{
-				Element: resource.NewStringProperty("shhh"),
+			raw: resource.NewProperty(resource.Output{
+				Element: resource.NewProperty("shhh"),
 				Known:   true,
 				Secret:  true,
 			}),
@@ -1068,8 +1068,8 @@ func TestOutputValueMarshaling(t *testing.T) {
 		{
 			name: "secret with deps (KeepSecrets)",
 			opts: MarshalOptions{KeepSecrets: true},
-			raw: resource.NewOutputProperty(resource.Output{
-				Element:      resource.NewStringProperty("shhh"),
+			raw: resource.NewProperty(resource.Output{
+				Element:      resource.NewProperty("shhh"),
 				Known:        true,
 				Secret:       true,
 				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
@@ -1092,8 +1092,8 @@ func TestOutputValueMarshaling(t *testing.T) {
 		{
 			name: "unknown secret (KeepUnknowns, KeepSecrets)",
 			opts: MarshalOptions{KeepUnknowns: true, KeepSecrets: true},
-			raw: resource.NewOutputProperty(resource.Output{
-				Element: resource.NewStringProperty("shhh"),
+			raw: resource.NewProperty(resource.Output{
+				Element: resource.NewProperty("shhh"),
 				Secret:  true,
 			}),
 			expected: &structpb.Value{
@@ -1114,8 +1114,8 @@ func TestOutputValueMarshaling(t *testing.T) {
 		{
 			name: "unknown secret with deps (KeepUnknowns, KeepSecrets)",
 			opts: MarshalOptions{KeepUnknowns: true, KeepSecrets: true},
-			raw: resource.NewOutputProperty(resource.Output{
-				Element:      resource.NewStringProperty("shhh"),
+			raw: resource.NewProperty(resource.Output{
+				Element:      resource.NewProperty("shhh"),
 				Secret:       true,
 				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
 			}),
@@ -1137,7 +1137,7 @@ func TestOutputValueMarshaling(t *testing.T) {
 		{
 			name: "unknown value (KeepOutputValues)",
 			opts: MarshalOptions{KeepOutputValues: true},
-			raw:  resource.MakeOutput(resource.NewStringProperty("")),
+			raw:  resource.MakeOutput(resource.NewProperty("")),
 			expected: &structpb.Value{
 				Kind: &structpb.Value_StructValue{
 					StructValue: &structpb.Struct{
@@ -1206,7 +1206,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.NewStringProperty("hello")),
+			expected: ptr(resource.NewProperty("hello")),
 		},
 		{
 			name: "known with deps (default)",
@@ -1234,7 +1234,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.NewStringProperty("hello")),
+			expected: ptr(resource.NewProperty("hello")),
 		},
 		{
 			name: "secret (default)",
@@ -1255,7 +1255,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.NewStringProperty("shhh")),
+			expected: ptr(resource.NewProperty("shhh")),
 		},
 		{
 			name: "secret with deps (default)",
@@ -1286,7 +1286,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.NewStringProperty("shhh")),
+			expected: ptr(resource.NewProperty("shhh")),
 		},
 		{
 			name: "unknown secret (default)",
@@ -1348,7 +1348,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeComputed(resource.NewStringProperty(""))),
+			expected: ptr(resource.MakeComputed(resource.NewProperty(""))),
 		},
 		{
 			name: "unknown with deps (KeepUnknowns)",
@@ -1374,7 +1374,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeComputed(resource.NewStringProperty(""))),
+			expected: ptr(resource.MakeComputed(resource.NewProperty(""))),
 		},
 		{
 			name: "unknown secret (KeepUnknowns)",
@@ -1393,7 +1393,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeComputed(resource.NewStringProperty(""))),
+			expected: ptr(resource.MakeComputed(resource.NewProperty(""))),
 		},
 		{
 			name: "unknown secret with deps (KeepUnknowns)",
@@ -1422,7 +1422,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeComputed(resource.NewStringProperty(""))),
+			expected: ptr(resource.MakeComputed(resource.NewProperty(""))),
 		},
 		{
 			name: "secret (KeepUnknowns)",
@@ -1444,7 +1444,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.NewStringProperty("shhh")),
+			expected: ptr(resource.NewProperty("shhh")),
 		},
 		{
 			name: "secret with deps (KeepUnknowns)",
@@ -1476,7 +1476,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.NewStringProperty("shhh")),
+			expected: ptr(resource.NewProperty("shhh")),
 		},
 		{
 			name: "secret (KeepSecrets)",
@@ -1498,7 +1498,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeSecret(resource.NewStringProperty("shhh"))),
+			expected: ptr(resource.MakeSecret(resource.NewProperty("shhh"))),
 		},
 		{
 			name: "secret with deps (KeepSecrets)",
@@ -1530,7 +1530,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeSecret(resource.NewStringProperty("shhh"))),
+			expected: ptr(resource.MakeSecret(resource.NewProperty("shhh"))),
 		},
 		{
 			name: "unknown secret (KeepUnknowns, KeepSecrets)",
@@ -1549,7 +1549,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeSecret(resource.MakeComputed(resource.NewStringProperty("")))),
+			expected: ptr(resource.MakeSecret(resource.MakeComputed(resource.NewProperty("")))),
 		},
 		{
 			name: "unknown secret with deps (KeepUnknowns, KeepSecrets)",
@@ -1578,7 +1578,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeSecret(resource.MakeComputed(resource.NewStringProperty("")))),
+			expected: ptr(resource.MakeSecret(resource.MakeComputed(resource.NewProperty("")))),
 		},
 	}
 	for _, tt := range tests {
@@ -1707,9 +1707,9 @@ func TestMarshalPropertiesDontSkipOutputs(t *testing.T) {
 			name: "Computed (KeepUnknowns)",
 			opts: MarshalOptions{KeepUnknowns: true},
 			props: resource.PropertyMap{
-				"message": resource.MakeComputed(resource.NewStringProperty("")),
-				"nested": resource.NewObjectProperty(resource.PropertyMap{
-					"value": resource.MakeComputed(resource.NewStringProperty("")),
+				"message": resource.MakeComputed(resource.NewProperty("")),
+				"nested": resource.NewProperty(resource.PropertyMap{
+					"value": resource.MakeComputed(resource.NewProperty("")),
 				}),
 			},
 			expected: &structpb.Struct{
@@ -1735,9 +1735,9 @@ func TestMarshalPropertiesDontSkipOutputs(t *testing.T) {
 			name: "Output (KeepUnknowns)",
 			opts: MarshalOptions{KeepUnknowns: true},
 			props: resource.PropertyMap{
-				"message": resource.NewOutputProperty(resource.Output{}),
-				"nested": resource.NewObjectProperty(resource.PropertyMap{
-					"value": resource.NewOutputProperty(resource.Output{}),
+				"message": resource.NewProperty(resource.Output{}),
+				"nested": resource.NewProperty(resource.PropertyMap{
+					"value": resource.NewProperty(resource.Output{}),
 				}),
 			},
 			expected: &structpb.Struct{
@@ -1763,9 +1763,9 @@ func TestMarshalPropertiesDontSkipOutputs(t *testing.T) {
 			name: "Output (KeepUnknowns, KeepOutputValues)",
 			opts: MarshalOptions{KeepUnknowns: true, KeepOutputValues: true},
 			props: resource.PropertyMap{
-				"message": resource.NewOutputProperty(resource.Output{}),
-				"nested": resource.NewObjectProperty(resource.PropertyMap{
-					"value": resource.NewOutputProperty(resource.Output{}),
+				"message": resource.NewProperty(resource.Output{}),
+				"nested": resource.NewProperty(resource.PropertyMap{
+					"value": resource.NewProperty(resource.Output{}),
 				}),
 			},
 			expected: &structpb.Struct{
@@ -1832,8 +1832,8 @@ func TestUpgradeToOutputValues(t *testing.T) {
 	// Unknown
 	{
 		prop, err := MarshalPropertyValue(pk,
-			resource.NewComputedProperty(
-				resource.Computed{Element: resource.NewStringProperty("")}), upgradeOpts)
+			resource.NewProperty(
+				resource.Computed{Element: resource.NewProperty("")}), upgradeOpts)
 		require.NoError(t, err)
 		propU, err := UnmarshalPropertyValue(pk, prop, opts)
 		require.NoError(t, err)
@@ -1843,8 +1843,8 @@ func TestUpgradeToOutputValues(t *testing.T) {
 	}
 	{
 		prop, err := MarshalPropertyValue(pk,
-			resource.NewComputedProperty(
-				resource.Computed{Element: resource.NewStringProperty("")}), opts)
+			resource.NewProperty(
+				resource.Computed{Element: resource.NewProperty("")}), opts)
 		require.NoError(t, err)
 		propU, err := UnmarshalPropertyValue(pk, prop, upgradeOpts)
 		require.NoError(t, err)
@@ -1855,9 +1855,9 @@ func TestUpgradeToOutputValues(t *testing.T) {
 
 	// Secrets
 	{
-		elem := resource.NewStringProperty("hello")
+		elem := resource.NewProperty("hello")
 		prop, err := MarshalPropertyValue(pk,
-			resource.NewSecretProperty(
+			resource.NewProperty(
 				&resource.Secret{Element: elem}), upgradeOpts)
 		require.NoError(t, err)
 		propU, err := UnmarshalPropertyValue(pk, prop, opts)
@@ -1868,9 +1868,9 @@ func TestUpgradeToOutputValues(t *testing.T) {
 		assert.Equal(t, elem, propU.OutputValue().Element)
 	}
 	{
-		elem := resource.NewStringProperty("hello")
+		elem := resource.NewProperty("hello")
 		prop, err := MarshalPropertyValue(pk,
-			resource.NewSecretProperty(
+			resource.NewProperty(
 				&resource.Secret{Element: elem}), opts)
 		require.NoError(t, err)
 		propU, err := UnmarshalPropertyValue(pk, prop, upgradeOpts)
@@ -1885,9 +1885,9 @@ func TestUpgradeToOutputValues(t *testing.T) {
 	{
 		elem := resource.ResourceReference{
 			URN: resource.CreateURN("name", "type", "", "project", "stack"),
-			ID:  resource.MakeComputed(resource.NewStringProperty("")),
+			ID:  resource.MakeComputed(resource.NewProperty("")),
 		}
-		prop, err := MarshalPropertyValue(pk, resource.NewResourceReferenceProperty(elem), upgradeOpts)
+		prop, err := MarshalPropertyValue(pk, resource.NewProperty(elem), upgradeOpts)
 		require.NoError(t, err)
 		propU, err := UnmarshalPropertyValue(pk, prop, opts)
 		require.NoError(t, err)
@@ -1900,9 +1900,9 @@ func TestUpgradeToOutputValues(t *testing.T) {
 	{
 		elem := resource.ResourceReference{
 			URN: resource.CreateURN("name", "type", "", "project", "stack"),
-			ID:  resource.MakeComputed(resource.NewStringProperty("")),
+			ID:  resource.MakeComputed(resource.NewProperty("")),
 		}
-		prop, err := MarshalPropertyValue(pk, resource.NewResourceReferenceProperty(elem), opts)
+		prop, err := MarshalPropertyValue(pk, resource.NewProperty(elem), opts)
 		require.NoError(t, err)
 		propU, err := UnmarshalPropertyValue(pk, prop, upgradeOpts)
 		require.NoError(t, err)

--- a/sdk/go/common/resource/properties_path.go
+++ b/sdk/go/common/resource/properties_path.go
@@ -228,13 +228,13 @@ func (p PropertyPath) Add(dest, v PropertyValue) (PropertyValue, bool) {
 			case dest.IsNull():
 				// If the destination array does not exist, create a new array with enough room to store the value at
 				// the requested index.
-				dest = NewArrayProperty(make([]PropertyValue, key+1))
+				dest = NewProperty(make([]PropertyValue, key+1))
 				set(dest)
 			case dest.IsArray():
 				// If the destination array does exist, ensure that it is large enough to accommodate the requested
 				// index.
 				if arr := dest.ArrayValue(); key >= len(arr) {
-					dest = NewArrayProperty(append(make([]PropertyValue, key+1-len(arr)), arr...))
+					dest = NewProperty(append(make([]PropertyValue, key+1-len(arr)), arr...))
 					set(dest)
 				}
 			default:
@@ -250,7 +250,7 @@ func (p PropertyPath) Add(dest, v PropertyValue) (PropertyValue, bool) {
 			switch {
 			case dest.IsNull():
 				// If the destination does not exist, create a new object.
-				dest = NewObjectProperty(PropertyMap{})
+				dest = NewProperty(PropertyMap{})
 				set(dest)
 			case dest.IsObject():
 				// OK
@@ -563,7 +563,7 @@ func (p PropertyPath) reset(old, new PropertyValue, oldIsSecret, newIsSecret boo
 // intermediate locations, it also won't create or delete array locations (because that would change the size
 // of the array).
 func (p PropertyPath) Reset(old, new PropertyMap) bool {
-	return p.reset(NewObjectProperty(old), NewObjectProperty(new), false, false)
+	return p.reset(NewProperty(old), NewProperty(new), false, false)
 }
 
 func requiresQuote(c rune) bool {

--- a/sdk/go/common/resource/properties_test.go
+++ b/sdk/go/common/resource/properties_test.go
@@ -18,9 +18,44 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestNewPropertyNonGeneric tests the non-generic NewProperty functions, ensuring they
+// behave the same as the generic NewProperty function.
+func TestNewPropertyNonGeneric(t *testing.T) {
+	t.Parallel()
+
+	assetValue, err := asset.FromText("hello world")
+	require.NoError(t, err)
+
+	archiveValue, err := archive.FromAssets(map[string]any{
+		"hello": assetValue,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, NewProperty(""), NewStringProperty(""))
+	assert.Equal(t, NewProperty("hi"), NewStringProperty("hi"))
+	assert.Equal(t, NewProperty(false), NewBoolProperty(false))
+	assert.Equal(t, NewProperty(true), NewBoolProperty(true))
+	assert.Equal(t, NewProperty(0.0), NewNumberProperty(0))
+	assert.Equal(t, NewProperty(42.0), NewNumberProperty(42))
+	assert.Equal(t, NewProperty([]PropertyValue{}), NewArrayProperty([]PropertyValue{}))
+	assert.Equal(t, NewProperty(assetValue), NewAssetProperty(assetValue))
+	assert.Equal(t, NewProperty(archiveValue), NewArchiveProperty(archiveValue))
+	assert.Equal(t, NewProperty(PropertyMap{}), NewObjectProperty(PropertyMap{}))
+	assert.Equal(t, NewProperty(Computed{Element: NewProperty("")}),
+		NewComputedProperty(Computed{Element: NewProperty("")}))
+	assert.Equal(t, NewProperty(Output{Element: NewProperty("")}),
+		NewOutputProperty(Output{Element: NewProperty("")}))
+	assert.Equal(t, NewProperty(&Secret{Element: NewProperty("")}),
+		NewSecretProperty(&Secret{Element: NewProperty("")}))
+	assert.Equal(t, NewProperty(ResourceReference{}),
+		NewResourceReferenceProperty(ResourceReference{}))
+}
 
 // TestMappable ensures that we properly convert from resource property maps to their "weakly typed" JSON-like
 // equivalents.

--- a/sdk/go/common/resource/properties_test.go
+++ b/sdk/go/common/resource/properties_test.go
@@ -409,19 +409,19 @@ func TestMapFromMapNestedPropertyValues(t *testing.T) {
 	t.Parallel()
 
 	actual := NewPropertyMapFromMap(map[string]interface{}{
-		"prop": NewStringProperty("value"),
+		"prop": NewProperty("value"),
 		"nested": map[string]interface{}{
-			"obj": NewObjectProperty(PropertyMap{
-				"k": NewStringProperty("v"),
+			"obj": NewProperty(PropertyMap{
+				"k": NewProperty("v"),
 			}),
 		},
 	})
 
 	expected := PropertyMap{
-		"prop": NewStringProperty("value"),
-		"nested": NewObjectProperty(PropertyMap{
-			"obj": NewObjectProperty(PropertyMap{
-				"k": NewStringProperty("v"),
+		"prop": NewProperty("value"),
+		"nested": NewProperty(PropertyMap{
+			"obj": NewProperty(PropertyMap{
+				"k": NewProperty("v"),
 			}),
 		}),
 	}

--- a/sdk/go/common/resource/property_compatibility.go
+++ b/sdk/go/common/resource/property_compatibility.go
@@ -42,27 +42,27 @@ func ToResourcePropertyValue(v property.Value) PropertyValue {
 	var r PropertyValue
 	switch {
 	case v.IsBool():
-		r = NewBoolProperty(v.AsBool())
+		r = NewProperty(v.AsBool())
 	case v.IsNumber():
-		r = NewNumberProperty(v.AsNumber())
+		r = NewProperty(v.AsNumber())
 	case v.IsString():
-		r = NewStringProperty(v.AsString())
+		r = NewProperty(v.AsString())
 	case v.IsArray():
 		vArr := v.AsArray().AsSlice()
 		arr := make([]PropertyValue, len(vArr))
 		for i, vElem := range vArr {
 			arr[i] = ToResourcePropertyValue(vElem)
 		}
-		r = NewArrayProperty(arr)
+		r = NewProperty(arr)
 	case v.IsMap():
-		r = NewObjectProperty(ToResourcePropertyMap(v.AsMap()))
+		r = NewProperty(ToResourcePropertyMap(v.AsMap()))
 	case v.IsAsset():
-		r = NewAssetProperty(v.AsAsset())
+		r = NewProperty(v.AsAsset())
 	case v.IsArchive():
-		r = NewArchiveProperty(v.AsArchive())
+		r = NewProperty(v.AsArchive())
 	case v.IsResourceReference():
 		ref := v.AsResourceReference()
-		r = NewResourceReferenceProperty(ResourceReference{
+		r = NewProperty(ResourceReference{
 			URN:            ref.URN,
 			ID:             ToResourcePropertyValue(ref.ID),
 			PackageVersion: ref.PackageVersion,
@@ -73,7 +73,7 @@ func ToResourcePropertyValue(v property.Value) PropertyValue {
 
 	switch {
 	case len(v.Dependencies()) > 0 || (v.Secret() && v.IsComputed()):
-		r = NewOutputProperty(Output{
+		r = NewProperty(Output{
 			Element:      r,
 			Known:        !v.IsComputed(),
 			Secret:       v.Secret(),

--- a/sdk/go/common/resource/testing/rapid.go
+++ b/sdk/go/common/resource/testing/rapid.go
@@ -171,7 +171,7 @@ func SemverStringGenerator() *rapid.Generator[string] {
 // UnknownPropertyGenerator generates the unknown resource.PropertyValue.
 func UnknownPropertyGenerator() *rapid.Generator[resource.PropertyValue] {
 	return rapid.Custom(func(t *rapid.T) resource.PropertyValue {
-		return rapid.Just(resource.MakeComputed(resource.NewStringProperty(""))).Draw(t, "unknowns")
+		return rapid.Just(resource.MakeComputed(resource.NewProperty(""))).Draw(t, "unknowns")
 	})
 }
 
@@ -185,21 +185,21 @@ func NullPropertyGenerator() *rapid.Generator[resource.PropertyValue] {
 // BoolPropertyGenerator generates boolean resource.PropertyValues.
 func BoolPropertyGenerator() *rapid.Generator[resource.PropertyValue] {
 	return rapid.Custom(func(t *rapid.T) resource.PropertyValue {
-		return resource.NewBoolProperty(rapid.Bool().Draw(t, "booleans"))
+		return resource.NewProperty(rapid.Bool().Draw(t, "booleans"))
 	})
 }
 
 // NumberPropertyGenerator generates numeric resource.PropertyValues.
 func NumberPropertyGenerator() *rapid.Generator[resource.PropertyValue] {
 	return rapid.Custom(func(t *rapid.T) resource.PropertyValue {
-		return resource.NewNumberProperty(rapid.Float64().Draw(t, "numbers"))
+		return resource.NewProperty(rapid.Float64().Draw(t, "numbers"))
 	})
 }
 
 // StringPropertyGenerator generates string resource.PropertyValues.
 func StringPropertyGenerator() *rapid.Generator[resource.PropertyValue] {
 	return rapid.Custom(func(t *rapid.T) resource.PropertyValue {
-		return resource.NewStringProperty(rapid.String().Draw(t, "strings"))
+		return resource.NewProperty(rapid.String().Draw(t, "strings"))
 	})
 }
 
@@ -220,7 +220,7 @@ func AssetGenerator() *rapid.Generator[*asset.Asset] {
 // AssetPropertyGenerator generates asset resource.PropertyValues.
 func AssetPropertyGenerator() *rapid.Generator[resource.PropertyValue] {
 	return rapid.Custom(func(t *rapid.T) resource.PropertyValue {
-		return resource.NewAssetProperty(AssetGenerator().Draw(t, "assets"))
+		return resource.NewProperty(AssetGenerator().Draw(t, "assets"))
 	})
 }
 
@@ -252,7 +252,7 @@ func ArchiveGenerator(maxDepth int) *rapid.Generator[*archive.Archive] {
 // ArchivePropertyGenerator generates archive resource.PropertyValues.
 func ArchivePropertyGenerator(maxDepth int) *rapid.Generator[resource.PropertyValue] {
 	return rapid.Custom(func(t *rapid.T) resource.PropertyValue {
-		return resource.NewArchiveProperty(ArchiveGenerator(maxDepth).Draw(t, "archives"))
+		return resource.NewProperty(ArchiveGenerator(maxDepth).Draw(t, "archives"))
 	})
 }
 
@@ -289,7 +289,7 @@ func resourceReferenceGenerator(ctx *StackContext) *rapid.Generator[resource.Res
 		if r.Custom {
 			id = rapid.OneOf(
 				UnknownPropertyGenerator(),
-				rapid.Just(resource.NewStringProperty(string(r.ID))),
+				rapid.Just(resource.NewProperty(string(r.ID))),
 			).Draw(t, "referenced ID")
 		}
 
@@ -308,7 +308,7 @@ func ResourceReferencePropertyGenerator() *rapid.Generator[resource.PropertyValu
 
 func resourceReferencePropertyGenerator(ctx *StackContext) *rapid.Generator[resource.PropertyValue] {
 	return rapid.Custom(func(t *rapid.T) resource.PropertyValue {
-		return resource.NewResourceReferenceProperty(resourceReferenceGenerator(ctx).Draw(t, "resource reference"))
+		return resource.NewProperty(resourceReferenceGenerator(ctx).Draw(t, "resource reference"))
 	})
 }
 
@@ -320,7 +320,7 @@ func ArrayPropertyGenerator(maxDepth int) *rapid.Generator[resource.PropertyValu
 
 func arrayPropertyGenerator(ctx *StackContext, maxDepth int) *rapid.Generator[resource.PropertyValue] {
 	return rapid.Custom(func(t *rapid.T) resource.PropertyValue {
-		return resource.NewArrayProperty(
+		return resource.NewProperty(
 			rapid.SliceOfN(propertyValueGenerator(ctx, maxDepth-1), 0, 32).
 				Draw(t, "array elements"))
 	})
@@ -359,7 +359,7 @@ func ObjectPropertyGenerator(maxDepth int) *rapid.Generator[resource.PropertyVal
 
 func objectPropertyGenerator(ctx *StackContext, maxDepth int) *rapid.Generator[resource.PropertyValue] {
 	return rapid.Custom(func(t *rapid.T) resource.PropertyValue {
-		return resource.NewObjectProperty(propertyMapGenerator(ctx, maxDepth).Draw(t, "object contents"))
+		return resource.NewProperty(propertyMapGenerator(ctx, maxDepth).Draw(t, "object contents"))
 	})
 }
 
@@ -391,7 +391,7 @@ func outputPropertyGenerator(ctx *StackContext, maxDepth int) *rapid.Generator[r
 			element = propertyValueGenerator(ctx, maxDepth-1).Draw(t, "output element")
 		}
 
-		return resource.NewOutputProperty(resource.Output{
+		return resource.NewProperty(resource.Output{
 			Element:      element,
 			Known:        known,
 			Secret:       rapid.Bool().Draw(t, "secret"),
@@ -408,7 +408,7 @@ func SecretPropertyGenerator(maxDepth int) *rapid.Generator[resource.PropertyVal
 
 func secretPropertyGenerator(ctx *StackContext, maxDepth int) *rapid.Generator[resource.PropertyValue] {
 	return rapid.Custom(func(t *rapid.T) resource.PropertyValue {
-		return resource.NewSecretProperty(&resource.Secret{
+		return resource.NewProperty(&resource.Secret{
 			Element: propertyValueGenerator(ctx, maxDepth-1).Draw(t, "secret element"),
 		})
 	})

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -832,7 +832,7 @@ func (ctx *Context) InvokePackage(
 	if err != nil {
 		return err
 	}
-	hasSecret, err := unmarshalOutput(ctx, resource.NewObjectProperty(outProps), resultV.Elem())
+	hasSecret, err := unmarshalOutput(ctx, resource.NewProperty(outProps), resultV.Elem())
 
 	if hasSecret {
 		return errors.New("unexpected secret result returned to invoke call, " +
@@ -857,7 +857,7 @@ func (ctx *Context) InvokePackageRaw(
 	if err != nil {
 		return false, err
 	}
-	hasSecret, err := unmarshalOutput(ctx, resource.NewObjectProperty(outProps), resultV.Elem())
+	hasSecret, err := unmarshalOutput(ctx, resource.NewProperty(outProps), resultV.Elem())
 	if err != nil {
 		return false, err
 	}
@@ -948,7 +948,7 @@ func (ctx *Context) InvokeOutput(
 		}
 
 		known := !outProps.ContainsUnknowns()
-		secret, err := unmarshalOutput(ctx, resource.NewObjectProperty(outProps), dest)
+		secret, err := unmarshalOutput(ctx, resource.NewProperty(outProps), dest)
 		if err != nil {
 			internal.RejectOutput(output, err)
 			return
@@ -1117,7 +1117,7 @@ func (ctx *Context) CallPackage(
 			var secret bool
 			dest := reflect.New(output.ElementType()).Elem()
 			known := !outprops.ContainsUnknowns()
-			secret, err = unmarshalOutput(ctx, resource.NewObjectProperty(outprops), dest)
+			secret, err = unmarshalOutput(ctx, resource.NewProperty(outprops), dest)
 			if err != nil {
 				internal.RejectOutput(output, err)
 			} else {
@@ -2144,9 +2144,9 @@ func (state *resourceState) resolve(ctx *Context, err error, inputs *resourceInp
 		return
 	}
 
-	outprops["urn"] = resource.NewStringProperty(urn)
+	outprops["urn"] = resource.NewProperty(urn)
 	if id != "" || !keepUnknowns {
-		outprops["id"] = resource.NewStringProperty(id)
+		outprops["id"] = resource.NewProperty(id)
 	} else {
 		outprops["id"] = resource.MakeComputed(resource.PropertyValue{})
 	}
@@ -2162,9 +2162,9 @@ func (state *resourceState) resolve(ctx *Context, err error, inputs *resourceInp
 			}
 		}
 		if !known {
-			outprops[""] = resource.MakeComputed(resource.NewStringProperty(""))
+			outprops[""] = resource.MakeComputed(resource.NewProperty(""))
 		} else {
-			outprops[""] = resource.NewObjectProperty(remaining)
+			outprops[""] = resource.NewProperty(remaining)
 		}
 	}
 

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -171,7 +171,7 @@ func TestCollapseAliases(t *testing.T) {
 	mocks := &testMonitor{
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
 			assert.Equal(t, "test:resource:type", args.TypeToken)
-			return "myID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+			return "myID", resource.PropertyMap{"foo": resource.NewProperty("qux")}, nil
 		},
 	}
 
@@ -589,7 +589,7 @@ func TestSourcePosition(t *testing.T) {
 			require.NotNil(t, sourcePosition)
 			assert.True(t, strings.HasSuffix(sourcePosition.Uri, "context_test.go"))
 
-			return "myID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+			return "myID", resource.PropertyMap{"foo": resource.NewProperty("qux")}, nil
 		},
 	}
 
@@ -639,7 +639,7 @@ func TestInvokeOutput(t *testing.T) {
 			if args.Token == "test:invoke:fail" {
 				return nil, errors.New("invoke error")
 			}
-			return resource.PropertyMap{"result": resource.NewStringProperty("success!")}, nil
+			return resource.PropertyMap{"result": resource.NewProperty("success!")}, nil
 		},
 	}
 
@@ -700,7 +700,7 @@ func TestCall(t *testing.T) {
 			if args.Token == "test:invoke:fail" {
 				return nil, errors.New("invoke error")
 			}
-			return resource.PropertyMap{"result": resource.NewStringProperty("success!")}, nil
+			return resource.PropertyMap{"result": resource.NewProperty("success!")}, nil
 		},
 	}
 
@@ -742,7 +742,7 @@ func TestCallSingle(t *testing.T) {
 			if args.Token == "test:invoke:fail" {
 				return nil, errors.New("invoke error")
 			}
-			return resource.PropertyMap{"result": resource.NewStringProperty("success!")}, nil
+			return resource.PropertyMap{"result": resource.NewProperty("success!")}, nil
 		},
 	}
 
@@ -782,8 +782,8 @@ func TestCallSingleFailsIfMultiField(t *testing.T) {
 				return nil, errors.New("invoke error")
 			}
 			return resource.PropertyMap{
-				"result":    resource.NewStringProperty("success!"),
-				"resultTwo": resource.NewStringProperty("but failure"),
+				"result":    resource.NewProperty("success!"),
+				"resultTwo": resource.NewProperty("but failure"),
 			}, nil
 		},
 	}
@@ -812,7 +812,7 @@ func TestInvokePlainWithOutputArgument(t *testing.T) {
 
 	mocks := &testMonitor{
 		CallF: func(args MockCallArgs) (resource.PropertyMap, error) {
-			return resource.PropertyMap{"result": resource.NewStringProperty("success!")}, nil
+			return resource.PropertyMap{"result": resource.NewProperty("success!")}, nil
 		},
 	}
 

--- a/sdk/go/pulumi/mocks.go
+++ b/sdk/go/pulumi/mocks.go
@@ -256,9 +256,9 @@ func (m *mockMonitor) ReadResource(ctx context.Context, in *pulumirpc.ReadResour
 	urn := m.newURN(in.GetParent(), in.GetType(), in.GetName())
 
 	m.resources.Store(urn, resource.PropertyMap{
-		resource.PropertyKey("urn"):   resource.NewStringProperty(urn),
-		resource.PropertyKey("id"):    resource.NewStringProperty(id),
-		resource.PropertyKey("state"): resource.NewObjectProperty(state),
+		resource.PropertyKey("urn"):   resource.NewProperty(urn),
+		resource.PropertyKey("id"):    resource.NewProperty(id),
+		resource.PropertyKey("state"): resource.NewProperty(state),
 	})
 
 	stateOut, err := plugin.MarshalProperties(state, plugin.MarshalOptions{
@@ -308,9 +308,9 @@ func (m *mockMonitor) RegisterResource(ctx context.Context, in *pulumirpc.Regist
 	urn := m.newURN(in.GetParent(), in.GetType(), in.GetName())
 
 	m.resources.Store(urn, resource.PropertyMap{
-		resource.PropertyKey("urn"):   resource.NewStringProperty(urn),
-		resource.PropertyKey("id"):    resource.NewStringProperty(id),
-		resource.PropertyKey("state"): resource.NewObjectProperty(state),
+		resource.PropertyKey("urn"):   resource.NewProperty(urn),
+		resource.PropertyKey("id"):    resource.NewProperty(id),
+		resource.PropertyKey("state"): resource.NewProperty(state),
 	})
 
 	stateOut, err := plugin.MarshalProperties(state, plugin.MarshalOptions{

--- a/sdk/go/pulumi/provider.go
+++ b/sdk/go/pulumi/provider.go
@@ -224,7 +224,7 @@ func createProviderResource(ctx *Context, ref string) (ProviderResource, error) 
 	// the intended provider type with its state, if it's been registered.
 	resource, err := unmarshalResourceReference(ctx, resource.ResourceReference{
 		URN: resource.URN(urn),
-		ID:  resource.NewStringProperty(id),
+		ID:  resource.NewProperty(id),
 	})
 	if err != nil {
 		return nil, err
@@ -324,7 +324,7 @@ func copyInputTo(ctx *Context, v resource.PropertyValue, dest reflect.Value) err
 			known, element = false, element.Input().Element
 		}
 		// Handle this as a secret output.
-		return copyInputTo(ctx, resource.NewOutputProperty(resource.Output{
+		return copyInputTo(ctx, resource.NewProperty(resource.Output{
 			Element: element,
 			Known:   known,
 			Secret:  true,

--- a/sdk/go/pulumi/provider_test.go
+++ b/sdk/go/pulumi/provider_test.go
@@ -595,7 +595,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// StringArgs
 		{
 			name:  "string no deps",
-			input: resource.NewStringProperty("hello"),
+			input: resource.NewProperty("hello"),
 			args:  &StringArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, "hello", actual)
@@ -611,20 +611,20 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name:          "string secret no deps",
-			input:         resource.MakeSecret(resource.NewStringProperty("hello")),
+			input:         resource.MakeSecret(resource.NewProperty("hello")),
 			args:          &StringArgs{},
 			expectedError: "expected destination type to implement pulumi.Input or pulumi.Output, got string",
 		},
 		{
 			name:          "string computed no deps",
-			input:         resource.MakeComputed(resource.NewStringProperty("")),
+			input:         resource.MakeComputed(resource.NewProperty("")),
 			args:          &StringArgs{},
 			expectedError: "expected destination type to implement pulumi.Input or pulumi.Output, got string",
 		},
 		{
 			name: "string output value known no deps",
-			input: resource.NewOutputProperty(resource.Output{
-				Element: resource.NewStringProperty("hello"),
+			input: resource.NewProperty(resource.Output{
+				Element: resource.NewProperty("hello"),
 				Known:   true,
 			}),
 			args: &StringArgs{},
@@ -634,8 +634,8 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "string output value known secret no deps",
-			input: resource.NewOutputProperty(resource.Output{
-				Element: resource.NewStringProperty("hello"),
+			input: resource.NewProperty(resource.Output{
+				Element: resource.NewProperty("hello"),
 				Known:   true,
 				Secret:  true,
 			}),
@@ -644,7 +644,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name:  "string deps",
-			input: resource.NewStringProperty("hello"),
+			input: resource.NewProperty("hello"),
 			deps:  map[URN]struct{}{"fakeURN": {}},
 			args:  &StringArgs{},
 			expectedError: "pulumi.StringArgs.Value is typed as string but must be a type that implements " +
@@ -654,7 +654,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// StringPtrArgs
 		{
 			name:  "string pointer no deps",
-			input: resource.NewStringProperty("hello"),
+			input: resource.NewProperty("hello"),
 			args:  &StringPtrArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, stringPtr("hello"), actual)
@@ -662,7 +662,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name:          "string pointer secret no deps",
-			input:         resource.MakeSecret(resource.NewStringProperty("hello")),
+			input:         resource.MakeSecret(resource.NewProperty("hello")),
 			args:          &StringPtrArgs{},
 			expectedError: "expected destination type to implement pulumi.Input or pulumi.Output, got string",
 		},
@@ -678,7 +678,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// StringInputArgs
 		{
 			name:  "StringInput no deps",
-			input: resource.NewStringProperty("hello"),
+			input: resource.NewProperty("hello"),
 			args:  &StringInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, String("hello"), actual)
@@ -686,7 +686,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name:  "StringInput known secret no deps",
-			input: resource.MakeSecret(resource.NewStringProperty("hello")),
+			input: resource.MakeSecret(resource.NewProperty("hello")),
 			args:  &StringInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assertOutputEqual(t, "hello", true, true, map[URN]struct{}{}, actual)
@@ -694,8 +694,8 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "StringInput output value known secret no deps",
-			input: resource.NewOutputProperty(resource.Output{
-				Element: resource.NewStringProperty("hello"),
+			input: resource.NewProperty(resource.Output{
+				Element: resource.NewProperty("hello"),
 				Known:   true,
 				Secret:  true,
 			}),
@@ -706,7 +706,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name:  "StringInput output value unknown no deps",
-			input: resource.NewOutputProperty(resource.Output{}),
+			input: resource.NewProperty(resource.Output{}),
 			args:  &StringInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assertOutputEqual(t, nil, false, false, map[URN]struct{}{}, actual)
@@ -714,7 +714,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "StringInput output value unknown secret no deps",
-			input: resource.NewOutputProperty(resource.Output{
+			input: resource.NewProperty(resource.Output{
 				Secret: true,
 			}),
 			args: &StringInputArgs{},
@@ -724,7 +724,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name:  "StringInput with deps",
-			input: resource.NewStringProperty("hello"),
+			input: resource.NewProperty("hello"),
 			deps:  map[URN]struct{}{"fakeURN": {}},
 			args:  &StringInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
@@ -735,7 +735,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// StringPtrInputArgs
 		{
 			name:  "StringPtrInput no deps",
-			input: resource.NewStringProperty("hello"),
+			input: resource.NewProperty("hello"),
 			args:  &StringPtrInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, String("hello"), actual)
@@ -753,7 +753,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// BoolInputArgs
 		{
 			name:  "BoolInput no deps",
-			input: resource.NewBoolProperty(true),
+			input: resource.NewProperty(true),
 			args:  &BoolInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, Bool(true), actual)
@@ -761,7 +761,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name:  "BoolInput known secret no deps",
-			input: resource.MakeSecret(resource.NewBoolProperty(true)),
+			input: resource.MakeSecret(resource.NewProperty(true)),
 			args:  &BoolInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assertOutputEqual(t, true, true, true, map[URN]struct{}{}, actual)
@@ -769,8 +769,8 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "BoolInput output value known secret no deps",
-			input: resource.NewOutputProperty(resource.Output{
-				Element: resource.NewBoolProperty(true),
+			input: resource.NewProperty(resource.Output{
+				Element: resource.NewProperty(true),
 				Known:   true,
 				Secret:  true,
 			}),
@@ -781,7 +781,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name:  "BoolInput output value unknown no deps",
-			input: resource.NewOutputProperty(resource.Output{}),
+			input: resource.NewProperty(resource.Output{}),
 			args:  &BoolInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assertOutputEqual(t, nil, false, false, map[URN]struct{}{}, actual)
@@ -789,7 +789,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "BoolInput output value unknown secret no deps",
-			input: resource.NewOutputProperty(resource.Output{
+			input: resource.NewProperty(resource.Output{
 				Secret: true,
 			}),
 			args: &BoolInputArgs{},
@@ -801,7 +801,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// BoolPtrInputArgs
 		{
 			name:  "BoolPtrInput no deps",
-			input: resource.NewBoolProperty(true),
+			input: resource.NewProperty(true),
 			args:  &BoolPtrInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, Bool(true), actual)
@@ -819,7 +819,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// IntArgs
 		{
 			name:  "int no deps",
-			input: resource.NewNumberProperty(42),
+			input: resource.NewProperty(42.0),
 			args:  &IntArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, 42, actual)
@@ -827,7 +827,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name:          "set field typed as int with string value",
-			input:         resource.NewStringProperty("foo"),
+			input:         resource.NewProperty("foo"),
 			args:          &IntArgs{},
 			expectedError: "unmarshaling value: expected an int, got a string",
 		},
@@ -835,7 +835,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// BoolEnumInputArgs
 		{
 			name:  "BoolEnumInput no deps",
-			input: resource.NewBoolProperty(true),
+			input: resource.NewProperty(true),
 			args:  &BoolEnumInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, BoolEnum(true), actual)
@@ -844,7 +844,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// IntEnumInputArgs
 		{
 			name:  "IntEnumInput no deps",
-			input: resource.NewNumberProperty(42),
+			input: resource.NewProperty(42.0),
 			args:  &IntEnumInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, IntEnum(42), actual)
@@ -853,7 +853,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// FloatEnumInputArgs
 		{
 			name:  "FloatEnumInput no deps",
-			input: resource.NewNumberProperty(42),
+			input: resource.NewProperty(42.0),
 			args:  &FloatEnumInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, FloatEnum(42), actual)
@@ -862,7 +862,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// StringEnumInputArgs
 		{
 			name:  "StringEnumInput no deps",
-			input: resource.NewStringProperty("hello"),
+			input: resource.NewProperty("hello"),
 			args:  &StringEnumInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, StringEnum("hello"), actual)
@@ -872,9 +872,9 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// StringArrayArgs
 		{
 			name: "StringArrayArgs no deps",
-			input: resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewStringProperty("hello"),
-				resource.NewStringProperty("world"),
+			input: resource.NewProperty([]resource.PropertyValue{
+				resource.NewProperty("hello"),
+				resource.NewProperty("world"),
 			}),
 			args: &StringArrayArgs{},
 			assert: func(t *testing.T, actual interface{}) {
@@ -885,9 +885,9 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// StringArrayInputArgs
 		{
 			name: "StringArrayInputArgs no deps",
-			input: resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewStringProperty("hello"),
-				resource.NewStringProperty("world"),
+			input: resource.NewProperty([]resource.PropertyValue{
+				resource.NewProperty("hello"),
+				resource.NewProperty("world"),
 			}),
 			args: &StringArrayInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
@@ -899,10 +899,10 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "StringArrayInputArgs no deps nested secret output",
-			input: resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewStringProperty("hello"),
-				resource.NewOutputProperty(resource.Output{
-					Element: resource.NewStringProperty("world"),
+			input: resource.NewProperty([]resource.PropertyValue{
+				resource.NewProperty("hello"),
+				resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("world"),
 					Known:   true,
 					Secret:  true,
 				}),
@@ -920,7 +920,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// StringMapArgs
 		{
 			name: "StringMapArgs no deps",
-			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+			input: resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": "hello",
 				"bar": "world",
 			})),
@@ -936,9 +936,9 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// StringMapInputArgs
 		{
 			name: "StringMapInputArgs no deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"foo": resource.NewStringProperty("hello"),
-				"bar": resource.NewStringProperty("world"),
+			input: resource.NewProperty(resource.PropertyMap{
+				"foo": resource.NewProperty("hello"),
+				"bar": resource.NewProperty("world"),
 			}),
 			args: &StringMapInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
@@ -950,10 +950,10 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "StringMapInputArgs no deps nested secret output",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"foo": resource.NewStringProperty("hello"),
-				"bar": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewStringProperty("world"),
+			input: resource.NewProperty(resource.PropertyMap{
+				"foo": resource.NewProperty("hello"),
+				"bar": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("world"),
 					Known:   true,
 					Secret:  true,
 				}),
@@ -969,10 +969,10 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "StringMapInputArgs with deps nested secret output",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"foo": resource.NewStringProperty("hello"),
-				"bar": resource.NewOutputProperty(resource.Output{
-					Element:      resource.NewStringProperty("world"),
+			input: resource.NewProperty(resource.PropertyMap{
+				"foo": resource.NewProperty("hello"),
+				"bar": resource.NewProperty(resource.Output{
+					Element:      resource.NewProperty("world"),
 					Known:        true,
 					Secret:       true,
 					Dependencies: []resource.URN{"fakeURN"},
@@ -990,10 +990,10 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "StringMapInputArgs with extra deps nested secret output",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"foo": resource.NewStringProperty("hello"),
-				"bar": resource.NewOutputProperty(resource.Output{
-					Element:      resource.NewStringProperty("world"),
+			input: resource.NewProperty(resource.PropertyMap{
+				"foo": resource.NewProperty("hello"),
+				"bar": resource.NewProperty(resource.Output{
+					Element:      resource.NewProperty("world"),
 					Known:        true,
 					Secret:       true,
 					Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
@@ -1016,7 +1016,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// NestedArgs
 		{
 			name: "NestedArgs no deps",
-			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+			input: resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": "hi",
 				"bar": 7,
 			})),
@@ -1027,7 +1027,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "set field typed as string with number value",
-			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+			input: resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": 500,
 				"bar": 42,
 			})),
@@ -1036,7 +1036,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "destination must be typed as input or output for secret value",
-			input: resource.MakeSecret(resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+			input: resource.MakeSecret(resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": "hello",
 				"bar": 42,
 			}))),
@@ -1045,7 +1045,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "destination must be typed as input or output for value with dependencies",
-			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+			input: resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": "hello",
 				"bar": 42,
 			})),
@@ -1058,7 +1058,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// NestedPtrArgs
 		{
 			name: "NestedPtrArgs no deps",
-			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+			input: resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": "pointer",
 				"bar": 2,
 			})),
@@ -1071,12 +1071,12 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// NestedArrayArgs
 		{
 			name: "NestedArrayArgs no deps",
-			input: resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+			input: resource.NewProperty([]resource.PropertyValue{
+				resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 					"foo": "1",
 					"bar": 1,
 				})),
-				resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+				resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 					"foo": "2",
 					"bar": 2,
 				})),
@@ -1093,7 +1093,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// NestedMapArgs
 		{
 			name: "NestedMapArgs no deps",
-			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+			input: resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 				"a": map[string]interface{}{
 					"foo": "3",
 					"bar": 3,
@@ -1115,7 +1115,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// NestedOutputArgs
 		{
 			name: "NestedOutputArgs no deps",
-			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+			input: resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": "hello",
 				"bar": 42,
 			})),
@@ -1131,7 +1131,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// NestedPtrOutputArgs
 		{
 			name: "NestedPtrOutputArgs no deps",
-			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+			input: resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": "world",
 				"bar": 100,
 			})),
@@ -1147,12 +1147,12 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// NestedArrayOutputArgs
 		{
 			name: "NestedArrayOutputArgs no deps",
-			input: resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+			input: resource.NewProperty([]resource.PropertyValue{
+				resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 					"foo": "a",
 					"bar": 1,
 				})),
-				resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+				resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 					"foo": "b",
 					"bar": 2,
 				})),
@@ -1169,7 +1169,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// NestedMapOutputArgs
 		{
 			name: "NestedMapOutputArgs no deps",
-			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+			input: resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 				"a": map[string]interface{}{
 					"foo": "c",
 					"bar": 3,
@@ -1191,9 +1191,9 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// PlainArrayArgs
 		{
 			name: "PlainArrayArgs no deps",
-			input: resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewStringProperty("foo"),
-				resource.NewStringProperty("bar"),
+			input: resource.NewProperty([]resource.PropertyValue{
+				resource.NewProperty("foo"),
+				resource.NewProperty("bar"),
 			}),
 			args: &PlainArrayArgs{},
 			assert: func(t *testing.T, actual interface{}) {
@@ -1205,9 +1205,9 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainArrayArgs secret no deps",
-			input: resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewStringProperty("foo"),
-				resource.MakeSecret(resource.NewStringProperty("bar")),
+			input: resource.NewProperty([]resource.PropertyValue{
+				resource.NewProperty("foo"),
+				resource.MakeSecret(resource.NewProperty("bar")),
 			}),
 			args: &PlainArrayArgs{},
 			assert: func(t *testing.T, actual interface{}) {
@@ -1220,9 +1220,9 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainArrayArgs computed no deps",
-			input: resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewStringProperty("foo"),
-				resource.MakeComputed(resource.NewStringProperty("")),
+			input: resource.NewProperty([]resource.PropertyValue{
+				resource.NewProperty("foo"),
+				resource.MakeComputed(resource.NewProperty("")),
 			}),
 			args: &PlainArrayArgs{},
 			assert: func(t *testing.T, actual interface{}) {
@@ -1235,10 +1235,10 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainArrayArgs output value known no deps",
-			input: resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewStringProperty("foo"),
-				resource.NewOutputProperty(resource.Output{
-					Element: resource.NewStringProperty("bar"),
+			input: resource.NewProperty([]resource.PropertyValue{
+				resource.NewProperty("foo"),
+				resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("bar"),
 					Known:   true,
 				}),
 			}),
@@ -1252,10 +1252,10 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainArrayArgs output value known secret no deps",
-			input: resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewStringProperty("foo"),
-				resource.NewOutputProperty(resource.Output{
-					Element: resource.NewStringProperty("bar"),
+			input: resource.NewProperty([]resource.PropertyValue{
+				resource.NewProperty("foo"),
+				resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("bar"),
 					Known:   true,
 					Secret:  true,
 				}),
@@ -1271,9 +1271,9 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainArrayArgs with deps",
-			input: resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewStringProperty("foo"),
-				resource.NewStringProperty("bar"),
+			input: resource.NewProperty([]resource.PropertyValue{
+				resource.NewProperty("foo"),
+				resource.NewProperty("bar"),
 			}),
 			deps: map[URN]struct{}{"fakeURN": {}},
 			args: &PlainArrayArgs{},
@@ -1289,7 +1289,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// PlainMapArgs
 		{
 			name: "PlainMapArgs no deps",
-			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+			input: resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": "bar",
 				"baz": "qux",
 			})),
@@ -1303,9 +1303,9 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainMapArgs secret no deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"foo": resource.NewStringProperty("bar"),
-				"baz": resource.MakeSecret(resource.NewStringProperty("qux")),
+			input: resource.NewProperty(resource.PropertyMap{
+				"foo": resource.NewProperty("bar"),
+				"baz": resource.MakeSecret(resource.NewProperty("qux")),
 			}),
 			args: &PlainMapArgs{},
 			assert: func(t *testing.T, actual interface{}) {
@@ -1318,9 +1318,9 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainMapArgs computed no deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"foo": resource.NewStringProperty("bar"),
-				"baz": resource.MakeComputed(resource.NewStringProperty("")),
+			input: resource.NewProperty(resource.PropertyMap{
+				"foo": resource.NewProperty("bar"),
+				"baz": resource.MakeComputed(resource.NewProperty("")),
 			}),
 			args: &PlainMapArgs{},
 			assert: func(t *testing.T, actual interface{}) {
@@ -1333,10 +1333,10 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainMapArgs output value known no deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"foo": resource.NewStringProperty("bar"),
-				"baz": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewStringProperty("qux"),
+			input: resource.NewProperty(resource.PropertyMap{
+				"foo": resource.NewProperty("bar"),
+				"baz": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("qux"),
 					Known:   true,
 				}),
 			}),
@@ -1350,10 +1350,10 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainMapArgs output value known secret no deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"foo": resource.NewStringProperty("bar"),
-				"baz": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewStringProperty("qux"),
+			input: resource.NewProperty(resource.PropertyMap{
+				"foo": resource.NewProperty("bar"),
+				"baz": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("qux"),
 					Known:   true,
 					Secret:  true,
 				}),
@@ -1369,7 +1369,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainMapArgs with deps",
-			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+			input: resource.NewProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": "bar",
 				"baz": "qux",
 			})),
@@ -1387,7 +1387,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// PlainOptionalNestedInputtyInputArgs
 		{
 			name:  "PlainOptionalNestedInputtyInputArgs empty no deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{}),
+			input: resource.NewProperty(resource.PropertyMap{}),
 			args:  &PlainOptionalNestedInputtyInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, &NestedInputtyInputArgs{}, actual)
@@ -1395,8 +1395,8 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainOptionalNestedInputtyInputArgs value no deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"something": resource.NewStringProperty("anything"),
+			input: resource.NewProperty(resource.PropertyMap{
+				"something": resource.NewProperty("anything"),
 			}),
 			args: &PlainOptionalNestedInputtyInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
@@ -1407,8 +1407,8 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainOptionalNestedInputtyInputArgs secret no deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"something": resource.MakeSecret(resource.NewStringProperty("anything")),
+			input: resource.NewProperty(resource.PropertyMap{
+				"something": resource.MakeSecret(resource.NewProperty("anything")),
 			}),
 			args: &PlainOptionalNestedInputtyInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
@@ -1419,8 +1419,8 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainOptionalNestedInputtyInputArgs computed no deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"something": resource.MakeComputed(resource.NewStringProperty("")),
+			input: resource.NewProperty(resource.PropertyMap{
+				"something": resource.MakeComputed(resource.NewProperty("")),
 			}),
 			args: &PlainOptionalNestedInputtyInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
@@ -1431,9 +1431,9 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainOptionalNestedInputtyInputArgs output value known no deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"something": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewStringProperty("anything"),
+			input: resource.NewProperty(resource.PropertyMap{
+				"something": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("anything"),
 					Known:   true,
 				}),
 			}),
@@ -1446,9 +1446,9 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainOptionalNestedInputtyInputArgs output value known secret no deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"something": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewStringProperty("anything"),
+			input: resource.NewProperty(resource.PropertyMap{
+				"something": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("anything"),
 					Known:   true,
 					Secret:  true,
 				}),
@@ -1462,9 +1462,9 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainOptionalNestedInputtyInputArgs output value known secret with deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"something": resource.NewOutputProperty(resource.Output{
-					Element:      resource.NewStringProperty("anything"),
+			input: resource.NewProperty(resource.PropertyMap{
+				"something": resource.NewProperty(resource.Output{
+					Element:      resource.NewProperty("anything"),
 					Known:        true,
 					Secret:       true,
 					Dependencies: []resource.URN{"fakeURN"},
@@ -1482,7 +1482,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// PlainOptionalNestedInputtyArgs
 		{
 			name:  "PlainOptionalNestedInputtyArgs empty no deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{}),
+			input: resource.NewProperty(resource.PropertyMap{}),
 			args:  &PlainOptionalNestedInputtyArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, &NestedInputtyArgs{}, actual)
@@ -1490,8 +1490,8 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainOptionalNestedInputtyArgs value no deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"something": resource.NewStringProperty("anything"),
+			input: resource.NewProperty(resource.PropertyMap{
+				"something": resource.NewProperty("anything"),
 			}),
 			args: &PlainOptionalNestedInputtyArgs{},
 			assert: func(t *testing.T, actual interface{}) {
@@ -1502,8 +1502,8 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainOptionalNestedInputtyArgs secret no deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"something": resource.MakeSecret(resource.NewStringProperty("anything")),
+			input: resource.NewProperty(resource.PropertyMap{
+				"something": resource.MakeSecret(resource.NewProperty("anything")),
 			}),
 			args: &PlainOptionalNestedInputtyArgs{},
 			assert: func(t *testing.T, actual interface{}) {
@@ -1514,8 +1514,8 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainOptionalNestedInputtyArgs computed no deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"something": resource.MakeComputed(resource.NewStringProperty("")),
+			input: resource.NewProperty(resource.PropertyMap{
+				"something": resource.MakeComputed(resource.NewProperty("")),
 			}),
 			args: &PlainOptionalNestedInputtyArgs{},
 			assert: func(t *testing.T, actual interface{}) {
@@ -1526,9 +1526,9 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainOptionalNestedInputtyArgs output value known no deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"something": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewStringProperty("anything"),
+			input: resource.NewProperty(resource.PropertyMap{
+				"something": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("anything"),
 					Known:   true,
 				}),
 			}),
@@ -1541,9 +1541,9 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainOptionalNestedInputtyArgs output value known secret no deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"something": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewStringProperty("anything"),
+			input: resource.NewProperty(resource.PropertyMap{
+				"something": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("anything"),
 					Known:   true,
 					Secret:  true,
 				}),
@@ -1557,9 +1557,9 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		},
 		{
 			name: "PlainOptionalNestedInputtyArgs output value known secret with deps",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"something": resource.NewOutputProperty(resource.Output{
-					Element:      resource.NewStringProperty("anything"),
+			input: resource.NewProperty(resource.PropertyMap{
+				"something": resource.NewProperty(resource.Output{
+					Element:      resource.NewProperty("anything"),
 					Known:        true,
 					Secret:       true,
 					Dependencies: []resource.URN{"fakeURN"},
@@ -1577,7 +1577,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// AssetArgs
 		{
 			name:  "AssetArgs no deps",
-			input: resource.NewAssetProperty(&rasset.Asset{Text: "hello"}),
+			input: resource.NewProperty(&rasset.Asset{Text: "hello"}),
 			args:  &AssetArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, NewStringAsset("hello"), actual)
@@ -1587,7 +1587,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// AssetInputArgs
 		{
 			name:  "AssetInputArgs no deps",
-			input: resource.NewAssetProperty(&rasset.Asset{Text: "hello"}),
+			input: resource.NewProperty(&rasset.Asset{Text: "hello"}),
 			args:  &AssetInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, NewStringAsset("hello"), actual)
@@ -1597,7 +1597,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// ArchiveArgs
 		{
 			name:  "ArchiveArgs no deps",
-			input: resource.NewArchiveProperty(&rarchive.Archive{Path: "path"}),
+			input: resource.NewProperty(&rarchive.Archive{Path: "path"}),
 			args:  &ArchiveArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, NewFileArchive("path"), actual)
@@ -1607,7 +1607,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// ArchiveInputArgs
 		{
 			name:  "ArchiveInputArgs no deps",
-			input: resource.NewArchiveProperty(&rarchive.Archive{Path: "path"}),
+			input: resource.NewProperty(&rarchive.Archive{Path: "path"}),
 			args:  &ArchiveInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, NewFileArchive("path"), actual)
@@ -1617,7 +1617,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// AssetOrArchiveArgs
 		{
 			name:  "AssetOrArchiveArgs no deps",
-			input: resource.NewAssetProperty(&rasset.Asset{Text: "hello"}),
+			input: resource.NewProperty(&rasset.Asset{Text: "hello"}),
 			args:  &AssetOrArchiveArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, NewStringAsset("hello"), actual)
@@ -1627,7 +1627,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// AssetOrArchiveInputArgs
 		{
 			name:  "AssetOrArchiveInputArgs no deps",
-			input: resource.NewAssetProperty(&rasset.Asset{Text: "hello"}),
+			input: resource.NewProperty(&rasset.Asset{Text: "hello"}),
 			args:  &AssetOrArchiveInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, NewStringAsset("hello"), actual)
@@ -1637,15 +1637,15 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// LaunchTemplateArgs
 		{
 			name: "LaunchTemplateArgs input types not registered nested known output value",
-			input: resource.NewObjectProperty(resource.PropertyMap{
-				"tagSpecifications": resource.NewArrayProperty([]resource.PropertyValue{
-					resource.NewObjectProperty(resource.PropertyMap{
-						"tags": resource.NewObjectProperty(resource.PropertyMap{
-							"Name": resource.NewOutputProperty(resource.Output{
-								Element: resource.NewStringProperty("Worker Node"),
+			input: resource.NewProperty(resource.PropertyMap{
+				"tagSpecifications": resource.NewProperty([]resource.PropertyValue{
+					resource.NewProperty(resource.PropertyMap{
+						"tags": resource.NewProperty(resource.PropertyMap{
+							"Name": resource.NewProperty(resource.Output{
+								Element: resource.NewProperty("Worker Node"),
 								Known:   true,
 							}),
-							"Test Name": resource.NewStringProperty("test name"),
+							"Test Name": resource.NewProperty("test name"),
 						}),
 					}),
 				}),
@@ -1716,8 +1716,8 @@ func TestConstructResult(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, resource.PropertyMap{
-		"foo":       resource.NewStringProperty("hi"),
-		"someValue": resource.NewStringProperty("something"),
+		"foo":       resource.NewProperty("hi"),
+		"someValue": resource.NewProperty("something"),
 	}, resolvedProps)
 }
 

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -1416,7 +1416,7 @@ func TestInvokeDependsOn(t *testing.T) {
 	monitor := &testMonitor{
 		CallF: func(args MockCallArgs) (resource.PropertyMap, error) {
 			return resource.PropertyMap{
-				"echo": resource.NewStringProperty("hello"),
+				"echo": resource.NewProperty("hello"),
 			}, nil
 		},
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
@@ -1457,7 +1457,7 @@ func TestInvokeDependsOnInputs(t *testing.T) {
 	monitor := &testMonitor{
 		CallF: func(args MockCallArgs) (resource.PropertyMap, error) {
 			return resource.PropertyMap{
-				"echo": resource.NewStringProperty("hello"),
+				"echo": resource.NewProperty("hello"),
 			}, nil
 		},
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
@@ -1552,7 +1552,7 @@ func TestInvokeDependsOnIgnored(t *testing.T) {
 	monitor := &testMonitor{
 		CallF: func(args MockCallArgs) (resource.PropertyMap, error) {
 			return resource.PropertyMap{
-				"echo": resource.NewStringProperty("hello"),
+				"echo": resource.NewProperty("hello"),
 			}, nil
 		},
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
@@ -1600,7 +1600,7 @@ func TestInvokeSecret(t *testing.T) {
 		CallF: func(args MockCallArgs) (resource.PropertyMap, error) {
 			return resource.PropertyMap{
 				// The invoke result contains a secret.
-				"echo": resource.MakeSecret(resource.NewStringProperty("hello")),
+				"echo": resource.MakeSecret(resource.NewProperty("hello")),
 			}, nil
 		},
 	}

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -316,7 +316,7 @@ func marshalInputOptionsImpl(v interface{},
 					}
 				}
 
-				return resource.NewOutputProperty(resource.Output{
+				return resource.NewProperty(resource.Output{
 					Element:      element,
 					Known:        known,
 					Secret:       secret,
@@ -348,7 +348,7 @@ func marshalInputOptionsImpl(v interface{},
 			if v.invalid {
 				return resource.PropertyValue{}, nil, errors.New("invalid asset")
 			}
-			return resource.NewAssetProperty(&rasset.Asset{
+			return resource.NewProperty(&rasset.Asset{
 				Path: v.Path(),
 				Text: v.Text(),
 				URI:  v.URI(),
@@ -369,7 +369,7 @@ func marshalInputOptionsImpl(v interface{},
 					assets[k] = aa.V
 				}
 			}
-			return resource.NewArchiveProperty(&rarchive.Archive{
+			return resource.NewProperty(&rarchive.Archive{
 				Assets: assets,
 				Path:   v.Path(),
 				URI:    v.URI(),
@@ -421,13 +421,13 @@ func marshalInputOptionsImpl(v interface{},
 		//nolint:exhaustive // We only need to handle the types we care about.
 		switch rv.Type().Kind() {
 		case reflect.Bool:
-			return resource.NewBoolProperty(rv.Bool()), deps, nil
+			return resource.NewProperty(rv.Bool()), deps, nil
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			return resource.NewNumberProperty(float64(rv.Int())), deps, nil
+			return resource.NewProperty(float64(rv.Int())), deps, nil
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			return resource.NewNumberProperty(float64(rv.Uint())), deps, nil
+			return resource.NewProperty(float64(rv.Uint())), deps, nil
 		case reflect.Float32, reflect.Float64:
-			return resource.NewNumberProperty(rv.Float()), deps, nil
+			return resource.NewProperty(rv.Float()), deps, nil
 		case reflect.Ptr, reflect.Interface:
 			// Dereference non-nil pointers and interfaces.
 			if rv.IsNil() {
@@ -439,7 +439,7 @@ func marshalInputOptionsImpl(v interface{},
 			v = rv.Elem().Interface()
 			continue
 		case reflect.String:
-			return resource.NewStringProperty(rv.String()), deps, nil
+			return resource.NewProperty(rv.String()), deps, nil
 		case reflect.Array, reflect.Slice:
 			if rv.IsNil() {
 				return resource.PropertyValue{}, deps, nil
@@ -458,7 +458,7 @@ func marshalInputOptionsImpl(v interface{},
 				arr = append(arr, e)
 				deps = append(deps, d...)
 			}
-			return resource.NewArrayProperty(arr), deps, nil
+			return resource.NewProperty(arr), deps, nil
 		case reflect.Map:
 			if rv.Type().Key().Kind() != reflect.String {
 				return resource.PropertyValue{}, nil,
@@ -484,7 +484,7 @@ func marshalInputOptionsImpl(v interface{},
 				}
 				deps = append(deps, d...)
 			}
-			return resource.NewObjectProperty(obj), deps, nil
+			return resource.NewProperty(obj), deps, nil
 		case reflect.Struct:
 			obj := resource.PropertyMap{}
 			typ := rv.Type()
@@ -507,7 +507,7 @@ func marshalInputOptionsImpl(v interface{},
 				}
 				deps = append(deps, d...)
 			}
-			return resource.NewObjectProperty(obj), deps, nil
+			return resource.NewProperty(obj), deps, nil
 		}
 		return resource.PropertyValue{}, nil, fmt.Errorf("unrecognized input property type: %v (%T)", v, v)
 	}

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -245,7 +245,7 @@ func TestMarshalRoundtrip(t *testing.T) {
 	assert.Equal(t, 25, len(pdeps))
 
 	// Now just unmarshal and ensure the resulting map matches.
-	resV, secret, err := unmarshalPropertyValue(ctx, resource.NewObjectProperty(resolved))
+	resV, secret, err := unmarshalPropertyValue(ctx, resource.NewProperty(resolved))
 	assert.False(t, secret)
 	require.NoError(t, err)
 	require.NotNil(t, resV)
@@ -478,7 +478,7 @@ func TestResourceState(t *testing.T) {
 	}, pdeps)
 	assert.Equal(t, []URN{"foo"}, deps)
 
-	res, secret, err := unmarshalPropertyValue(ctx, resource.NewObjectProperty(resolved))
+	res, secret, err := unmarshalPropertyValue(ctx, resource.NewProperty(resolved))
 	require.NoError(t, err)
 	assert.False(t, secret)
 	assert.Equal(t, map[string]interface{}{
@@ -528,7 +528,7 @@ func TestUnmarshalInternalMapValue(t *testing.T) {
 	m := make(map[string]interface{})
 	m["foo"] = "bar"
 	m["__default"] = "buzz"
-	pmap := resource.NewObjectProperty(resource.NewPropertyMapFromMap(m))
+	pmap := resource.NewProperty(resource.NewPropertyMapFromMap(m))
 
 	var mv map[string]string
 	_, err = unmarshalOutput(ctx, pmap, reflect.ValueOf(&mv).Elem())
@@ -591,7 +591,7 @@ func TestMarshalRoundtripNestedSecret(t *testing.T) {
 	assert.Equal(t, 15, len(pdeps))
 
 	// Now just unmarshal and ensure the resulting map matches.
-	resV, secret, err := unmarshalPropertyValue(ctx, resource.NewObjectProperty(resolved))
+	resV, secret, err := unmarshalPropertyValue(ctx, resource.NewProperty(resolved))
 	assert.True(t, secret)
 	require.NoError(t, err)
 	require.NotNil(t, resV)
@@ -842,7 +842,7 @@ func TestInvalidAsset(t *testing.T) {
 	require.NoError(t, err)
 
 	var d Asset
-	_, err = unmarshalOutput(ctx, resource.NewStringProperty("foo"), reflect.ValueOf(&d).Elem())
+	_, err = unmarshalOutput(ctx, resource.NewProperty("foo"), reflect.ValueOf(&d).Elem())
 	require.NoError(t, err)
 	require.NotNil(t, d)
 	require.True(t, d.(*asset).invalid)
@@ -858,7 +858,7 @@ func TestInvalidArchive(t *testing.T) {
 	require.NoError(t, err)
 
 	var d Archive
-	_, err = unmarshalOutput(ctx, resource.NewStringProperty("foo"), reflect.ValueOf(&d).Elem())
+	_, err = unmarshalOutput(ctx, resource.NewProperty("foo"), reflect.ValueOf(&d).Elem())
 	require.NoError(t, err)
 	require.NotNil(t, d)
 	require.True(t, d.(*archive).invalid)
@@ -881,7 +881,7 @@ func TestUnmarshalPointer(t *testing.T) {
 	RegisterResourceModule("test", "index", &testResourceModule{
 		version: semver.MustParse("2.0.0"),
 	})
-	_, err = unmarshalOutput(ctx, resource.NewResourceReferenceProperty(res), reflect.ValueOf(&d).Elem())
+	_, err = unmarshalOutput(ctx, resource.NewProperty(res), reflect.ValueOf(&d).Elem())
 	require.NoError(t, err)
 	assert.IsType(t, &simpleComponentResource{}, d)
 }
@@ -949,12 +949,12 @@ func TestOutputValueMarshalling(t *testing.T) {
 		expected resource.PropertyValue
 	}{
 		{value: nil, expected: resource.NewNullProperty()},
-		{value: 0, expected: resource.NewNumberProperty(0)},
-		{value: 1, expected: resource.NewNumberProperty(1)},
-		{value: "", expected: resource.NewStringProperty("")},
-		{value: "hi", expected: resource.NewStringProperty("hi")},
-		{value: map[string]string{}, expected: resource.NewObjectProperty(resource.PropertyMap{})},
-		{value: []string{}, expected: resource.NewArrayProperty([]resource.PropertyValue{})},
+		{value: 0, expected: resource.NewProperty(0.0)},
+		{value: 1, expected: resource.NewProperty(1.0)},
+		{value: "", expected: resource.NewProperty("")},
+		{value: "hi", expected: resource.NewProperty("hi")},
+		{value: map[string]string{}, expected: resource.NewProperty(resource.PropertyMap{})},
+		{value: []string{}, expected: resource.NewProperty([]resource.PropertyValue{})},
 	}
 	//nolint:paralleltest // parallel parent, would require refactor to silence lint
 	for _, value := range values {
@@ -982,7 +982,7 @@ func TestOutputValueMarshalling(t *testing.T) {
 						if known {
 							v.Element = value.expected
 						}
-						expectedValue = resource.NewOutputProperty(v)
+						expectedValue = resource.NewProperty(v)
 					}
 
 					expected := resource.PropertyMap{"value": expectedValue}
@@ -1279,15 +1279,15 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 		{
 			name:     "empty",
 			input:    fooArgs{},
-			expected: resource.NewObjectProperty(resource.PropertyMap{}),
+			expected: resource.NewProperty(resource.PropertyMap{}),
 		},
 		{
 			name: "options empty",
 			input: fooArgs{
 				TemplateOptions: TemplateOptionsArgs{},
 			},
-			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"templateOptions": resource.NewObjectProperty(resource.PropertyMap{}),
+			expected: resource.NewProperty(resource.PropertyMap{
+				"templateOptions": resource.NewProperty(resource.PropertyMap{}),
 			}),
 		},
 		{
@@ -1295,8 +1295,8 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 			input: fooArgs{
 				TemplateOptions: unknownTemplateOptionsPtrOutput,
 			},
-			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"templateOptions": resource.NewOutputProperty(resource.Output{}),
+			expected: resource.NewProperty(resource.PropertyMap{
+				"templateOptions": resource.NewProperty(resource.Output{}),
 			}),
 		},
 		{
@@ -1304,8 +1304,8 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 			input: fooArgs{
 				TemplateOptions: unknownSecretTemplateOptionsPtrOutput,
 			},
-			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"templateOptions": resource.NewOutputProperty(resource.Output{
+			expected: resource.NewProperty(resource.PropertyMap{
+				"templateOptions": resource.NewProperty(resource.Output{
 					Secret: true,
 				}),
 			}),
@@ -1317,9 +1317,9 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 					Description: String("hello"),
 				},
 			},
-			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"templateOptions": resource.NewObjectProperty(resource.PropertyMap{
-					"description": resource.NewStringProperty("hello"),
+			expected: resource.NewProperty(resource.PropertyMap{
+				"templateOptions": resource.NewProperty(resource.PropertyMap{
+					"description": resource.NewProperty("hello"),
 				}),
 			}),
 		},
@@ -1330,10 +1330,10 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 					Description: ToSecret(String("hello")).(StringOutput),
 				},
 			},
-			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"templateOptions": resource.NewObjectProperty(resource.PropertyMap{
-					"description": resource.NewOutputProperty(resource.Output{
-						Element: resource.NewStringProperty("hello"),
+			expected: resource.NewProperty(resource.PropertyMap{
+				"templateOptions": resource.NewProperty(resource.PropertyMap{
+					"description": resource.NewProperty(resource.Output{
+						Element: resource.NewProperty("hello"),
 						Known:   true,
 						Secret:  true,
 					}),
@@ -1347,10 +1347,10 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 					Description: ToSecret(String("hello")).(StringOutput),
 				}.ToTemplateOptionsOutput(),
 			},
-			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"templateOptions": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewObjectProperty(resource.PropertyMap{
-						"description": resource.NewStringProperty("hello"),
+			expected: resource.NewProperty(resource.PropertyMap{
+				"templateOptions": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty(resource.PropertyMap{
+						"description": resource.NewProperty("hello"),
 					}),
 					Known:  true,
 					Secret: true,
@@ -1364,9 +1364,9 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 					Description: unknownStringOutput,
 				},
 			},
-			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"templateOptions": resource.NewObjectProperty(resource.PropertyMap{
-					"description": resource.NewOutputProperty(resource.Output{}),
+			expected: resource.NewProperty(resource.PropertyMap{
+				"templateOptions": resource.NewProperty(resource.PropertyMap{
+					"description": resource.NewProperty(resource.Output{}),
 				}),
 			}),
 		},
@@ -1385,14 +1385,14 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 					},
 				},
 			},
-			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"templateOptions": resource.NewObjectProperty(resource.PropertyMap{
-					"tagSpecifications": resource.NewArrayProperty([]resource.PropertyValue{
-						resource.NewObjectProperty(resource.PropertyMap{
-							"name": resource.NewStringProperty("hello"),
-							"tags": resource.NewObjectProperty(resource.PropertyMap{
-								"first": resource.NewStringProperty("second"),
-								"third": resource.NewOutputProperty(resource.Output{}),
+			expected: resource.NewProperty(resource.PropertyMap{
+				"templateOptions": resource.NewProperty(resource.PropertyMap{
+					"tagSpecifications": resource.NewProperty([]resource.PropertyValue{
+						resource.NewProperty(resource.PropertyMap{
+							"name": resource.NewProperty("hello"),
+							"tags": resource.NewProperty(resource.PropertyMap{
+								"first": resource.NewProperty("second"),
+								"third": resource.NewProperty(resource.Output{}),
 							}),
 						}),
 					}),
@@ -1404,8 +1404,8 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 			input: &BucketObjectArgs{
 				Source: NewFileAsset("foo.txt"),
 			},
-			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"source": resource.NewAssetProperty(&rasset.Asset{
+			expected: resource.NewProperty(resource.PropertyMap{
+				"source": resource.NewProperty(&rasset.Asset{
 					Path: "foo.txt",
 				}),
 			}),
@@ -1415,8 +1415,8 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 			input: &BucketObjectArgs{
 				Source: NewFileArchive("bar.zip"),
 			},
-			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"source": resource.NewArchiveProperty(&rarchive.Archive{
+			expected: resource.NewProperty(resource.PropertyMap{
+				"source": resource.NewProperty(&rarchive.Archive{
 					Path: "bar.zip",
 				}),
 			}),
@@ -1426,8 +1426,8 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 			input: &BucketObjectArgs{
 				Source: fileAssetOutput,
 			},
-			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"source": resource.NewAssetProperty(&rasset.Asset{
+			expected: resource.NewProperty(resource.PropertyMap{
+				"source": resource.NewProperty(&rasset.Asset{
 					Path: "foo.txt",
 				}),
 			}),
@@ -1437,9 +1437,9 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 			input: &BucketObjectArgs{
 				Source: fileAssetSecretOutput,
 			},
-			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"source": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewAssetProperty(&rasset.Asset{
+			expected: resource.NewProperty(resource.PropertyMap{
+				"source": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty(&rasset.Asset{
 						Path: "foo.txt",
 					}),
 					Known:  true,
@@ -1452,9 +1452,9 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 			input: &BucketObjectArgs{
 				Source: fileAssetOutputDeps,
 			},
-			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"source": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewAssetProperty(&rasset.Asset{
+			expected: resource.NewProperty(resource.PropertyMap{
+				"source": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty(&rasset.Asset{
 						Path: "foo.txt",
 					}),
 					Known:        true,
@@ -1467,10 +1467,10 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 			input: &MyResourceArgs{
 				Res: NewResourceInput(newSimpleCustomResource(ctx, "fakeURN", "fakeID")),
 			},
-			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"res": resource.NewResourceReferenceProperty(resource.ResourceReference{
+			expected: resource.NewProperty(resource.PropertyMap{
+				"res": resource.NewProperty(resource.ResourceReference{
 					URN: "fakeURN",
-					ID:  resource.NewStringProperty("fakeID"),
+					ID:  resource.NewProperty("fakeID"),
 				}),
 			}),
 		},
@@ -1479,8 +1479,8 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 			input: &MyNestedOutputArgs{
 				Nested: nestedOutput,
 			},
-			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"nested": resource.NewAssetProperty(&rasset.Asset{
+			expected: resource.NewProperty(resource.PropertyMap{
+				"nested": resource.NewProperty(&rasset.Asset{
 					Path: "foo.txt",
 				}),
 			}),
@@ -1490,8 +1490,8 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 			input: &MyNestedOutputArgs{
 				Nested: nestedPtrOutput,
 			},
-			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"nested": resource.NewAssetProperty(&rasset.Asset{
+			expected: resource.NewProperty(resource.PropertyMap{
+				"nested": resource.NewProperty(&rasset.Asset{
 					Path: "foo.txt",
 				}),
 			}),
@@ -1501,8 +1501,8 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 			input: &MyNestedOutputArgs{
 				Nested: nestedNestedOutput,
 			},
-			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"nested": resource.NewAssetProperty(&rasset.Asset{
+			expected: resource.NewProperty(resource.PropertyMap{
+				"nested": resource.NewProperty(&rasset.Asset{
 					Path: "foo.txt",
 				}),
 			}),
@@ -1756,8 +1756,8 @@ func TestOutputValueMarshallingEnums(t *testing.T) {
 			input: &RubberTreeArgs{
 				Size: TreeSize("medium"),
 			},
-			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"size": resource.NewStringProperty("medium"),
+			expected: resource.NewProperty(resource.PropertyMap{
+				"size": resource.NewProperty("medium"),
 			}),
 		},
 	}
@@ -1785,8 +1785,8 @@ func TestMarshalInputsPropertyDependencies(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, resource.PropertyMap{
-		"s": resource.NewStringProperty("a string"),
-		"a": resource.NewBoolProperty(true),
+		"s": resource.NewProperty("a string"),
+		"a": resource.NewProperty(true),
 	}, pmap)
 	assert.Nil(t, deps)
 	// Expect a non-empty property deps map, even when there aren't any deps.
@@ -1810,9 +1810,9 @@ func TestUnmarshalPropertyMap(t *testing.T) {
 			name: "primitive types",
 			input: resource.PropertyMap{
 				"nil":    resource.NewNullProperty(),
-				"bool":   resource.NewBoolProperty(true),
-				"number": resource.NewNumberProperty(42),
-				"string": resource.NewStringProperty("hello"),
+				"bool":   resource.NewProperty(true),
+				"number": resource.NewProperty(42.0),
+				"string": resource.NewProperty("hello"),
 			},
 			expected: Map{
 				"nil":    nil,
@@ -1824,11 +1824,11 @@ func TestUnmarshalPropertyMap(t *testing.T) {
 		{
 			name: "array",
 			input: resource.PropertyMap{
-				"array": resource.NewArrayProperty([]resource.PropertyValue{
+				"array": resource.NewProperty([]resource.PropertyValue{
 					resource.NewNullProperty(),
-					resource.NewBoolProperty(true),
-					resource.NewNumberProperty(42),
-					resource.NewStringProperty("hello"),
+					resource.NewProperty(true),
+					resource.NewProperty(42.0),
+					resource.NewProperty("hello"),
 				}),
 			},
 			expected: Map{
@@ -1843,11 +1843,11 @@ func TestUnmarshalPropertyMap(t *testing.T) {
 		{
 			name: "object",
 			input: resource.PropertyMap{
-				"object": resource.NewObjectProperty(resource.PropertyMap{
+				"object": resource.NewProperty(resource.PropertyMap{
 					"nil":    resource.NewNullProperty(),
-					"bool":   resource.NewBoolProperty(true),
-					"number": resource.NewNumberProperty(42),
-					"string": resource.NewStringProperty("hello"),
+					"bool":   resource.NewProperty(true),
+					"number": resource.NewProperty(42.0),
+					"string": resource.NewProperty("hello"),
 				}),
 			},
 			expected: Map{
@@ -1882,8 +1882,8 @@ func TestUnmarshalPropertyMap(t *testing.T) {
 		require.NoError(t, err)
 
 		actual, err := unmarshalPropertyMap(ctx, resource.PropertyMap{
-			"computed": resource.NewComputedProperty(resource.Computed{}),
-			"unknown":  resource.MakeComputed(resource.NewStringProperty("")),
+			"computed": resource.NewProperty(resource.Computed{}),
+			"unknown":  resource.MakeComputed(resource.NewProperty("")),
 		})
 		require.NoError(t, err)
 
@@ -1906,8 +1906,8 @@ func TestUnmarshalPropertyMap(t *testing.T) {
 		require.NoError(t, err)
 
 		actual, err := unmarshalPropertyMap(ctx, resource.PropertyMap{
-			"secret":  resource.MakeSecret(resource.NewStringProperty("secret string")),
-			"unknown": resource.MakeSecret(resource.MakeComputed(resource.NewStringProperty(""))),
+			"secret":  resource.MakeSecret(resource.NewProperty("secret string")),
+			"unknown": resource.MakeSecret(resource.MakeComputed(resource.NewProperty(""))),
 		})
 		require.NoError(t, err)
 
@@ -1933,28 +1933,28 @@ func TestUnmarshalPropertyMap(t *testing.T) {
 		dependencies := []resource.URN{"urn:pulumi:test_stack::test_project::pkg:index:type::name"}
 
 		actual, err := unmarshalPropertyMap(ctx, resource.PropertyMap{
-			"standard": resource.NewOutputProperty(resource.Output{
-				Element:      resource.NewStringProperty("a string"),
+			"standard": resource.NewProperty(resource.Output{
+				Element:      resource.NewProperty("a string"),
 				Known:        true,
 				Secret:       false,
 				Dependencies: dependencies,
 			}),
-			"secret": resource.NewOutputProperty(resource.Output{
-				Element:      resource.NewStringProperty("secret string"),
+			"secret": resource.NewProperty(resource.Output{
+				Element:      resource.NewProperty("secret string"),
 				Known:        true,
 				Secret:       true,
 				Dependencies: dependencies,
 			}),
-			"unknown": resource.NewOutputProperty(resource.Output{
+			"unknown": resource.NewProperty(resource.Output{
 				Dependencies: dependencies,
 			}),
-			"secret unknown": resource.NewOutputProperty(resource.Output{
+			"secret unknown": resource.NewProperty(resource.Output{
 				Dependencies: dependencies,
 				Secret:       true,
 			}),
-			"nested": resource.NewOutputProperty(resource.Output{
-				Element: resource.NewOutputProperty(resource.Output{
-					Element: resource.NewNumberProperty(42),
+			"nested": resource.NewProperty(resource.Output{
+				Element: resource.NewProperty(resource.Output{
+					Element: resource.NewProperty(42.0),
 					Known:   true,
 					Secret:  true,
 				}),
@@ -2015,7 +2015,7 @@ func TestUnmarshalPropertyMap(t *testing.T) {
 		require.NoError(t, err)
 
 		actual, err := unmarshalPropertyMap(ctx, resource.PropertyMap{
-			"unknown id": resource.NewResourceReferenceProperty(resource.ResourceReference{
+			"unknown id": resource.NewProperty(resource.ResourceReference{
 				URN: "urn:pulumi:test_stack::test_project::pkg:index:type::name",
 			}),
 		})

--- a/sdk/go/pulumi/run_test.go
+++ b/sdk/go/pulumi/run_test.go
@@ -153,7 +153,7 @@ func TestRegisterResource(t *testing.T) {
 				assert.Equal(t, "", args.Provider)
 				assert.Equal(t, "", args.ID)
 
-				return "someID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+				return "someID", resource.PropertyMap{"foo": resource.NewProperty("qux")}, nil
 			case "test:resource:complextype":
 				assert.Equal(t, "resB", args.Name)
 				assert.True(t, args.Inputs.DeepEquals(resource.NewPropertyMapFromMap(map[string]interface{}{
@@ -166,9 +166,9 @@ func TestRegisterResource(t *testing.T) {
 				assert.Equal(t, "", args.ID)
 
 				return "someID", resource.PropertyMap{
-					"foo":    resource.NewStringProperty("qux"),
-					"secret": resource.MakeSecret(resource.NewStringProperty("shh")),
-					"output": resource.MakeOutput(resource.NewStringProperty("known unknown")),
+					"foo":    resource.NewProperty("qux"),
+					"secret": resource.MakeSecret(resource.NewProperty("shh")),
+					"output": resource.MakeOutput(resource.NewProperty("known unknown")),
 				}, nil
 			default:
 				assert.Fail(t, "Expected a valid resource type, got %v", args.TypeToken)
@@ -278,7 +278,7 @@ func TestReadResource(t *testing.T) {
 			assert.Equal(t, "", args.Provider)
 			assert.Equal(t, "someID", args.ID)
 
-			return args.ID, resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+			return args.ID, resource.PropertyMap{"foo": resource.NewProperty("qux")}, nil
 		},
 	}
 
@@ -569,7 +569,7 @@ func TestRemoteComponent(t *testing.T) {
 			case "pkg:index:Instance":
 				return "i-1234567890abcdef0", resource.PropertyMap{}, nil
 			case "pkg:index:MyRemoteComponent":
-				outprop := resource.NewStringProperty("output: " + args.Inputs["inprop"].StringValue())
+				outprop := resource.NewProperty("output: " + args.Inputs["inprop"].StringValue())
 				return args.Name + "_id", resource.PropertyMap{
 					"inprop":  args.Inputs["inprop"],
 					"outprop": outprop,
@@ -611,7 +611,7 @@ func TestWaitOrphanedApply(t *testing.T) {
 
 	mocks := &testMonitor{
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
-			return "someID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+			return "someID", resource.PropertyMap{"foo": resource.NewProperty("qux")}, nil
 		},
 	}
 
@@ -640,7 +640,7 @@ func TestWaitOrphanedNestedApply(t *testing.T) {
 
 	mocks := &testMonitor{
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
-			return "someID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+			return "someID", resource.PropertyMap{"foo": resource.NewProperty("qux")}, nil
 		},
 	}
 
@@ -672,7 +672,7 @@ func TestWaitOrphanedAllApply(t *testing.T) {
 
 	mocks := &testMonitor{
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
-			return "someID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+			return "someID", resource.PropertyMap{"foo": resource.NewProperty("qux")}, nil
 		},
 	}
 
@@ -704,7 +704,7 @@ func TestWaitOrphanedAnyApply(t *testing.T) {
 
 	mocks := &testMonitor{
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
-			return "someID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+			return "someID", resource.PropertyMap{"foo": resource.NewProperty("qux")}, nil
 		},
 	}
 
@@ -746,7 +746,7 @@ func TestWaitOrphanedContextAllApply(t *testing.T) {
 
 	mocks := &testMonitor{
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
-			return "someID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+			return "someID", resource.PropertyMap{"foo": resource.NewProperty("qux")}, nil
 		},
 	}
 
@@ -778,7 +778,7 @@ func TestWaitOrphanedContextAnyApply(t *testing.T) {
 
 	mocks := &testMonitor{
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
-			return "someID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+			return "someID", resource.PropertyMap{"foo": resource.NewProperty("qux")}, nil
 		},
 	}
 
@@ -820,7 +820,7 @@ func TestWaitOrphanedResource(t *testing.T) {
 
 	mocks := &testMonitor{
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
-			return "someID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+			return "someID", resource.PropertyMap{"foo": resource.NewProperty("qux")}, nil
 		},
 	}
 
@@ -844,7 +844,7 @@ func TestWaitResourceInsideApply(t *testing.T) {
 
 	mocks := &testMonitor{
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
-			return "someID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+			return "someID", resource.PropertyMap{"foo": resource.NewProperty("qux")}, nil
 		},
 	}
 
@@ -875,7 +875,7 @@ func TestWaitOrphanedApplyOnResourceInsideApply(t *testing.T) {
 
 	mocks := &testMonitor{
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
-			return "someID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+			return "someID", resource.PropertyMap{"foo": resource.NewProperty("qux")}, nil
 		},
 	}
 
@@ -913,7 +913,7 @@ func TestWaitRecursiveApply(t *testing.T) {
 
 	mocks := &testMonitor{
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
-			return "someID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+			return "someID", resource.PropertyMap{"foo": resource.NewProperty("qux")}, nil
 		},
 	}
 
@@ -952,7 +952,7 @@ func TestWaitOrphanedManualOutput(t *testing.T) {
 
 	mocks := &testMonitor{
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
-			return "someID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+			return "someID", resource.PropertyMap{"foo": resource.NewProperty("qux")}, nil
 		},
 	}
 
@@ -989,7 +989,7 @@ func TestWaitOrphanedDeprecatedOutput(t *testing.T) {
 
 	mocks := &testMonitor{
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
-			return "someID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+			return "someID", resource.PropertyMap{"foo": resource.NewProperty("qux")}, nil
 		},
 	}
 
@@ -1010,7 +1010,7 @@ func TestExportResource(t *testing.T) {
 
 	mocks := &testMonitor{
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
-			return "someID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+			return "someID", resource.PropertyMap{"foo": resource.NewProperty("qux")}, nil
 		},
 	}
 
@@ -1092,10 +1092,10 @@ func TestResourceInput(t *testing.T) {
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
 			switch args.TypeToken {
 			case "test:resource:type":
-				return "someID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+				return "someID", resource.PropertyMap{"foo": resource.NewProperty("qux")}, nil
 			case "pkg:index:MyRemoteComponent":
 				return args.Name + "_id", resource.PropertyMap{
-					"outprop": resource.NewStringProperty("bar"),
+					"outprop": resource.NewProperty("bar"),
 				}, nil
 			default:
 				return "", nil, fmt.Errorf("unknown resource %s", args.TypeToken)

--- a/sdk/go/pulumi/stack_reference_test.go
+++ b/sdk/go/pulumi/stack_reference_test.go
@@ -152,7 +152,7 @@ func TestStackReferenceSecrets(t *testing.T) {
 		properties[resource.PropertyKey(k)] = v
 	}
 
-	outputs := resource.NewObjectProperty(properties)
+	outputs := resource.NewProperty(properties)
 
 	mocks := &testMonitor{
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
@@ -164,7 +164,7 @@ func TestStackReferenceSecrets(t *testing.T) {
 			assert.Equal(t, "", args.Provider)
 			assert.Equal(t, args.Inputs["name"].StringValue(), args.ID)
 			return args.Inputs["name"].StringValue(), resource.PropertyMap{
-				"name":    resource.NewStringProperty("stack"),
+				"name":    resource.NewProperty("stack"),
 				"outputs": outputs,
 			}, nil
 		},
@@ -213,9 +213,9 @@ func TestStackReference_GetOutputDetails(t *testing.T) {
 	t.Parallel()
 
 	outputs := resource.PropertyMap{
-		"bucket": resource.NewStringProperty("mybucket-1234"),
-		"password": resource.NewSecretProperty(&resource.Secret{
-			Element: resource.NewStringProperty("supersecretpassword"),
+		"bucket": resource.NewProperty("mybucket-1234"),
+		"password": resource.NewProperty(&resource.Secret{
+			Element: resource.NewProperty("supersecretpassword"),
 		}),
 	}
 	mocks := testMonitor{
@@ -223,8 +223,8 @@ func TestStackReference_GetOutputDetails(t *testing.T) {
 			assert.Equal(t, "pulumi:pulumi:StackReference", args.TypeToken)
 			assert.Equal(t, "ref", args.Name)
 			return args.Name, resource.PropertyMap{
-				"name":    resource.NewStringProperty(args.Name),
-				"outputs": resource.NewObjectProperty(outputs),
+				"name":    resource.NewProperty(args.Name),
+				"outputs": resource.NewProperty(outputs),
 			}, nil
 		},
 	}

--- a/sdk/go/pulumix/context_test.go
+++ b/sdk/go/pulumix/context_test.go
@@ -70,78 +70,78 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 		{
 			desc: "pux.String/pu.String",
 			give: &testResourceInputs{PuxString: pulumi.String("a")},
-			want: resource.PropertyMap{"puxString": resource.NewStringProperty("a")},
+			want: resource.PropertyMap{"puxString": resource.NewProperty("a")},
 		},
 		{
 			desc: "pux.String/pu.StringOutput",
 			give: &testResourceInputs{PuxString: pulumi.String("b").ToStringOutput()},
-			want: resource.PropertyMap{"puxString": resource.NewStringProperty("b")},
+			want: resource.PropertyMap{"puxString": resource.NewProperty("b")},
 		},
 		{
 			desc: "pux.String/pux.Output[string]",
 			give: &testResourceInputs{PuxString: pulumix.Val("c")},
-			want: resource.PropertyMap{"puxString": resource.NewStringProperty("c")},
+			want: resource.PropertyMap{"puxString": resource.NewProperty("c")},
 		},
 
 		// --- pulumi.StringInput ---
 		{
 			desc: "pu.String/pu.String",
 			give: &testResourceInputs{PuString: pulumi.String("d")},
-			want: resource.PropertyMap{"puString": resource.NewStringProperty("d")},
+			want: resource.PropertyMap{"puString": resource.NewProperty("d")},
 		},
 		{
 			desc: "pu.String/pu.StringOutput",
 			give: &testResourceInputs{PuString: pulumi.String("e").ToStringOutput()},
-			want: resource.PropertyMap{"puString": resource.NewStringProperty("e")},
+			want: resource.PropertyMap{"puString": resource.NewProperty("e")},
 		},
 		{
 			desc: "pu.String/pux.Output[string] untyped",
 			give: &testResourceInputs{PuString: pulumix.Val("f").Untyped().(pulumi.StringOutput)},
-			want: resource.PropertyMap{"puString": resource.NewStringProperty("f")},
+			want: resource.PropertyMap{"puString": resource.NewProperty("f")},
 		},
 
 		// --- pulumix.Input[*string] ---
 		{
 			desc: "pux.StringPtr/pu.String PtrOf",
 			give: &testResourceInputs{PuxStringPtr: pulumix.PtrOf[string](pulumi.String("g"))},
-			want: resource.PropertyMap{"puxStringPtr": resource.NewStringProperty("g")},
+			want: resource.PropertyMap{"puxStringPtr": resource.NewProperty("g")},
 		},
 		{
 			desc: "pux.StringPtr/pu.StringPtrOutput",
 			give: &testResourceInputs{PuxStringPtr: pulumi.String("h").ToStringPtrOutput()},
-			want: resource.PropertyMap{"puxStringPtr": resource.NewStringProperty("h")},
+			want: resource.PropertyMap{"puxStringPtr": resource.NewProperty("h")},
 		},
 		{
 			desc: "pux.StringPtr/pux.PtrOutput[string]",
 			give: &testResourceInputs{PuxStringPtr: pulumix.Ptr("i")},
-			want: resource.PropertyMap{"puxStringPtr": resource.NewStringProperty("i")},
+			want: resource.PropertyMap{"puxStringPtr": resource.NewProperty("i")},
 		},
 		{
 			desc: "pux.StringPtr/pux.Output[*string]",
 			give: &testResourceInputs{PuxStringPtr: pulumix.Val[*string](&j)},
-			want: resource.PropertyMap{"puxStringPtr": resource.NewStringProperty("j")},
+			want: resource.PropertyMap{"puxStringPtr": resource.NewProperty("j")},
 		},
 
 		// --- pulumi.StringPtrInput ---
 		{
 			desc: "pu.StringPtr/pu.StringPtr",
 			give: &testResourceInputs{PuStringPtr: pulumi.StringPtr("j")},
-			want: resource.PropertyMap{"puStringPtr": resource.NewStringProperty("j")},
+			want: resource.PropertyMap{"puStringPtr": resource.NewProperty("j")},
 		},
 		{
 			desc: "pu.StringPtr/pu.String",
 			give: &testResourceInputs{PuStringPtr: pulumi.String("k")},
-			want: resource.PropertyMap{"puStringPtr": resource.NewStringProperty("k")},
+			want: resource.PropertyMap{"puStringPtr": resource.NewProperty("k")},
 		},
 		{
 			desc: "pu.StringPtr/pu.StringPtrOutput",
 			give: &testResourceInputs{PuStringPtr: pulumi.String("l").ToStringPtrOutput()},
-			want: resource.PropertyMap{"puStringPtr": resource.NewStringProperty("l")},
+			want: resource.PropertyMap{"puStringPtr": resource.NewProperty("l")},
 		},
 		{
 			desc: "pu.StringPtr/pux.PtrOutput[string] untyped",
 			give: &testResourceInputs{PuStringPtr: pulumix.Ptr("m").Untyped().(pulumi.StringPtrOutput)},
-			want: resource.PropertyMap{"puStringPtr": resource.NewStringProperty("m")},
+			want: resource.PropertyMap{"puStringPtr": resource.NewProperty("m")},
 		},
 		{
 			desc: "pu.StringPtr/pux.GPtrOutput[string] untyped",
@@ -150,7 +150,7 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 					pulumix.Ptr("n"),
 				).Untyped().(pulumi.StringPtrOutput),
 			},
-			want: resource.PropertyMap{"puStringPtr": resource.NewStringProperty("n")},
+			want: resource.PropertyMap{"puStringPtr": resource.NewProperty("n")},
 		},
 
 		// --- pulumix.Input[[]int] ---
@@ -164,11 +164,11 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 				},
 			},
 			want: resource.PropertyMap{
-				"puxIntArray": resource.NewArrayProperty(
+				"puxIntArray": resource.NewProperty(
 					[]resource.PropertyValue{
-						resource.NewNumberProperty(1),
-						resource.NewNumberProperty(2),
-						resource.NewNumberProperty(3),
+						resource.NewProperty(1.0),
+						resource.NewProperty(2.0),
+						resource.NewProperty(3.0),
 					},
 				),
 			},
@@ -183,11 +183,11 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 				}.ToIntArrayOutput(),
 			},
 			want: resource.PropertyMap{
-				"puxIntArray": resource.NewArrayProperty(
+				"puxIntArray": resource.NewProperty(
 					[]resource.PropertyValue{
-						resource.NewNumberProperty(4),
-						resource.NewNumberProperty(5),
-						resource.NewNumberProperty(6),
+						resource.NewProperty(4.0),
+						resource.NewProperty(5.0),
+						resource.NewProperty(6.0),
 					},
 				),
 			},
@@ -198,11 +198,11 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 				PuxIntArray: pulumix.Val([]int{7, 8, 9}),
 			},
 			want: resource.PropertyMap{
-				"puxIntArray": resource.NewArrayProperty(
+				"puxIntArray": resource.NewProperty(
 					[]resource.PropertyValue{
-						resource.NewNumberProperty(7),
-						resource.NewNumberProperty(8),
-						resource.NewNumberProperty(9),
+						resource.NewProperty(7.0),
+						resource.NewProperty(8.0),
+						resource.NewProperty(9.0),
 					},
 				),
 			},
@@ -215,11 +215,11 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 				),
 			},
 			want: resource.PropertyMap{
-				"puxIntArray": resource.NewArrayProperty(
+				"puxIntArray": resource.NewProperty(
 					[]resource.PropertyValue{
-						resource.NewNumberProperty(10),
-						resource.NewNumberProperty(11),
-						resource.NewNumberProperty(12),
+						resource.NewProperty(10.0),
+						resource.NewProperty(11.0),
+						resource.NewProperty(12.0),
 					},
 				),
 			},
@@ -232,11 +232,11 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 				),
 			},
 			want: resource.PropertyMap{
-				"puxIntArray": resource.NewArrayProperty(
+				"puxIntArray": resource.NewProperty(
 					[]resource.PropertyValue{
-						resource.NewNumberProperty(13),
-						resource.NewNumberProperty(14),
-						resource.NewNumberProperty(15),
+						resource.NewProperty(13.0),
+						resource.NewProperty(14.0),
+						resource.NewProperty(15.0),
 					},
 				),
 			},
@@ -249,11 +249,11 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 				PuIntArray: pulumix.Val([]int{1, 2, 3}).Untyped().(pulumi.IntArrayOutput),
 			},
 			want: resource.PropertyMap{
-				"puIntArray": resource.NewArrayProperty(
+				"puIntArray": resource.NewProperty(
 					[]resource.PropertyValue{
-						resource.NewNumberProperty(1),
-						resource.NewNumberProperty(2),
-						resource.NewNumberProperty(3),
+						resource.NewProperty(1.0),
+						resource.NewProperty(2.0),
+						resource.NewProperty(3.0),
 					},
 				),
 			},
@@ -266,11 +266,11 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 				).Untyped().(pulumi.IntArrayOutput),
 			},
 			want: resource.PropertyMap{
-				"puIntArray": resource.NewArrayProperty(
+				"puIntArray": resource.NewProperty(
 					[]resource.PropertyValue{
-						resource.NewNumberProperty(4),
-						resource.NewNumberProperty(5),
-						resource.NewNumberProperty(6),
+						resource.NewProperty(4.0),
+						resource.NewProperty(5.0),
+						resource.NewProperty(6.0),
 					},
 				),
 			},
@@ -283,11 +283,11 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 				).Untyped().(pulumi.IntArrayOutput),
 			},
 			want: resource.PropertyMap{
-				"puIntArray": resource.NewArrayProperty(
+				"puIntArray": resource.NewProperty(
 					[]resource.PropertyValue{
-						resource.NewNumberProperty(7),
-						resource.NewNumberProperty(8),
-						resource.NewNumberProperty(9),
+						resource.NewProperty(7.0),
+						resource.NewProperty(8.0),
+						resource.NewProperty(9.0),
 					},
 				),
 			},
@@ -300,10 +300,10 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 				PuxIntMap: pulumi.IntMap{"a": pulumi.Int(1), "b": pulumi.Int(2)},
 			},
 			want: resource.PropertyMap{
-				"puxIntMap": resource.NewObjectProperty(
+				"puxIntMap": resource.NewProperty(
 					resource.PropertyMap{
-						"a": resource.NewNumberProperty(1),
-						"b": resource.NewNumberProperty(2),
+						"a": resource.NewProperty(1.0),
+						"b": resource.NewProperty(2.0),
 					},
 				),
 			},
@@ -314,10 +314,10 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 				PuxIntMap: pulumi.IntMap{"c": pulumi.Int(3), "d": pulumi.Int(4)}.ToIntMapOutput(),
 			},
 			want: resource.PropertyMap{
-				"puxIntMap": resource.NewObjectProperty(
+				"puxIntMap": resource.NewProperty(
 					resource.PropertyMap{
-						"c": resource.NewNumberProperty(3),
-						"d": resource.NewNumberProperty(4),
+						"c": resource.NewProperty(3.0),
+						"d": resource.NewProperty(4.0),
 					},
 				),
 			},
@@ -328,10 +328,10 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 				PuxIntMap: pulumix.Val(map[string]int{"e": 5, "f": 6}),
 			},
 			want: resource.PropertyMap{
-				"puxIntMap": resource.NewObjectProperty(
+				"puxIntMap": resource.NewProperty(
 					resource.PropertyMap{
-						"e": resource.NewNumberProperty(5),
-						"f": resource.NewNumberProperty(6),
+						"e": resource.NewProperty(5.0),
+						"f": resource.NewProperty(6.0),
 					},
 				),
 			},
@@ -344,10 +344,10 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 				),
 			},
 			want: resource.PropertyMap{
-				"puxIntMap": resource.NewObjectProperty(
+				"puxIntMap": resource.NewProperty(
 					resource.PropertyMap{
-						"g": resource.NewNumberProperty(7),
-						"h": resource.NewNumberProperty(8),
+						"g": resource.NewProperty(7.0),
+						"h": resource.NewProperty(8.0),
 					},
 				),
 			},
@@ -360,10 +360,10 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 				),
 			},
 			want: resource.PropertyMap{
-				"puxIntMap": resource.NewObjectProperty(
+				"puxIntMap": resource.NewProperty(
 					resource.PropertyMap{
-						"i": resource.NewNumberProperty(9),
-						"j": resource.NewNumberProperty(10),
+						"i": resource.NewProperty(9.0),
+						"j": resource.NewProperty(10.0),
 					},
 				),
 			},
@@ -376,10 +376,10 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 				PuIntMap: pulumi.IntMap{"a": pulumi.Int(1), "b": pulumi.Int(2)},
 			},
 			want: resource.PropertyMap{
-				"puIntMap": resource.NewObjectProperty(
+				"puIntMap": resource.NewProperty(
 					resource.PropertyMap{
-						"a": resource.NewNumberProperty(1),
-						"b": resource.NewNumberProperty(2),
+						"a": resource.NewProperty(1.0),
+						"b": resource.NewProperty(2.0),
 					},
 				),
 			},
@@ -390,10 +390,10 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 				PuIntMap: pulumix.Val(map[string]int{"c": 3, "d": 4}).Untyped().(pulumi.IntMapOutput),
 			},
 			want: resource.PropertyMap{
-				"puIntMap": resource.NewObjectProperty(
+				"puIntMap": resource.NewProperty(
 					resource.PropertyMap{
-						"c": resource.NewNumberProperty(3),
-						"d": resource.NewNumberProperty(4),
+						"c": resource.NewProperty(3.0),
+						"d": resource.NewProperty(4.0),
 					},
 				),
 			},
@@ -406,10 +406,10 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 				).Untyped().(pulumi.IntMapOutput),
 			},
 			want: resource.PropertyMap{
-				"puIntMap": resource.NewObjectProperty(
+				"puIntMap": resource.NewProperty(
 					resource.PropertyMap{
-						"e": resource.NewNumberProperty(5),
-						"f": resource.NewNumberProperty(6),
+						"e": resource.NewProperty(5.0),
+						"f": resource.NewProperty(6.0),
 					},
 				),
 			},
@@ -422,10 +422,10 @@ func TestRegisterResource_inputSerialization(t *testing.T) {
 				).Untyped().(pulumi.IntMapOutput),
 			},
 			want: resource.PropertyMap{
-				"puIntMap": resource.NewObjectProperty(
+				"puIntMap": resource.NewProperty(
 					resource.PropertyMap{
-						"g": resource.NewNumberProperty(7),
-						"h": resource.NewNumberProperty(8),
+						"g": resource.NewProperty(7.0),
+						"h": resource.NewProperty(8.0),
 					},
 				),
 			},

--- a/tests/integration/backend/diy/backend_postgres_test.go
+++ b/tests/integration/backend/diy/backend_postgres_test.go
@@ -327,11 +327,11 @@ func TestPostgresBackend(t *testing.T) {
 			Custom: true,
 			ID:     "test-resource-id",
 			Inputs: resource.PropertyMap{
-				"name": resource.NewStringProperty("test-resource"),
+				"name": resource.NewProperty("test-resource"),
 			},
 			Outputs: resource.PropertyMap{
-				"name": resource.NewStringProperty("test-resource"),
-				"arn":  resource.NewStringProperty("arn:test:resource"),
+				"name": resource.NewProperty("test-resource"),
+				"arn":  resource.NewProperty("arn:test:resource"),
 			},
 		},
 	}, nil, deploy.SnapshotMetadata{})

--- a/tests/testprovider/named.go
+++ b/tests/testprovider/named.go
@@ -77,7 +77,7 @@ func (p *namedProvider) Check(ctx context.Context, req *rpc.CheckRequest) (*rpc.
 			}
 		}
 		if generatedName != "" {
-			news["name"] = resource.NewStringProperty(generatedName)
+			news["name"] = resource.NewProperty(generatedName)
 		}
 	}
 

--- a/tests/testprovider/random.go
+++ b/tests/testprovider/random.go
@@ -133,7 +133,7 @@ func (p *randomProvider) Create(ctx context.Context, req *rpc.CreateRequest) (*r
 		"result": prefix + result,
 	})
 	if prefix != "" {
-		outputs["prefix"] = resource.NewStringProperty(prefix)
+		outputs["prefix"] = resource.NewProperty(prefix)
 	}
 	outputs["result"] = resource.MakeSecret(outputs["result"])
 


### PR DESCRIPTION
Replace uses of the non-generic `resource.New(String|Bool|Number|etc.)Property` functions with the generic `resource.NewProperty` function.

It's a minor pet peeve of mine that the non-generic functions continue to be used (even in new code) when the simpler generic version could be used instead.