### PR TITLE
Replace assert.Equal(t, 0, len(x)) with assert.Empty(t, x)

### DIFF
--- a/cmd/pulumi-test-language/tests/l2_target_up_with_new_dependency.go
+++ b/cmd/pulumi-test-language/tests/l2_target_up_with_new_dependency.go
@@ -45,7 +45,7 @@ func init() {
 
 					unrelated := RequireSingleNamedResource(l, snap.Resources, "unrelated")
 					require.Equal(l, "simple:index:Resource", unrelated.Type.String(), "expected simple resource")
-					require.Equal(l, 0, len(unrelated.Dependencies), "expected no dependencies")
+					require.Empty(l, unrelated.Dependencies, "expected no dependencies")
 				},
 			},
 			{
@@ -65,7 +65,7 @@ func init() {
 					require.Equal(l, "simple:index:Resource", target.Type.String(), "expected simple resource")
 					unrelated := RequireSingleNamedResource(l, snap.Resources, "unrelated")
 					require.Equal(l, "simple:index:Resource", unrelated.Type.String(), "expected simple resource")
-					require.Equal(l, 0, len(unrelated.Dependencies), "expected still no dependencies")
+					require.Empty(l, unrelated.Dependencies, "expected still no dependencies")
 				},
 			},
 		},

--- a/pkg/cmd/pulumi/state/state_move_test.go
+++ b/pkg/cmd/pulumi/state/state_move_test.go
@@ -333,10 +333,10 @@ Successfully moved resources from organization/test/sourceStack to organization/
 		destSnapshot.Resources[1].URN)
 	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::d:e:f$a:b:c::resToMove"),
 		destSnapshot.Resources[2].URN)
-	assert.Equal(t, 0, len(destSnapshot.Resources[2].Dependencies))
+	assert.Empty(t, destSnapshot.Resources[2].Dependencies)
 	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::d:e:f$a:b:c::movedChildURN"),
 		destSnapshot.Resources[3].URN)
-	assert.Equal(t, 0, len(destSnapshot.Resources[3].Dependencies))
+	assert.Empty(t, destSnapshot.Resources[3].Dependencies)
 	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::d:e:f$a:b:c::dependsOnMovedChildURN"),
 		destSnapshot.Resources[4].URN)
 	assert.Equal(t, 1, len(destSnapshot.Resources[4].Dependencies))

--- a/pkg/codegen/hcl2/model/type_test.go
+++ b/pkg/codegen/hcl2/model/type_test.go
@@ -33,7 +33,7 @@ func testTraverse(t *testing.T, receiver Traversable, traverser hcl.Traverser, e
 	if expectDiags {
 		assert.Greater(t, len(diags), 0)
 	} else {
-		assert.Equal(t, 0, len(diags))
+		assert.Empty(t, diags)
 	}
 }
 

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -322,7 +322,7 @@ output cidrBlock {
 `
 	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(diags), "There are no diagnostics")
+	assert.Empty(t, diags, "There are no diagnostics")
 	require.NotNil(t, program)
 }
 
@@ -350,7 +350,7 @@ func TestUsingDynamicConfigAsRange(t *testing.T) {
 
 	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(diags), "There are no diagnostics")
+	assert.Empty(t, diags, "There are no diagnostics")
 	require.NotNil(t, program)
 }
 
@@ -365,7 +365,7 @@ func TestLengthFunctionCanBeUsedWithDynamic(t *testing.T) {
 `
 	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(diags), "There are no diagnostics")
+	assert.Empty(t, diags, "There are no diagnostics")
 	require.NotNil(t, program)
 }
 
@@ -531,7 +531,7 @@ func TestTraversalOfOptionalObject(t *testing.T) {
 	// first assert that binding the program works
 	program, diags, err := ParseAndBindProgram(t, source, "program.pp")
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(diags), "There are no diagnostics")
+	assert.Empty(t, diags, "There are no diagnostics")
 	require.NotNil(t, program)
 
 	// get the output variable

--- a/pkg/engine/lifecycletest/analyzer_test.go
+++ b/pkg/engine/lifecycletest/analyzer_test.go
@@ -586,7 +586,7 @@ func TestRemediateFailure(t *testing.T) {
 	snap, res := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 	require.NotNil(t, res)
 	require.NotNil(t, snap)
-	assert.Equal(t, 0, len(snap.Resources))
+	assert.Empty(t, snap.Resources)
 }
 
 func TestSimpleAnalyzeResourceFailureRemediateDowngradedToMandatory(t *testing.T) {

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -1237,7 +1237,7 @@ func TestRefreshUpdateWithDeletedResource(t *testing.T) {
 
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, old)
-	assert.Equal(t, 0, len(snap.Resources))
+	assert.Empty(t, snap.Resources)
 }
 
 // Test that we can run a simple refresh by executing the program for it.

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -2998,7 +2998,7 @@ func TestDependencyUnreleatedToTargetUpdatedSucceeds(t *testing.T) {
 	assert.Equal(t, 4, len(snap.Resources))
 	unrelatedURN := snap.Resources[3].URN
 	assert.Equal(t, "unrelated", unrelatedURN.Name())
-	assert.Equal(t, 0, len(snap.Resources[2].Dependencies))
+	assert.Empty(t, snap.Resources[2].Dependencies)
 }
 
 func TestTargetUntargetedParentWithUpdatedDependency(t *testing.T) {
@@ -3099,7 +3099,7 @@ func TestTargetUntargetedParentWithUpdatedDependency(t *testing.T) {
 		assert.Equal(t, "parent", parentURN.Name())
 		assert.Equal(t, parentURN, snap.Resources[4].Parent)
 		parentDeps := snap.Resources[3].Dependencies
-		assert.Equal(t, 0, len(parentDeps))
+		assert.Empty(t, parentDeps)
 	})
 
 	//nolint:paralleltest // Requires serial access to TestPlan

--- a/pkg/operations/resources_test.go
+++ b/pkg/operations/resources_test.go
@@ -86,7 +86,7 @@ func TestCrawler(t *testing.T) {
 	topic, ok := components.GetChild("cloud:topic:Topic", "countDown")
 	assert.True(t, ok)
 	require.NotNil(t, topic)
-	assert.Equal(t, 0, len(topic.State.Inputs))
+	assert.Empty(t, topic.State.Inputs)
 	assert.Equal(t, 1, len(topic.Children))
 	topic, ok = topic.GetChild("aws:sns/topic:Topic", "countDown")
 	assert.True(t, ok)

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -148,7 +148,7 @@ func TestDeploymentSerialization(t *testing.T) {
 	assert.Equal(t, true, dep.Inputs["in-array"].([]interface{})[1])
 	assert.Equal(t, float64(32), dep.Inputs["in-array"].([]interface{})[2])
 	require.NotNil(t, dep.Inputs["in-empty-array"])
-	assert.Equal(t, 0, len(dep.Inputs["in-empty-array"].([]interface{})))
+	assert.Empty(t, dep.Inputs["in-empty-array"].([]interface{}))
 	require.NotNil(t, dep.Inputs["in-map"])
 	inmap := dep.Inputs["in-map"].(map[string]interface{})
 	assert.Equal(t, 4, len(inmap))
@@ -161,7 +161,7 @@ func TestDeploymentSerialization(t *testing.T) {
 	require.NotNil(t, inmap["d"])
 	assert.Equal(t, "d-dee-daw", inmap["d"].(string))
 	require.NotNil(t, dep.Inputs["in-empty-map"])
-	assert.Equal(t, 0, len(dep.Inputs["in-empty-map"].(map[string]interface{})))
+	assert.Empty(t, dep.Inputs["in-empty-map"].(map[string]interface{}))
 	assert.Equal(t, map[string]interface{}{
 		resource.SigKey:  resource.ResourceReferenceSig,
 		"urn":            "urn",
@@ -194,7 +194,7 @@ func TestDeploymentSerialization(t *testing.T) {
 	assert.Equal(t, false, dep.Outputs["out-array"].([]interface{})[0])
 	assert.Equal(t, "zzxx", dep.Outputs["out-array"].([]interface{})[1])
 	require.NotNil(t, dep.Outputs["out-empty-array"])
-	assert.Equal(t, 0, len(dep.Outputs["out-empty-array"].([]interface{})))
+	assert.Empty(t, dep.Outputs["out-empty-array"].([]interface{}))
 	require.NotNil(t, dep.Outputs["out-map"])
 	outmap := dep.Outputs["out-map"].(map[string]interface{})
 	assert.Equal(t, 3, len(outmap))
@@ -205,7 +205,7 @@ func TestDeploymentSerialization(t *testing.T) {
 	require.NotNil(t, outmap["z"])
 	assert.Equal(t, float64(999.9), outmap["z"].(float64))
 	require.NotNil(t, dep.Outputs["out-empty-map"])
-	assert.Equal(t, 0, len(dep.Outputs["out-empty-map"].(map[string]interface{})))
+	assert.Empty(t, dep.Outputs["out-empty-map"].(map[string]interface{}))
 }
 
 // TestSerializeDeploymentWithMetadata tests that the appropriate version and features are used when

--- a/pkg/workspace/plugins_install_test.go
+++ b/pkg/workspace/plugins_install_test.go
@@ -316,5 +316,5 @@ func TestGetPluginsSkipsPartial(t *testing.T) {
 
 	plugins, err := workspace.GetPluginsFromDir(dir)
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(plugins))
+	assert.Empty(t, plugins)
 }

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -2579,7 +2579,7 @@ func TestSupportsStackOutputs(t *testing.T) {
 		t.FailNow()
 	}
 
-	assert.Equal(t, 0, len(initialOutputs))
+	assert.Empty(t, initialOutputs)
 
 	// -- pulumi up --
 	res, err := s.Up(ctx)
@@ -2617,7 +2617,7 @@ func TestSupportsStackOutputs(t *testing.T) {
 		t.FailNow()
 	}
 
-	assert.Equal(t, 0, len(outputsAfterDestroy))
+	assert.Empty(t, outputsAfterDestroy)
 }
 
 func TestShallowClone(t *testing.T) {

--- a/sdk/go/common/resource/asset_test.go
+++ b/sdk/go/common/resource/asset_test.go
@@ -355,7 +355,7 @@ func TestArchiveSerialize(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, isarchive)
 		assert.True(t, archiveDes.IsAssets())
-		assert.Equal(t, 0, len(archiveDes.Assets))
+		assert.Empty(t, archiveDes.Assets)
 	})
 	t.Run("empty archive", func(t *testing.T) {
 		t.Parallel()
@@ -363,7 +363,7 @@ func TestArchiveSerialize(t *testing.T) {
 		// Check that a fully empty archive is treated as an empty assets archive.
 		empty := &rarchive.Archive{}
 		assert.True(t, empty.IsAssets())
-		assert.Equal(t, 0, len(empty.Assets))
+		assert.Empty(t, empty.Assets)
 		emptySer := empty.Serialize()
 		emptyDes, isarchive, err := rarchive.Deserialize(emptySer)
 		require.NoError(t, err)

--- a/sdk/go/common/resource/properties_diff_test.go
+++ b/sdk/go/common/resource/properties_diff_test.go
@@ -131,9 +131,9 @@ func TestArrayPropertyValueDiffs(t *testing.T) {
 	require.NotNil(t, d3)
 	require.NotNil(t, d3.Array)
 	assert.Nil(t, d3.Object)
-	assert.Equal(t, 0, len(d3.Array.Adds))
-	assert.Equal(t, 0, len(d3.Array.Deletes))
-	assert.Equal(t, 0, len(d3.Array.Sames))
+	assert.Empty(t, d3.Array.Adds)
+	assert.Empty(t, d3.Array.Deletes)
+	assert.Empty(t, d3.Array.Sames)
 	assert.Equal(t, 3, len(d3.Array.Updates))
 	for i, update := range d3.Array.Updates {
 		assert.Equal(t, d3a1.ArrayValue()[i], update.Old)
@@ -151,7 +151,7 @@ func TestArrayPropertyValueDiffs(t *testing.T) {
 	require.NotNil(t, d4)
 	require.NotNil(t, d4.Array)
 	assert.Nil(t, d4.Object)
-	assert.Equal(t, 0, len(d4.Array.Adds))
+	assert.Empty(t, d4.Array.Adds)
 	assert.Equal(t, 1, len(d4.Array.Deletes))
 	for i, delete := range d4.Array.Deletes {
 		assert.Equal(t, 2, i)
@@ -186,7 +186,7 @@ func TestArrayPropertyValueDiffs(t *testing.T) {
 		assert.Equal(t, 2, i)
 		assert.Equal(t, d5a2.ArrayValue()[i], add)
 	}
-	assert.Equal(t, 0, len(d5.Array.Deletes))
+	assert.Empty(t, d5.Array.Deletes)
 	assert.Equal(t, 1, len(d5.Array.Sames))
 	for i, same := range d5.Array.Sames {
 		assert.Equal(t, 1, i)
@@ -234,9 +234,9 @@ func TestObjectPropertyValueDiffs(t *testing.T) {
 		assertDeepEqualsIffEmptyDiff(t, NewPropertyValue(obj1), NewPropertyValue(obj2))
 		d3 := obj1.Diff(obj2)
 		require.NotNil(t, d3)
-		assert.Equal(t, 0, len(d3.Adds))
-		assert.Equal(t, 0, len(d3.Deletes))
-		assert.Equal(t, 0, len(d3.Sames))
+		assert.Empty(t, d3.Adds)
+		assert.Empty(t, d3.Deletes)
+		assert.Empty(t, d3.Sames)
 		assert.Equal(t, 3, len(d3.Updates))
 		d3pa := d3.Updates[PropertyKey("prop-a")]
 		assert.Nil(t, d3pa.Array)
@@ -255,9 +255,9 @@ func TestObjectPropertyValueDiffs(t *testing.T) {
 		d3pc := d3.Updates[PropertyKey("prop-c")]
 		assert.Nil(t, d3pc.Array)
 		require.NotNil(t, d3pc.Object)
-		assert.Equal(t, 0, len(d3pc.Object.Adds))
-		assert.Equal(t, 0, len(d3pc.Object.Deletes))
-		assert.Equal(t, 0, len(d3pc.Object.Sames))
+		assert.Empty(t, d3pc.Object.Adds)
+		assert.Empty(t, d3pc.Object.Deletes)
+		assert.Empty(t, d3pc.Object.Sames)
 		assert.Equal(t, 1, len(d3pc.Object.Updates))
 		d3pcu := d3pc.Object.Updates[PropertyKey("inner-prop-a")]
 		assert.True(t, d3pcu.Old.IsNumber())

--- a/sdk/go/common/slice/slice_test.go
+++ b/sdk/go/common/slice/slice_test.go
@@ -43,7 +43,7 @@ func TestPrealloc(t *testing.T) {
 
 		result := Prealloc[string](5)
 		require.NotNil(t, result)
-		assert.Equal(t, 0, len(result))
+		assert.Empty(t, result)
 		assert.Equal(t, 5, cap(result))
 	})
 }

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -970,7 +970,7 @@ config: ./some/path`
 	project, projectError := loadProjectFromText(t, projectYaml)
 	require.NoError(t, projectError, "Shold be able to load the project")
 	assert.Equal(t, "./some/path", project.StackConfigDir, "Stack config dir is read from the config property")
-	assert.Equal(t, 0, len(project.Config), "Config should be empty")
+	assert.Empty(t, project.Config, "Config should be empty")
 }
 
 func TestDefningBothConfigAndStackConfigDirErrorsOut(t *testing.T) {

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -587,7 +587,7 @@ func TestMarshalRoundtripNestedSecret(t *testing.T) {
 	// in the unmarshaled value.
 	const resourceFields = 10
 	assert.Equal(t, reflect.TypeOf(inputs).NumField()-resourceFields, len(resolved))
-	assert.Equal(t, 0, len(deps))
+	assert.Empty(t, deps)
 	assert.Equal(t, 15, len(pdeps))
 
 	// Now just unmarshal and ensure the resulting map matches.

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -222,7 +222,7 @@ func TestStackOutputsNodeJS(t *testing.T) {
 				stackRes := stackInfo.Deployment.Resources[0]
 				require.NotNil(t, stackRes)
 				assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
-				assert.Equal(t, 0, len(stackRes.Inputs))
+				assert.Empty(t, stackRes.Inputs)
 				assert.Equal(t, 2, len(stackRes.Outputs))
 				assert.Equal(t, "ABC", stackRes.Outputs["xyz"])
 				assert.Equal(t, float64(42), stackRes.Outputs["foo"])
@@ -464,7 +464,7 @@ func TestStackDependencyGraph(t *testing.T) {
 				urn := string(res.URN)
 				if strings.Contains(urn, "dynamic:Resource::first") {
 					// The first resource doesn't depend on anything.
-					assert.Equal(t, 0, len(res.Dependencies))
+					assert.Empty(t, res.Dependencies)
 					sawFirst = true
 				} else if strings.Contains(urn, "dynamic:Resource::second") {
 					// The second resource uses an Output property of the first resource, so it

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -106,7 +106,7 @@ func TestStackOutputsPython(t *testing.T) {
 				stackRes := stackInfo.Deployment.Resources[0]
 				require.NotNil(t, stackRes)
 				assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
-				assert.Equal(t, 0, len(stackRes.Inputs))
+				assert.Empty(t, stackRes.Inputs)
 				assert.Equal(t, 2, len(stackRes.Outputs))
 				assert.Equal(t, "ABC", stackRes.Outputs["xyz"])
 				assert.Equal(t, float64(42), stackRes.Outputs["foo"])

--- a/tests/stack/stack_test.go
+++ b/tests/stack/stack_test.go
@@ -68,7 +68,7 @@ func TestStackCommands(t *testing.T) {
 		e.RunCommand("pulumi", "stack", "rm", "foo", "--yes")
 
 		stacks, _ = integration.GetStacks(e)
-		assert.Equal(t, 0, len(stacks))
+		assert.Empty(t, stacks)
 	})
 
 	t.Run("StackSelect", func(t *testing.T) {
@@ -198,7 +198,7 @@ func TestStackCommands(t *testing.T) {
 
 		e.RunCommand("pulumi", "stack", "rm", "blighttown", "--yes")
 		stacks, _ = integration.GetStacks(e)
-		assert.Equal(t, 0, len(stacks))
+		assert.Empty(t, stacks)
 
 		// Error
 		out, err := e.RunCommandExpectError("pulumi", "stack", "rm", "anor-londo", "--yes")


### PR DESCRIPTION
This gives better error messages in the cases where x is not empty, showing what the list/map constains rather than just 0!=N.

I'll do a follow up for other `len` checks to use `assert.Len`.