### PR TITLE
Close plugin.Context

### DIFF
--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -652,6 +652,7 @@ func (eng *languageTestServer) RunLanguageTest(
 	if err != nil {
 		return nil, fmt.Errorf("setup plugin context: %w", err)
 	}
+	defer contract.IgnoreClose(pctx)
 
 	// NewContextWithRoot will make a default plugin host, but we want to make sure we never actually use that
 	pctx.Host = nil

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/util/pdag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
@@ -120,6 +121,7 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 					if err != nil {
 						return err
 					}
+					defer contract.IgnoreClose(pctx)
 
 					// Cloud registry is linked to a backend, but we don't have
 					// one available in a plugin. Use the unauthenticated

--- a/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
@@ -68,7 +68,6 @@ empty string.`,
 			if err != nil {
 				return fmt.Errorf("load provider: %w", err)
 			}
-			defer p.Provider.Close()
 
 			// If provider parameters have been provided, parameterize the provider with them before requesting a mapping.
 			if len(args) > 3 {

--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -150,7 +150,7 @@ func GenSDK(language, out string, pkg *schema.Package, overlays string, local bo
 		if err != nil {
 			return nil, fmt.Errorf("create plugin context: %w", err)
 		}
-		defer contract.IgnoreClose(pCtx.Host)
+		defer contract.IgnoreClose(pCtx)
 		programInfo := plugin.NewProgramInfo(cwd, cwd, ".", nil)
 		languagePlugin, err := pCtx.Host.LanguageRuntime(language, programInfo)
 		if err != nil {

--- a/pkg/cmd/pulumi/policy/policy_publish.go
+++ b/pkg/cmd/pulumi/policy/policy_publish.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
 )
@@ -129,6 +130,7 @@ func (cmd *policyPublishCmd) Run(ctx context.Context, lm cmdBackend.LoginManager
 	if err != nil {
 		return err
 	}
+	defer contract.IgnoreClose(plugctx)
 
 	// Get optional data about the environment performing the publish operation,
 	// e.g. the current source code control commit information.

--- a/pkg/workspace/plugin.go
+++ b/pkg/workspace/plugin.go
@@ -371,7 +371,7 @@ func InstallPluginAtPath(pctx *plugin.Context, proj *workspace.PluginProject, st
 	}
 	entryPoint := "." // Plugin's are not able to set a non-standard entry point.
 	pInfo := plugin.NewProgramInfo(pctx.Root, pctx.Pwd, entryPoint, proj.Runtime.Options())
-	runtime, err := plugin.NewLanguageRuntime(pctx.Host, pctx, proj.Runtime.Name(), pctx.Pwd, pInfo)
+	runtime, err := pctx.Host.LanguageRuntime(proj.Runtime.Name(), pInfo)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`TestPulumiInstallInstallsPackagesIntoTheCorrectDirectory`  is flaky

https://github.com/pulumi/pulumi/actions/runs/19624448306/job/56231516334

We’re creating a language runtime directly without it being attached to the host. This leaves the runtime running even after we close & exit.

Also Fixes https://github.com/pulumi/pulumi/issues/20783