### PR TITLE
enable journaling in testing

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -47,6 +47,11 @@ on:
         default: 0
         required: false
         type: number
+      enable-journaling:
+        description: "Whether journaling is enabled for running the tests"
+        required: false
+        default: true
+        type: boolean
 
       version-set:
         required: false
@@ -79,7 +84,7 @@ env:
   PULUMI_TEST_USE_SERVICE: ${{ !contains(inputs.version, '-') }}
   # We're hitting a lot of github limits because of deploytest trying to auto install plugins, skip that for now.
   PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION: "true"
-  PULUMI_ENABLE_JOURNALING: "true"
+  PULUMI_ENABLE_JOURNALING: "${{ inputs.enable-journaling }}"
   PYTHON: python
   GO_TEST_PARALLELISM: 8
   GO_TEST_PKG_PARALLELISM: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,11 @@ on:
         default: false
         required: false
         type: boolean
+      enable-journaling:
+        description: "Whether journaling is enabled in tests"
+        default: true
+        required: false
+        type: boolean
       fail-fast:
         required: false
         default: false
@@ -360,6 +365,7 @@ jobs:
       test-command: ${{ matrix.test-suite.command }}
       is-integration-test: false
       enable-coverage: ${{ inputs.enable-coverage }}
+      enable-journaling: ${{ inputs.enable-journaling }}
       test-retries: ${{ inputs.test-retries }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
@@ -386,6 +392,7 @@ jobs:
       test-command: ${{ matrix.test-suite.command }}
       is-integration-test: true
       enable-coverage: ${{ inputs.enable-coverage }}
+      enable-journaling: ${{ inputs.enable-journaling }}
       test-retries: ${{ inputs.test-retries }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
@@ -413,6 +420,7 @@ jobs:
       test-command: ${{ matrix.test-suite.command }}
       is-integration-test: true
       enable-coverage: false
+      enable-journaling: ${{ inputs.enable-journaling }}
       test-retries: ${{ inputs.test-retries }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
@@ -440,6 +448,7 @@ jobs:
       test-command: ${{ matrix.test-suite.command }}
       is-integration-test: true
       enable-coverage: false
+      enable-journaling: ${{ inputs.enable-journaling }}
       test-retries: ${{ inputs.test-retries }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 

--- a/.github/workflows/cron-test-all.yml
+++ b/.github/workflows/cron-test-all.yml
@@ -43,6 +43,7 @@ jobs:
       # data on every merge to main, so getting it in the daily cro
       # job is not important.
       enable-coverage: false
+      enable-journaling: false
     secrets: inherit
 
   performance-gate:


### PR DESCRIPTION
As the first step in our rollout plan for journaling, we want to enable it in our CI tests.  This will allow us to get some initial test coverage. The feature flag for turning this on is already enabled for the moolumi and pulumi-test orgs. This can be disabled anytime by either reverting this PR, or disabling the feature flag in LaunchDarkly.

Part of https://github.com/pulumi/home/issues/4404