### PR TITLE
add a version to the journal entry

### DIFF
--- a/pkg/backend/journal.go
+++ b/pkg/backend/journal.go
@@ -75,6 +75,7 @@ func SerializeJournalEntry(
 	}
 
 	serializedEntry := apitype.JournalEntry{
+		Version:               1,
 		Kind:                  apitype.JournalEntryKind(je.Kind),
 		SequenceID:            je.SequenceID,
 		OperationID:           je.OperationID,

--- a/sdk/go/common/apitype/journal.go
+++ b/sdk/go/common/apitype/journal.go
@@ -27,6 +27,9 @@ const (
 )
 
 type JournalEntry struct {
+	// Version of the journal entry format.
+	Version int `json:"version"`
+	// Kind of journal entry.
 	Kind JournalEntryKind `json:"kind"`
 	// Sequence ID of the operation.
 	SequenceID int64 `json:"sequenceID"`


### PR DESCRIPTION
We want to be sure to be able to evolve journal entries.  Add a version to each journal entry, so we can do that. We could just version them by negotiating the version number with the service, but this makes things safer.

Based on top of https://github.com/pulumi/pulumi/pull/20559