### PR TITLE
add refreshV2 and `up --refresh --run-program` to the fuzzer

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/reprogen.go
+++ b/pkg/engine/lifecycletest/fuzzing/reprogen.go
@@ -269,6 +269,8 @@ func writeSnapshotTestFunction(
 				operation = "engine.Update"
 			case PlanOperationRefresh:
 				operation = "engine.Refresh"
+			case PlanOperationRefreshV2:
+				operation = "engine.RefreshV2"
 			case PlanOperationDestroy:
 				operation = "engine.Destroy"
 			case PlanOperationDestroyV2:
@@ -425,6 +427,8 @@ func writeFrameworkTestFunction(
 				operation = "engine.Update"
 			case PlanOperationRefresh:
 				operation = "engine.Refresh"
+			case PlanOperationRefreshV2:
+				operation = "engine.RefreshV2"
 			case PlanOperationDestroy:
 				operation = "engine.Destroy"
 			case PlanOperationDestroyV2:


### PR DESCRIPTION
We currently don't run these during fuzz testing, but we should.  Add them.