### PR TITLE
temporarily disable journal validation

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -40,7 +40,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/diy"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
-	backend_secrets "github.com/pulumi/pulumi/pkg/v3/backend/secrets"
 	sdkDisplay "github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
@@ -1652,30 +1651,12 @@ func (b *cloudBackend) runEngineAction(
 	// We only need a snapshot manager if we're doing an update.
 	var combinedManager engine.SnapshotManager
 	var snapshotManager *backend.SnapshotManager
-	var journal *backend.SnapshotJournaler
 	var validationErrs []error
-	journalPersister := &backend.ValidatingPersister{
-		ErrorFunc: func(err error) {
-			if err != nil {
-				validationErrs = append(validationErrs,
-					fmt.Errorf("journal snapshot validation error: %w", err))
-			}
-		},
-	}
 	if kind != apitype.PreviewUpdate && !dryRun {
 		persister := b.newSnapshotPersister(ctx, update, tokenSource)
-		journal, err = backend.NewSnapshotJournaler(
-			ctx, journalPersister, op.SecretsManager, backend_secrets.DefaultProvider, u.Target.Snapshot)
-		if err != nil {
-			validationErrs = append(validationErrs, err)
-		}
-		journalManager, err := engine.NewJournalSnapshotManager(journal, u.Target.Snapshot, op.SecretsManager)
-		if err != nil {
-			validationErrs = append(validationErrs, err)
-		}
 		snapshotManager = backend.NewSnapshotManager(persister, op.SecretsManager, u.Target.Snapshot)
 		combinedManager = &engine.CombinedManager{
-			Managers: []engine.SnapshotManager{journalManager, snapshotManager},
+			Managers: []engine.SnapshotManager{snapshotManager},
 		}
 	}
 
@@ -1688,18 +1669,12 @@ func (b *cloudBackend) runEngineAction(
 		Events:        engineEvents,
 		BackendClient: httpstateBackendClient{backend: backend.NewBackendClient(b, op.SecretsProvider)},
 		FinalizeUpdateFunc: func() {
-			if snapshotManager == nil || journalPersister == nil {
+			if snapshotManager == nil {
 				return
 			}
 			err := errors.Join(validationErrs...)
 			err = errors.Join(err, combinedManager.Close())
 			snapshotManagerClosed = true
-			err = errors.Join(err, snapshotManager.Snap().AssertEqual(journalPersister.Snap))
-			if journal != nil {
-				for _, e := range journal.Errors() {
-					err = errors.Join(err, e)
-				}
-			}
 			if err != nil {
 				engineEvents <- engine.NewEvent(engine.ErrorEventPayload{
 					Error: fmt.Sprintf("snapshot mismatch: %s", err),


### PR DESCRIPTION
Journal validation requires encrypting/decrypting more secrets in its current implementation, which costs a lot of money on the service side.  Avoid doing this for now, until we have a solution to make this cheaper.