### PR TITLE
pin @swc/core

### DIFF
--- a/tests/integration/nodejs/swc/package.json
+++ b/tests/integration/nodejs/swc/package.json
@@ -2,7 +2,7 @@
   "name": "swc",
   "dependencies": {
     "@pulumi/pulumi": "latest",
-    "@swc/core": "^1.10.0",
+    "@swc/core": "1.10.0",
     "ts-node": "^10.4.0",
     "typescript": "^5.6.0"
   }


### PR DESCRIPTION
The latest version (1.13.21, published 6h ago at the time of this writing), seems to have an issue on MacOS, making the `TestTranspileOnly/swc` test fail:

```
=== FAIL: integration TestTranspileOnly/swc (35.47s)
    environment.go:89: Created new test environment:  /var/folders/q0/wmf37v850txck86cpnvwm_zw0000gn/T/test-env219623908
    environment.go:228: Running command /Users/runner/hostedtoolcache/node/25.0.0/arm64/bin/yarn install
    environment.go:228: Running command /Users/runner/hostedtoolcache/node/25.0.0/arm64/bin/yarn add /Users/runner/work/pulumi/pulumi/sdk/nodejs/bin
    environment.go:228: Running command /Users/runner/work/pulumi/pulumi/bin/pulumi login --cloud-url file:///var/folders/q0/wmf37v850txck86cpnvwm_zw0000gn/T/test-env219623908
    environment.go:228: Running command /Users/runner/work/pulumi/pulumi/bin/pulumi stack init test851e931170f79d8a
    environment.go:228: Running command /Users/runner/work/pulumi/pulumi/bin/pulumi stack select test851e931170f79d8a
    environment.go:228: Running command /Users/runner/work/pulumi/pulumi/bin/pulumi up --yes
    integration_nodejs_test.go:1806: Run Error: exit status 255
    integration_nodejs_test.go:1806: STDOUT: Previewing update (test851e931170f79d8a):

        @ previewing update....
            pulumi:pulumi:Stack swc-test851e931170f79d8a  error: Error: Failed to load native binding
        @ previewing update....
            pulumi:pulumi:Stack swc-test851e931170f79d8a  1 error
        Diagnostics:
          pulumi:pulumi:Stack (swc-test851e931170f79d8a):
            error: Error: Failed to load native binding
                at Object.<anonymous> (/private/var/folders/q0/wmf37v850txck86cpnvwm_zw0000gn/T/test-env219623908/node_modules/@swc/core/binding.js:333:11)
                at Module._compile (node:internal/modules/cjs/loader:1759:14)
                at Object..js (node:internal/modules/cjs/loader:1892:10)
                at Module.load (node:internal/modules/cjs/loader:1479:32)
                at Module._load (node:internal/modules/cjs/loader:1298:12)
                at TracingChannel.traceSync (node:diagnostics_channel:328:14)
                at wrapModuleLoad (node:internal/modules/cjs/loader:244:24)
                at Module.require (node:internal/modules/cjs/loader:1502:12)
                at require (node:internal/modules/helpers:152:16)
                at Object.<anonymous> (/private/var/folders/q0/wmf37v850txck86cpnvwm_zw0000gn/T/test-env219623908/node_modules/@swc/core/index.js:49:17)

        Resources:
            1 errored

    integration_nodejs_test.go:1806: STDERR:
    integration_nodejs_test.go:1806: Ran command pulumi args [up --yes] and expected success. Instead got failure.

=== FAIL: integration TestTranspileOnly (0.00s)
```

From a quick look at the test, it should be fine to just pin this dependency to make this work again.