### PR TITLE
fix panic in `pulumi preview` when default providers are updated

### DIFF
--- a/changelog/pending/20250917--engine--fix-a-panic-in-preview-that-could-happen-in-some-cases-when-default-providers-get-updated.yaml
+++ b/changelog/pending/20250917--engine--fix-a-panic-in-preview-that-could-happen-in-some-cases-when-default-providers-get-updated.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix a panic in preview, that could happen in some cases when default providers get updated

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -822,7 +822,7 @@ func newPreviewActions(ctx *Context, opts *deploymentOptions) *previewActions {
 }
 
 func (acts *previewActions) OnSnapshotWrite(base *deploy.Snapshot) error {
-	return acts.Context.SnapshotManager.Write(base)
+	return nil
 }
 
 func (acts *previewActions) OnResourceStepPre(step deploy.Step) (interface{}, error) {


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/19862, we introduced a new `OnSnapshotWrite` function, which is called whenever default providers are migrated for any reason.  This can happen, e.g. when a provider has `Input`s, but has no `Output`s.

During `preview`, we don't have a `SnapshotManager` set, as we don't update any snapshots.  We however still try to call `SnapshotManager.Write` in that function in `previewActions`, while we should simply be returning `nil`.  Because we try to call that, but `SnapshotManager` is not set, this results in a `panic`.  Fix this by simply returning `nil`, and not using the `SnapshotManager` at all, similar how the `OnResourceStep{Pre,Post}` functions handle this.

We didn't notice this issue in testing, because the lifecycletests *always* set a `SnapshotManager`, no matter if we run a `preview` or `update`.  Also make sure we only set a `SnapshotManager` when we actually run an update, so we increase test coverage here.

Fixes https://github.com/pulumi/pulumi/issues/20496