### PR TITLE
make new arguments to resource initialize optional

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1467,9 +1467,9 @@ export class ComponentResource<TData = any> extends Resource {
      */
     protected async initialize(
         args: Inputs,
-        opts: ComponentResourceOptions,
-        name: string,
-        type: string,
+        opts?: ComponentResourceOptions,
+        name?: string,
+        type?: string,
     ): Promise<TData> {
         return <TData>undefined!;
     }

--- a/tests/integration/construct_component_provider/testcomponent/index.ts
+++ b/tests/integration/construct_component_provider/testcomponent/index.ts
@@ -21,6 +21,7 @@ class Component extends pulumi.ComponentResource {
     }
 
     protected async initialize(args: pulumi.Inputs) {
+        super.initialize(args);
         const provider = this.getProvider("testcomponent::");
         if (!(provider instanceof Provider)) {
             throw new Error("provider is not an instance of Provider");


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/20618, we added more arguments to `resource.initialize`, so that users could use them. Unfortunately this was backwards incompatible with for anyone that used to call `super.initialize`.  Make the new arguments optional, to make the introduction of these new parameters backwards compatible.

See https://github.com/pulumi/pulumi/discussions/20640#discussioncomment-14575911