### PR TITLE
Fix failure message in TestRunningViaCLIWrapper

### DIFF
--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1921,7 +1921,7 @@ func TestRunningViaCLIWrapper(t *testing.T) {
 			_ = cmd.Wait()
 		}
 
-		require.Failf(t, "pulumi up hung after %s - likely trying to set raw mode without foreground control."+
+		require.Failf(t, "up hung", "pulumi up hung after %s - likely trying to set raw mode without foreground control."+
 			" Output so far: %s", timeout.String(), <-out)
 	}
 }


### PR DESCRIPTION
The first message argument to Failf is an unformatted message.