### PR TITLE
Fix not using already-installed package when PULUMI_EXPERIMENTAL=1

### DIFF
--- a/changelog/pending/20250903--cli-package--fix-not-using-already-installed-package-in-pulumi-package-add-when-pulumi_experimental-1.yaml
+++ b/changelog/pending/20250903--cli-package--fix-not-using-already-installed-package-in-pulumi-package-add-when-pulumi_experimental-1.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/package
+  description: Fix not using already-installed package in 'pulumi package add' when PULUMI_EXPERIMENTAL=1

--- a/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
+++ b/pkg/cmd/pulumi/packagecmd/project_sdk_link.go
@@ -918,10 +918,12 @@ func ProviderFromSource(
 	result, err := packageresolution.Resolve(
 		pctx.Base(),
 		reg,
+		packageresolution.DefaultWorkspace(),
 		pluginSpec,
 		packageresolution.Options{
-			DisableRegistryResolve: env.DisableRegistryResolve.Value(),
-			Experimental:           env.Experimental.Value(),
+			DisableRegistryResolve:      env.DisableRegistryResolve.Value(),
+			Experimental:                env.Experimental.Value(),
+			IncludeInstalledInWorkspace: true,
 		},
 		pctx.Root,
 	)
@@ -939,7 +941,7 @@ func ProviderFromSource(
 	switch res := result.(type) {
 	case packageresolution.LocalPathResult:
 		return setupProviderFromPath(res.LocalPluginPathAbs, pctx)
-	case packageresolution.ExternalSourceResult:
+	case packageresolution.ExternalSourceResult, packageresolution.InstalledInWorkspaceResult:
 		return setupProvider(descriptor, nil)
 	case packageresolution.RegistryResult:
 		return setupProviderFromRegistryMeta(res.Metadata, setupProvider)

--- a/pkg/cmd/pulumi/plugin/plugin.go
+++ b/pkg/cmd/pulumi/plugin/plugin.go
@@ -49,8 +49,9 @@ func NewPluginCmd() *cobra.Command {
 	}
 
 	packageResolutionOptions := packageresolution.Options{
-		DisableRegistryResolve: env.DisableRegistryResolve.Value(),
-		Experimental:           env.Experimental.Value(),
+		DisableRegistryResolve:      env.DisableRegistryResolve.Value(),
+		Experimental:                env.Experimental.Value(),
+		IncludeInstalledInWorkspace: false,
 	}
 	cmd.AddCommand(newPluginInstallCmd(packageResolutionOptions))
 	cmd.AddCommand(newPluginLsCmd())

--- a/pkg/cmd/pulumi/plugin/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install.go
@@ -338,7 +338,8 @@ func (cmd *pluginInstallCmd) resolvePluginSpec(
 	ctx context.Context, pluginSpec workspace.PluginSpec, absProjectDir string,
 ) (workspace.PluginSpec, error) {
 	resolutionEnv := cmd.packageResolutionOptions
-	result, err := packageresolution.Resolve(ctx, cmd.registry, pluginSpec, resolutionEnv, absProjectDir)
+	result, err := packageresolution.Resolve(
+		ctx, cmd.registry, packageresolution.DefaultWorkspace(), pluginSpec, resolutionEnv, absProjectDir)
 	if err != nil {
 		var packageNotFoundErr *packageresolution.PackageNotFoundError
 		if errors.As(err, &packageNotFoundErr) {
@@ -353,7 +354,9 @@ func (cmd *pluginInstallCmd) resolvePluginSpec(
 	}
 
 	switch res := result.(type) {
-	case packageresolution.LocalPathResult, packageresolution.ExternalSourceResult:
+	case packageresolution.LocalPathResult,
+		packageresolution.ExternalSourceResult,
+		packageresolution.InstalledInWorkspaceResult:
 		return pluginSpec, nil
 	case packageresolution.RegistryResult:
 		pluginSpec.Name = res.Metadata.Name

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -1041,6 +1041,11 @@ func TestImportParameterizedSmokeFreshState(t *testing.T) {
 	testImportParameterizedSmoke(t, false)
 }
 
+func TestImportParameterizedSmokeFreshStateWithExperimental(t *testing.T) {
+	t.Setenv("PULUMI_EXPERIMENTAL", "true")
+	testImportParameterizedSmoke(t, false)
+}
+
 // Test for https://github.com/pulumi/pulumi/issues/18814, check that --parallel respects cgroups limits.
 func TestParallelCgroups(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
If a package is already installed, we should always default to using it instead of resolving to some other package. Otherwise, in this sequence:

```
e.RunCommand("pulumi", "plugin", "install", "resource", "terraform-provider", "0.3.1")
e.RunCommand("pulumi", "package", "add", "terraform-provider", "hashicorp/random", "3.6.3")
```

The second command will run the package resolver and try to install the latest-available version of `terraform-provider`, which may not be `0.3.1` (in the case of our tests, it was `0.13.0`).

:information_source: Using the already-installed version is in conformance with previous behavior of `pulumi package add`. See this issue for a wider exploration: https://github.com/pulumi/pulumi/issues/20450

Fixes https://github.com/pulumi/pulumi/issues/20441

Should hopefully unblock #20361 after this merges and we rebase.