### PR TITLE
[config] Clarify string coercion

### DIFF
--- a/sdk/go/common/resource/config/map.go
+++ b/sdk/go/common/resource/config/map.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
@@ -81,7 +80,7 @@ func (m Map) AsDecryptedPropertyMap(ctx context.Context, decrypter Decrypter) (r
 	pm := resource.PropertyMap{}
 
 	for k, v := range m {
-		newV, err := adjustObjectValue(v)
+		newV, err := v.coerceObject()
 		if err != nil {
 			return resource.PropertyMap{}, err
 		}
@@ -185,7 +184,7 @@ func (m Map) Set(k Key, v Value, path bool) error {
 
 	var newV object
 	if len(p) > 1 || v.typ != TypeUnknown {
-		newV, err = adjustObjectValue(v)
+		newV, err = v.coerceObject()
 		if err != nil {
 			return err
 		}
@@ -299,57 +298,4 @@ func parseKeyPath(k Key) (resource.PropertyPath, Key, error) {
 	configKey := MustMakeKey(k.Namespace(), firstKey)
 
 	return p, configKey, nil
-}
-
-// adjustObjectValue returns a more suitable value for objects:
-func adjustObjectValue(v Value) (object, error) {
-	// If it's a secure value or an object, return as-is.
-	if v.Secure() || v.Object() {
-		return v.unmarshalObject()
-	}
-
-	switch v.typ {
-	case TypeString:
-		return newObject(v.value), nil
-	case TypeInt:
-		i, err := strconv.Atoi(v.value)
-		if err != nil {
-			return object{}, err
-		}
-		return newObject(int64(i)), nil
-	case TypeBool:
-		return newObject(v.value == "true"), nil
-	case TypeFloat:
-		f, err := strconv.ParseFloat(v.value, 64)
-		if err != nil {
-			return object{}, err
-		}
-		return newObject(f), nil
-	}
-
-	// If "false" or "true", return the boolean value.
-	switch v.value {
-	case "false":
-		return newObject(false), nil
-	case "true":
-		return newObject(true), nil
-	}
-
-	// If the value has more than one character and starts with "0", return the value as-is
-	// so values like "0123456" are saved as a string (without stripping any leading zeros)
-	// rather than as the integer 123456.
-	if len(v.value) > 1 && v.value[0] == '0' {
-		return v.unmarshalObject()
-	}
-
-	// If it's convertible to an int, return the int.
-	if i, err := strconv.ParseInt(v.value, 10, 64); err == nil {
-		return newObject(i), nil
-	}
-	if i, err := strconv.ParseUint(v.value, 10, 64); err == nil {
-		return newObject(i), nil
-	}
-
-	// Otherwise, just return the string value.
-	return v.unmarshalObject()
 }

--- a/sdk/go/common/resource/config/object.go
+++ b/sdk/go/common/resource/config/object.go
@@ -537,6 +537,12 @@ func (c object) toDecryptedPropertyValue(ctx context.Context, decrypter Decrypte
 	return plaintext.PropertyValue(), nil
 }
 
+// coerce attempts to coerce v to a boolean or number value. Returns the coerced value and true if coercion succeeds
+// and (nil, false) otherwise.
+//
+// The coercion rules are:
+// - "false" and "true" coerce to false and true, respectively
+// - strings of base-10 digits that do not begin with '0' are coerced to int64 or uint64
 func coerce(v string) (any, bool) {
 	// If "false" or "true", return the boolean value.
 	switch v {

--- a/sdk/go/common/resource/config/plaintext.go
+++ b/sdk/go/common/resource/config/plaintext.go
@@ -81,6 +81,25 @@ func (c Plaintext) Value() any {
 	return c.value
 }
 
+// Coerce converts its receiver from a non-secure string to a boolean or number if possible.
+func (c Plaintext) Coerce() Plaintext {
+	if s, ok := c.Value().(string); ok && !c.secure {
+		if coerced, ok := coerce(s); ok {
+			switch coerced := coerced.(type) {
+			case bool:
+				return NewPlaintext(coerced)
+			case int64:
+				return NewPlaintext(coerced)
+			case uint64:
+				return NewPlaintext(coerced)
+			default:
+				contract.Failf("unreachable")
+			}
+		}
+	}
+	return c
+}
+
 // GoValue returns the inner plaintext value as a plain Go value:
 //
 //   - secure strings are mapped to their plaintext
@@ -105,6 +124,7 @@ func (c Plaintext) GoValue() any {
 	}
 }
 
+// PropertyValue converts a plaintext value into a resource.PropertyValue.
 func (c Plaintext) PropertyValue() resource.PropertyValue {
 	var prop resource.PropertyValue
 	switch v := c.Value().(type) {

--- a/sdk/go/common/resource/config/plaintext.go
+++ b/sdk/go/common/resource/config/plaintext.go
@@ -81,25 +81,6 @@ func (c Plaintext) Value() any {
 	return c.value
 }
 
-// Coerce converts its receiver from a non-secure string to a boolean or number if possible.
-func (c Plaintext) Coerce() Plaintext {
-	if s, ok := c.Value().(string); ok && !c.secure {
-		if coerced, ok := coerce(s); ok {
-			switch coerced := coerced.(type) {
-			case bool:
-				return NewPlaintext(coerced)
-			case int64:
-				return NewPlaintext(coerced)
-			case uint64:
-				return NewPlaintext(coerced)
-			default:
-				contract.Failf("unreachable")
-			}
-		}
-	}
-	return c
-}
-
 // GoValue returns the inner plaintext value as a plain Go value:
 //
 //   - secure strings are mapped to their plaintext


### PR DESCRIPTION
These changes rename adjustObjectValue to coerceObject and clarify its
documentation and logic. This refactoring is not a behavioral change.