### PR TITLE
reduce wasm binary size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ bin/pulumi: build_proto .make/ensure/go .make/ensure/phony
 
 .PHONY: bin/pulumi-display.wasm
 bin/pulumi-display.wasm:: .make/ensure/go .make/ensure/phony pkg/backend/display/wasm/gold-size.txt
-	cd pkg && GOOS=js GOARCH=wasm go build -o ../bin/pulumi-display.wasm -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ./backend/display/wasm
+	cd pkg && GOOS=js GOARCH=wasm go build -o ../bin/pulumi-display.wasm -ldflags "-w -s -X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" -trimpath ./backend/display/wasm
 	python3 scripts/wasm-size-check.py bin/pulumi-display.wasm pkg/backend/display/wasm/gold-size.txt
 
 .PHONY: build


### PR DESCRIPTION
A very simple thing to reduce the wasm binary size we can do is to strip out the debug symbols. I don't think we need them in a wasm binary, and it's something we do for providers already afaik.

The size reduction is pretty small, so we could decide to not do this, but it's still better than nothing.

Also use `-trimpath` to remove the full paths, and only leave the package paths. There's no need for the full paths in the binary anyway, as they are just GitHub actions paths that are not very useful.

Before:
```
$ ls -l bin/pulumi-display.wasm
-rwxr-xr-x 1 tgummerer tgummerer 50236617 Oct 14 10:53 bin/pulumi-display.wasm
```

After:
```
$ ls -l bin/pulumi-display.wasm
-rwxr-xr-x 1 tgummerer tgummerer 48588261 Oct 14 10:53 bin/pulumi-display.wasm
```

Something I remembered yesterday after the meeting.  cc @pgavlin 