### PR TITLE
Log diagnostics to stderr instead of stdout

### DIFF
--- a/changelog/pending/20250904--cli--log-diagnostics-to-stderr-instead-of-stdout.yaml
+++ b/changelog/pending/20250904--cli--log-diagnostics-to-stderr-instead-of-stdout.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Log diagnostics to stderr instead of stdout

--- a/sdk/go/common/util/cmdutil/diag.go
+++ b/sdk/go/common/util/cmdutil/diag.go
@@ -87,7 +87,7 @@ func Diag() diag.Sink {
 	snkMutex.Lock()
 	defer snkMutex.Unlock()
 	if snk == nil {
-		snk = diag.DefaultSink(os.Stdout, os.Stderr, diag.FormatOptions{
+		snk = diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{
 			Color: GetGlobalColorization(),
 		})
 	}
@@ -97,5 +97,5 @@ func Diag() diag.Sink {
 // InitDiag forces initialization of the diagnostics sink with the given options.
 func InitDiag(opts diag.FormatOptions) {
 	contract.Assertf(snk == nil, "Cannot initialize diagnostics sink more than once")
-	snk = diag.DefaultSink(os.Stdout, os.Stderr, opts)
+	snk = diag.DefaultSink(os.Stderr, os.Stderr, opts)
 }

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1332,9 +1332,10 @@ func TestAboutPython(t *testing.T) {
 	defer e.DeleteIfNotFailed()
 	e.ImportDirectory(dir)
 
+	e.RunCommand("pulumi", "install")
 	stdout, _ := e.RunCommand("pulumi", "about")
 	// Assert we parsed the dependencies
-	assert.Contains(t, stdout, "pulumi-kubernetes")
+	assert.Contains(t, stdout, "pulumi_kubernetes")
 	// Assert we parsed the language plugin, we don't assert against the minor version number
 	assert.Regexp(t, regexp.MustCompile(`language\W+python\W+3\.`), stdout)
 }


### PR DESCRIPTION
Diagnostics, other than those generated during deployments, should be printed to stderr, not stdout. Stdout is where actual data goes, stderr is where out of band messages should go. Diagnostics during deployments get tied to the stack or a specific resource and rendered by the display code, they don't go the default sink from `cmdutil.Diag`.