### PR TITLE
Allow for local component resource registration with props in the Go SDK

### DIFF
--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1833,6 +1833,12 @@ func (ctx *Context) RegisterComponentResource(
 	return ctx.registerResource(t, name, nil /*props*/, resource, false /*remote*/, "" /* packageRef */, opts...)
 }
 
+func (ctx *Context) RegisterComponentResourceWithProps(
+	t, name string, props Input, resource ComponentResource, opts ...ResourceOption,
+) error {
+	return ctx.registerResource(t, name, props, resource, false /*remote*/, "" /* packageRef */, opts...)
+}
+
 func (ctx *Context) RegisterRemoteComponentResource(
 	t, name string, props Input, resource ComponentResource, opts ...ResourceOption,
 ) error {


### PR DESCRIPTION
Part of https://github.com/pulumi/pulumi/issues/10533