### PR TITLE
Pin bun to 1.2

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -241,6 +241,8 @@ jobs:
           npm install -g yarn pnpm
       - name: Install bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2
       - name: Install Python deps
         run: |
           python -m pip install --upgrade pip requests wheel urllib3 chardet build


### PR DESCRIPTION
There’s a test failing on the newly released 1.3, see https://github.com/pulumi/pulumi/issues/20724

Pin to 1.2 for while we figure out the cause.
