### PR TITLE
fix bool type parsing and single length path value adjustments

### DIFF
--- a/sdk/go/common/resource/config/map.go
+++ b/sdk/go/common/resource/config/map.go
@@ -192,6 +192,15 @@ func (m Map) Set(k Key, v Value, path bool) error {
 	}
 
 	if len(p) == 1 {
+
+		if v.typ != TypeUnknown {
+			text, _, _, err := newV.MarshalString()
+			if err != nil {
+				return err
+			}
+			v.value = text
+		}
+
 		m[configKey] = v
 		return nil
 	}
@@ -318,7 +327,11 @@ func adjustObjectValue(v Value) (object, error) {
 		}
 		return newObject(int64(i)), nil
 	case TypeBool:
-		return newObject(v.value == "true"), nil
+		b, err := strconv.ParseBool(v.value)
+		if err != nil {
+			return object{}, err
+		}
+		return newObject(b), nil
 	case TypeFloat:
 		f, err := strconv.ParseFloat(v.value, 64)
 		if err != nil {

--- a/sdk/go/common/resource/config/map_test.go
+++ b/sdk/go/common/resource/config/map_test.go
@@ -1226,6 +1226,134 @@ func TestSetSuccess(t *testing.T) {
 				MustMakeKey("my", "special"): NewObjectValue(`{"object":{"fizz":"buzz","foo":"bar"},"thing1":1,"thing2":2}`),
 			},
 		},
+		{
+			Key:   "my:typedbool",
+			Path:  true,
+			Value: NewTypedValue("true", TypeBool),
+			Expected: Map{
+				MustMakeKey("my", "typedbool"): NewTypedValue("true", TypeBool),
+			},
+		},
+		{
+			Key:   "my:typedbool",
+			Path:  true,
+			Value: NewTypedValue("True", TypeBool),
+			Expected: Map{
+				MustMakeKey("my", "typedbool"): NewTypedValue("true", TypeBool),
+			},
+		},
+		{
+			Key:   "my:typedbool",
+			Path:  true,
+			Value: NewTypedValue("TRUE", TypeBool),
+			Expected: Map{
+				MustMakeKey("my", "typedbool"): NewTypedValue("true", TypeBool),
+			},
+		},
+		{
+			Key:   "my:typedbool",
+			Path:  true,
+			Value: NewTypedValue("1", TypeBool),
+			Expected: Map{
+				MustMakeKey("my", "typedbool"): NewTypedValue("true", TypeBool),
+			},
+		},
+		{
+			Key:   "my:typedbool",
+			Path:  true,
+			Value: NewTypedValue("false", TypeBool),
+			Expected: Map{
+				MustMakeKey("my", "typedbool"): NewTypedValue("false", TypeBool),
+			},
+		},
+		{
+			Key:   "my:typedbool",
+			Path:  true,
+			Value: NewTypedValue("False", TypeBool),
+			Expected: Map{
+				MustMakeKey("my", "typedbool"): NewTypedValue("false", TypeBool),
+			},
+		},
+		{
+			Key:   "my:typedbool",
+			Path:  true,
+			Value: NewTypedValue("FALSE", TypeBool),
+			Expected: Map{
+				MustMakeKey("my", "typedbool"): NewTypedValue("false", TypeBool),
+			},
+		},
+		{
+			Key:   "my:typedbool",
+			Path:  true,
+			Value: NewTypedValue("0", TypeBool),
+			Expected: Map{
+				MustMakeKey("my", "typedbool"): NewTypedValue("false", TypeBool),
+			},
+		},
+		{
+			Key:   "my:typedstring",
+			Path:  true,
+			Value: NewTypedValue("testValue", TypeString),
+			Expected: Map{
+				MustMakeKey("my", "typedstring"): NewTypedValue("testValue", TypeString),
+			},
+		},
+		{
+			Key:   "my:typedint",
+			Path:  true,
+			Value: NewTypedValue("10", TypeInt),
+			Expected: Map{
+				MustMakeKey("my", "typedint"): NewTypedValue("10", TypeInt),
+			},
+		},
+		{
+			Key:   "my:typedint",
+			Path:  true,
+			Value: NewTypedValue("+10", TypeInt),
+			Expected: Map{
+				MustMakeKey("my", "typedint"): NewTypedValue("10", TypeInt),
+			},
+		},
+		{
+			Key:   "my:typedint",
+			Path:  true,
+			Value: NewTypedValue("0042", TypeInt),
+			Expected: Map{
+				MustMakeKey("my", "typedint"): NewTypedValue("42", TypeInt),
+			},
+		},
+		{
+			Key:   "my:typedfloat",
+			Path:  true,
+			Value: NewTypedValue("10.5", TypeFloat),
+			Expected: Map{
+				MustMakeKey("my", "typedfloat"): NewTypedValue("10.5", TypeFloat),
+			},
+		},
+		{
+			Key:   "my:typedfloat",
+			Path:  true,
+			Value: NewTypedValue("+10.5", TypeFloat),
+			Expected: Map{
+				MustMakeKey("my", "typedfloat"): NewTypedValue("10.5", TypeFloat),
+			},
+		},
+		{
+			Key:   "my:typedfloat",
+			Path:  true,
+			Value: NewTypedValue("0042.5", TypeFloat),
+			Expected: Map{
+				MustMakeKey("my", "typedfloat"): NewTypedValue("42.5", TypeFloat),
+			},
+		},
+		{
+			Key:   "my:typedfloat",
+			Path:  true,
+			Value: NewTypedValue("1e3", TypeFloat),
+			Expected: Map{
+				MustMakeKey("my", "typedfloat"): NewTypedValue("1000", TypeFloat),
+			},
+		},
 	}
 
 	//nolint:paralleltest // false positive because range var isn't used directly in t.Run(name) arg


### PR DESCRIPTION
When using `pulumi config set --type bool etc` it will now support all bool applicable values. There was also seemingly a bug where if the number of parts in the key path was 1 it would not use the adjusted value even if you passed the type