### PR TITLE
Fix parents in python components

### DIFF
--- a/changelog/pending/20250917--components-python--fix-parenting-of-python-components.yaml
+++ b/changelog/pending/20250917--components-python--fix-parenting-of-python-components.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: components/python
+  description: Fix parenting of python components

--- a/sdk/python/lib/pulumi/provider/experimental/server.py
+++ b/sdk/python/lib/pulumi/provider/experimental/server.py
@@ -248,7 +248,7 @@ class ProviderServicer(ResourceProviderServicer):
     @staticmethod
     def _construct_options(request: proto.ConstructRequest) -> pulumi.ResourceOptions:
         parent = None
-        if not _empty_as_none(request.parent):
+        if request.parent:
             parent = DependencyResource(request.parent)
         return pulumi.ResourceOptions(
             aliases=list(request.aliases),

--- a/sdk/python/lib/pulumi/provider/server.py
+++ b/sdk/python/lib/pulumi/provider/server.py
@@ -243,7 +243,7 @@ class ProviderServicer(ResourceProviderServicer):
     @staticmethod
     def _construct_options(request: proto.ConstructRequest) -> pulumi.ResourceOptions:
         parent = None
-        if not _empty_as_none(request.parent):
+        if request.parent:
             parent = DependencyResource(request.parent)
 
         deleted_with = None

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -848,6 +848,8 @@ class Resource:
 
         if dependency:
             self._providers = {}
+            self._transformations = []
+            self._childResources = set()
             return
 
         if props is None:

--- a/tests/integration/component_provider/nodejs/component-provider-host/nodejs-npm/index.ts
+++ b/tests/integration/component_provider/nodejs/component-provider-host/nodejs-npm/index.ts
@@ -11,6 +11,8 @@ import * as random from "@pulumi/random"
 import * as assert from "node:assert";
 assert(random);
 
+let parent = new pulumi.ComponentResource("ParentComponent", "parent");
+
 let comp = new provider.MyComponent("comp", {
     aNumber: 123,
     anOptionalString: "Bonnie",
@@ -21,7 +23,7 @@ let comp = new provider.MyComponent("comp", {
             aNumber: 9,
         }
     }
-})
+}, { parent: parent })
 
 export const urn = comp.urn;
 export const aNumberOutput = comp.aNumberOutput;

--- a/tests/integration/component_provider/nodejs/component-provider-host/nodejs-pnpm/index.ts
+++ b/tests/integration/component_provider/nodejs/component-provider-host/nodejs-pnpm/index.ts
@@ -11,6 +11,8 @@ import * as random from "@pulumi/random"
 import * as assert from "node:assert";
 assert(random);
 
+let parent = new pulumi.ComponentResource("ParentComponent", "parent");
+
 let comp = new provider.MyComponent("comp", {
     aNumber: 123,
     anOptionalString: "Bonnie",
@@ -21,7 +23,7 @@ let comp = new provider.MyComponent("comp", {
             aNumber: 9,
         }
     }
-})
+}, { parent: parent })
 
 export const urn = comp.urn;
 export const aNumberOutput = comp.aNumberOutput;

--- a/tests/integration/component_provider/nodejs/component-provider-host/python/__main__.py
+++ b/tests/integration/component_provider/nodejs/component-provider-host/python/__main__.py
@@ -1,12 +1,19 @@
 import pulumi
 import pulumi_nodejs_component_provider as provider
 
+class ParentComponent(pulumi.ComponentResource):
+    def __init__(self, name, opts=None):
+        super().__init__('ParentComponent', name, {}, opts)
+
+parent = ParentComponent("parent")
+
 comp = provider.MyComponent(
     "comp",
     a_number=123,
     an_optional_string="Bonnie",
     a_boolean_input=pulumi.Output.from_input(True),
     a_complex_type_input={"aNumber": 7, "nestedComplexType": {"aNumber": 9}},
+    opts=pulumi.ResourceOptions(parent=parent),
 )
 
 pulumi.export("urn", comp.urn)

--- a/tests/integration/component_provider/python/component-provider-host/nodejs/index.ts
+++ b/tests/integration/component_provider/python/component-provider-host/nodejs/index.ts
@@ -16,6 +16,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as provider from "@pulumi/provider";
 
+let parent = new pulumi.ComponentResource("ParentComponent", "parent");
+
 let comp = new provider.MyComponent("comp", {
     strInput: "hello",
     optionalIntInput: 42,
@@ -32,7 +34,7 @@ let comp = new provider.MyComponent("comp", {
         asset1: new pulumi.asset.StringAsset("im inside an archive"),
     }),
     enumInput: provider.Emu.A,
-})
+}, { parent: parent })
 
 export const urn = comp.urn;
 export const strOutput = comp.strOutput;

--- a/tests/integration/component_provider/python/component-provider-host/python/__main__.py
+++ b/tests/integration/component_provider/python/component-provider-host/python/__main__.py
@@ -1,6 +1,12 @@
 import pulumi
 import pulumi_provider as provider
 
+class ParentComponent(pulumi.ComponentResource):
+    def __init__(self, name, opts=None):
+        super().__init__('ParentComponent', name, {}, opts)
+
+parent = ParentComponent("parent")
+
 comp = provider.MyComponent(
     "comp",
     str_input="hello",
@@ -18,6 +24,7 @@ comp = provider.MyComponent(
         {"asset1": pulumi.StringAsset("im inside an archive")}
     ),
     enum_input=provider.Emu.A,
+    opts=pulumi.ResourceOptions(parent=parent)
 )
 
 pulumi.export("urn", comp.urn)

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2972,7 +2972,14 @@ func TestNodejsComponentProviderRun(t *testing.T) {
 					t.Logf("Outputs: %v", stack.Outputs)
 					urn, err := resource.ParseURN(stack.Outputs["urn"].(string))
 					require.NoError(t, err)
-					require.Equal(t, tokens.Type("nodejs-component-provider:index:MyComponent"), urn.Type())
+					expectedType := tokens.Type("nodejs-component-provider:index:MyComponent")
+					expectedQualifiedType := "ParentComponent$" + expectedType
+					if runtime == "yaml" {
+						// yaml doesn't have components
+						expectedQualifiedType = expectedType
+					}
+					require.Equal(t, expectedQualifiedType, urn.QualifiedType())
+					require.Equal(t, expectedType, urn.Type())
 					require.Equal(t, "comp", urn.Name())
 					t.Logf("stack.Outputs = %+v", stack.Outputs)
 					require.Equal(t, float64(246), stack.Outputs["aNumberOutput"].(float64))

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -2054,7 +2054,14 @@ func TestPythonComponentProviderRun(t *testing.T) {
 				ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 					urn, err := resource.ParseURN(stack.Outputs["urn"].(string))
 					require.NoError(t, err)
-					require.Equal(t, tokens.Type("component:index:MyComponent"), urn.Type())
+					expectedType := tokens.Type("component:index:MyComponent")
+					expectedQualifiedType := "ParentComponent$" + expectedType
+					if runtime == "yaml" {
+						// yaml doesn't have components
+						expectedQualifiedType = expectedType
+					}
+					require.Equal(t, expectedQualifiedType, urn.QualifiedType())
+					require.Equal(t, expectedType, urn.Type())
 					require.Equal(t, "comp", urn.Name())
 					t.Logf("Outputs: %v", stack.Outputs)
 					require.Equal(t, "HELLO", stack.Outputs["strOutput"].(string))


### PR DESCRIPTION
The server code for python components had it's if condition flipped for applying parents. That is if the URN was non-empty it ignored it, and if it was empty it tired to construct a dependency resource with an empty URN.

This fixes the condition and changed the component tests to show parenting works.

Fixes https://github.com/pulumi/pulumi/issues/20507