### PR TITLE
Fix plugin killing during cancellation

### DIFF
--- a/changelog/pending/20250922--sdk--fix-plugin-killing-during-cancellation.yaml
+++ b/changelog/pending/20250922--sdk--fix-plugin-killing-during-cancellation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk
+  description: Fix plugin killing during cancellation

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -572,7 +572,7 @@ func ExecPlugin(ctx *Context, bin, prefix string, kind apitype.PluginKind,
 		cmdutil.InterruptChildren(cmd.Process.Pid)
 
 		// Give the process 5 seconds to shut down, or kill it forcibly.
-		timeout, cancel := context.WithTimeout(ctx.Base(), 5*time.Second)
+		timeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		_, err := wait.Promise().Result(timeout)
 		if !errors.Is(err, context.DeadlineExceeded) {

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1810,9 +1810,7 @@ func TestAutomationAPIErrorInResource(t *testing.T) {
 }
 
 // TestRunningViaCLIWrapper tests that we can interrupt an operation when
-// running via a CLI wrapper tool like the 1Password CLI. This test also checks
-// that a provider also receives a SIGINT signal when the operation is
-// interrupted.
+// running via a CLI wrapper tool like the 1Password CLI.
 //
 // Regression test for https://github.com/pulumi/pulumi/issues/20154
 func TestRunningViaCLIWrapper(t *testing.T) {
@@ -1838,11 +1836,6 @@ func TestRunningViaCLIWrapper(t *testing.T) {
 	e.RunCommand("yarn", "link", "@pulumi/pulumi")
 	e.RunCommand("pulumi", "package", "add", providerPath)
 	e.CWD = e.RootPath
-
-	// package add creates `interrupted.txt`, remove it so we can test its
-	// creation during the program run below.
-	err := os.Remove(filepath.Join(programPath, "interrupted.txt"))
-	require.NoError(t, err)
 
 	// Run pulumi via a wrapper that does not start Pulumi in its own process group.
 	// This simulates the behaviour of the 1password CLI.
@@ -1896,22 +1889,7 @@ func TestRunningViaCLIWrapper(t *testing.T) {
 	}()
 
 	go func() {
-		err := cmd.Wait()
-		// The provider might not have exited yet when the pulumi command exits,
-		// wait for interrupted.txt to be created by the provider after it
-		// received SIGINT.
-		end := time.Now().Add(timeout)
-		found := false
-		for time.Now().Before(end) {
-			if _, err := os.Stat(filepath.Join(programPath, "interrupted.txt")); err == nil {
-				t.Logf("Found `interrupted.txt`")
-				found = true
-				break
-			}
-			time.Sleep(wait)
-		}
-		require.True(t, found, "interrupted.txt should exist - did the provider not get SIGINT?")
-		processFinished <- err
+		processFinished <- cmd.Wait()
 	}()
 
 	select {

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1839,6 +1839,11 @@ func TestRunningViaCLIWrapper(t *testing.T) {
 	e.RunCommand("pulumi", "package", "add", providerPath)
 	e.CWD = e.RootPath
 
+	// package add creates `interrupted.txt`, remove it so we can test its
+	// creation during the program run below.
+	err := os.Remove(filepath.Join(programPath, "interrupted.txt"))
+	require.NoError(t, err)
+
 	// Run pulumi via a wrapper that does not start Pulumi in its own process group.
 	// This simulates the behaviour of the 1password CLI.
 	cmd := e.SetupCommandIn(context.TODO(), filepath.Join(e.RootPath, "wrapper"), "go", "run", ".",

--- a/tests/integration/interrupt/program/index.js
+++ b/tests/integration/interrupt/program/index.js
@@ -1,7 +1,12 @@
 // Copyright 2025, Pulumi Corporation.  All rights reserved.
 
 import * as fs from 'fs';
+import * as provider from '@pulumi/provider';
 
-fs.writeFileSync('ready.txt', 'ready');
+const comp = new provider.MyComponent("comp")
+
+comp.urn.apply(_ => {
+    fs.writeFileSync('ready.txt', 'ready');
+})
 
 export const wait = new Promise(resolve => setTimeout(resolve, 5 * 60 * 1000));

--- a/tests/integration/interrupt/provider/__main__.py
+++ b/tests/integration/interrupt/provider/__main__.py
@@ -12,18 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import signal
-from typing import Any
 from pulumi.provider.experimental import component_provider_host
 from component import MyComponent
-
-
-def signal_handler(sig: int, frame: Any):
-    with open("interrupted.txt", "w") as f:
-        f.write("Signal received\n")
-
-
-signal.signal(signal.SIGINT, signal_handler)
 
 if __name__ == "__main__":
     component_provider_host([MyComponent], "provider")


### PR DESCRIPTION
`TestRunningViaCLIWrapper` tests cancellation via `Ctrl-C/SIGINT`. The test was broken in two ways:

* `pulumi package add ...` runs the component provider and then shuts it down normally. This sends a `SIGINT` to the plugin, so it creates the `interrupted.txt` sentinel file.
* The program did not actually use the provider, so during the update operation we didn’t start the component provider.

Fixing the test by removing the `interrupted.txt` created during `pulumi package add`, and creating a component in the program revealed a bug in how we shutdown plugins.

Plugins are first sent a `SIGINT`. If the plugin does not terminate within 5 seconds, we send a SIGKILL. However if the operation is cancelled, the `context.Context` created for the 5 second timeout was parented to a cancelled context, so it was also cancelled. This meant we never sent a `SIGKILL`.

Usually this is not a problem, but because this provider implements a `SIGINT` handler, it did not have the default `SIGINT` behaviour of exiting, and would stay running when receiving the signal. In this case we needed the `SIGKILL` fallback, but that didn’t work because of the cancelled context.

In a 2nd step, the `SIGINT` handler was removed. During cancellation, the GRPC request context will be cancelled, and that should propagate down to the `exec.Command` that runs the plugin, thus terminating it. That's not actually the case for `pip` right now, but is fixed in https://github.com/pulumi/pulumi/pull/20412/files#diff-75498333780a90536eb6873a8241af8e13709c9e1714775b8998ace450576b8dL103-R103