### PR TITLE
lifecycletests: log diag events

### DIFF
--- a/pkg/engine/lifecycletest/framework/framework.go
+++ b/pkg/engine/lifecycletest/framework/framework.go
@@ -311,6 +311,13 @@ func (op TestOp) runWithContext(
 		return nil, nil, err
 	}
 
+	for _, event := range firedEvents {
+		if event.Type == engine.DiagEvent {
+			payload := event.Payload().(engine.DiagEventPayload)
+			opts.T.Logf("%s: %s", payload.Severity, payload.Message)
+		}
+	}
+
 	if validate != nil {
 		var entries engine.JournalEntries
 		if !dryRun {


### PR DESCRIPTION
When there is an error during the lifecycletests it's often useful to also see the diag events that the engine issued. For example when the step generator errors, we just get a very generic "step generator errored" error message, while the diag events actually hold the useful information.

Logging them makes the lifecycletests a little easier to debug when there are errors, so do that.