### PR TITLE
Validate config using caching batch encrypt and decrypt

### DIFF
--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -37,6 +37,7 @@ import (
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/cloud"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -911,11 +912,13 @@ func listConfig(
 	}
 
 	var pulumiEnv esc.Value
+	var secretsManager secrets.Manager
 	var envCrypter config.Encrypter
 	if env != nil {
 		pulumiEnv = env.Properties["pulumiConfig"]
 
-		stackEncrypter, state, err := ssml.GetEncrypter(ctx, stack, ps)
+		var state cmdStack.SecretsManagerState
+		secretsManager, state, err = ssml.GetSecretsManager(ctx, stack, ps)
 		if err != nil {
 			return err
 		}
@@ -925,7 +928,9 @@ func listConfig(
 				return fmt.Errorf("save stack config: %w", err)
 			}
 		}
-		envCrypter = stackEncrypter
+		// secretsManager's crypter has a cache for crypto operations. As we are encrypting all environment secrets
+		// with the secretManager's encrypter ensure to use its decrypter later on when reading the merged config.
+		envCrypter = secretsManager.Encrypter()
 	}
 
 	stackName := stack.Ref().Name().String()
@@ -945,17 +950,19 @@ func listConfig(
 	// By default, we will use a blinding decrypter to show "[secret]". If requested, display secrets in plaintext.
 	decrypter := config.NewBlindingDecrypter()
 	if cfg.HasSecureValue() && showSecrets {
-		stackDecrypter, state, err := ssml.GetDecrypter(ctx, stack, ps)
-		if err != nil {
-			return err
-		}
-		// This may have setup the stack's secrets provider, so save the stack if needed.
-		if state != cmdStack.SecretsManagerUnchanged {
-			if err = cmdStack.SaveProjectStack(ctx, stack, ps); err != nil {
-				return fmt.Errorf("save stack config: %w", err)
+		if secretsManager == nil {
+			var state cmdStack.SecretsManagerState
+			if secretsManager, state, err = ssml.GetSecretsManager(ctx, stack, ps); err != nil {
+				return err
+			}
+			// This may have setup the stack's secrets provider, so save the stack if needed.
+			if state != cmdStack.SecretsManagerUnchanged {
+				if err = cmdStack.SaveProjectStack(ctx, stack, ps); err != nil {
+					return fmt.Errorf("save stack config: %w", err)
+				}
 			}
 		}
-		decrypter = stackDecrypter
+		decrypter = secretsManager.Decrypter()
 	}
 
 	var keys config.KeyArray
@@ -966,6 +973,11 @@ func listConfig(
 	}
 	sort.Sort(keys)
 
+	decryptedCfg, err := cfg.Decrypt(decrypter)
+	if err != nil {
+		return fmt.Errorf("could not decrypt configuration values: %w", err)
+	}
+
 	if jsonOut {
 		configValues := make(map[string]configValueJSON)
 		for _, key := range keys {
@@ -973,10 +985,7 @@ func listConfig(
 				Secret: cfg[key].Secure(),
 			}
 
-			decrypted, err := cfg[key].Value(decrypter)
-			if err != nil {
-				return fmt.Errorf("could not decrypt configuration value: %w", err)
-			}
+			decrypted := decryptedCfg[key]
 			entry.Value = &decrypted
 
 			if cfg[key].Object() {
@@ -1004,11 +1013,7 @@ func listConfig(
 	} else {
 		rows := []cmdutil.TableRow{}
 		for _, key := range keys {
-			decrypted, err := cfg[key].Value(decrypter)
-			if err != nil {
-				return fmt.Errorf("could not decrypt configuration value: %w", err)
-			}
-
+			decrypted := decryptedCfg[key]
 			rows = append(rows, cmdutil.TableRow{Columns: []string{PrettyKey(key), decrypted}})
 		}
 
@@ -1088,12 +1093,13 @@ func getConfig(
 	}
 
 	var pulumiEnv esc.Value
+	var secretsManager secrets.Manager
 	var envCrypter config.Encrypter
 	if env != nil {
 		pulumiEnv = env.Properties["pulumiConfig"]
 
-		stackEncrypter, state, err := ssml.GetEncrypter(ctx, stack, ps)
-		if err != nil {
+		var state cmdStack.SecretsManagerState
+		if secretsManager, state, err = ssml.GetSecretsManager(ctx, stack, ps); err != nil {
 			return err
 		}
 		// This may have setup the stack's secrets provider, so save the stack if needed.
@@ -1102,7 +1108,9 @@ func getConfig(
 				return fmt.Errorf("save stack config: %w", err)
 			}
 		}
-		envCrypter = stackEncrypter
+		// secretsManager's crypter has a cache for crypto operations. As we are encrypting all environment secrets
+		// with the secretManager's encrypter ensure to use its decrypter later on when reading the merged config.
+		envCrypter = secretsManager.Encrypter()
 	}
 
 	stackName := stack.Ref().Name().String()
@@ -1125,17 +1133,19 @@ func getConfig(
 	if ok {
 		var d config.Decrypter
 		if v.Secure() {
-			var err error
-			var state cmdStack.SecretsManagerState
-			if d, state, err = ssml.GetDecrypter(ctx, stack, ps); err != nil {
-				return fmt.Errorf("could not create a decrypter: %w", err)
-			}
-			// This may have setup the stack's secrets provider, so save the stack if needed.
-			if state != cmdStack.SecretsManagerUnchanged {
-				if err = cmdStack.SaveProjectStack(ctx, stack, ps); err != nil {
-					return fmt.Errorf("save stack config: %w", err)
+			if secretsManager == nil {
+				var state cmdStack.SecretsManagerState
+				if secretsManager, state, err = ssml.GetSecretsManager(ctx, stack, ps); err != nil {
+					return err
+				}
+				// This may have setup the stack's secrets provider, so save the stack if needed.
+				if state != cmdStack.SecretsManagerUnchanged {
+					if err = cmdStack.SaveProjectStack(ctx, stack, ps); err != nil {
+						return fmt.Errorf("save stack config: %w", err)
+					}
 				}
 			}
+			d = secretsManager.Decrypter()
 		} else {
 			d = config.NewPanicCrypter()
 		}

--- a/sdk/go/common/resource/config/plaintext.go
+++ b/sdk/go/common/resource/config/plaintext.go
@@ -178,6 +178,23 @@ func encryptMap(ctx context.Context, plaintextMap map[Key]Plaintext, encrypter E
 	return result, nil
 }
 
+func EncryptMap(ctx context.Context, plaintextMap map[Key]Plaintext, encrypter Encrypter) (map[Key]Value, error) {
+	objectMap, err := encryptMap(ctx, plaintextMap, encrypter)
+	if err != nil {
+		return nil, err
+	}
+
+	result := Map{}
+	for k, obj := range objectMap {
+		v, err := obj.marshalValue()
+		if err != nil {
+			return nil, err
+		}
+		result[k] = v
+	}
+	return result, nil
+}
+
 // Encrypt converts the receiver as a Value. All secure strings in the result are encrypted using encrypter.
 func (c Plaintext) Encrypt(ctx context.Context, encrypter Encrypter) (Value, error) {
 	obj, err := c.encrypt(ctx, nil, encrypter)

--- a/sdk/go/common/workspace/config_test.go
+++ b/sdk/go/common/workspace/config_test.go
@@ -1,0 +1,101 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+)
+
+func TestValidateStackConfigValues(t *testing.T) {
+	t.Run("No Decrypter Returns Nil", func(t *testing.T) {
+		t.Parallel()
+		// If decrypter is nil, function should return immediately with no error.
+		project := &Project{Name: "testProject"}
+		stackCfg := config.Map{}
+		err := validateStackConfigValues("stackA", project, stackCfg, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("Empty Project With Decrypter Returns Nil", func(t *testing.T) {
+		t.Parallel()
+		// Non-nil decrypter but no project config entries -> nothing to validate.
+		project := &Project{Name: "testProject"}
+		stackCfg := config.Map{}
+
+		err := validateStackConfigValues("stackA", project, stackCfg, config.NopDecrypter)
+		require.NoError(t, err)
+	})
+
+	t.Run("Decrypt Error Is Propagated", func(t *testing.T) {
+		t.Parallel()
+		// Decrypter returns an error; validateStackConfigValues should return that error.
+		project := &Project{Name: "testProject"}
+		stackCfg := config.Map{
+			config.MustMakeKey("testProject", "someKey"): config.NewSecureValue("someVal"),
+		}
+		wantErr := "decrypt failed"
+		dec := config.NewErrorCrypter(wantErr)
+
+		err := validateStackConfigValues("stackA", project, stackCfg, dec)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), wantErr)
+	})
+
+	t.Run("Secret Enforced", func(t *testing.T) {
+		t.Parallel()
+		// When project says config is secret, stack value must be secure.
+		projectConfigKey := "proj:secretKey"
+		pct := ProjectConfigType{
+			Secret: true,
+		}
+		// create a non-secure stack value
+		stackVal := config.NewValue("plain")
+		err := validateStackConfigValue("stack1", projectConfigKey, pct, stackVal, "plain")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must be encrypted")
+	})
+
+	t.Run("Object Unmarshal Error", func(t *testing.T) {
+		t.Parallel()
+		projectConfigKey := "proj:objKey"
+		// object stack value with invalid JSON content should return unmarshal error
+		stackVal := config.NewObjectValue("not-a-json")
+		pct := ProjectConfigType{}
+		err := validateStackConfigValue("stackX", projectConfigKey, pct, stackVal, "not-a-json")
+		require.Error(t, err)
+		// error should be json unmarshal related
+		require.Contains(t, err.Error(), "invalid character")
+	})
+
+	t.Run("Type Mismatch", func(t *testing.T) {
+		t.Parallel()
+		// Project config expects a numeric type but the stack value is a non-numeric string.
+		projectConfigKey := "proj:typeKey"
+		typ := "number"
+		pct := ProjectConfigType{
+			Type: &typ,
+		}
+		// non-numeric stack value
+		stackVal := config.NewValue("not-a-number")
+
+		err := validateStackConfigValue("stackX", projectConfigKey, pct, stackVal, "not-a-number")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must be of type")
+	})
+}


### PR DESCRIPTION
To validate the config this PR makes use caching batch encrypt and decrypt calls introduced in https://github.com/pulumi/pulumi/pull/20578 and https://github.com/pulumi/pulumi/pull/20579

Resolves: https://github.com/pulumi/pulumi/issues/20338