### PR TITLE
fuzzing: generate PropertyDependencies field correctly

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/reprogen.go
+++ b/pkg/engine/lifecycletest/fuzzing/reprogen.go
@@ -567,7 +567,7 @@ func writeSnapshotStatements(t require.TestingT, snapSpec *SnapshotSpec) func(g 
 
 					if len(r.PropertyDependencies) > 0 {
 						g.writeBlock(
-							"PropertyDeps: map[resource.PropertyKey][]resource.URN{",
+							"PropertyDependencies: map[resource.PropertyKey][]resource.URN{",
 							func(g *generator) {
 								for k, deps := range r.PropertyDependencies {
 									g.writeBlock(


### PR DESCRIPTION
A `resource.State` has no `PropertyDeps` field, but it's named `PropertyDependencies`.  Confusingly, this is named `PropertyDeps` in `deploytest.ResourceOptions`, where this was probably copy pasted from.  Fix this, so we get closer to generating a valid test when generating a repro.