### PR TITLE
don't include rootstack when --include-parents is given

### DIFF
--- a/changelog/pending/20251003--cli-state--exclude-root-stack-correctly-when-moving-resources-and-when-include-parents-is-passed.yaml
+++ b/changelog/pending/20251003--cli-state--exclude-root-stack-correctly-when-moving-resources-and-when-include-parents-is-passed.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Exclude root stack correctly when moving resources and when --include-parents is passed

--- a/pkg/cmd/pulumi/state/state_move.go
+++ b/pkg/cmd/pulumi/state/state_move.go
@@ -245,7 +245,7 @@ func (cmd *stateMoveCmd) Run(
 	if cmd.IncludeParents {
 		for _, res := range resourcesToMove {
 			for _, parent := range sourceDepGraph.ParentsOf(res) {
-				if res.Type == resource.RootStackType && res.Parent == "" ||
+				if (parent.Type == resource.RootStackType && parent.Parent == "") ||
 					strings.HasPrefix(string(parent.Type), providerPrefix) {
 					// We don't move the root stack or providers explicitly, the code below
 					// will take care of dealing with that correctly.


### PR DESCRIPTION
We had a wrong condition when calculating the parents that need to be included in a move.  This caused us to always include the root stack when --include-parents was given, if the resource to be moved had a parent. Fix that condition, and update the test to also reflect that.