### PR TITLE
Revert "allow python tests to run in parallel"

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -34,7 +34,6 @@ dev = [
     'pyright==1.1.404',
     'pytest~=8.4.0',
     'pytest-timeout',
-    'pytest-xdist',
     'types-pyyaml',
     'types-protobuf',
     'pytest-asyncio~=1.2.0',

--- a/sdk/python/scripts/test_auto.sh
+++ b/sdk/python/scripts/test_auto.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 mkdir -p ../../junit
 JUNIT_DIR=$(realpath ../../junit)
 
-coverage run --append -m pytest -n auto --junitxml "$JUNIT_DIR/python-test-auto.xml" lib/test/automation
+coverage run --append -m pytest --junitxml "$JUNIT_DIR/python-test-auto.xml" lib/test/automation
 
 if [[ "$PULUMI_TEST_COVERAGE_PATH" ]]; then
     if [ -e .coverage ]; then

--- a/sdk/python/scripts/test_fast.sh
+++ b/sdk/python/scripts/test_fast.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 mkdir -p ../../junit
 JUNIT_DIR=$(realpath ../../junit)
 
-coverage run --append -m pytest -n auto --junitxml "$JUNIT_DIR/python-test-fast.xml" lib/test \
+coverage run --append -m pytest --junitxml "$JUNIT_DIR/python-test-fast.xml" lib/test \
              --ignore lib/test/automation
 
 # Using python -m also adds lib/test_with_mocks to sys.path which

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -297,15 +297,6 @@ wheels = [
 ]
 
 [[package]]
-name = "execnet"
-version = "2.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524, upload-time = "2024-04-08T09:04:19.245Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612, upload-time = "2024-04-08T09:04:17.414Z" },
-]
-
-[[package]]
 name = "grpcio"
 version = "1.75.1"
 source = { registry = "https://pypi.org/simple" }
@@ -668,7 +659,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "twine" },
     { name = "types-grpcio" },
@@ -697,7 +687,6 @@ dev = [
     { name = "pytest", specifier = "~=8.4.0" },
     { name = "pytest-asyncio", specifier = "~=1.2.0" },
     { name = "pytest-timeout" },
-    { name = "pytest-xdist" },
     { name = "ruff", specifier = "==0.13.2" },
     { name = "twine", specifier = ">=6.0.1" },
     { name = "types-grpcio", specifier = ">=1.0.0.20250703" },
@@ -788,19 +777,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/93/0d/04719abc7a4bdb3a7a1f968f24b0f5253d698c9cc94975330e9d3145befb/pytest-timeout-2.3.1.tar.gz", hash = "sha256:12397729125c6ecbdaca01035b9e5239d4db97352320af155b3f5de1ba5165d9", size = 17697, upload-time = "2024-03-07T21:04:01.069Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/27/14af9ef8321f5edc7527e47def2a21d8118c6f329a9342cc61387a0c0599/pytest_timeout-2.3.1-py3-none-any.whl", hash = "sha256:68188cb703edfc6a18fad98dc25a3c61e9f24d644b0b70f33af545219fc7813e", size = 14148, upload-time = "2024-03-07T21:03:58.764Z" },
-]
-
-[[package]]
-name = "pytest-xdist"
-version = "3.8.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "execnet" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Reverts pulumi/pulumi#20838. I think this is a likely cause for the flakyness we've seen in the Python tests lately in CI. I'd rather have no parallel tests if that means no flakes.

Fixes https://github.com/pulumi/pulumi/issues/20869