### PR TITLE
Handle RangeErrors from util.inspect

### DIFF
--- a/changelog/pending/20251009--sdk-nodejs--handle-rangeerrors-from-util-inspect-stringifying-error-objects.yaml
+++ b/changelog/pending/20251009--sdk-nodejs--handle-rangeerrors-from-util-inspect-stringifying-error-objects.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Handle RangeErrors from util.inspect stringifying error objects

--- a/sdk/nodejs/cmd/run/error.ts
+++ b/sdk/nodejs/cmd/run/error.ts
@@ -24,8 +24,14 @@ import * as util from "util";
  */
 export function defaultErrorMessage(err: any): string {
     if (err?.stack) {
-        // colorize stack trace if exists
-        return util.inspect(err, { colors: true });
+        // colorize stack trace if exists, but fallback to just the message if inspect fails. See
+        // https://github.com/pulumi/pulumi/issues/20567 where this can cause RangeErrors due to large strings
+        // when colors is true.
+        try {
+            return util.inspect(err, { colors: true });
+        } catch {
+            return util.inspect(err);
+        }
     }
     if (err?.message) {
         return err.message;


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/20567

Comment on the issue pointed out this seems to be specifically an issue with `colors: true`, so we just try/catch that and fall back to a plain `util.inspect` in the catch block.