### PR TITLE
Share CurrentProjectContradictsWorkspace between backends

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -58,6 +59,26 @@ type StackReference interface {
 
 	// Fully qualified name of the stack, including any organization, project, or other information.
 	FullyQualifiedName() tokens.QName
+}
+
+// Confirm the specified stack's project doesn't contradict the name of the current project.
+func CurrentProjectContradictsWorkspace(proj *workspace.Project, stack StackReference) error {
+	contract.Requiref(stack != nil, "stack", "is nil")
+
+	if proj == nil {
+		return nil
+	}
+
+	project, has := stack.Project()
+	if !has {
+		return nil
+	}
+
+	if string(proj.Name) != string(project) {
+		return fmt.Errorf("provided project name %q doesn't match Pulumi.yaml", project)
+	}
+
+	return nil
 }
 
 // PolicyPackReference is an opaque type that refers to a PolicyPack managed by a backend. The CLI


### PR DESCRIPTION
Taking some inspiration from https://github.com/pulumi/pulumi/pull/19866. One of the few places where Will had kept things still diverging was the check for if the project name matched the stack name. But I think we can actually unify this logic now, and also save the working directory traversal. 

Non-backend specific `StackReference`s can be checked for their project name, we don't need to know what backend were working with to check that. Also backends keep track of the current project, so there's no need to go crawl the working directory to find it again.

So this deletes the two private `currentProjectContradictsWorkspace` functions in the diy and http packages and adds a new public `CurrentProjectContradictsWorkspace` in the backend package that both backends then use.

I've also moved the check for the http backend earlier in the apply function. Up from `createAndStartUpdate` to the method above `apply`. This matches where the check is done in the diy backend.