### PR TITLE
Fix TestParameterizedPython

### DIFF
--- a/tests/integration/python/parameterized/test.py
+++ b/tests/integration/python/parameterized/test.py
@@ -2,20 +2,27 @@ import pulumi
 import pulumi.runtime
 import unittest
 
+
 class Mocks(pulumi.runtime.Mocks):
     def call(self, args):
-        raise Exception(f"unknown function {args['token']}")
+        raise Exception(f"unknown function {args.token}")
 
     def new_resource(self, args):
-        return [f"{args['name']}_id", args['inputs']]
+        return [f"{args.name}_id", args.inputs]
 
-pulumi.runtime.set_mocks(Mocks(), project="project", stack="stack", preview=False)
 
-class TestPackage(unittest.TestCase):
+class TestPackage(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        pulumi.runtime.set_mocks(
+            Mocks(), project="project", stack="stack", preview=False
+        )
+        await pulumi.runtime.settings._load_monitor_feature_support()
+
     async def test_should_create_random_resource(self):
         import pulumi_pkg as pkg
+
         random = pkg.Random("random", length=8)
         assert random is not None
 
-        result = await random.id.promise()
+        result = await random.id.future()
         assert result == "random_id"


### PR DESCRIPTION
The python unit tests for this test never ran correctly. The test has an async function, but this is not awaited. Ensure the function is awaited by using `unittest.IsolatedAsyncioTestCase`, and fix the fall out from the rest of the brokenness in this test.
