### PR TITLE
expand snapshot integrity check to check that resources are well formed

### DIFF
--- a/changelog/pending/20250918--engine--expand-snapshot-integrity-check-for-resources.yaml
+++ b/changelog/pending/20250918--engine--expand-snapshot-integrity-check-for-resources.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Expand snapshot integrity check for resources

--- a/pkg/cmd/pulumi/state/state_rename_test.go
+++ b/pkg/cmd/pulumi/state/state_rename_test.go
@@ -31,15 +31,17 @@ func TestRenameProvider(t *testing.T) {
 	// Define a state with a single provider and a single resource dependent on that provider.
 	provURN := resource.URN("urn:pulumi:dev::prog-aws-typescript::pulumi:providers:random::my-provider")
 	prov := resource.State{
-		URN:  provURN,
-		ID:   "81cd12dd-2a90-4f21-a521-f4c71c1f11eb",
-		Type: "pulumi:providers:random",
+		URN:    provURN,
+		ID:     "81cd12dd-2a90-4f21-a521-f4c71c1f11eb",
+		Type:   "pulumi:providers:random",
+		Custom: true,
 	}
 
 	providerRefString := string(prov.URN) + "::" + string(prov.ID)
 
 	res1 := resource.State{
 		URN:      resource.URN("urn:pulumi:dev::prog-aws-typescript::random:index/randomPet:RandomPet::pet-0"),
+		Type:     "random:index/randomPet:RandomPet",
 		Provider: providerRefString,
 	}
 	snap := &deploy.Snapshot{
@@ -82,20 +84,23 @@ func TestStateRename_updatesChildren(t *testing.T) {
 	snap := deploy.Snapshot{
 		Resources: []*resource.State{
 			{
-				URN:  provider,
-				ID:   "provider-id",
-				Type: "pulumi:provider:random",
+				URN:    provider,
+				ID:     "provider-id",
+				Type:   "pulumi:provider:random",
+				Custom: true,
 			},
 			{
-				URN:  parent,
-				ID:   "parent-id",
-				Type: "random:index/randomPet:RandomPet",
+				URN:    parent,
+				ID:     "parent-id",
+				Type:   "random:index/randomPet:RandomPet",
+				Custom: true,
 			},
 			{
 				URN:    child,
 				ID:     "child-id",
 				Type:   "random:index/randomPet:RandomPet",
 				Parent: parent,
+				Custom: true,
 			},
 		},
 	}

--- a/pkg/cmd/pulumi/state/state_repair_test.go
+++ b/pkg/cmd/pulumi/state/state_repair_test.go
@@ -92,8 +92,8 @@ func TestStateRepair_ConfirmationIncludesReorderSummary(t *testing.T) {
 
 	// Arrange.
 	fx := newStateRepairCmdFixture(t, []*resource.State{
-		{URN: "b", Dependencies: []resource.URN{"a"}},
-		{URN: "a"},
+		{URN: "b", Type: "simple:index:Resource", Dependencies: []resource.URN{"a"}},
+		{URN: "a", Type: "simple:index:Resource"},
 	})
 
 	fx.stdin.buf.WriteString("no\r\n")
@@ -117,7 +117,7 @@ func TestStateRepair_ConfirmationIncludesModificationSummary(t *testing.T) {
 
 	// Arrange.
 	fx := newStateRepairCmdFixture(t, []*resource.State{
-		{URN: "c", Dependencies: []resource.URN{"d"}},
+		{URN: "c", Type: "simple:index:Resource", Dependencies: []resource.URN{"d"}},
 	})
 
 	fx.stdin.buf.WriteString("no\r\n")
@@ -141,9 +141,9 @@ func TestStateRepair_ConfirmationIncludesCombinedSummaries(t *testing.T) {
 
 	// Arrange.
 	fx := newStateRepairCmdFixture(t, []*resource.State{
-		{URN: "b", Dependencies: []resource.URN{"a"}},
-		{URN: "a"},
-		{URN: "c", Dependencies: []resource.URN{"d"}},
+		{URN: "b", Type: "simple:index:Resource", Dependencies: []resource.URN{"a"}},
+		{URN: "a", Type: "simple:index:Resource"},
+		{URN: "c", Type: "simple:index:Resource", Dependencies: []resource.URN{"d"}},
 	})
 
 	fx.stdin.buf.WriteString("no\r\n")
@@ -167,8 +167,8 @@ func TestStateRepair_PromptsForConfirmationAndCancels(t *testing.T) {
 
 	// Arrange.
 	fx := newStateRepairCmdFixture(t, []*resource.State{
-		{URN: "b", Dependencies: []resource.URN{"a"}},
-		{URN: "a"},
+		{URN: "b", Type: "simple:index:Resource", Dependencies: []resource.URN{"a"}},
+		{URN: "a", Type: "simple:index:Resource"},
 	})
 
 	fx.stdin.buf.WriteString("no\r\n")
@@ -192,8 +192,8 @@ func TestStateRepair_PromptsForConfirmationAndProceeds(t *testing.T) {
 
 	// Arrange.
 	fx := newStateRepairCmdFixture(t, []*resource.State{
-		{URN: "b", Dependencies: []resource.URN{"a"}},
-		{URN: "a"},
+		{URN: "b", Type: "simple:index:Resource", Dependencies: []resource.URN{"a"}},
+		{URN: "a", Type: "simple:index:Resource"},
 	})
 
 	fx.stdin.buf.WriteString("yes\r\n")
@@ -211,8 +211,8 @@ func TestStateRepair_PromptsForConfirmationAndProceeds(t *testing.T) {
 func TestStateRepair_SkipsConfirmationIfYesFlagIsSet(t *testing.T) {
 	// Arrange.
 	fx := newStateRepairCmdFixture(t, []*resource.State{
-		{URN: "b", Dependencies: []resource.URN{"a"}},
-		{URN: "a"},
+		{URN: "b", Type: "simple:index:Resource", Dependencies: []resource.URN{"a"}},
+		{URN: "a", Type: "simple:index:Resource"},
 	})
 	fx.cmd.Args.Yes = true
 
@@ -231,7 +231,11 @@ func TestStateRepair_DoesNotWriteIfRepairFails(t *testing.T) {
 	//
 	// Dangling provider references can't be fixed, so this snapshot should fail to repair.
 	fx := newStateRepairCmdFixture(t, []*resource.State{
-		{URN: "a", Provider: "urn:pulumi:stack::project::pulumi:providers:p::x::id"},
+		{
+			URN:      "a",
+			Type:     "simple:index:Resource",
+			Provider: "urn:pulumi:stack::project::pulumi:providers:p::x::id",
+		},
 	})
 	fx.cmd.Args.Yes = true
 
@@ -248,8 +252,8 @@ func TestStateRepair_DoesNotWriteIfRepairFails(t *testing.T) {
 func TestStateRepair_RepairsSnapshots(t *testing.T) {
 	// Arrange.
 	fx := newStateRepairCmdFixture(t, []*resource.State{
-		{URN: "b", Dependencies: []resource.URN{"a"}},
-		{URN: "a"},
+		{URN: "b", Type: "simple:index:Resource", Dependencies: []resource.URN{"a"}},
+		{URN: "a", Type: "simple:index:Resource"},
 	})
 	fx.cmd.Args.Yes = true
 

--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -515,7 +515,7 @@ func TestImportUpdatedID(t *testing.T) {
 	stackResource := newResource(
 		stackURN,
 		"",
-		"foo",
+		"",
 		"",
 		nil,
 		nil,

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -1694,12 +1694,12 @@ func generateParentedTestDependencyGraph(t *testing.T, p *lt.TestPlan) (
 
 	old := &deploy.Snapshot{
 		Resources: []*resource.State{
-			newResource(urnA, "", "0", nil, nil),
-			newResource(urnB, "", "1", nil, nil),
+			newResource(urnA, "", "", nil, nil),
+			newResource(urnB, "", "", nil, nil),
 			newResource(urnC, "", "2", nil, nil),
-			newResource(urnD, urnA, "3", nil, nil),
-			newResource(urnE, urnB, "4", nil, nil),
-			newResource(urnF, urnB, "5", nil, nil),
+			newResource(urnD, urnA, "", nil, nil),
+			newResource(urnE, urnB, "", nil, nil),
+			newResource(urnF, urnB, "", nil, nil),
 			newResource(urnG, urnD, "6", nil, nil),
 			newResource(urnH, urnD, "7", nil, nil),
 			newResource(urnI, urnA, "8", []resource.URN{urnG},

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -520,12 +520,21 @@ func (snap *Snapshot) VerifyIntegrity() error {
 			return SnapshotIntegrityErrorf("magic cookie mismatch; possible tampering/corruption detected")
 		}
 
-		// Now check the resources.  For now, we just verify that parents come before children, and that there aren't
-		// any duplicate URNs.
+		// Now check the resources.  Check that the resources are well formed, that there
+		// are no duplicate URNs and that all dependencies exist in the snapshot.
 		urns := make(map[resource.URN][]*resource.State)
 		provs := make(map[providers.Reference]struct{})
 		for i, state := range snap.Resources {
 			urn := state.URN
+			if urn == "" {
+				return SnapshotIntegrityErrorf("resource at index %d missing required 'urn' field", i)
+			}
+			if state.Type == "" {
+				return SnapshotIntegrityErrorf("resource '%s' missing required 'type' field", urn)
+			}
+			if !state.Custom && state.ID != "" {
+				return SnapshotIntegrityErrorf("resource '%s' has 'custom false but non-empty ID", urn)
+			}
 
 			if providers.IsProviderType(state.Type) {
 				ref, err := providers.NewReference(urn, state.ID)

--- a/pkg/resource/deploy/snapshot_test.go
+++ b/pkg/resource/deploy/snapshot_test.go
@@ -31,7 +31,7 @@ func createSnapshot() Snapshot {
 	}
 	resources := []*resource.State{}
 	for _, u := range resourceUrns {
-		resources = append(resources, &resource.State{URN: u})
+		resources = append(resources, &resource.State{URN: u, Type: "pulumi:pulumi:Stack"})
 	}
 	return Snapshot{Resources: resources}
 }
@@ -90,6 +90,7 @@ func TestSnapshotPrune_IgnoresDanglingProviderReferences(t *testing.T) {
 			{
 				URN:      "urn:pulumi:stack::project::t::b",
 				Provider: danglingProviderRef,
+				Type:     "pulumi:pulumi:Stack",
 			},
 		},
 	}
@@ -116,50 +117,61 @@ func TestSnapshotPrune_PreservesValidSnapshots(t *testing.T) {
 		{
 			name: "a single resource",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 			},
 		},
 		{
 			name: "two unrelated resources",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
-				{URN: "urn:pulumi:stack::project::t::b"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
+				{URN: "urn:pulumi:stack::project::t::b", Type: "pulumi:pulumi:Stack"},
 			},
 		},
 		{
 			name: "two resources with a valid provider dependency",
 			given: []*resource.State{
 				{
-					Type: "pulumi:providers:p",
-					URN:  "urn:pulumi:stack::project::pulumi:providers:p::a",
-					ID:   "id",
+					Type:   "pulumi:providers:p",
+					URN:    "urn:pulumi:stack::project::pulumi:providers:p::a",
+					ID:     "id",
+					Custom: true,
 				},
 				{
-					URN:      "urn:pulumi:stack::project::t::b",
+					URN:      "urn:pulumi:stack::project::pulumi:providers:t::b",
 					Provider: "urn:pulumi:stack::project::pulumi:providers:p::a::id",
+					Type:     "pulumi:providers:p",
 				},
 			},
 		},
 		{
 			name: "two resources with a valid parent-child relationship",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
-				{URN: "urn:pulumi:stack::project::t$t::b", Parent: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::pulumi:providers:t::a", Type: "pulumi:pulumi:Stack"},
+				{
+					URN:    "urn:pulumi:stack::project::pulumi:providers:t$pulumi:providers:t::b",
+					Parent: "urn:pulumi:stack::project::pulumi:providers:t::a",
+					Type:   "pulumi:providers:p",
+				},
 			},
 		},
 		{
 			name: "two resources with a valid dependency",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
-				{URN: "urn:pulumi:stack::project::t::b", Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"}},
+				{URN: "urn:pulumi:stack::project::pulumi:providers:t::a", Type: "pulumi:pulumi:Stack"},
+				{
+					URN:          "urn:pulumi:stack::project::pulumi:providers:t::b",
+					Type:         "pulumi:providers:p",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::pulumi:providers:t::a"},
+				},
 			},
 		},
 		{
 			name: "two resources with a valid property dependency",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 				{
-					URN: "urn:pulumi:stack::project::t::b",
+					URN:  "urn:pulumi:stack::project::pulumi:providers:t::b",
+					Type: "pulumi:providers:t",
 					PropertyDependencies: map[resource.PropertyKey][]resource.URN{
 						"p": {"urn:pulumi:stack::project::t::a"},
 					},
@@ -169,24 +181,31 @@ func TestSnapshotPrune_PreservesValidSnapshots(t *testing.T) {
 		{
 			name: "two resources with a valid deleted-with relationship",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
-				{URN: "urn:pulumi:stack::project::t::b", DeletedWith: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::pulumi:providers:t::a", Type: "pulumi:providers:t"},
+				{
+					URN:         "urn:pulumi:stack::project::pulumi:providers:t::b",
+					Type:        "pulumi:providers:t",
+					DeletedWith: "urn:pulumi:stack::project::pulumi:providers:t::a",
+				},
 			},
 		},
 		{
 			name: "duplicate URNs due to deleted/non-deleted",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 				{
 					URN:          "urn:pulumi:stack::project::t::b",
+					Type:         "pulumi:pulumi:Stack",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
 				},
 				{
 					URN:    "urn:pulumi:stack::project::t::a",
+					Type:   "pulumi:pulumi:Stack",
 					Delete: true,
 				},
 				{
 					URN:          "urn:pulumi:stack::project::t::b",
+					Type:         "pulumi:pulumi:Stack",
 					Delete:       true,
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
 				},
@@ -195,13 +214,15 @@ func TestSnapshotPrune_PreservesValidSnapshots(t *testing.T) {
 		{
 			name: "duplicate URNs due to deleted/non-deleted (false cycle)",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 				{
 					URN:          "urn:pulumi:stack::project::t::b",
+					Type:         "pulumi:pulumi:Stack",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
 				},
 				{
 					URN:          "urn:pulumi:stack::project::t::a",
+					Type:         "pulumi:pulumi:Stack",
 					Delete:       true,
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::b"},
 				},
@@ -210,34 +231,40 @@ func TestSnapshotPrune_PreservesValidSnapshots(t *testing.T) {
 		{
 			name: "multiple sets of dependent resources",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 				{
 					URN:          "urn:pulumi:stack::project::t::b",
+					Type:         "pulumi:pulumi:Stack",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
 				},
 				{
 					URN:          "urn:pulumi:stack::project::t::c",
+					Type:         "pulumi:pulumi:Stack",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
 				},
 				{
-					URN: "urn:pulumi:stack::project::t::d",
+					URN:  "urn:pulumi:stack::project::t::d",
+					Type: "pulumi:pulumi:Stack",
 					PropertyDependencies: map[resource.PropertyKey][]resource.URN{
 						"pa": {"urn:pulumi:stack::project::t::a"},
 						"pb": {"urn:pulumi:stack::project::t::b"},
 					},
 				},
 				{
-					URN: "urn:pulumi:stack::project::t::e",
+					URN:  "urn:pulumi:stack::project::t::e",
+					Type: "pulumi:pulumi:Stack",
 					Dependencies: []resource.URN{
 						"urn:pulumi:stack::project::t::c",
 						"urn:pulumi:stack::project::t::d",
 					},
 				},
 				{
-					URN: "urn:pulumi:stack::project::t::f",
+					URN:  "urn:pulumi:stack::project::t::f",
+					Type: "pulumi:pulumi:Stack",
 				},
 				{
 					URN:         "urn:pulumi:stack::project::t::g",
+					Type:        "pulumi:pulumi:Stack",
 					DeletedWith: "urn:pulumi:stack::project::t::f",
 				},
 			},
@@ -278,11 +305,13 @@ func TestSnapshotPrune_FixesDanglingReferences(t *testing.T) {
 				{
 					URN:    "urn:pulumi:stack::project::t$t::b",
 					Parent: "urn:pulumi:stack::project::t::a",
+					Type:   "pulumi:pulumi:Stack",
 				},
 			},
 			want: []*resource.State{
 				{
-					URN: "urn:pulumi:stack::project::t::b",
+					URN:  "urn:pulumi:stack::project::t::b",
+					Type: "pulumi:pulumi:Stack",
 				},
 			},
 			results: []PruneResult{
@@ -300,12 +329,14 @@ func TestSnapshotPrune_FixesDanglingReferences(t *testing.T) {
 			given: []*resource.State{
 				{
 					URN:          "urn:pulumi:stack::project::t::b",
+					Type:         "pulumi:pulumi:Stack",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
 				},
 			},
 			want: []*resource.State{
 				{
 					URN:          "urn:pulumi:stack::project::t::b",
+					Type:         "pulumi:pulumi:Stack",
 					Dependencies: []resource.URN{},
 				},
 			},
@@ -322,9 +353,10 @@ func TestSnapshotPrune_FixesDanglingReferences(t *testing.T) {
 		{
 			name: "some missing dependencies",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::b"},
+				{URN: "urn:pulumi:stack::project::t::b", Type: "pulumi:pulumi:Stack"},
 				{
-					URN: "urn:pulumi:stack::project::t::c",
+					URN:  "urn:pulumi:stack::project::t::c",
+					Type: "pulumi:pulumi:Stack",
 					Dependencies: []resource.URN{
 						"urn:pulumi:stack::project::t::a",
 						"urn:pulumi:stack::project::t::b",
@@ -332,9 +364,10 @@ func TestSnapshotPrune_FixesDanglingReferences(t *testing.T) {
 				},
 			},
 			want: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::b"},
+				{URN: "urn:pulumi:stack::project::t::b", Type: "pulumi:pulumi:Stack"},
 				{
-					URN: "urn:pulumi:stack::project::t::c",
+					URN:  "urn:pulumi:stack::project::t::c",
+					Type: "pulumi:pulumi:Stack",
 					Dependencies: []resource.URN{
 						"urn:pulumi:stack::project::t::b",
 					},
@@ -354,7 +387,8 @@ func TestSnapshotPrune_FixesDanglingReferences(t *testing.T) {
 			name: "missing property dependency",
 			given: []*resource.State{
 				{
-					URN: "urn:pulumi:stack::project::t::b",
+					URN:  "urn:pulumi:stack::project::t::b",
+					Type: "pulumi:pulumi:Stack",
 					PropertyDependencies: map[resource.PropertyKey][]resource.URN{
 						"p": {"urn:pulumi:stack::project::t::a"},
 					},
@@ -363,6 +397,7 @@ func TestSnapshotPrune_FixesDanglingReferences(t *testing.T) {
 			want: []*resource.State{
 				{
 					URN:                  "urn:pulumi:stack::project::t::b",
+					Type:                 "pulumi:pulumi:Stack",
 					PropertyDependencies: map[resource.PropertyKey][]resource.URN{},
 				},
 			},
@@ -383,9 +418,10 @@ func TestSnapshotPrune_FixesDanglingReferences(t *testing.T) {
 		{
 			name: "some missing property dependencies",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::b"},
+				{URN: "urn:pulumi:stack::project::t::b", Type: "pulumi:pulumi:Stack"},
 				{
-					URN: "urn:pulumi:stack::project::t::d",
+					URN:  "urn:pulumi:stack::project::t::d",
+					Type: "pulumi:pulumi:Stack",
 					PropertyDependencies: map[resource.PropertyKey][]resource.URN{
 						"pa":  {"urn:pulumi:stack::project::t::a"},
 						"pbc": {"urn:pulumi:stack::project::t::b", "urn:pulumi:stack::project::t::c"},
@@ -393,9 +429,10 @@ func TestSnapshotPrune_FixesDanglingReferences(t *testing.T) {
 				},
 			},
 			want: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::b"},
+				{URN: "urn:pulumi:stack::project::t::b", Type: "pulumi:pulumi:Stack"},
 				{
-					URN: "urn:pulumi:stack::project::t::d",
+					URN:  "urn:pulumi:stack::project::t::d",
+					Type: "pulumi:pulumi:Stack",
 					PropertyDependencies: map[resource.PropertyKey][]resource.URN{
 						"pbc": {"urn:pulumi:stack::project::t::b"},
 					},
@@ -426,11 +463,13 @@ func TestSnapshotPrune_FixesDanglingReferences(t *testing.T) {
 				{
 					URN:         "urn:pulumi:stack::project::t::b",
 					DeletedWith: "urn:pulumi:stack::project::t::a",
+					Type:        "pulumi:pulumi:Stack",
 				},
 			},
 			want: []*resource.State{
 				{
-					URN: "urn:pulumi:stack::project::t::b",
+					URN:  "urn:pulumi:stack::project::t::b",
+					Type: "pulumi:pulumi:Stack",
 				},
 			},
 			results: []PruneResult{
@@ -449,27 +488,33 @@ func TestSnapshotPrune_FixesDanglingReferences(t *testing.T) {
 				{
 					URN:    "urn:pulumi:stack::project::t$t::b",
 					Parent: "urn:pulumi:stack::project::t::a",
+					Type:   "pulumi:pulumi:Stack",
 				},
 				{
 					URN:    "urn:pulumi:stack::project::t$t$u::c",
 					Parent: "urn:pulumi:stack::project::t$t::b",
+					Type:   "pulumi:pulumi:Stack",
 				},
 				{
 					URN:    "urn:pulumi:stack::project::t$t$u$v::d",
 					Parent: "urn:pulumi:stack::project::t$t$u::c",
+					Type:   "pulumi:pulumi:Stack",
 				},
 			},
 			want: []*resource.State{
 				{
-					URN: "urn:pulumi:stack::project::t::b",
+					URN:  "urn:pulumi:stack::project::t::b",
+					Type: "pulumi:pulumi:Stack",
 				},
 				{
 					URN:    "urn:pulumi:stack::project::t$u::c",
 					Parent: "urn:pulumi:stack::project::t::b",
+					Type:   "pulumi:pulumi:Stack",
 				},
 				{
 					URN:    "urn:pulumi:stack::project::t$u$v::d",
 					Parent: "urn:pulumi:stack::project::t$u::c",
+					Type:   "pulumi:pulumi:Stack",
 				},
 			},
 			results: []PruneResult{
@@ -496,17 +541,21 @@ func TestSnapshotPrune_FixesDanglingReferences(t *testing.T) {
 				{
 					URN:    "urn:pulumi:stack::project::t$t::b",
 					Parent: "urn:pulumi:stack::project::t::a",
+					Type:   "pulumi:pulumi:Stack",
 				},
 				{
 					URN:    "urn:pulumi:stack::project::t$t$u::c",
 					Parent: "urn:pulumi:stack::project::t$t::b",
+					Type:   "pulumi:pulumi:Stack",
 				},
 				{
 					URN:          "urn:pulumi:stack::project::t::d",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t$t::b"},
+					Type:         "pulumi:pulumi:Stack",
 				},
 				{
-					URN: "urn:pulumi:stack::project::t::e",
+					URN:  "urn:pulumi:stack::project::t::e",
+					Type: "pulumi:pulumi:Stack",
 					PropertyDependencies: map[resource.PropertyKey][]resource.URN{
 						"p": {"urn:pulumi:stack::project::t$t$u::c"},
 						"q": {"urn:pulumi:stack::project::t::q"},
@@ -515,6 +564,7 @@ func TestSnapshotPrune_FixesDanglingReferences(t *testing.T) {
 				},
 				{
 					URN:    "urn:pulumi:stack::project::t$t$u$v::f",
+					Type:   "pulumi:pulumi:Stack",
 					Parent: "urn:pulumi:stack::project::t$t$u::c",
 					Dependencies: []resource.URN{
 						"urn:pulumi:stack::project::t$t::b",
@@ -524,15 +574,18 @@ func TestSnapshotPrune_FixesDanglingReferences(t *testing.T) {
 			},
 			want: []*resource.State{
 				{
-					URN: "urn:pulumi:stack::project::t::b",
+					URN:  "urn:pulumi:stack::project::t::b",
+					Type: "pulumi:pulumi:Stack",
 				},
 				{
 					URN:    "urn:pulumi:stack::project::t$u::c",
 					Parent: "urn:pulumi:stack::project::t::b",
+					Type:   "pulumi:pulumi:Stack",
 				},
 				{
 					URN:          "urn:pulumi:stack::project::t::d",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::b"},
+					Type:         "pulumi:pulumi:Stack",
 				},
 				{
 					URN: "urn:pulumi:stack::project::t::e",
@@ -540,11 +593,13 @@ func TestSnapshotPrune_FixesDanglingReferences(t *testing.T) {
 						"p": {"urn:pulumi:stack::project::t$u::c"},
 					},
 					DeletedWith: "urn:pulumi:stack::project::t::d",
+					Type:        "pulumi:pulumi:Stack",
 				},
 				{
 					URN:          "urn:pulumi:stack::project::t$u$v::f",
 					Parent:       "urn:pulumi:stack::project::t$u::c",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::b"},
+					Type:         "pulumi:pulumi:Stack",
 				},
 			},
 			results: []PruneResult{
@@ -585,38 +640,46 @@ func TestSnapshotPrune_FixesDanglingReferences(t *testing.T) {
 				{
 					URN:    "urn:pulumi:stack::project::t$t::b",
 					Parent: "urn:pulumi:stack::project::t::a",
+					Type:   "pulumi:pulumi:Stack",
 				},
 				{
 					URN:         "urn:pulumi:stack::project::t::c",
 					DeletedWith: "urn:pulumi:stack::project::t$t::b",
+					Type:        "pulumi:pulumi:Stack",
 				},
 				{
 					URN:    "urn:pulumi:stack::project::t$t::b",
 					Parent: "urn:pulumi:stack::project::t::a",
 					Delete: true,
+					Type:   "pulumi:pulumi:Stack",
 				},
 				{
 					URN:    "urn:pulumi:stack::project::t$t$u::c",
 					Parent: "urn:pulumi:stack::project::t$t::b",
 					Delete: true,
+					Type:   "pulumi:pulumi:Stack",
 				},
 			},
 			want: []*resource.State{
 				{
-					URN: "urn:pulumi:stack::project::t::b",
+					URN:  "urn:pulumi:stack::project::t::b",
+					Type: "pulumi:pulumi:Stack",
 				},
 				{
 					URN:         "urn:pulumi:stack::project::t::c",
 					DeletedWith: "urn:pulumi:stack::project::t::b",
+					Type:        "pulumi:pulumi:Stack",
 				},
 				{
 					URN:    "urn:pulumi:stack::project::t::b",
 					Delete: true,
+					Type:   "pulumi:pulumi:Stack",
 				},
 				{
 					URN:    "urn:pulumi:stack::project::t$u::c",
 					Parent: "urn:pulumi:stack::project::t::b",
 					Delete: true,
+					Type:   "pulumi:pulumi:Stack",
 				},
 			},
 			results: []PruneResult{
@@ -690,133 +753,160 @@ func TestSnapshotToposort_PreservesValidSnapshots(t *testing.T) {
 		{
 			name: "a single resource",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 			},
 		},
 		{
 			name: "two unrelated resources",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
-				{URN: "urn:pulumi:stack::project::t::b"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
+				{URN: "urn:pulumi:stack::project::t::b", Type: "pulumi:pulumi:Stack"},
 			},
 		},
 		{
 			name: "two resources with a valid provider dependency",
 			given: []*resource.State{
 				{
-					Type: "pulumi:providers:p",
-					URN:  "urn:pulumi:stack::project::pulumi:providers:p::a",
-					ID:   "id",
+					Type:   "pulumi:providers:p",
+					URN:    "urn:pulumi:stack::project::pulumi:providers:p::a",
+					ID:     "id",
+					Custom: true,
 				},
 				{
 					URN:      "urn:pulumi:stack::project::t::b",
 					Provider: "urn:pulumi:stack::project::pulumi:providers:p::a::id",
+					Type:     "pulumi:pulumi:Stack",
 				},
 			},
 		},
 		{
 			name: "two resources with a valid parent-child relationship",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
-				{URN: "urn:pulumi:stack::project::t$t::b", Parent: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
+				{URN: "urn:pulumi:stack::project::t$t::b", Parent: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 			},
 		},
 		{
 			name: "two resources with a valid dependency",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
-				{URN: "urn:pulumi:stack::project::t::b", Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"}},
+				{
+					URN:    "urn:pulumi:stack::project::pulumi:providers:t::a",
+					Type:   "pulumi:providers:p",
+					Custom: true,
+				},
+				{
+					URN:          "urn:pulumi:stack::project::pulumi:providers:t::b",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::pulumi:providers:t::a"},
+					Type:         "pulumi:providers:t",
+					Custom:       true,
+				},
 			},
 		},
 		{
 			name: "two resources with a valid property dependency",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 				{
 					URN: "urn:pulumi:stack::project::t::b",
 					PropertyDependencies: map[resource.PropertyKey][]resource.URN{
 						"p": {"urn:pulumi:stack::project::t::a"},
 					},
+					Type: "pulumi:pulumi:Stack",
 				},
 			},
 		},
 		{
 			name: "two resources with a valid deleted-with relationship",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
-				{URN: "urn:pulumi:stack::project::t::b", DeletedWith: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
+				{
+					URN:         "urn:pulumi:stack::project::t::b",
+					DeletedWith: "urn:pulumi:stack::project::t::a",
+					Type:        "pulumi:pulumi:Stack",
+				},
 			},
 		},
 		{
 			name: "duplicate URNs due to deleted/non-deleted",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 				{
 					URN:          "urn:pulumi:stack::project::t::b",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+					Type:         "pulumi:pulumi:Stack",
 				},
 				{
 					URN:    "urn:pulumi:stack::project::t::a",
 					Delete: true,
+					Type:   "pulumi:pulumi:Stack",
 				},
 				{
 					URN:          "urn:pulumi:stack::project::t::b",
 					Delete:       true,
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+					Type:         "pulumi:pulumi:Stack",
 				},
 			},
 		},
 		{
 			name: "duplicate URNs due to deleted/non-deleted (false cycle)",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 				{
 					URN:          "urn:pulumi:stack::project::t::b",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+					Type:         "pulumi:pulumi:Stack",
 				},
 				{
 					URN:          "urn:pulumi:stack::project::t::a",
 					Delete:       true,
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::b"},
+					Type:         "pulumi:pulumi:Stack",
 				},
 			},
 		},
 		{
 			name: "multiple duplicate URNs due to multiple deleted",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 				{
 					URN:          "urn:pulumi:stack::project::t::b",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+					Type:         "pulumi:pulumi:Stack",
 				},
 				{
 					URN:          "urn:pulumi:stack::project::t::a",
 					Delete:       true,
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::b"},
+					Type:         "pulumi:pulumi:Stack",
 				},
 				{
 					URN:          "urn:pulumi:stack::project::t::c",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
 					Delete:       true,
+					Type:         "pulumi:pulumi:Stack",
 				},
 				{
 					URN:          "urn:pulumi:stack::project::t::a",
 					Delete:       true,
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::b"},
+					Type:         "pulumi:pulumi:Stack",
 				},
 			},
 		},
 		{
 			name: "multiple sets of dependent resources",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 				{
 					URN:          "urn:pulumi:stack::project::t::b",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+					Type:         "pulumi:pulumi:Stack",
 				},
 				{
 					URN:          "urn:pulumi:stack::project::t::c",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+					Type:         "pulumi:pulumi:Stack",
 				},
 				{
 					URN: "urn:pulumi:stack::project::t::d",
@@ -824,6 +914,7 @@ func TestSnapshotToposort_PreservesValidSnapshots(t *testing.T) {
 						"pa": {"urn:pulumi:stack::project::t::a"},
 						"pb": {"urn:pulumi:stack::project::t::b"},
 					},
+					Type: "pulumi:pulumi:Stack",
 				},
 				{
 					URN: "urn:pulumi:stack::project::t::e",
@@ -831,13 +922,16 @@ func TestSnapshotToposort_PreservesValidSnapshots(t *testing.T) {
 						"urn:pulumi:stack::project::t::c",
 						"urn:pulumi:stack::project::t::d",
 					},
+					Type: "pulumi:pulumi:Stack",
 				},
 				{
-					URN: "urn:pulumi:stack::project::t::f",
+					URN:  "urn:pulumi:stack::project::t::f",
+					Type: "pulumi:pulumi:Stack",
 				},
 				{
 					URN:         "urn:pulumi:stack::project::t::g",
 					DeletedWith: "urn:pulumi:stack::project::t::f",
+					Type:        "pulumi:pulumi:Stack",
 				},
 			},
 		},
@@ -875,46 +969,57 @@ func TestSnapshotToposort_FixesOrderInvalidSnapshots(t *testing.T) {
 			given: []*resource.State{
 				{
 					URN:      "urn:pulumi:stack::project::t::b",
+					Type:     "pulumi:pulumi:Stack",
 					Provider: "urn:pulumi:stack::project::pulumi:providers:p::a::id",
 				},
 				{
-					Type: "pulumi:providers:p",
-					URN:  "urn:pulumi:stack::project::pulumi:providers:p::a",
-					ID:   "id",
+					Type:   "pulumi:providers:p",
+					URN:    "urn:pulumi:stack::project::pulumi:providers:p::a",
+					ID:     "id",
+					Custom: true,
 				},
 			},
 		},
 		{
 			name: "two resources with an out-of-order parent-child relationship",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t$t::b", Parent: "urn:pulumi:stack::project::t::a"},
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t$t::b", Parent: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 			},
 		},
 		{
 			name: "two resources with an out-of-order dependency",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::b", Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"}},
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{
+					URN:          "urn:pulumi:stack::project::t::b",
+					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+					Type:         "pulumi:pulumi:Stack",
+				},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 			},
 		},
 		{
 			name: "two resources with an out-of-order property dependency",
 			given: []*resource.State{
 				{
-					URN: "urn:pulumi:stack::project::t::b",
+					URN:  "urn:pulumi:stack::project::t::b",
+					Type: "pulumi:pulumi:Stack",
 					PropertyDependencies: map[resource.PropertyKey][]resource.URN{
 						"p": {"urn:pulumi:stack::project::t::a"},
 					},
 				},
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 			},
 		},
 		{
 			name: "two resources with an out-of-order deleted-with relationship",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t::b", DeletedWith: "urn:pulumi:stack::project::t::a"},
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{
+					URN:         "urn:pulumi:stack::project::t::b",
+					Type:        "pulumi:pulumi:Stack",
+					DeletedWith: "urn:pulumi:stack::project::t::a",
+				},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 			},
 		},
 		{
@@ -922,16 +1027,19 @@ func TestSnapshotToposort_FixesOrderInvalidSnapshots(t *testing.T) {
 			given: []*resource.State{
 				{
 					URN:          "urn:pulumi:stack::project::t::b",
+					Type:         "pulumi:pulumi:Stack",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
 				},
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 				{
 					URN:          "urn:pulumi:stack::project::t::b",
+					Type:         "pulumi:pulumi:Stack",
 					Delete:       true,
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
 				},
 				{
 					URN:    "urn:pulumi:stack::project::t::a",
+					Type:   "pulumi:pulumi:Stack",
 					Delete: true,
 				},
 			},
@@ -941,11 +1049,13 @@ func TestSnapshotToposort_FixesOrderInvalidSnapshots(t *testing.T) {
 			given: []*resource.State{
 				{
 					URN:          "urn:pulumi:stack::project::t::b",
+					Type:         "pulumi:pulumi:Stack",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
 				},
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 				{
 					URN:          "urn:pulumi:stack::project::t::a",
+					Type:         "pulumi:pulumi:Stack",
 					Delete:       true,
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::b"},
 				},
@@ -956,26 +1066,31 @@ func TestSnapshotToposort_FixesOrderInvalidSnapshots(t *testing.T) {
 			given: []*resource.State{
 				{
 					URN:          "urn:pulumi:stack::project::t::b",
+					Type:         "pulumi:pulumi:Stack",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
 				},
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 				{
 					URN:          "urn:pulumi:stack::project::t::c",
+					Type:         "pulumi:pulumi:Stack",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
 					Delete:       true,
 				},
 				{
 					URN:          "urn:pulumi:stack::project::t::a",
+					Type:         "pulumi:pulumi:Stack",
 					Delete:       true,
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::d"},
 				},
 				{
 					URN:          "urn:pulumi:stack::project::t::a",
+					Type:         "pulumi:pulumi:Stack",
 					Delete:       true,
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::b"},
 				},
 				{
 					URN:    "urn:pulumi:stack::project::t::d",
+					Type:   "pulumi:pulumi:Stack",
 					Delete: true,
 				},
 			},
@@ -985,11 +1100,13 @@ func TestSnapshotToposort_FixesOrderInvalidSnapshots(t *testing.T) {
 			given: []*resource.State{
 				{
 					URN:          "urn:pulumi:stack::project::t::c",
+					Type:         "pulumi:pulumi:Stack",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
 				},
-				{URN: "urn:pulumi:stack::project::t::a"},
+				{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
 				{
-					URN: "urn:pulumi:stack::project::t::e",
+					URN:  "urn:pulumi:stack::project::t::e",
+					Type: "pulumi:pulumi:Stack",
 					Dependencies: []resource.URN{
 						"urn:pulumi:stack::project::t::c",
 						"urn:pulumi:stack::project::t::d",
@@ -997,10 +1114,12 @@ func TestSnapshotToposort_FixesOrderInvalidSnapshots(t *testing.T) {
 				},
 				{
 					URN:          "urn:pulumi:stack::project::t::b",
+					Type:         "pulumi:pulumi:Stack",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
 				},
 				{
-					URN: "urn:pulumi:stack::project::t::d",
+					URN:  "urn:pulumi:stack::project::t::d",
+					Type: "pulumi:pulumi:Stack",
 					PropertyDependencies: map[resource.PropertyKey][]resource.URN{
 						"pa": {"urn:pulumi:stack::project::t::a"},
 						"pb": {"urn:pulumi:stack::project::t::b"},
@@ -1008,10 +1127,12 @@ func TestSnapshotToposort_FixesOrderInvalidSnapshots(t *testing.T) {
 				},
 				{
 					URN:         "urn:pulumi:stack::project::t::g",
+					Type:        "pulumi:pulumi:Stack",
 					DeletedWith: "urn:pulumi:stack::project::t::f",
 				},
 				{
-					URN: "urn:pulumi:stack::project::t::f",
+					URN:  "urn:pulumi:stack::project::t::f",
+					Type: "pulumi:pulumi:Stack",
 				},
 			},
 		},
@@ -1050,6 +1171,7 @@ func TestSnapshotToposort_DetectsCycles(t *testing.T) {
 				{
 					URN:      "urn:pulumi:stack::project::t::b",
 					Provider: "urn:pulumi:stack::project::pulumi:providers:p::a::id",
+					Type:     "pulumi:pulumi:Stack",
 				},
 				{
 					Type:         "pulumi:providers:p",
@@ -1062,14 +1184,20 @@ func TestSnapshotToposort_DetectsCycles(t *testing.T) {
 		{
 			name: "long-chain cycle",
 			given: []*resource.State{
-				{URN: "urn:pulumi:stack::project::t$t::b", Parent: "urn:pulumi:stack::project::t::a"},
+				{
+					URN:    "urn:pulumi:stack::project::t$t::b",
+					Parent: "urn:pulumi:stack::project::t::a",
+					Type:   "pulumi:pulumi:Stack",
+				},
 				{
 					URN:          "urn:pulumi:stack::project::t::a",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::c"},
+					Type:         "pulumi:pulumi:Stack",
 				},
 				{
 					URN:         "urn:pulumi:stack::project::t::c",
 					DeletedWith: "urn:pulumi:stack::project::t$t::b",
+					Type:        "pulumi:pulumi:Stack",
 				},
 			},
 		},
@@ -1079,20 +1207,24 @@ func TestSnapshotToposort_DetectsCycles(t *testing.T) {
 				{
 					URN:          "urn:pulumi:stack::project::t::b",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::a"},
+					Type:         "pulumi:pulumi:Stack",
 				},
 				{
 					URN:         "urn:pulumi:stack::project::t::a",
 					DeletedWith: "urn:pulumi:stack::project::t::b",
+					Type:        "pulumi:pulumi:Stack",
 				},
 				{
 					URN: "urn:pulumi:stack::project::t::d",
 					PropertyDependencies: map[resource.PropertyKey][]resource.URN{
 						"pc": {"urn:pulumi:stack::project::t::c"},
 					},
+					Type: "pulumi:pulumi:Stack",
 				},
 				{
 					URN:          "urn:pulumi:stack::project::t::c",
 					Dependencies: []resource.URN{"urn:pulumi:stack::project::t::d"},
+					Type:         "pulumi:pulumi:Stack",
 				},
 			},
 		},
@@ -1104,6 +1236,7 @@ func TestSnapshotToposort_DetectsCycles(t *testing.T) {
 					PropertyDependencies: map[resource.PropertyKey][]resource.URN{
 						"p": {"urn:pulumi:stack::project::t::a"},
 					},
+					Type: "pulumi:pulumi:Stack",
 				},
 			},
 		},


### PR DESCRIPTION
When [deserializing resources](https://github.com/pulumi/pulumi/blob/f5953999c151ea354a448c5f641c5cc37b33d2f3/pkg/resource/stack/deployment.go#L651-L661), we currently check some properties of resources, e.g. that it has a URN, a type, and that component resources have no ID.

However we currently don't check the same when verifying snapshot integrity.  This means we could pass a snapshot integrity check, and send the snapshot to the backend, but could then fail to derserialize the snapshot.  Fix this by expanding the snapshot integrity check, and fixing up the tests that violate these checks.

I'm a little scared of the `VerifyIntegrity` changes, since it could be that we get more snapshot integrity errors from this, although I *think* users should already be getting deserialization errors if that was the case.  The test changes should be merged either way imo, and are going to be necessary for a future PR I'm working on.