### PR TITLE
update tests to explicitly use dotnet 8.0

### DIFF
--- a/sdk/go/auto/test/errors/compilation_error/dotnet/dotnet.csproj
+++ b/sdk/go/auto/test/errors/compilation_error/dotnet/dotnet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/sdk/go/auto/test/errors/runtime_error/dotnet/adsfsdf.csproj
+++ b/sdk/go/auto/test/errors/runtime_error/dotnet/adsfsdf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/sdk/python/lib/test/automation/errors/compilation_error/dotnet/dotnet.csproj
+++ b/sdk/python/lib/test/automation/errors/compilation_error/dotnet/dotnet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/sdk/python/lib/test/automation/errors/runtime_error/dotnet/adsfsdf.csproj
+++ b/sdk/python/lib/test/automation/errors/runtime_error/dotnet/adsfsdf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tests/testdata/codegen/external-enum/dotnet/Pulumi.Example.csproj
+++ b/tests/testdata/codegen/external-enum/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>


### PR DESCRIPTION
Update our tests to use dotnet 8.0 as target framework. This makes these tests work by default on developers machines that have a supported dotnet framework installed.

In CI this still works because we set `DOTNET_ROLL_FORWARD=Major`, so it automatically uses newer versions, but we shouldn't expect everyone to have that set, and it's not obvious from the output that setting that would work. This makes it a little confusing why this test works in CI, but not locally, having the same versions of the framework installed.