### PR TITLE
skip another flaky tail test

### DIFF
--- a/sdk/go/common/tail/tail_test.go
+++ b/sdk/go/common/tail/tail_test.go
@@ -670,6 +670,9 @@ func TestIncompleteLinesWithReopens(t *testing.T) {
 func TestIncompleteLinesWithoutFollow(t *testing.T) {
 	t.Parallel()
 
+	// TODO[pulumi/pulumi#19888]: Skipping flaky test
+	t.Skip("Skipping because the tail library is flaky.  See pulumi/pulumi#19888")
+
 	tailTest, cleanup := NewTailTest("incomplete-lines-no-follow", t)
 	defer cleanup()
 	filename := "test.txt"


### PR DESCRIPTION
We know this library is flaky, and are hopefully starting to wean ourselves off it, at least in the automation API. Skip the flaky test as we do with others for this.