### PR TITLE
`PULUMI_INTEGRATION_REBUILD_BINARIES` should build all binaries

### DIFF
--- a/tests/testutil/test_main_util.go
+++ b/tests/testutil/test_main_util.go
@@ -35,7 +35,11 @@ func SetupPulumiBinary() {
 	}
 	repoRoot := strings.TrimSpace(string(stdout))
 	if os.Getenv("PULUMI_INTEGRATION_REBUILD_BINARIES") == "true" {
-		cmd := exec.Command("make", "build")
+		cmd := exec.Command("make",
+			"bin/pulumi",
+			"bin/pulumi-language-python",
+			"bin/pulumi-language-go",
+			"bin/pulumi-language-nodejs")
 		cmd.Dir = repoRoot
 		stdout, err = cmd.CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
This change (stacked on top of https://github.com/pulumi/pulumi/pull/21018) enables building all Go binaries that integration tests might depend on, not just `bin/pulumi`.