### PR TITLE
Move workspace.W to pkgWorkspace

### DIFF
--- a/pkg/backend/state/stacks.go
+++ b/pkg/backend/state/stacks.go
@@ -21,12 +21,12 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 )
 
 // CurrentStack reads the current stack and returns an instance connected to its backend provider.
-func CurrentStack(ctx context.Context, b backend.Backend) (backend.Stack, error) {
-	stackName, err := getCurrentStackName()
+func CurrentStack(ctx context.Context, ws pkgWorkspace.Context, b backend.Backend) (backend.Stack, error) {
+	stackName, err := getCurrentStackName(ws)
 	if err != nil {
 		return nil, err
 	} else if stackName == "" {
@@ -46,13 +46,13 @@ func CurrentStack(ctx context.Context, b backend.Backend) (backend.Stack, error)
 	return b.GetStack(ctx, ref)
 }
 
-func getCurrentStackName() (string, error) {
+func getCurrentStackName(ws pkgWorkspace.Context) (string, error) {
 	// PULUMI_STACK environment variable overrides any stack name in the workspace settings
 	if stackName, ok := os.LookupEnv("PULUMI_STACK"); ok {
 		return stackName, nil
 	}
 
-	w, err := workspace.New()
+	w, err := ws.New()
 	if err != nil {
 		return "", err
 	}
@@ -82,9 +82,9 @@ func getStackNameWithLegacyOrgNameIfNeeded(b backend.Backend, stackName string) 
 }
 
 // SetCurrentStack changes the current stack to the given stack name.
-func SetCurrentStack(name string) error {
+func SetCurrentStack(ws pkgWorkspace.Context, name string) error {
 	// Switch the current workspace to that stack.
-	w, err := workspace.New()
+	w, err := ws.New()
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/state/stacks_test.go
+++ b/pkg/backend/state/stacks_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,6 +43,7 @@ func TestCurrentStack(t *testing.T) {
 			fullyQualifiedName := fmt.Sprintf("%s/%s/%s", org, project, stack)
 			t.Setenv("PULUMI_STACK", fullyQualifiedName)
 
+			ws := &pkgWorkspace.MockContext{}
 			backend := &backend.MockBackend{
 				GetStackF: func(ctx context.Context, ref backend.StackReference) (backend.Stack, error) {
 					assert.Equal(t, fullyQualifiedName, ref.FullyQualifiedName().String())
@@ -49,7 +51,7 @@ func TestCurrentStack(t *testing.T) {
 				},
 			}
 
-			_, err := CurrentStack(ctx, backend)
+			_, err := CurrentStack(ctx, ws, backend)
 			require.NoError(t, err)
 		})
 
@@ -57,6 +59,7 @@ func TestCurrentStack(t *testing.T) {
 			orgQualifiedName := fmt.Sprintf("%s/%s", project, stack)
 			t.Setenv("PULUMI_STACK", orgQualifiedName)
 
+			ws := &pkgWorkspace.MockContext{}
 			backend := &backend.MockBackend{
 				GetStackF: func(ctx context.Context, ref backend.StackReference) (backend.Stack, error) {
 					assert.Equal(t, orgQualifiedName, ref.FullyQualifiedName().String())
@@ -64,7 +67,7 @@ func TestCurrentStack(t *testing.T) {
 				},
 			}
 
-			_, err := CurrentStack(ctx, backend)
+			_, err := CurrentStack(ctx, ws, backend)
 			require.NoError(t, err)
 		})
 
@@ -78,6 +81,7 @@ func TestCurrentStack(t *testing.T) {
 
 			writeConfig(t, tempdir, []byte("{}"))
 
+			ws := &pkgWorkspace.MockContext{}
 			backend := &backend.MockBackend{
 				SupportsOrganizationsF: func() bool {
 					return true
@@ -91,7 +95,7 @@ func TestCurrentStack(t *testing.T) {
 				},
 			}
 
-			_, err := CurrentStack(ctx, backend)
+			_, err := CurrentStack(ctx, ws, backend)
 			require.NoError(t, err)
 		})
 
@@ -111,6 +115,7 @@ func TestCurrentStack(t *testing.T) {
 			}`, backendURL, org)
 			writeConfig(t, tempdir, []byte(stub))
 
+			ws := &pkgWorkspace.MockContext{}
 			backend := &backend.MockBackend{
 				SupportsOrganizationsF: func() bool {
 					return true
@@ -121,13 +126,14 @@ func TestCurrentStack(t *testing.T) {
 				},
 			}
 
-			_, err := CurrentStack(ctx, backend)
+			_, err := CurrentStack(ctx, ws, backend)
 			require.NoError(t, err)
 		})
 
 		t.Run("`$stack` does not qualify with org if backend does not support orgs", func(t *testing.T) {
 			t.Setenv("PULUMI_STACK", stack)
 
+			ws := &pkgWorkspace.MockContext{}
 			backend := &backend.MockBackend{
 				SupportsOrganizationsF: func() bool {
 					return false
@@ -138,7 +144,7 @@ func TestCurrentStack(t *testing.T) {
 				},
 			}
 
-			_, err := CurrentStack(ctx, backend)
+			_, err := CurrentStack(ctx, ws, backend)
 			require.NoError(t, err)
 		})
 	})

--- a/pkg/cmd/pulumi/about/about.go
+++ b/pkg/cmd/pulumi/about/about.go
@@ -190,7 +190,7 @@ func getSummaryAbout(
 		addError(err, "Could not access the backend")
 	} else if backend != nil {
 		var stack currentStackAbout
-		if stack, err = getCurrentStackAbout(ctx, backend, selectedStack); err != nil {
+		if stack, err = getCurrentStackAbout(ctx, ws, backend, selectedStack); err != nil {
 			addError(err, "Failed to get information about the current stack")
 		} else {
 			result.CurrentStack = &stack
@@ -374,11 +374,13 @@ type aboutState struct {
 	URN  string `json:"urn"`
 }
 
-func getCurrentStackAbout(ctx context.Context, b backend.Backend, selectedStack string) (currentStackAbout, error) {
+func getCurrentStackAbout(
+	ctx context.Context, ws pkgWorkspace.Context, b backend.Backend, selectedStack string,
+) (currentStackAbout, error) {
 	var s backend.Stack
 	var err error
 	if selectedStack == "" {
-		s, err = state.CurrentStack(ctx, b)
+		s, err = state.CurrentStack(ctx, ws, b)
 	} else {
 		var ref backend.StackReference
 		ref, err = b.ParseStackReference(selectedStack)

--- a/pkg/cmd/pulumi/console/console.go
+++ b/pkg/cmd/pulumi/console/console.go
@@ -75,7 +75,7 @@ func NewConsoleCmd(ws pkgWorkspace.Context) *cobra.Command {
 						return nil
 					}
 				} else {
-					stack, err = state.CurrentStack(ctx, currentBackend)
+					stack, err = state.CurrentStack(ctx, ws, currentBackend)
 					if err != nil {
 						return err
 					}

--- a/pkg/cmd/pulumi/newcmd/new.go
+++ b/pkg/cmd/pulumi/newcmd/new.go
@@ -414,7 +414,7 @@ func runNew(ctx context.Context, args newArgs) error {
 
 	// Ensure the stack is selected.
 	if !args.generateOnly && s != nil {
-		contract.IgnoreError(state.SetCurrentStack(s.Ref().FullyQualifiedName().String()))
+		contract.IgnoreError(state.SetCurrentStack(ws, s.Ref().FullyQualifiedName().String()))
 	}
 
 	// Install dependencies.

--- a/pkg/cmd/pulumi/newcmd/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_acceptance_test.go
@@ -335,7 +335,7 @@ func currentUser(t *testing.T) string {
 }
 
 func loadStackName(t *testing.T) string {
-	w, err := workspace.New()
+	w, err := pkgWorkspace.Instance.New()
 	require.NoError(t, err)
 	return w.Settings().Stack
 }

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -593,6 +593,10 @@ type mockWorkspace struct {
 
 var _ pkgWorkspace.Context = &mockWorkspace{}
 
+func (m *mockWorkspace) New() (pkgWorkspace.W, error) {
+	return nil, m.readProjectErr
+}
+
 func (m *mockWorkspace) ReadProject() (*workspace.Project, string, error) {
 	return nil, "", m.readProjectErr
 }

--- a/pkg/cmd/pulumi/stack/io.go
+++ b/pkg/cmd/pulumi/stack/io.go
@@ -178,7 +178,7 @@ func requireCurrentStack(
 	if err != nil {
 		return nil, err
 	}
-	stack, err := state.CurrentStack(ctx, b)
+	stack, err := state.CurrentStack(ctx, ws, b)
 	if err != nil {
 		return nil, err
 	} else if stack != nil {
@@ -241,7 +241,7 @@ func ChooseStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 
 	// If a stack is already selected, make that the default.
 	var defaultOption string
-	currStack, currErr := state.CurrentStack(ctx, b)
+	currStack, currErr := state.CurrentStack(ctx, ws, b)
 	contract.IgnoreError(currErr)
 	if currStack != nil {
 		defaultOption = currStack.Ref().String()
@@ -319,7 +319,7 @@ func ChooseStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 
 	// If setCurrent is true, we'll persist this choice so it'll be used for future CLI operations.
 	if lopt.SetCurrent() {
-		if err = state.SetCurrentStack(stackRef.FullyQualifiedName().String()); err != nil {
+		if err = state.SetCurrentStack(ws, stackRef.FullyQualifiedName().String()); err != nil {
 			return nil, err
 		}
 	}
@@ -420,7 +420,7 @@ func CreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 	}
 
 	if setCurrent {
-		if err = state.SetCurrentStack(stack.Ref().FullyQualifiedName().String()); err != nil {
+		if err = state.SetCurrentStack(ws, stack.Ref().FullyQualifiedName().String()); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/cmd/pulumi/stack/stack_ls.go
+++ b/pkg/cmd/pulumi/stack/stack_ls.go
@@ -155,7 +155,7 @@ func runStackLS(ctx context.Context, args stackLSArgs) error {
 
 	// Get the current stack so we can print a '*' next to it.
 	var current string
-	if s, _ := state.CurrentStack(ctx, b); s != nil {
+	if s, _ := state.CurrentStack(ctx, ws, b); s != nil {
 		// If we couldn't figure out the current stack, just don't print the '*' later on instead of failing.
 		current = s.Ref().String()
 	}

--- a/pkg/cmd/pulumi/stack/stack_rename.go
+++ b/pkg/cmd/pulumi/stack/stack_rename.go
@@ -97,7 +97,7 @@ func newStackRenameCmd() *cobra.Command {
 			}
 
 			// Update the current workspace state to have selected the new stack.
-			if err := state.SetCurrentStack(newStackRef.FullyQualifiedName().String()); err != nil {
+			if err := state.SetCurrentStack(ws, newStackRef.FullyQualifiedName().String()); err != nil {
 				return fmt.Errorf("setting current stack: %w", err)
 			}
 

--- a/pkg/cmd/pulumi/stack/stack_rm.go
+++ b/pkg/cmd/pulumi/stack/stack_rm.go
@@ -121,7 +121,7 @@ func newStackRmCmd() *cobra.Command {
 			msg := fmt.Sprintf("%sStack '%s' has been removed!%s", colors.SpecAttention, s.Ref(), colors.Reset)
 			fmt.Println(opts.Color.Colorize(msg))
 
-			contract.IgnoreError(state.SetCurrentStack(""))
+			contract.IgnoreError(state.SetCurrentStack(ws, ""))
 			return nil
 		},
 	}

--- a/pkg/cmd/pulumi/stack/stack_select.go
+++ b/pkg/cmd/pulumi/stack/stack_select.go
@@ -87,7 +87,7 @@ func newStackSelectCmd() *cobra.Command {
 				if stackErr != nil {
 					return stackErr
 				} else if s != nil {
-					return state.SetCurrentStack(stackRef.FullyQualifiedName().String())
+					return state.SetCurrentStack(ws, stackRef.FullyQualifiedName().String())
 				}
 				// If create flag was passed and stack was not found, create it and select it.
 				if create && stack != "" {
@@ -95,7 +95,7 @@ func newStackSelectCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					return state.SetCurrentStack(s.Ref().FullyQualifiedName().String())
+					return state.SetCurrentStack(ws, s.Ref().FullyQualifiedName().String())
 				}
 
 				return fmt.Errorf("no stack named '%s' found", stackRef)
@@ -115,7 +115,7 @@ func newStackSelectCmd() *cobra.Command {
 			}
 
 			contract.Assertf(stack != nil, "must select a stack")
-			return state.SetCurrentStack(stack.Ref().FullyQualifiedName().String())
+			return state.SetCurrentStack(ws, stack.Ref().FullyQualifiedName().String())
 		},
 	}
 	cmd.PersistentFlags().StringVarP(

--- a/pkg/cmd/pulumi/stack/stack_unselect.go
+++ b/pkg/cmd/pulumi/stack/stack_unselect.go
@@ -17,8 +17,8 @@ package stack
 import (
 	"fmt"
 
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +34,7 @@ func newStackUnselectCmd() *cobra.Command {
 			"from.\n",
 		Args: cmdutil.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			currentWorkspace, err := workspace.New()
+			currentWorkspace, err := pkgWorkspace.Instance.New()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/state/state_delete_test.go
+++ b/pkg/cmd/pulumi/state/state_delete_test.go
@@ -79,7 +79,7 @@ func TestNoProject(t *testing.T) {
 	cmd := newStateDeleteCommand(ws, lm)
 	cmd.SetArgs([]string{"urn:pulumi:proj::stk::pkg:index:typ::res"})
 	err := cmd.ExecuteContext(context.Background())
-	assert.ErrorContains(t, err, "no Pulumi.yaml project file found")
+	assert.ErrorContains(t, err, "no project file found")
 }
 
 func TestStateDeleteURN(t *testing.T) {

--- a/pkg/cmd/pulumi/templatecmd/template_publish_test.go
+++ b/pkg/cmd/pulumi/templatecmd/template_publish_test.go
@@ -330,6 +330,10 @@ type mockTemplateWorkspace struct {
 
 var _ pkgWorkspace.Context = &mockTemplateWorkspace{}
 
+func (m *mockTemplateWorkspace) New() (pkgWorkspace.W, error) {
+	return nil, m.readProjectErr
+}
+
 func (m *mockTemplateWorkspace) ReadProject() (*workspace.Project, string, error) {
 	return nil, "", m.readProjectErr
 }

--- a/pkg/workspace/context.go
+++ b/pkg/workspace/context.go
@@ -23,6 +23,10 @@ import (
 // Context is an interface that represents the context of a workspace. It provides access to loading projects and
 // plugins.
 type Context interface {
+	// New creates a new workspace using the current working directory. Requires a Pulumi.yaml file be present
+	// in the folder hierarchy between the current working directory and the .pulumi folder.
+	New() (W, error)
+
 	// ReadProject attempts to detect and read a Pulumi project for the current workspace. If the
 	// project is successfully detected and read, it is returned along with the path to its containing
 	// directory, which will be used as the root of the project's Pulumi program.
@@ -35,6 +39,10 @@ type Context interface {
 var Instance Context = &workspaceContext{}
 
 type workspaceContext struct{}
+
+func (c *workspaceContext) New() (W, error) {
+	return newW()
+}
 
 func (c *workspaceContext) ReadProject() (*workspace.Project, string, error) {
 	proj, path, err := workspace.DetectProjectAndPath()

--- a/pkg/workspace/mock.go
+++ b/pkg/workspace/mock.go
@@ -19,8 +19,16 @@ import (
 )
 
 type MockContext struct {
+	NewF                  func() (W, error)
 	ReadProjectF          func() (*workspace.Project, string, error)
 	GetStoredCredentialsF func() (workspace.Credentials, error)
+}
+
+func (c *MockContext) New() (W, error) {
+	if c.NewF != nil {
+		return c.NewF()
+	}
+	return nil, workspace.ErrProjectNotFound
 }
 
 func (c *MockContext) ReadProject() (*workspace.Project, string, error) {

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -383,3 +383,8 @@ func GetPulumiPath(elem ...string) (string, error) {
 
 	return filepath.Join(append([]string{homeDir}, elem...)...), nil
 }
+
+// qnameFileName takes a qname and cleans it for use as a filename (by replacing tokens.QNameDelimter with a dash)
+func qnameFileName(nm tokens.QName) string {
+	return strings.ReplaceAll(string(nm), tokens.QNameDelimiter, "-")
+}


### PR DESCRIPTION
Moves `workspace.W` from the sdk/go/common folder to pkg/workspace as part of the `Context` object. This is only used inside other pkg code.