### PR TITLE
fix: Include invalid property names in bind errors

### DIFF
--- a/changelog/pending/20251118--pkg--include-invalid-property-names-in-bind-errors.yaml
+++ b/changelog/pending/20251118--pkg--include-invalid-property-names-in-bind-errors.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pkg
+  description: Include invalid property names in bind errors

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -1178,7 +1178,7 @@ func (t *types) bindProperties(path string, properties map[string]PropertySpec, 
 		}
 	}
 	if diags.HasErrors() {
-		return nil, nil, diags, errors.New("invalid property names")
+		return nil, nil, diags, fmt.Errorf("invalid property names: %s", diags.Error())
 	}
 
 	// Bind property types and constant or default values.
@@ -1680,7 +1680,7 @@ func (t *types) bindProvider(decl *Resource, options ValidationOptions) (hcl.Dia
 			diags = diags.Append(errorf(path, "%s", property.Name+" is a reserved provider input property name"))
 		}
 		if diags.HasErrors() {
-			return diags, errors.New("invalid property names")
+			return diags, fmt.Errorf("invalid property names: %s", diags.Error())
 		}
 	}
 


### PR DESCRIPTION
This will make it much easier to track down problematic properties.