### PR TITLE
Add GetRegisteredResources to the MockMonitor (NodeJS)

### DIFF
--- a/changelog/pending/20250922--sdk-nodejs--registered-resources-can-now-be-retrieved-from-the-mock-monitor-for-test-assertions.yaml
+++ b/changelog/pending/20250922--sdk-nodejs--registered-resources-can-now-be-retrieved-from-the-mock-monitor-for-test-assertions.yaml
@@ -1,0 +1,6 @@
+component: sdk/nodejs
+kind: feat
+body: Registered resources can now be retrieved from the mock monitor for test assertions
+time: 2026-06-10T11:44:00.000000+00:00
+custom:
+    PR: "20539"

--- a/sdk/nodejs/runtime/mocks.ts
+++ b/sdk/nodejs/runtime/mocks.ts
@@ -214,6 +214,10 @@ export class MockMonitor {
         }
     }
 
+    public getRegisteredResources(): Map<string, { urn: string; id: string | null; state: any }> {
+        return new Map(this.resources);
+    }
+
     public registerResourceOutputs(req: any, callback: (err: any, innerResponse: any) => void) {
         try {
             const registeredResource = this.resources.get(req.getUrn());

--- a/sdk/nodejs/tests_with_mocks/mocks.spec.ts
+++ b/sdk/nodejs/tests_with_mocks/mocks.spec.ts
@@ -15,6 +15,7 @@
 import * as assert from "assert";
 import * as pulumi from "../index";
 import { CustomResourceOptions } from "../resource";
+import { MockMonitor } from "../runtime/mocks";
 import { MockCallArgs, MockCallResult, MockResourceArgs, MockResourceResult } from "../runtime";
 
 const callMock = (args: MockCallArgs): MockCallResult => {
@@ -140,6 +141,17 @@ setups.forEach(([test, isAsyncNewResource, isAsyncCall]) => {
             read = MyCustom.get("mycustom", "read");
             invokeResult = invoke();
             remoteComponent = new MyRemoteComponent("myremotecomponent", pulumi.interpolate`hello: ${instance.id}`);
+        });
+
+        describe("registered resources", function () {
+            it("exposes currently registered resources", async function () {
+                const monitor = pulumi.runtime.getMonitor() as MockMonitor | undefined;
+                const resources = monitor?.getRegisteredResources();
+
+                for (const resource of [component, instance, custom, remoteComponent]) {
+                    assert.ok(resources?.has(await resource.urn.promise()));
+                }
+            });
         });
 
         describe("component", function () {


### PR DESCRIPTION
Continuation of #20472 to address #6113.

Long-time listeners may remember this PR from before, and our conversations to avoid it using the event stream. While I still think that's a better fix, this issue needs closing, and the code already exists in Go, so we should probably just add this for now and deprecate it when we have a better solution.