### PR TITLE
fix snapshot integrity error in destroy v2

### DIFF
--- a/changelog/pending/20251008--engine--fix-a-potential-snapshot-integrity-error-when-a-resources-dependency-fails-to-be-destroyed-using-destroy-run-program.yaml
+++ b/changelog/pending/20251008--engine--fix-a-potential-snapshot-integrity-error-when-a-resources-dependency-fails-to-be-destroyed-using-destroy-run-program.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix a potential snapshot integrity error when a resources dependency fails to be destroyed using `destroy --run-program`


### PR DESCRIPTION
When destroying resources we work through antichains of resources that can be executed in parallel. This is so we first delete a resource, and only then its dependencies. Otherwise we might delete a dependency that is still needed later in the program.

When a resource fails to be destroyed, we look its dependencies up in the dependency graph, and remove the dependencies from the resources to be deleted, so we always get a valid snapshot, with all dependencies intact.

With destroy V2 we get a problem here, because the dependency graph can contain multiple versions of a resource, with the same URN, but a different pointer value.  So when trying to check the dependencies, we don't find the correct one to exclude from the resources to be deleted.

To fix this, we also need to check the dependency graph for the `toDelete` resources that we previously accumulated in the step generator.  If a resource is contained in the "toDelete" dependency graph, we know we also need to find its transitive dependencies in that dependency graph.