### PR TITLE
Add preserve-config flag to destroy

### DIFF
--- a/changelog/pending/20251025--cli--add-preserve-config-flag-to-destroy.yaml
+++ b/changelog/pending/20251025--cli--add-preserve-config-flag-to-destroy.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add preserve-config flag to destroy

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -81,6 +81,7 @@ func NewDestroyCmd() *cobra.Command {
 	var excludeDependents bool
 	var excludeProtected bool
 	var continueOnError bool
+	var preserveConfig bool
 
 	// Flags for Copilot.
 	var copilotEnabled bool
@@ -340,6 +341,11 @@ func NewDestroyCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
+
+					if preserveConfig {
+						fmt.Printf("The resources in the stack have been deleted, and history is removed.\n")
+						return nil
+					}
 					// Remove also the stack config file.
 					if _, path, detectErr := workspace.DetectProjectStackPath(s.Ref().Name().Q()); detectErr == nil {
 						if detectErr = os.Remove(path); detectErr != nil && !os.IsNotExist(detectErr) {
@@ -367,6 +373,8 @@ func NewDestroyCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&remove, "remove", false,
 		"Remove the stack and its config file after all resources in the stack have been deleted")
+	cmd.PersistentFlags().BoolVar(&preserveConfig, "preserve-config", false,
+		"preserves the stack config file")
 	cmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")


### PR DESCRIPTION
added a preserve config flag to destroy Cmd  now config is intact on `pulumi destroy --remove --preserve-config`.

closes #15069 