### PR TITLE
Improve crypter calls in tests

### DIFF
--- a/pkg/cmd/pulumi/config/io_test.go
+++ b/pkg/cmd/pulumi/config/io_test.go
@@ -306,15 +306,15 @@ func TestStackEnvConfig(t *testing.T) {
 
 	mockSecretsManager := &secrets.MockSecretsManager{
 		EncrypterF: func() config.Encrypter {
-			encrypter := &secrets.MockEncrypter{EncryptValueF: func() string { return "ciphertext" }}
+			encrypter := &secrets.MockEncrypter{EncryptValueF: func(_ string) string { return "ciphertext" }}
 			return encrypter
 		},
 		DecrypterF: func() config.Decrypter {
 			decrypter := &secrets.MockDecrypter{
-				DecryptValueF: func() string {
+				DecryptValueF: func(_ string) string {
 					return "plaintext"
 				},
-				BatchDecryptF: func() []string {
+				BatchDecryptF: func(_ []string) []string {
 					return []string{
 						"whatiamdoing",
 					}
@@ -391,15 +391,15 @@ func TestCopyConfig(t *testing.T) {
 
 	mockSecretsManager := &secrets.MockSecretsManager{
 		EncrypterF: func() config.Encrypter {
-			encrypter := &secrets.MockEncrypter{EncryptValueF: func() string { return "ciphertext" }}
+			encrypter := &secrets.MockEncrypter{EncryptValueF: func(_ string) string { return "ciphertext" }}
 			return encrypter
 		},
 		DecrypterF: func() config.Decrypter {
 			decrypter := &secrets.MockDecrypter{
-				DecryptValueF: func() string {
+				DecryptValueF: func(_ string) string {
 					return "plaintext"
 				},
-				BatchDecryptF: func() []string {
+				BatchDecryptF: func(_ []string) []string {
 					return []string{
 						"whatiamdoing",
 					}

--- a/pkg/cmd/pulumi/stack/secrets_test.go
+++ b/pkg/cmd/pulumi/stack/secrets_test.go
@@ -63,7 +63,7 @@ func TestStackSecretsManagerLoaderDecrypterFallsBack(t *testing.T) {
 	sm := &secrets.MockSecretsManager{
 		TypeF: func() string { return "mock" },
 		DecrypterF: func() config.Decrypter {
-			return &secrets.MockDecrypter{DecryptValueF: func() string { return "defaulted plaintext" }}
+			return &secrets.MockDecrypter{DecryptValueF: func(_ string) string { return "defaulted plaintext" }}
 		},
 	}
 	snap := &deploy.Snapshot{SecretsManager: sm}
@@ -134,7 +134,7 @@ func TestStackSecretsManagerLoaderDecrypterUsesDefaultSecretsManager(t *testing.
 	sm := &secrets.MockSecretsManager{
 		TypeF: func() string { return "mock" },
 		DecrypterF: func() config.Decrypter {
-			return &secrets.MockDecrypter{DecryptValueF: func() string { return "defaulted plaintext" }}
+			return &secrets.MockDecrypter{DecryptValueF: func(_ string) string { return "defaulted plaintext" }}
 		},
 	}
 
@@ -171,7 +171,7 @@ func TestStackSecretsManagerLoaderEncrypterFallsBack(t *testing.T) {
 	sm := &secrets.MockSecretsManager{
 		TypeF: func() string { return "mock" },
 		EncrypterF: func() config.Encrypter {
-			return &secrets.MockEncrypter{EncryptValueF: func() string { return "defaulted ciphertext" }}
+			return &secrets.MockEncrypter{EncryptValueF: func(_ string) string { return "defaulted ciphertext" }}
 		},
 	}
 	snap := &deploy.Snapshot{SecretsManager: sm}
@@ -242,7 +242,7 @@ func TestStackSecretsManagerLoaderEncrypterUsesDefaultSecretsManager(t *testing.
 	sm := &secrets.MockSecretsManager{
 		TypeF: func() string { return "mock" },
 		EncrypterF: func() config.Encrypter {
-			return &secrets.MockEncrypter{EncryptValueF: func() string { return "defaulted ciphertext" }}
+			return &secrets.MockEncrypter{EncryptValueF: func(_ string) string { return "defaulted ciphertext" }}
 		},
 	}
 

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -2001,6 +2001,10 @@ func TestEvalSource(t *testing.T) {
 								decrypterCalled = true
 								return "", errors.New("expected fail")
 							},
+							BatchDecryptF: func(ctx context.Context, ciphertexts []string) ([]string, error) {
+								decrypterCalled = true
+								return nil, errors.New("expected fail")
+							},
 						},
 					},
 				},
@@ -2035,6 +2039,15 @@ func TestEvalSource(t *testing.T) {
 									return "", nil
 								}
 								return "", errors.New("expected fail")
+							},
+							BatchDecryptF: func(ctx context.Context, ciphertexts []string) ([]string, error) {
+								decrypterCalled = true
+								if called == 0 {
+									// Will cause the next invocation to fail.
+									called++
+									return []string{}, nil
+								}
+								return nil, errors.New("expected fail")
 							},
 						},
 					},

--- a/pkg/secrets/mock.go
+++ b/pkg/secrets/mock.go
@@ -65,13 +65,13 @@ func (msm *MockSecretsManager) Decrypter() config.Decrypter {
 }
 
 type MockEncrypter struct {
-	EncryptValueF func() string
-	BatchEncryptF func() []string
+	EncryptValueF func(plaintext string) string
+	BatchEncryptF func(secrets []string) []string
 }
 
 func (me *MockEncrypter) EncryptValue(ctx context.Context, plaintext string) (string, error) {
 	if me.EncryptValueF != nil {
-		return me.EncryptValueF(), nil
+		return me.EncryptValueF(plaintext), nil
 	}
 
 	return "", errors.New("mock value not provided")
@@ -79,19 +79,19 @@ func (me *MockEncrypter) EncryptValue(ctx context.Context, plaintext string) (st
 
 func (me *MockEncrypter) BatchEncrypt(ctx context.Context, secrets []string) ([]string, error) {
 	if me.BatchEncryptF != nil {
-		return me.BatchEncryptF(), nil
+		return me.BatchEncryptF(secrets), nil
 	}
 	return nil, errors.New("batch encrypt mock not provided")
 }
 
 type MockDecrypter struct {
-	DecryptValueF func() string
-	BatchDecryptF func() []string
+	DecryptValueF func(ciphertext string) string
+	BatchDecryptF func(ciphertexts []string) []string
 }
 
 func (md *MockDecrypter) DecryptValue(ctx context.Context, ciphertext string) (string, error) {
 	if md.DecryptValueF != nil {
-		return md.DecryptValueF(), nil
+		return md.DecryptValueF(ciphertext), nil
 	}
 
 	return "", errors.New("mock value not provided")
@@ -99,7 +99,7 @@ func (md *MockDecrypter) DecryptValue(ctx context.Context, ciphertext string) (s
 
 func (md *MockDecrypter) BatchDecrypt(ctx context.Context, ciphertexts []string) ([]string, error) {
 	if md.BatchDecryptF != nil {
-		return md.BatchDecryptF(), nil
+		return md.BatchDecryptF(ciphertexts), nil
 	}
 
 	return nil, errors.New("mock value not provided")

--- a/sdk/go/common/resource/config/crypt.go
+++ b/sdk/go/common/resource/config/crypt.go
@@ -323,7 +323,7 @@ func (c *base64Crypter) EncryptValue(ctx context.Context, s string) (string, err
 }
 
 func (c *base64Crypter) BatchEncrypt(ctx context.Context, secrets []string) ([]string, error) {
-	return nil, errors.New("BatchEncrypt not supported for base64Crypter")
+	return DefaultBatchEncrypt(ctx, c, secrets)
 }
 
 func (c *base64Crypter) DecryptValue(ctx context.Context, s string) (string, error) {


### PR DESCRIPTION
This PR improves several crypter calls in tests:
- Pass parameters in mocked encrypt/decrypt calls
- Make base64 crypter use default batch encryption
- Handle batch calls in source eval test