### PR TITLE
Add a public export map accessor for unit testing

### DIFF
--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -2703,6 +2703,11 @@ func (ctx *Context) Export(name string, value Input) {
 	ctx.state.exports[name] = value
 }
 
+// Get a copy of the current export map. Primarily useful for testing.
+func (ctx *Context) GetCurrentExportMap() map[string]Input {
+	return maps.Clone(ctx.state.exports)
+}
+
 // RegisterStackTransformation adds a transformation to all future resources constructed in this Pulumi stack.
 func (ctx *Context) RegisterStackTransformation(t ResourceTransformation) error {
 	ctx.state.stack.addTransformation(t)

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -631,6 +631,26 @@ func TestWithValue(t *testing.T) {
 	assert.Equal(t, newCtx.state, testCtx.state)
 }
 
+func TestExportMap(t *testing.T) {
+	t.Parallel()
+
+	var output map[string]Input
+	err := RunErr(func(ctx *Context) error {
+		ctx.Export("first", String("hello"))
+		ctx.Export("second", String("world"))
+
+		output = ctx.GetCurrentExportMap()
+		return nil
+	}, WithMocks("project", "stack", &testMonitor{}))
+	require.NoError(t, err)
+
+	expected := map[string]Input{
+		"first":  String("hello"),
+		"second": String("world"),
+	}
+	assert.Equal(t, expected, output)
+}
+
 func TestInvokeOutput(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Part of #6113.

It's nice to be able to write a unit test that runs your program to produce some exports, and then verify the contents of those exports. Currently, there's no way to see the created exports after the fact as the export map is private. This PR creates a public accessor for this map for the purposes of unit testing.