### PR TITLE
clean up debugging output

### DIFF
--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -401,9 +401,7 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 			ResourceHooks:           nil,
 		}.Make()
 		// TODO(seqnum) should default providers be created with 1? When do they ever get recreated/replaced?
-		fmt.Println("issuing check errors", resp.Failures)
 		if issueCheckErrors(i.deployment, state, urn, resp.Failures) {
-			fmt.Println("provider check had failures")
 			return nil, errors.New("provider check failed")
 		}
 


### PR DESCRIPTION
A couple of Println statements seem to have slipped through in https://github.com/pulumi/pulumi/pull/20904.

Fix that.