### PR TITLE
[backend] Add benchmarks for snapshot managers

### DIFF
--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1231,6 +1231,20 @@ func (pc *Client) PatchUpdateCheckpointDelta(ctx context.Context, update UpdateI
 		updateAccessToken(token), httpCallOptions{RetryPolicy: retryAllMethods, GzipCompress: true})
 }
 
+// AppendUpdateJournalEntry appends a new entry to the journal for the given update.
+func (pc *Client) AppendUpdateJournalEntry(ctx context.Context, update UpdateIdentifier,
+	entry apitype.JournalEntry,
+	token UpdateTokenSource,
+) error {
+	req := apitype.AppendUpdateJournalEntryRequest{
+		Entry: entry,
+	}
+
+	// It is safe to retry because SequenceNumber serves as an idempotency key.
+	return pc.updateRESTCall(ctx, "POST", getUpdatePath(update, "journal"), nil, req, nil,
+		updateAccessToken(token), httpCallOptions{RetryPolicy: retryAllMethods, GzipCompress: true})
+}
+
 // CancelUpdate cancels the indicated update.
 func (pc *Client) CancelUpdate(ctx context.Context, update UpdateIdentifier) error {
 	// It is safe to retry this PATCH operation, because it is logically idempotent.

--- a/pkg/backend/httpstate/snapshot.go
+++ b/pkg/backend/httpstate/snapshot.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
@@ -106,6 +107,10 @@ func (persister *cloudSnapshotPersister) saveFullVerbatim(ctx context.Context,
 	return persister.backend.client.PatchUpdateCheckpointVerbatim(
 		persister.context, persister.update, differ.SequenceNumber(),
 		deployment, deploymentVersion, token)
+}
+
+func (persister *cloudSnapshotPersister) Append(ctx context.Context, entry apitype.JournalEntry) error {
+	return persister.backend.client.AppendUpdateJournalEntry(ctx, persister.update, entry, persister.tokenSource)
 }
 
 var _ backend.SnapshotPersister = (*cloudSnapshotPersister)(nil)

--- a/pkg/backend/httpstate/snapshot_benchmark_test.go
+++ b/pkg/backend/httpstate/snapshot_benchmark_test.go
@@ -1,0 +1,731 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpstate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/gofrs/uuid"
+	"github.com/pgavlin/fx/v2"
+	fxm "github.com/pgavlin/fx/v2/maps"
+	fxs "github.com/pgavlin/fx/v2/slices"
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
+	"github.com/pulumi/pulumi/pkg/v3/util/cancel"
+	"github.com/pulumi/pulumi/pkg/v3/util/gsync"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/require"
+)
+
+// The snapshotBackendClient allows calls to the builtin pulumi:pulumi provider to work. A more complete implementation
+// would keep track of stack and resource outputs and return real data in replies.
+type snapshotBackendClient struct{}
+
+func (snapshotBackendClient) GetStackOutputs(
+	ctx context.Context,
+	name string,
+	onDecryptError func(error) error,
+) (resource.PropertyMap, error) {
+	return resource.PropertyMap{}, nil
+}
+
+func (snapshotBackendClient) GetStackResourceOutputs(
+	ctx context.Context,
+	stackName string,
+) (resource.PropertyMap, error) {
+	return resource.PropertyMap{}, nil
+}
+
+// The snapshotBenchProvider implements plugin.Provider by mapping resource URNs to preloaded data. This allows test
+// programs to use arbitrary custom resources without the need to implement providers.
+type snapshotBenchProvider struct {
+	deploytest.Provider
+
+	outputs gsync.Map[resource.URN, resource.PropertyMap]
+}
+
+// Implement Parameterize so that we can return legal results for arbitrary parameterizations.
+func (p *snapshotBenchProvider) Parameterize(
+	ctx context.Context,
+	params plugin.ParameterizeRequest,
+) (plugin.ParameterizeResponse, error) {
+	var name string
+	if v, ok := params.Parameters.(*plugin.ParameterizeValue); ok {
+		name = v.Name
+	} else {
+		uuid, err := uuid.NewV4()
+		if err != nil {
+			return plugin.ParameterizeResponse{}, err
+		}
+		name = uuid.String()
+	}
+
+	return plugin.ParameterizeResponse{
+		Name:    name,
+		Version: semver.MustParse("1.0.0"),
+	}, nil
+}
+
+// Implement Configure to allow for multiple calls
+func (p *snapshotBenchProvider) Configure(
+	ctx context.Context,
+	req plugin.ConfigureRequest,
+) (plugin.ConfigureResponse, error) {
+	return plugin.ConfigureResponse{}, nil
+}
+
+func (p *snapshotBenchProvider) Create(ctx context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+	outputs, ok := p.outputs.Load(req.URN)
+	if !ok {
+		return plugin.CreateResponse{}, fmt.Errorf("unknown resource %v", req.URN)
+	}
+	return plugin.CreateResponse{
+		ID:         "id",
+		Properties: outputs,
+	}, nil
+}
+
+func (p *snapshotBenchProvider) Read(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+	outputs, ok := p.outputs.Load(req.URN)
+	if !ok {
+		return plugin.ReadResponse{}, fmt.Errorf("unknown resource %v", req.URN)
+	}
+	return plugin.ReadResponse{
+		ReadResult: plugin.ReadResult{
+			ID:      "id",
+			Outputs: outputs,
+		},
+	}, nil
+}
+
+func (p *snapshotBenchProvider) Update(ctx context.Context, req plugin.UpdateRequest) (plugin.UpdateResponse, error) {
+	outputs, ok := p.outputs.Load(req.URN)
+	if !ok {
+		return plugin.UpdateResponse{}, fmt.Errorf("unknown resource %v", req.URN)
+	}
+	return plugin.UpdateResponse{
+		Properties: outputs,
+	}, nil
+}
+
+// update drives an update for snapshot manager benchmarking.
+func update(
+	t testing.TB,
+	project string,
+	stack string,
+	base *deploy.Snapshot,
+	snapshots engine.SnapshotManager,
+	program func(info plugin.RunInfo, monitor *deploytest.ResourceMonitor, provider *snapshotBenchProvider) error,
+) error {
+	defer contract.IgnoreClose(snapshots)
+
+	stackName, err := tokens.ParseStackName(stack)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancelF := context.WithCancel(t.Context())
+	defer cancelF()
+
+	cancelCtx, cancelSrc := cancel.NewContext(ctx)
+	defer cancelSrc.Cancel()
+
+	// Drain events.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	defer wg.Wait()
+
+	events := make(chan engine.Event)
+	go func() {
+		for range events {
+		}
+		wg.Done()
+	}()
+	defer close(events)
+
+	provider := &snapshotBenchProvider{}
+	lang := deploytest.NewLanguageRuntime(func(info plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		return program(info, monitor, provider)
+	})
+	host := deploytest.NewPluginHost(nil, nil, lang,
+		// Set up the bench provider to match any provider request.
+		deploytest.NewProviderLoader("*", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return provider, nil
+		}),
+	)
+
+	_, _, err = engine.Update(
+		engine.UpdateInfo{
+			Root: t.TempDir(),
+			Project: &workspace.Project{
+				Name:    tokens.PackageName(project),
+				Runtime: workspace.NewProjectRuntimeInfo("test", nil),
+			},
+			Target: &deploy.Target{
+				Name:      stackName,
+				Config:    nil,
+				Decrypter: config.NopDecrypter,
+				Snapshot:  base,
+			},
+		},
+		&engine.Context{
+			Cancel:          cancelCtx,
+			Events:          events,
+			SnapshotManager: snapshots,
+			PluginManager:   framework.NopPluginManager{},
+			BackendClient:   snapshotBackendClient{},
+		},
+		engine.UpdateOptions{Host: host},
+		false,
+	)
+	require.NoError(t, err)
+
+	return err
+}
+
+// testOrBenchmarkSnapshotManager tests or benchmarks a snapshot manager by running the given program with the given
+// snapshot manager. The program will start from an empty statefile.
+func testOrBenchmarkSnapshotManager(
+	t testing.TB,
+	project string,
+	stack string,
+	newManager func(testing.TB, *deploy.Snapshot) engine.SnapshotManager,
+	program func(info plugin.RunInfo, monitor *deploytest.ResourceMonitor, provider *snapshotBenchProvider) error,
+) {
+	base := &deploy.Snapshot{
+		SecretsManager: b64.NewBase64SecretsManager(),
+	}
+	snapshots := newManager(t, base)
+
+	err := update(t, project, stack, base, snapshots, program)
+	require.NoError(t, err)
+}
+
+// getRun returns a function that can be invoked with a testing.TB in order to run a single benchmark.
+//
+// The returned function will run an update that creates the configured number of independent resources with the
+// configured amount of random deadweight in each resource state.
+func (c dynamicStackCase) getRun(
+	t testing.TB,
+	newManager func(testing.TB, *deploy.Snapshot) engine.SnapshotManager,
+) func(t testing.TB) {
+	return func(t testing.TB) {
+		r := rand.New(rand.NewSource(int64(c.seed))) //nolint:gosec
+		testOrBenchmarkSnapshotManager(
+			t,
+			"test",
+			"test",
+			newManager,
+			func(info plugin.RunInfo, monitor *deploytest.ResourceMonitor, provider *snapshotBenchProvider) error {
+				cancelCtx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				ctx, err := pulumi.NewContext(cancelCtx, pulumi.RunInfo{
+					Project:     info.Project,
+					Stack:       info.Stack,
+					Parallel:    info.Parallel,
+					DryRun:      info.DryRun,
+					MonitorAddr: info.MonitorAddress,
+				})
+				if err != nil {
+					return fmt.Errorf("creating context: %w", err)
+				}
+				defer contract.IgnoreClose(ctx)
+
+				return pulumi.RunWithContext(ctx, func(ctx *pulumi.Context) error {
+					type Dummy struct {
+						pulumi.CustomResourceState
+					}
+
+					for i := 0; i < c.resourceCount; i++ { //nolint:staticcheck
+						name := fmt.Sprintf("dummy-%d", i)
+						urn := resource.NewURN("test", "test", "", "test:dummy:Dummy", name)
+
+						deadweight := c.pseudoRandomString(r, c.resourcePayloadBytes)
+						provider.outputs.Store(urn, resource.PropertyMap{
+							"deadweight": resource.NewProperty(deadweight),
+						})
+
+						var dummy Dummy
+						return ctx.RegisterResource("test:dummy:Dummy", name, pulumi.Map{}, &dummy)
+					}
+					return nil
+				})
+			})
+	}
+}
+
+// recordedReplayCases lists a set of test/benchmark cases, each of which is represented by a state file.
+//
+// The contents of this slice are determined by the comma-separated list of paths in the PULUMI_TEST_SNAPSHOT_REPLAY
+// environment variable.
+var recordedReplayCases = []recordedReplayCase{}
+
+func init() {
+	for _, c := range strings.Split(os.Getenv("PULUMI_TEST_SNAPSHOT_REPLAY"), ",") {
+		if c != "" {
+			recordedReplayCases = append(recordedReplayCases, recordedReplayCase(c))
+		}
+	}
+}
+
+type recordedReplayCase string
+
+func (c recordedReplayCase) getName() string {
+	return filepath.Base(string(c))
+}
+
+// getRun returns a function that can be invoked with a testing.TB in order to run a single benchmark.
+//
+// The returned function will run an update that registers the resources present in its state file in appropriate
+// dependency order.
+func (c recordedReplayCase) getRun(
+	t testing.TB,
+	newManager func(testing.TB, *deploy.Snapshot) engine.SnapshotManager,
+) func(t testing.TB) {
+	type deployment struct {
+		Version    int                   `json:"version"`
+		Deployment *apitype.DeploymentV3 `json:"deployment"`
+	}
+
+	f, err := os.Open(string(c))
+	require.NoError(t, err)
+	defer f.Close()
+
+	var d deployment
+	err = json.NewDecoder(f).Decode(&d)
+	require.NoError(t, err)
+	require.Equal(t, 3, d.Version)
+
+	project, stack := "test", "test"
+	if len(d.Deployment.Resources) != 0 {
+		urn := d.Deployment.Resources[0].URN
+		project, stack = string(urn.Project()), string(urn.Stack())
+	}
+
+	return func(t testing.TB) {
+		testOrBenchmarkSnapshotManager(
+			t,
+			project,
+			stack,
+			newManager,
+			func(info plugin.RunInfo, monitor *deploytest.ResourceMonitor, provider *snapshotBenchProvider) error {
+				r := registrar{project: info.Project, stack: info.Stack, monitor: monitor.Client()}
+
+				// First create resourceData nodes for all of our resources.
+				for _, res := range d.Deployment.Resources {
+					r.declareResource(t.Context(), res)
+				}
+				// Next kick off registration for each resource. The registration of a single resource R will wait on
+				// any resources that R depends upon.
+				for _, res := range d.Deployment.Resources {
+					r.registerResource(context.Background(), res, provider)
+				}
+
+				r.resources.Range(func(_ resource.URN, res *resourceData) bool {
+					if _, _, e := res.wait(); e != nil {
+						err = errors.Join(err, fmt.Errorf("registering resource: %w", e))
+					}
+					return true
+				})
+				return err
+			},
+		)
+	}
+}
+
+func toStrings[S ~string](s []S) []string {
+	return slice.Map(s, func(s S) string { return string(s) })
+}
+
+// A resourceData node serves as a promise for a resource's URN, ID, and registration error.
+type resourceData struct {
+	c *sync.Cond
+
+	done bool
+	urn  string
+	id   string
+	err  error
+}
+
+func newResourceData() *resourceData {
+	m := &sync.Mutex{}
+	return &resourceData{c: sync.NewCond(m)}
+}
+
+func (r *resourceData) resolve(urn, id string, err error) {
+	r.c.L.Lock()
+	defer r.c.L.Unlock()
+
+	r.done, r.urn, r.id, r.err = true, urn, id, err
+	r.c.Broadcast()
+}
+
+func (r *resourceData) wait() (urn, id string, _ error) {
+	r.c.L.Lock()
+	for !r.done {
+		r.c.Wait()
+	}
+	defer r.c.L.Unlock()
+	return r.urn, r.id, r.err
+}
+
+// The registrar is responsible for registring resources from a state file and ensuring that registration happens in
+// dependency order.
+type registrar struct {
+	stack     string
+	project   string
+	monitor   pulumirpc.ResourceMonitorClient
+	resources gsync.Map[resource.URN, *resourceData]
+}
+
+func (r *registrar) DecryptValue(ctx context.Context, v string) (string, error) {
+	return "null", nil
+}
+
+func (r *registrar) BatchDecrypt(ctx context.Context, ciphertexts []string) ([]string, error) {
+	return config.DefaultBatchDecrypt(ctx, r, ciphertexts)
+}
+
+func (r *registrar) mapResourceWithID(resURN resource.URN) (urn, id string, err error) {
+	if resURN == "" {
+		return "", "", nil
+	}
+
+	res, ok := r.resources.Load(resURN)
+	if !ok {
+		return "", "", fmt.Errorf("missing resource %v", urn)
+	}
+	return res.wait()
+}
+
+func (r *registrar) mapResource(resURN resource.URN) (string, error) {
+	urn, _, err := r.mapResourceWithID(resURN)
+	return urn, err
+}
+
+func (r *registrar) mapResources(urns []resource.URN) ([]string, error) {
+	return fxs.TryCollect(fxs.MapUnpack(urns, r.mapResource))
+}
+
+func (r *registrar) mapPropertyDependencies(
+	deps map[resource.PropertyKey][]resource.URN,
+) (map[string]*pulumirpc.RegisterResourceRequest_PropertyDependencies, error) {
+	return fxm.TryCollect(fxm.Map(deps, func(k resource.PropertyKey, deps []resource.URN) (
+		kvp fx.Pair[string, *pulumirpc.RegisterResourceRequest_PropertyDependencies],
+		_ error,
+	) {
+		urns, err := r.mapResources(deps)
+		if err != nil {
+			return kvp, err
+		}
+		return fx.Pack(string(k), &pulumirpc.RegisterResourceRequest_PropertyDependencies{Urns: urns}), nil
+	}))
+}
+
+func (r *registrar) declareResource(ctx context.Context, res apitype.ResourceV3) {
+	if res.Delete || providers.IsDefaultProvider(res.URN) {
+		return
+	}
+	out := newResourceData()
+	r.resources.Store(res.URN, out)
+}
+
+func (r *registrar) registerResource(ctx context.Context, res apitype.ResourceV3, provider *snapshotBenchProvider) {
+	if res.Delete || providers.IsDefaultProvider(res.URN) {
+		return
+	}
+
+	out, ok := r.resources.Load(res.URN)
+	if !ok {
+		return
+	}
+	typ, name := string(res.URN.Type()), res.URN.Name()
+	go func() {
+		out.resolve(func() (resURN, resID string, _ error) {
+			inputs, err := stack.DeserializeProperties(res.Inputs, r)
+			if err != nil {
+				return "", "", fmt.Errorf("deserializing inputs for %v: %w", res.URN, err)
+			}
+			inputObject, err := plugin.MarshalProperties(inputs, plugin.MarshalOptions{
+				KeepSecrets:   true,
+				KeepResources: true,
+			})
+			if err != nil {
+				return "", "", fmt.Errorf("marshaling inputs for %v: %w", res.URN, err)
+			}
+
+			outputs, err := stack.DeserializeProperties(res.Outputs, r)
+			if err != nil {
+				return "", "", fmt.Errorf("deserializing outputs for %v: %w", res.URN, err)
+			}
+
+			parent, err := r.mapResource(res.Parent)
+			if err != nil {
+				return "", "", fmt.Errorf("mapping parent for %v: %w", res.URN, err)
+			}
+
+			deps, err := r.mapResources(res.Dependencies)
+			if err != nil {
+				return "", "", fmt.Errorf("mapping deps for %v: %w", res.URN, err)
+			}
+
+			propertyDeps, err := r.mapPropertyDependencies(res.PropertyDependencies)
+			if err != nil {
+				return "", "", fmt.Errorf("mapping property deps for %v: %w", res.URN, err)
+			}
+
+			var providerRef string
+			if res.Custom {
+				provider.outputs.Store(res.URN, outputs)
+
+				if res.Provider != "" {
+					ref, err := providers.ParseReference(res.Provider)
+					if err != nil {
+						return "", "", fmt.Errorf("parsing provider for %v: %w", res.URN, err)
+					}
+					if !providers.IsDefaultProvider(ref.URN()) {
+						mappedURN, mappedID, err := r.mapResourceWithID(ref.URN())
+						if err != nil {
+							return "", "", fmt.Errorf("mapping provider for %v: %w", res.URN, err)
+						}
+						ref, err = providers.NewReference(resource.URN(mappedURN), resource.ID(mappedID))
+						if err != nil {
+							return "", "", fmt.Errorf("mapping provider for %v: %w", res.URN, err)
+						}
+						providerRef = ref.String()
+					}
+				}
+			}
+
+			var urn, id string
+			if res.External {
+				resp, err := r.monitor.ReadResource(ctx, &pulumirpc.ReadResourceRequest{
+					Id:           res.ID.String(),
+					Type:         typ,
+					Name:         name,
+					Parent:       parent,
+					Properties:   inputObject,
+					Dependencies: deps,
+					Provider:     providerRef,
+				})
+				if err != nil {
+					return "", "", err
+				}
+				urn, id = resp.Urn, res.ID.String()
+			} else {
+				resp, err := r.monitor.RegisterResource(ctx, &pulumirpc.RegisterResourceRequest{
+					Type:                    typ,
+					Name:                    name,
+					Parent:                  parent,
+					Custom:                  res.Custom,
+					ImportId:                string(res.ImportID),
+					Object:                  inputObject,
+					Protect:                 &res.Protect,
+					Dependencies:            deps,
+					PropertyDependencies:    propertyDeps,
+					AcceptSecrets:           true,
+					AdditionalSecretOutputs: toStrings(res.AdditionalSecretOutputs),
+					AliasURNs:               toStrings(res.Aliases),
+					SupportsPartialValues:   true,
+					Remote:                  false,
+					AcceptResources:         true,
+					DeletedWith:             string(res.DeletedWith),
+					Provider:                providerRef,
+				})
+				if err != nil {
+					return "", "", err
+				}
+				urn, id = resp.Urn, resp.Id
+			}
+
+			if !res.Custom {
+				outputObject, oerr := plugin.MarshalProperties(outputs, plugin.MarshalOptions{
+					KeepSecrets:   true,
+					KeepResources: true,
+				})
+				if oerr != nil {
+					return "", "", fmt.Errorf("marshaling outputs for %v: %w", res.URN, oerr)
+				}
+
+				_, err = r.monitor.RegisterResourceOutputs(ctx, &pulumirpc.RegisterResourceOutputsRequest{
+					Urn:     urn,
+					Outputs: outputObject,
+				})
+			}
+			return urn, id, err
+		}())
+	}()
+}
+
+// newMockPersister creates a new cloudSnapshotPersister that uses a mock token source and targets the given httptest
+// server.
+func newMockPersister(t testing.TB, server *httptest.Server) *cloudSnapshotPersister {
+	newMockTokenSource := func() tokenSourceCapability {
+		return tokenSourceFn(func() (string, error) {
+			return "token", nil
+		})
+	}
+
+	sink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+	backendGeneric, err := New(t.Context(), sink, server.URL, &workspace.Project{}, false)
+	require.NoError(t, err)
+
+	backend := backendGeneric.(*cloudBackend)
+	stackID := client.StackIdentifier{Owner: "owner", Project: "project", Stack: tokens.MustParseStackName("stack")}
+	return backend.newSnapshotPersister(context.Background(), client.UpdateIdentifier{
+		StackIdentifier: stackID,
+		UpdateKind:      "update",
+		UpdateID:        "update",
+	}, newMockTokenSource())
+}
+
+type benchmarkServer struct {
+	t          testing.TB
+	p          *cloudSnapshotPersister
+	totalCalls int
+	totalBytes int64
+}
+
+// newServerPersister creates a new benchmarkServer that implements both SnapshotPersister and JournalPersister. The
+// benchmarkServer is responsible for tracking the total number of calls made and bytes sent to persistence endpoints.
+func newServerPersister(t testing.TB) *benchmarkServer {
+	s := &benchmarkServer{t: t}
+	srv := httptest.NewServer(s)
+	t.Cleanup(srv.Close)
+	s.p = newMockPersister(t, srv)
+	return s
+}
+
+// reset prepares the sever for use in a new benchmark iteration.
+func (s *benchmarkServer) reset() {
+	s.totalCalls, s.totalBytes = 0, 0
+}
+
+// persist measures the number of bytes present in the request body and increments the call count.
+func (s *benchmarkServer) persist(req *http.Request) {
+	n, err := io.Copy(io.Discard, req.Body)
+	require.NoError(s.t, err)
+	s.totalCalls, s.totalBytes = s.totalCalls+1, s.totalBytes+n
+}
+
+func (s *benchmarkServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	_, base := path.Split(req.URL.Path)
+	switch base {
+	case "capabilities":
+		bytes, err := json.Marshal(apitype.DeltaCheckpointUploadsConfigV2{})
+		require.NoError(s.t, err)
+		resp := apitype.CapabilitiesResponse{Capabilities: []apitype.APICapabilityConfig{{
+			Version:       2,
+			Capability:    apitype.DeltaCheckpointUploadsV2,
+			Configuration: json.RawMessage(bytes),
+		}}}
+		err = json.NewEncoder(w).Encode(resp)
+		require.NoError(s.t, err)
+	case "checkpointverbatim", "checkpointdelta", "checkpoint", "journal":
+		s.persist(req)
+		_, err := w.Write([]byte("{}"))
+		require.NoError(s.t, err)
+	default:
+		s.t.Errorf("unsupported path %q", req.URL.Path)
+	}
+}
+
+func (s *benchmarkServer) Save(snapshot *deploy.Snapshot) error {
+	return s.p.Save(snapshot)
+}
+
+func (s *benchmarkServer) Append(ctx context.Context, entry apitype.JournalEntry) error {
+	return s.p.Append(ctx, entry)
+}
+
+func BenchmarkSnapshot(b *testing.B) {
+	useJournal := os.Getenv("PULUMI_TEST_SNAPSHOT") == "journal"
+
+	p := newServerPersister(b)
+	getManager := func(t testing.TB, base *deploy.Snapshot) engine.SnapshotManager {
+		return backend.NewSnapshotManager(p, base.SecretsManager, base)
+	}
+	if useJournal {
+		getManager = func(t testing.TB, base *deploy.Snapshot) engine.SnapshotManager {
+			j, err := backend.NewJournaler(t.Context(), p, base.SecretsManager, base)
+			require.NoError(b, err)
+			m, err := engine.NewJournalSnapshotManager(j, base, base.SecretsManager)
+			require.NoError(b, err)
+			return m
+		}
+	}
+
+	b.Run("Dynamic", func(b *testing.B) {
+		for _, c := range dynamicCases {
+			b.Run(c.getName(), func(b *testing.B) {
+				run := c.getRun(b, getManager)
+				for i := 0; i < b.N; i++ {
+					p.reset()
+					run(b)
+					b.ReportMetric(float64(p.totalCalls), "calls/op")
+					b.ReportMetric(float64(p.totalBytes), "bytes_sent/op")
+				}
+			})
+		}
+	})
+	if len(recordedReplayCases) != 0 {
+		b.Run("Recorded", func(b *testing.B) {
+			for _, c := range recordedReplayCases {
+				b.Run(c.getName(), func(b *testing.B) {
+					run := c.getRun(b, getManager)
+					for i := 0; i < b.N; i++ {
+						p.reset()
+						run(b)
+						b.ReportMetric(float64(p.totalCalls), "calls/op")
+						b.ReportMetric(float64(p.totalBytes), "bytes_sent/op")
+					}
+				})
+			}
+		})
+	}
+}

--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -864,10 +864,10 @@ type diffStackCase interface {
 	getSnaps(t testing.TB) []*apitype.DeploymentV3
 }
 
-func testOrBenchmarkDiffStack[TB testingTB[TB]](
+func testOrBenchmarkDiffStack[TB testingTB[TB], Case diffStackCase](
 	tb TB,
 	inner diffStackTestFunc[TB],
-	cases []diffStackCase,
+	cases []Case,
 ) {
 	for _, c := range cases {
 		name, snaps := c.getName(), c.getSnaps(tb)
@@ -894,43 +894,50 @@ func (c dynamicStackCase) getSnaps(tb testing.TB) []*apitype.DeploymentV3 {
 	return generateSnapshots(tb, r, c.resourceCount, c.resourcePayloadBytes)
 }
 
-var dynamicCases = []diffStackCase{
-	dynamicStackCase{seed: 0, resourceCount: 1, resourcePayloadBytes: 2},
-	dynamicStackCase{seed: 0, resourceCount: 2, resourcePayloadBytes: 2},
-	dynamicStackCase{seed: 0, resourceCount: 4, resourcePayloadBytes: 2},
-	dynamicStackCase{seed: 0, resourceCount: 8, resourcePayloadBytes: 2},
-	dynamicStackCase{seed: 0, resourceCount: 16, resourcePayloadBytes: 2},
-	dynamicStackCase{seed: 0, resourceCount: 32, resourcePayloadBytes: 2},
-	dynamicStackCase{seed: 0, resourceCount: 48, resourcePayloadBytes: 2},
-	dynamicStackCase{seed: 0, resourceCount: 64, resourcePayloadBytes: 2},
-	dynamicStackCase{seed: 0, resourceCount: 1, resourcePayloadBytes: 8192},
-	dynamicStackCase{seed: 0, resourceCount: 2, resourcePayloadBytes: 8192},
-	dynamicStackCase{seed: 0, resourceCount: 4, resourcePayloadBytes: 8192},
-	dynamicStackCase{seed: 0, resourceCount: 8, resourcePayloadBytes: 8192},
-	dynamicStackCase{seed: 0, resourceCount: 16, resourcePayloadBytes: 8192},
-	dynamicStackCase{seed: 0, resourceCount: 32, resourcePayloadBytes: 8192},
-	dynamicStackCase{seed: 0, resourceCount: 48, resourcePayloadBytes: 8192},
-	dynamicStackCase{seed: 0, resourceCount: 64, resourcePayloadBytes: 8192},
-	dynamicStackCase{seed: 0, resourceCount: 1, resourcePayloadBytes: 32768},
-	dynamicStackCase{seed: 0, resourceCount: 2, resourcePayloadBytes: 32768},
-	dynamicStackCase{seed: 0, resourceCount: 4, resourcePayloadBytes: 32768},
-	dynamicStackCase{seed: 0, resourceCount: 8, resourcePayloadBytes: 32768},
-	dynamicStackCase{seed: 0, resourceCount: 16, resourcePayloadBytes: 32768},
-	dynamicStackCase{seed: 0, resourceCount: 32, resourcePayloadBytes: 32768},
-	dynamicStackCase{seed: 0, resourceCount: 48, resourcePayloadBytes: 32768},
-	dynamicStackCase{seed: 0, resourceCount: 64, resourcePayloadBytes: 32768},
-	dynamicStackCase{seed: 0, resourceCount: 2, resourcePayloadBytes: 131072},
-	dynamicStackCase{seed: 0, resourceCount: 4, resourcePayloadBytes: 131072},
-	dynamicStackCase{seed: 0, resourceCount: 8, resourcePayloadBytes: 131072},
-	dynamicStackCase{seed: 0, resourceCount: 16, resourcePayloadBytes: 131072},
-	dynamicStackCase{seed: 0, resourceCount: 32, resourcePayloadBytes: 131072},
-	dynamicStackCase{seed: 0, resourceCount: 48, resourcePayloadBytes: 131072},
-	dynamicStackCase{seed: 0, resourceCount: 64, resourcePayloadBytes: 131072},
-	dynamicStackCase{seed: 0, resourceCount: 1, resourcePayloadBytes: 524288},
-	dynamicStackCase{seed: 0, resourceCount: 2, resourcePayloadBytes: 524288},
-	dynamicStackCase{seed: 0, resourceCount: 4, resourcePayloadBytes: 524288},
-	dynamicStackCase{seed: 0, resourceCount: 8, resourcePayloadBytes: 524288},
-	dynamicStackCase{seed: 0, resourceCount: 16, resourcePayloadBytes: 524288},
+func (c dynamicStackCase) pseudoRandomString(r *rand.Rand, desiredLength int) string {
+	buf := make([]byte, desiredLength)
+	r.Read(buf)
+	text := base64.StdEncoding.EncodeToString(buf)
+	return text[0:desiredLength]
+}
+
+var dynamicCases = []dynamicStackCase{
+	{seed: 0, resourceCount: 1, resourcePayloadBytes: 2},
+	{seed: 0, resourceCount: 2, resourcePayloadBytes: 2},
+	{seed: 0, resourceCount: 4, resourcePayloadBytes: 2},
+	{seed: 0, resourceCount: 8, resourcePayloadBytes: 2},
+	{seed: 0, resourceCount: 16, resourcePayloadBytes: 2},
+	{seed: 0, resourceCount: 32, resourcePayloadBytes: 2},
+	{seed: 0, resourceCount: 48, resourcePayloadBytes: 2},
+	{seed: 0, resourceCount: 64, resourcePayloadBytes: 2},
+	{seed: 0, resourceCount: 1, resourcePayloadBytes: 8192},
+	{seed: 0, resourceCount: 2, resourcePayloadBytes: 8192},
+	{seed: 0, resourceCount: 4, resourcePayloadBytes: 8192},
+	{seed: 0, resourceCount: 8, resourcePayloadBytes: 8192},
+	{seed: 0, resourceCount: 16, resourcePayloadBytes: 8192},
+	{seed: 0, resourceCount: 32, resourcePayloadBytes: 8192},
+	{seed: 0, resourceCount: 48, resourcePayloadBytes: 8192},
+	{seed: 0, resourceCount: 64, resourcePayloadBytes: 8192},
+	{seed: 0, resourceCount: 1, resourcePayloadBytes: 32768},
+	{seed: 0, resourceCount: 2, resourcePayloadBytes: 32768},
+	{seed: 0, resourceCount: 4, resourcePayloadBytes: 32768},
+	{seed: 0, resourceCount: 8, resourcePayloadBytes: 32768},
+	{seed: 0, resourceCount: 16, resourcePayloadBytes: 32768},
+	{seed: 0, resourceCount: 32, resourcePayloadBytes: 32768},
+	{seed: 0, resourceCount: 48, resourcePayloadBytes: 32768},
+	{seed: 0, resourceCount: 64, resourcePayloadBytes: 32768},
+	{seed: 0, resourceCount: 2, resourcePayloadBytes: 131072},
+	{seed: 0, resourceCount: 4, resourcePayloadBytes: 131072},
+	{seed: 0, resourceCount: 8, resourcePayloadBytes: 131072},
+	{seed: 0, resourceCount: 16, resourcePayloadBytes: 131072},
+	{seed: 0, resourceCount: 32, resourcePayloadBytes: 131072},
+	{seed: 0, resourceCount: 48, resourcePayloadBytes: 131072},
+	{seed: 0, resourceCount: 64, resourcePayloadBytes: 131072},
+	{seed: 0, resourceCount: 1, resourcePayloadBytes: 524288},
+	{seed: 0, resourceCount: 2, resourcePayloadBytes: 524288},
+	{seed: 0, resourceCount: 4, resourcePayloadBytes: 524288},
+	{seed: 0, resourceCount: 8, resourcePayloadBytes: 524288},
+	{seed: 0, resourceCount: 16, resourcePayloadBytes: 524288},
 }
 
 func BenchmarkDiffStack(b *testing.B) {

--- a/pkg/backend/journal.go
+++ b/pkg/backend/journal.go
@@ -658,3 +658,107 @@ func (sj SnapshotJournaler) Close() error {
 	sj.cancel <- true
 	return <-sj.done
 }
+
+type journaler struct {
+	ctx            context.Context
+	persister      JournalPersister
+	snapshot       *apitype.DeploymentV3
+	secretsManager secrets.Manager
+}
+
+// A JournalPersister implements persistence of journal entries in some store.
+type JournalPersister interface {
+	// Append appends a new entry to the journal.
+	Append(ctx context.Context, entry apitype.JournalEntry) error
+}
+
+// NewSnapshotJournaler creates a new Journal that uses a SnapshotPersister to persist the
+// snapshot created from the journal entries.
+//
+// The snapshot code works on journal entries. Each resource step produces new journal entries
+// for beginning and finishing an operation. These journal entries can then be replayed
+// in conjunction with the immutable base snapshot, to rebuild the new snapshot.
+//
+// Currently the backend only supports saving full snapshots, in which case only one journal
+// entry is allowed to be processed at a time. In the future journal entries will be processed
+// asynchronously in the cloud backend, allowing for better throughput for independent operations.
+//
+// Serialization is performed by pushing the journal entries onto a channel, where another
+// goroutine is polling the channel and creating new snapshots using the entries as they come.
+// This function optionally verifies the integrity of the snapshot before and after mutation.
+//
+// Each journal entry may indicate that its corresponding checkpoint write may be safely elided by
+// setting the `ElideWrite` field. As of this writing, we only elide writes after same steps with no
+// meaningful changes (see sameSnapshotMutation.mustWrite for details). Any elided writes
+// are flushed by the next non-elided write or the next call to Close.
+func NewJournaler(
+	ctx context.Context,
+	persister JournalPersister,
+	secretsManager secrets.Manager,
+	baseSnap *deploy.Snapshot,
+) (engine.Journal, error) {
+	snapCopy := &deploy.Snapshot{}
+	if baseSnap != nil {
+		snapCopy = &deploy.Snapshot{
+			Manifest:          baseSnap.Manifest,
+			SecretsManager:    baseSnap.SecretsManager,
+			Resources:         make([]*resource.State, 0),
+			PendingOperations: make([]resource.Operation, 0),
+			Metadata:          baseSnap.Metadata,
+		}
+		// Copy the resources from the base snapshot to the new snapshot.
+		for _, res := range baseSnap.Resources {
+			snapCopy.Resources = append(snapCopy.Resources, res.Copy())
+		}
+		// Copy the pending operations from the base snapshot to the new snapshot.
+		for _, op := range baseSnap.PendingOperations {
+			snapCopy.PendingOperations = append(snapCopy.PendingOperations, op.Copy())
+		}
+
+		if snapCopy.SecretsManager == nil {
+			snapCopy.SecretsManager = secretsManager
+		}
+	}
+
+	var deployment *apitype.DeploymentV3
+	if baseSnap != nil {
+		var err error
+		deployment, _, _, err = stack.SerializeDeploymentWithMetadata(ctx, snapCopy, false)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		deployment = &apitype.DeploymentV3{}
+	}
+
+	return &journaler{
+		ctx:            ctx,
+		persister:      persister,
+		snapshot:       deployment,
+		secretsManager: secretsManager,
+	}, nil
+}
+
+func (sj *journaler) AddJournalEntry(entry engine.JournalEntry) error {
+	var completeBatch stack.CompleteCrypterBatch
+	enc := sj.secretsManager.Encrypter()
+
+	if batchingSecretsManager, ok := sj.secretsManager.(stack.BatchingSecretsManager); ok {
+		enc, completeBatch = batchingSecretsManager.BeginBatchEncryption()
+	}
+	serializedEntry, err := SerializeJournalEntry(
+		sj.ctx, entry, enc)
+	if err != nil {
+		return fmt.Errorf("failed to serialize journal entry: %w", err)
+	}
+	if completeBatch != nil {
+		if err := completeBatch(sj.ctx); err != nil {
+			return fmt.Errorf("failed to complete batch encryption: %w", err)
+		}
+	}
+	return sj.persister.Append(sj.ctx, serializedEntry)
+}
+
+func (sj journaler) Close() error {
+	return nil
+}

--- a/pkg/engine/lifecycletest/framework/framework.go
+++ b/pkg/engine/lifecycletest/framework/framework.go
@@ -82,10 +82,10 @@ type TB interface {
 	Failed() bool
 }
 
-// The nopPluginManager is used by the test framework to avoid any interactions with ambient plugins.
-type nopPluginManager struct{}
+// The NopPluginManager is used by the test framework to avoid any interactions with ambient plugins.
+type NopPluginManager struct{}
 
-func (nopPluginManager) GetPluginPath(
+func (NopPluginManager) GetPluginPath(
 	ctx context.Context,
 	d diag.Sink,
 	spec workspace.PluginSpec,
@@ -94,22 +94,22 @@ func (nopPluginManager) GetPluginPath(
 	return "installed", nil
 }
 
-func (nopPluginManager) HasPlugin(spec workspace.PluginSpec) bool {
+func (NopPluginManager) HasPlugin(spec workspace.PluginSpec) bool {
 	return true
 }
 
-func (nopPluginManager) HasPluginGTE(spec workspace.PluginSpec) (bool, error) {
+func (NopPluginManager) HasPluginGTE(spec workspace.PluginSpec) (bool, error) {
 	return true, nil
 }
 
-func (nopPluginManager) GetLatestPluginVersion(
+func (NopPluginManager) GetLatestPluginVersion(
 	ctx context.Context,
 	spec workspace.PluginSpec,
 ) (*semver.Version, error) {
 	return semver.New("1.0.0")
 }
 
-func (nopPluginManager) DownloadPlugin(
+func (NopPluginManager) DownloadPlugin(
 	ctx context.Context,
 	plugin workspace.PluginSpec,
 	wrapper func(stream io.ReadCloser, size int64) io.ReadCloser,
@@ -118,7 +118,7 @@ func (nopPluginManager) DownloadPlugin(
 	return io.NopCloser(bytes.NewReader(nil)), 0, nil
 }
 
-func (nopPluginManager) InstallPlugin(
+func (NopPluginManager) InstallPlugin(
 	ctx context.Context,
 	plugin workspace.PluginSpec,
 	content pkgWorkspace.PluginContent,
@@ -272,7 +272,7 @@ func (op TestOp) runWithContext(
 		Events:          events,
 		SnapshotManager: combined,
 		BackendClient:   backendClient,
-		PluginManager:   nopPluginManager{},
+		PluginManager:   NopPluginManager{},
 	}
 
 	updateOpts := opts.Options()

--- a/pkg/resource/deploy/deploytest/languageruntime.go
+++ b/pkg/resource/deploy/deploytest/languageruntime.go
@@ -79,7 +79,9 @@ func (p *languageRuntime) Run(info plugin.RunInfo) (string, bool, error) {
 	if p.closed {
 		return "", false, ErrLanguageRuntimeIsClosed
 	}
-	monitor, err := dialMonitor(context.Background(), info.MonitorAddress)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	monitor, err := dialMonitor(ctx, info.MonitorAddress)
 	if err != nil {
 		return "", false, err
 	}

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -151,12 +151,13 @@ func (nopCloserT) Close() error { return nil }
 var nopCloser io.Closer = nopCloserT(0)
 
 type grpcWrapper struct {
-	stop chan bool
+	stop   chan bool
+	handle rpcutil.ServeHandle
 }
 
 func (w *grpcWrapper) Close() error {
-	go func() { w.stop <- true }()
-	return nil
+	w.stop <- true
+	return <-w.handle.Done
 }
 
 func wrapProviderWithGrpc(provider plugin.Provider) (plugin.Provider, io.Closer, error) {
@@ -172,6 +173,7 @@ func wrapProviderWithGrpc(provider plugin.Provider) (plugin.Provider, io.Closer,
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not start resource provider service: %w", err)
 	}
+	wrapper.handle = handle
 	conn, err := grpc.NewClient(
 		fmt.Sprintf("127.0.0.1:%v", handle.Port),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -195,6 +197,7 @@ type hostEngine struct {
 
 	address string
 	stop    chan bool
+	handle  rpcutil.ServeHandle
 }
 
 func (e *hostEngine) Log(_ context.Context, req *pulumirpc.LogRequest) (*emptypb.Empty, error) {
@@ -288,6 +291,7 @@ func NewPluginHost(sink, statusSink diag.Sink, languageRuntime plugin.LanguageRu
 		panic(fmt.Errorf("could not start engine service: %w", err))
 	}
 	engine.address = fmt.Sprintf("127.0.0.1:%v", handle.Port)
+	engine.handle = handle
 
 	return &pluginHost{
 		pluginLoaders:   pluginLoaders,
@@ -310,12 +314,12 @@ func (host *pluginHost) plugin(kind apitype.PluginKind, name string, version *se
 ) (interface{}, error) {
 	var best *PluginLoader
 	for _, l := range host.pluginLoaders {
-		if l.kind != kind || l.name != name {
+		if l.kind != kind || (l.name != name && l.name != "*") {
 			continue
 		}
 
 		if version != nil {
-			if l.version.EQ(*version) {
+			if l.name == "*" || l.version.EQ(*version) {
 				best = l
 				break
 			}
@@ -426,11 +430,12 @@ func (host *pluginHost) Close() error {
 	var err error
 	for _, closer := range host.plugins {
 		if pErr := closer.Close(); pErr != nil {
-			err = pErr
+			err = errors.Join(err, pErr)
 		}
 	}
 
-	go func() { host.engine.stop <- true }()
+	host.engine.stop <- true
+	err = <-host.engine.handle.Done
 	host.closed = true
 	return err
 }

--- a/pkg/resource/deploy/deploytest/resourcemonitor.go
+++ b/pkg/resource/deploy/deploytest/resourcemonitor.go
@@ -150,6 +150,10 @@ func (rm *ResourceMonitor) Close() error {
 	return rm.conn.Close()
 }
 
+func (rm *ResourceMonitor) Client() pulumirpc.ResourceMonitorClient {
+	return rm.resmon
+}
+
 func NewResourceMonitor(resmon pulumirpc.ResourceMonitorClient) *ResourceMonitor {
 	return &ResourceMonitor{resmon: resmon}
 }

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -283,6 +283,8 @@ func (iter *evalSourceIterator) forkRun(
 	go func() {
 		// Next, launch the language plugin.
 		run := func() error {
+			defer contract.IgnoreClose(iter.loaderServer)
+
 			rt := iter.src.runinfo.Proj.Runtime.Name()
 
 			rtopts := iter.src.runinfo.Proj.Runtime.Options()

--- a/sdk/go/common/apitype/journal.go
+++ b/sdk/go/common/apitype/journal.go
@@ -130,3 +130,7 @@ func (e JournalEntry) String() string {
 type JournalEntries struct {
 	Entries []JournalEntry `json:"entries,omitempty"`
 }
+
+type AppendUpdateJournalEntryRequest struct {
+	Entry JournalEntry `json:"entry,omitempty"`
+}


### PR DESCRIPTION
Add a new set of benchmarks for measuring the performance of our various
snapshot managers (mainly the delta patcher and the in-progress journaler).

Each benchmark case is an instantation of a general case that runs an
update from an empty base snapshot. The update itself s captured by the
case. Each case is itself parameterizable by the snapshot manager used
for persistence.

There are two kinds of cases: one performs an update by issuing a
set of mutually-independent resources with state that contains random
data, and one replays the registrations and reads implied by the
resources in a state file.

For the former cases, the number of resources and the amount of random
data stored in state are parameterizable. A set list of instantiations
is used to drive the top-level benchmark.

For the latter cases, the benchmarks accept a comma-separated list of
state files in the PULUMI_TEST_SNAPSHOT_REPLAY environment variable.
No state files are included in the test data by default to to the
potential for including sensitive information.

All benchmarks use an httptest server to serve the tiny subset of the
Pulumi Cloud API needed for persistence. This server measures the number
total number of bytes sent over the wire and the total number of calls
made to the server. These metrics are reported by the benchmarks.
