### PR TITLE
Minor test cleanup

### DIFF
--- a/pkg/cmd/pulumi/metadata/metadata_test.go
+++ b/pkg/cmd/pulumi/metadata/metadata_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2024-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Some minor test cleanup to the metadata tests:

- Avoid `e.RunCommand("mkdir", "subdirectory")` to make the tests more portable
- Use `assert.Equal` rather than `assert.EqualValues`
- Use `assert.[Not]Contains` rather than `assert.True/False`
- Use `require.True` rather than `t.Errorf`
- Pass the expected value to `assert.Equal` in the right param position

Based on feedback on #20528, with some additional cleanup while already cleaning up here.