### PR TITLE
Run tests for Node.js 25

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -139,7 +139,7 @@ ALL_PLATFORMS = ["ubuntu-latest", "windows-latest", "macos-latest"]
 ALL_VERSION_SET = {
     "dotnet": ["8", "9"],
     "go": ["1.24.x", "1.25.x"],
-    "nodejs": ["20.x", "22.x", "23.x", "24.x"],
+    "nodejs": ["20.x", "22.x", "24.x", "25.x"],
     # When updating the minimum Python version here, also update `pyproject.toml`, including the
     # `mypy` and `ruff` sections.
     "python": ["3.10.x", "3.11.x", "3.12.x", "3.13.x", "3.14.x"],


### PR DESCRIPTION
Node.js 25 was released last week https://nodejs.org/en/blog/release/v25.0.0

Run tests on 25. 23 is EOL and we can drop testing on that version https://nodejs.org/en/about/previous-releases.