### PR TITLE
Add a login test for --insecure

### DIFF
--- a/changelog/pending/20251003--backend-service--fix-the-insecure-flag-in-pulumi-login.yaml
+++ b/changelog/pending/20251003--backend-service--fix-the-insecure-flag-in-pulumi-login.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/service
+  description: Fix the --insecure flag in `pulumi login`

--- a/pkg/cmd/pulumi/auth/login.go
+++ b/pkg/cmd/pulumi/auth/login.go
@@ -168,7 +168,7 @@ func NewLoginCmd(ws pkgWorkspace.Context) *cobra.Command {
 			}
 
 			be, err := backend.DefaultLoginManager.Login(
-				ctx, ws, cmdutil.Diag(), cloudURL, project, true /* setCurrent */, displayOptions.Color)
+				ctx, ws, cmdutil.Diag(), cloudURL, project, true /* setCurrent */, insecure, displayOptions.Color)
 			if err != nil {
 				return fmt.Errorf("problem logging in: %w", err)
 			}

--- a/pkg/cmd/pulumi/backend/backend.go
+++ b/pkg/cmd/pulumi/backend/backend.go
@@ -78,7 +78,8 @@ func CurrentBackend(
 	if err != nil {
 		return nil, fmt.Errorf("could not get cloud url: %w", err)
 	}
+	insecure := pkgWorkspace.GetCloudInsecure(ws, url)
 
 	// Only set current if we don't currently have a cloud URL set.
-	return lm.Login(ctx, ws, cmdutil.Diag(), url, project, url == "", opts.Color)
+	return lm.Login(ctx, ws, cmdutil.Diag(), url, project, url == "", insecure, opts.Color)
 }

--- a/pkg/cmd/pulumi/backend/login_manager.go
+++ b/pkg/cmd/pulumi/backend/login_manager.go
@@ -49,6 +49,7 @@ type LoginManager interface {
 		url string,
 		project *workspace.Project,
 		setCurrent bool,
+		insecure bool,
 		color colors.Colorization,
 	) (backend.Backend, error)
 }
@@ -75,7 +76,7 @@ func (f *lm) Current(
 
 func (f *lm) Login(
 	ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink, url string, project *workspace.Project, setCurrent bool,
-	color colors.Colorization,
+	insecure bool, color colors.Colorization,
 ) (backend.Backend, error) {
 	if diy.IsDIYBackendURL(url) {
 		if setCurrent {
@@ -84,7 +85,6 @@ func (f *lm) Login(
 		return diy.New(ctx, sink, url, project)
 	}
 
-	insecure := pkgWorkspace.GetCloudInsecure(ws, url)
 	lm := httpstate.NewLoginManager()
 	// Color is the only thing used by lm.Login, so we can just request a colors.Colorization and only fill that part of
 	// the display options in. It's hard to change Login itself because it's circularly depended on by esc.
@@ -115,6 +115,7 @@ type MockLoginManager struct {
 		url string,
 		project *workspace.Project,
 		setCurrent bool,
+		insecure bool,
 		color colors.Colorization,
 	) (backend.Backend, error)
 }
@@ -128,10 +129,11 @@ func (lm *MockLoginManager) Login(
 	url string,
 	project *workspace.Project,
 	setCurrent bool,
+	insecure bool,
 	color colors.Colorization,
 ) (backend.Backend, error) {
 	if lm.LoginF != nil {
-		return lm.LoginF(ctx, ws, sink, url, project, setCurrent, color)
+		return lm.LoginF(ctx, ws, sink, url, project, setCurrent, insecure, color)
 	}
 	panic("not implemented")
 }

--- a/pkg/cmd/pulumi/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_test.go
@@ -957,7 +957,8 @@ func TestPulumiNewWithOrgTemplates(t *testing.T) {
 			return mockBackend, nil
 		},
 		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-			url string, project *workspace.Project, setCurrent bool, color colors.Colorization,
+			url string, project *workspace.Project, setCurrent bool,
+			insecure bool, color colors.Colorization,
 		) (backend.Backend, error) {
 			return mockBackend, nil
 		},
@@ -1032,7 +1033,7 @@ func TestPulumiNewWithRegistryTemplates(t *testing.T) {
 			return mockBackend, nil
 		},
 		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-			url string, project *workspace.Project, setCurrent bool, color colors.Colorization,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
 		) (backend.Backend, error) {
 			return mockBackend, nil
 		},
@@ -1207,7 +1208,7 @@ resources:
 			return mockBackend, nil
 		},
 		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-			url string, project *workspace.Project, setCurrent bool, color colors.Colorization,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
 		) (backend.Backend, error) {
 			return mockBackend, nil
 		},

--- a/pkg/cmd/pulumi/policy/policy_publish.go
+++ b/pkg/cmd/pulumi/policy/policy_publish.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
-	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -167,11 +166,8 @@ func loginToCloudBackend(
 	if err != nil {
 		return nil, fmt.Errorf("`pulumi policy` command requires the user to be logged into the Pulumi Cloud: %w", err)
 	}
-	displayOptions := display.Options{
-		Color: cmdutil.GetGlobalColorization(),
-	}
 
-	return lm.Login(ctx, ws, cmdutil.Diag(), cloudURL, project, true /* setCurrent*/, displayOptions.Color)
+	return lm.Current(ctx, ws, cmdutil.Diag(), cloudURL, project, true /* setCurrent*/)
 }
 
 // requirePolicyPack attempts to log into the cloud backend and retrieves the requested policy

--- a/pkg/cmd/pulumi/policy/policy_publish_test.go
+++ b/pkg/cmd/pulumi/policy/policy_publish_test.go
@@ -25,7 +25,6 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
@@ -42,14 +41,13 @@ func TestPolicyPublishCmd_default(t *testing.T) {
 	}
 
 	lm := &cmdBackend.MockLoginManager{
-		LoginF: func(
+		CurrentF: func(
 			ctx context.Context,
 			ws pkgWorkspace.Context,
 			sink diag.Sink,
 			url string,
 			project *workspace.Project,
 			setCurrent bool,
-			color colors.Colorization,
 		) (backend.Backend, error) {
 			return &backend.MockBackend{
 				GetPolicyPackF: func(ctx context.Context, name string, d diag.Sink) (backend.PolicyPack, error) {
@@ -87,14 +85,13 @@ func TestPolicyPublishCmd_orgNamePassedIn(t *testing.T) {
 	}
 
 	lm := &cmdBackend.MockLoginManager{
-		LoginF: func(
+		CurrentF: func(
 			ctx context.Context,
 			ws pkgWorkspace.Context,
 			sink diag.Sink,
 			url string,
 			project *workspace.Project,
 			setCurrent bool,
-			color colors.Colorization,
 		) (backend.Backend, error) {
 			return &backend.MockBackend{
 				GetPolicyPackF: func(ctx context.Context, name string, d diag.Sink) (backend.PolicyPack, error) {
@@ -152,14 +149,13 @@ func TestPolicyPublishCmd_Metadata(t *testing.T) {
 	}
 
 	lm := &cmdBackend.MockLoginManager{
-		LoginF: func(
+		CurrentF: func(
 			ctx context.Context,
 			ws pkgWorkspace.Context,
 			sink diag.Sink,
 			url string,
 			project *workspace.Project,
 			setCurrent bool,
-			color colors.Colorization,
 		) (backend.Backend, error) {
 			return &backend.MockBackend{
 				GetPolicyPackF: func(ctx context.Context, name string, d diag.Sink) (backend.PolicyPack, error) {

--- a/pkg/cmd/pulumi/state/state_delete_test.go
+++ b/pkg/cmd/pulumi/state/state_delete_test.go
@@ -69,7 +69,7 @@ func TestNoProject(t *testing.T) {
 	lm := &cmdBackend.MockLoginManager{
 		LoginF: func(
 			ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-			url string, project *workspace.Project, setCurrent bool, color colors.Colorization,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
 		) (backend.Backend, error) {
 			assert.Equal(t, "", url)
 			return mockBackend, nil
@@ -123,7 +123,7 @@ func TestStateDeleteURN(t *testing.T) {
 	lm := &cmdBackend.MockLoginManager{
 		LoginF: func(
 			_ context.Context, _ pkgWorkspace.Context, _ diag.Sink,
-			url string, project *workspace.Project, _ bool, _ colors.Colorization,
+			url string, project *workspace.Project, _ bool, _ bool, _ colors.Colorization,
 		) (backend.Backend, error) {
 			assert.Equal(t, "", url)
 			assert.Equal(t, tokens.PackageName("proj"), project.Name)
@@ -177,7 +177,7 @@ func TestStateDeleteDependency(t *testing.T) {
 	lm := &cmdBackend.MockLoginManager{
 		LoginF: func(
 			_ context.Context, _ pkgWorkspace.Context, _ diag.Sink,
-			url string, project *workspace.Project, _ bool, _ colors.Colorization,
+			url string, project *workspace.Project, _ bool, _ bool, _ colors.Colorization,
 		) (backend.Backend, error) {
 			assert.Equal(t, "", url)
 			assert.Equal(t, tokens.PackageName("proj"), project.Name)
@@ -236,7 +236,7 @@ func TestStateDeleteProtected(t *testing.T) {
 	lm := &cmdBackend.MockLoginManager{
 		LoginF: func(
 			_ context.Context, _ pkgWorkspace.Context, _ diag.Sink,
-			url string, project *workspace.Project, _ bool, _ colors.Colorization,
+			url string, project *workspace.Project, _ bool, _ bool, _ colors.Colorization,
 		) (backend.Backend, error) {
 			assert.Equal(t, "", url)
 			assert.Equal(t, tokens.PackageName("proj"), project.Name)
@@ -309,7 +309,7 @@ func TestStateDeleteAll(t *testing.T) {
 	lm := &cmdBackend.MockLoginManager{
 		LoginF: func(
 			_ context.Context, _ pkgWorkspace.Context, _ diag.Sink,
-			url string, project *workspace.Project, _ bool, _ colors.Colorization,
+			url string, project *workspace.Project, _ bool, _ bool, _ colors.Colorization,
 		) (backend.Backend, error) {
 			assert.Equal(t, "", url)
 			assert.Equal(t, tokens.PackageName("proj"), project.Name)

--- a/pkg/cmd/pulumi/state/state_repair_test.go
+++ b/pkg/cmd/pulumi/state/state_repair_test.go
@@ -334,6 +334,7 @@ func newStateRepairCmdFixture(
 			string,
 			*workspace.Project,
 			bool,
+			bool,
 			colors.Colorization,
 		) (backend.Backend, error) {
 			return b, nil

--- a/pkg/cmd/pulumi/state/state_upgrade_test.go
+++ b/pkg/cmd/pulumi/state/state_upgrade_test.go
@@ -90,7 +90,7 @@ func TestStateUpgradeCommand_Run_upgrade(t *testing.T) {
 	}
 	lm := &cmdBackend.MockLoginManager{
 		LoginF: func(
-			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, colors.Colorization,
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, bool, colors.Colorization,
 		) (backend.Backend, error) {
 			return be, nil
 		},
@@ -120,7 +120,7 @@ func TestStateUpgradeCommand_Run_upgrade_yes_flag(t *testing.T) {
 	}
 	lm := &cmdBackend.MockLoginManager{
 		LoginF: func(
-			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, colors.Colorization,
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, bool, colors.Colorization,
 		) (backend.Backend, error) {
 			return be, nil
 		},
@@ -148,7 +148,7 @@ func TestStateUpgradeCommand_Run_upgradeRejected(t *testing.T) {
 	}
 	lm := &cmdBackend.MockLoginManager{
 		LoginF: func(
-			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, colors.Colorization,
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, bool, colors.Colorization,
 		) (backend.Backend, error) {
 			return be, nil
 		},
@@ -171,7 +171,7 @@ func TestStateUpgradeCommand_Run_unsupportedBackend(t *testing.T) {
 	be := &backend.MockBackend{}
 	lm := &cmdBackend.MockLoginManager{
 		LoginF: func(
-			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, colors.Colorization,
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, bool, colors.Colorization,
 		) (backend.Backend, error) {
 			return be, nil
 		},
@@ -194,7 +194,7 @@ func TestStateUpgradeCmd_Run_backendError(t *testing.T) {
 	ws := &pkgWorkspace.MockContext{}
 	lm := &cmdBackend.MockLoginManager{
 		LoginF: func(
-			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, colors.Colorization,
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, bool, colors.Colorization,
 		) (backend.Backend, error) {
 			return nil, giveErr
 		},

--- a/pkg/cmd/pulumi/templates/templates_test.go
+++ b/pkg/cmd/pulumi/templates/templates_test.go
@@ -104,7 +104,7 @@ func TestFilterOnName(t *testing.T) {
 				return mockBackend, nil
 			},
 			LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-				url string, project *workspace.Project, setCurrent bool, color colors.Colorization,
+				url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
 			) (backend.Backend, error) {
 				return mockBackend, nil
 			},
@@ -150,7 +150,7 @@ func TestFilterOnName(t *testing.T) {
 				return mockBackend, nil
 			},
 			LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-				url string, project *workspace.Project, setCurrent bool, color colors.Colorization,
+				url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
 			) (backend.Backend, error) {
 				return mockBackend, nil
 			},
@@ -205,7 +205,7 @@ func TestMultipleTemplateSources_OrgTemplates(t *testing.T) {
 			return mockBackend, nil
 		},
 		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-			url string, project *workspace.Project, setCurrent bool, color colors.Colorization,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
 		) (backend.Backend, error) {
 			return mockBackend, nil
 		},
@@ -271,7 +271,7 @@ func TestSurfaceListTemplateErrors_OrgTemplates(t *testing.T) {
 			return mockBackend, nil
 		},
 		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-			url string, project *workspace.Project, setCurrent bool, color colors.Colorization,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
 		) (backend.Backend, error) {
 			return mockBackend, nil
 		},
@@ -313,7 +313,7 @@ func TestSurfaceListTemplateErrors_RegistryTemplates(t *testing.T) {
 			return mockBackend, nil
 		},
 		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-			url string, project *workspace.Project, setCurrent bool, color colors.Colorization,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
 		) (backend.Backend, error) {
 			return mockBackend, nil
 		},
@@ -355,7 +355,7 @@ func TestSurfaceOnEmptyError_OrgTemplates(t *testing.T) {
 			return mockBackend, nil
 		},
 		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-			url string, project *workspace.Project, setCurrent bool, color colors.Colorization,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
 		) (backend.Backend, error) {
 			return mockBackend, nil
 		},
@@ -397,7 +397,7 @@ func TestSurfaceOnEmptyError_RegistryTemplates(t *testing.T) {
 			return mockBackend, nil
 		},
 		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-			url string, project *workspace.Project, setCurrent bool, color colors.Colorization,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
 		) (backend.Backend, error) {
 			return mockBackend, nil
 		},
@@ -468,7 +468,7 @@ description: An ASP.NET application running a simple container in a EKS Cluster
 			return mockBackend, nil
 		},
 		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-			url string, project *workspace.Project, setCurrent bool, color colors.Colorization,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
 		) (backend.Backend, error) {
 			return mockBackend, nil
 		},

--- a/pkg/cmd/pulumi/whoami/whoami_test.go
+++ b/pkg/cmd/pulumi/whoami/whoami_test.go
@@ -40,7 +40,7 @@ func TestWhoAmICmd_default(t *testing.T) {
 	}
 	lm := &cmdBackend.MockLoginManager{
 		LoginF: func(
-			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, colors.Colorization,
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, bool, colors.Colorization,
 		) (backend.Backend, error) {
 			return be, nil
 		},
@@ -69,7 +69,7 @@ func TestWhoAmICmd_verbose(t *testing.T) {
 	}
 	lm := &cmdBackend.MockLoginManager{
 		LoginF: func(
-			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, colors.Colorization,
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, bool, colors.Colorization,
 		) (backend.Backend, error) {
 			return be, nil
 		},
@@ -103,7 +103,7 @@ func TestWhoAmICmd_json(t *testing.T) {
 	}
 	lm := &cmdBackend.MockLoginManager{
 		LoginF: func(
-			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, colors.Colorization,
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, bool, colors.Colorization,
 		) (backend.Backend, error) {
 			return be, nil
 		},
@@ -140,7 +140,7 @@ func TestWhoAmICmd_verbose_teamToken(t *testing.T) {
 	}
 	lm := &cmdBackend.MockLoginManager{
 		LoginF: func(
-			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, colors.Colorization,
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, bool, colors.Colorization,
 		) (backend.Backend, error) {
 			return be, nil
 		},
@@ -178,7 +178,7 @@ func TestWhoAmICmd_json_teamToken(t *testing.T) {
 	}
 	lm := &cmdBackend.MockLoginManager{
 		LoginF: func(
-			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, colors.Colorization,
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, bool, colors.Colorization,
 		) (backend.Backend, error) {
 			return be, nil
 		},
@@ -215,7 +215,7 @@ func TestWhoAmICmd_verbose_unknownToken(t *testing.T) {
 	}
 	lm := &cmdBackend.MockLoginManager{
 		LoginF: func(
-			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, colors.Colorization,
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, bool, colors.Colorization,
 		) (backend.Backend, error) {
 			return be, nil
 		},

--- a/tests/login/login_test.go
+++ b/tests/login/login_test.go
@@ -15,10 +15,14 @@
 package tests
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLogin(t *testing.T) {
@@ -36,4 +40,42 @@ func TestLogin(t *testing.T) {
 		e.RunCommand("pulumi", "logout", "--all")
 		e.RunCommand("pulumi", "logout", "--all")
 	})
+}
+
+func TestInsecureLogin(t *testing.T) {
+	t.Parallel()
+
+	// Setup a mock server to act as a Pulumi Service backend.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Reply to the whoami request with a mock user.
+		if r.URL.Path == "/api/user" {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{"githubLogin":"mock-user","name":"Mock User","email":"mock-user@example.com"}`))
+			require.NoError(t, err)
+			return
+		}
+		if r.URL.Path == "/api/capabilities" {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{}`))
+			require.NoError(t, err)
+			return
+		}
+		require.Fail(t, "%v", r)
+	}))
+	t.Cleanup(server.Close)
+
+	// Login to the mock server using an insecure connection.
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+
+	// First check that without "--insecure" we get tls err
+	_, stderr := e.RunCommandExpectError("pulumi", "login", "--cloud-url", server.URL)
+	assert.Contains(t, stderr, "x509: certificate signed by unknown authority")
+
+	// Now login with "--insecure" and expect success.
+	e.RunCommand("pulumi", "login", "--cloud-url", server.URL, "--insecure")
+
+	// Then run another command to verify that the CLI remembers to stay in insecure mode.
+	stdout, _ := e.RunCommand("pulumi", "whoami")
+	assert.Contains(t, stdout, "mock-user")
 }


### PR DESCRIPTION
I think this should fix https://github.com/pulumi/pulumi/issues/20645. There were two issues, firstly at some point we just totally stopped looking at the `--insecure` flag during the `login` command. Secondly we didn't always re-lookup the insecure flag when loading the current logged in account.