### PR TITLE
log NodeJS command that Pulumi will run

### DIFF
--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -809,7 +809,7 @@ func (host *nodeLanguageHost) execNodejs(ctx context.Context, req *pulumirpc.Run
 	// #nosec G204
 	cmd := exec.CommandContext(ctx, nodeBin, nodeargs...)
 
-	logging.V(9).Infof("Constructed NodeJS command to run: %s", cmd)
+	logging.V(5).Infof("Constructed NodeJS command to run: %s", cmd)
 
 	// Copy cmd.Stdout to os.Stdout. Nodejs sometimes changes the blocking mode of its stdout/stderr,
 	// so it's unsafe to assign cmd.Stdout directly to os.Stdout. See the description of
@@ -1501,11 +1501,6 @@ func (host *nodeLanguageHost) RunPlugin(
 		return err
 	}
 
-	if logging.V(5) {
-		commandStr := strings.Join(req.Args, " ")
-		logging.V(5).Infoln("Language host launching process: ", nodeBin, commandStr)
-	}
-
 	opts, err := parseOptions(req.Info.Options.AsMap())
 	if err != nil {
 		return err
@@ -1557,6 +1552,8 @@ func (host *nodeLanguageHost) RunPlugin(
 	cmd.Dir = req.Pwd
 	cmd.Env = env
 	cmd.Stdout, cmd.Stderr = stdout, stderr
+
+	logging.V(5).Infof("Constructed NodeJS command to run: %s", cmd)
 
 	run := func() error {
 		if err := cmd.Start(); err != nil {


### PR DESCRIPTION
Log V(9) the exact command that will be executed when running a Pulumi NodeJS program. This is useful when debugging issues with how NodeJS is invoked when running `pulumi up`.