### PR TITLE
Clean up the get-language-providers.sh script

### DIFF
--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -27,12 +27,16 @@ download_release() {
 #
 # * When updating .Net, you should also update PulumiDotnetSDKVersion in pulumi/pkg/codegen/testing/test/helpers.go
 #
-# shellcheck disable=SC2043
-for i in "github.com/pulumi/pulumi-java java v1.16.2" "github.com/pulumi/pulumi-yaml yaml v1.24.0" "github.com/pulumi/pulumi-dotnet dotnet v3.91.0"; do
+LANGUAGES=(
+  "dotnet v3.91.0"
+  "java v1.16.2"
+  "yaml v1.24.0"
+)
+
+for i in "${LANGUAGES[@]}"; do
   set -- $i # treat strings in loop as args
-  REPO="$1"
-  PULUMI_LANG="$2"
-  TAG="$3"
+  PULUMI_LANG="$1"
+  TAG="$2"
 
   LANG_DIST="$(pwd)/bin"
   mkdir -p "${LANG_DIST}"


### PR DESCRIPTION
Put each language/version on its own line for easier updating and line history, and delete the unused `REPO` variable.