### PR TITLE
feat: Adding support for configuring the templates directory from env vars

### DIFF
--- a/changelog/pending/20250930--cli-about-new--add-environment-variables-to-pulumi-new-pulumi-about-env.yaml
+++ b/changelog/pending/20250930--cli-about-new--add-environment-variables-to-pulumi-new-pulumi-about-env.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/about,new
+  description: Add environment variables to override template repository settings. The new PULUMI_TEMPLATE_GIT_REPOSITORY, PULUMI_TEMPLATE_BRANCH, PULUMI_POLICY_TEMPLATE_GIT_REPOSITORY, and PULUMI_POLICY_TEMPLATE_BRANCH environment variables allow runtime customization of template sources

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -193,3 +193,32 @@ without using the system itself, or show that the validation is too strict. Over
 removed and enforced to be validated.`)
 
 var DisableRegistryResolve = env.Bool("DISABLE_REGISTRY_RESOLVE", "Use the Pulumi Registry to resolve package names")
+
+// Environment variables that affect template discovery and caching
+var (
+	// TemplatePath is a path to the folder where templates are stored.
+	// It is used in sandboxed environments where the classic template folder may not be writable.
+	TemplatePath = env.String("TEMPLATE_PATH", "Path to a writable template cache directory.")
+
+	// PolicyTemplatePath is a path to the folder where policy templates are stored.
+	// It is used in sandboxed environments where the classic policy template folder may not be writable.
+	PolicyTemplatePath = env.String("POLICY_TEMPLATE_PATH", "Path to a writable policy template cache directory.")
+
+	// TemplateGitRepository is the Git URL for Pulumi program templates.
+	// If set, it overrides the compile-time default pulumiTemplateGitRepository.
+	TemplateGitRepository = env.String("TEMPLATE_GIT_REPOSITORY",
+		"Git URL for Pulumi program templates (overrides default).")
+
+	// TemplateBranch is the branch name for the template repository.
+	// If set, it overrides the compile-time default pulumiTemplateBranch.
+	TemplateBranch = env.String("TEMPLATE_BRANCH", "Branch name for Pulumi program templates repository.")
+
+	// PolicyTemplateGitRepository is the Git URL for Pulumi Policy Pack templates.
+	// If set, it overrides the compile-time default pulumiPolicyTemplateGitRepository.
+	PolicyTemplateGitRepository = env.String("POLICY_TEMPLATE_GIT_REPOSITORY",
+		"Git URL for Pulumi Policy Pack templates (overrides default).")
+
+	// PolicyTemplateBranch is the branch name for the policy pack template repository.
+	// If set, it overrides the compile-time default pulumiPolicyTemplateBranch.
+	PolicyTemplateBranch = env.String("POLICY_TEMPLATE_BRANCH", "Branch name for Pulumi Policy Pack templates repository.")
+)

--- a/sdk/go/common/workspace/templates_test.go
+++ b/sdk/go/common/workspace/templates_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,9 +21,158 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestGetTemplateGitRepository tests that environment variables correctly override
+// the compile-time defaults for template repository URLs.
+func TestGetTemplateGitRepository(t *testing.T) {
+	tests := []struct {
+		name            string
+		templateKind    TemplateKind
+		envVar          string
+		envValue        string
+		setEmptyString  bool
+		expectedDefault string
+	}{
+		{
+			name:            "PulumiProject without env var",
+			templateKind:    TemplateKindPulumiProject,
+			envVar:          env.TemplateGitRepository.Var().Name(),
+			envValue:        "",
+			setEmptyString:  false,
+			expectedDefault: "https://github.com/pulumi/templates.git",
+		},
+		{
+			name:            "PulumiProject with empty string env var",
+			templateKind:    TemplateKindPulumiProject,
+			envVar:          env.TemplateGitRepository.Var().Name(),
+			envValue:        "",
+			setEmptyString:  true,
+			expectedDefault: "https://github.com/pulumi/templates.git",
+		},
+		{
+			name:            "PulumiProject with env var",
+			templateKind:    TemplateKindPulumiProject,
+			envVar:          env.TemplateGitRepository.Var().Name(),
+			envValue:        "https://github.com/custom/templates.git",
+			setEmptyString:  false,
+			expectedDefault: "https://github.com/custom/templates.git",
+		},
+		{
+			name:            "PolicyPack without env var",
+			templateKind:    TemplateKindPolicyPack,
+			envVar:          env.PolicyTemplateGitRepository.Var().Name(),
+			envValue:        "",
+			setEmptyString:  false,
+			expectedDefault: "https://github.com/pulumi/templates-policy.git",
+		},
+		{
+			name:            "PolicyPack with empty string env var",
+			templateKind:    TemplateKindPolicyPack,
+			envVar:          env.PolicyTemplateGitRepository.Var().Name(),
+			envValue:        "",
+			setEmptyString:  true,
+			expectedDefault: "https://github.com/pulumi/templates-policy.git",
+		},
+		{
+			name:            "PolicyPack with env var",
+			templateKind:    TemplateKindPolicyPack,
+			envVar:          env.PolicyTemplateGitRepository.Var().Name(),
+			envValue:        "https://github.com/custom/templates-policy.git",
+			setEmptyString:  false,
+			expectedDefault: "https://github.com/custom/templates-policy.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment variable if specified
+			if tt.envValue != "" || tt.setEmptyString {
+				t.Setenv(tt.envVar, tt.envValue)
+			}
+
+			result := getTemplateGitRepository(tt.templateKind)
+			assert.Equal(t, tt.expectedDefault, result)
+		})
+	}
+}
+
+// TestGetTemplateBranch tests that environment variables correctly override
+// the compile-time defaults for template branch names.
+func TestGetTemplateBranch(t *testing.T) {
+	tests := []struct {
+		name            string
+		templateKind    TemplateKind
+		envVar          string
+		envValue        string
+		setEmptyString  bool
+		expectedDefault string
+	}{
+		{
+			name:            "PulumiProject without env var",
+			templateKind:    TemplateKindPulumiProject,
+			envVar:          env.TemplateBranch.Var().Name(),
+			envValue:        "",
+			setEmptyString:  false,
+			expectedDefault: "master",
+		},
+		{
+			name:            "PulumiProject with empty string env var",
+			templateKind:    TemplateKindPulumiProject,
+			envVar:          env.TemplateBranch.Var().Name(),
+			envValue:        "",
+			setEmptyString:  true,
+			expectedDefault: "master",
+		},
+		{
+			name:            "PulumiProject with env var",
+			templateKind:    TemplateKindPulumiProject,
+			envVar:          env.TemplateBranch.Var().Name(),
+			envValue:        "custom-branch",
+			setEmptyString:  false,
+			expectedDefault: "custom-branch",
+		},
+		{
+			name:            "PolicyPack without env var",
+			templateKind:    TemplateKindPolicyPack,
+			envVar:          env.PolicyTemplateBranch.Var().Name(),
+			envValue:        "",
+			setEmptyString:  false,
+			expectedDefault: "master",
+		},
+		{
+			name:            "PolicyPack with empty string env var",
+			templateKind:    TemplateKindPolicyPack,
+			envVar:          env.PolicyTemplateBranch.Var().Name(),
+			envValue:        "",
+			setEmptyString:  true,
+			expectedDefault: "master",
+		},
+		{
+			name:            "PolicyPack with env var",
+			templateKind:    TemplateKindPolicyPack,
+			envVar:          env.PolicyTemplateBranch.Var().Name(),
+			envValue:        "custom-branch",
+			setEmptyString:  false,
+			expectedDefault: "custom-branch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment variable if specified
+			if tt.envValue != "" || tt.setEmptyString {
+				t.Setenv(tt.envVar, tt.envValue)
+			}
+
+			result := getTemplateBranch(tt.templateKind)
+			assert.Equal(t, tt.expectedDefault, result)
+		})
+	}
+}
 
 //nolint:paralleltest // uses shared state in pulumi dir
 func TestRetrieveNonExistingTemplate(t *testing.T) {


### PR DESCRIPTION
Adding support for configuring the templates directory from env variables so that smoke tests can run from a separate git repository