### PR TITLE
fix fuzzing target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,14 +170,16 @@ test_lifecycle:
 test_lifecycle_fuzz: GO_TEST_RACE = false
 test_lifecycle_fuzz: export PULUMI_LIFECYCLE_TEST_FUZZ := 1
 test_lifecycle_fuzz:
-	@cd pkg && $(GO_TEST) github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest \
+	@cd pkg && go test github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest \
 		-run '^TestFuzz$$' \
+		-tags all \
 		-rapid.checks=$(LIFECYCLE_TEST_FUZZ_CHECKS)
 
 test_lifecycle_fuzz_from_state_file: GO_TEST_RACE = false
 test_lifecycle_fuzz_from_state_file:
-	@cd pkg && $(GO_TEST) github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest \
+	@cd pkg && go test github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest \
 		-run '^TestFuzzFromStateFile$$' \
+		-tags all \
 		-rapid.checks=$(LIFECYCLE_TEST_FUZZ_CHECKS)
 
 lang=$(subst test_codegen_,,$(word 1,$(subst !, ,$@)))


### PR DESCRIPTION
This target is currently broken if `gotestsum` is installed, as it doesn't pass the `-rapid.checks` target correctly. Not sure why `gotestsum` acts like that, but we don't necessarily need it, and can just run directly through `go test` to fix this.