### PR TITLE
stop trying to compare journal and snapshot when journaling is enabled

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1665,10 +1665,8 @@ func (b *cloudBackend) runEngineAction(
 			if err != nil {
 				validationErrs = append(validationErrs, err)
 			}
-			noopPersister := backend.ValidatingPersister{}
-			snapshotManager = backend.NewSnapshotManager(&noopPersister, op.SecretsManager, u.Target.Snapshot)
 			combinedManager = &engine.CombinedManager{
-				Managers: []engine.SnapshotManager{journalManager, snapshotManager},
+				Managers: []engine.SnapshotManager{journalManager},
 			}
 		} else {
 			persister := b.newSnapshotPersister(ctx, update, tokenSource)


### PR DESCRIPTION
Right now, when journaling is enabled, we still try to compare the snapshot we get from the journaler to the one we get from the full snapshot manager.  Doing so makes the journaler go slower the larger the snapshot gets.

Since we haven't found any issues with this comparison mechanism since a while, we don't need to keep this code that slows us down for the new implementation.  Remove it to get the best performance.

We initially had both, because we wanted to keep the comparison between journal and snapshot, even when the journaler was enabled.  However since the metabase dashboard has been clean for a while with this enabled, I wouldn't expect to get too much more data out of this, and it's fine to remove. The `snapshotManager` was only there for this comparison, it had no other functionality.