### PR TITLE
skip another flaky tail test

### DIFF
--- a/sdk/go/common/tail/tail_test.go
+++ b/sdk/go/common/tail/tail_test.go
@@ -548,6 +548,9 @@ func reOpen(t *testing.T, poll bool) {
 func TestInotify_WaitForCreateThenMove(t *testing.T) {
 	t.Parallel()
 
+	// TODO[pulumi/pulumi#19888]: Skipping flaky test
+	t.Skip("Skipping because the tail library is flaky.  See pulumi/pulumi#19888")
+
 	tailTest, cleanup := NewTailTest("wait-for-create-then-reopen", t)
 	defer cleanup()
 	os.Remove(tailTest.path + "/test.txt") // Make sure the file does NOT exist.


### PR DESCRIPTION
The `tail` library is unfortunately known to be flaky.  We already have an open issue, let's add this test to be skipped as well, since I've seen it flake in https://github.com/pulumi/pulumi/actions/runs/18095949940/attempts/1?pr=20599.