### PR TITLE
allow resources in same steps to be marked for deletion

### DIFF
--- a/changelog/pending/20251007--engine--fix-assert-when-a-resource-thats-not-targeted-on-a-destroy-is-marked-as-delete.yaml
+++ b/changelog/pending/20251007--engine--fix-assert-when-a-resource-thats-not-targeted-on-a-destroy-is-marked-as-delete.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix assert when a resource that's not targeted on a destroy is marked as Delete

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -97,14 +97,12 @@ func NewSameStep(deployment *Deployment, reg RegisterResourceEvent, old, new *re
 	contract.Requiref(old.ID != "" || !old.Custom, "old", "must have an ID if it is custom")
 	contract.Requiref(!old.Custom || old.Provider != "" || providers.IsProviderType(old.Type),
 		"old", "must have or be a provider if it is a custom resource")
-	contract.Requiref(!old.Delete, "old", "must not be marked for deletion")
 
 	contract.Requiref(new != nil, "new", "must not be nil")
 	contract.Requiref(new.URN != "", "new", "must have a URN")
 	contract.Requiref(new.ID == "", "new", "must not have an ID")
 	contract.Requiref(!new.Custom || new.Provider != "" || providers.IsProviderType(new.Type),
 		"new", "must have or be a provider if it is a custom resource")
-	contract.Requiref(!new.Delete, "new", "must not be marked for deletion")
 
 	return &SameStep{
 		deployment: deployment,


### PR DESCRIPTION
Since #20061 we generate same steps for untargeted resources during a destroy. When generating same steps, we assert that `Delete` of the resource is set to "false". However it is possible for `Delete` to be set on the resource, and it not being targeted in a destroy in this case, which triggers the assertion.

We can be a bit more lenient here, and allow same steps to be generated for resources that are marked for deletion to fix this.

(Found using fuzz testing, the fuzz tester crashed on this)

/cc @Frassle, you might have more context on whether it's okay to have a resource be marked as `Delete` during a same step. I think it's okay, but would appreciate a sanity check.