### PR TITLE
Replace terminfo package

### DIFF
--- a/changelog/pending/20250903--cli-display--replace-ijc-gotty-terminfo-package-with-xo-terminfo.yaml
+++ b/changelog/pending/20250903--cli-display--replace-ijc-gotty-terminfo-package-with-xo-terminfo.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli/display
+  description: Replace ijc/Gotty terminfo package with xo/terminfo

--- a/cmd/pulumi-test-language/go.mod
+++ b/cmd/pulumi-test-language/go.mod
@@ -116,7 +116,6 @@ require (
 	github.com/hashicorp/go-sockaddr v1.0.6 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/vault/api v1.12.0 // indirect
-	github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
@@ -171,6 +170,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/zclconf/go-cty v1.13.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect

--- a/cmd/pulumi-test-language/go.sum
+++ b/cmd/pulumi-test-language/go.sum
@@ -363,8 +363,6 @@ github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHL
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd h1:anPrsicrIi2ColgWTVPk+TrN42hJIWlfPHSBP9S0ZkM=
-github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd/go.mod h1:3LVOLeyx9XVvwPgrt2be44XgSqndprz1G18rSk8KD84=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
@@ -533,6 +531,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHo
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
+github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
+github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/backend/display/diff_test.go
+++ b/pkg/backend/display/diff_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -132,7 +132,7 @@ func TestDiffEvents(t *testing.T) {
 		path := filepath.Join("testdata/not-truncated", entry.Name())
 		t.Run(entry.Name(), func(t *testing.T) {
 			t.Parallel()
-			testDiffEvents(t, path, accept, false)
+			testDiffEvents(t, path, accept, false /* truncateOutput */)
 		})
 	}
 
@@ -147,7 +147,7 @@ func TestDiffEvents(t *testing.T) {
 		path := filepath.Join("testdata/truncated", entry.Name())
 		t.Run(entry.Name(), func(t *testing.T) {
 			t.Parallel()
-			testDiffEvents(t, path, accept, true)
+			testDiffEvents(t, path, accept, true /* truncateOutput */)
 		})
 	}
 }
@@ -168,7 +168,7 @@ func TestJsonYamlDiff(t *testing.T) {
 		path := filepath.Join("testdata/json-yaml", entry.Name())
 		t.Run(entry.Name(), func(t *testing.T) {
 			t.Parallel()
-			testDiffEvents(t, path, accept, false)
+			testDiffEvents(t, path, accept, false /* truncateOutput */)
 		})
 	}
 }

--- a/pkg/backend/display/internal/terminal/simple.go
+++ b/pkg/backend/display/internal/terminal/simple.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2024, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ import (
 	"sync"
 )
 
+// SimpleTerminal is a terminal which ignores terminal codes and writes its
+// output to a buffer.
 type SimpleTerminal struct {
 	m sync.Mutex
 
@@ -38,20 +40,10 @@ func NewSimpleTerminal(dest io.Writer, width, height int) *SimpleTerminal {
 		width:  width,
 		height: height,
 		raw:    true,
-		info:   info{simpleTermInfo(0)},
+		info:   nil,
 		keys:   make(chan string),
 		dest:   dest,
 	}
-}
-
-// A mock terminal info implementation that prints out terminal codes as
-// explicit strings for identification in test outputs.
-type simpleTermInfo int
-
-var _ termInfo = simpleTermInfo(0)
-
-func (ti simpleTermInfo) Parse(attr string, params ...interface{}) (string, error) {
-	return "", nil
 }
 
 func (t *SimpleTerminal) IsRaw() bool {
@@ -74,33 +66,13 @@ func (t *SimpleTerminal) Write(b []byte) (int, error) {
 	return t.dest.Write(b)
 }
 
-func (t *SimpleTerminal) ClearLine() {
-	t.info.ClearLine(t)
-}
-
-func (t *SimpleTerminal) ClearEnd() {
-	t.info.ClearEnd(t)
-}
-
-func (t *SimpleTerminal) CarriageReturn() {
-	// No op, as we don't have a cursor to move.
-}
-
-func (t *SimpleTerminal) CursorUp(count int) {
-	t.info.CursorUp(t, count)
-}
-
-func (t *SimpleTerminal) CursorDown(count int) {
-	t.info.CursorDown(t, count)
-}
-
-func (t *SimpleTerminal) HideCursor() {
-	t.info.HideCursor(t)
-}
-
-func (t *SimpleTerminal) ShowCursor() {
-	t.info.ShowCursor(t)
-}
+func (t *SimpleTerminal) ClearLine()           {}
+func (t *SimpleTerminal) ClearEnd()            {}
+func (t *SimpleTerminal) CarriageReturn()      {}
+func (t *SimpleTerminal) CursorUp(count int)   {}
+func (t *SimpleTerminal) CursorDown(count int) {}
+func (t *SimpleTerminal) HideCursor()          {}
+func (t *SimpleTerminal) ShowCursor()          {}
 
 func (t *SimpleTerminal) ReadKey() (string, error) {
 	k, ok := <-t.keys

--- a/pkg/backend/display/progress_test.go
+++ b/pkg/backend/display/progress_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -111,8 +111,8 @@ func testProgressEvents(
 
 //nolint:paralleltest // sets the TERM environment variable
 func TestProgressEvents(t *testing.T) {
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		// TODO[pulumi/pulumi#19675]: Fix this test on Windows and MacOS
+	if runtime.GOOS == "windows" {
+		// TODO[pulumi/pulumi#19675]: Fix this test on Windows
 		t.Skip("Skipping tests on Windows and MacOS.")
 	}
 	t.Setenv("TERM", "vt102")
@@ -147,14 +147,14 @@ func TestProgressEvents(t *testing.T) {
 						suffix := fmt.Sprintf(".interactive-%vx%v", width, height)
 						opts := defaultOpts()
 						opts.IsInteractive = true
-						testProgressEvents(t, path, accept, suffix, opts, width, height, true)
+						testProgressEvents(t, path, accept, suffix, opts, width, height, true /* raw */)
 					})
 
 					t.Run("cooked", func(t *testing.T) {
 						suffix := fmt.Sprintf(".interactive-%vx%v-cooked", width, height)
 						opts := defaultOpts()
 						opts.IsInteractive = true
-						testProgressEvents(t, path, accept, suffix, opts, width, height, false)
+						testProgressEvents(t, path, accept, suffix, opts, width, height, false /* raw */)
 					})
 
 					t.Run("plain", func(t *testing.T) {

--- a/pkg/backend/display/progress_test.go
+++ b/pkg/backend/display/progress_test.go
@@ -113,7 +113,7 @@ func testProgressEvents(
 func TestProgressEvents(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		// TODO[pulumi/pulumi#19675]: Fix this test on Windows
-		t.Skip("Skipping tests on Windows and MacOS.")
+		t.Skip("Skipping tests on Windows.")
 	}
 	t.Setenv("TERM", "vt102")
 

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/hcl/v2 v2.22.0
 	github.com/iancoleman/strcase v0.2.0
-	github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/moby/moby v28.3.3+incompatible
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
@@ -98,6 +97,7 @@ require (
 	github.com/segmentio/encoding v0.3.5
 	github.com/shirou/gopsutil/v3 v3.22.3
 	github.com/spf13/afero v1.9.5
+	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.36.0
 	go.opentelemetry.io/otel/sdk v1.36.0

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -405,8 +405,6 @@ github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHL
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd h1:anPrsicrIi2ColgWTVPk+TrN42hJIWlfPHSBP9S0ZkM=
-github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd/go.mod h1:3LVOLeyx9XVvwPgrt2be44XgSqndprz1G18rSk8KD84=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
@@ -620,6 +618,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHo
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
+github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
+github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -141,7 +141,6 @@ require (
 	github.com/hashicorp/vault/api v1.12.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/hexops/valast v1.4.4 // indirect
-	github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/iwdgo/sigintwindows v0.2.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -219,6 +218,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zclconf/go-cty v1.13.2 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -2631,7 +2631,6 @@ github.com/ianlancetaylor/demangle v0.0.0-20220319035150-800ac71e25c2/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20220517205856-0058ec4f073c/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/ianlancetaylor/demangle v0.0.0-20230524184225-eabc099b10ab/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 github.com/ianlancetaylor/demangle v0.0.0-20240312041847-bd984b5ce465/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
-github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd h1:anPrsicrIi2ColgWTVPk+TrN42hJIWlfPHSBP9S0ZkM=
 github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd/go.mod h1:3LVOLeyx9XVvwPgrt2be44XgSqndprz1G18rSk8KD84=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -3461,6 +3460,8 @@ github.com/xhit/go-str2duration v1.2.0/go.mod h1:3cPSlfZlUHVlneIVfePFWcJZsuwf+P1
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
+github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
+github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -3752,6 +3753,7 @@ golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EH
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20220328175248-053ad81199eb/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
+golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/exp v0.0.0-20230108222341-4b8118a2686a/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/exp v0.0.0-20230206171751-46f607a40771/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=


### PR DESCRIPTION
The `github.com/ijc/Gotty` package doesn't know how to load the terminfo file on macOS (or FreeBSD), so we were always using the fallback paths on these systems (and on Windows, because terminfo is not a thing there).

The tests run with `TERM=vt102`, and the escape codes for some operations are different from those in the fallback paths, so the golden files are inconsistent. Now that we can correctly load the terminfo file, we get consistent behaviour in the tests when running on Linux and macOS.

Ref https://github.com/pulumi/pulumi/issues/19675