### PR TITLE
Improve how policy severity is displayed

### DIFF
--- a/changelog/pending/20251023--cli-display--improve-how-the-severity-is-displayed-for-policy-violations.yaml
+++ b/changelog/pending/20251023--cli-display--improve-how-the-severity-is-displayed-for-policy-violations.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Improve how the severity is displayed for policy violations

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -215,11 +215,11 @@ func renderDiffPolicyViolationEvent(payload engine.PolicyViolationEventPayload,
 
 	var severity string
 	if payload.Severity != apitype.PolicySeverityUnspecified {
-		severity = fmt.Sprintf(": %s", payload.Severity)
+		severity = fmt.Sprintf(" [severity: %s]", payload.Severity)
 	}
 
 	// Print the individual policy's name and target resource type/name.
-	policyLine := fmt.Sprintf("%s[%s%s]  %s%s  (%s: %s)",
+	policyLine := fmt.Sprintf("%s[%s]%s  %s%s  (%s: %s)",
 		c, payload.EnforcementLevel, severity, payload.PolicyName, colors.Reset,
 		payload.ResourceURN.Type(), payload.ResourceURN.Name())
 

--- a/pkg/engine/lifecycletest/testdata/output/TestSimpleAnalyzeResourceFailure/diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestSimpleAnalyzeResourceFailure/diff.stdout.txt
@@ -1,6 +1,6 @@
 <{%fg 2%}>+ pulumi:providers:pkgA: (create)
 <{%fg 2%}>    [urn=urn:pulumi:test::test::pulumi:providers:pkgA::default]
-<{%reset%}><{%reset%}>    <{%fg 5%}>analyzerA@v <{%reset%}><{%fg 1%}>[mandatory: high]  always-fails<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
+<{%reset%}><{%reset%}>    <{%fg 5%}>analyzerA@v <{%reset%}><{%fg 1%}>[mandatory] [severity: high]  always-fails<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
 <{%fg 13%}><{%bold%}>Resources:<{%reset%}>
 
 <{%fg 13%}><{%bold%}>Policy Packs run:<{%reset%}>

--- a/pkg/engine/lifecycletest/testdata/output/TestSimpleAnalyzeResourceFailure/progress.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestSimpleAnalyzeResourceFailure/progress.stdout.txt
@@ -8,6 +8,6 @@
  <{%reset%}>  <{%reset%}> pulumi:pulumi:Stack project-stack <{%reset%}><{%reset%}> 
 <{%fg 13%}><{%bold%}>Policies:<{%reset%}>
     ❌ <{%fg 5%}>analyzerA@v<{%reset%}>
-        - <{%fg 1%}>[mandatory: high]  always-fails<{%reset%}>  (pkgA:m:typA: resA)
+        - <{%fg 1%}>[mandatory] [severity: high]  always-fails<{%reset%}>  (pkgA:m:typA: resA)
           <{%reset%}>a policy failed<{%reset%}>
 

--- a/pkg/engine/lifecycletest/testdata/output/TestSimpleAnalyzeResourceFailureSeverityOverride/diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestSimpleAnalyzeResourceFailureSeverityOverride/diff.stdout.txt
@@ -1,6 +1,6 @@
 <{%fg 2%}>+ pulumi:providers:pkgA: (create)
 <{%fg 2%}>    [urn=urn:pulumi:test::test::pulumi:providers:pkgA::default]
-<{%reset%}><{%reset%}>    <{%fg 5%}>analyzerA@v <{%reset%}><{%fg 1%}>[mandatory: critical]  always-fails<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
+<{%reset%}><{%reset%}>    <{%fg 5%}>analyzerA@v <{%reset%}><{%fg 1%}>[mandatory] [severity: critical]  always-fails<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
 <{%fg 13%}><{%bold%}>Resources:<{%reset%}>
 
 <{%fg 13%}><{%bold%}>Policy Packs run:<{%reset%}>

--- a/pkg/engine/lifecycletest/testdata/output/TestSimpleAnalyzeResourceFailureSeverityOverride/progress.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestSimpleAnalyzeResourceFailureSeverityOverride/progress.stdout.txt
@@ -8,6 +8,6 @@
  <{%reset%}>  <{%reset%}> pulumi:pulumi:Stack project-stack <{%reset%}><{%reset%}> 
 <{%fg 13%}><{%bold%}>Policies:<{%reset%}>
     ❌ <{%fg 5%}>analyzerA@v<{%reset%}>
-        - <{%fg 1%}>[mandatory: critical]  always-fails<{%reset%}>  (pkgA:m:typA: resA)
+        - <{%fg 1%}>[mandatory] [severity: critical]  always-fails<{%reset%}>  (pkgA:m:typA: resA)
           <{%reset%}>a policy failed<{%reset%}>
 

--- a/pkg/engine/lifecycletest/testdata/output/TestSimpleAnalyzeResourceMultipleViolations/diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestSimpleAnalyzeResourceMultipleViolations/diff.stdout.txt
@@ -1,15 +1,15 @@
 <{%fg 2%}>+ pulumi:providers:pkgA: (create)
 <{%fg 2%}>    [urn=urn:pulumi:test::test::pulumi:providers:pkgA::default]
 <{%reset%}><{%reset%}>    <{%fg 5%}>analyzerA@v1.0.0 <{%reset%}><{%fg 3%}>[advisory]  always-fails-advisory-unspecified<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
-    <{%fg 5%}>analyzerA@v1.0.0 <{%reset%}><{%fg 3%}>[advisory: low]  always-fails-advisory-low<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
-    <{%fg 5%}>analyzerA@v1.0.0 <{%reset%}><{%fg 3%}>[advisory: medium]  always-fails-advisory-medium<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
-    <{%fg 5%}>analyzerA@v1.0.0 <{%reset%}><{%fg 3%}>[advisory: high]  always-fails-advisory-high<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
-    <{%fg 5%}>analyzerA@v1.0.0 <{%reset%}><{%fg 3%}>[advisory: critical]  always-fails-advisory-critical<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
+    <{%fg 5%}>analyzerA@v1.0.0 <{%reset%}><{%fg 3%}>[advisory] [severity: low]  always-fails-advisory-low<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
+    <{%fg 5%}>analyzerA@v1.0.0 <{%reset%}><{%fg 3%}>[advisory] [severity: medium]  always-fails-advisory-medium<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
+    <{%fg 5%}>analyzerA@v1.0.0 <{%reset%}><{%fg 3%}>[advisory] [severity: high]  always-fails-advisory-high<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
+    <{%fg 5%}>analyzerA@v1.0.0 <{%reset%}><{%fg 3%}>[advisory] [severity: critical]  always-fails-advisory-critical<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
     <{%fg 5%}>analyzerA@v1.0.0 <{%reset%}><{%fg 1%}>[mandatory]  always-fails-unspecified<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
-    <{%fg 5%}>analyzerA@v1.0.0 <{%reset%}><{%fg 1%}>[mandatory: low]  always-fails-low<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
-    <{%fg 5%}>analyzerA@v1.0.0 <{%reset%}><{%fg 1%}>[mandatory: medium]  always-fails-medium<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
-    <{%fg 5%}>analyzerA@v1.0.0 <{%reset%}><{%fg 1%}>[mandatory: high]  always-fails-high<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
-    <{%fg 5%}>analyzerA@v1.0.0 <{%reset%}><{%fg 1%}>[mandatory: critical]  always-fails-critical<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
+    <{%fg 5%}>analyzerA@v1.0.0 <{%reset%}><{%fg 1%}>[mandatory] [severity: low]  always-fails-low<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
+    <{%fg 5%}>analyzerA@v1.0.0 <{%reset%}><{%fg 1%}>[mandatory] [severity: medium]  always-fails-medium<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
+    <{%fg 5%}>analyzerA@v1.0.0 <{%reset%}><{%fg 1%}>[mandatory] [severity: high]  always-fails-high<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
+    <{%fg 5%}>analyzerA@v1.0.0 <{%reset%}><{%fg 1%}>[mandatory] [severity: critical]  always-fails-critical<{%reset%}>  (pkgA:m:typA: resA)<{%reset%}>a policy failed<{%reset%}>
 <{%fg 13%}><{%bold%}>Resources:<{%reset%}>
 
 <{%fg 13%}><{%bold%}>Policy Packs run:<{%reset%}>

--- a/pkg/engine/lifecycletest/testdata/output/TestSimpleAnalyzeResourceMultipleViolations/progress.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestSimpleAnalyzeResourceMultipleViolations/progress.stdout.txt
@@ -8,23 +8,23 @@
  <{%reset%}>  <{%reset%}> pulumi:pulumi:Stack project-stack <{%reset%}><{%reset%}> 
 <{%fg 13%}><{%bold%}>Policies:<{%reset%}>
     ❌ <{%fg 5%}>analyzerA@v1.0.0<{%reset%}>
-        - <{%fg 1%}>[mandatory: critical]  always-fails-critical<{%reset%}>  (pkgA:m:typA: resA)
+        - <{%fg 1%}>[mandatory] [severity: critical]  always-fails-critical<{%reset%}>  (pkgA:m:typA: resA)
           <{%reset%}>a policy failed<{%reset%}>
-        - <{%fg 1%}>[mandatory: high]  always-fails-high<{%reset%}>  (pkgA:m:typA: resA)
+        - <{%fg 1%}>[mandatory] [severity: high]  always-fails-high<{%reset%}>  (pkgA:m:typA: resA)
           <{%reset%}>a policy failed<{%reset%}>
-        - <{%fg 1%}>[mandatory: medium]  always-fails-medium<{%reset%}>  (pkgA:m:typA: resA)
+        - <{%fg 1%}>[mandatory] [severity: medium]  always-fails-medium<{%reset%}>  (pkgA:m:typA: resA)
           <{%reset%}>a policy failed<{%reset%}>
-        - <{%fg 1%}>[mandatory: low]  always-fails-low<{%reset%}>  (pkgA:m:typA: resA)
+        - <{%fg 1%}>[mandatory] [severity: low]  always-fails-low<{%reset%}>  (pkgA:m:typA: resA)
           <{%reset%}>a policy failed<{%reset%}>
         - <{%fg 1%}>[mandatory]  always-fails-unspecified<{%reset%}>  (pkgA:m:typA: resA)
           <{%reset%}>a policy failed<{%reset%}>
-        - <{%fg 3%}>[advisory: critical]  always-fails-advisory-critical<{%reset%}>  (pkgA:m:typA: resA)
+        - <{%fg 3%}>[advisory] [severity: critical]  always-fails-advisory-critical<{%reset%}>  (pkgA:m:typA: resA)
           <{%reset%}>a policy failed<{%reset%}>
-        - <{%fg 3%}>[advisory: high]  always-fails-advisory-high<{%reset%}>  (pkgA:m:typA: resA)
+        - <{%fg 3%}>[advisory] [severity: high]  always-fails-advisory-high<{%reset%}>  (pkgA:m:typA: resA)
           <{%reset%}>a policy failed<{%reset%}>
-        - <{%fg 3%}>[advisory: medium]  always-fails-advisory-medium<{%reset%}>  (pkgA:m:typA: resA)
+        - <{%fg 3%}>[advisory] [severity: medium]  always-fails-advisory-medium<{%reset%}>  (pkgA:m:typA: resA)
           <{%reset%}>a policy failed<{%reset%}>
-        - <{%fg 3%}>[advisory: low]  always-fails-advisory-low<{%reset%}>  (pkgA:m:typA: resA)
+        - <{%fg 3%}>[advisory] [severity: low]  always-fails-advisory-low<{%reset%}>  (pkgA:m:typA: resA)
           <{%reset%}>a policy failed<{%reset%}>
         - <{%fg 3%}>[advisory]  always-fails-advisory-unspecified<{%reset%}>  (pkgA:m:typA: resA)
           <{%reset%}>a policy failed<{%reset%}>


### PR DESCRIPTION
This change improves how severities are displayed for policy violations. Currently, if a policy has a severity, we'd show it within the enforcement level's brackets, separated by a colon (e.g. `[mandatory: high]`). With this change, we move the severity to it's own brackets and include "severity" so users know what it is (e.g. `[mandatory] [severity: high]`).

Before: `[mandatory: high]`
 After: `[mandatory] [severity: high]`

Fixes #20804