### PR TITLE
Stabilize template registry operations

### DIFF
--- a/changelog/pending/20250904--cli--template-operations-no-longer-experimental.yaml
+++ b/changelog/pending/20250904--cli--template-operations-no-longer-experimental.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli
+  description: No longer require the `PULUMI_EXPERIMENTAL` flag for Private Registry template operations (`pulumi template publish`, registry-based template resolution in `pulumi new`), while registry-backed template resolution in `pulumi new` may still be disabled using `PULUMI_DISABLE_REGISTRY_RESOLVE=true pulumi new`

--- a/pkg/backend/httpstate/client/api_endpoints.go
+++ b/pkg/backend/httpstate/client/api_endpoints.go
@@ -129,6 +129,6 @@ func init() {
 	addEndpoint("POST", "/api/preview/registry/packages/{source}/{publisher}/{name}/versions/{version}/complete", "completePackagePublish")
 
 	// APIs for interacting with the Template Registry
-	addEndpoint("POST", "/api/preview/registry/templates/{source}/{publisher}/{name}/versions", "publishTemplate")
-	addEndpoint("POST", "/api/preview/registry/templates/{source}/{publisher}/{name}/versions/{version}/complete", "completeTemplatePublish")
+	addEndpoint("POST", "/api/registry/templates/{source}/{publisher}/{name}/versions", "publishTemplate")
+	addEndpoint("POST", "/api/registry/templates/{source}/{publisher}/{name}/versions/{version}/complete", "completeTemplatePublish")
 }

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -269,11 +269,11 @@ func completePackagePublishPath(source, publisher, name, version string) string 
 }
 
 func publishTemplatePath(source, publisher, name string) string {
-	return fmt.Sprintf("/api/preview/registry/templates/%s/%s/%s/versions", source, publisher, name)
+	return fmt.Sprintf("/api/registry/templates/%s/%s/%s/versions", source, publisher, name)
 }
 
 func completeTemplatePublishPath(source, publisher, name string, version semver.Version) string {
-	return fmt.Sprintf("/api/preview/registry/templates/%s/%s/%s/versions/%s/complete", source, publisher, name, version)
+	return fmt.Sprintf("/api/registry/templates/%s/%s/%s/versions/%s/complete", source, publisher, name, version)
 }
 
 // Copied from https://github.com/pulumi/pulumi-service/blob/master/pkg/apitype/users.go#L7-L16
@@ -1679,8 +1679,6 @@ func (pc *Client) GetPackage(
 	return resp, err
 }
 
-// GetTemplate is a preview API, and should not be used without an approved EOL plan for
-// deprecation.
 func (pc *Client) GetTemplate(
 	ctx context.Context, source, publisher, name string, version *semver.Version,
 ) (apitype.TemplateMetadata, error) {
@@ -1688,7 +1686,7 @@ func (pc *Client) GetTemplate(
 	if version != nil {
 		v = version.String()
 	}
-	url := fmt.Sprintf("/api/preview/registry/templates/%s/%s/%s/versions/%s", source, publisher, name, v)
+	url := fmt.Sprintf("/api/registry/templates/%s/%s/%s/versions/%s", source, publisher, name, v)
 	var resp apitype.TemplateMetadata
 	err := pc.restCall(ctx, "GET", url, nil, nil, &resp)
 	return resp, err
@@ -1780,10 +1778,8 @@ func (pc *Client) ListPackages(ctx context.Context, name *string) iter.Seq2[apit
 	}
 }
 
-// ListTemplates is a preview API, and should not be used without an approved EOL plan for
-// deprecation.
 func (pc *Client) ListTemplates(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
-	url := "/api/preview/registry/templates?limit=499"
+	url := "/api/registry/templates?limit=499"
 	if name != nil {
 		url += "&name=" + *name
 	}

--- a/pkg/backend/httpstate/client/client_template_test.go
+++ b/pkg/backend/httpstate/client/client_template_test.go
@@ -62,7 +62,7 @@ func TestStartTemplatePublish(t *testing.T) {
 			name: "SuccessfulStartPublish",
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if r.URL.Path == "/api/preview/registry/templates/private/test-publisher/test-template/versions" {
+					if r.URL.Path == "/api/registry/templates/private/test-publisher/test-template/versions" {
 						w.WriteHeader(http.StatusAccepted)
 						response := StartTemplatePublishResponse{
 							OperationID: "test-operation-id",
@@ -153,7 +153,7 @@ func TestCompleteTemplatePublish(t *testing.T) {
 			name: "SuccessfulCompletePublish",
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if r.URL.Path == "/api/preview/registry/templates/private/test-publisher/test-template/versions/1.0.0/complete" {
+					if r.URL.Path == "/api/registry/templates/private/test-publisher/test-template/versions/1.0.0/complete" {
 						w.WriteHeader(http.StatusCreated)
 						response := PublishTemplateVersionCompleteResponse{}
 						require.NoError(t, json.NewEncoder(w).Encode(response))
@@ -236,7 +236,7 @@ func TestPublishTemplate_Integration(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/templates/private/test-publisher/test-template/versions":
+					case "/api/registry/templates/private/test-publisher/test-template/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := StartTemplatePublishResponse{
 							OperationID: "test-operation-id",
@@ -246,7 +246,7 @@ func TestPublishTemplate_Integration(t *testing.T) {
 						}
 						require.NoError(t, json.NewEncoder(w).Encode(response))
 
-					case "/api/preview/registry/templates/private/test-publisher/test-template/versions/1.0.0/complete":
+					case "/api/registry/templates/private/test-publisher/test-template/versions/1.0.0/complete":
 						w.WriteHeader(http.StatusCreated)
 					}
 				}))
@@ -266,7 +266,7 @@ func TestPublishTemplate_Integration(t *testing.T) {
 			},
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if r.URL.Path == "/api/preview/registry/templates/private/test-publisher/test-template/versions" {
+					if r.URL.Path == "/api/registry/templates/private/test-publisher/test-template/versions" {
 						w.WriteHeader(http.StatusInternalServerError)
 						_, err := w.Write([]byte("Internal Server Error"))
 						require.NoError(t, err)
@@ -294,7 +294,7 @@ func TestPublishTemplate_Integration(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/templates/private/test-publisher/test-template/versions":
+					case "/api/registry/templates/private/test-publisher/test-template/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := StartTemplatePublishResponse{
 							OperationID: "test-operation-id",
@@ -323,7 +323,7 @@ func TestPublishTemplate_Integration(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/templates/private/test-publisher/test-template/versions":
+					case "/api/registry/templates/private/test-publisher/test-template/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := StartTemplatePublishResponse{
 							OperationID: "test-operation-id",
@@ -332,7 +332,7 @@ func TestPublishTemplate_Integration(t *testing.T) {
 							},
 						}
 						require.NoError(t, json.NewEncoder(w).Encode(response))
-					case "/api/preview/registry/templates/private/test-publisher/test-template/versions/1.0.0/complete":
+					case "/api/registry/templates/private/test-publisher/test-template/versions/1.0.0/complete":
 						w.WriteHeader(http.StatusInternalServerError)
 						_, err := w.Write([]byte("Failed to complete"))
 						require.NoError(t, err)
@@ -363,7 +363,7 @@ func TestPublishTemplate_Integration(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/templates/private/test-publisher/test-template/versions":
+					case "/api/registry/templates/private/test-publisher/test-template/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := StartTemplatePublishResponse{
 							OperationID: "test-operation-id",
@@ -679,7 +679,7 @@ func TestListTemplates(t *testing.T) {
 
 		// Set up mock server
 		mockServer := newMockServerRequestProcessor(200, func(req *http.Request) string {
-			assert.Contains(t, req.URL.String(), "/api/preview/registry/templates?limit=499")
+			assert.Contains(t, req.URL.String(), "/api/registry/templates?limit=499")
 			assert.Equal(t, "GET", req.Method)
 
 			data, err := json.Marshal(mockResponse)
@@ -752,7 +752,7 @@ func TestListTemplates(t *testing.T) {
 
 			switch requestCount {
 			case 0:
-				assert.Equal(t, "/api/preview/registry/templates?limit=499&name=my-template", req.URL.String())
+				assert.Equal(t, "/api/registry/templates?limit=499&name=my-template", req.URL.String())
 				assert.NotContains(t, "continuationToken", req.URL.String())
 
 				responseData, err = json.Marshal(apitype.ListTemplatesResponse{
@@ -762,7 +762,7 @@ func TestListTemplates(t *testing.T) {
 				require.NoError(t, err)
 			case 1:
 				assert.Equal(t,
-					"/api/preview/registry/templates?limit=499&name=my-template&continuationToken=next-page-token-1",
+					"/api/registry/templates?limit=499&name=my-template&continuationToken=next-page-token-1",
 					req.URL.String())
 
 				responseData, err = json.Marshal(apitype.ListTemplatesResponse{
@@ -772,7 +772,7 @@ func TestListTemplates(t *testing.T) {
 				require.NoError(t, err)
 			case 2:
 				assert.Equal(t,
-					"/api/preview/registry/templates?limit=499&name=my-template&continuationToken=next-page-token-2",
+					"/api/registry/templates?limit=499&name=my-template&continuationToken=next-page-token-2",
 					req.URL.String())
 
 				responseData, err = json.Marshal(apitype.ListTemplatesResponse{

--- a/pkg/cmd/pulumi/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_test.go
@@ -229,6 +229,13 @@ func TestCreatingProjectWithExistingArgsSpecifiedNameFails(t *testing.T) {
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return name == projectName, nil
 		},
+		GetReadOnlyCloudRegistryF: func() registry.Registry {
+			return &backend.MockCloudRegistry{
+				ListTemplatesF: func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+					return func(yield func(apitype.TemplateMetadata, error) bool) {}
+				},
+			}
+		},
 	})
 
 	args := newArgs{
@@ -251,12 +258,21 @@ func TestCreatingProjectWithExistingPromptedNameFails(t *testing.T) {
 	tempdir := tempProjectDir(t)
 	chdir(t, tempdir)
 
+	listTemplates := func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+		assert.Nil(t, name)
+		return func(yield func(apitype.TemplateMetadata, error) bool) {}
+	}
+
 	testutil.MockBackendInstance(t, &backend.MockBackend{
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return name == projectName, nil
 		},
-		SupportsTemplatesF: func() bool { return false },
-		NameF:              func() string { return "mock" },
+		NameF: func() string { return "mock" },
+		GetReadOnlyCloudRegistryF: func() registry.Registry {
+			return &backend.MockCloudRegistry{
+				ListTemplatesF: listTemplates,
+			}
+		},
 	})
 
 	args := newArgs{
@@ -281,8 +297,15 @@ func TestGeneratingProjectWithExistingArgsSpecifiedNameSucceeds(t *testing.T) {
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return true, nil
 		},
-		SupportsTemplatesF: func() bool { return false },
-		NameF:              func() string { return "mock" },
+		GetReadOnlyCloudRegistryF: func() registry.Registry {
+			return &backend.MockCloudRegistry{
+				ListTemplatesF: func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+					assert.Nil(t, name)
+					return func(yield func(apitype.TemplateMetadata, error) bool) {}
+				},
+			}
+		},
+		NameF: func() string { return "mock" },
 	})
 
 	// Generate-only command is not creating any stacks, so don't bother with with the name uniqueness check.
@@ -314,8 +337,15 @@ func TestGeneratingProjectWithExistingPromptedNameSucceeds(t *testing.T) {
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return true, nil
 		},
-		SupportsTemplatesF: func() bool { return false },
-		NameF:              func() string { return "mock" },
+		GetReadOnlyCloudRegistryF: func() registry.Registry {
+			return &backend.MockCloudRegistry{
+				ListTemplatesF: func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+					assert.Nil(t, name)
+					return func(yield func(apitype.TemplateMetadata, error) bool) {}
+				},
+			}
+		},
+		NameF: func() string { return "mock" },
 	})
 
 	// Generate-only command is not creating any stacks, so don't bother with with the name uniqueness check.
@@ -384,6 +414,13 @@ func TestGeneratingProjectWithInvalidArgsSpecifiedNameFails(t *testing.T) {
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return true, nil
 		},
+		GetReadOnlyCloudRegistryF: func() registry.Registry {
+			return &backend.MockCloudRegistry{
+				ListTemplatesF: func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+					return func(yield func(apitype.TemplateMetadata, error) bool) {}
+				},
+			}
+		},
 	})
 
 	// Generate-only command is not creating any stacks, so don't bother with with the name uniqueness check.
@@ -412,8 +449,15 @@ func TestGeneratingProjectWithInvalidPromptedNameFails(t *testing.T) {
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return true, nil
 		},
-		SupportsTemplatesF: func() bool { return false },
-		NameF:              func() string { return "mock" },
+		GetReadOnlyCloudRegistryF: func() registry.Registry {
+			return &backend.MockCloudRegistry{
+				ListTemplatesF: func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+					assert.Nil(t, name)
+					return func(yield func(apitype.TemplateMetadata, error) bool) {}
+				},
+			}
+		},
+		NameF: func() string { return "mock" },
 	})
 
 	// Generate-only command is not creating any stacks, so don't bother with with the name uniqueness check.
@@ -539,6 +583,13 @@ func TestValidateStackRefAndProjectName(t *testing.T) {
 				return nil, fmt.Errorf("invalid stack reference %q", s)
 			}
 		},
+		GetReadOnlyCloudRegistryF: func() registry.Registry {
+			return &backend.MockCloudRegistry{
+				ListTemplatesF: func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+					return func(yield func(apitype.TemplateMetadata, error) bool) {}
+				},
+			}
+		},
 	}
 
 	tests := []struct {
@@ -606,6 +657,13 @@ func TestProjectExists(t *testing.T) {
 			}
 			_, exists := orgProjects[ProjectName(projectName)]
 			return exists, nil
+		},
+		GetReadOnlyCloudRegistryF: func() registry.Registry {
+			return &backend.MockCloudRegistry{
+				ListTemplatesF: func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+					return func(yield func(apitype.TemplateMetadata, error) bool) {}
+				},
+			}
 		},
 	}
 
@@ -697,6 +755,13 @@ func TestPulumiNewConflictingProject(t *testing.T) {
 				return true, nil
 			}
 			return false, nil
+		},
+		GetReadOnlyCloudRegistryF: func() registry.Registry {
+			return &backend.MockCloudRegistry{
+				ListTemplatesF: func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+					return func(yield func(apitype.TemplateMetadata, error) bool) {}
+				},
+			}
 		},
 	}
 
@@ -835,6 +900,8 @@ func TestPulumiPromptRuntimeOptions(t *testing.T) {
 
 //nolint:paralleltest // Sets a global mock backend
 func TestPulumiNewWithOrgTemplates(t *testing.T) {
+	// Set environment variable to disable registry resolution and use org templates
+	t.Setenv("PULUMI_DISABLE_REGISTRY_RESOLVE", "true")
 	mockBackend := &backend.MockBackend{
 		SupportsTemplatesF: func() bool { return true },
 		CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
@@ -872,6 +939,13 @@ func TestPulumiNewWithOrgTemplates(t *testing.T) {
 				return apitype.ListOrgTemplatesResponse{OrgHasTemplates: false}, nil
 			default:
 				return apitype.ListOrgTemplatesResponse{}, fmt.Errorf("unknown org %q", orgName)
+			}
+		},
+		GetReadOnlyCloudRegistryF: func() registry.Registry {
+			return &backend.MockCloudRegistry{
+				ListTemplatesF: func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+					return func(yield func(apitype.TemplateMetadata, error) bool) {}
+				},
 			}
 		},
 	}
@@ -1033,8 +1107,15 @@ Available Templates:
 //nolint:paralleltest // Sets a global mock backend
 func TestPulumiNewWithoutTemplateSupport(t *testing.T) {
 	testutil.MockBackendInstance(t, &backend.MockBackend{
-		SupportsTemplatesF: func() bool { return false },
-		NameF:              func() string { return "mock" },
+		GetReadOnlyCloudRegistryF: func() registry.Registry {
+			return &backend.MockCloudRegistry{
+				ListTemplatesF: func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+					assert.Nil(t, name)
+					return func(yield func(apitype.TemplateMetadata, error) bool) {}
+				},
+			}
+		},
+		NameF: func() string { return "mock" },
 	})
 
 	newCmd := NewNewCmd()
@@ -1055,6 +1136,8 @@ Available Templates:
 
 //nolint:paralleltest // Sets a global mock backend, changes the directory
 func TestPulumiNewOrgTemplate(t *testing.T) {
+	// Set environment variable to disable registry resolution and use org templates
+	t.Setenv("PULUMI_DISABLE_REGISTRY_RESOLVE", "true")
 	tempdir := tempProjectDir(t)
 	chdir(t, tempdir)
 	mockBackend := &backend.MockBackend{
@@ -1106,6 +1189,13 @@ resources:
     type: aws:s3:BucketV2
 `},
 			}, nil
+		},
+		GetReadOnlyCloudRegistryF: func() registry.Registry {
+			return &backend.MockCloudRegistry{
+				ListTemplatesF: func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+					return func(yield func(apitype.TemplateMetadata, error) bool) {}
+				},
+			}
 		},
 	}
 	testutil.MockBackendInstance(t, mockBackend)
@@ -1170,8 +1260,15 @@ func TestNoPromptWithYes(t *testing.T) {
 			}
 
 			mockBackend := &backend.MockBackend{
-				SupportsTemplatesF: func() bool { return false },
-				NameF:              func() string { return "mock" },
+				GetReadOnlyCloudRegistryF: func() registry.Registry {
+					return &backend.MockCloudRegistry{
+						ListTemplatesF: func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error] {
+							assert.Nil(t, name)
+							return func(yield func(apitype.TemplateMetadata, error) bool) {}
+						},
+					}
+				},
+				NameF: func() string { return "mock" },
 			}
 
 			require.False(t, shouldPromptForAIOrTemplate(args, mockBackend))

--- a/pkg/cmd/pulumi/templatecmd/template.go
+++ b/pkg/cmd/pulumi/templatecmd/template.go
@@ -15,7 +15,6 @@
 package templatecmd
 
 import (
-	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -24,15 +23,10 @@ func NewTemplateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "template",
 		Short: "Work with Pulumi templates",
-		Long: `[EXPERIMENTAL] Work with Pulumi templates
+		Long: `Work with Pulumi templates
 
 Publish and manage Pulumi templates.`,
-		// NB: the `pulumi template` namespace depends on pulumi-service APIs that
-		// are currently behind `/preview`. The `pulumi template` namespace should
-		// not be made generally available before those APIs are stabilized out of
-		// `/preview`.
-		Hidden: !env.Experimental.Value(),
-		Args:   cmdutil.NoArgs,
+		Args: cmdutil.NoArgs,
 	}
 	cmd.AddCommand(
 		newTemplatePublishCmd(),

--- a/pkg/cmd/pulumi/templates/cloud.go
+++ b/pkg/cmd/pulumi/templates/cloud.go
@@ -124,7 +124,7 @@ func (s *Source) getCloudTemplates(
 	ctx context.Context, templateName string,
 	wg *sync.WaitGroup, e env.Env,
 ) {
-	if !e.GetBool(env.DisableRegistryResolve) && e.GetBool(env.Experimental) {
+	if !e.GetBool(env.DisableRegistryResolve) {
 		s.getRegistryTemplates(ctx, e, templateName)
 		return
 	}

--- a/pkg/cmd/pulumi/templates/templates_test.go
+++ b/pkg/cmd/pulumi/templates/templates_test.go
@@ -157,7 +157,6 @@ func TestFilterOnName(t *testing.T) {
 		})
 		testFilterOnName(t, env.MapStore{
 			"PULUMI_DISABLE_REGISTRY_RESOLVE": "false",
-			"PULUMI_EXPERIMENTAL":             "true",
 		})
 	})
 }

--- a/sdk/go/common/registry/registry.go
+++ b/sdk/go/common/registry/registry.go
@@ -50,16 +50,10 @@ type Registry interface {
 	// there are no matching packages in the Registry.
 	ListPackages(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error]
 
-	// GetTemplate is a preview API, and should not be used without an approved EOL
-	// plan for deprecation. The safest way to do this is to flag functionality behind
-	// `PULUMI_EXPERIMENTAL`, which removes any backwards comparability requirements.
 	GetTemplate(
 		ctx context.Context, source, publisher, name string, version *semver.Version,
 	) (apitype.TemplateMetadata, error)
 
-	// ListTemplates is a preview API, and should not be used without an approved EOL
-	// plan for deprecation. The safest way to do this is to flag functionality behind
-	// `PULUMI_EXPERIMENTAL`, which removes any backwards comparability requirements.
 	ListTemplates(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error]
 
 	// DownloadTemplate downloads a template given the value of


### PR DESCRIPTION
This removes the experimental flag requirement for template-related operations in the Pulumi CLI:

- `pulumi template publish` command is no longer hidden behind PULUMI_EXPERIMENTAL
- Registry-based template resolution in `pulumi new` works without experimental flag
- Template API endpoints moved from `/api/preview/registry/` to `/api/registry/`
- Updated template client methods and tests to use stable endpoints
- Registry template resolution can still be disabled with PULUMI_DISABLE_REGISTRY_RESOLVE=true

This change makes template publishing and registry-based template discovery available to all users without requiring experimental flags, while keeping package operations separate for future stabilization.

If registry services are or not working as expected, set `PULUMI_DISABLE_REGISTRY_RESOLVE=true` to make `pulumi new` fall back to the previous public and organization-based template resolution mechanism.

This PR redoes part of https://github.com/pulumi/pulumi/pull/20361 as we've realized registry-backed package resolution is not yet ready for stabilization, seeing as we've found a few bugs with it and are not confident that there aren't more:

- https://github.com/pulumi/pulumi/pull/20442
- https://github.com/pulumi/pulumi/pull/20413
- https://github.com/pulumi/pulumi/issues/20450