### PR TITLE
misc: add a script for WASM size analysis

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -23,5 +23,6 @@ python = '3.11'
 uv = "0.8.22"
 "go:github.com/mitranim/gow" = "latest"
 "go:go.abhg.dev/requiredfield/cmd/requiredfield" = "0.7.1"
+"github:WebAssembly/wabt" = "1.0.37"
 
 [plugins]

--- a/scripts/wasm-size-breakdown.py
+++ b/scripts/wasm-size-breakdown.py
@@ -1,0 +1,87 @@
+import argparse, json, os, re, subprocess, sys
+
+parser = argparse.ArgumentParser(prog="wasm-size-breakdown")
+parser.add_argument("binary")
+parser.add_argument("--json", action="store_true")
+args = parser.parse_args()
+
+func_re = re.compile(r' - func\[\d+\] size=(\d+) <(.*)>')
+segment_re = re.compile(r' - segment\[\d+\] memory=\d+ size=(\d+)')
+
+result = subprocess.run(["wasm-objdump", "-x", args.binary], capture_output=True, text=True)
+lines = result.stdout.splitlines()
+
+def index(s, c, start=None):
+    try:
+        if start is None:
+            return s.index(c)
+        return s.index(c, start)
+    except ValueError:
+        return None
+
+package_sizes = {}
+code_size = 0
+data_size = 0
+for l in lines:
+    m = func_re.match(l)
+    if m is not None:
+        (size, func) = m.group(1, 2)
+
+        size = int(size)
+        code_size += size
+
+        # pkg.member
+        # std_pkg.member
+        # host.name_pkg.member
+
+        first_underscore = func.find("_")
+        first_dot = func.find(".")
+        prev_dot = func.rfind(".", 0, first_underscore)
+        next_dot = func.find(".", first_underscore if first_underscore > 0 else 0)
+
+        end = next_dot
+        if end == -1 or first_underscore != -1 and prev_dot != -1 and first_underscore == prev_dot + 1:
+            end = first_dot
+        end = end if end != -1 else len(func)
+
+        package = func[:end].replace("_", "/")
+
+        if package not in package_sizes:
+            package_sizes[package] = size
+        else:
+            package_sizes[package] = package_sizes[package] + size
+    else:
+        m = segment_re.match(l)
+        if m is not None:
+            size = int(m.group(1))
+            data_size += size
+
+sorted_sizes = list(sorted(package_sizes.items(), key=lambda pair: pair[1], reverse=True))
+if args.json:
+    print(json.dumps({
+        "code_size": code_size,
+        "data_size": data_size,
+        "packages": sorted_sizes,
+        "total_size": code_size + data_size,
+    }))
+else:
+    print(f"total size: {code_size + data_size}")
+    print(f"code size: {code_size}")
+    print(f"data size: {data_size}")
+    print()
+
+    sum = 0
+    rows = [["package", "size", "percentage", "sum(size)", "sum(percentage)"]]
+    for (package, size) in sorted_sizes:
+        sum += size
+        rows += [[package, size, f"{100.0 * size / code_size:.2f}%", sum, f"{100.0 * sum / code_size:.2f}%"]]
+
+    column_widths = [0, 0, 0, 0, 0]
+    for i in range(0, len(column_widths)):
+        column_widths[i] = max(map(lambda row: len(str(row[i])), rows))
+
+    for r in rows:
+        for (i, c) in enumerate(r):
+            pad = " " * (column_widths[i] - len(str(c)) + 2)
+            print(f"{c}{pad}", end="")
+        print()


### PR DESCRIPTION
misc: add a script for WASM size analysis

These changes add a script for analyzing the size of a WASM module by
breaking down the number of bytes contributed by each Go package
contained in the module. Only code bytes are broken down by package;
data bytes do not carry sufficient information for analysis.

Here is the output of the tool on the Pulumi display WASM module as of
this commit, truncated to only the top 10 contributing modules:

```
total size: 47226227
code size: 28380755
data size: 18845472

package                                                          size     percentage  sum(size)  sum(percentage)
github.com/pgavlin/goldmark/util                                 2000308  7.05%       2000308    7.05%
google.golang.org/protobuf/internal/impl                         1129382  3.98%       3129690    11.03%
runtime                                                          1074362  3.79%       4204052    14.81%
net/http                                                         945988   3.33%       5150040    18.15%
github.com/gogo/protobuf/proto                                   829368   2.92%       5979408    21.07%
crypto/tls                                                       689394   2.43%       6668802    23.50%
github.com/pulumi/pulumi/sdk/v3/proto/go                         595150   2.10%       7263952    25.59%
github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin        575216   2.03%       7839168    27.62%
golang.org/x/crypto/ssh                                          567299   2.00%       8406467    29.62%
net                                                              560684   1.98%       8967151    31.60%
```

This information can be used as input to other analyzers to inform
refactorings aimed at reducing the size of the WASM module. For example,
focusing on github.com/pgavlin/goldmark/util, we can use
[`goda`](https://github.com/loov/goda) to generate a dependency graph
that shows that this package is included as a transitive dependency of
github.com/pulumi/pulumi/pkg/v3/resource/deploy, so removing any
dependency on that package will trim the size of the output by at least
7%.