### PR TITLE
Remove errant format specifier from convert workflow error message

### DIFF
--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -1159,7 +1159,7 @@ func (host *goLanguageHost) InstallDependencies(
 	cmd.Stdout, cmd.Stderr = stdout, stderr
 
 	if err := cmd.Run(); err != nil {
-		return errutil.ErrorWithStderr(err, "`go mod tidy` failed to install dependencies: %w")
+		return errutil.ErrorWithStderr(err, "`go mod tidy` failed to install dependencies")
 	}
 
 	stdout.Write([]byte("Finished installing dependencies\n\n"))


### PR DESCRIPTION
I got this error message when trying to convert a terraform module:
```
✗ pulumi convert --from terraform --language go
Converting from terraform...
Converting to go...
Installing dependencies...

go: github.com/pulumi/pulumi-std/sdk/v2@v2.2.0: sdk/go.mod has non-.../v2 module path "github.com/pulumi/pulumi-std/sdk" (and .../v2/go.mod does not exist) at revision sdk/v2.2.0
error: installing dependencies failed: `go mod tidy` failed to install dependencies: %w: exit status 1
`go mod tidy` failed to install dependencies: %w: exit status 1
`go mod tidy` failed to install dependencies: %w: exit status 1
Run `pulumi install` to complete the installation.
```

This PR simply fixes the call to `ErrorWithStderr` to remove the unused format specifier.