### PR TITLE
Remove package descriptor argument from LinkPackage

### DIFF
--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -597,21 +597,15 @@ func generateAndLinkSdksForPackages(
 			return fmt.Errorf("generated root is not a valid pulumi workspace %q: %w", convertOutputDirectory, err)
 		}
 
-		packageDescriptor, err := pkgSchema.Descriptor(pctx.Base())
-		if err != nil {
-			return err
-		}
-
 		sdkRelPath := filepath.Join("sdks", pkg.Parameterization.Name)
 		err = packages.LinkPackage(&packages.LinkPackageContext{
-			Writer:            os.Stdout,
-			Project:           proj,
-			Language:          language,
-			Root:              "./",
-			Pkg:               pkgSchema,
-			PluginContext:     pctx,
-			PackageDescriptor: packageDescriptor,
-			Out:               sdkRelPath,
+			Writer:        os.Stdout,
+			Project:       proj,
+			Language:      language,
+			Root:          "./",
+			Pkg:           pkgSchema,
+			PluginContext: pctx,
+			Out:           sdkRelPath,
 
 			// Don't install the SDK if we've been told to `--generate-only`.
 			Install: !generateOnly,


### PR DESCRIPTION
Small refactor to prepare splitting up package generation, linking & installation. We don’t need to pass in the descriptor argument, we can create it from the `Pkg` argument.

Towards https://github.com/pulumi/pulumi/issues/19311