### PR TITLE
Deprecate `sdk/go/common/util/rpcutil.Serve`

### DIFF
--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -2579,12 +2579,13 @@ func startUpdate(t *testing.T, hostF deploytest.PluginHostFactory) (*updateConte
 	}
 
 	stop := make(chan bool)
-	port, _, err := rpcutil.Serve(0, stop, []func(*grpc.Server) error{
-		func(srv *grpc.Server) error {
+	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+		Cancel: stop,
+		Init: func(srv *grpc.Server) error {
 			pulumirpc.RegisterLanguageRuntimeServer(srv, ctx)
 			return nil
 		},
-	}, nil)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -2593,7 +2594,7 @@ func startUpdate(t *testing.T, hostF deploytest.PluginHostFactory) (*updateConte
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 		Runtime: "client",
 		RuntimeOptions: map[string]interface{}{
-			"address": fmt.Sprintf("127.0.0.1:%d", port),
+			"address": fmt.Sprintf("127.0.0.1:%d", handle.Port),
 		},
 	}
 

--- a/sdk/go/common/util/rpcutil/serve.go
+++ b/sdk/go/common/util/rpcutil/serve.go
@@ -136,7 +136,7 @@ func serveWithOptions(opts ServeOptions) (ServeHandle, chan error, error) {
 	return ServeHandle{Port: port, Done: done}, done, nil
 }
 
-// Deprecated. Please use ServeWithOptions and OpenTracingServerInterceptorOptions.
+// Deprecated: Please use [ServeWithOptions] and [OpenTracingServerInterceptorOptions].
 func Serve(port int, cancel chan bool, registers []func(*grpc.Server) error,
 	parentSpan opentracing.Span, options ...otgrpc.Option,
 ) (int, chan error, error) {


### PR DESCRIPTION
This function was previously marked deprecated, and has been since November 2022. This PR moves `pulumi/pulumi` off of the deprecated function and changes the deprecation syntax so [`staticcheck`](https://github.com/dominikh/go-tools) (via `golangci-lint`) actually flags the deprecation.

This is in preparation for switching from open tracing to open telemetry.