### PR TITLE
Use property module in the config module

### DIFF
--- a/sdk/go/common/resource/config/map.go
+++ b/sdk/go/common/resource/config/map.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // Map is a bag of config stored in the settings file.
@@ -123,26 +124,26 @@ func (m Map) HasSecureValue() bool {
 }
 
 // AsDecryptedPropertyMap returns the config as a property map, with secret values decrypted.
-func (m Map) AsDecryptedPropertyMap(ctx context.Context, decrypter Decrypter) (resource.PropertyMap, error) {
+func (m Map) AsDecryptedPropertyMap(ctx context.Context, decrypter Decrypter) (property.Map, error) {
 	objectMap := map[Key]object{}
 	for k, v := range m {
 		obj, err := v.coerceObject()
 		if err != nil {
-			return nil, err
+			return property.Map{}, err
 		}
 		objectMap[k] = obj
 	}
 
 	plaintextMap, err := decryptMap(ctx, objectMap, decrypter)
 	if err != nil {
-		return nil, err
+		return property.Map{}, err
 	}
 
-	result := resource.PropertyMap{}
+	result := map[string]property.Value{}
 	for k, pt := range plaintextMap {
-		result[resource.PropertyKey(k.String())] = pt.PropertyValue()
+		result[k.String()] = pt.PropertyValue()
 	}
-	return result, nil
+	return property.NewMap(result), nil
 }
 
 // Get gets the value for a given key. If path is true, the key's name portion is treated as a path.

--- a/sdk/go/common/resource/config/map_test.go
+++ b/sdk/go/common/resource/config/map_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
@@ -1436,92 +1436,92 @@ func TestPropertyMap(t *testing.T) {
 
 	tests := []struct {
 		Config   Map
-		Expected resource.PropertyMap
+		Expected property.Map
 	}{
 		{
 			Config: Map{
 				MustMakeKey("my", "testKey"): NewValue("testValue"),
 			},
-			Expected: resource.PropertyMap{
-				"my:testKey": resource.NewProperty("testValue"),
-			},
+			Expected: property.NewMap(map[string]property.Value{
+				"my:testKey": property.New("testValue"),
+			}),
 		},
 		{
 			Config: Map{
 				MustMakeKey("my", "testKey"): NewValue("1"),
 			},
-			Expected: resource.PropertyMap{
-				"my:testKey": resource.NewProperty(1.0),
-			},
+			Expected: property.NewMap(map[string]property.Value{
+				"my:testKey": property.New(1.0),
+			}),
 		},
 		{
 			Config: Map{
 				MustMakeKey("my", "testKey"): NewValue("18446744073709551615"),
 			},
-			Expected: resource.PropertyMap{
-				"my:testKey": resource.NewProperty(1.8446744073709552e+19),
-			},
+			Expected: property.NewMap(map[string]property.Value{
+				"my:testKey": property.New(1.8446744073709552e+19),
+			}),
 		},
 		{
 			Config: Map{
 				MustMakeKey("my", "testKey"): NewValue("true"),
 			},
-			Expected: resource.PropertyMap{
-				"my:testKey": resource.NewProperty(true),
-			},
+			Expected: property.NewMap(map[string]property.Value{
+				"my:testKey": property.New(true),
+			}),
 		},
 		{
 			Config: Map{
 				MustMakeKey("my", "testKey"): NewSecureValue("stackAsecurevalue"),
 			},
-			Expected: resource.PropertyMap{
-				"my:testKey": resource.MakeSecret(resource.NewProperty("stackAsecurevalue")),
-			},
+			Expected: property.NewMap(map[string]property.Value{
+				"my:testKey": property.New("stackAsecurevalue").WithSecret(true),
+			}),
 		},
 		{
 			Config: Map{
 				MustMakeKey("my", "testKey"): NewObjectValue(`{"inner":"value"}`),
 			},
-			Expected: resource.PropertyMap{
-				"my:testKey": resource.NewProperty(resource.PropertyMap{
-					"inner": resource.NewProperty("value"),
+			Expected: property.NewMap(map[string]property.Value{
+				"my:testKey": property.New(map[string]property.Value{
+					"inner": property.New("value"),
 				}),
-			},
+			}),
 		},
 		{
 			Config: Map{
 				//nolint:lll
 				MustMakeKey("my", "testKey"): NewSecureObjectValue(`[{"inner":{"secure":"stackAsecurevalue"}},{"secure":"stackAsecurevalue2"}]`),
 			},
-			Expected: resource.PropertyMap{
+			Expected: property.NewMap(map[string]property.Value{
 				//nolint:lll
-				"my:testKey": resource.NewProperty([]resource.PropertyValue{
-					resource.NewProperty(resource.PropertyMap{
-						"inner": resource.MakeSecret(resource.NewProperty("stackAsecurevalue")),
+				"my:testKey": property.New([]property.Value{
+					property.New(map[string]property.Value{
+						"inner": property.New("stackAsecurevalue").WithSecret(true),
 					}),
-					resource.MakeSecret(resource.NewProperty("stackAsecurevalue2")),
+					property.New("stackAsecurevalue2").WithSecret(true),
 				}),
-			},
+			}),
 		},
 		{
 			Config: Map{
 				MustMakeKey("my", "test.Key"): NewValue("testValue"),
 			},
-			Expected: resource.PropertyMap{
-				"my:test.Key": resource.NewProperty("testValue"),
-			},
+			Expected: property.NewMap(map[string]property.Value{
+				"my:test.Key": property.New("testValue"),
+			}),
 		},
 		{
 			Config: Map{
 				MustMakeKey("my", "name"): NewObjectValue(`[["value"]]`),
 			},
-			Expected: resource.PropertyMap{
-				"my:name": resource.NewProperty([]resource.PropertyValue{
-					resource.NewProperty([]resource.PropertyValue{
-						resource.NewProperty("value"),
+			Expected: property.NewMap(map[string]property.Value{
+				"my:name": property.New([]property.Value{
+					property.New([]property.Value{
+						property.New("value"),
 					}),
 				}),
-			},
+			}),
 		},
 	}
 

--- a/sdk/go/common/resource/config/object.go
+++ b/sdk/go/common/resource/config/object.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 var errSecureReprReserved = errors.New(`maps with the single key "secure" are reserved`)
@@ -549,10 +550,10 @@ func isSecureValue(v any) (bool, CiphertextSecret) {
 	return false, CiphertextSecret{}
 }
 
-func (c object) toDecryptedPropertyValue(ctx context.Context, decrypter Decrypter) (resource.PropertyValue, error) {
+func (c object) toDecryptedPropertyValue(ctx context.Context, decrypter Decrypter) (property.Value, error) {
 	plaintext, err := c.decrypt(ctx, nil, decrypter)
 	if err != nil {
-		return resource.PropertyValue{}, err
+		return property.Value{}, err
 	}
 	return plaintext.PropertyValue(), nil
 }

--- a/sdk/go/common/resource/config/object_test.go
+++ b/sdk/go/common/resource/config/object_test.go
@@ -19,7 +19,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +33,7 @@ func TestEmptyObject(t *testing.T) {
 	crypter := nopCrypter{}
 	v, err := o.toDecryptedPropertyValue(context.Background(), crypter)
 	require.NoError(t, err)
-	assert.Equal(t, resource.NewNullProperty(), v)
+	assert.Equal(t, property.Value{}, v)
 }
 
 func TestMarshallingRoundtrip(t *testing.T) {

--- a/sdk/go/common/resource/config/plaintext.go
+++ b/sdk/go/common/resource/config/plaintext.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // PlaintextType describes the allowed types for a Plaintext.
@@ -101,39 +102,39 @@ func (c Plaintext) GoValue() any {
 	}
 }
 
-// PropertyValue converts a plaintext value into a resource.PropertyValue.
-func (c Plaintext) PropertyValue() resource.PropertyValue {
-	var prop resource.PropertyValue
+// PropertyValue converts a plaintext value into a property.Value.
+func (c Plaintext) PropertyValue() property.Value {
+	var prop property.Value
 	switch v := c.Value().(type) {
 	case bool:
-		prop = resource.NewProperty(v)
+		prop = property.New(v)
 	case int64:
-		prop = resource.NewProperty(float64(v))
+		prop = property.New(float64(v))
 	case uint64:
-		prop = resource.NewProperty(float64(v))
+		prop = property.New(float64(v))
 	case float64:
-		prop = resource.NewProperty(v)
+		prop = property.New(v)
 	case string:
-		prop = resource.NewProperty(v)
+		prop = property.New(v)
 	case PlaintextSecret:
-		prop = resource.MakeSecret(resource.NewProperty(string(v)))
+		prop = property.New(string(v)).WithSecret(true)
 	case []Plaintext:
-		vs := make([]resource.PropertyValue, len(v))
+		vs := make([]property.Value, len(v))
 		for i, v := range v {
 			vs[i] = v.PropertyValue()
 		}
-		prop = resource.NewProperty(vs)
+		prop = property.New(vs)
 	case map[string]Plaintext:
-		vs := make(resource.PropertyMap, len(v))
+		vs := make(map[string]property.Value, len(v))
 		for k, v := range v {
-			vs[resource.PropertyKey(k)] = v.PropertyValue()
+			vs[k] = v.PropertyValue()
 		}
-		prop = resource.NewProperty(vs)
+		prop = property.New(vs)
 	case nil:
-		prop = resource.NewNullProperty()
+		prop = property.New(property.Null)
 	default:
 		contract.Failf("unexpected value of type %T", v)
-		return resource.PropertyValue{}
+		return property.Value{}
 	}
 	return prop
 }


### PR DESCRIPTION
We want to move off of `"github.com/pulumi/pulumi/sdk/v3/go/common/resource".PropertyMap/Value` to the newly designed `"github.com/pulumi/pulumi/sdk/v3/go/property"` package. There's a lot to change, so we're doing it piecemeal, there are converters to and from each type to allow interop at the intermediate boundaries we create doing this.

This replaces uses internal uses of `PropertyMap/Value` with the new package in the  `"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"` package.