### PR TITLE
Add policy summary events

### DIFF
--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -107,6 +107,12 @@ func RenderDiffEvent(event engine.Event, seen map[resource.URN]engine.StepEventM
 		return ""
 	case engine.ErrorEvent:
 		return ""
+	case engine.PolicyAnalyzeSummaryEvent:
+		return ""
+	case engine.PolicyRemediateSummaryEvent:
+		return ""
+	case engine.PolicyAnalyzeStackSummaryEvent:
+		return ""
 
 		// Currently, prelude, summary, and stdout events are printed the same for both the diff and
 		// progress displays.

--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -133,6 +133,53 @@ func ConvertEngineEvent(e engine.Event, showSecrets bool) (apitype.EngineEvent, 
 			After:                after,
 		}
 
+	case engine.PolicyAnalyzeSummaryEvent:
+		p, ok := e.Payload().(engine.PolicyAnalyzeSummaryEventPayload)
+		if !ok {
+			return apiEvent, eventTypePayloadMismatch
+		}
+		apiEvent.PolicyAnalyzeSummaryEvent = &apitype.PolicyAnalyzeSummaryEvent{
+			ResourceURN:          string(p.ResourceURN),
+			PolicyPackName:       p.PolicyPackName,
+			PolicyPackVersion:    p.PolicyPackVersion,
+			PolicyPackVersionTag: p.PolicyPackVersion,
+			Disabled:             p.Disabled,
+			NotApplicable:        p.NotApplicable,
+			Passed:               p.Passed,
+			Failed:               p.Failed,
+		}
+
+	case engine.PolicyRemediateSummaryEvent:
+		p, ok := e.Payload().(engine.PolicyRemediateSummaryEventPayload)
+		if !ok {
+			return apiEvent, eventTypePayloadMismatch
+		}
+		apiEvent.PolicyRemediateSummaryEvent = &apitype.PolicyRemediateSummaryEvent{
+			ResourceURN:          string(p.ResourceURN),
+			PolicyPackName:       p.PolicyPackName,
+			PolicyPackVersion:    p.PolicyPackVersion,
+			PolicyPackVersionTag: p.PolicyPackVersion,
+			Disabled:             p.Disabled,
+			NotApplicable:        p.NotApplicable,
+			Passed:               p.Passed,
+			Failed:               p.Failed,
+		}
+
+	case engine.PolicyAnalyzeStackSummaryEvent:
+		p, ok := e.Payload().(engine.PolicyAnalyzeStackSummaryEventPayload)
+		if !ok {
+			return apiEvent, eventTypePayloadMismatch
+		}
+		apiEvent.PolicyAnalyzeStackSummaryEvent = &apitype.PolicyAnalyzeStackSummaryEvent{
+			PolicyPackName:       p.PolicyPackName,
+			PolicyPackVersion:    p.PolicyPackVersion,
+			PolicyPackVersionTag: p.PolicyPackVersion,
+			Disabled:             p.Disabled,
+			NotApplicable:        p.NotApplicable,
+			Passed:               p.Passed,
+			Failed:               p.Failed,
+		}
+
 	case engine.PreludeEvent:
 		p, ok := e.Payload().(engine.PreludeEventPayload)
 		if !ok {
@@ -383,6 +430,41 @@ func ConvertJSONEvent(apiEvent apitype.EngineEvent) (engine.Event, error) {
 			PolicyPackVersion: p.PolicyPackVersion,
 			Before:            before,
 			After:             after,
+		})
+
+	case apiEvent.PolicyAnalyzeSummaryEvent != nil:
+		p := apiEvent.PolicyAnalyzeSummaryEvent
+		event = engine.NewEvent(engine.PolicyAnalyzeSummaryEventPayload{
+			ResourceURN:       resource.URN(p.ResourceURN),
+			PolicyPackName:    p.PolicyPackName,
+			PolicyPackVersion: p.PolicyPackVersion,
+			Disabled:          p.Disabled,
+			NotApplicable:     p.NotApplicable,
+			Passed:            p.Passed,
+			Failed:            p.Failed,
+		})
+
+	case apiEvent.PolicyRemediateSummaryEvent != nil:
+		p := apiEvent.PolicyRemediateSummaryEvent
+		event = engine.NewEvent(engine.PolicyRemediateSummaryEventPayload{
+			ResourceURN:       resource.URN(p.ResourceURN),
+			PolicyPackName:    p.PolicyPackName,
+			PolicyPackVersion: p.PolicyPackVersion,
+			Disabled:          p.Disabled,
+			NotApplicable:     p.NotApplicable,
+			Passed:            p.Passed,
+			Failed:            p.Failed,
+		})
+
+	case apiEvent.PolicyAnalyzeStackSummaryEvent != nil:
+		p := apiEvent.PolicyAnalyzeStackSummaryEvent
+		event = engine.NewEvent(engine.PolicyAnalyzeStackSummaryEventPayload{
+			PolicyPackName:    p.PolicyPackName,
+			PolicyPackVersion: p.PolicyPackVersion,
+			Disabled:          p.Disabled,
+			NotApplicable:     p.NotApplicable,
+			Passed:            p.Passed,
+			Failed:            p.Failed,
 		})
 
 	case apiEvent.PreludeEvent != nil:

--- a/pkg/backend/display/json.go
+++ b/pkg/backend/display/json.go
@@ -221,7 +221,8 @@ func ShowPreviewDigest(events <-chan engine.Event, done chan<- bool, opts Option
 			continue
 
 		// Events occurring late:
-		case engine.PolicyViolationEvent, engine.PolicyLoadEvent, engine.PolicyRemediationEvent:
+		case engine.PolicyViolationEvent, engine.PolicyLoadEvent, engine.PolicyRemediationEvent,
+			engine.PolicyAnalyzeSummaryEvent, engine.PolicyRemediateSummaryEvent, engine.PolicyAnalyzeStackSummaryEvent:
 			// At this point in time, we don't handle policy events in JSON serialization
 			continue
 		case engine.SummaryEvent:

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -1179,6 +1179,10 @@ func (display *ProgressDisplay) processNormalEvent(event engine.Event) {
 		return
 	case engine.ErrorEvent:
 		return
+	case engine.PolicyAnalyzeSummaryEvent,
+		engine.PolicyAnalyzeStackSummaryEvent,
+		engine.PolicyRemediateSummaryEvent:
+		return
 	}
 
 	// At this point, all events should relate to resources.

--- a/pkg/backend/display/query.go
+++ b/pkg/backend/display/query.go
@@ -99,7 +99,8 @@ func renderQueryEvent(event engine.Event, opts Options) string {
 		contract.Failf("query mode does not support resource operations")
 		return ""
 
-	case engine.PolicyLoadEvent, engine.PolicyViolationEvent, engine.PolicyRemediationEvent:
+	case engine.PolicyLoadEvent, engine.PolicyViolationEvent, engine.PolicyRemediationEvent,
+		engine.PolicyAnalyzeSummaryEvent, engine.PolicyRemediateSummaryEvent, engine.PolicyAnalyzeStackSummaryEvent:
 		return ""
 
 	case engine.ProgressEvent:

--- a/pkg/backend/display/watch.go
+++ b/pkg/backend/display/watch.go
@@ -59,7 +59,8 @@ func ShowWatchEvents(op string, permalink string, events <-chan engine.Event, do
 			engine.PolicyLoadEvent, engine.PolicyRemediationEvent, engine.ErrorEvent:
 			// Ignore it
 			continue
-		case engine.PolicyViolationEvent:
+		case engine.PolicyViolationEvent, engine.PolicyAnalyzeSummaryEvent, engine.PolicyRemediateSummaryEvent,
+			engine.PolicyAnalyzeStackSummaryEvent:
 			// At this point in time, we don't handle policy events as part of pulumi watch
 			continue
 		case engine.DiagEvent:

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -767,6 +767,18 @@ func (acts *updateActions) OnPolicyRemediation(urn resource.URN, t plugin.Remedi
 	acts.Opts.Events.policyRemediationEvent(urn, t, before, after)
 }
 
+func (acts *updateActions) OnPolicyAnalyzeSummary(s plugin.PolicySummary) {
+	acts.Opts.Events.policyAnalyzeSummaryEvent(s)
+}
+
+func (acts *updateActions) OnPolicyRemediateSummary(s plugin.PolicySummary) {
+	acts.Opts.Events.policyRemediateSummaryEvent(s)
+}
+
+func (acts *updateActions) OnPolicyAnalyzeStackSummary(s plugin.PolicySummary) {
+	acts.Opts.Events.policyAnalyzeStackSummaryEvent(s)
+}
+
 func (acts *updateActions) MaybeCorrupt() bool {
 	return acts.maybeCorrupt
 }
@@ -910,6 +922,18 @@ func (acts *previewActions) OnPolicyRemediation(urn resource.URN, t plugin.Remed
 	before resource.PropertyMap, after resource.PropertyMap,
 ) {
 	acts.Opts.Events.policyRemediationEvent(urn, t, before, after)
+}
+
+func (acts *previewActions) OnPolicyAnalyzeSummary(s plugin.PolicySummary) {
+	acts.Opts.Events.policyAnalyzeSummaryEvent(s)
+}
+
+func (acts *previewActions) OnPolicyRemediateSummary(s plugin.PolicySummary) {
+	acts.Opts.Events.policyRemediateSummaryEvent(s)
+}
+
+func (acts *previewActions) OnPolicyAnalyzeStackSummary(s plugin.PolicySummary) {
+	acts.Opts.Events.policyAnalyzeStackSummaryEvent(s)
 }
 
 func (acts *previewActions) MaybeCorrupt() bool {

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -241,6 +241,9 @@ type StepExecutorEvents interface {
 type PolicyEvents interface {
 	OnPolicyViolation(resource.URN, plugin.AnalyzeDiagnostic)
 	OnPolicyRemediation(resource.URN, plugin.Remediation, resource.PropertyMap, resource.PropertyMap)
+	OnPolicyAnalyzeSummary(plugin.PolicySummary)
+	OnPolicyRemediateSummary(plugin.PolicySummary)
+	OnPolicyAnalyzeStackSummary(plugin.PolicySummary)
 }
 
 // Events is an interface that can be used to hook interesting engine events.

--- a/pkg/resource/deploy/step_executor_test.go
+++ b/pkg/resource/deploy/step_executor_test.go
@@ -93,6 +93,18 @@ func (e *mockEvents) OnPolicyRemediation(resource.URN, plugin.Remediation, resou
 	panic("unimplemented")
 }
 
+func (e *mockEvents) OnPolicyAnalyzeSummary(plugin.PolicySummary) {
+	panic("unimplemented")
+}
+
+func (e *mockEvents) OnPolicyRemediateSummary(plugin.PolicySummary) {
+	panic("unimplemented")
+}
+
+func (e *mockEvents) OnPolicyAnalyzeStackSummary(plugin.PolicySummary) {
+	panic("unimplemented")
+}
+
 func (e *mockEvents) OnSnapshotWrite(base *Snapshot) error {
 	return nil
 }

--- a/sdk/go/common/apitype/events.go
+++ b/sdk/go/common/apitype/events.go
@@ -76,6 +76,72 @@ type PolicyRemediationEvent struct {
 	After                map[string]interface{} `json:"after,omitempty"`
 }
 
+// PolicyNotApplicable describes a policy that was not applicable, including an optional reason why.
+type PolicyNotApplicable struct {
+	// The name of the policy that was not applicable.
+	PolicyName string `json:"policyName"`
+	// An optional reason why the policy was not applicable.
+	Reason string `json:"reason,omitempty"`
+}
+
+// PolicyAnalyzeSummaryEvent is emitted after a call to Analyze on an analyzer, summarizing the results.
+type PolicyAnalyzeSummaryEvent struct {
+	// The URN of the resource being analyzed.
+	ResourceURN string `json:"resourceUrn"`
+	// The name of the policy pack.
+	PolicyPackName string `json:"policyPackName"`
+	// The version of the policy pack.
+	PolicyPackVersion string `json:"policyPackVersion"`
+	// The version tag of the policy pack.
+	PolicyPackVersionTag string `json:"policyPackVersionTag"`
+	// Names of resource policies in the policy pack that were disabled.
+	Disabled []string `json:"disabled,omitempty"`
+	// Not applicable resource policies in the policy pack.
+	NotApplicable []PolicyNotApplicable `json:"notApplicable,omitempty"`
+	// The names of resource policies that passed (i.e. did not produce any violations).
+	Passed []string `json:"passed,omitempty"`
+	// The names of resource policies that failed (i.e. produced violations).
+	Failed []string `json:"failed,omitempty"`
+}
+
+// PolicyRemediateSummaryEvent is emitted after a call to Remediate on an analyzer, summarizing the results.
+type PolicyRemediateSummaryEvent struct {
+	// The URN of the resource being remediated.
+	ResourceURN string `json:"resourceUrn"`
+	// The name of the policy pack.
+	PolicyPackName string `json:"policyPackName"`
+	// The version of the policy pack.
+	PolicyPackVersion string `json:"policyPackVersion"`
+	// The version tag of the policy pack.
+	PolicyPackVersionTag string `json:"policyPackVersionTag"`
+	// Names of resource policies in the policy pack that were disabled.
+	Disabled []string `json:"disabled,omitempty"`
+	// Not applicable resource policies in the policy pack.
+	NotApplicable []PolicyNotApplicable `json:"notApplicable,omitempty"`
+	// The names of resource policies that passed (i.e. did not produce any violations).
+	Passed []string `json:"passed,omitempty"`
+	// The names of resource policies that failed (i.e. produced violations).
+	Failed []string `json:"failed,omitempty"`
+}
+
+// PolicyAnalyzeStackSummaryEvent is emitted after a call to AnalyzeStack on an analyzer, summarizing the results.
+type PolicyAnalyzeStackSummaryEvent struct {
+	// The name of the policy pack.
+	PolicyPackName string `json:"policyPackName"`
+	// The version of the policy pack.
+	PolicyPackVersion string `json:"policyPackVersion"`
+	// The version tag of the policy pack.
+	PolicyPackVersionTag string `json:"policyPackVersionTag"`
+	// Names of stack policies in the policy pack that were disabled.
+	Disabled []string `json:"disabled,omitempty"`
+	// Not applicable stack policies in the policy pack.
+	NotApplicable []PolicyNotApplicable `json:"notApplicable,omitempty"`
+	// The names of stack policies that passed (i.e. did not produce any violations).
+	Passed []string `json:"passed,omitempty"`
+	// The names of stack policies that failed (i.e. produced violations).
+	Failed []string `json:"failed,omitempty"`
+}
+
 // PreludeEvent is emitted at the start of an update.
 type PreludeEvent struct {
 	// Config contains the keys and values for the update.
@@ -261,20 +327,23 @@ type EngineEvent struct {
 	// Timestamp is a Unix timestamp (seconds) of when the event was emitted.
 	Timestamp int `json:"timestamp"`
 
-	CancelEvent            *CancelEvent            `json:"cancelEvent,omitempty"`
-	StdoutEvent            *StdoutEngineEvent      `json:"stdoutEvent,omitempty"`
-	DiagnosticEvent        *DiagnosticEvent        `json:"diagnosticEvent,omitempty"`
-	PreludeEvent           *PreludeEvent           `json:"preludeEvent,omitempty"`
-	SummaryEvent           *SummaryEvent           `json:"summaryEvent,omitempty"`
-	ResourcePreEvent       *ResourcePreEvent       `json:"resourcePreEvent,omitempty"`
-	ResOutputsEvent        *ResOutputsEvent        `json:"resOutputsEvent,omitempty"`
-	ResOpFailedEvent       *ResOpFailedEvent       `json:"resOpFailedEvent,omitempty"`
-	PolicyEvent            *PolicyEvent            `json:"policyEvent,omitempty"`
-	PolicyRemediationEvent *PolicyRemediationEvent `json:"policyRemediationEvent,omitempty"`
-	PolicyLoadEvent        *PolicyLoadEvent        `json:"policyLoadEvent,omitempty"`
-	StartDebuggingEvent    *StartDebuggingEvent    `json:"startDebuggingEvent,omitempty"`
-	ProgressEvent          *ProgressEvent          `json:"progressEvent,omitempty"`
-	ErrorEvent             *ErrorEvent             `json:"errorEvent,omitempty"`
+	CancelEvent                    *CancelEvent                    `json:"cancelEvent,omitempty"`
+	StdoutEvent                    *StdoutEngineEvent              `json:"stdoutEvent,omitempty"`
+	DiagnosticEvent                *DiagnosticEvent                `json:"diagnosticEvent,omitempty"`
+	PreludeEvent                   *PreludeEvent                   `json:"preludeEvent,omitempty"`
+	SummaryEvent                   *SummaryEvent                   `json:"summaryEvent,omitempty"`
+	ResourcePreEvent               *ResourcePreEvent               `json:"resourcePreEvent,omitempty"`
+	ResOutputsEvent                *ResOutputsEvent                `json:"resOutputsEvent,omitempty"`
+	ResOpFailedEvent               *ResOpFailedEvent               `json:"resOpFailedEvent,omitempty"`
+	PolicyEvent                    *PolicyEvent                    `json:"policyEvent,omitempty"`
+	PolicyRemediationEvent         *PolicyRemediationEvent         `json:"policyRemediationEvent,omitempty"`
+	PolicyLoadEvent                *PolicyLoadEvent                `json:"policyLoadEvent,omitempty"`
+	PolicyAnalyzeSummaryEvent      *PolicyAnalyzeSummaryEvent      `json:"policyAnalyzeSummaryEvent,omitempty"`
+	PolicyRemediateSummaryEvent    *PolicyRemediateSummaryEvent    `json:"policyRemediateSummaryEvent,omitempty"`
+	PolicyAnalyzeStackSummaryEvent *PolicyAnalyzeStackSummaryEvent `json:"policyAnalyzeStackSummaryEvent,omitempty"`
+	StartDebuggingEvent            *StartDebuggingEvent            `json:"startDebuggingEvent,omitempty"`
+	ProgressEvent                  *ProgressEvent                  `json:"progressEvent,omitempty"`
+	ErrorEvent                     *ErrorEvent                     `json:"errorEvent,omitempty"`
 }
 
 // EngineEventBatch is a group of engine events.

--- a/sdk/go/common/resource/plugin/analyzer.go
+++ b/sdk/go/common/resource/plugin/analyzer.go
@@ -115,6 +115,31 @@ type Remediation struct {
 	Diagnostic        string
 }
 
+// PolicyNotApplicable describes a policy that was not applicable, including an optional reason why.
+type PolicyNotApplicable struct {
+	// The name of the policy that was not applicable.
+	PolicyName string
+	// An optional reason why the policy was not applicable.
+	Reason string
+}
+
+type PolicySummary struct {
+	// The URN of the resource. This will be empty for AnalyzeStack.
+	URN resource.URN
+	// The name of the policy pack.
+	PolicyPackName string
+	// The version of the policy pack.
+	PolicyPackVersion string
+	// Names of policies in the policy pack that were disabled.
+	Disabled []string
+	// Not applicable resource policies in the policy pack.
+	NotApplicable []PolicyNotApplicable
+	// The names of policies that passed (i.e. did not produce any violations).
+	Passed []string
+	// The names of policies that failed (i.e. produced violations).
+	Failed []string
+}
+
 // AnalyzerInfo provides metadata about a PolicyPack inside an analyzer.
 type AnalyzerInfo struct {
 	Name           string


### PR DESCRIPTION
Add `PolicyAnalyzeSummaryEvent`, `PolicyRemediateSummaryEvent`, and `PolicyAnalyzeStackSummaryEvent` events that summarize which policies passed, failed, and were not applicable for each `Analyze`, `Remediate`, or `AnalyzeStack` call.

This is the first step of introducing these new events. Next will be consuming the new events from the service, followed by actually emitting the events from the CLI.