### PR TITLE
Skip update check on command init

### DIFF
--- a/sdk/go/auto/cmd.go
+++ b/sdk/go/auto/cmd.go
@@ -112,6 +112,7 @@ func NewPulumiCommand(opts *PulumiCommandOptions) (PulumiCommand, error) {
 	}
 
 	cmd := exec.Command(command, "version")
+	cmd.Env = append(os.Environ(), "PULUMI_SKIP_UPDATE_CHECK=true")
 	out, err := cmd.Output()
 	if err != nil {
 		return pulumiCommand{}, fmt.Errorf("failed to run `pulumi version`: %w", err)

--- a/sdk/nodejs/automation/cmd.ts
+++ b/sdk/nodejs/automation/cmd.ts
@@ -83,7 +83,7 @@ export class PulumiCommand {
      */
     static async get(opts?: PulumiCommandOptions): Promise<PulumiCommand> {
         const command = opts?.root ? path.resolve(path.join(opts.root, "bin/pulumi")) : "pulumi";
-        const { stdout } = await exec(command, ["version"]);
+        const { stdout } = await exec(command, ["version"], undefined, { PULUMI_SKIP_UPDATE_CHECK: "true" });
         const skipVersionCheck = !!opts?.skipVersionCheck || !!process.env[SKIP_VERSION_CHECK_VAR];
         let min = minimumVersion;
         if (opts?.version && semver.gt(opts.version, minimumVersion)) {

--- a/sdk/python/lib/pulumi/automation/_cmd.py
+++ b/sdk/python/lib/pulumi/automation/_cmd.py
@@ -71,8 +71,12 @@ class PulumiCommand:
         min_version = _MINIMUM_VERSION
         if version and version.compare(min_version) > 0:
             min_version = version
+        env = os.environ.copy()
+        env["PULUMI_SKIP_UPDATE_CHECK"] = "true"
         current_version = (
-            subprocess.check_output([self.command, "version"]).decode("utf-8").strip()
+            subprocess.check_output([self.command, "version"], env=env)
+            .decode("utf-8")
+            .strip()
         )
         if current_version.startswith("v"):
             current_version = current_version[1:]


### PR DESCRIPTION
When initializing the PulumiCommand object, we need to load the CLI version.

By default, this will also perform an update check and print a warning if out of date. In this context, the warning will not be displayed, but the addional network call will slow down construction of workspaces etc.

Therefore, this is a small optimization to disable the update check for this command.