### PR TITLE
Change the default for --show-full-output from true to false

### DIFF
--- a/changelog/pending/20250905--cli-display--change-the-default-for-show-full-output-from-true-to-false.yaml
+++ b/changelog/pending/20250905--cli-display--change-the-default-for-show-full-output-from-true-to-false.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/display
+  description: Change the default for --show-full-output from true to false

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -429,7 +429,7 @@ func NewDestroyCmd() *cobra.Command {
 		&suppressOutputs, "suppress-outputs", false,
 		"Suppress display of stack outputs (in case they contain sensitive values)")
 	cmd.PersistentFlags().BoolVar(
-		&showFullOutput, "show-full-output", true,
+		&showFullOutput, "show-full-output", false,
 		"Display full length of inputs & outputs")
 	cmd.PersistentFlags().BoolVar(
 		&suppressProgress, "suppress-progress", false,

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -670,7 +670,7 @@ func NewPreviewCmd() *cobra.Command {
 		&suppressOutputs, "suppress-outputs", false,
 		"Suppress display of stack outputs (in case they contain sensitive values)")
 	cmd.PersistentFlags().BoolVar(
-		&showFullOutput, "show-full-output", true,
+		&showFullOutput, "show-full-output", false,
 		"Display full length of inputs & outputs")
 	cmd.PersistentFlags().BoolVar(
 		&suppressProgress, "suppress-progress", false,

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -749,7 +749,7 @@ func NewUpCmd() *cobra.Command {
 		&suppressProgress, "suppress-progress", false,
 		"Suppress display of periodic progress dots")
 	cmd.PersistentFlags().BoolVar(
-		&showFullOutput, "show-full-output", true,
+		&showFullOutput, "show-full-output", false,
 		"Display full length of inputs & outputs")
 	cmd.PersistentFlags().StringVar(
 		&suppressPermalink, "suppress-permalink", "",


### PR DESCRIPTION
The flag was fixed in https://github.com/pulumi/pulumi/pull/20464 to apply to resource & stack outputs, and to work for `preview` and `destroy`.

Flip the default to false. Long text lines will now be truncated to 150 characters or 3 lines. Use `--show-full-output=true` to get back the old behaviour.
