### PR TITLE
Use property package in the backend package

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // StackReference is an opaque type that refers to a stack managed by a backend.  The CLI uses the ParseStackReference
@@ -393,67 +394,67 @@ func (c *backendClient) GetStackOutputs(
 	ctx context.Context,
 	name string,
 	onDecryptError func(err error) error,
-) (resource.PropertyMap, error) {
+) (property.Map, error) {
 	ref, err := c.backend.ParseStackReference(name)
 	if err != nil {
-		return nil, err
+		return property.Map{}, err
 	}
 	s, err := c.backend.GetStack(ctx, ref)
 	if err != nil {
-		return nil, err
+		return property.Map{}, err
 	}
 	if s == nil {
-		return nil, fmt.Errorf("unknown stack %q", name)
+		return property.Map{}, fmt.Errorf("unknown stack %q", name)
 	}
 
 	secretsProvider := newErrorCatchingSecretsProvider(c.secretsProvider, onDecryptError)
 	snap, err := s.Snapshot(ctx, secretsProvider)
 	if err != nil {
-		return nil, err
+		return property.Map{}, err
 	}
 
 	res, err := stack.GetRootStackResource(snap)
 	if err != nil {
-		return nil, fmt.Errorf("getting root stack resources: %w", err)
+		return property.Map{}, fmt.Errorf("getting root stack resources: %w", err)
 	}
 
 	if res == nil {
-		return resource.PropertyMap{}, nil
+		return property.Map{}, nil
 	}
-	return res.Outputs, nil
+	return resource.FromResourcePropertyMap(res.Outputs), nil
 }
 
 func (c *backendClient) GetStackResourceOutputs(
 	ctx context.Context, name string,
-) (resource.PropertyMap, error) {
+) (property.Map, error) {
 	ref, err := c.backend.ParseStackReference(name)
 	if err != nil {
-		return nil, err
+		return property.Map{}, err
 	}
 	s, err := c.backend.GetStack(ctx, ref)
 	if err != nil {
-		return nil, err
+		return property.Map{}, err
 	}
 	if s == nil {
-		return nil, fmt.Errorf("unknown stack %q", name)
+		return property.Map{}, fmt.Errorf("unknown stack %q", name)
 	}
 	snap, err := s.Snapshot(ctx, c.secretsProvider)
 	if err != nil {
-		return nil, err
+		return property.Map{}, err
 	}
-	pm := resource.PropertyMap{}
+	pm := map[string]property.Value{}
 	for _, r := range snap.Resources {
 		if r.Delete {
 			continue
 		}
 
-		resc := resource.PropertyMap{
-			resource.PropertyKey("type"):    resource.NewProperty(string(r.Type)),
-			resource.PropertyKey("outputs"): resource.NewProperty(r.Outputs),
+		resc := map[string]property.Value{
+			"type":    property.New(string(r.Type)),
+			"outputs": property.New(resource.FromResourcePropertyMap(r.Outputs)),
 		}
-		pm[resource.PropertyKey(r.URN)] = resource.NewProperty(resc)
+		pm[string(r.URN)] = property.New(resc)
 	}
-	return pm, nil
+	return property.NewMap(pm), nil
 }
 
 // ErrTeamsNotSupported is returned by backends

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -73,33 +73,33 @@ func TestGetStackResourceOutputs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify resource outputs for resc1.
-	resc1Actual, exists := outs[resource.PropertyKey(testURN(typ, "resc1"))]
+	resc1Actual, exists := outs.GetOk(string(testURN(typ, "resc1")))
 	assert.True(t, exists)
-	assert.True(t, resc1Actual.IsObject())
+	assert.True(t, resc1Actual.IsMap())
 
-	resc1Type, exists := resc1Actual.ObjectValue()["type"]
+	resc1Type, exists := resc1Actual.AsMap().GetOk("type")
 	assert.True(t, exists)
-	assert.Equal(t, typ, resc1Type.V)
+	assert.Equal(t, typ, resc1Type.AsString())
 
-	resc1Outs, exists := resc1Actual.ObjectValue()["outputs"]
+	resc1Outs, exists := resc1Actual.AsMap().GetOk("outputs")
 	assert.True(t, exists)
-	assert.True(t, resc1Outs.IsObject())
+	assert.True(t, resc1Outs.IsMap())
 
 	// Verify resource outputs for resc2.
-	resc2Actual, exists := outs[resource.PropertyKey(testURN(typ, "resc2"))]
+	resc2Actual, exists := outs.GetOk(string(testURN(typ, "resc2")))
 	assert.True(t, exists)
-	assert.True(t, resc2Actual.IsObject())
+	assert.True(t, resc2Actual.IsMap())
 
-	resc2Type, exists := resc2Actual.ObjectValue()["type"]
+	resc2Type, exists := resc2Actual.AsMap().GetOk("type")
 	assert.True(t, exists)
-	assert.Equal(t, typ, resc2Type.V) // Same type.
+	assert.Equal(t, typ, resc2Type.AsString()) // Same type.
 
-	resc2Outs, exists := resc2Actual.ObjectValue()["outputs"]
+	resc2Outs, exists := resc2Actual.AsMap().GetOk("outputs")
 	assert.True(t, exists)
-	assert.True(t, resc2Outs.IsObject())
+	assert.True(t, resc2Outs.IsMap())
 
 	// Verify the deleted resource is not present.
-	_, exists = outs[resource.PropertyKey(deletedName)]
+	_, exists = outs.GetOk(deletedName)
 	assert.False(t, exists)
 }
 

--- a/pkg/backend/diy/stack.go
+++ b/pkg/backend/diy/stack.go
@@ -20,8 +20,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -40,7 +40,7 @@ type diyStack struct {
 	snapshot atomic.Pointer[*deploy.Snapshot]
 	// snapshotStackOutputs contains the stack outputs of the latest deployment snapshot, allocated on first use.
 	// It's valid for the outputs property map itself to be nil.
-	snapshotStackOutputs atomic.Pointer[resource.PropertyMap]
+	snapshotStackOutputs atomic.Pointer[property.Map]
 	// a pointer to the backend this stack belongs to.
 	b *diyBackend
 }
@@ -84,14 +84,14 @@ func (s *diyStack) Snapshot(ctx context.Context, secretsProvider secrets.Provide
 
 func (s *diyStack) SnapshotStackOutputs(
 	ctx context.Context, secretsProvider secrets.Provider,
-) (resource.PropertyMap, error) {
+) (property.Map, error) {
 	if v := s.snapshotStackOutputs.Load(); v != nil {
 		return *v, nil
 	}
 
 	outputs, err := s.b.getSnapshotStackOutputs(ctx, secretsProvider, s.ref)
 	if err != nil {
-		return nil, err
+		return property.Map{}, err
 	}
 
 	if s.snapshotStackOutputs.CompareAndSwap(nil, &outputs) {

--- a/pkg/backend/diy/state.go
+++ b/pkg/backend/diy/state.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/snapshot"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/retry"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 
 	"gocloud.dev/blob"
 	"gocloud.dev/gcerrors"
@@ -159,17 +160,21 @@ func (b *diyBackend) getSnapshot(ctx context.Context,
 
 func (b *diyBackend) getSnapshotStackOutputs(ctx context.Context,
 	secretsProvider secrets.Provider, ref *diyBackendReference,
-) (resource.PropertyMap, error) {
+) (property.Map, error) {
 	contract.Requiref(ref != nil, "ref", "must not be nil")
 
 	checkpoint, _, _, err := b.getCheckpoint(ctx, ref)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load checkpoint: %w", err)
+		return property.Map{}, fmt.Errorf("failed to load checkpoint: %w", err)
 	}
 	if checkpoint == nil || checkpoint.Latest == nil {
-		return nil, nil
+		return property.Map{}, nil
 	}
-	return stack.DeserializeStackOutputs(ctx, *checkpoint.Latest, secretsProvider)
+	outputs, err := stack.DeserializeStackOutputs(ctx, *checkpoint.Latest, secretsProvider)
+	if err != nil {
+		return property.Map{}, err
+	}
+	return resource.FromResourcePropertyMap(outputs), nil
 }
 
 // getCheckpoint loads a checkpoint file for the given stack in this project, from the current project workspace,

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -55,7 +55,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/snapshot"
@@ -66,6 +65,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/retry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 type PulumiAILanguage string
@@ -2406,13 +2406,14 @@ func (c httpstateBackendClient) GetStackOutputs(
 	ctx context.Context,
 	name string,
 	onDecryptError func(error) error,
-) (resource.PropertyMap, error) {
+) (property.Map, error) {
 	// When using the cloud backend, require that stack references are fully qualified so they
 	// look like "<org>/<project>/<stack>"
 	if strings.Count(name, "/") != 2 {
-		return nil, errors.New("a stack reference's name should be of the form '<organization>/<project>/<stack>'. " +
-			"See https://www.pulumi.com/docs/using-pulumi/stack-outputs-and-references/#using-stack-references " +
-			"for more information.")
+		return property.Map{}, errors.New(
+			"a stack reference's name should be of the form '<organization>/<project>/<stack>'. " +
+				"See https://www.pulumi.com/docs/using-pulumi/stack-outputs-and-references/#using-stack-references " +
+				"for more information.")
 	}
 
 	return c.backend.GetStackOutputs(ctx, name, onDecryptError)
@@ -2420,7 +2421,7 @@ func (c httpstateBackendClient) GetStackOutputs(
 
 func (c httpstateBackendClient) GetStackResourceOutputs(
 	ctx context.Context, name string,
-) (resource.PropertyMap, error) {
+) (property.Map, error) {
 	return c.backend.GetStackResourceOutputs(ctx, name)
 }
 

--- a/pkg/backend/httpstate/snapshot_benchmark_test.go
+++ b/pkg/backend/httpstate/snapshot_benchmark_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/require"
@@ -69,15 +70,15 @@ func (snapshotBackendClient) GetStackOutputs(
 	ctx context.Context,
 	name string,
 	onDecryptError func(error) error,
-) (resource.PropertyMap, error) {
-	return resource.PropertyMap{}, nil
+) (property.Map, error) {
+	return property.Map{}, nil
 }
 
 func (snapshotBackendClient) GetStackResourceOutputs(
 	ctx context.Context,
 	stackName string,
-) (resource.PropertyMap, error) {
-	return resource.PropertyMap{}, nil
+) (property.Map, error) {
+	return property.Map{}, nil
 }
 
 // The snapshotBenchProvider implements plugin.Provider by mapping resource URNs to preloaded data. This allows test

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -27,12 +27,12 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/service"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // Stack is a cloud stack.  This simply adds some cloud-specific properties atop the standard backend stack interface.
@@ -114,7 +114,7 @@ type cloudStack struct {
 	snapshot atomic.Pointer[*deploy.Snapshot]
 	// snapshotStackOutputs contains the stack outputs of the latest deployment snapshot, allocated on first use.
 	// It's valid for the outputs property map itself to be nil.
-	snapshotStackOutputs atomic.Pointer[resource.PropertyMap]
+	snapshotStackOutputs atomic.Pointer[property.Map]
 	// b is a pointer to the backend that this stack belongs to.
 	b *cloudBackend
 	// tags contains metadata tags describing additional, extensible properties about this stack.
@@ -238,14 +238,14 @@ func (s *cloudStack) Snapshot(ctx context.Context, secretsProvider secrets.Provi
 
 func (s *cloudStack) SnapshotStackOutputs(
 	ctx context.Context, secretsProvider secrets.Provider,
-) (resource.PropertyMap, error) {
+) (property.Map, error) {
 	if v := s.snapshotStackOutputs.Load(); v != nil {
 		return *v, nil
 	}
 
 	outputs, err := s.b.getSnapshotStackOutputs(ctx, secretsProvider, s.ref)
 	if err != nil {
-		return nil, err
+		return property.Map{}, err
 	}
 
 	if s.snapshotStackOutputs.CompareAndSwap(nil, &outputs) {

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 //
@@ -645,19 +646,19 @@ func (ms *MockStack) Snapshot(ctx context.Context, secretsProvider secrets.Provi
 
 func (ms *MockStack) SnapshotStackOutputs(
 	ctx context.Context, secretsProvider secrets.Provider,
-) (resource.PropertyMap, error) {
+) (property.Map, error) {
 	snapshot, err := ms.Snapshot(ctx, secretsProvider)
 	if err != nil {
-		return nil, err
+		return property.Map{}, err
 	}
 	res, err := stack.GetRootStackResource(snapshot)
 	if err != nil {
-		return nil, fmt.Errorf("getting root stack resources: %w", err)
+		return property.Map{}, fmt.Errorf("getting root stack resources: %w", err)
 	}
 	if res == nil {
-		return resource.PropertyMap{}, nil
+		return property.Map{}, nil
 	}
-	return res.Outputs, nil
+	return resource.FromResourcePropertyMap(res.Outputs), nil
 }
 
 func (ms *MockStack) Tags() map[apitype.StackTagName]string {

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -25,12 +25,12 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 type StackConfigLocation struct {
@@ -53,7 +53,7 @@ type Stack interface {
 	// Snapshot returns the latest deployment snapshot.
 	Snapshot(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error)
 	// SnapshotStackOutputs returns the stack outputs of the latest deployment snapshot.
-	SnapshotStackOutputs(ctx context.Context, secretsProvider secrets.Provider) (resource.PropertyMap, error)
+	SnapshotStackOutputs(ctx context.Context, secretsProvider secrets.Provider) (property.Map, error)
 	// Backend returns the backend this stack belongs to.
 	Backend() Backend
 	// Tags return the stack's existing tags.

--- a/pkg/cmd/pulumi/stack/stack_output.go
+++ b/pkg/cmd/pulumi/stack/stack_output.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -140,11 +141,12 @@ func (cmd *stackOutputCmd) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	snapshotStackOutputsMap := resource.ToResourcePropertyMap(snapshotStackOutputs)
 
 	// massageSecrets will remove all the secrets from the property map, so it should be safe to pass a panic
 	// crypter. This also ensures that if for some reason we didn't remove everything, we don't accidentally disclose
 	// secret values!
-	outputs, err := stack.SerializeProperties(ctx, display.MassageSecrets(snapshotStackOutputs, cmd.showSecrets),
+	outputs, err := stack.SerializeProperties(ctx, display.MassageSecrets(snapshotStackOutputsMap, cmd.showSecrets),
 		config.NewPanicCrypter(), cmd.showSecrets)
 	if err != nil {
 		return fmt.Errorf("getting outputs: %w", err)

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
@@ -1025,14 +1026,14 @@ func TestStackReference(t *testing.T) {
 	})
 	p := &lt.TestPlan{
 		BackendClient: &deploytest.BackendClient{
-			GetStackOutputsF: func(ctx context.Context, name string, _ func(error) error) (resource.PropertyMap, error) {
+			GetStackOutputsF: func(ctx context.Context, name string, _ func(error) error) (property.Map, error) {
 				switch name {
 				case "other":
-					return resource.NewPropertyMapFromMap(map[string]any{
-						"foo": "bar",
+					return property.NewMap(map[string]property.Value{
+						"foo": property.New("bar"),
 					}), nil
 				default:
-					return nil, fmt.Errorf("unknown stack \"%s\"", name)
+					return property.Map{}, fmt.Errorf("unknown stack \"%s\"", name)
 				}
 			},
 		},
@@ -1181,14 +1182,14 @@ func TestStackReferenceRegister(t *testing.T) {
 
 	p := &lt.TestPlan{
 		BackendClient: &deploytest.BackendClient{
-			GetStackOutputsF: func(ctx context.Context, name string, _ func(error) error) (resource.PropertyMap, error) {
+			GetStackOutputsF: func(ctx context.Context, name string, _ func(error) error) (property.Map, error) {
 				switch name {
 				case "other":
-					return resource.NewPropertyMapFromMap(map[string]any{
-						"foo": "bar",
+					return property.NewMap(map[string]property.Value{
+						"foo": property.New("bar"),
 					}), nil
 				default:
-					return nil, fmt.Errorf("unknown stack \"%s\"", name)
+					return property.Map{}, fmt.Errorf("unknown stack \"%s\"", name)
 				}
 			},
 		},

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -303,9 +303,9 @@ func (p *builtinProvider) readStackReference(inputs resource.PropertyMap) (resou
 	}
 
 	secretOutputs := make([]resource.PropertyValue, 0)
-	for k, v := range outputs {
-		if v.ContainsSecrets() {
-			secretOutputs = append(secretOutputs, resource.NewProperty(string(k)))
+	for k, v := range outputs.All {
+		if v.HasSecrets() {
+			secretOutputs = append(secretOutputs, resource.NewProperty(k))
 		}
 	}
 
@@ -316,7 +316,7 @@ func (p *builtinProvider) readStackReference(inputs resource.PropertyMap) (resou
 
 	return resource.PropertyMap{
 		"name":              name,
-		"outputs":           resource.NewProperty(outputs),
+		"outputs":           resource.NewProperty(resource.ToResourcePropertyMap(outputs)),
 		"secretOutputNames": resource.NewProperty(secretOutputs),
 	}, nil
 }
@@ -337,7 +337,7 @@ func (p *builtinProvider) readStackResourceOutputs(inputs resource.PropertyMap) 
 
 	return resource.PropertyMap{
 		"name":    name,
-		"outputs": resource.NewProperty(outputs),
+		"outputs": resource.NewProperty(resource.ToResourcePropertyMap(outputs)),
 	}, nil
 }
 

--- a/pkg/resource/deploy/builtins_test.go
+++ b/pkg/resource/deploy/builtins_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -177,12 +178,12 @@ func TestBuiltinProvider(t *testing.T) {
 				var called bool
 				p := &builtinProvider{
 					backendClient: &deploytest.BackendClient{
-						GetStackOutputsF: func(ctx context.Context, name string, _ func(error) error) (resource.PropertyMap, error) {
+						GetStackOutputsF: func(ctx context.Context, name string, _ func(error) error) (property.Map, error) {
 							called = true
-							return resource.PropertyMap{
-								"normal": resource.NewProperty("foo"),
-								"secret": resource.MakeSecret(resource.NewProperty("bar")),
-							}, nil
+							return property.NewMap(map[string]property.Value{
+								"normal": property.New("foo"),
+								"secret": property.New("bar").WithSecret(true),
+							}), nil
 						},
 					},
 				}
@@ -220,9 +221,9 @@ func TestBuiltinProvider(t *testing.T) {
 				var called bool
 				p := &builtinProvider{
 					backendClient: &deploytest.BackendClient{
-						GetStackResourceOutputsF: func(ctx context.Context, name string) (resource.PropertyMap, error) {
+						GetStackResourceOutputsF: func(ctx context.Context, name string) (property.Map, error) {
 							called = true
-							return resource.PropertyMap{}, nil
+							return property.Map{}, nil
 						},
 					},
 				}

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // BackendClient is used to retrieve information about stacks from a backend.
@@ -50,14 +51,14 @@ type BackendClient interface {
 		ctx context.Context,
 		name string,
 		onDecryptError func(error) error,
-	) (resource.PropertyMap, error)
+	) (property.Map, error)
 
 	// GetStackResourceOutputs returns the resource outputs for a stack, or an error if the stack
 	// cannot be found. Resources are retrieved from the latest stack snapshot, which may include
-	// ongoing updates. They are returned in a `PropertyMap` mapping resource URN to another
-	// `Propertymap` with members `type` (containing the Pulumi type ID for the resource) and
+	// ongoing updates. They are returned in a `property.Map` mapping resource URN to another
+	// `property.Map` with members `type` (containing the Pulumi type ID for the resource) and
 	// `outputs` (containing the resource outputs themselves).
-	GetStackResourceOutputs(ctx context.Context, stackName string) (resource.PropertyMap, error)
+	GetStackResourceOutputs(ctx context.Context, stackName string) (property.Map, error)
 }
 
 // Options controls the deployment process.

--- a/pkg/resource/deploy/deploytest/backendclient.go
+++ b/pkg/resource/deploy/deploytest/backendclient.go
@@ -17,7 +17,7 @@ package deploytest
 import (
 	"context"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // BackendClient provides a simple implementation of deploy.BackendClient that defers to a function value.
@@ -26,9 +26,9 @@ type BackendClient struct {
 		ctx context.Context,
 		name string,
 		onDecryptError func(error) error,
-	) (resource.PropertyMap, error)
+	) (property.Map, error)
 
-	GetStackResourceOutputsF func(ctx context.Context, name string) (resource.PropertyMap, error)
+	GetStackResourceOutputsF func(ctx context.Context, name string) (property.Map, error)
 }
 
 // GetStackOutputs returns the outputs (if any) for the named stack, returning an error if the stack cannot be found or
@@ -38,7 +38,7 @@ func (b *BackendClient) GetStackOutputs(
 	ctx context.Context,
 	name string,
 	onDecryptError func(error) error,
-) (resource.PropertyMap, error) {
+) (property.Map, error) {
 	return b.GetStackOutputsF(ctx, name, onDecryptError)
 }
 
@@ -49,6 +49,6 @@ func (b *BackendClient) GetStackOutputs(
 // `outputs` (containing the resource outputs themselves).
 func (b *BackendClient) GetStackResourceOutputs(
 	ctx context.Context, name string,
-) (resource.PropertyMap, error) {
+) (property.Map, error) {
 	return b.GetStackResourceOutputsF(ctx, name)
 }


### PR DESCRIPTION
Continuing the roll out of using the new property module, this replaces all uses in the `backend` package, and required callsites. I haven't drilled down into fixing the display module as well yet.