### PR TITLE
snapshot manager: filter unavailable dependencies correctly

### DIFF
--- a/pkg/engine/test_journal.go
+++ b/pkg/engine/test_journal.go
@@ -45,7 +45,7 @@ type JournalEntries []TestJournalEntry
 func (entries JournalEntries) Snap(base *deploy.Snapshot) (*deploy.Snapshot, error) {
 	// Build up a list of current resources by replaying the journal.
 	resources, dones := []*resource.State{}, make(map[*resource.State]bool)
-	refreshDeletes := make(map[resource.URN]bool)
+	isRefresh := false
 	ops, doneOps := []resource.Operation{}, make(map[*resource.State]bool)
 	for _, e := range entries {
 		logging.V(7).Infof("%v %v (%v)", e.Step.Op(), e.Step.URN(), e.Kind)
@@ -115,10 +115,9 @@ func (entries JournalEntries) Snap(base *deploy.Snapshot) (*deploy.Snapshot, err
 				refreshStep, isRefreshStep := e.Step.(*deploy.RefreshStep)
 				viewStep, isViewStep := e.Step.(*deploy.ViewStep)
 				if (isViewStep && viewStep.Persisted()) || (isRefreshStep && refreshStep.Persisted()) {
+					isRefresh = true
 					if e.Step.New() != nil {
 						resources = append(resources, e.Step.New())
-					} else {
-						refreshDeletes[e.Step.Old().URN] = true
 					}
 					dones[e.Step.Old()] = true
 				}
@@ -148,7 +147,9 @@ func (entries JournalEntries) Snap(base *deploy.Snapshot) (*deploy.Snapshot, err
 		}
 	}
 
-	FilterRefreshDeletes(refreshDeletes, filteredResources)
+	if isRefresh {
+		FilterRefreshDeletes(filteredResources)
+	}
 
 	// Append any pending operations.
 	var operations []resource.Operation
@@ -275,16 +276,16 @@ func NewTestJournal() *TestJournal {
 	return j
 }
 
-// FilterRefreshDeletes filters out any dependencies and parents from 'resources' that refer to a URN that has
-// been deleted by a refresh operation. This is pretty much the same as `rebuildBaseState` in the deployment
+// FilterRefreshDeletes filters out any dependencies and parents from 'resources' that refer to a URN that is
+// not present in 'resources', due to refreshes. This is pretty much the same as `rebuildBaseState` in the deployment
 // executor (see that function for a lot of details about why this is necessary). The main difference is that
 // this function does not mutate the state objects in place instead returning a new state object with the
 // appropriate fields filtered out, note that the slice containing the states is mutated.
 func FilterRefreshDeletes(
-	refreshDeletes map[resource.URN]bool,
 	resources []*resource.State,
 ) {
 	availableParents := map[resource.URN]resource.URN{}
+	referenceable := make(map[resource.URN]bool)
 
 	for i, res := range resources {
 		newDeps := []resource.URN{}
@@ -297,7 +298,7 @@ func FilterRefreshDeletes(
 		for _, dep := range allDeps {
 			switch dep.Type {
 			case resource.ResourceParent:
-				if !refreshDeletes[dep.URN] {
+				if referenceable[dep.URN] {
 					availableParents[res.URN] = dep.URN
 					newParent = dep.URN
 				} else {
@@ -311,25 +312,27 @@ func FilterRefreshDeletes(
 					filtered = true
 				}
 			case resource.ResourceDependency:
-				if !refreshDeletes[dep.URN] {
+				if referenceable[dep.URN] {
 					newDeps = append(newDeps, dep.URN)
 				} else {
 					filtered = true
 				}
 			case resource.ResourcePropertyDependency:
-				if !refreshDeletes[dep.URN] {
+				if referenceable[dep.URN] {
 					newPropDeps[dep.Key] = append(newPropDeps[dep.Key], dep.URN)
 				} else {
 					filtered = true
 				}
 			case resource.ResourceDeletedWith:
-				if !refreshDeletes[dep.URN] {
+				if referenceable[dep.URN] {
 					newDeletedWith = dep.URN
 				} else {
 					filtered = true
 				}
 			}
 		}
+
+		referenceable[res.URN] = true
 
 		if !filtered {
 			continue


### PR DESCRIPTION
In `refresh --run-program`, we filter out dependencies that become unavailable due to them being deleted during a refresh. However that's not the only way a resource can be unavailable during a refresh.

For example a user might create a new resource in the program, and add that resource as a dependency of a resource that already exists and is now being refreshed. Because we run the program, the resource being refreshed now has that dependency, but we're not filtering it out, because the new resource we're depending on has not been deleted by the refresh. Instead it's created as a skipped create, which will never end up in the snapshot.

Fix this by being more aggressive in filtering dependencies, filtering them every time we have a persisted refresh step. This matches what the journaling code does, and avoids the snapshot integrity error.

Note that there is a test that catches this
(`TestRefreshWithProviderThatHasDependencies`), but because the journaling code wasn't copying new resources correctly, it also affected the state of the resources in the normal snapshot manager, and thus this issue wasn't caught by the test (and wouldn't have been visible to users any longer). However we want to fix the journaling code to always copy resources, and shouldn't rely on that to do the filtering in the first place.

I noticed this while trying to merge https://github.com/pulumi/pulumi/pull/20526, but I think this deserves a separate PR with a separate explanation.  No new test, because existing tests cover this (once #20526 is merged anyway), and I confirmed manually that the tests pass in combination with that PR.

cc https://github.com/pulumi/pulumi/pull/20541
Closes https://github.com/pulumi/pulumi/pull/20216
Fixes https://github.com/pulumi/pulumi/issues/20215
Fixes https://github.com/pulumi/pulumi/issues/20535