### PR TITLE
Use "Private Registry", not cloud or Pulumi registry, in CLI output

### DIFF
--- a/changelog/pending/20250902--cli--use-private-registry-not-cloud-or-pulumi-registry-in-cli-output.yaml
+++ b/changelog/pending/20250902--cli--use-private-registry-not-cloud-or-pulumi-registry-in-cli-output.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Use "Private Registry", not cloud or Pulumi registry, in CLI output

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1552,7 +1552,7 @@ func (b *diyBackend) getParallel() int {
 }
 
 func (b *diyBackend) GetCloudRegistry() (backend.CloudRegistry, error) {
-	return nil, errors.New("cloud registry is not supported by diy backends")
+	return nil, errors.New("Private Registry is not supported by diy backends")
 }
 
 func (b *diyBackend) GetReadOnlyCloudRegistry() registry.Registry {

--- a/pkg/cmd/pulumi/cmd/registry.go
+++ b/pkg/cmd/pulumi/cmd/registry.go
@@ -46,6 +46,6 @@ func NewDefaultRegistry(
 		if b == nil || errors.Is(err, backenderr.ErrLoginRequired) {
 			return unauthenticatedregistry.New(diag, env), nil
 		}
-		return nil, fmt.Errorf("could not get registry backend: %w", err)
+		return nil, fmt.Errorf("could not get Private Registry backend: %w", err)
 	})
 }

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -41,10 +41,11 @@ import (
 )
 
 const (
-	// The default package source is "private" for packages published to the Pulumi Registry. This corresponds to the
-	// private registry of an organization.
-	// Examples of other sources include "pulumi" for the public registry and "opentofu" for packages published to the
-	// OpenTofu Registry.
+	// The default package source is "private" for packages published to the
+	// Private Registry. This corresponds to an organization's own packages
+	// inaccessible to others. Examples of other sources include "pulumi" for
+	// public packages and "opentofu" for packages published to the OpenTofu
+	// registry, but available through an organization's Private Registry.
 	defaultPackageSource = "private"
 )
 
@@ -70,9 +71,9 @@ func newPackagePublishCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "publish <provider|schema> --readme <path> [--] [provider-parameter...]",
 		Args:  cmdutil.MinimumNArgs(1),
-		Short: "Publish a package to the Pulumi Registry",
-		Long: "Publish a package to the Pulumi Registry.\n\n" +
-			"This command publishes a package to the Pulumi Registry. The package can be a provider " +
+		Short: "Publish a package to the Private Registry",
+		Long: "Publish a package to the Private Registry.\n\n" +
+			"This command publishes a package to the Private Registry. The package can be a provider " +
 			"or a schema.\n\n" +
 			"When <provider> is specified as a PLUGIN[@VERSION] reference, Pulumi attempts to " +
 			"resolve a resource plugin first, installing it on-demand, similarly to:\n\n" +
@@ -99,7 +100,7 @@ func newPackagePublishCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(
 		&args.source, "source", defaultPackageSource,
-		"The origin of the package (e.g., 'pulumi', 'private', 'opentofu'). Defaults to the private registry.")
+		"The origin of the package (e.g., 'pulumi', 'private', 'opentofu'). Defaults to 'private'.")
 	if !env.Dev.Value() {
 		// hide the source flag from the help output. Only registry administrators can set the source. Regular users can only
 		// publish private packages.
@@ -202,7 +203,7 @@ func (cmd *packagePublishCmd) Run(
 
 	registry, err := b.GetCloudRegistry()
 	if err != nil {
-		return fmt.Errorf("failed to get cloud registry: %w", err)
+		return fmt.Errorf("failed to get the Private Registry backend: %w", err)
 	}
 
 	// We need to set the content-size header for S3 puts. For byte buffers (or deterministic readers)

--- a/pkg/cmd/pulumi/templatecmd/template_publish.go
+++ b/pkg/cmd/pulumi/templatecmd/template_publish.go
@@ -52,9 +52,9 @@ func newTemplatePublishCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "publish <directory>",
 		Args:  cmdutil.ExactArgs(1),
-		Short: "Publish a template to the Pulumi Registry",
-		Long: "Publish a template to the Pulumi Registry.\n\n" +
-			"This command publishes a template directory to the Pulumi Registry.",
+		Short: "Publish a template to the Private Registry",
+		Long: "Publish a template to the Private Registry.\n\n" +
+			"This command publishes a template directory to the Private Registry.",
 		RunE: func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := cmd.Context()
 			tplPublishCmd := templatePublishCmd{defaultOrg: backend.GetDefaultOrg}
@@ -111,7 +111,7 @@ func (tplCmd *templatePublishCmd) Run(
 
 	_, err = b.GetCloudRegistry()
 	if err != nil {
-		return fmt.Errorf("backend does not support registry operations: %w", err)
+		return fmt.Errorf("backend does not support Private Registry operations: %w", err)
 	}
 
 	var publisher string
@@ -160,7 +160,7 @@ func (tplCmd *templatePublishCmd) publishTemplate(
 ) error {
 	registry, err := b.GetCloudRegistry()
 	if err != nil {
-		return fmt.Errorf("failed to get cloud registry: %w", err)
+		return fmt.Errorf("failed to get the Private Registry backend: %w", err)
 	}
 
 	publishInput := apitype.TemplatePublishOp{


### PR DESCRIPTION
The correct term is "Private Registry". This PR updates CLI output to call it that.

Docs: https://www.pulumi.com/docs/idp/get-started/private-registry/