### PR TITLE
Mark TestNoPromptWithYes with t.Parallel()

### DIFF
--- a/pkg/cmd/pulumi/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_test.go
@@ -1247,7 +1247,6 @@ func assertTemplateContains(t *testing.T, actual, expected string) {
 	}
 }
 
-//nolint:paralleltest
 func TestNoPromptWithYes(t *testing.T) {
 	t.Parallel()
 	for _, interactive := range []bool{true, false} {


### PR DESCRIPTION
The comment here was wrong, this does not mock global state and we can run the tests in parallel.
