### PR TITLE
Remove usage of golang.org/x/net/context

### DIFF
--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -43,7 +43,7 @@ require (
 	gocloud.dev v0.37.0
 	gocloud.dev/secrets/hashivault v0.37.0
 	golang.org/x/crypto v0.39.0 // indirect
-	golang.org/x/net v0.41.0
+	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.15.0
 	google.golang.org/api v0.169.0

--- a/pkg/resource/provider/component_provider.go
+++ b/pkg/resource/provider/component_provider.go
@@ -15,12 +15,12 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"

--- a/pkg/resource/provider/host.go
+++ b/pkg/resource/provider/host.go
@@ -15,6 +15,7 @@
 package provider
 
 import (
+	"context"
 	"io"
 	"os"
 	"strings"
@@ -24,7 +25,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/grpclog"

--- a/sdk/go/common/resource/plugin/host_server.go
+++ b/sdk/go/common/resource/plugin/host_server.go
@@ -15,10 +15,10 @@
 package plugin
 
 import (
+	"context"
 	"fmt"
 	"sync/atomic"
 
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -17,6 +17,7 @@ package plugin
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -33,7 +34,6 @@ import (
 
 	multierror "github.com/hashicorp/go-multierror"
 	opentracing "github.com/opentracing/opentracing-go"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
@@ -185,7 +185,8 @@ func dialPlugin[T any](
 	// TODO[pulumi/pulumi#337]: in theory, this should be unnecessary.  gRPC's default WaitForReady behavior
 	//     should auto-retry appropriately.  On Linux, however, we are observing different behavior.  In the meantime
 	//     while this bug exists, we'll simply do a bit of waiting of our own up front.
-	timeout, _ := context.WithTimeout(context.Background(), pluginRPCConnectionTimeout)
+	timeout, cancel := context.WithTimeout(context.Background(), pluginRPCConnectionTimeout)
+	defer cancel()
 	for {
 		s := conn.GetState()
 		if s == connectivity.Ready {
@@ -488,7 +489,7 @@ func ExecPlugin(ctx *Context, bin, prefix string, kind apitype.PluginKind,
 			return nil, fmt.Errorf("loading runtime: %w", err)
 		}
 
-		rctx, kill := context.WithCancel(ctx.Request())
+		rctx, kill := context.WithCancel(ctx.Request()) //nolint:govet // lostcancel
 
 		stdout, stderr, done, err := runtime.RunPlugin(rctx, RunPluginInfo{
 			Info:             info,
@@ -499,7 +500,7 @@ func ExecPlugin(ctx *Context, bin, prefix string, kind apitype.PluginKind,
 			AttachDebugger:   attachDebugger,
 		})
 		if err != nil {
-			return nil, err
+			return nil, err //nolint:govet // lostcancel
 		}
 
 		return &Plugin{

--- a/sdk/go/pulumi/asset.go
+++ b/sdk/go/pulumi/asset.go
@@ -15,10 +15,10 @@
 package pulumi
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"golang.org/x/net/context"
 )
 
 // AssetOrArchive represents either an Asset or an Archive.

--- a/sdk/go/pulumi/callback.go
+++ b/sdk/go/pulumi/callback.go
@@ -15,6 +15,7 @@
 package pulumi
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -23,7 +24,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 )

--- a/sdk/go/pulumi/log.go
+++ b/sdk/go/pulumi/log.go
@@ -17,10 +17,10 @@
 package pulumi
 
 import (
+	"context"
 	"strings"
 
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"golang.org/x/net/context"
 )
 
 // Log is a group of logging functions that can be called from a Go application that will be logged

--- a/sdk/go/pulumi/mocks.go
+++ b/sdk/go/pulumi/mocks.go
@@ -15,12 +15,12 @@
 package pulumi
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"reflect"
 	"sync"
 
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/sdk/go/pulumi/resource_hooks.go
+++ b/sdk/go/pulumi/resource_hooks.go
@@ -15,11 +15,11 @@
 package pulumi
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"golang.org/x/net/context"
 )
 
 // marshalResourceHooks marshals a `ResourceHookBinding` to a protobuf message.

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -15,6 +15,7 @@
 package pulumi
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -24,7 +25,6 @@ import (
 
 	"github.com/blang/semver"
 	"golang.org/x/exp/maps"
-	"golang.org/x/net/context"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	rarchive "github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"

--- a/sdk/go/pulumi/transform.go
+++ b/sdk/go/pulumi/transform.go
@@ -14,7 +14,7 @@
 
 package pulumi
 
-import "golang.org/x/net/context"
+import "context"
 
 // ResourceTransformArgs is the argument bag passed to a resource transform.
 type ResourceTransformArgs struct {


### PR DESCRIPTION
This has been in the standard lib forever, and the latest x/net release finally marks this as deprecated.

https://go.googlesource.com/net/+/07cefd8a6bb170785052142a96034f2b2f7115bc
