### PR TITLE
Move stdout/stderr IO out of GenSDK and LinkPackage

### DIFF
--- a/changelog/pending/20250923--cli-package--move-stdout-stderr-io-out-of-gensdk-and-linkpackage.yaml
+++ b/changelog/pending/20250923--cli-package--move-stdout-stderr-io-out-of-gensdk-and-linkpackage.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli/package
+  description: Move stdout/stderr IO out of GenSDK and LinkPackage

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -560,13 +560,14 @@ func generateAndLinkSdksForPackages(
 			return fmt.Errorf("creating package schema: %w", err)
 		}
 
-		err = packages.GenSDK(
+		diags, err := packages.GenSDK(
 			language,
 			tempOut,
 			pkgSchema,
 			/*overlays*/ "",
 			/*local*/ true,
 		)
+		cmdDiag.PrintDiagnostics(pctx.Diag, diags)
 		if err != nil {
 			return fmt.Errorf("error generating sdk: %w", err)
 		}
@@ -599,6 +600,7 @@ func generateAndLinkSdksForPackages(
 
 		sdkRelPath := filepath.Join("sdks", pkg.Parameterization.Name)
 		err = packages.LinkPackage(&packages.LinkPackageContext{
+			Writer:    os.Stdout,
 			Workspace: ws,
 			Language:  language,
 			Root:      "./",

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	cmdDiag "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/diag"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packagecmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/policy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -204,8 +205,9 @@ func installPackagesFromProject(
 		}
 
 		parameters := &plugin.ParameterizeArgs{Args: packageSpec.Parameters}
-		_, _, err := packagecmd.InstallPackage(
+		_, _, diags, err := packagecmd.InstallPackage(
 			pkgWorkspace.Instance, pctx, proj.Runtime.Name(), root, installSource, parameters, registry)
+		cmdDiag.PrintDiagnostics(pctx.Diag, diags)
 		if err != nil {
 			return fmt.Errorf("failed to install package '%s': %w", name, err)
 		}

--- a/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	cmdDiag "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/diag"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packages"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -89,7 +90,8 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 
 			if language == "all" {
 				for _, lang := range []string{"dotnet", "go", "java", "nodejs", "python"} {
-					err := packages.GenSDK(lang, out, pkg, overlays, local)
+					diags, err := packages.GenSDK(lang, out, pkg, overlays, local)
+					cmdDiag.PrintDiagnostics(pctx.Diag, diags)
 					if err != nil {
 						return err
 					}
@@ -97,7 +99,8 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 				fmt.Fprintf(os.Stderr, "SDKs have been written to %s\n", out)
 				return nil
 			}
-			err = packages.GenSDK(language, out, pkg, overlays, local)
+			diags, err := packages.GenSDK(language, out, pkg, overlays, local)
+			cmdDiag.PrintDiagnostics(pctx.Diag, diags)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Let the callers decide where informational output and diagnostics should
be printed.