### PR TITLE
convert copyright to a range

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -20,7 +20,7 @@ sys.path.append(os.path.abspath("./_ext"))
 # -- Project information -----------------------------------------------------
 
 project = "Pulumi"
-copyright = "Pulumi 2024"
+copyright = "Pulumi 2024-2025"
 author = "Pulumi engineering"
 
 


### PR DESCRIPTION
Fixes #20694 

I wanted to use `copyright = "Pulumi 2024-%Y" as shown in [the docs](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-copyright) for an automatically updated value, but it didn't interpolate it in my tests so I've settled for hard-coding the string.

See you next year!