### PR TITLE
allow setting pulumi backend url for NodeJS automation API tests

### DIFF
--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -2041,8 +2041,12 @@ function withCloudBackend(
     description?: string,
     runtime?: string,
 ): LocalWorkspaceOptions {
+    let url = "https://api.pulumi.com";
+    if (process.env.PULUMI_BACKEND_URL) {
+        url = process.env.PULUMI_BACKEND_URL;
+    }
     const backend = {
-        url: "https://api.pulumi.com",
+        url: url,
     };
     if (name === undefined) {
         name = "node_test";


### PR DESCRIPTION
We currently hardcode the url for NodeJS automation API tests to `api.pulumi.com`. Internally however it is often useful to be able to run those tests against a review stack or even a local setup of the service. Allow setting `PULUMI_BACKEND_URL` to override the default backend for these tests.