### PR TITLE
Log gRPC requests before invoking them in gRPC debug interceptor

### DIFF
--- a/changelog/pending/20251027--cli--log-grpc-requests-before-invoking-them-in-grpc-debug-interceptor.yaml
+++ b/changelog/pending/20251027--cli--log-grpc-requests-before-invoking-them-in-grpc-debug-interceptor.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Log gRPC requests before invoking them in gRPC debug interceptor

--- a/pkg/util/rpcdebug/logformat.go
+++ b/pkg/util/rpcdebug/logformat.go
@@ -16,10 +16,11 @@ package rpcdebug
 
 import (
 	"encoding/json"
+	"time"
 )
 
 // JSON format for tracking gRPC conversations. Normal methods have
-// one entry for each req-resp conversation, streaming methods have
+// two entries for each request-response interaction. Streaming methods have
 // one entry per each request or response over the stream.
 type debugInterceptorLogEntry struct {
 	Method   string          `json:"method"`
@@ -27,4 +28,8 @@ type debugInterceptorLogEntry struct {
 	Response json.RawMessage `json:"response,omitempty"`
 	Errors   []string        `json:"errors,omitempty"`
 	Metadata any             `json:"metadata,omitempty"`
+	// Indicates the state of RPC methods, can be "request_started" or "response_completed"
+	Progress  string        `json:"progress,omitempty"`
+	Timestamp time.Time     `json:"timestamp"`
+	Duration  time.Duration `json:"duration,omitempty"`
 }


### PR DESCRIPTION
When using `PULUMI_DEBUG_GRPC`, the log entries only record full operations after they are completed with their requests and responses. This is not ideal if an operation is blocked/stuck, it won't show up in the logs. 

This PR makes it such that we log two entries per operation
   - entry with request and + field `progress: request_started` before invoking the operation
   - entry with request and response + field `progress: response_completed` after invoking the operation