### PR TITLE
Expose Default Provider Events in JSON Output

### DIFF
--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -94,10 +94,14 @@ func ShowEvents(
 		stampedEvents, done = startEventLogger(stampedEvents, done, opts)
 	}
 
-	// Need to filter the engine events here to exclude any internal events.
-	stampedEvents = channel.FilterRead(stampedEvents, func(e engine.StampedEvent) bool {
-		return !e.Internal()
-	})
+	// Filter internal events for non-JSON display modes only.
+	// JSON output should include internal events (e.g., default providers) so that
+	// programmatic consumers can access full provider version/parameterization info.
+	if !opts.JSONDisplay {
+		stampedEvents = channel.FilterRead(stampedEvents, func(e engine.StampedEvent) bool {
+			return !e.Internal()
+		})
+	}
 
 	streamPreview := env.EnableStreamingJSONPreview.Value()
 


### PR DESCRIPTION
Fixes #20764

### Summary
Internal events are now included in `--json` output while remaining hidden from the UI.
This allows programmatic consumers to access complete provider version and parameterization information.

### Changes
- **pkg/backend/display/display.go**: Modified filtering to only exclude internal events from non-JSON display modes

### Behavior
- **UI Display**: Default providers remain hidden (no change)
- **JSON Output** (`--json`): Default providers now included in event stream
- **Backend Persistence**: No changes to event persistence behavior