### PR TITLE
[program-gen] Fix panic in RewriteApplies when encountering warning diagnostics

### DIFF
--- a/changelog/pending/20250903--programgen--fix-panic-in-rewriteapplies-when-encountering-warning-diagnostics.yaml
+++ b/changelog/pending/20250903--programgen--fix-panic-in-rewriteapplies-when-encountering-warning-diagnostics.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Fix panic in RewriteApplies when encountering warning diagnostics

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -1129,3 +1129,54 @@ resource "name" "random:index/randomString:RandomString" {
 	require.Equal(t, 1, len(diags), "There is one node")
 	require.Equal(t, hcl.DiagWarning, diags[0].Severity, "The diagnostic is a warning")
 }
+
+type nameInfo int
+
+func (nameInfo) Format(name string) string {
+	return name
+}
+
+func TestRewriteAppliesDoesNotPanicInNonStrictMode(t *testing.T) {
+	source := `
+config "vpcId" "string" {
+  description = "The ID of the VPC"
+}
+
+resource "ptfeService" "aws:ec2/vpcEndpoint:VpcEndpoint" {
+  __logicalName     = "ptfe_service"
+  vpcId             = vpcId
+  vpcEndpointType   = "Interface"
+  privateDnsEnabled = false
+}
+
+resource "ptfeServiceRecord" "aws:route53/record:Record" {
+  __logicalName = "ptfe_service"
+  zoneId        = "example_zone_id"
+  name          = "example"
+  type          = "CNAME"
+  ttl           = "300"
+  records       = [ptfeService.dnsEntries[0]["dns_name"]]
+}
+	`
+
+	program, diags, error := ParseAndBindProgram(t, source, "program.pp", pcl.NonStrictBindOptions()...)
+	require.NoError(t, error)
+	require.False(t, diags.HasErrors(), "There are no error diagnostics")
+	require.NotNil(t, program)
+
+	var resource *pcl.Resource
+	for _, n := range program.Nodes {
+		if r, ok := n.(*pcl.Resource); ok && r.Name() == "ptfeServiceRecord" {
+			resource = r
+			break
+		}
+	}
+	require.NotNil(t, resource, "there is a resource named ptfeServiceRecord")
+
+	for _, attr := range resource.Inputs {
+		value := attr.Value
+		expr, diags := pcl.RewriteApplies(value, nameInfo(0), false)
+		require.False(t, diags.HasErrors(), "there are no diagnostics")
+		require.NotNil(t, expr, "the expression is not nil")
+	}
+}

--- a/pkg/codegen/pcl/rewrite_apply.go
+++ b/pkg/codegen/pcl/rewrite_apply.go
@@ -575,7 +575,7 @@ func (ctx *observeContext) PostVisit(expr model.Expression) (model.Expression, h
 
 	// TODO(pdg): arrays of outputs, for expressions, etc.
 	diagnostics := expr.Typecheck(false)
-	contract.Assertf(len(diagnostics) == 0, "error typechecking expression: %v", diagnostics)
+	contract.Assertf(diagnostics.HasErrors(), "error typechecking expression: %v", diagnostics)
 
 	if isIteratorExpr, _ := ctx.isIteratorExpr(expr); isIteratorExpr {
 		return expr, nil


### PR DESCRIPTION
Fixes #20419

Starting from Pulumi CLI v3.191.0 an example conversion in AWS upgrade started panic'ing where as previously it didn't. 

Looking into changes PCL in v.3.191.0 we merged the following PRs

 - [programgen] Emit warnings instead of errors in non-strict mode when binding resource blocks
https://github.com/pulumi/pulumi/pull/20347

 - [programgen] Simplify range value types when it is derived from object of objects and warn on unknown properties
https://github.com/pulumi/pulumi/pull/20345

 - [programgen] Warn instead of erroring out when traversing a NoneType in PCL
https://github.com/pulumi/pulumi/pull/20342

After investigating, undoing each of the PRs separately it turns out that the first PR https://github.com/pulumi/pulumi/pull/20347 is the culprit.

The reason it was panic'ing when converting to a specific language is that before https://github.com/pulumi/pulumi/pull/20347, we would error out at the bind/typecheck phase and not generate any program.  Now with https://github.com/pulumi/pulumi/pull/20347, we turned error diagnostics (in non-strict mode) into warning diagnostics so that program generators can handle the rest. At least that was the assumption, turns out that when we are generating a program and we run `RewriteApplies(...)` against expressions in the resource blocks, they cannot have any type errors (e.g. indexing a non-existent property) otherwise it violates a contract in the implementation of `RewriteApplies`

This PR fixes the issue by making the contract assert against _error_ diagnostics rather than no diagnostics at all, thus allowing for warning diagnostics to pass without panic'ing. 