### PR TITLE
Return error while creating the project name pulumi

### DIFF
--- a/changelog/pending/20251014--pkg--generate-error-message-when-the-project-is-named-pulumi.yaml
+++ b/changelog/pending/20251014--pkg--generate-error-message-when-the-project-is-named-pulumi.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pkg
+  description: Generate error message when the project is named pulumi

--- a/pkg/util/cmdutil/install_dependencies.go
+++ b/pkg/util/cmdutil/install_dependencies.go
@@ -16,8 +16,11 @@ package cmdutil
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -27,6 +30,15 @@ import (
 // complete. Standard output and error are streamed to os.Stdout and os.Stderr, respectively, and any errors encountered
 // during the installation or streaming of its output are returned.
 func InstallDependencies(lang plugin.LanguageRuntime, req plugin.InstallDependenciesRequest) error {
+	root_dir := req.Info.RootDirectory()
+	fmt.Printf("Installing dependencies for project in '%s'...\n", root_dir)
+	baseDir := filepath.Base(root_dir)
+	if strings.ToLower(baseDir) == "pulumi" {
+		return fmt.Errorf("the directory '%s' is named 'pulumi', which is not allowed. "+
+			"Please rename the directory to something else to avoid collision with standard libraries. "+
+			"Please run `pulumi destroy` to remove the current incompleted stack.", baseDir)
+	}
+
 	stdout, stderr, done, err := lang.InstallDependencies(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
Description:
`If you create a new python project in a folder called pulumi, the pyproject.toml file sets the name of the project to be pulumi, and because that is the name of the python package it downloads it fails with the following error:`

Error Message:
`Creating virtual environment at: .venv error: Requirement name pulumimatches project namepulumi, but self-dependencies are not permitted without the --devor--optional flags. If your project name (pulumi) is shadowing that of a third-party dependency, consider renaming the project. error: installing dependencies failed: error installing dependecies from requirements.txt: exit status 2 error installing dependecies from requirements.txt: exit status 2 error installing dependecies from requirements.txt: exit status 2 Run pulumi install to complete the installation.`

Detail:
https://github.com/pulumi/pulumi/discussions/20729

Fixes :
https://github.com/pulumi/pulumi/issues/20297

Set up:
1. Create a new folder called pulumi and change to this folder: mkdir pulumi && cd pulumi
2. Create a new python project: pulumi new python
3. Choose project name pulumi.

It will fail while installing tool chain dependencies as below

<img width="1046" height="534" alt="Pulumi_error_install" src="https://github.com/user-attachments/assets/3abe5796-0a6c-4b02-bbd7-cc5d04c64b0a" />

Checklist
 Linter Ckecked Passed
 Added Changelog Message