### PR TITLE
fix assert in refreshV2

### DIFF
--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -745,13 +745,13 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, boo
 				sg.refreshStates[old] = state
 				sg.refreshAliasLock.Unlock()
 			}
-			contract.AssertNoErrorf(err, "expected a result from refresh step")
 			sg.events <- &continueResourceRefreshEvent{
 				RegisterResourceEvent: event,
 				urn:                   urn,
 				old:                   state,
 				new:                   new,
 				invalid:               invalid,
+				err:                   err,
 			}
 		}()
 
@@ -822,6 +822,10 @@ func (sg *stepGenerator) continueStepsFromRefresh(event ContinueResourceRefreshE
 	urn := event.URN()
 	old := event.Old()
 	new := event.New()
+	err := event.Error()
+	if err != nil {
+		return nil, false, err
+	}
 
 	// If this is a refresh deployment we're _always_ going to do a skip create or refresh step here for
 	// custom non-provider resources. We also need to skip refreshes for custom provider resources if they

--- a/pkg/resource/deploy/step_generator_events.go
+++ b/pkg/resource/deploy/step_generator_events.go
@@ -104,6 +104,7 @@ type ContinueResourceRefreshEvent interface {
 	Old() *resource.State
 	New() *resource.State
 	Invalid() bool
+	Error() error
 }
 
 type continueResourceRefreshEvent struct {
@@ -112,6 +113,7 @@ type continueResourceRefreshEvent struct {
 	old     *resource.State // the old state of the resource being processed.
 	new     *resource.State // the new state of the resource being processed.
 	invalid bool            // whether the resource is invalid.
+	err     error           // any error that occurred during refresh
 }
 
 var _ ContinueResourceRefreshEvent = (*continueResourceRefreshEvent)(nil)
@@ -132,6 +134,10 @@ func (g *continueResourceRefreshEvent) New() *resource.State {
 
 func (g *continueResourceRefreshEvent) Invalid() bool {
 	return g.invalid
+}
+
+func (g *continueResourceRefreshEvent) Error() error {
+	return g.err
 }
 
 // ContinueResourceImportEvent is a step that asks the engine to continue provisioning a resource after an import, it is


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/20781, we made it so refreshes don't hang anymore.  However the fix had a problem in that it is now possible that the completion source returns errors, and would assert in that case.  We want to avoid that assert, so plug the error through and return it at the appropriate step instead.

Unfortunately I'm not sure how to repro this, but the fuzzer no longer crashes after this fix.