### PR TITLE
fuzzing: don't generate ID for non-custom resources

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/resource.go
+++ b/pkg/engine/lifecycletest/fuzzing/resource.go
@@ -418,7 +418,11 @@ func GeneratedResourceSpec(
 
 		typ := GeneratedResourceType(pkg).Draw(t, "ResourceSpec.Type")
 		name := GeneratedResourceName.Draw(t, "ResourceSpec.Name")
-		id := GeneratedResourceID.Draw(t, "ResourceSpec.ID")
+		custom := rso.Custom.Draw(t, "ResourceSpec.Custom")
+		id := resource.ID("")
+		if custom {
+			id = GeneratedResourceID.Draw(t, "ResourceSpec.ID")
+		}
 
 		r := &ResourceSpec{
 			Project: tokens.PackageName(sso.Project),
@@ -427,7 +431,7 @@ func GeneratedResourceSpec(
 			Name:    name,
 			ID:      id,
 
-			Custom:             rso.Custom.Draw(t, "ResourceSpec.Custom"),
+			Custom:             custom,
 			Delete:             false,
 			Protect:            rso.Protect.Draw(t, "ResourceSpec.Protect"),
 			PendingReplacement: rso.PendingReplacement.Draw(t, "ResourceSpec.PendingReplacement"),


### PR DESCRIPTION
Only custom resources can have an ID.  Since #20519, we also check that in the snapshot integrity code.  The fuzz tester doesn't generate resources correctly yet in this case, make it do so.