### PR TITLE
Revert "pass context through to ProjectInfoContext (#20397)"

### DIFF
--- a/pkg/cmd/pulumi/about/about.go
+++ b/pkg/cmd/pulumi/about/about.go
@@ -137,7 +137,7 @@ func getSummaryAbout(
 	} else {
 		projinfo := &engine.Projinfo{Proj: proj, Root: pwd}
 		pwd, program, pluginContext, err := engine.ProjectInfoContext(
-			ctx, projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), nil, false, nil, nil)
+			projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), nil, false, nil, nil)
 		if err != nil {
 			addError(err, "Failed to create plugin context")
 		} else {

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -481,14 +481,13 @@ func runConvert(
 		}
 
 		projinfo := &engine.Projinfo{Proj: proj, Root: root}
-		_, main, pctx, err := engine.ProjectInfoContext(
-			ctx, projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), nil, false, nil, nil)
+		_, main, ctx, err := engine.ProjectInfoContext(projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), nil, false, nil, nil)
 		if err != nil {
 			return err
 		}
-		defer pctx.Close()
+		defer ctx.Close()
 
-		if err := newcmd.InstallDependencies(pctx, &proj.Runtime, main); err != nil {
+		if err := newcmd.InstallDependencies(ctx, &proj.Runtime, main); err != nil {
 			return err
 		}
 	}

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -106,7 +106,6 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 			span := opentracing.SpanFromContext(ctx)
 			projinfo := &engine.Projinfo{Proj: proj, Root: root}
 			pwd, main, pctx, err := engine.ProjectInfoContext(
-				ctx,
 				projinfo,
 				nil,
 				cmdutil.Diag(),

--- a/pkg/cmd/pulumi/newcmd/new.go
+++ b/pkg/cmd/pulumi/newcmd/new.go
@@ -361,7 +361,6 @@ func runNew(ctx context.Context, args newArgs) error {
 		span := opentracing.SpanFromContext(ctx)
 		projinfo := &engine.Projinfo{Proj: proj, Root: root}
 		_, entryPoint, pluginCtx, err := engine.ProjectInfoContext(
-			ctx,
 			projinfo,
 			nil,
 			cmdutil.Diag(),
@@ -423,7 +422,6 @@ func runNew(ctx context.Context, args newArgs) error {
 		span := opentracing.SpanFromContext(ctx)
 		projinfo := &engine.Projinfo{Proj: proj, Root: root}
 		_, entryPoint, pluginCtx, err := engine.ProjectInfoContext(
-			ctx,
 			projinfo,
 			nil,
 			cmdutil.Diag(),

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -406,8 +406,7 @@ func NewUpCmd() *cobra.Command {
 		// Install dependencies.
 
 		projinfo := &engine.Projinfo{Proj: proj, Root: root}
-		_, main, pctx, err := engine.ProjectInfoContext(
-			ctx, projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), nil, false, nil, nil)
+		_, main, pctx, err := engine.ProjectInfoContext(projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), nil, false, nil, nil)
 		if err != nil {
 			return fmt.Errorf("building project context: %w", err)
 		}

--- a/pkg/cmd/pulumi/plugin/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install.go
@@ -216,7 +216,7 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 		}
 
 		// If a specific plugin wasn't given, compute the set of plugins the current project needs.
-		plugins, err := getProjectPlugins(ctx)
+		plugins, err := getProjectPlugins()
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/plugin/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin/plugin_ls.go
@@ -40,12 +40,11 @@ func newPluginLsCmd() *cobra.Command {
 			var plugins []workspace.PluginInfo
 			var err error
 			if projectOnly {
-				ctx := cmd.Context()
 				var pluginSpecs []workspace.PluginSpec
-				if pluginSpecs, err = getProjectPlugins(ctx); err != nil {
+				if pluginSpecs, err = getProjectPlugins(); err != nil {
 					return fmt.Errorf("loading project plugins: %w", err)
 				}
-				plugins, err = resolvePlugins(ctx, pluginSpecs)
+				plugins, err = resolvePlugins(pluginSpecs)
 				if err != nil {
 					return fmt.Errorf("loading project plugins: %w", err)
 				}

--- a/pkg/cmd/pulumi/policy/io.go
+++ b/pkg/cmd/pulumi/policy/io.go
@@ -57,7 +57,6 @@ func InstallPluginDependencies(ctx context.Context, root string, projRuntime wor
 		Runtime: projRuntime,
 	}, Root: root}
 	_, main, pluginCtx, err := engine.ProjectInfoContext(
-		ctx,
 		projinfo,
 		nil,
 		cmdutil.Diag(),

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -41,7 +41,7 @@ import (
 const clientRuntimeName = "client"
 
 // ProjectInfoContext returns information about the current project, including its pwd, main, and plugin context.
-func ProjectInfoContext(ctx context.Context, projinfo *Projinfo, host plugin.Host,
+func ProjectInfoContext(projinfo *Projinfo, host plugin.Host,
 	diag, statusDiag diag.Sink, debugging plugin.DebugContext, disableProviderPreview bool,
 	tracingSpan opentracing.Span, config map[config.Key]string,
 ) (string, string, *plugin.Context, error) {
@@ -54,7 +54,7 @@ func ProjectInfoContext(ctx context.Context, projinfo *Projinfo, host plugin.Hos
 	}
 
 	// Create a context for plugins.
-	pctx, err := plugin.NewContextWithRoot(ctx, diag, statusDiag, host, pwd, projinfo.Root,
+	ctx, err := plugin.NewContextWithRoot(context.TODO(), diag, statusDiag, host, pwd, projinfo.Root,
 		projinfo.Proj.Runtime.Options(), disableProviderPreview, tracingSpan, projinfo.Proj.Plugins,
 		projinfo.Proj.GetPackageSpecs(), config, debugging)
 	if err != nil {
@@ -64,12 +64,12 @@ func ProjectInfoContext(ctx context.Context, projinfo *Projinfo, host plugin.Hos
 	if logFile := env.DebugGRPC.Value(); logFile != "" {
 		di, err := interceptors.NewDebugInterceptor(interceptors.DebugInterceptorOptions{
 			LogFile: logFile,
-			Mutex:   pctx.DebugTraceMutex,
+			Mutex:   ctx.DebugTraceMutex,
 		})
 		if err != nil {
 			return "", "", nil, err
 		}
-		pctx.DialOptions = func(metadata interface{}) []grpc.DialOption {
+		ctx.DialOptions = func(metadata interface{}) []grpc.DialOption {
 			return di.DialOptions(interceptors.LogOptions{
 				Metadata: metadata,
 			})
@@ -86,14 +86,14 @@ func ProjectInfoContext(ctx context.Context, projinfo *Projinfo, host plugin.Hos
 		if !ok {
 			return "", "", nil, errors.New("address of language runtime service must be a string")
 		}
-		host, err := connectToLanguageRuntime(pctx, address)
+		host, err := connectToLanguageRuntime(ctx, address)
 		if err != nil {
 			return "", "", nil, err
 		}
-		pctx.Host = host
+		ctx.Host = host
 	}
 
-	return pwd, main, pctx, nil
+	return pwd, main, ctx, nil
 }
 
 // newDeploymentContext creates a context for a subsequent deployment. Callers must call Close on the context after the
@@ -190,7 +190,7 @@ func newDeployment(
 
 	// Create a context for plugins.
 	debugContext := newDebugContext(opts.Events, opts.AttachDebugger)
-	pwd, main, plugctx, err := ProjectInfoContext(ctx.Cancel.Base(), projinfo, opts.Host,
+	pwd, main, plugctx, err := ProjectInfoContext(projinfo, opts.Host,
 		opts.Diag, opts.StatusDiag, debugContext, opts.DisableProviderPreview, info.TracingSpan, config)
 	if err != nil {
 		return nil, err

--- a/pkg/util/cancel/context.go
+++ b/pkg/util/cancel/context.go
@@ -61,10 +61,6 @@ func NewContext(ctx context.Context) (*Context, *Source) {
 	return c, s
 }
 
-func (c *Context) Base() context.Context {
-	return c.cancel
-}
-
 // Canceled returns a channel that will be closed when the context is canceled or terminated.
 func (c *Context) Canceled() <-chan struct{} {
 	return c.cancel.Done()


### PR DESCRIPTION
This reverts commit 3e5b321f1a4d6ba9b0e716bbdd7653e812832ad5.

It looks like the daily matrix has been failing consistently starting 18/09 on TestCancelSignal since [the context PR](https://github.com/pulumi/pulumi/pull/20397) was merged on 17/09 https://github.com/pulumi/pulumi/issues/20469

When an operation is cancelled, the context is canceled, causing downstream work to cancel or not proceed at all, for example provider RPC calls for `SignalCancellation` fail immediately because of the cancelled context.

This also seems to create some test flakiness. The cancellation induces an error in the program, which is reported as a bail error. This races with the intended cancellation in the step executor. This can result in different error reporting for tests that validate cancellation or error paths.