### PR TITLE
Fix coloring of cobra error messages on windows

### DIFF
--- a/changelog/pending/20250903--cli-display--fix-coloring-of-cobra-error-messages-on-windows.yaml
+++ b/changelog/pending/20250903--cli-display--fix-coloring-of-cobra-error-messages-on-windows.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Fix coloring of cobra error messages on windows

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -209,6 +209,10 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 		}
 	}
 
+	// We run this method for its side-effects. On windows, this will enable the windows terminal
+	// to understand ANSI escape codes.
+	_, _, _ = term.StdStreams()
+
 	cmd := &cobra.Command{
 		Use:           "pulumi",
 		Short:         "Pulumi command line",
@@ -231,10 +235,6 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 			"\n" +
 			"For more information, please visit the project page: https://www.pulumi.com/docs/",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			// We run this method for its side-effects. On windows, this will enable the windows terminal
-			// to understand ANSI escape codes.
-			_, _, _ = term.StdStreams()
-
 			// If we fail before we start the async update check, go ahead and close the
 			// channel since we know it will never receive a value.
 			var waitForUpdateCheck bool


### PR DESCRIPTION
By default cmd.exe does not handle ansi escape codes. To enable this you need to call `SetConsoleMode`. We do this via `github.com/moby/term -> term.StdStreams`, which we used to run in `PersistentPreRunE`. However cobra errors like a missing argument don’t go through `PersistentPreRunE`. To fix this we move the setup outside of the function to ensure it always runs.

I have no good way of testing this. I manually compiled a windows binary and run it with a bad command.

Fixes https://github.com/pulumi/pulumi/issues/4609
