### PR TITLE
Remove incorrect info line in package info

### DIFF
--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -305,10 +305,6 @@ func showResourceInfo(spec *schema.PackageSpec, moduleName, resourceName string,
 	fmt.Fprintln(stdout, bold("Outputs")+":")
 	hasPresent := false
 	for _, name := range maputil.SortedKeys(res.Properties) {
-		// Skip input properties, as they are already shown above.
-		if _, ok := res.InputProperties[name]; ok {
-			continue
-		}
 		prop := res.Properties[name]
 		presentStr := ""
 		if slices.Contains(res.Required, name) {

--- a/pkg/cmd/pulumi/packagecmd/package_info_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info_test.go
@@ -203,5 +203,7 @@ Inputs marked with '*' are required
  - \x1b[1marrayProp\x1b[0m (\x1b[4m[]TestType\x1b[0m\x1b[4m\x1b[0m): this is an array property
  - \x1b[1menumProp\x1b[0m (\x1b[4menum(string){EnumValue1, value2}\x1b[0m\x1b[4m\x1b[0m): this is an enum property
  - \x1b[1mmapProp\x1b[0m (\x1b[4mmap[string]string\x1b[0m\x1b[4m\x1b[0m): this is a map property
+ - \x1b[1mprop1\x1b[0m (\x1b[4mstring\x1b[0m\x1b[4m*\x1b[0m): this is a string property
+Outputs marked with '*' are always present
 `, strings.ReplaceAll(output.String(), "\x1b", "\\x1b"))
 }


### PR DESCRIPTION
This info line that inputs are always outputs isn't correct. Our schema model differentiates between inputs and outputs, its just _normally_ providers will export every input as an output.