### PR TITLE
Do not print Neo explanation deeplinks if organization is single-user

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1480,11 +1480,13 @@ func (b *cloudBackend) createAndStartUpdate(
 		userName = "unknown"
 	}
 	// Check if the user's org (stack's owner) has Neo enabled. If not, we don't show the link to Neo.
+	// Also check that the org is not a single-user org, as those do not support Neo.
 	isNeoEnabled := updateDetails.IsNeoIntegrationEnabled
+	isSingleUserOrg := updateDetails.IsSingleUserOrg
 	b.neoEnabledForCurrentProject = &isNeoEnabled
 	neoEnabledValueString := "is"
 	continuationString := ""
-	if isNeoEnabled {
+	if isNeoEnabled && !isSingleUserOrg {
 		if env.SuppressNeoLink.Value() {
 			// Neo is enabled in user's org, but the environment variable to suppress the link to Neo is set.
 			op.Opts.Display.ShowLinkToNeo = false
@@ -1494,7 +1496,12 @@ func (b *cloudBackend) createAndStartUpdate(
 	} else {
 		op.Opts.Display.ShowLinkToNeo = false
 		op.Opts.Display.ShowNeoFeatures = false
-		neoEnabledValueString = "is not"
+		if isSingleUserOrg {
+			neoEnabledValueString = "is not"
+			continuationString = " (single-user organization does not support Neo)"
+		} else {
+			neoEnabledValueString = "is not"
+		}
 	}
 	logging.V(7).Infof("Neo in org '%s' %s enabled for user '%s'%s",
 		stackID.Owner, neoEnabledValueString, userName, continuationString)

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -742,6 +742,7 @@ type CreateUpdateDetails struct {
 	Messages                []apitype.Message
 	RequiredPolicies        []apitype.RequiredPolicy
 	IsNeoIntegrationEnabled bool
+	IsSingleUserOrg         bool
 }
 
 // CreateUpdate creates a new update for the indicated stack with the given kind and assorted options. If the update
@@ -819,6 +820,7 @@ func (pc *Client) CreateUpdate(
 			Messages:                updateResponse.Messages,
 			RequiredPolicies:        updateResponse.RequiredPolicies,
 			IsNeoIntegrationEnabled: updateResponse.AISettings.CopilotIsEnabled,
+			IsSingleUserOrg:         updateResponse.AISettings.IsSingleUserOrg,
 		}, nil
 }
 

--- a/sdk/go/common/apitype/updates.go
+++ b/sdk/go/common/apitype/updates.go
@@ -94,6 +94,7 @@ type Message struct {
 
 type AISettingsForUpdate struct {
 	CopilotIsEnabled bool `json:"copilotIsEnabled"`
+	IsSingleUserOrg  bool `json:"isSingleUserOrg"`
 }
 
 // UpdateProgramResponse is the result of an update program request.


### PR DESCRIPTION
Checks if the stack that the user performed an update on belongs to a single user organization. If so, the link to explain failed updates/previews with Neo will not be displayed.

Related PR: https://github.com/pulumi/pulumi-service/pull/34933

Part of: https://github.com/pulumi/pulumi-service/issues/33630
