### PR TITLE
Use immutable results in simplified invokes

### DIFF
--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -1392,7 +1392,7 @@ func (mod *modContext) functionReturnType(fun *schema.Function) string {
 		}
 
 		// otherwise, the object type is a reference to an output type
-		return mod.typeString(fun.ReturnType, "Outputs", false, false, true)
+		return mod.typeString(fun.ReturnType, "Outputs", false, false, false)
 	}
 
 	return ""
@@ -1412,10 +1412,6 @@ func runtimeInvokeFunction(fun *schema.Function) string {
 		return "Invoke"
 	// If the function has an object return type, it is a normal invoke function.
 	case *schema.ObjectType:
-		return "Invoke"
-	// If the function has an object return type, it is also a normal invoke function.
-	// because the deserialization can handle it
-	case *schema.MapType:
 		return "Invoke"
 	default:
 		// Anything else needs to be handled by InvokeSingle

--- a/tests/testdata/codegen/simplified-invokes/dotnet/GetArrayCustomResult.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/GetArrayCustomResult.cs
@@ -11,20 +11,20 @@ namespace Pulumi.Std
 {
     public static class GetArrayCustomResult
     {
-        public static async Task<List<Outputs.CustomResult>> InvokeAsync(double? a = null, InvokeOptions? invokeOptions = null)
+        public static async Task<ImmutableArray<Outputs.CustomResult>> InvokeAsync(double? a = null, InvokeOptions? invokeOptions = null)
         {
             var builder = ImmutableDictionary.CreateBuilder<string, object?>();
             builder["a"] = a;
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
-            return await global::Pulumi.Deployment.Instance.InvokeSingleAsync<List<Outputs.CustomResult>>("std:index:GetArrayCustomResult", args, invokeOptions.WithDefaults());
+            return await global::Pulumi.Deployment.Instance.InvokeSingleAsync<ImmutableArray<Outputs.CustomResult>>("std:index:GetArrayCustomResult", args, invokeOptions.WithDefaults());
         }
 
-        public static Output<List<Outputs.CustomResult>> Invoke(Input<double?>? a = null, InvokeOptions? invokeOptions = null)
+        public static Output<ImmutableArray<Outputs.CustomResult>> Invoke(Input<double?>? a = null, InvokeOptions? invokeOptions = null)
         {
             var builder = ImmutableDictionary.CreateBuilder<string, object?>();
             builder["a"] = a;
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
-            return global::Pulumi.Deployment.Instance.InvokeSingle<List<Outputs.CustomResult>>("std:index:GetArrayCustomResult", args, invokeOptions.WithDefaults());
+            return global::Pulumi.Deployment.Instance.InvokeSingle<ImmutableArray<Outputs.CustomResult>>("std:index:GetArrayCustomResult", args, invokeOptions.WithDefaults());
         }
     }
 }

--- a/tests/testdata/codegen/simplified-invokes/dotnet/GetDictionary.cs
+++ b/tests/testdata/codegen/simplified-invokes/dotnet/GetDictionary.cs
@@ -11,20 +11,20 @@ namespace Pulumi.Std
 {
     public static class GetDictionary
     {
-        public static async Task<Dictionary<string, Outputs.AnotherCustomResult>> InvokeAsync(double? a = null, InvokeOptions? invokeOptions = null)
+        public static async Task<ImmutableDictionary<string, Outputs.AnotherCustomResult>> InvokeAsync(double? a = null, InvokeOptions? invokeOptions = null)
         {
             var builder = ImmutableDictionary.CreateBuilder<string, object?>();
             builder["a"] = a;
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
-            return await global::Pulumi.Deployment.Instance.InvokeAsync<Dictionary<string, Outputs.AnotherCustomResult>>("std:index:GetDictionary", args, invokeOptions.WithDefaults());
+            return await global::Pulumi.Deployment.Instance.InvokeSingleAsync<ImmutableDictionary<string, Outputs.AnotherCustomResult>>("std:index:GetDictionary", args, invokeOptions.WithDefaults());
         }
 
-        public static Output<Dictionary<string, Outputs.AnotherCustomResult>> Invoke(Input<double?>? a = null, InvokeOptions? invokeOptions = null)
+        public static Output<ImmutableDictionary<string, Outputs.AnotherCustomResult>> Invoke(Input<double?>? a = null, InvokeOptions? invokeOptions = null)
         {
             var builder = ImmutableDictionary.CreateBuilder<string, object?>();
             builder["a"] = a;
             var args = new global::Pulumi.DictionaryInvokeArgs(builder.ToImmutableDictionary());
-            return global::Pulumi.Deployment.Instance.Invoke<Dictionary<string, Outputs.AnotherCustomResult>>("std:index:GetDictionary", args, invokeOptions.WithDefaults());
+            return global::Pulumi.Deployment.Instance.InvokeSingle<ImmutableDictionary<string, Outputs.AnotherCustomResult>>("std:index:GetDictionary", args, invokeOptions.WithDefaults());
         }
     }
 }


### PR DESCRIPTION
This was never end to end tested when first merged, but the dotnet sdk has limitations on what types are allowed in the return type. So this changes "scalar invokes" to use the acceptable "Immutable" variants in codegen, which we can then pull into the dotnet repo to test with.

This also fixes the generator to use `SingleInvoke` for maps. They still need to be nested one property down to handle secret maps.