### PR TITLE
Lazy `PROJECT_PKGS`, `TESTS_PKGS` and `VERSION` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ _ := $(shell mkdir -p bin)
 
 PKG_CODEGEN := github.com/pulumi/pulumi/pkg/v3/codegen
 # nodejs and python codegen tests are much slower than go/dotnet:
-PROJECT_PKGS    := $(shell cd ./pkg && go list ./... | grep -v -E '^${PKG_CODEGEN}/(dotnet|go|nodejs|python)')
+PROJECT_PKGS    = $(shell cd ./pkg && go list ./... | grep -v -E '^${PKG_CODEGEN}/(dotnet|go|nodejs|python)')
 INTEGRATION_PKG := github.com/pulumi/pulumi/tests/integration
 PERFORMANCE_PKG := github.com/pulumi/pulumi/tests/performance
-TESTS_PKGS      := $(shell cd ./tests && go list -tags all ./... | grep -v tests/templates | grep -v ^${INTEGRATION_PKG}$ | grep -v ^${PERFORMANCE_PKG}$)
-VERSION         := $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell ./scripts/pulumi-version.sh))
+TESTS_PKGS      = $(shell cd ./tests && go list -tags all ./... | grep -v tests/templates | grep -v ^${INTEGRATION_PKG}$ | grep -v ^${PERFORMANCE_PKG}$)
+VERSION         = $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell ./scripts/pulumi-version.sh))
 
 # Relative paths to directories with go.mod files that should be linted.
 LINT_GOLANG_PKGS := sdk pkg tests sdk/go/pulumi-language-go sdk/nodejs/cmd/pulumi-language-nodejs sdk/python/cmd/pulumi-language-python cmd/pulumi-test-language


### PR DESCRIPTION
These variables are not always used. The most expensive ones, `PROJECT_PKGS` and `TESTS_PKGS`, are only used for tests.

This improves performance of `make bin/pulumi` on a no-op build by 2.13 times:

    𝛌 hyperfine --prepare 'git checkout iwahbe/lazy-make-variables' --warmup 5 -n lazy-make-variables 'make bin/pulumi' --prepare 'git checkout master' -n master 'make bin/pulumi'
    Benchmark 1: lazy-make-variables
      Time (mean ± σ):      1.078 s ±  0.020 s    [User: 1.132 s, System: 4.986 s]
      Range (min … max):    1.032 s …  1.095 s    10 runs

    Benchmark 2: master
      Time (mean ± σ):      2.296 s ±  0.015 s    [User: 2.771 s, System: 6.635 s]
      Range (min … max):    2.267 s …  2.325 s    10 runs

    Summary
      lazy-make-variables ran
        2.13 ± 0.04 times faster than master