### PR TITLE
Update error message URL for ConflictingUpdateError

### DIFF
--- a/pkg/backend/backenderr/backenderr.go
+++ b/pkg/backend/backenderr/backenderr.go
@@ -61,7 +61,7 @@ type ConflictingUpdateError struct {
 
 func (c ConflictingUpdateError) Error() string {
 	return fmt.Sprintf("%s\nTo learn more about possible reasons and resolution, visit "+
-		"https://www.pulumi.com/docs/troubleshooting/#conflict", c.Err)
+		"https://www.pulumi.com/docs/support/troubleshooting/common-issues/update-conflicts/", c.Err)
 }
 
 // MissingEnvVarForNonInteractiveError represents a situation where the CLI is run in


### PR DESCRIPTION
The current 409 conflict page we are pointing our customers no longer exists: https://github.com/pulumi/pulumi/issues/20846