### PR TITLE
state move: treat providers as providers even if they are parents

### DIFF
--- a/changelog/pending/20251002--cli-state--treat-providers-that-are-marked-as-parents-in-a-move-as-providers-still-instead-of-as-regular-resources.yaml
+++ b/changelog/pending/20251002--cli-state--treat-providers-that-are-marked-as-parents-in-a-move-as-providers-still-instead-of-as-regular-resources.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Treat providers that are marked as parents in a move as providers still instead of as regular resources


### PR DESCRIPTION
In `pulumi state move`, we always copy providers from the source stack to the destination. This is 1) so we don't include all the children of a resource every time we move one, and 2) because providers are not physically backed resources, so it's fine to have copies of them.

However currently when `--include-parents` is given, and the provider is a parent of the resource we're moving, we treat it as a regular resource, and move it instead of just copying it. Similarly if the provider is a child of a resource (although in that case it doesn't matter as much, as any children of the provider will be moved either way).

Make sure we only copy the provider as needed and don't move it when it is a parent of the moved resources.

Fixes https://github.com/pulumi/pulumi/issues/20622