### PR TITLE
[sdk/python] Fix marshaling int property values

### DIFF
--- a/changelog/pending/20251121--sdk-python--fix-marshaling-int-property-values.yaml
+++ b/changelog/pending/20251121--sdk-python--fix-marshaling-int-property-values.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix marshaling int property values

--- a/sdk/python/lib/pulumi/provider/experimental/property_value.py
+++ b/sdk/python/lib/pulumi/provider/experimental/property_value.py
@@ -313,7 +313,7 @@ class PropertyValue:
             if isinstance(value, bool):
                 return struct_pb2.Value(bool_value=value)
 
-            if isinstance(value, float):
+            if isinstance(value, (int, float)):
                 return struct_pb2.Value(number_value=value)
 
             if isinstance(value, str):

--- a/sdk/python/lib/test/provider/experimental/test_property_value.py
+++ b/sdk/python/lib/test/provider/experimental/test_property_value.py
@@ -6,6 +6,9 @@ def test_property_value_type():
     value = PropertyValue(2.0)
     assert value.type == PropertyValueType.NUMBER
 
+    value = PropertyValue(42)
+    assert value.type == PropertyValueType.NUMBER
+
     value = PropertyValue("hello")
     assert value.type == PropertyValueType.STRING
 
@@ -91,3 +94,10 @@ def test_nesting():
     pbvalue = PropertyValue.marshal_map(value)
     result = PropertyValue.unmarshal_map(pbvalue)
     assert value == result
+
+
+def test_marshal_int_as_number():
+    value = PropertyValue(42)
+    pbvalue = value.marshal()
+
+    assert pbvalue.number_value == 42


### PR DESCRIPTION
It's possible a `PropertyValue` is created from an `int` rather than `float`. We already handle this case for the `PropertyValue.type` property. This change also handles it for the `PropertyValue.marshal` method.

Fixes #21026