### PR TITLE
only build coverage enabled binaries on linux

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -119,7 +119,7 @@ jobs:
         env:
           GORELEASER_CURRENT_TAG: v${{ inputs.version }}
           PULUMI_VERSION: ${{ inputs.dev-version || inputs.version }}
-          PULUMI_BUILD_MODE: ${{ inputs.enable-coverage && 'coverage' || 'normal' }}
+          PULUMI_BUILD_MODE: ${{ inputs.enable-coverage && runner.os == 'Linux' && 'coverage' || 'normal' }}
           PULUMI_ENABLE_RACE_DETECTION: ${{ inputs.enable-race-detection && 'true' || 'false' }}
         run: |
           set -euxo pipefail


### PR DESCRIPTION
We only collect coverage data for integration tests on Linux, and explicitly disable it for [windows](https://github.com/pulumi/pulumi/blob/master/.github/workflows/ci.yml#L399) and [macOS](https://github.com/pulumi/pulumi/blob/master/.github/workflows/ci.yml#L426).

I don't remember the reasoning for this, but I think it was something about not running on the same platforms during PR checks and in the merge queue.

Additionally collecting coverage data on Windows is unfortunately often flaky.  Since we're pretty much running the same code on all platforms, with only very minor differences, the code coverage shouldn't be that different either way.

However despite not collecting the coverage data on Windows or MacOS, we still compile the binaries with the `-cover` flag enabled, leading to test failures because of above mentioned flakyness. Avoid building the binaries with coverage enabled to reduce the flakyness of our test suite.

(note this will not reduce the flakyness of everything we consider unit tests I think, but it should be an improvement nonetheless)