### PR TITLE
Update help text for pulumi plugin commands

### DIFF
--- a/pkg/cmd/pulumi/plugin/plugin.go
+++ b/pkg/cmd/pulumi/plugin/plugin.go
@@ -34,15 +34,10 @@ func NewPluginCmd() *cobra.Command {
 		Long: "Manage language and resource provider plugins.\n" +
 			"\n" +
 			"Pulumi uses dynamically loaded plugins as an extensibility mechanism for\n" +
-			"supporting any number of languages and resource providers.  These plugins are\n" +
-			"distributed out of band and must be installed manually.  Attempting to use a\n" +
-			"package that provisions resources without the corresponding plugin will fail.\n" +
-			"\n" +
-			"You may write your own plugins, for example to implement custom languages or\n" +
-			"resources, although most people will never need to do this.  To understand how to\n" +
-			"write and distribute your own plugins, please consult the relevant documentation.\n" +
-			"\n" +
-			"The plugin family of commands provides a way of explicitly managing plugins.\n" +
+			"supporting any number of languages and resource providers. The Pulumi CLI\n" +
+			"automatically downloads and installs plugins as needed during normal operations\n" +
+			"such as 'pulumi up' or 'pulumi preview'. The plugin family of commands provides\n" +
+			"a way of explicitly managing plugins when automatic installation is not sufficient.\n" +
 			"\n" +
 			"For a list of available resource plugins, please see https://www.pulumi.com/registry/.",
 		Args: cmdutil.NoArgs,

--- a/pkg/cmd/pulumi/plugin/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install.go
@@ -51,11 +51,17 @@ func newPluginInstallCmd(packageResolutionOptions packageresolution.Options) *co
 		Short: "Install one or more plugins",
 		Long: "Install one or more plugins.\n" +
 			"\n" +
-			"This command is used to manually install plugins required by your program. It\n" +
-			"may be run with a specific KIND, NAME, and optionally, VERSION, or by omitting\n" +
-			"these arguments and letting Pulumi compute the set of plugins required by the\n" +
-			"current project. When Pulumi computes the download set automatically, it may\n" +
-			"download more plugins than are strictly necessary.\n" +
+			"The Pulumi CLI automatically downloads and installs plugins as needed during\n" +
+			"normal operations. This command is provided for scenarios where manual plugin\n" +
+			"installation is necessary, such as pre-downloading plugins or working in\n" +
+			"air-gapped environments.\n" +
+			"\n" +
+			"This command may be run with a specific KIND, NAME, and optionally, VERSION, or\n" +
+			"by omitting these arguments and letting Pulumi compute the set of plugins\n" +
+			"required by the current project. When Pulumi computes the download set\n" +
+			"automatically, it may download more plugins than are strictly necessary.\n" +
+			"\n" +
+			"Valid values for KIND are: resource, language, analyzer, converter, and tool.\n" +
 			"\n" +
 			"If VERSION is specified, it cannot be a range; it must be a specific number.\n" +
 			"If VERSION is unspecified, Pulumi will attempt to look up the latest version of\n" +

--- a/pkg/cmd/pulumi/plugin/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin/plugin_ls.go
@@ -34,7 +34,11 @@ func newPluginLsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ls",
 		Short: "List plugins",
-		Args:  cmdutil.NoArgs,
+		Long: "List plugins.\n" +
+			"\n" +
+			"Lists plugins that have been installed in the plugin cache. This includes\n" +
+			"resource and converter plugins.",
+		Args: cmdutil.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Produce a list of plugins, sorted by name and version.
 			var plugins []workspace.PluginInfo

--- a/pkg/cmd/pulumi/plugin/plugin_rm.go
+++ b/pkg/cmd/pulumi/plugin/plugin_rm.go
@@ -44,13 +44,15 @@ func newPluginRmCmd() *cobra.Command {
 		Long: "Remove one or more plugins from the download cache.\n" +
 			"\n" +
 			"Specify KIND, NAME, and/or VERSION to narrow down what will be removed.\n" +
-			"If none are specified, the entire cache will be cleared.  If only KIND and\n" +
+			"If none are specified, the entire cache will be cleared. If only KIND and\n" +
 			"NAME are specified, but not VERSION, all versions of the plugin with the\n" +
-			"given KIND and NAME will be removed.  VERSION may be a range.\n" +
+			"given KIND and NAME will be removed. VERSION may be a range.\n" +
 			"\n" +
-			"This removal cannot be undone.  If a deleted plugin is subsequently required\n" +
-			"in order to execute a Pulumi program, it must be re-downloaded and installed\n" +
-			"using the plugin install command.",
+			"Valid values for KIND are: resource, language, analyzer, converter, and tool.\n" +
+			"\n" +
+			"This removal cannot be undone. If a deleted plugin is subsequently required\n" +
+			"in order to execute a Pulumi program, the Pulumi CLI will often download it\n" +
+			"automatically, or you can manually reinstall it using 'pulumi plugin install'.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			yes = yes || env.SkipConfirmations.Value()
 			opts := display.Options{


### PR DESCRIPTION
Improves the help documentation for plugin-related commands to better reflect how the Pulumi CLI automatically manages plugins:

- pulumi plugin: Clarifies that plugins are automatically downloaded during normal operations and removes misleading "must be installed manually" text. Removes section about authoring custom plugins.

- pulumi plugin ls: Adds description clarifying which plugin types are listed (resource and converter plugins).

- pulumi plugin install: Adds context that the CLI normally handles installation automatically, and explains when manual installation might be needed. Includes list of valid KIND values.

- pulumi plugin rm: Updates to reflect that the CLI will often automatically re-download deleted plugins when needed. Includes list of valid KIND values.

Fixes #20777

🤖 Generated with [Claude Code](https://claude.com/claude-code)