### PR TITLE
Show the commands run by `scripts/run-conformance.sh`

### DIFF
--- a/scripts/run-conformance.sh
+++ b/scripts/run-conformance.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -euox pipefail
 
 ROOT=$(git rev-parse --show-toplevel)
 
@@ -8,11 +8,11 @@ ROOT=$(git rev-parse --show-toplevel)
 # This script is a helper to do that. It takes a single argument which is the name of the test to run and goes and runs
 # that test for each language.
 
-cd "$ROOT/sdk/go/pulumi-language-go" && go test ./... -v -count=1 -run TestLanguage/$1
+cd "$ROOT/sdk/go/pulumi-language-go" && go test ./... -v -count=1 -run "TestLanguage/$1"
 
-cd "$ROOT/sdk/nodejs/cmd/pulumi-language-nodejs" && go test ./... -v -count=1 -run TestLanguage/forceTsc=false/$1
-cd "$ROOT/sdk/nodejs/cmd/pulumi-language-nodejs" && go test ./... -v -count=1 -run TestLanguage/forceTsc=true/$1
+cd "$ROOT/sdk/nodejs/cmd/pulumi-language-nodejs" && go test ./... -v -count=1 -run "TestLanguage/forceTsc=false/$1"
+cd "$ROOT/sdk/nodejs/cmd/pulumi-language-nodejs" && go test ./... -v -count=1 -run "TestLanguage/forceTsc=true/$1"
 
-cd "$ROOT/sdk/python/cmd/pulumi-language-python" && go test ./... -v -count=1 -run TestLanguage/default/$1
-cd "$ROOT/sdk/python/cmd/pulumi-language-python" && go test ./... -v -count=1 -run TestLanguage/toml/$1
-cd "$ROOT/sdk/python/cmd/pulumi-language-python" && go test ./... -v -count=1 -run TestLanguage/classes/$1
+cd "$ROOT/sdk/python/cmd/pulumi-language-python" && go test ./... -v -count=1 -run "TestLanguage/default/$1"
+cd "$ROOT/sdk/python/cmd/pulumi-language-python" && go test ./... -v -count=1 -run "TestLanguage/toml/$1"
+cd "$ROOT/sdk/python/cmd/pulumi-language-python" && go test ./... -v -count=1 -run "TestLanguage/classes/$1"


### PR DESCRIPTION
The `-x` option in bash instructs bash to print out each command run before executing the command. I have set the flag for this script since it makes it easy to re-run a specific failing command, avoiding the wait for running tests that already pass.