### PR TITLE
copy new resources as well as old ones

### DIFF
--- a/pkg/backend/journal.go
+++ b/pkg/backend/journal.go
@@ -154,14 +154,20 @@ func (sj *snapshotJournaler) snap() *deploy.Snapshot {
 			if entry.RemoveOld != nil {
 				toDeleteInSnapshot[*entry.RemoveOld] = struct{}{}
 			}
-			if entry.Delete != nil {
-				markAsDeletion[*entry.Delete] = struct{}{}
-			}
 			if entry.RemoveNew != nil {
 				toRemove[*entry.RemoveNew] = struct{}{}
 			}
-			if entry.PendingReplacement != nil {
-				markAsPendingReplacement[*entry.PendingReplacement] = struct{}{}
+			if entry.DeleteOld != nil {
+				markAsDeletion[*entry.DeleteOld] = struct{}{}
+			}
+			if entry.DeleteNew != nil {
+				newResources[operationIDToResourceIndex[*entry.DeleteNew]].Delete = true
+			}
+			if entry.PendingReplacementOld != nil {
+				markAsPendingReplacement[*entry.PendingReplacementOld] = struct{}{}
+			}
+			if entry.PendingReplacementNew != nil {
+				newResources[operationIDToResourceIndex[*entry.PendingReplacementNew]].PendingReplacement = true
 			}
 
 			if entry.IsRefresh {

--- a/pkg/engine/journal_snapshot.go
+++ b/pkg/engine/journal_snapshot.go
@@ -127,16 +127,20 @@ type JournalEntry struct {
 	// The ID of the operation that this journal entry is associated with.  Note that operation
 	// IDs start at 1, only Write operations have ID 0.
 	OperationID int64
-	// The index of the resource in the base snapshot to delete, or -1 if no deletion is needed.
+	// The index of the resource in the base snapshot to delete.
 	RemoveOld *int64
 	// The operation ID of a new resource that should be deleted.
 	RemoveNew *int64
 	// The index of the resource in the base snapshot that should be marked as pending
-	// replacement, or -1 if no pending replacement is needed.
-	PendingReplacement *int64
+	// replacement.
+	PendingReplacementOld *int64
+	// The operation ID of the new resource that should be marked as pending replacement
 	// The index of the resource in the base snapshot that should be marked as deleted,
+	PendingReplacementNew *int64
 	// or -1 if no deletion is needed.
-	Delete *int64
+	DeleteOld *int64
+	// The operation ID of the new resource that should be marked as deleted.
+	DeleteNew *int64
 	// The resource state associated with this journal entry.
 	State *resource.State
 	// The operation associated with this journal entry, if any.
@@ -164,38 +168,42 @@ func (sm *JournalSnapshotManager) newJournalEntry(kind JournalEntryKind, operati
 func (sm *JournalSnapshotManager) RegisterResourceOutputs(step deploy.Step) error {
 	operationID := sm.operationIDCounter.Add(1)
 
+	old, new := step.Old(), step.New()
+
 	journalEntry := sm.newJournalEntry(JournalEntryOutputs, operationID)
-	journalEntry.ElideWrite = step.Old() != nil && step.New() != nil && step.Old().Outputs.DeepEquals(step.New().Outputs)
-	// If the outputs have changed, we create a journal entry.  This will cause the resource
-	// to be replaced in the snapshot, and thus the new outputs written.
-	if step.Old() != nil && step.New() != nil && !step.Old().Outputs.DeepEquals(step.New().Outputs) {
-		journalEntry.State = step.New()
-		sm.newResources.Store(step.New(), operationID)
-		sm.markEntryForRemoval(&journalEntry, step.Old())
-	}
+	journalEntry.ElideWrite = old != nil && new != nil && old.Outputs.DeepEquals(new.Outputs)
+	journalEntry.State = step.New().Copy()
+	// We always need to mark the *new* resource for removal here, because registering outputs
+	// is not a really a separate step, but the step we're getting here has already been executed.
+	// We need to replace the resource that step already added, hence step.New() below.
+	journalEntry.RemoveOld, journalEntry.RemoveNew = sm.findResourceInNewOrOld(step.New())
 	return sm.journal.EndOperation(journalEntry)
 }
 
-// markEntryForRemoval marks the given resource state for deletion in the journal entry. We compare the
-// pointer to the resource state in the base snapshot, to find the position in the baseSnapshot here,
-// in case the resource is already in the base snapshot.
+// findResourceInOldOrNew looks for a resource in either the base snapshot, or in the list of new
+// resources.
+//
+// We compare the pointer to the resource state in the base snapshot, to find the position in the
+// baseSnapshot here, in case the resource is already in the base snapshot.
 //
 // If we have a new resource that was created in this plan, but then gets deleted by a subsequent step,
 // we record the operation ID of the new resource, so the snapshot generation can skip the earlier operation,
 // and thus the new resource won't be written to the snapshot.
-func (sm *JournalSnapshotManager) markEntryForRemoval(journalEntry *JournalEntry, toRemove *resource.State) {
+//
+// The first return value if set is the index in the base snapshot, the second one is the operation ID.  Only
+// one of them will be set.
+func (sm *JournalSnapshotManager) findResourceInNewOrOld(toFind *resource.State) (*int64, *int64) {
 	if sm.baseSnapshot != nil {
 		for i, res := range sm.baseSnapshot.Resources {
-			if res == toRemove {
+			if res == toFind {
 				index := int64(i)
-				journalEntry.RemoveOld = &index
-				return
+				return &index, nil
 			}
 		}
 	}
-	rm, ok := sm.newResources.Load(toRemove)
-	journalEntry.RemoveNew = &rm
-	contract.Assertf(ok, "could not find resource that's supposed to be deleted %v", toRemove)
+	rm, ok := sm.newResources.Load(toFind)
+	contract.Assertf(ok, "could not find resource in snapshot or new resources %v", toFind)
+	return nil, &rm
 }
 
 // BeginMutation signals to the SnapshotManager that the engine intends to mutate the global snapshot
@@ -410,10 +418,10 @@ func (ssm *sameSnapshotMutation) End(step deploy.Step, successful bool) error {
 
 	sameStep, isSameStep := step.(*deploy.SameStep)
 	if !isSameStep || !sameStep.IsSkippedCreate() {
-		journalEntry.State = step.New()
+		journalEntry.State = step.New().Copy()
 		ssm.manager.newResources.Store(step.New(), ssm.operationID)
 		if old := step.Old(); old != nil {
-			ssm.manager.markEntryForRemoval(&journalEntry, step.Old())
+			journalEntry.RemoveOld, journalEntry.RemoveNew = ssm.manager.findResourceInNewOrOld(step.Old())
 		}
 	}
 
@@ -451,23 +459,17 @@ func (csm *createSnapshotMutation) End(step deploy.Step, successful bool) error 
 		kind = JournalEntryFailure
 	}
 	journalEntry := csm.manager.newJournalEntry(kind, csm.operationID)
-	journalEntry.State = step.New()
+	journalEntry.State = step.New().Copy()
 	csm.manager.newResources.Store(step.New(), csm.operationID)
 	if old := step.Old(); old != nil && old.PendingReplacement {
-		csm.manager.markEntryForRemoval(&journalEntry, old)
+		journalEntry.RemoveOld, journalEntry.RemoveNew = csm.manager.findResourceInNewOrOld(old)
 	}
 
 	// If this step is a create replacement, we need to mark the old resource for deletion.
 	// The engine marks this in its in-memory representation, but since the snapshot manager
 	// is operating on a copy of the snapshot, we need to explicitly mark the resource.
 	if step.Old() != nil && !step.Old().PendingReplacement && csm.manager.baseSnapshot != nil {
-		for i, res := range csm.manager.baseSnapshot.Resources {
-			if res == step.Old() {
-				index := int64(i)
-				journalEntry.Delete = &index
-				break
-			}
-		}
+		journalEntry.DeleteOld, journalEntry.DeleteNew = csm.manager.findResourceInNewOrOld(step.Old())
 	}
 
 	return csm.manager.journal.EndOperation(journalEntry)
@@ -500,9 +502,9 @@ func (usm *updateSnapshotMutation) End(step deploy.Step, successful bool) error 
 	}
 	journalEntry := usm.manager.newJournalEntry(kind, usm.operationID)
 	if old := step.Old(); old != nil {
-		usm.manager.markEntryForRemoval(&journalEntry, step.Old())
+		journalEntry.RemoveOld, journalEntry.RemoveNew = usm.manager.findResourceInNewOrOld(step.Old())
 	}
-	journalEntry.State = step.New()
+	journalEntry.State = step.New().Copy()
 	usm.manager.newResources.Store(step.New(), usm.operationID)
 	return usm.manager.journal.EndOperation(journalEntry)
 }
@@ -542,19 +544,10 @@ func (dsm *deleteSnapshotMutation) End(step deploy.Step, successful bool) error 
 			step.Old().Protect, step.Op())
 
 		if step.Old().PendingReplacement {
-			if dsm.manager.baseSnapshot != nil {
-				for i, res := range dsm.manager.baseSnapshot.Resources {
-					if res == step.Old() {
-						index := int64(i)
-						journalEntry.PendingReplacement = &index
-						break
-					}
-				}
-			}
-		}
-
-		if !step.Old().PendingReplacement {
-			dsm.manager.markEntryForRemoval(&journalEntry, step.Old())
+			journalEntry.PendingReplacementOld,
+				journalEntry.PendingReplacementNew = dsm.manager.findResourceInNewOrOld(step.Old())
+		} else {
+			journalEntry.RemoveOld, journalEntry.RemoveNew = dsm.manager.findResourceInNewOrOld(step.Old())
 		}
 	}
 	return dsm.manager.journal.EndOperation(journalEntry)
@@ -600,10 +593,10 @@ func (rsm *readSnapshotMutation) End(step deploy.Step, successful bool) error {
 		kind = JournalEntryFailure
 	}
 	journalEntry := rsm.manager.newJournalEntry(kind, rsm.operationID)
-	journalEntry.State = step.New()
+	journalEntry.State = step.New().Copy()
 	rsm.manager.newResources.Store(step.New(), rsm.operationID)
 	if old := step.Old(); old != nil && rsm.manager.baseSnapshot != nil {
-		rsm.manager.markEntryForRemoval(&journalEntry, step.Old())
+		journalEntry.RemoveOld, journalEntry.RemoveNew = rsm.manager.findResourceInNewOrOld(step.Old())
 	}
 	return rsm.manager.journal.EndOperation(journalEntry)
 }
@@ -635,7 +628,7 @@ func (rsm *refreshSnapshotMutation) End(step deploy.Step, successful bool) error
 	journalEntry := rsm.manager.newJournalEntry(kind, rsm.operationID)
 
 	if step.New() != nil {
-		journalEntry.State = step.New()
+		journalEntry.State = step.New().Copy()
 		rsm.manager.newResources.Store(step.New(), rsm.operationID)
 	}
 
@@ -648,11 +641,12 @@ func (rsm *refreshSnapshotMutation) End(step deploy.Step, successful bool) error
 		// the resource needs to be updated in place, to make sure all ordering constraints
 		// are satisfied.
 		journalEntry.Kind = JournalEntrySuccess
-		// We still need to know it is a refresh, so we can update dependencies correctly.
-		journalEntry.IsRefresh = true
 	}
+
+	journalEntry.IsRefresh = true
+
 	if old := step.Old(); old != nil {
-		rsm.manager.markEntryForRemoval(&journalEntry, old)
+		journalEntry.RemoveOld, journalEntry.RemoveNew = rsm.manager.findResourceInNewOrOld(old)
 	}
 
 	return rsm.manager.journal.EndOperation(journalEntry)
@@ -681,7 +675,7 @@ func (rsm *removePendingReplaceSnapshotMutation) End(step deploy.Step, successfu
 		"must be %q, got %q", deploy.OpRemovePendingReplace, step.Op())
 	journalEntry := rsm.manager.newJournalEntry(JournalEntrySuccess, rsm.operationID)
 	if step.Old() != nil {
-		rsm.manager.markEntryForRemoval(&journalEntry, step.Old())
+		journalEntry.RemoveOld, journalEntry.RemoveNew = rsm.manager.findResourceInNewOrOld(step.Old())
 	}
 	return rsm.manager.journal.EndOperation(journalEntry)
 }
@@ -713,18 +707,12 @@ func (ism *importSnapshotMutation) End(step deploy.Step, successful bool) error 
 		kind = JournalEntryFailure
 	}
 	journalEntry := ism.manager.newJournalEntry(kind, ism.operationID)
-	journalEntry.State = step.New()
+	journalEntry.State = step.New().Copy()
 	importStep, isImportStep := step.(*deploy.ImportStep)
 	contract.Assertf(isImportStep, "step must be an ImportStep, got %T", step)
 	if importStep.Original() != nil && ism.manager.baseSnapshot != nil {
 		// This is a import replacement, so we need to mark the old resource for deletion.
-		for i, res := range ism.manager.baseSnapshot.Resources {
-			if res == importStep.Original() {
-				index := int64(i)
-				journalEntry.Delete = &index
-				break
-			}
-		}
+		journalEntry.DeleteOld, journalEntry.DeleteNew = ism.manager.findResourceInNewOrOld(importStep.Original())
 	}
 	ism.manager.newResources.Store(step.New(), ism.operationID)
 	return ism.manager.journal.EndOperation(journalEntry)

--- a/pkg/engine/journal_snapshot.go
+++ b/pkg/engine/journal_snapshot.go
@@ -134,10 +134,9 @@ type JournalEntry struct {
 	// The index of the resource in the base snapshot that should be marked as pending
 	// replacement.
 	PendingReplacementOld *int64
-	// The operation ID of the new resource that should be marked as pending replacement
-	// The index of the resource in the base snapshot that should be marked as deleted,
+	// The operation ID of the new resource that should be marked as pending replacement.
 	PendingReplacementNew *int64
-	// or -1 if no deletion is needed.
+	// The index of the resource in the base snapshot that should be marked as deleted.
 	DeleteOld *int64
 	// The operation ID of the new resource that should be marked as deleted.
 	DeleteNew *int64

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -310,6 +310,7 @@ func (snap *Snapshot) AssertEqual(expected *Snapshot) error {
 
 	for _, mr := range expected.Resources {
 		if len(mr.PropertyDependencies) > 0 {
+			// We normalize empty slices away, so we don't get `nil != [] != key missing` diffs.
 			newPropDeps := map[resource.PropertyKey][]resource.URN{}
 			for k, v := range mr.PropertyDependencies {
 				if len(v) > 0 {
@@ -323,6 +324,7 @@ func (snap *Snapshot) AssertEqual(expected *Snapshot) error {
 
 	for _, jr := range snap.Resources {
 		if len(jr.PropertyDependencies) > 0 {
+			// We normalize empty slices away, so we don't get `nil != [] != key missing` diffs.
 			newPropDeps := map[resource.PropertyKey][]resource.URN{}
 			for k, v := range jr.PropertyDependencies {
 				if len(v) > 0 {

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -309,10 +309,29 @@ func (snap *Snapshot) AssertEqual(expected *Snapshot) error {
 	resourcesMap := make(map[resource.URN][]*resource.State)
 
 	for _, mr := range expected.Resources {
+		if len(mr.PropertyDependencies) > 0 {
+			newPropDeps := map[resource.PropertyKey][]resource.URN{}
+			for k, v := range mr.PropertyDependencies {
+				if len(v) > 0 {
+					newPropDeps[k] = v
+				}
+			}
+			mr.PropertyDependencies = newPropDeps
+		}
 		resourcesMap[mr.URN] = append(resourcesMap[mr.URN], mr)
 	}
 
 	for _, jr := range snap.Resources {
+		if len(jr.PropertyDependencies) > 0 {
+			newPropDeps := map[resource.PropertyKey][]resource.URN{}
+			for k, v := range jr.PropertyDependencies {
+				if len(v) > 0 {
+					newPropDeps[k] = v
+				}
+			}
+			jr.PropertyDependencies = newPropDeps
+		}
+
 		found := false
 		var diffStr string
 		for _, mr := range resourcesMap[jr.URN] {


### PR DESCRIPTION
Currently in the journal implementation we only made copies of the old snapshot, but then added new resources without copying them.  This meant that the engine was still updating pointers, which is not what we want, as that doesn't translate to the service.

Make the journal make copies of new entries as well to avoid this.

This reveals a few places where we were still relying on the pointers
of resources for correct operation of the journal. This commit fixes
them. In particular:

- It's possible that new resources are later marked as
  Delete/PendingReplacement, so we need to split those fields out into
  DeleteNew/DeleteOld and PendingReplacementNew/PendingReplacementOld.
- RegisterResourceOutputs always piggybacks on a step that has already
  happened, as there is no special step for it. This step has always
  already been executed by the time we get to RegisterResourceOutputs.
  To register the outputs correctly, we therefore need to replace
  the *New()* part of the step with the new outputs, as that's the one
  that's in the intermediate state at this point.
- rebuildDependencies and rebuildBaseState are called at different
  points in the lifecycle.  This can lead to resources that have
  PropertyDependency maps with keys that have an empty list as value
  in the normal snapshot, whereas the journal would have filtered that
  empty list out, because `rebuildDependencies` for the journal runs
  later.  Since empty lists are functionally equivalent to the key not
  being there at all, we can simply account for this in the comparison
  code.