### PR TITLE
[PCL] Fix panic in parseProxyApply when encoutering warning diagnostics

### DIFF
--- a/changelog/pending/20250925--programgen--fix-panic-in-parseproxyapply-when-encoutering-warning-diagnostics.yaml
+++ b/changelog/pending/20250925--programgen--fix-panic-in-parseproxyapply-when-encoutering-warning-diagnostics.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Fix panic in parseProxyApply when encoutering warning diagnostics

--- a/pkg/codegen/nodejs/gen_program_lower.go
+++ b/pkg/codegen/nodejs/gen_program_lower.go
@@ -127,7 +127,7 @@ func (g *generator) parseProxyApply(parameters codegen.Set, args []model.Express
 	}
 
 	diags := arg.Typecheck(false)
-	contract.Assertf(len(diags) == 0, "unexpected type error: %v", diags)
+	contract.Assertf(!diags.HasErrors(), "unexpected type error: %v", diags)
 	return arg, true
 }
 

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -572,7 +572,11 @@ func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 						}),
 					}
 					diags := condExpr.Typecheck(false)
-					contract.Assertf(len(diags) == 0, "failed to typecheck conditional expression: %v", diags)
+					checkDiagnostics := len(diags) == 0
+					if b.options.skipResourceTypecheck {
+						checkDiagnostics = !diags.HasErrors()
+					}
+					contract.Assertf(checkDiagnostics, "failed to typecheck conditional expression: %v", diags)
 
 					node.VariableType = condExpr.Type()
 				case model.InputType(model.NumberType).ConversionFrom(typ) == model.SafeConversion:
@@ -593,7 +597,11 @@ func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 						Value: model.VariableReference(resourceVar),
 					}
 					diags := rangeExpr.Typecheck(false)
-					contract.Assertf(len(diags) == 0, "failed to typecheck range expression: %v", diags)
+					checkDiagnostics := len(diags) == 0
+					if b.options.skipResourceTypecheck {
+						checkDiagnostics = !diags.HasErrors()
+					}
+					contract.Assertf(checkDiagnostics, "failed to typecheck range expression: %v", diags)
 
 					rangeValue = model.IntType
 

--- a/pkg/codegen/python/gen_program_lower.go
+++ b/pkg/codegen/python/gen_program_lower.go
@@ -72,7 +72,7 @@ func (g *generator) parseProxyApply(parameters codegen.Set, args []model.Express
 	}
 
 	diags := arg.Typecheck(false)
-	contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
+	contract.Assertf(!diags.HasErrors(), "unexpected error diagnostics: %v", diags)
 	return arg, true
 }
 


### PR DESCRIPTION
Follow up to #20453 

It looks like there were a few more places where we needed to check for warnings instead of errors of after `<expr>.Typecheck(...)`otherwise we panic as reported by @guineveresaenger [here](https://github.com/pulumi/pulumi/issues/20419#issuecomment-3335436933)

Fixes #20419