### PR TITLE
Avoid printing a double new line when showing secrets in the outputs

### DIFF
--- a/changelog/pending/20250902--cli-display--avoid-printing-a-double-new-line-when-showing-secrets-in-the-outputs.yaml
+++ b/changelog/pending/20250902--cli-display--avoid-printing-a-double-new-line-when-showing-secrets-in-the-outputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Avoid printing a double new line when showing secrets in the outputs

--- a/pkg/backend/display/object_diff_test.go
+++ b/pkg/backend/display/object_diff_test.go
@@ -351,17 +351,12 @@ func TestGetResourceOutputsPropertiesString(t *testing.T) {
 				"\"shhhh\"<{%reset%}>" +
 				"<{%reset%}>" +
 				"\n<{%reset%}>" +
-				"<{%reset%}>" +
-				// TODO https://github.com/pulumi/pulumi/issues/20416 - there is a double newline here
-				"\n<{%reset%}>" +
 				"<{%fg 2%}>  + secretObj: <{%reset%}>" +
 				"<{%fg 2%}>{\n<{%reset%}" +
 				"><{%fg 2%}>      + a: <{%reset%}" +
 				"><{%fg 2%}>\"1\"<{%reset%}>" +
 				"<{%fg 2%}>\n<{%reset%}>" +
 				"<{%fg 2%}>    }<{%reset%}>" +
-				"<{%fg 2%}>\n<{%reset%}>" +
-				// TODO https://github.com/pulumi/pulumi/issues/20416 - there is a double newline here
 				"<{%fg 2%}>\n<{%reset%}>",
 		},
 	} {


### PR DESCRIPTION
I noticed this while working on https://github.com/pulumi/pulumi/issues/2909

Fixes https://github.com/pulumi/pulumi/issues/20416
