### PR TITLE
Revert "Use RunPlugin instead of policy shim plugins (#20412)"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,9 +63,13 @@ tests/testdata/codegen/*-pp/*/tsconfig.json
 goreleaser
 pulumi-resource-pulumi-nodejs
 pulumi-resource-pulumi-python
+pulumi-analyzer-policy
+pulumi-analyzer-policy-python
 pulumi-language-python-exec
 pulumi-resource-pulumi-nodejs.cmd
 pulumi-resource-pulumi-python.cmd
+pulumi-analyzer-policy.cmd
+pulumi-analyzer-policy-python.cmd
 artifacts/
 goreleaser-downloads/
 goreleaser-prebuilt/

--- a/changelog/pending/20250917--sdk-nodejs-python--use-new-policy-plugin-support-to-run-policy-packs.yaml
+++ b/changelog/pending/20250917--sdk-nodejs-python--use-new-policy-plugin-support-to-run-policy-packs.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: fix
-  scope: sdk/nodejs,python
-  description: Use new policy plugin support to run policy packs

--- a/scripts/prep-for-goreleaser.sh
+++ b/scripts/prep-for-goreleaser.sh
@@ -26,8 +26,14 @@ install_file () {
     done
 }
 
+install_file sdk/nodejs/dist/pulumi-analyzer-policy                         linux   darwin
+install_file sdk/nodejs/dist/pulumi-analyzer-policy.cmd                     windows
+
 install_file sdk/nodejs/dist/pulumi-resource-pulumi-nodejs                  linux   darwin
 install_file sdk/nodejs/dist/pulumi-resource-pulumi-nodejs.cmd              windows
+
+install_file sdk/python/dist/pulumi-analyzer-policy-python                  linux   darwin
+install_file sdk/python/dist/pulumi-analyzer-policy-python.cmd              windows
 
 install_file sdk/python/dist/pulumi-resource-pulumi-python                  linux   darwin
 install_file sdk/python/dist/pulumi-resource-pulumi-python.cmd              windows

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -139,29 +139,40 @@ func NewPolicyAnalyzer(
 		return res, nil
 	}
 
-	// This first section is a back compatibility bit for the old way of running analyzer plugins where we
-	// would look for a plugin called "pulumi-analyzer-policy-<runtime>" and invoke that plugin with two
-	// arguments, the engine address and the policy pack path. We don't do this for actual "languages" (i.e.
-	// things with language plugins), but have to leave this in to ensure things like
-	// https://github.com/pulumi/pulumi-policy-opa continue to work (although in time they could probably be
-	// moved to just be language runtimes like the rest).
-	if hasPlugin == nil {
-		hasPlugin = func(spec workspace.PluginSpec) bool {
-			path, err := workspace.GetPluginPath(
-				ctx.baseContext,
-				ctx.Diag,
-				spec,
-				host.GetProjectPlugins())
-			return err == nil && path != ""
-		}
-	}
-	foundLanguagePlugin := hasPlugin(workspace.PluginSpec{Name: proj.Runtime.Name(), Kind: apitype.LanguagePlugin})
+	// This first section is a back compatibility bit for the old way of running analyzer plugins where we would look
+	// for a plugin called "pulumi-analyzer-policy-<runtime>" and invoke that plugin with two arguments, the engine
+	// address and the policy pack path. We still do this for python and nodejs, but not for other actual "languages"
+	// (i.e. things with language plugins), but have to leave this in to ensure things like
+	// https://github.com/pulumi/pulumi-policy-opa continue to work (although in time they could probably be moved to
+	// just be language runtimes like the rest).
 
 	var plug *Plugin
+	var foundLanguagePlugin bool
+	// Try to load the language plugin for the runtime, except for python and node that _for now_ continue using the
+	// legacy behavior.
+	if proj.Runtime.Name() != "python" && proj.Runtime.Name() != "nodejs" {
+		if hasPlugin == nil {
+			hasPlugin = func(spec workspace.PluginSpec) bool {
+				path, err := workspace.GetPluginPath(
+					ctx.baseContext,
+					ctx.Diag,
+					spec,
+					host.GetProjectPlugins())
+				return err == nil && path != ""
+			}
+		}
+
+		foundLanguagePlugin = hasPlugin(workspace.PluginSpec{Name: proj.Runtime.Name(), Kind: apitype.LanguagePlugin})
+	}
 	if !foundLanguagePlugin {
-		// Couldn't get a language plugin, fall back to the old behavior, of trying to run
-		// "pulumi-analyzer-policy-<runtime>".
-		policyAnalyzerName := "policy-" + proj.Runtime.Name()
+		// Couldn't get a language plugin, fall back to the old behavior
+
+		// For historical reasons, the Node.js plugin name is just "policy".
+		// All other languages have the runtime appended, e.g. "policy-<runtime>".
+		policyAnalyzerName := "policy"
+		if !strings.EqualFold(proj.Runtime.Name(), "nodejs") {
+			policyAnalyzerName = "policy-" + proj.Runtime.Name()
+		}
 
 		// Load the policy-booting analyzer plugin (i.e., `pulumi-analyzer-${policyAnalyzerName}`).
 		var pluginPath string

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1985,7 +1985,9 @@ func IsPluginBundled(kind apitype.PluginKind, name string) bool {
 		(kind == apitype.LanguagePlugin && name == "yaml") ||
 		(kind == apitype.LanguagePlugin && name == "java") ||
 		(kind == apitype.ResourcePlugin && name == "pulumi-nodejs") ||
-		(kind == apitype.ResourcePlugin && name == "pulumi-python")
+		(kind == apitype.ResourcePlugin && name == "pulumi-python") ||
+		(kind == apitype.AnalyzerPlugin && name == "policy") ||
+		(kind == apitype.AnalyzerPlugin && name == "policy-python")
 }
 
 // GetPluginPath finds a plugin's path by its kind, name, and optional version.  It will match the latest version that

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -50,6 +50,7 @@ build_package:: ensure
 
 build_plugin: ../../bin/pulumi-language-nodejs
 	cp ./dist/pulumi-resource-pulumi-nodejs ../../bin
+	cp ./dist/pulumi-analyzer-policy ../../bin
 
 .PHONY: ../../bin/pulumi-language-nodejs
 ../../bin/pulumi-language-nodejs:
@@ -62,6 +63,7 @@ build:: build_package build_plugin
 
 install_package:: build
 	cp dist/pulumi-resource-pulumi-nodejs* "$(PULUMI_BIN)"
+	cp dist/pulumi-analyzer-policy* "$(PULUMI_BIN)"
 
 install_plugin:: build
 	GOBIN=$(PULUMI_BIN) go install -C cmd/pulumi-language-nodejs \
@@ -133,12 +135,14 @@ dist::
 	go install -C cmd/pulumi-language-nodejs \
 		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
 	cp dist/pulumi-resource-pulumi-nodejs "${GOBIN}"
+	cp dist/pulumi-analyzer-policy "${GOBIN}"
 
 brew:: BREW_VERSION := $(shell ../../scripts/get-version HEAD)
 brew::
 	go install -C cmd/pulumi-language-nodejs \
 	   -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
 	cp dist/pulumi-resource-pulumi-nodejs "$$(go env GOPATH)"/bin/
+	cp dist/pulumi-analyzer-policy "$$(go env GOPATH)"/bin/
 
 publish::
 	bash -c ../../scripts/publish_npm.sh

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -58,7 +58,6 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -84,6 +83,9 @@ const (
 	// The path to the "run" program which will spawn the rest of the language host. This may be overridden with
 	// PULUMI_LANGUAGE_NODEJS_RUN_PATH, which we do in some testing cases.
 	defaultRunPath = "@pulumi/pulumi/cmd/run"
+
+	// The path to the NodeJS plugin launcher.
+	defaultRunPluginPath = "@pulumi/pulumi/cmd/run-plugin"
 
 	// The runtime expects the config object to be saved to this environment variable.
 	pulumiConfigVar = "PULUMI_CONFIG"
@@ -1506,18 +1508,9 @@ func (host *nodeLanguageHost) RunPlugin(
 		env = append(env, "PULUMI_NODEJS_TSCONFIG_PATH="+opts.tsconfigpath)
 	}
 
-	// TODO: Pretty sure this isn't right for convert/tool plugins.
-	runPath := ""
-	if req.Kind == string(apitype.ResourcePlugin) {
-		runPath = os.Getenv("PULUMI_LANGUAGE_NODEJS_RUN_PATH")
-		if runPath == "" {
-			runPath = "@pulumi/pulumi/cmd/run-plugin"
-		}
-	} else if req.Kind == string(apitype.AnalyzerPlugin) {
-		// Policy packs (i.e. kind=analyzer) need to be treated specially for back compatibility reasons. We
-		// used to have a dedicated shim plugin "pulumi-analyzer-policy" that would start policy packs up, but
-		// now we just let the nodejs RunPlugin code handle that logic.
-		runPath = "@pulumi/pulumi/cmd/run-policy-pack"
+	runPath := os.Getenv("PULUMI_LANGUAGE_NODEJS_RUN_PATH")
+	if runPath == "" {
+		runPath = defaultRunPluginPath
 	}
 
 	runPath, err = locateModule(ctx, runPath, req.Info.ProgramDirectory, nodeBin, true)
@@ -1543,25 +1536,14 @@ func (host *nodeLanguageHost) RunPlugin(
 		return err
 	}
 
+	nodeargs = append(nodeargs, req.Info.ProgramDirectory)
+
 	args = append(args, nodeargs...)
-	// For policy analyzers we need to send the program directory as an argument _last_, for everything else it comes first
-	if req.Kind == string(apitype.AnalyzerPlugin) {
-		args = append(args, req.Args...)
-		args = append(args, req.Info.ProgramDirectory)
-	} else {
-		args = append(args, req.Info.ProgramDirectory)
-		args = append(args, req.Args...)
-	}
+	args = append(args, req.Args...)
 
 	// Now simply spawn a process to execute the requested program, wiring up stdout/stderr directly.
-	cmd := exec.CommandContext(server.Context(), nodeBin, args...)
-	// node policy packs used to always run with the working directory set to the policy pack directory, not
-	// the main working directory. We need to continue that for backwards compatibility.
-	if req.Kind == string(apitype.AnalyzerPlugin) {
-		cmd.Dir = req.Info.ProgramDirectory
-	} else {
-		cmd.Dir = req.Pwd
-	}
+	cmd := exec.Command(nodeBin, args...)
+	cmd.Dir = req.Pwd
 	cmd.Env = env
 	cmd.Stdout, cmd.Stderr = stdout, stderr
 

--- a/sdk/nodejs/dist/pulumi-analyzer-policy
+++ b/sdk/nodejs/dist/pulumi-analyzer-policy
@@ -1,0 +1,5 @@
+#!/bin/sh
+PULUMI_RUN_SCRIPT_PATH=$(node -e "try { console.log(require.resolve('@pulumi/pulumi/cmd/run-policy-pack')) } catch (e) { console.error(e.message) }")
+if [ ! -z "$PULUMI_RUN_SCRIPT_PATH" ]; then
+    node "$PULUMI_RUN_SCRIPT_PATH" $@
+fi

--- a/sdk/nodejs/dist/pulumi-analyzer-policy.cmd
+++ b/sdk/nodejs/dist/pulumi-analyzer-policy.cmd
@@ -1,0 +1,6 @@
+@echo off
+setlocal
+for /f "delims=" %%i in ('node -e "console.log(require.resolve('@pulumi/pulumi/cmd/run-policy-pack'))"') do set PULUMI_RUN_SCRIPT_PATH=%%i
+if DEFINED PULUMI_RUN_SCRIPT_PATH (
+   @node "%PULUMI_RUN_SCRIPT_PATH%" %*
+)

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -26,6 +26,7 @@ build_package:: ensure
 build_plugin: ../../bin/pulumi-language-python
 	cp ./cmd/pulumi-language-python-exec ../../bin/
 	cp ./dist/pulumi-resource-pulumi-python ../../bin/
+	cp ./dist/pulumi-analyzer-policy-python ../../bin/
 
 .PHONY: ../../bin/pulumi-language-python
 ../../bin/pulumi-language-python:
@@ -52,6 +53,7 @@ format:: ensure
 install_package:: build_package
 	cp ./cmd/pulumi-language-python-exec "$(PULUMI_BIN)"
 	cp ./dist/pulumi-resource-pulumi-python "$(PULUMI_BIN)"
+	cp ./dist/pulumi-analyzer-policy-python "$(PULUMI_BIN)"
 
 install_plugin:: build_plugin
 	GOBIN=$(PULUMI_BIN) go install -C cmd/pulumi-language-python \
@@ -79,6 +81,7 @@ dist::
 		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
 	cp ./cmd/pulumi-language-python-exec "${GOBIN}"
 	cp ./dist/pulumi-resource-pulumi-python "${GOBIN}"
+	cp ./dist/pulumi-analyzer-policy-python "${GOBIN}"
 
 brew:: BREW_VERSION := $(shell ../../scripts/get-version HEAD)
 brew::
@@ -86,6 +89,7 @@ brew::
 		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${BREW_VERSION}" ${LANGHOST_PKG}
 	cp ./cmd/pulumi-language-python-exec "$$(go env GOPATH)"/bin/
 	cp ./dist/pulumi-resource-pulumi-python "$$(go env GOPATH)"/bin/
+	cp ./dist/pulumi-analyzer-policy-python "$$(go env GOPATH)"/bin/
 
 publish:: ensure
 	for file in ../../artifacts/sdk-python-*.whl; do \

--- a/sdk/python/dist/pulumi-analyzer-policy-python
+++ b/sdk/python/dist/pulumi-analyzer-policy-python
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# Parse the -virtualenv command line argument and recreate %@ without it.
+virtualenv=""
+for arg do
+  case $arg in
+    -virtualenv=*)
+      virtualenv="${arg#*=}"
+      shift
+      ;;
+    *)
+      set -- "$@" "$arg"
+      shift
+      ;;
+  esac
+done
+
+if [ -n "${virtualenv:-}" ] ; then
+    # Remove trailing slash.
+    virtualenv=${virtualenv%/}
+
+    # Make the path absolute (if not already).
+    case $virtualenv in
+        /*) : ;;
+        *) virtualenv=$PWD/$virtualenv;;
+    esac
+
+    # If python exists in the virtual environment, set PATH and run it.
+    if [ -f "$virtualenv/bin/python" ]; then
+        # Update PATH and unset PYTHONHOME.
+        PATH="$virtualenv/bin:$PATH"
+        export PATH
+        if [ -n "${PYTHONHOME:-}" ] ; then
+            unset PYTHONHOME
+        fi
+
+        # Run python from the virtual environment.
+        "$virtualenv/bin/python" -u -m pulumi.policy "$@"
+    else
+        if [ -d "$virtualenv" ]; then
+            1>&2 echo "The 'virtualenv' option in PulumiPolicy.yaml is set to \"$virtualenv\", but \"$virtualenv\" doesn't appear to be a virtual environment."
+        else
+            1>&2 echo "The 'virtualenv' option in PulumiPolicy.yaml is set to \"$virtualenv\", but \"$virtualenv\" doesn't exist."
+        fi
+        1>&2 echo "Run the following commands to create the virtual environment and install dependencies into it:"
+        1>&2 echo "    1. python3 -m venv $virtualenv"
+        1>&2 echo "    2. $virtualenv/bin/python -m pip install --upgrade pip setuptools wheel"
+        1>&2 echo "    3. $virtualenv/bin/python -m pip install -r $PWD/requirements.txt"
+        1>&2 echo "For more information see: https://www.pulumi.com/docs/intro/languages/python/#virtual-environments"
+        exit 1
+    fi
+else
+    # Otherwise, run either PULUMI_PYTHON_CMD (if set) or python3.
+    "${PULUMI_PYTHON_CMD:-python3}" -u -m pulumi.policy "$@"
+fi

--- a/sdk/python/dist/pulumi-analyzer-policy-python.cmd
+++ b/sdk/python/dist/pulumi-analyzer-policy-python.cmd
@@ -1,0 +1,47 @@
+@echo off
+
+REM Parse the -virtualenv command line argument and populate `args` with all other arguments.
+set pulumi_runtime_python_virtualenv=
+set args=
+:parse
+if "%~1"=="" goto endparse
+if "%~1"=="-virtualenv" (
+    REM Get the value as a fully-qualified path.
+    set "pulumi_runtime_python_virtualenv=%~f2"
+    shift /1
+) else (
+    set args=%args% %~1
+)
+shift /1
+goto parse
+:endparse
+
+if defined pulumi_runtime_python_virtualenv (
+    REM If python exists in the virtual environment, set PATH and run it.
+    if exist "%pulumi_runtime_python_virtualenv%\Scripts\python.exe" (
+        REM Update PATH and unset PYTHONHOME.
+        set "PATH=%pulumi_runtime_python_virtualenv%\Scripts;%PATH%"
+        set PYTHONHOME=
+
+        REM Run python from the virtual environment.
+        "%pulumi_runtime_python_virtualenv%\Scripts\python.exe" -u -m pulumi.policy %args%
+        exit /B
+    ) else (
+        echo The 'virtualenv' option in PulumiPolicy.yaml is set to %pulumi_runtime_python_virtualenv%, but %pulumi_runtime_python_virtualenv% doesn't appear to be a virtual environment. 1>&2
+        echo Run the following commands to create the virtual environment and install dependencies into it: 1>&2
+        echo     1. python -m venv %pulumi_runtime_python_virtualenv% 1>&2
+        echo     2. %pulumi_runtime_python_virtualenv%\Scripts\python.exe -m pip install --upgrade pip setuptools wheel 1>&2
+        echo     3. %pulumi_runtime_python_virtualenv%\Scripts\python.exe -m pip install -r %cd%\requirements.txt 1>&2
+        echo For more information see: https://www.pulumi.com/docs/intro/languages/python/#virtual-environments 1>&2
+        exit 1
+    )
+) else (
+    if defined PULUMI_PYTHON_CMD (
+        REM If PULUMI_PYTHON_CMD is defined, run it.
+        "%PULUMI_PYTHON_CMD%" -u -m pulumi.policy %args%
+    ) else (
+        REM Otherwise, just run python. We use `python` instead of `python3` because Windows
+        REM Python installers install only `python.exe` by default.
+        @python -u -m pulumi.policy %args%
+    )
+)

--- a/sdk/python/toolchain/pip.go
+++ b/sdk/python/toolchain/pip.go
@@ -100,7 +100,7 @@ func (p *pip) Command(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 		name = name + ".exe"
 	}
 	cmdPath := filepath.Join(p.virtualenvPath, virtualEnvBinDirName(), name)
-	cmd = exec.CommandContext(ctx, cmdPath, arg...)
+	cmd = exec.Command(cmdPath, arg...)
 
 	cmd.Env = ActivateVirtualEnv(os.Environ(), p.virtualenvPath)
 


### PR DESCRIPTION
This reverts commit 2fcbdb7b161e081c9a05866646e2971ac950d38f because integration tests in pulumi-policy are failing with the change. We'll need to expand conformance test coverage in pulumi/pulumi, and ensure the pulumi-policy tests pass before re-introducing the change.

Fixes https://github.com/pulumi/pulumi-policy/issues/418