### PR TITLE
improve usage string for pulumi config set

### DIFF
--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -605,7 +605,7 @@ func newConfigSetCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 	configSetCmd := &configSetCmd{LoadProjectStack: cmdStack.LoadProjectStack}
 
 	setCmd := &cobra.Command{
-		Use:   "set <key> [value]",
+		Use:   "set [flags] <key> [--] [value]",
 		Short: "Set configuration value",
 		Long: "Configuration values can be accessed when a stack is being deployed and used to configure behavior. \n" +
 			"If a value is not present on the command line, pulumi will prompt for the value. Multi-line values\n" +
@@ -662,6 +662,7 @@ func newConfigSetCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 	setCmd.PersistentFlags().StringVar(
 		&configSetCmd.Type, "type", "", "Save the value as the given type.  Allowed values are string, bool, int, and float")
 	setCmd.MarkFlagsMutuallyExclusive("secret", "plaintext", "type")
+	setCmd.DisableFlagsInUseLine = true
 
 	return setCmd
 }


### PR DESCRIPTION
In `pulumi config set`, `--` can be used to disambiguate values that look like flags, iow, they have the format `--<value>`.  Make this clear in the usage string.  Note that this means flags should be set before the `--`, so move the `[flags]` part earlier in the usage string as well.

Fixes https://github.com/pulumi/pulumi/issues/20434