### PR TITLE
Send vcs metadata when publishing policy packs

### DIFF
--- a/changelog/config.yaml
+++ b/changelog/config.yaml
@@ -18,6 +18,7 @@ scopes:
     - new
     - plugin
     - package
+    - policy
     - state
   components: [dotnet, go, java, nodejs, python, yaml]
   docs: []

--- a/changelog/pending/20250919--cli-policy--send-vcs-metadata-when-publishing-policy-packs.yaml
+++ b/changelog/pending/20250919--cli-policy--send-vcs-metadata-when-publishing-policy-packs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/policy
+  description: Send vcs metadata when publishing policy packs

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -882,6 +882,7 @@ func (pc *Client) ListPolicyPacks(ctx context.Context, orgName string, inContTok
 // the Policy Pack, it returns the version of the pack.
 func (pc *Client) PublishPolicyPack(ctx context.Context, orgName string,
 	analyzerInfo plugin.AnalyzerInfo, dirArchive io.Reader,
+	metadata map[string]string,
 ) (string, error) {
 	//
 	// Step 1: Send POST containing policy metadata to service. This begins process of creating
@@ -924,6 +925,7 @@ func (pc *Client) PublishPolicyPack(ctx context.Context, orgName string,
 		Provider:    analyzerInfo.Provider,
 		Tags:        analyzerInfo.Tags,
 		Repository:  analyzerInfo.Repository,
+		Metadata:    metadata,
 	}
 
 	// Print a publishing message. We have to handle the case where an older version of pulumi/policy

--- a/pkg/backend/httpstate/client/client_publish_policy_pack_test.go
+++ b/pkg/backend/httpstate/client/client_publish_policy_pack_test.go
@@ -121,8 +121,11 @@ func TestPublishPolicyPack_AllAnalyzerInfoFieldsAreSent(t *testing.T) {
 	// Create a mock archive
 	archive := bytes.NewReader([]byte("mock-archive-data"))
 
+	// Empty metadata.
+	var metadata map[string]string
+
 	// Call PublishPolicyPack
-	version, err := client.PublishPolicyPack(context.Background(), "test-org", analyzerInfo, archive)
+	version, err := client.PublishPolicyPack(context.Background(), "test-org", analyzerInfo, archive, metadata)
 	require.NoError(t, err)
 	assert.Equal(t, "1.2.3", version)
 
@@ -218,7 +221,10 @@ func TestPublishPolicyPack_EmptyOptionalFields(t *testing.T) {
 	client := newMockClient(server)
 	archive := bytes.NewReader([]byte("mock-archive-data"))
 
-	_, err := client.PublishPolicyPack(context.Background(), "test-org", analyzerInfo, archive)
+	// Empty metadata.
+	var metadata map[string]string
+
+	_, err := client.PublishPolicyPack(context.Background(), "test-org", analyzerInfo, archive, metadata)
 	require.NoError(t, err)
 
 	// Verify required fields are present
@@ -285,7 +291,10 @@ func TestPublishPolicyPack_LegacyVersionHandling(t *testing.T) {
 	client := newMockClient(server)
 	archive := bytes.NewReader([]byte("mock-archive-data"))
 
-	version, err := client.PublishPolicyPack(context.Background(), "test-org", analyzerInfo, archive)
+	// Empty metadata.
+	var metadata map[string]string
+
+	version, err := client.PublishPolicyPack(context.Background(), "test-org", analyzerInfo, archive, metadata)
 	require.NoError(t, err)
 
 	// Verify that server-assigned version is returned when client version is empty
@@ -379,7 +388,10 @@ func TestPublishPolicyPack_PolicyConfigSchemaConversion(t *testing.T) {
 	client := newMockClient(server)
 	archive := bytes.NewReader([]byte("mock-archive-data"))
 
-	_, err := client.PublishPolicyPack(context.Background(), "test-org", analyzerInfo, archive)
+	// Empty metadata.
+	var metadata map[string]string
+
+	_, err := client.PublishPolicyPack(context.Background(), "test-org", analyzerInfo, archive, metadata)
 	require.NoError(t, err)
 
 	// Verify config schema conversion
@@ -458,7 +470,10 @@ func TestPublishPolicyPack_NilConfigSchema(t *testing.T) {
 	client := newMockClient(server)
 	archive := bytes.NewReader([]byte("mock-archive-data"))
 
-	_, err := client.PublishPolicyPack(context.Background(), "test-org", analyzerInfo, archive)
+	// Empty metadata.
+	var metadata map[string]string
+
+	_, err := client.PublishPolicyPack(context.Background(), "test-org", analyzerInfo, archive, metadata)
 	require.NoError(t, err)
 
 	// Verify nil config schema is handled correctly
@@ -519,7 +534,10 @@ func TestPublishPolicyPack_NilComplianceFramework(t *testing.T) {
 	client := newMockClient(server)
 	archive := bytes.NewReader([]byte("mock-archive-data"))
 
-	_, err := client.PublishPolicyPack(context.Background(), "test-org", analyzerInfo, archive)
+	// Empty metadata.
+	var metadata map[string]string
+
+	_, err := client.PublishPolicyPack(context.Background(), "test-org", analyzerInfo, archive, metadata)
 	require.NoError(t, err)
 
 	// Verify nil compliance framework is handled correctly

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -215,7 +215,8 @@ func (pack *cloudPolicyPack) Publish(
 
 	fmt.Println("Uploading policy pack to Pulumi service")
 
-	publishedVersion, err := pack.cl.PublishPolicyPack(ctx, pack.ref.orgName, analyzerInfo, bytes.NewReader(packTarball))
+	publishedVersion, err := pack.cl.PublishPolicyPack(
+		ctx, pack.ref.orgName, analyzerInfo, bytes.NewReader(packTarball), op.Metadata)
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/policypack.go
+++ b/pkg/backend/policypack.go
@@ -28,6 +28,10 @@ type PublishOperation struct {
 	PlugCtx    *plugin.Context
 	PolicyPack *workspace.PolicyPackProject
 	Scopes     CancellationScopeSource
+
+	// Metadata contains optional data about the environment performing the publish operation,
+	// e.g. the current source code control commit information.
+	Metadata map[string]string
 }
 
 // PolicyPackOperation is used to make various operations against a Policy Pack.

--- a/pkg/cmd/pulumi/metadata/metadata.go
+++ b/pkg/cmd/pulumi/metadata/metadata.go
@@ -41,6 +41,22 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 )
 
+// GetPolicyPublishMetadata returns optional data about the environment performing a
+// `pulumi policy publish` command.
+func GetPolicyPublishMetadata(root string) map[string]string {
+	m := &backend.UpdateMetadata{
+		Environment: make(map[string]string),
+	}
+
+	if err := addGitMetadata(root, m); err != nil {
+		logging.V(3).Infof("errors detecting git metadata: %s", err)
+	}
+
+	addCIMetadataToEnvironment(m.Environment)
+
+	return m.Environment
+}
+
 // GetUpdateMetadata returns an UpdateMetadata object, with optional data about the environment
 // performing the update.
 func GetUpdateMetadata(

--- a/pkg/cmd/pulumi/policy/policy_publish.go
+++ b/pkg/cmd/pulumi/policy/policy_publish.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -130,12 +131,20 @@ func (cmd *policyPublishCmd) Run(ctx context.Context, lm cmdBackend.LoginManager
 		return err
 	}
 
+	// Get optional data about the environment performing the publish operation,
+	// e.g. the current source code control commit information.
+	m := metadata.GetPolicyPublishMetadata(root)
+
 	//
 	// Attempt to publish the PolicyPack.
 	//
 
 	err = policyPack.Publish(ctx, backend.PublishOperation{
-		Root: root, PlugCtx: plugctx, PolicyPack: proj, Scopes: backend.CancellationScopes,
+		Root:       root,
+		PlugCtx:    plugctx,
+		PolicyPack: proj,
+		Scopes:     backend.CancellationScopes,
+		Metadata:   m,
 	})
 	if err != nil {
 		return err

--- a/sdk/go/common/apitype/policy.go
+++ b/sdk/go/common/apitype/policy.go
@@ -54,6 +54,10 @@ type CreatePolicyPackRequest struct {
 
 	// A URL to the repository where the policy pack is defined.
 	Repository string `json:"repository,omitempty"`
+
+	// Metadata contains optional data about the environment performing the publish operation,
+	// e.g. the current source code control commit information.
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 // CreatePolicyPackResponse is the response from creating a Policy Pack. It returns


### PR DESCRIPTION
When publishing a policy pack, include vcs metadata (i.e. git source location), so tools like Neo know where the source of a policy pack lives. The vcs metadata is the same metadata that's sent as part of Pulumi operations like `pulumi up`.

Fixes #20516