### PR TITLE
Implement stack vcs:root tag

### DIFF
--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -232,7 +232,7 @@ func addGitMetadataToStackTags(tags map[apitype.StackTagName]string, projPath st
 	if wt, err := repo.Worktree(); err == nil {
 		repoRelPath, err := filepath.Rel(wt.Filesystem.Root(), projPath)
 		if err == nil && filepath.IsLocal(repoRelPath) {
-			tags[apitype.VCSRepositoryRootTag] = repoRelPath
+			tags[apitype.VCSRepositoryRootTag] = filepath.ToSlash(repoRelPath)
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/20696

The type already existed but was not used:

	// VCSRepositoryRootTag is a tag that represents the root directory of the repository on the cloud VCS that
	// this stack may be associated with (pulled from git by the CLI)
	VCSRepositoryRootTag StackTagName = "vcs:root"

The tag was introduced in this commit (https://github.com/pulumi/pulumi/commit/88290d8cb2234773c71fb120ddaff206b7935847) where it was also introduced in the update metadata using the similar `vcs.root`, but the same wasn't added for the stack tag.

The difference between the stack tags and the update metadata is that a stack can exist without an update, and therefore stack tags allow the stack to be properly located without having performed a deployment.

We don't currently have any automated integration tests for stack tags. A manual test shows the tag displaying correctly in the console:

<img width="1231" height="565" alt="image" src="https://github.com/user-attachments/assets/00702b95-33cd-49c6-8007-c75bd22f7372" />