### PR TITLE
Fix invalid build constrains: `integration_nodejs_test.go`

### DIFF
--- a/pkg/workspace/plugins_install_nodejs_test.go
+++ b/pkg/workspace/plugins_install_nodejs_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package workspace
 
 import (

--- a/pkg/workspace/plugins_install_python_test.go
+++ b/pkg/workspace/plugins_install_python_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build python || all
-
 package workspace
 
 import (

--- a/tests/integration/aliases/aliases_go_test.go
+++ b/tests/integration/aliases/aliases_go_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go || all
-
 package ints
 
 import (

--- a/tests/integration/aliases/aliases_nodejs_test.go
+++ b/tests/integration/aliases/aliases_nodejs_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/integration/aliases/aliases_py_test.go
+++ b/tests/integration/aliases/aliases_py_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build python || all
-
 package ints
 
 import (

--- a/tests/integration/custom_timeouts/custom_timeouts_test.go
+++ b/tests/integration/custom_timeouts/custom_timeouts_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build python || all
-
 package ints
 
 import (

--- a/tests/integration/delete_before_create/delete_before_create_test.go
+++ b/tests/integration/delete_before_create/delete_before_create_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/integration/dependency_steps/dependency_steps_test.go
+++ b/tests/integration/dependency_steps/dependency_steps_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/integration/double_pending_delete/double_pending_delete_test.go
+++ b/tests/integration/double_pending_delete/double_pending_delete_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/integration/duplicate_urns/duplicate_urns_test.go
+++ b/tests/integration/duplicate_urns/duplicate_urns_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/integration/integration_acceptance_test.go
+++ b/tests/integration/integration_acceptance_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build all
-
 package ints
 
 import (

--- a/tests/integration/integration_go_acceptance_test.go
+++ b/tests/integration/integration_go_acceptance_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go || all
-
 package ints
 
 import (

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go || all
-
 package ints
 
 import (

--- a/tests/integration/integration_nodejs_acceptance_test.go
+++ b/tests/integration/integration_nodejs_acceptance_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build all
-
 package ints
 
 import (

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build python || all
-
 package ints
 
 import (

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build python || all
-
 package ints
 
 import (

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build all
-
 package ints
 
 import (

--- a/tests/integration/partial_state/partial_state_test.go
+++ b/tests/integration/partial_state/partial_state_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/integration/program_error/program_error_go_test.go
+++ b/tests/integration/program_error/program_error_go_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go || all
-
 package ints
 
 import (

--- a/tests/integration/program_error/program_error_nodejs_test.go
+++ b/tests/integration/program_error/program_error_nodejs_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/integration/program_error/program_error_python_test.go
+++ b/tests/integration/program_error/program_error_python_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build python || all
-
 package ints
 
 import (

--- a/tests/integration/protect_resources/protect_test.go
+++ b/tests/integration/protect_resources/protect_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/integration/read/import_acquire/import_acquire_test.go
+++ b/tests/integration/read/import_acquire/import_acquire_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/integration/read/read_dbr/read_dbr_test.go
+++ b/tests/integration/read/read_dbr/read_dbr_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/integration/read/read_relinquish/read_relinquish_test.go
+++ b/tests/integration/read/read_relinquish/read_relinquish_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/integration/read/read_replace/read_dbr_test.go
+++ b/tests/integration/read/read_replace/read_dbr_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/integration/recreate_resource_check/resource_recreate_check_test.go
+++ b/tests/integration/recreate_resource_check/resource_recreate_check_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/integration/resource_hooks/resource_hooks_go_test.go
+++ b/tests/integration/resource_hooks/resource_hooks_go_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go || all
-
 package ints
 
 import (

--- a/tests/integration/resource_hooks/resource_hooks_nodejs_test.go
+++ b/tests/integration/resource_hooks/resource_hooks_nodejs_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/integration/resource_hooks/resource_hooks_py_test.go
+++ b/tests/integration/resource_hooks/resource_hooks_py_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build python || all
-
 package ints
 
 import (

--- a/tests/integration/resource_hooks/test_utils.go
+++ b/tests/integration/resource_hooks/test_utils.go
@@ -1,4 +1,16 @@
-//go:build nodejs || go || python || all
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package ints
 

--- a/tests/integration/state_protect_unprotect_test.go
+++ b/tests/integration/state_protect_unprotect_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build all
-
 package ints
 
 import (

--- a/tests/integration/state_taint_untaint_test.go
+++ b/tests/integration/state_taint_untaint_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build all
-
 package ints
 
 import (

--- a/tests/integration/steps/steps_test.go
+++ b/tests/integration/steps/steps_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/integration/transformations/transformations_go_test.go
+++ b/tests/integration/transformations/transformations_go_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go || all
-
 package ints
 
 import (

--- a/tests/integration/transformations/transformations_nodejs_test.go
+++ b/tests/integration/transformations/transformations_nodejs_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/integration/transformations/transformations_py_test.go
+++ b/tests/integration/transformations/transformations_py_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build python || all
-
 package ints
 
 import (

--- a/tests/integration/transforms/transforms_go_test.go
+++ b/tests/integration/transforms/transforms_go_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go || all
-
 package ints
 
 import (

--- a/tests/integration/transforms/transforms_nodejs_test.go
+++ b/tests/integration/transforms/transforms_nodejs_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/integration/transforms/transforms_py_test.go
+++ b/tests/integration/transforms/transforms_py_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build python || all
-
 package ints
 
 import (

--- a/tests/integration/types/types_test.go
+++ b/tests/integration/types/types_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build python || all
-
 package ints
 
 import (

--- a/tests/integration/valid-property-names/steps_test.go
+++ b/tests/integration/valid-property-names/steps_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || all
-
 package ints
 
 import (

--- a/tests/performance/performance_test.go
+++ b/tests/performance/performance_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build all
-
 package perf
 
 import (


### PR DESCRIPTION
`tests/integration/integration_nodejs_test.go` does not work when the only flag passed to it is `nodejs`

```console
$ go test -test.run \^TestPrintfNodeJS\$ -test.v -tags=nodejs
./integration_nodejs_test.go:2131:2: undefined: testConstructProviderPropagation
FAIL	github.com/pulumi/pulumi/tests/integration [build failed]
```

Assuming that `all` -> `nodejs`, and since we know that `nodejs` is never standalone, we know it is safe to reduce `all || nodejs` to `all`.