### PR TITLE
ignore changes in arrays better

### DIFF
--- a/pkg/resource/deploy/step_generator_test.go
+++ b/pkg/resource/deploy/step_generator_test.go
@@ -167,6 +167,50 @@ func TestIgnoreChanges(t *testing.T) {
 			expected:      map[string]interface{}{},
 			ignoreChanges: []string{"a.b"},
 		},
+		{
+			name: "Arrays with different lengths",
+			oldInputs: map[string]interface{}{
+				"a": []interface{}{
+					map[string]string{"b": "foo", "c": "bar"},
+					map[string]string{"b": "bar", "c": "baz"},
+				},
+			},
+			newInputs: map[string]interface{}{
+				"a": []interface{}{
+					map[string]string{"b": "bar", "c": "bar"},
+					map[string]string{"b": "qux", "c": "baz"},
+					map[string]string{"b": "baz", "c": "qux"},
+				},
+			},
+			expected: map[string]interface{}{
+				"a": []interface{}{
+					map[string]string{"b": "foo", "c": "bar"},
+					map[string]string{"b": "bar", "c": "baz"},
+					map[string]string{"b": "baz", "c": "qux"},
+				},
+			},
+			ignoreChanges: []string{"a[*].b"},
+		},
+		{
+			name: "Shorter new array",
+			oldInputs: map[string]interface{}{
+				"a": []interface{}{
+					map[string]string{"b": "foo", "c": "bar"},
+					map[string]string{"b": "bar", "c": "baz"},
+				},
+			},
+			newInputs: map[string]interface{}{
+				"a": []interface{}{
+					map[string]string{"b": "bar", "c": "bar"},
+				},
+			},
+			expected: map[string]interface{}{
+				"a": []interface{}{
+					map[string]string{"b": "foo", "c": "bar"},
+				},
+			},
+			ignoreChanges: []string{"a[*].b"},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
When we ignore changes, and the arrays don't match in length, we used to just error out.  Since https://github.com/pulumi/pulumi/pull/20278, we no longer error out, but just show a diagnostics message.

However in such cases, we just use the *new* inputs as a result. This can be a bit confusing as it results in spurious diffs. We can do a bit better here, and use the old values for the array, where they are available.  E.g. if we had `[1, 2]` as old inputs, and `[7, 8, 9]` as new inputs, we should still ignore the changes to values we had, and the result should be `[1, 2, 9]`.

Make this so by updating the arrays even if they are different lenghts.  Luckily the `path.Reset` function only seems to be used in the step generator, so the impact of this change seems pretty contained.

Note that we still show a warning here. I could probably be convinced not to show that anymore, but in some ways there's a change to the array we can't really ignore, so I decided to leave the warning for now.

Fixes https://github.com/pulumi/pulumi/issues/20447