### PR TITLE
feat: enable `env` for `pulumi about env` in `pulumi about --help`

### DIFF
--- a/changelog/pending/20251001--cli-about--adding-pulumi-about-env-to-help.yaml
+++ b/changelog/pending/20251001--cli-about--adding-pulumi-about-env-to-help.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: cli/about
-  description: Adding `pulumi about env` to help
+  description: Add `pulumi about env` to help

--- a/changelog/pending/20251001--cli-about--adding-pulumi-about-env-to-help.yaml
+++ b/changelog/pending/20251001--cli-about--adding-pulumi-about-env-to-help.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/about
+  description: Adding `pulumi about env` to help

--- a/pkg/cmd/pulumi/about/about_env.go
+++ b/pkg/cmd/pulumi/about/about_env.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	declared "github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 )
@@ -36,10 +35,6 @@ func newAboutEnvCmd() *cobra.Command {
 		Use:   "env",
 		Short: "An overview of the environmental variables used by pulumi",
 		Args:  cmdutil.NoArgs,
-		// Since most variables won't be included here, we hide the command. We will
-		// unhide once most existing variables are using the new env var framework and
-		// show up here.
-		Hidden: !env.Experimental.Value(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			table := cmdutil.Table{
 				Headers: []string{"Variable", "Description", "Value"},


### PR DESCRIPTION
Previously `pulumi about env` was not able to be found when a user ran `pulumi about --help` this is because we did not have enough environment variables documented. This has improved significantly, and while it may not be every environment variable, its enough, to help users find most things they need.