### PR TITLE
simplify template display

### DIFF
--- a/pkg/cmd/pulumi/newcmd/template.go
+++ b/pkg/cmd/pulumi/newcmd/template.go
@@ -78,7 +78,7 @@ func templatesToOptionArrayAndMap(templates []cmdTemplates.Template) ([]string, 
 	nameToTemplateMap := make(map[string]cmdTemplates.Template)
 	for _, template := range templates {
 		// Create the option string that combines the name, padding, and description.
-		desc := template.DisplayDescription()
+		desc := template.Description()
 		// If template is broken, indicate it in the description.
 		if template.Error() != nil {
 			desc = BrokenTemplateDescription

--- a/pkg/cmd/pulumi/templates/cloud.go
+++ b/pkg/cmd/pulumi/templates/cloud.go
@@ -174,6 +174,8 @@ type registryTemplate struct {
 	source   *Source
 }
 
+var _ Template = registryTemplate{}
+
 func (r registryTemplate) Name() string {
 	switch r.t.Source {
 	case "github", "gitlab":
@@ -185,26 +187,12 @@ func (r registryTemplate) Name() string {
 }
 
 func (r registryTemplate) Description() string {
-	if r.t.Description == nil {
-		return ""
-	}
-	return *r.t.Description
-}
-
-func (r registryTemplate) DisplayDescription() string {
 	var parts []string
 	parts = append(parts, "[Private Registry]")
 	if r.t.Description != nil {
 		parts = append(parts, *r.t.Description)
 	}
 	return strings.Join(parts, " ")
-}
-
-func (r registryTemplate) ProjectDescription() string {
-	if r.t.Description == nil {
-		return ""
-	}
-	return *r.t.Description
 }
 
 func (r registryTemplate) Error() error { return nil }
@@ -369,11 +357,11 @@ type orgTemplate struct {
 	backend backend.Backend
 }
 
-func (t orgTemplate) Name() string               { return t.t.Name }
-func (t orgTemplate) Description() string        { return "" }
-func (t orgTemplate) DisplayDescription() string { return t.t.Description }
-func (t orgTemplate) ProjectDescription() string { return t.t.Description }
-func (t orgTemplate) Error() error               { return nil }
+var _ Template = (*orgTemplate)(nil)
+
+func (t orgTemplate) Name() string        { return t.t.Name }
+func (t orgTemplate) Description() string { return t.t.Description }
+func (t orgTemplate) Error() error        { return nil }
 func (t orgTemplate) Download(ctx context.Context) (workspace.Template, error) {
 	templateDir, err := os.MkdirTemp("", "pulumi-template-")
 	if err != nil {

--- a/pkg/cmd/pulumi/templates/templates.go
+++ b/pkg/cmd/pulumi/templates/templates.go
@@ -119,12 +119,12 @@ func (s *Source) Close() error {
 	return errors.Join(errs...)
 }
 
+// A template entry to show in the chooser.
 type Template interface {
 	Name() string
 	Description() string
-	DisplayDescription() string
-	ProjectDescription() string
 	Error() error
+	// Download the template and return an instantiable [workspace.Template] for this template.
 	Download(ctx context.Context) (workspace.Template, error)
 }
 

--- a/pkg/cmd/pulumi/templates/workspace.go
+++ b/pkg/cmd/pulumi/templates/workspace.go
@@ -116,7 +116,5 @@ type workspaceTemplate struct {
 
 func (t workspaceTemplate) Name() string                                             { return t.t.Name }
 func (t workspaceTemplate) Description() string                                      { return t.t.Description }
-func (t workspaceTemplate) DisplayDescription() string                               { return t.t.Description }
-func (t workspaceTemplate) ProjectDescription() string                               { return t.t.ProjectDescription }
 func (t workspaceTemplate) Error() error                                             { return t.t.Error }
 func (t workspaceTemplate) Download(ctx context.Context) (workspace.Template, error) { return t.t, nil }


### PR DESCRIPTION
On top of @fnune's work here https://github.com/pulumi/pulumi/pull/20701

The `Template` interface used in the UI does not need to concern itself with project description vs template description vs display description. We can simplify the interface and drop some of the confusing properties used to determine the template description.
