### PR TITLE
make roundtripping serialized resources with secrets work

### DIFF
--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -724,8 +724,10 @@ func DeserializeProperties(props map[string]interface{}, dec config.Decrypter,
 	return result, nil
 }
 
-// DeserializeSecret deserializes a secret value from its SecretV1 representation.
-func DeserializeSecret(ctx context.Context, secret *apitype.SecretV1, dec config.Decrypter) (resource.PropertyValue, error) {
+// deserializeSecret deserializes a secret value from its SecretV1 representation.
+func deserializeSecret(
+	ctx context.Context, secret *apitype.SecretV1, dec config.Decrypter,
+) (resource.PropertyValue, error) {
 	prop := resource.MakeSecret(resource.NewNullProperty())
 	propSecret := prop.SecretValue()
 
@@ -825,7 +827,7 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter,
 						Plaintext:  plaintext,
 						Ciphertext: ciphertext,
 					}
-					return DeserializeSecret(ctx, secret, dec)
+					return deserializeSecret(ctx, secret, dec)
 				case resource.ResourceReferenceSig:
 					var packageVersion string
 					if packageVersionV, ok := objmap["packageVersion"]; ok {
@@ -887,7 +889,7 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter,
 			// Otherwise, it's just a weakly typed object map.
 			return resource.NewProperty(obj), nil
 		case *apitype.SecretV1:
-			return DeserializeSecret(ctx, w, dec)
+			return deserializeSecret(ctx, w, dec)
 		default:
 			contract.Failf("Unrecognized property type %T: %v", v, reflect.ValueOf(v))
 		}


### PR DESCRIPTION
When serializing resources with secrets, we use the `SerializePropertyValue` function, which internally uses `apitype.SecretV1` to represent secrets.  However the corresponding `DeserializePropertyValue` function only supports
`map[string]any`. This works currently because we usually roundtrip these property values through the backend, and deserializing from JSON we get the `map` value back, even when we originally serialized a `SecretV1`.

In subsequent PRs we want to introduce serializing and deserializing of resources within the CLI, so deserializing a `SecretV1` needs to work. Make that so. The alternative would be to just return a map from `SerializePropertyValue`, but that seems worse than using the proper types where we can.

The serializing and deserializing within the CLI comes from the desire to share the journal replay logic with the service. For this it needs to work with serialized journal entries, but then to do comparisons on the deployment we need to deserialize it.