### PR TITLE
Move GenSDK & related functions to `packages`

### DIFF
--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2024, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,9 +32,9 @@ import (
 
 	cmdDiag "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/diag"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/newcmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packages"
 
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
-	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packagecmd"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -201,7 +201,7 @@ func runConvert(
 	// the plugin context uses the output directory as the working directory
 	// of the generated program because in general, where Pulumi.yaml lives is
 	// the root of the project.
-	pCtx, err := packagecmd.NewPluginContext(outDir)
+	pCtx, err := packages.NewPluginContext(outDir)
 	if err != nil {
 		return fmt.Errorf("create plugin host: %w", err)
 	}
@@ -549,7 +549,7 @@ func generateAndLinkSdksForPackages(
 			continue
 		}
 
-		pkgSchema, _, err := packagecmd.SchemaFromSchemaSource(
+		pkgSchema, _, err := packages.SchemaFromSchemaSource(
 			pctx,
 			pkg.Name,
 			&plugin.ParameterizeValue{Value: pkg.Parameterization.Value},
@@ -559,7 +559,7 @@ func generateAndLinkSdksForPackages(
 			return fmt.Errorf("creating package schema: %w", err)
 		}
 
-		err = packagecmd.GenSDK(
+		err = packages.GenSDK(
 			language,
 			tempOut,
 			pkgSchema,
@@ -571,7 +571,7 @@ func generateAndLinkSdksForPackages(
 		}
 
 		sdkOut := filepath.Join(sdkTargetDirectory, pkg.Parameterization.Name)
-		err = packagecmd.CopyAll(sdkOut, filepath.Join(tempOut, language))
+		err = packages.CopyAll(sdkOut, filepath.Join(tempOut, language))
 		if err != nil {
 			return fmt.Errorf("failed to move SDK to project: %w", err)
 		}
@@ -597,7 +597,7 @@ func generateAndLinkSdksForPackages(
 		}
 
 		sdkRelPath := filepath.Join("sdks", pkg.Parameterization.Name)
-		err = packagecmd.LinkPackage(&packagecmd.LinkPackageContext{
+		err = packages.LinkPackage(&packages.LinkPackageContext{
 			Workspace: ws,
 			Language:  language,
 			Root:      "./",

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -1,4 +1,4 @@
-// Copyright 2024, Pulumi Corporation.
+// Copyright 2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packages"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -40,7 +41,7 @@ func InstallPackage(ws pkgWorkspace.Context, pctx *plugin.Context, language, roo
 	schemaSource string, parameters plugin.ParameterizeParameters,
 	registry registry.Registry,
 ) (*schema.Package, *workspace.PackageSpec, error) {
-	pkg, specOverride, err := SchemaFromSchemaSource(pctx, schemaSource, parameters, registry)
+	pkg, specOverride, err := packages.SchemaFromSchemaSource(pctx, schemaSource, parameters, registry)
 	if err != nil {
 		var diagErr hcl.Diagnostics
 		if errors.As(err, &diagErr) {
@@ -62,7 +63,7 @@ func InstallPackage(ws pkgWorkspace.Context, pctx *plugin.Context, language, roo
 	// `package add` we know that this is just a local package and it's ok for module paths and similar to be different.
 	pkg.SupportPack = true
 
-	err = GenSDK(
+	err = packages.GenSDK(
 		language,
 		tempOut,
 		pkg,
@@ -92,13 +93,13 @@ func InstallPackage(ws pkgWorkspace.Context, pctx *plugin.Context, language, roo
 		}
 	}
 
-	err = CopyAll(out, filepath.Join(tempOut, language))
+	err = packages.CopyAll(out, filepath.Join(tempOut, language))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to move SDK to project: %w", err)
 	}
 
 	// Link the package to the project
-	if err := LinkPackage(&LinkPackageContext{
+	if err := packages.LinkPackage(&packages.LinkPackageContext{
 		Workspace: ws,
 		Language:  language,
 		Root:      root,

--- a/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packages"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -63,7 +64,7 @@ empty string.`,
 			}()
 
 			registry := cmdCmd.NewDefaultRegistry(cmd.Context(), pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global())
-			p, _, err := ProviderFromSource(pctx, source, registry)
+			p, _, err := packages.ProviderFromSource(pctx, source, registry)
 			if err != nil {
 				return fmt.Errorf("load provider: %w", err)
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2024, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packages"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -55,7 +56,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 			}()
 
 			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
-			pkg, _, err := SchemaFromSchemaSource(pctx, source, parameters,
+			pkg, _, err := packages.SchemaFromSchemaSource(pctx, source, parameters,
 				cmdCmd.NewDefaultRegistry(cmd.Context(), pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global()))
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2024, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packages"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -63,7 +64,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 			}()
 
 			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
-			pkg, _, err := SchemaFromSchemaSource(pctx, source, parameters,
+			pkg, _, err := packages.SchemaFromSchemaSource(pctx, source, parameters,
 				cmdCmd.NewDefaultRegistry(cmd.Context(), pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global()))
 			if err != nil {
 				return err
@@ -88,7 +89,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 
 			if language == "all" {
 				for _, lang := range []string{"dotnet", "go", "java", "nodejs", "python"} {
-					err := GenSDK(lang, out, pkg, overlays, local)
+					err := packages.GenSDK(lang, out, pkg, overlays, local)
 					if err != nil {
 						return err
 					}
@@ -96,7 +97,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 				fmt.Fprintf(os.Stderr, "SDKs have been written to %s\n", out)
 				return nil
 			}
-			err = GenSDK(language, out, pkg, overlays, local)
+			err = packages.GenSDK(language, out, pkg, overlays, local)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packages"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -61,7 +62,7 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 			}()
 
 			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
-			pkg, _, err := SchemaFromSchemaSource(pctx, args[0], parameters,
+			pkg, _, err := packages.SchemaFromSchemaSource(pctx, args[0], parameters,
 				cmdCmd.NewDefaultRegistry(cmd.Context(), pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global()))
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/packagecmd/package_pack_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_pack_sdk.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2024, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packages"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -38,7 +39,7 @@ func newPackagePackSdkCmd() *cobra.Command {
 				return fmt.Errorf("get current working directory: %w", err)
 			}
 
-			pCtx, err := NewPluginContext(cwd)
+			pCtx, err := packages.NewPluginContext(cwd)
 			if err != nil {
 				return fmt.Errorf("create plugin context: %w", err)
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packages"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -92,7 +93,7 @@ func newPackagePublishCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := cmd.Context()
 			pkgPublishCmd.defaultOrg = backend.GetDefaultOrg
-			pkgPublishCmd.extractSchema = SchemaFromSchemaSource
+			pkgPublishCmd.extractSchema = packages.SchemaFromSchemaSource
 			parameters := &plugin.ParameterizeArgs{Args: cliArgs[1:]}
 			return pkgPublishCmd.Run(ctx, args, cliArgs[0], parameters)
 		},

--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -1,4 +1,4 @@
-// Copyright 2024, Pulumi Corporation.
+// Copyright 2024-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package packagecmd
+package packages
 
 import (
 	"context"

--- a/pkg/cmd/pulumi/packages/packages_test.go
+++ b/pkg/cmd/pulumi/packages/packages_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024, Pulumi Corporation.
+// Copyright 2024-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package packagecmd
+package packages
 
 import (
 	"bytes"


### PR DESCRIPTION
These functions are used in multiple commands (install, package ..., convert). Move them to their own package so `...cmd` packages don’t depend on each other.

There’s some more tidying and refactoring to do here, but this first PR only moves `project_sdk_link{,_test}.go` to keep the diff readable.
