### PR TITLE
Avoid running dependency installation during `pulumi about`

### DIFF
--- a/changelog/pending/20250919--sdk-python--avoid-running-dependency-installation-during-pulumi-about.yaml
+++ b/changelog/pending/20250919--sdk-python--avoid-running-dependency-installation-during-pulumi-about.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Avoid running dependency installation during `pulumi about`

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -290,20 +290,6 @@ func (host *pythonLanguageHost) GetRequiredPackages(ctx context.Context,
 		return nil, err
 	}
 
-	tc, err := toolchain.ResolveToolchain(opts)
-	if err != nil {
-		return nil, err
-	}
-
-	stdout, stderr, err := host.createEngineWriters(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if err := tc.EnsureVenv(ctx, req.Info.ProgramDirectory, false, /*useLanguageVersionTools */
-		true /* showOutput */, stdout, stderr); err != nil {
-		return nil, err
-	}
-
 	validateVersion(ctx, opts)
 
 	// Now, determine which Pulumi packages are installed.


### PR DESCRIPTION
We should not run dependency installation during `pulumi about`.
