### PR TITLE
Add a public export map accessor for unit testing (NodeJS)

### DIFF
--- a/changelog/pending/20250925--sdk-nodejs--allow-access-to-the-exported-properties-for-test-assertions.yaml
+++ b/changelog/pending/20250925--sdk-nodejs--allow-access-to-the-exported-properties-for-test-assertions.yaml
@@ -1,0 +1,6 @@
+component: sdk/nodejs
+kind: feat
+body: Allow access to the exported properties for test assertions
+time: 2026-06-10T11:44:00.000000+00:00
+custom:
+    PR: "20575"

--- a/sdk/nodejs/runtime/stack.ts
+++ b/sdk/nodejs/runtime/stack.ts
@@ -73,10 +73,15 @@ export class Stack extends ComponentResource<Inputs> {
         // Set the global reference to the stack resource before invoking this init() function
         setStackResource(this);
 
+        const store = getStore();
+        store.currentExportMap = undefined;
+
         let outputs: Inputs | undefined;
         try {
             const inputs = await args.init();
-            outputs = await massage(undefined, inputs, []);
+            outputs = massage(undefined, inputs, []);
+
+            store.currentExportMap = await output(outputs).promise(true);
         } finally {
             // We want to expose stack outputs as simple pojo objects (including Resources).  This
             // helps ensure that outputs can point to resources, and that that is stored and

--- a/sdk/nodejs/runtime/state.ts
+++ b/sdk/nodejs/runtime/state.ts
@@ -16,6 +16,7 @@ import { AsyncLocalStorage } from "async_hooks";
 import { ICallbackServer } from "./callbacks";
 import * as config from "./config";
 import { Stack } from "./stack";
+import { Inputs } from "../output";
 
 import * as engrpc from "../proto/engine_grpc_pb";
 import * as resrpc from "../proto/resource_grpc_pb";
@@ -126,6 +127,7 @@ export interface Store {
     leakCandidates: Set<Promise<any>>;
     logErrorCount: number;
     terminated: boolean;
+    currentExportMap?: Inputs;
 
     /**
      * Tells us if the resource monitor we are connected to is able to support
@@ -250,6 +252,7 @@ export class LocalStore implements Store {
         [config.configSecretKeysEnvKey]: process.env[config.configSecretKeysEnvKey] || "",
     };
     stackResource = undefined;
+    currentExportMap = undefined;
 
     /**
      * Tracks the list of potential leak candidates.

--- a/sdk/nodejs/tests_with_mocks/exports.spec.ts
+++ b/sdk/nodejs/tests_with_mocks/exports.spec.ts
@@ -1,0 +1,52 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import "mocha";
+import * as assert from "assert";
+import * as pulumi from "../index";
+import { getStore } from "../runtime/state";
+
+describe("program exports via runtime stack", () => {
+    before(() => {
+        pulumi.runtime.setMocks({
+            call: () => ({}),
+            newResource: (args) => ({ id: `${args.name}_id`, state: args.inputs }),
+        });
+    });
+
+    it("resolves exports to plain values and records export map", async () => {
+        const outs = await pulumi.runtime.runInPulumiStack(async () => {
+            const nested = pulumi.output(Promise.resolve({ n: 1 }));
+            return {
+                a: 42,
+                b: pulumi.output(99),
+                c: { x: nested, y: "z" },
+            } as const;
+        });
+
+        assert.deepStrictEqual(outs, { a: 42, b: 99, c: { x: { n: 1 }, y: "z" } });
+
+        const exportMap = getStore().currentExportMap as Record<string, any> | undefined;
+        assert.ok(exportMap, "expected currentExportMap to be set after stack outputs registration");
+        assert.deepStrictEqual(exportMap, { a: 42, b: 99, c: { x: { n: 1 }, y: "z" } });
+    });
+
+    it("replaces the export map on each sequential stack run", async () => {
+        await pulumi.runtime.runInPulumiStack(async () => ({ first: 1 }));
+        assert.deepStrictEqual(getStore().currentExportMap, { first: 1 });
+
+        await pulumi.runtime.runInPulumiStack(async () => ({ second: 2 }));
+        assert.deepStrictEqual(getStore().currentExportMap, { second: 2 });
+    });
+});

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -129,6 +129,7 @@
         "tests/provider/experimental/analyzer.spec.ts",
         "tests/provider/experimental/schema.spec.ts",
         "tests_with_mocks/mocks.spec.ts",
+        "tests_with_mocks/exports.spec.ts",
         "npm/testdata/nested/project/index.ts",
         "types/arborist.d.ts",
         "types/fdir.d.ts"


### PR DESCRIPTION
Continuation of https://github.com/pulumi/pulumi/pull/20472 to address https://github.com/pulumi/pulumi/issues/6113.

Long-time listeners may remember this PR from before, and our conversations to avoid it using the event stream. While I still think that's a better fix, this issue needs closing, and the code already exists in Go, so we should probably just add this for now and deprecate it when we have a better solution.