### PR TITLE
Fix 'required' check for resource inputs in package info

### DIFF
--- a/changelog/pending/20251013--cli-package--fix-required-flag-for-resource-inputs-in-package-info.yaml
+++ b/changelog/pending/20251013--cli-package--fix-required-flag-for-resource-inputs-in-package-info.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/package
+  description: Fix 'required' flag for resource inputs in `package info`

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -284,7 +284,7 @@ func showResourceInfo(spec *schema.PackageSpec, moduleName, resourceName string,
 	for _, name := range maputil.SortedKeys(res.InputProperties) {
 		prop := res.InputProperties[name]
 		requiredStr := ""
-		if !slices.Contains(res.RequiredInputs, name) {
+		if slices.Contains(res.RequiredInputs, name) {
 			hasRequired = true
 			requiredStr = "*"
 		}

--- a/pkg/cmd/pulumi/packagecmd/package_info_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info_test.go
@@ -86,6 +86,15 @@ another paragraph`,
 				ObjectTypeSpec: schema.ObjectTypeSpec{
 					Description: "this is another test resource",
 				},
+				InputProperties: map[string]schema.PropertySpec{
+					"propA": {
+						Description: "this is propA",
+						TypeSpec: schema.TypeSpec{
+							Type: "string",
+						},
+					},
+				},
+				RequiredInputs: []string{"propA"},
 			},
 			"test:another/Test:Test": {},
 		},
@@ -196,8 +205,7 @@ func TestResourceInfo(t *testing.T) {
 \x1b[1mDescription\x1b[0m: test resource description
 
 \x1b[1mInputs\x1b[0m:
- - \x1b[1mprop1\x1b[0m (\x1b[4mstring\x1b[0m\x1b[4m*\x1b[0m): this is a string property
-Inputs marked with '*' are required
+ - \x1b[1mprop1\x1b[0m (\x1b[4mstring\x1b[0m\x1b[4m\x1b[0m): this is a string property
 
 \x1b[1mOutputs\x1b[0m:
  - \x1b[1marrayProp\x1b[0m (\x1b[4m[]TestType\x1b[0m\x1b[4m\x1b[0m): this is an array property
@@ -205,5 +213,21 @@ Inputs marked with '*' are required
  - \x1b[1mmapProp\x1b[0m (\x1b[4mmap[string]string\x1b[0m\x1b[4m\x1b[0m): this is a map property
  - \x1b[1mprop1\x1b[0m (\x1b[4mstring\x1b[0m\x1b[4m*\x1b[0m): this is a string property
 Outputs marked with '*' are always present
+`, strings.ReplaceAll(output.String(), "\x1b", "\\x1b"))
+
+	cmd.SetArgs([]string{"--module", "index", "--resource", "Test2", schemaPath})
+	output.Reset()
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	err = cmd.Execute()
+	require.NoError(t, err)
+	require.Equal(t, `\x1b[1mResource\x1b[0m: test:index:Test2
+\x1b[1mDescription\x1b[0m: this is another test resource
+
+\x1b[1mInputs\x1b[0m:
+ - \x1b[1mpropA\x1b[0m (\x1b[4mstring\x1b[0m\x1b[4m*\x1b[0m): this is propA
+Inputs marked with '*' are required
+
+\x1b[1mOutputs\x1b[0m:
 `, strings.ReplaceAll(output.String(), "\x1b", "\\x1b"))
 }


### PR DESCRIPTION
The check for if an input was required or not was flipped. This PR fixes that and adds another test so we can verify that required properties show with a star and optional fields show without.