### PR TITLE
[Node.js] Pass secret values as Output objects to resource hooks

### DIFF
--- a/changelog/pending/20251022--sdk-nodejs--pass-secret-values-as-output-objects-to-resource-hooks-to-properly-maintain-their-secretness-previously-hooks-received-an-internal-representation-for-secret-values.yaml
+++ b/changelog/pending/20251022--sdk-nodejs--pass-secret-values-as-output-objects-to-resource-hooks-to-properly-maintain-their-secretness-previously-hooks-received-an-internal-representation-for-secret-values.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Pass secret values as Output objects to resource hooks to properly maintain their secretness. Previously hooks received an internal representation for secret values.

--- a/tests/integration/resource_hooks/nodejs_secret/Pulumi.yaml
+++ b/tests/integration/resource_hooks/nodejs_secret/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: resource_hooks_nodejs_transform
+description: A program with a resource hook set by a transform
+runtime: nodejs

--- a/tests/integration/resource_hooks/nodejs_secret/echo.ts
+++ b/tests/integration/resource_hooks/nodejs_secret/echo.ts
@@ -1,0 +1,15 @@
+// Copyright 2025, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+interface EchoArgs {
+    echo: pulumi.Input<string>;
+}
+
+export class Echo extends pulumi.CustomResource {
+    declare public readonly echo: pulumi.Output<string>;
+    constructor(name: string, args: EchoArgs, opts?: pulumi.CustomResourceOptions) {
+        const props = { echo: args.echo }
+        super("testprovider:index:Echo", name, props, opts);
+    }
+}

--- a/tests/integration/resource_hooks/nodejs_secret/index.ts
+++ b/tests/integration/resource_hooks/nodejs_secret/index.ts
@@ -1,0 +1,19 @@
+// Copyright 2025, Pulumi Corporation.  All rights reserved.
+
+import * as assert from "assert";
+import { log, ResourceHook, ResourceHookArgs, ResourceOptions, secret } from "@pulumi/pulumi";
+import { Echo } from "./echo";
+
+
+async function fun(args: ResourceHookArgs) {
+    const out = args.newInputs["echo"]
+    assert.strictEqual(true, await out.isSecret)
+    assert.strictEqual("hello secret", await out.promise())
+    log.info("hook called")
+}
+
+new Echo("echo", { echo: secret("hello secret") }, {
+    hooks: {
+        beforeCreate: [fun]
+    }
+});

--- a/tests/integration/resource_hooks/nodejs_secret/package.json
+++ b/tests/integration/resource_hooks/nodejs_secret/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "resource-hook",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "@pulumi/pulumi": "latest"
+  },
+  "dependencies": {
+    "@types/node": "^20"
+  }
+}

--- a/tests/integration/resource_hooks/resource_hooks_nodejs_test.go
+++ b/tests/integration/resource_hooks/resource_hooks_nodejs_test.go
@@ -82,3 +82,20 @@ func TestNodejsResourceHooksTransform(t *testing.T) {
 		},
 	})
 }
+
+// Test that hooks receives secrets as secret outputs
+//
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestNodejsResourceHooksSecrets(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          "nodejs_secret",
+		Dependencies: []string{"@pulumi/pulumi"},
+		LocalProviders: []integration.LocalDependency{
+			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+		},
+		Quick: true,
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			requirePrinted(t, stack, "info", "hook called")
+		},
+	})
+}


### PR DESCRIPTION
Node.js part of https://github.com/pulumi/pulumi/issues/20520

Secret values should be Outputs marked as secret, instead of the JSON wire representation of secret values.
