### PR TITLE
Elide function values from resource inputs

### DIFF
--- a/changelog/pending/20250930--sdk-nodejs--dont-attempt-to-serialise-function-values-for-resource-inputs-outputs.yaml
+++ b/changelog/pending/20250930--sdk-nodejs--dont-attempt-to-serialise-function-values-for-resource-inputs-outputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Don't attempt to serialise function values for resource inputs/outputs

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -388,9 +388,13 @@ export async function serializeProperty(
     dependentResources?: Set<Resource>,
     opts?: SerializationOptions,
 ): Promise<any> {
-    // IMPORTANT:
-    // IMPORTANT: Keep this in sync with serializePropertiesSync in invoke.ts
-    // IMPORTANT:
+    // if prop is a function type just return undefined, we don't want to try and keep these values around.
+    if (typeof prop === "function") {
+        if (excessiveDebugOutput) {
+            log.debug(`Serialize property [${ctx}]: function=${prop}`);
+        }
+        return undefined;
+    }
 
     if (
         prop === undefined ||


### PR DESCRIPTION
As part of https://github.com/pulumi/pulumi/issues/10533 we want to send component inputs to the engine. One component input is the Stack itself, and for NodeJS that always has an input property "init" which is the main function to run to make the stack. We don't want to send that, or any other functions that people happen to be passing down to components, to the engine. 

Currently values of this type fall into the final clause of `serializeProperty` which tries to treat it as an object and serialise all the keys, this results in things like `init = {}` being sent to the engine.

With this change these values are just returned as `undefined` and so dropped completely from the input struct sent to the engine.