### PR TITLE
Show a message that the Go program is being compiled

### DIFF
--- a/changelog/pending/20250904--sdk-go--show-a-message-that-the-go-program-is-being-compiled.yaml
+++ b/changelog/pending/20250904--sdk-go--show-a-message-that-the-go-program-is-being-compiled.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Show a message that the Go program is being compiled

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -81,10 +81,8 @@ func compileProgram(
 	withDebugFlags bool,
 	stdout, stderr io.Writer,
 ) (string, error) {
-	streamID := int32(0) // rand.Int31() //nolint:gosec
 	if _, err := engineClient.Log(ctx, &pulumirpc.LogRequest{
 		Severity:  pulumirpc.LogSeverity_INFO,
-		StreamId:  streamID,
 		Urn:       "",
 		Message:   "Compiling the program ...",
 		Ephemeral: true,
@@ -136,7 +134,6 @@ func compileProgram(
 	}
 	if _, err := engineClient.Log(ctx, &pulumirpc.LogRequest{
 		Severity:  pulumirpc.LogSeverity_INFO,
-		StreamId:  streamID,
 		Urn:       "",
 		Message:   "Finished compiling",
 		Ephemeral: true,

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -1252,7 +1252,7 @@ func (host *goLanguageHost) RunPlugin(
 	defer contract.IgnoreClose(closer)
 
 	program, err := compileProgram(
-		context.TODO(), engineClient, req.Info.ProgramDirectory, "", false, os.Stdout, os.Stderr)
+		server.Context(), engineClient, req.Info.ProgramDirectory, "", false, os.Stdout, os.Stderr)
 	if err != nil {
 		return errutil.ErrorWithStderr(err, "error in compiling Go")
 	}

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -73,7 +73,25 @@ const preferredDebugPort = 57134
 // This function takes a file target to specify where to compile to.
 // If `outfile` is "", the binary is compiled to a new temporary file.
 // This function returns the path of the file that was produced.
-func compileProgram(programDirectory string, outfile string, withDebugFlags bool) (string, error) {
+func compileProgram(
+	ctx context.Context,
+	engineClient pulumirpc.EngineClient,
+	programDirectory string,
+	outfile string,
+	withDebugFlags bool,
+	stdout, stderr io.Writer,
+) (string, error) {
+	streamID := int32(0) // rand.Int31() //nolint:gosec
+	if _, err := engineClient.Log(ctx, &pulumirpc.LogRequest{
+		Severity:  pulumirpc.LogSeverity_INFO,
+		StreamId:  streamID,
+		Urn:       "",
+		Message:   "Compiling the program ...",
+		Ephemeral: true,
+	}); err != nil {
+		logging.V(6).Infof("Failed to log message: %v", err)
+	}
+
 	goFileSearchPattern := filepath.Join(programDirectory, "*.go")
 	if matches, err := filepath.Glob(goFileSearchPattern); err != nil || len(matches) == 0 {
 		return "", fmt.Errorf("Failed to find go files for 'go build' matching %s", goFileSearchPattern)
@@ -103,7 +121,7 @@ func compileProgram(programDirectory string, outfile string, withDebugFlags bool
 	}
 	buildCmd := exec.Command(gobin, args...)
 	buildCmd.Dir = programDirectory
-	buildCmd.Stdout, buildCmd.Stderr = os.Stdout, os.Stderr
+	buildCmd.Stdout, buildCmd.Stderr = stdout, stderr
 
 	if err := buildCmd.Run(); err != nil {
 		return "", fmt.Errorf("unable to run `go build`: %w", err)
@@ -115,6 +133,15 @@ func compileProgram(programDirectory string, outfile string, withDebugFlags bool
 	}
 	if !isExecutable {
 		return "", errors.New("go program is not executable, does your program have a 'main' package?")
+	}
+	if _, err := engineClient.Log(ctx, &pulumirpc.LogRequest{
+		Severity:  pulumirpc.LogSeverity_INFO,
+		StreamId:  streamID,
+		Urn:       "",
+		Message:   "Finished compiling",
+		Ephemeral: true,
+	}); err != nil {
+		logging.V(6).Infof("Failed to log message: %v", err)
 	}
 
 	return outfile, nil
@@ -1017,7 +1044,8 @@ func (host *goLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest) 
 	// user did not specify a binary and we will compile and run the binary on-demand
 	logging.V(5).Infof("No prebuilt executable specified, attempting invocation via compilation")
 
-	program, err := compileProgram(req.Info.ProgramDirectory, opts.buildTarget, req.GetAttachDebugger())
+	program, err := compileProgram(
+		ctx, engineClient, req.Info.ProgramDirectory, opts.buildTarget, req.GetAttachDebugger(), os.Stdout, os.Stderr)
 	if err != nil {
 		return nil, errutil.ErrorWithStderr(err, "error in compiling Go")
 	}
@@ -1223,7 +1251,8 @@ func (host *goLanguageHost) RunPlugin(
 	}
 	defer contract.IgnoreClose(closer)
 
-	program, err := compileProgram(req.Info.ProgramDirectory, "", false)
+	program, err := compileProgram(
+		context.TODO(), engineClient, req.Info.ProgramDirectory, "", false, os.Stdout, os.Stderr)
 	if err != nil {
 		return errutil.ErrorWithStderr(err, "error in compiling Go")
 	}

--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"flag"
 	"os"
@@ -29,6 +30,8 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 func TestParseRunParams(t *testing.T) {
@@ -462,5 +465,84 @@ func testPluginsAndDependencies(t *testing.T, progDir string) {
 			"github.com/pulumi/go-dependency-testdata/dep":             "v1.6.0",
 			"github.com/pulumi/go-dependency-testdata/indirect-dep/v2": "v2.1.0",
 		}, gotDeps)
+	})
+}
+
+type mockEngine struct {
+	logs []*pulumirpc.LogRequest
+}
+
+func (m *mockEngine) Log(ctx context.Context, in *pulumirpc.LogRequest,
+	opts ...grpc.CallOption,
+) (*emptypb.Empty, error) {
+	m.logs = append(m.logs, in)
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockEngine) GetRootResource(ctx context.Context, in *pulumirpc.GetRootResourceRequest,
+	opts ...grpc.CallOption,
+) (*pulumirpc.GetRootResourceResponse, error) {
+	return &pulumirpc.GetRootResourceResponse{}, nil
+}
+
+func (m *mockEngine) SetRootResource(ctx context.Context, in *pulumirpc.SetRootResourceRequest,
+	opts ...grpc.CallOption,
+) (*pulumirpc.SetRootResourceResponse, error) {
+	return &pulumirpc.SetRootResourceResponse{}, nil
+}
+
+func (m *mockEngine) StartDebugging(ctx context.Context, in *pulumirpc.StartDebuggingRequest,
+	opts ...grpc.CallOption,
+) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func TestCompileProgram(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no .go files", func(t *testing.T) {
+		t.Parallel()
+		tmp := t.TempDir()
+		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+		_, err := compileProgram(
+			context.Background(), &mockEngine{}, tmp, "", false /* withDebugFlags */, stdout, stderr)
+		require.ErrorContains(t, err, "Failed to find go files")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		tmp := t.TempDir()
+		goMod := `module example`
+		program := `package main
+func main() {}
+`
+		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+		engineClient := &mockEngine{}
+		require.NoError(t, os.WriteFile(filepath.Join(tmp, "go.mod"), []byte(goMod), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(tmp, "main.go"), []byte(program), 0o600))
+		expectedOut := filepath.Join(tmp, "out")
+		out, err := compileProgram(
+			context.Background(), engineClient, tmp, expectedOut, false /* withDebugFlags */, stdout, stderr)
+		require.NoError(t, err)
+		require.Equal(t, expectedOut, out)
+		require.Len(t, engineClient.logs, 2)
+		require.Equal(t, "Compiling the program ...", engineClient.logs[0].Message)
+		require.Equal(t, "Finished compiling", engineClient.logs[1].Message)
+	})
+
+	t.Run("compile error", func(t *testing.T) {
+		t.Parallel()
+		tmp := t.TempDir()
+		goMod := `module example`
+		badProgram := `package main
+func main() {
+`
+		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+		require.NoError(t, os.WriteFile(filepath.Join(tmp, "go.mod"), []byte(goMod), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(tmp, "main.go"), []byte(badProgram), 0o600))
+		_, err := compileProgram(
+			context.Background(), &mockEngine{}, tmp, "", false /* withDebugFlags */, stdout, stderr)
+		require.ErrorContains(t, err, "unable to run `go build`: exit status 1")
+		require.Contains(t, stderr.String(), "main.go:3:1: syntax error")
 	})
 }


### PR DESCRIPTION
It can take a while to compile large Go programs, especially if the go tooling has to download dependencies. Show a message so that the user knows what’s happening and it doesn’t look like a stuck program.

Fixes https://github.com/pulumi/pulumi/issues/19672


https://github.com/user-attachments/assets/52477cb5-f096-489d-8911-7dba0e8fa112

