### PR TITLE
Move InstallPackage from cmd/packagecmd to cmd/packages

### DIFF
--- a/changelog/pending/20250923--cli-package--move-installpackage-from-cmd-packagecmd-to-cmd-packages.yaml
+++ b/changelog/pending/20250923--cli-package--move-installpackage-from-cmd-packagecmd-to-cmd-packages.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli/package
+  description: Move InstallPackage from cmd/packagecmd to cmd/packages

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -24,7 +24,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	cmdDiag "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/diag"
-	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packagecmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packages"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/policy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
@@ -189,14 +189,14 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 func installPackagesFromProject(
 	pctx *plugin.Context, proj *workspace.Project, root string, registry registry.Registry,
 ) error {
-	packages := proj.GetPackageSpecs()
-	if len(packages) == 0 {
+	pkgs := proj.GetPackageSpecs()
+	if len(pkgs) == 0 {
 		return nil
 	}
 
 	fmt.Println("Installing packages defined in Pulumi.yaml...")
 
-	for name, packageSpec := range packages {
+	for name, packageSpec := range pkgs {
 		fmt.Printf("Installing package '%s'...\n", name)
 
 		installSource := packageSpec.Source
@@ -205,7 +205,7 @@ func installPackagesFromProject(
 		}
 
 		parameters := &plugin.ParameterizeArgs{Args: packageSpec.Parameters}
-		_, _, diags, err := packagecmd.InstallPackage(
+		_, _, diags, err := packages.InstallPackage(
 			pkgWorkspace.Instance, pctx, proj.Runtime.Name(), root, installSource, parameters, registry)
 		cmdDiag.PrintDiagnostics(pctx.Diag, diags)
 		if err != nil {

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -15,105 +15,21 @@
 package packagecmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/hashicorp/hcl/v2"
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	cmdDiag "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/diag"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packages"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
 )
-
-// InstallPackage installs a package to the project by generating an SDK and linking it.
-// It returns the path to the installed package.
-func InstallPackage(ws pkgWorkspace.Context, pctx *plugin.Context, language, root,
-	schemaSource string, parameters plugin.ParameterizeParameters,
-	registry registry.Registry,
-) (*schema.Package, *workspace.PackageSpec, hcl.Diagnostics, error) {
-	pkg, specOverride, err := packages.SchemaFromSchemaSource(pctx, schemaSource, parameters, registry)
-	if err != nil {
-		var diagErr hcl.Diagnostics
-		if errors.As(err, &diagErr) {
-			return nil, nil, nil, fmt.Errorf("failed to get schema. Diagnostics: %w", errors.Join(diagErr.Errs()...))
-		}
-		return nil, nil, nil, fmt.Errorf("failed to get schema: %w", err)
-	}
-
-	tempOut, err := os.MkdirTemp("", "pulumi-package-")
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to create temporary directory: %w", err)
-	}
-	defer os.RemoveAll(tempOut)
-
-	local := true
-
-	// We _always_ want SupportPack turned on for `package add`, this is an option on schemas because it can change
-	// things like module paths for Go and we don't want every user using gen-sdk to be affected by that. But for
-	// `package add` we know that this is just a local package and it's ok for module paths and similar to be different.
-	pkg.SupportPack = true
-
-	diags, err := packages.GenSDK(
-		language,
-		tempOut,
-		pkg,
-		"",    /*overlays*/
-		local, /*local*/
-	)
-	if err != nil {
-		return nil, nil, diags, fmt.Errorf("failed to generate SDK: %w", err)
-	}
-
-	out := filepath.Join(root, "sdks")
-	err = os.MkdirAll(out, 0o755)
-	if err != nil {
-		return nil, nil, diags, fmt.Errorf("failed to create directory for SDK: %w", err)
-	}
-
-	outName := pkg.Name
-	if pkg.Namespace != "" {
-		outName = pkg.Namespace + "-" + outName
-	}
-	out = filepath.Join(out, outName)
-
-	// If directory already exists, remove it completely before copying new files
-	if _, err := os.Stat(out); err == nil {
-		if err := os.RemoveAll(out); err != nil {
-			return nil, nil, diags, fmt.Errorf("failed to clean existing SDK directory: %w", err)
-		}
-	}
-
-	err = packages.CopyAll(out, filepath.Join(tempOut, language))
-	if err != nil {
-		return nil, nil, diags, fmt.Errorf("failed to move SDK to project: %w", err)
-	}
-
-	// Link the package to the project
-	if err := packages.LinkPackage(&packages.LinkPackageContext{
-		Writer:    os.Stdout,
-		Workspace: ws,
-		Language:  language,
-		Root:      root,
-		Pkg:       pkg,
-		Out:       out,
-		Install:   true,
-	}); err != nil {
-		return nil, nil, diags, err
-	}
-
-	return pkg, specOverride, diags, nil
-}
 
 // Constructs the `pulumi package add` command.
 func newPackageAddCmd() *cobra.Command {
@@ -188,7 +104,7 @@ from the parameters, as in:
 			pluginSource := args[0]
 			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
 
-			pkg, packageSpec, diags, err := InstallPackage(ws, pctx, language, root, pluginSource, parameters,
+			pkg, packageSpec, diags, err := packages.InstallPackage(ws, pctx, language, root, pluginSource, parameters,
 				cmdCmd.NewDefaultRegistry(cmd.Context(), ws, proj, cmdutil.Diag(), env.Global()))
 			cmdDiag.PrintDiagnostics(pctx.Diag, diags)
 			if err != nil {


### PR DESCRIPTION
This is used in `pulumi install` and in `pulumi package add`, move it to `packages` for cleaner sharing.