### PR TITLE
Log deleteProvider calls

### DIFF
--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -442,9 +442,11 @@ func (r *Registry) deleteProvider(ref providers.Reference) (plugin.Provider, boo
 
 	provider, ok := r.providers[ref]
 	if !ok {
+		logging.V(7).Infof("deleteProvider(%v): false", ref)
 		return nil, false
 	}
 	delete(r.providers, ref)
+	logging.V(7).Infof("deleteProvider(%v): true", ref)
 	return provider, true
 }
 


### PR DESCRIPTION
We having logging calls in both `GetProvider` and `setProvider` but was missing any in `deleteProvider`.