### PR TITLE
Add renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,6 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["github>pulumi/renovate-config//default.json5"],
+  // TODO: Remove this setting once we're happy with the configuration
+  baseBranchPatterns: ["renovate-dev"]
+}


### PR DESCRIPTION
This adds a renovate configuration that points to the `renovate-dev` branch. We should then hopefully be able to iterate on the configuration on that branch.
