### PR TITLE
document CustomTimeouts resource option

### DIFF
--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -53,6 +53,7 @@ class CustomTimeouts:
     CustomTimeouts allows specifying custom timeouts for resource operations. Timeouts can
     be specified separately for create, update, and delete operations.
     """
+
     create: Optional[str]
     """
     create is the optional create timout represented as a string e.g. 5m, 40s, 1d.


### PR DESCRIPTION
This resource option was missing documentation. Add it.

Fixes https://github.com/pulumi/pulumi/issues/20884