### PR TITLE
add SuppressDiagEventsInDiff option to display opts

### DIFF
--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -143,7 +143,8 @@ func RenderDiffEvent(event engine.Event, seen map[resource.URN]engine.StepEventM
 }
 
 func renderDiffDiagEvent(payload engine.DiagEventPayload, opts Options) string {
-	if payload.Severity == diag.Debug && !opts.Debug {
+	if opts.SuppressDiagEventsInDiff ||
+		payload.Severity == diag.Debug && !opts.Debug {
 		return ""
 	}
 	return opts.Color.Colorize(payload.Prefix + payload.Message)

--- a/pkg/backend/display/options.go
+++ b/pkg/backend/display/options.go
@@ -35,28 +35,29 @@ const (
 
 // Options controls how the output of events are rendered
 type Options struct {
-	Color                  colors.Colorization // colorization to apply to events.
-	ShowConfig             bool                // true if we should show configuration information.
-	ShowPolicyRemediations bool                // true if we should show detailed policy remediations.
-	ShowResourceChanges    bool                // true if we should print detailed resource changes.
-	ShowReplacementSteps   bool                // true to show the replacement steps in the plan.
-	ShowSameResources      bool                // true to show the resources that aren't updated in addition to updates.
-	ShowReads              bool                // true to show resources that are being read in
-	TruncateOutput         bool                // true if we should truncate long outputs
-	SuppressOutputs        bool                // true to suppress output summarization, e.g. if contains sensitive info.
-	SuppressPermalink      bool                // true to suppress state permalink (including in DIY backends)
-	SummaryDiff            bool                // true if diff display should be summarized.
-	IsInteractive          bool                // true if we should display things interactively.
-	Type                   Type                // type of display (rich diff, progress, or query).
-	JSONDisplay            bool                // true if we should emit the entire diff as JSON.
-	EventLogPath           string              // the path to the file to use for logging events, if any.
-	Debug                  bool                // true to enable debug output.
-	Stdin                  io.Reader           // the reader to use for stdin. Defaults to os.Stdin if unset.
-	Stdout                 io.Writer           // the writer to use for stdout. Defaults to os.Stdout if unset.
-	Stderr                 io.Writer           // the writer to use for stderr. Defaults to os.Stderr if unset.
-	SuppressTimings        bool                // true to suppress displaying timings of resource actions
-	SuppressProgress       bool                // true to suppress displaying progress spinner.
-	ShowSecrets            bool                // true to display secrets in the output.
+	Color                    colors.Colorization // colorization to apply to events.
+	ShowConfig               bool                // true if we should show configuration information.
+	ShowPolicyRemediations   bool                // true if we should show detailed policy remediations.
+	ShowResourceChanges      bool                // true if we should print detailed resource changes.
+	ShowReplacementSteps     bool                // true to show the replacement steps in the plan.
+	ShowSameResources        bool                // true to show the resources that aren't updated in addition to updates.
+	ShowReads                bool                // true to show resources that are being read in
+	TruncateOutput           bool                // true if we should truncate long outputs
+	SuppressOutputs          bool                // true to suppress output summarization, e.g. if contains sensitive info.
+	SuppressPermalink        bool                // true to suppress state permalink (including in DIY backends)
+	SummaryDiff              bool                // true if diff display should be summarized.
+	IsInteractive            bool                // true if we should display things interactively.
+	Type                     Type                // type of display (rich diff, progress, or query).
+	JSONDisplay              bool                // true if we should emit the entire diff as JSON.
+	EventLogPath             string              // the path to the file to use for logging events, if any.
+	Debug                    bool                // true to enable debug output.
+	Stdin                    io.Reader           // the reader to use for stdin. Defaults to os.Stdin if unset.
+	Stdout                   io.Writer           // the writer to use for stdout. Defaults to os.Stdout if unset.
+	Stderr                   io.Writer           // the writer to use for stderr. Defaults to os.Stderr if unset.
+	SuppressTimings          bool                // true to suppress displaying timings of resource actions
+	SuppressProgress         bool                // true to suppress displaying progress spinner.
+	ShowSecrets              bool                // true to display secrets in the output.
+	SuppressDiagEventsInDiff bool                // true to suppress displaying diagnostic events in the diff display
 
 	// Copilot options
 	ShowLinkToCopilot   bool // true to display a 'explainFailure' link to Copilot.


### PR DESCRIPTION
This is only used in the service, but I was asked to keep the code between the service and the CLI as similar as possible in https://github.com/pulumi/pulumi-service/pull/33085#discussion_r2395233830.