### PR TITLE
Upgrade action-homebrew-bump-formula from v3 to v6

### DIFF
--- a/.github/workflows/trigger-homebrew-event.yml
+++ b/.github/workflows/trigger-homebrew-event.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Add Homebrew to the PATH
         run: |
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> "${GITHUB_PATH}"
-      - uses: dawidd6/action-homebrew-bump-formula@v3
+      - uses: dawidd6/action-homebrew-bump-formula@v6
         with:
           token: ${{secrets.PULUMI_BOT_HOMEBREW_TOKEN}}
           formula: pulumi


### PR DESCRIPTION
According to release notes, all existing parameters remain compatible with no configuration changes
needed. https://github.com/dawidd6/action-homebrew-bump-formula/releases/tag/v6 adds compatibility with homebrew v5:
https://github.com/dawidd6/action-homebrew-bump-formula/pull/101. My suspicion is that is what is causing https://github.com/pulumi/pulumi/issues/21011.