### PR TITLE
Show invokes/functions in package info

### DIFF
--- a/changelog/pending/20251014--cli-package--show-functions-in-package-info.yaml
+++ b/changelog/pending/20251014--cli-package--show-functions-in-package-info.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/package
+  description: Show functions in `package info`


### PR DESCRIPTION
Add function info to that shown by `package info`. This lists the number of functions in packages/modules and can also look at a specific function with the `--function` parameter.