### PR TITLE
Avoid cancellations due to do slow processing of requests in the callbacks server

### DIFF
--- a/changelog/pending/20251112--sdk-python--avoid-cancellations-due-to-do-slow-processing-of-requests-in-the-callbacks-server.yaml
+++ b/changelog/pending/20251112--sdk-python--avoid-cancellations-due-to-do-slow-processing-of-requests-in-the-callbacks-server.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Avoid cancellations due to do slow processing of requests in the callbacks server

--- a/sdk/python/lib/pulumi/runtime/_callbacks.py
+++ b/sdk/python/lib/pulumi/runtime/_callbacks.py
@@ -58,7 +58,14 @@ if TYPE_CHECKING:
 
 # _MAX_RPC_MESSAGE_SIZE raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb)
 _MAX_RPC_MESSAGE_SIZE = 1024 * 1024 * 400
-_GRPC_CHANNEL_OPTIONS = [("grpc.max_receive_message_length", _MAX_RPC_MESSAGE_SIZE)]
+_GRPC_CHANNEL_OPTIONS = [
+    ("grpc.max_receive_message_length", _MAX_RPC_MESSAGE_SIZE),
+    # This is the time a message can be received by the GRPC server and wait in the queue without being handled. If
+    # there is blocking happening in the pulumi program, and/or there are a lot of requests and other asyncio tasks to
+    # process by the event loop, this can take longer than the default 30 seconds. Requests that take longer end up
+    # being cancelled, causing the operation to fail.
+    ("grpc.server_max_unrequested_time_in_server", 300),
+]
 
 # Workaround for https://github.com/grpc/grpc/issues/38679,
 # https://github.com/grpc/grpc/issues/22365#issuecomment-2254278769


### PR DESCRIPTION
`grpc.server_max_unrequested_time_in_server` is the time a message can be received by the GRPC server and wait in the queue without being handled. Requests that take longer end up being cancelled. This can be triggered if there is blocking happening in the pulumi program, and/or there are a lot of requests and other asyncio tasks to process by the event loop.

The following program demonstrates the problem. This fails reliably on my machine (MacBook Pro 2023, M3 Pro, 36 GB), but the number of resources and sleep time likely require adjusting to hit the same case on other machines

```python
import asyncio
import logging
import time

import pulumi
import pulumi_random

logging.getLogger("asyncio").setLevel(logging.DEBUG)

async def transform_1(args: pulumi.ResourceTransformArgs):
    return pulumi.ResourceTransformResult(props=args.props, opts=args.opts)

async def transform_2(args: pulumi.ResourceTransformArgs):
    return pulumi.ResourceTransformResult(props=args.props, opts=args.opts)

async def transform_3(args: pulumi.ResourceTransformArgs):
    return pulumi.ResourceTransformResult(props=args.props, opts=args.opts)

pulumi.runtime.register_resource_transform(transform_1)
pulumi.runtime.register_resource_transform(transform_2)
pulumi.runtime.register_resource_transform(transform_3)

async def create_resources():
    for i in range(3000):
        await asyncio.sleep(0)
        if i % 300 == 0:
            time.sleep(10)
        pulumi_random.RandomPet(f"pet_{i}")

pulumi.export("x", asyncio.ensure_future(create_resources()))
```

To trigger the issue, a resource registration needs to get to the point where it is received by the engine, the engine calls back into the language runtime to run the transforms, and then the callback requests sits in the grpc server queue for more than 30 seconds before being processed.

As a first step to mitigate the issue we increase the timeout from 30 to 300 seconds. This helps for large programs, but it is conceivable that there are still cases where this can cause failures.

As a follow up we need to investigate sources of blocking. Is there any blocking happening within the pulumi SDK that's contributing to the problem? Can we emit warnings to the user if there are large amounts of blocking? Is 300s a sensible value? Do we need to make this configurable?

Fixes https://github.com/pulumi/pulumi/issues/20247
