### PR TITLE
fix typo in error message

### DIFF
--- a/pkg/backend/diy/state.go
+++ b/pkg/backend/diy/state.go
@@ -262,7 +262,7 @@ func (b *diyBackend) saveStack(
 	contract.Requiref(ref != nil, "ref", "ref was nil")
 	chk, err := stack.SerializeCheckpoint(ref.FullyQualifiedName(), snap, false /* showSecrets */)
 	if err != nil {
-		return "", fmt.Errorf("serializaing checkpoint: %w", err)
+		return "", fmt.Errorf("serializing checkpoint: %w", err)
 	}
 
 	backup, file, err := b.saveCheckpoint(ctx, ref, chk)


### PR DESCRIPTION
Noticed this while looking at the error message in https://github.com/pulumi/pulumi/pull/20843.