### PR TITLE
Stop passing root and runtime options as args to language plugins

### DIFF
--- a/changelog/pending/20251125--engine--dont-send-root-directory-and-runtime-options-to-language-plugins-as-command-line-arguments.yaml
+++ b/changelog/pending/20251125--engine--dont-send-root-directory-and-runtime-options-to-language-plugins-as-command-line-arguments.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: engine
+  description: Don't send root directory and runtime options to language plugins as command line arguments

--- a/cmd/pulumi-test-language/test_host.go
+++ b/cmd/pulumi-test-language/test_host.go
@@ -167,7 +167,7 @@ func (h *testHost) CloseProvider(provider plugin.Provider) error {
 
 // LanguageRuntime returns the language runtime initialized by the test host.
 // ProgramInfo is only used here for compatibility reasons and will be removed from this function.
-func (h *testHost) LanguageRuntime(runtime string, info plugin.ProgramInfo) (plugin.LanguageRuntime, error) {
+func (h *testHost) LanguageRuntime(runtime string) (plugin.LanguageRuntime, error) {
 	if runtime != h.runtimeName {
 		return nil, fmt.Errorf("unexpected runtime %s", runtime)
 	}

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -318,12 +318,12 @@ func installRequiredPolicy(ctx *plugin.Context, finalDir string, tgz io.ReadClos
 		}
 	}
 
-	info := plugin.NewProgramInfo(finalDir, finalDir, ".", proj.Runtime.Options())
-	language, err := ctx.Host.LanguageRuntime(proj.Runtime.Name(), info)
+	language, err := ctx.Host.LanguageRuntime(proj.Runtime.Name())
 	if err != nil {
 		return fmt.Errorf("failed to load language plugin %s: %w", proj.Runtime.Name(), err)
 	}
 
+	info := plugin.NewProgramInfo(finalDir, finalDir, ".", proj.Runtime.Options())
 	err = pkgCmdUtil.InstallDependencies(language, plugin.InstallDependenciesRequest{
 		Info:                    info,
 		UseLanguageVersionTools: false,

--- a/pkg/cmd/pulumi/about/about.go
+++ b/pkg/cmd/pulumi/about/about.go
@@ -151,11 +151,11 @@ func getSummaryAbout(
 				result.Plugins = plugins
 			}
 
-			programInfo := plugin.NewProgramInfo(projinfo.Root, pwd, program, proj.Runtime.Options())
-			lang, err := pluginContext.Host.LanguageRuntime(proj.Runtime.Name(), programInfo)
+			lang, err := pluginContext.Host.LanguageRuntime(proj.Runtime.Name())
 			if err != nil {
 				addError(err, "Failed to load language plugin "+proj.Runtime.Name())
 			} else {
+				programInfo := plugin.NewProgramInfo(projinfo.Root, pwd, program, proj.Runtime.Options())
 				aboutResponse, err := lang.About(programInfo)
 				if err != nil {
 					addError(err, "Failed to get information about the project runtime")

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -237,8 +237,7 @@ func runConvert(
 		) (hcl.Diagnostics, error) {
 			contract.Requiref(proj != nil, "proj", "must not be nil")
 
-			programInfo := plugin.NewProgramInfo(cwd, cwd, ".", nil)
-			languagePlugin, err := pCtx.Host.LanguageRuntime(language, programInfo)
+			languagePlugin, err := pCtx.Host.LanguageRuntime(language)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -173,11 +173,12 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 			// First make sure the language plugin is present.  We need this to load the required resource plugins.
 			// TODO: we need to think about how best to version this.  For now, it always picks the latest.
 			runtime := proj.Runtime
-			programInfo := plugin.NewProgramInfo(pctx.Root, pwd, main, runtime.Options())
-			lang, err := pctx.Host.LanguageRuntime(runtime.Name(), programInfo)
+			lang, err := pctx.Host.LanguageRuntime(runtime.Name())
 			if err != nil {
 				return fmt.Errorf("load language plugin %s: %w", runtime.Name(), err)
 			}
+
+			programInfo := plugin.NewProgramInfo(pctx.Root, pwd, main, runtime.Options())
 
 			if !noDependencies {
 				err = pkgCmdUtil.InstallDependencies(lang, plugin.InstallDependenciesRequest{

--- a/pkg/cmd/pulumi/newcmd/install.go
+++ b/pkg/cmd/pulumi/newcmd/install.go
@@ -27,12 +27,12 @@ import (
 func InstallDependencies(ctx *plugin.Context, runtime *workspace.ProjectRuntimeInfo, main string) error {
 	// First make sure the language plugin is present.  We need this to load the required resource plugins.
 	// TODO: we need to think about how best to version this.  For now, it always picks the latest.
-	programInfo := plugin.NewProgramInfo(ctx.Root, ctx.Pwd, main, runtime.Options())
-	lang, err := ctx.Host.LanguageRuntime(runtime.Name(), programInfo)
+	lang, err := ctx.Host.LanguageRuntime(runtime.Name())
 	if err != nil {
 		return fmt.Errorf("failed to load language plugin %s: %w", runtime.Name(), err)
 	}
 
+	programInfo := plugin.NewProgramInfo(ctx.Root, ctx.Pwd, main, runtime.Options())
 	err = cmdutil.InstallDependencies(lang, plugin.InstallDependenciesRequest{
 		Info:     programInfo,
 		IsPlugin: false,

--- a/pkg/cmd/pulumi/newcmd/new.go
+++ b/pkg/cmd/pulumi/newcmd/new.go
@@ -375,12 +375,13 @@ func runNew(ctx context.Context, args newArgs) error {
 	}
 	defer pluginCtx.Close()
 
-	programInfo := plugin.NewProgramInfo(pluginCtx.Root, pluginCtx.Pwd, entryPoint, proj.Runtime.Options())
-	lang, err := pluginCtx.Host.LanguageRuntime(proj.Runtime.Name(), programInfo)
+	lang, err := pluginCtx.Host.LanguageRuntime(proj.Runtime.Name())
 	if err != nil {
 		return fmt.Errorf("failed to load language plugin %s: %w", proj.Runtime.Name(), err)
 	}
 	defer lang.Close()
+
+	programInfo := plugin.NewProgramInfo(pluginCtx.Root, pluginCtx.Pwd, entryPoint, proj.Runtime.Options())
 
 	// Query the language runtime for additional options.
 	if args.promptRuntimeOptions != nil {

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -901,8 +901,7 @@ func NewImportCmd() *cobra.Command {
 					return nil, nil, err
 				}
 				defer contract.IgnoreClose(pCtx.Host)
-				programInfo := plugin.NewProgramInfo(cwd, cwd, ".", nil)
-				languagePlugin, err := ctx.Host.LanguageRuntime(proj.Runtime.Name(), programInfo)
+				languagePlugin, err := ctx.Host.LanguageRuntime(proj.Runtime.Name())
 				if err != nil {
 					return nil, nil, err
 				}

--- a/pkg/cmd/pulumi/packagecmd/package_pack_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_pack_sdk.go
@@ -19,7 +19,6 @@ import (
 	"os"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packages"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/spf13/cobra"
@@ -48,8 +47,7 @@ func newPackagePackSdkCmd() *cobra.Command {
 			language := args[0]
 			path := args[1]
 
-			programInfo := plugin.NewProgramInfo(pCtx.Root, cwd, ".", nil)
-			languagePlugin, err := pCtx.Host.LanguageRuntime(language, programInfo)
+			languagePlugin, err := pCtx.Host.LanguageRuntime(language)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -151,8 +151,7 @@ func GenSDK(language, out string, pkg *schema.Package, overlays string, local bo
 			return nil, fmt.Errorf("create plugin context: %w", err)
 		}
 		defer contract.IgnoreClose(pCtx)
-		programInfo := plugin.NewProgramInfo(cwd, cwd, ".", nil)
-		languagePlugin, err := pCtx.Host.LanguageRuntime(language, programInfo)
+		languagePlugin, err := pCtx.Host.LanguageRuntime(language)
 		if err != nil {
 			return nil, err
 		}
@@ -241,8 +240,7 @@ func linkPackage(ctx *LinkPackagesContext) error {
 	if err != nil {
 		return err
 	}
-	programInfo := plugin.NewProgramInfo(root, root, ".", ctx.Project.RuntimeInfo().Options())
-	languagePlugin, err := ctx.PluginContext.Host.LanguageRuntime(ctx.Project.RuntimeInfo().Name(), programInfo)
+	languagePlugin, err := ctx.PluginContext.Host.LanguageRuntime(ctx.Project.RuntimeInfo().Name())
 	if err != nil {
 		return err
 	}
@@ -280,6 +278,7 @@ func linkPackage(ctx *LinkPackagesContext) error {
 			Descriptor: packageDescriptor,
 		})
 	}
+	programInfo := plugin.NewProgramInfo(root, root, ".", ctx.Project.RuntimeInfo().Options())
 	instructions, err := languagePlugin.Link(programInfo, deps, grpcServer.Addr())
 	if err != nil {
 		return fmt.Errorf("linking package: %w", err)

--- a/pkg/cmd/pulumi/policy/io.go
+++ b/pkg/cmd/pulumi/policy/io.go
@@ -72,12 +72,12 @@ func InstallPluginDependencies(ctx context.Context, root string, projRuntime wor
 	}
 	defer pluginCtx.Close()
 
-	programInfo := plugin.NewProgramInfo(pluginCtx.Root, pluginCtx.Pwd, main, projRuntime.Options())
-	lang, err := pluginCtx.Host.LanguageRuntime(projRuntime.Name(), programInfo)
+	lang, err := pluginCtx.Host.LanguageRuntime(projRuntime.Name())
 	if err != nil {
 		return fmt.Errorf("failed to load language plugin %s: %w", projRuntime.Name(), err)
 	}
 
+	programInfo := plugin.NewProgramInfo(pluginCtx.Root, pluginCtx.Pwd, main, projRuntime.Options())
 	err = pkgCmdUtil.InstallDependencies(lang, plugin.InstallDependenciesRequest{
 		Info:     programInfo,
 		IsPlugin: true,

--- a/pkg/engine/plugin_host.go
+++ b/pkg/engine/plugin_host.go
@@ -47,7 +47,6 @@ func connectToLanguageRuntime(ctx *plugin.Context, address string) (plugin.Host,
 
 func (host *clientLanguageRuntimeHost) LanguageRuntime(
 	runtime string,
-	info plugin.ProgramInfo,
 ) (plugin.LanguageRuntime, error) {
 	// If the system has asked for the special "client" runtime, return the connection we have to the language runtime
 	// plugin. Else, delegate to the host's LanguageRuntime method for loading other actual runtimes like
@@ -55,7 +54,7 @@ func (host *clientLanguageRuntimeHost) LanguageRuntime(
 	if runtime == clientRuntimeName {
 		return host.languageRuntime, nil
 	}
-	return host.Host.LanguageRuntime(runtime, info)
+	return host.Host.LanguageRuntime(runtime)
 }
 
 func langRuntimePluginDialOptions(ctx *plugin.Context, address string) []grpc.DialOption {

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -302,7 +302,7 @@ func GetRequiredPlugins(
 
 	// First make sure the language plugin is present.  We need this to load the required resource plugins.
 	// TODO: we need to think about how best to version this.  For now, it always picks the latest.
-	lang, err := host.LanguageRuntime(runtime, info)
+	lang, err := host.LanguageRuntime(runtime)
 	if lang == nil || err != nil {
 		return nil, fmt.Errorf("failed to load language plugin %s: %w", runtime, err)
 	}
@@ -343,7 +343,7 @@ func GetRequiredPlugins(
 func gatherPackagesFromProgram(plugctx *plugin.Context, runtime string, info plugin.ProgramInfo) (PackageSet, error) {
 	logging.V(preparePluginLog).Infof("gatherPackagesFromProgram(): gathering plugins from language host")
 
-	lang, err := plugctx.Host.LanguageRuntime(runtime, info)
+	lang, err := plugctx.Host.LanguageRuntime(runtime)
 	if lang == nil || err != nil {
 		return nil, fmt.Errorf("failed to load language plugin %s: %w", runtime, err)
 	}

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -424,7 +424,7 @@ func (host *pluginHost) Provider(descriptor workspace.PackageDescriptor) (plugin
 	return plug.(plugin.Provider), nil
 }
 
-func (host *pluginHost) LanguageRuntime(root string, info plugin.ProgramInfo) (plugin.LanguageRuntime, error) {
+func (host *pluginHost) LanguageRuntime(root string) (plugin.LanguageRuntime, error) {
 	if host.isClosed() {
 		return nil, ErrHostIsClosed
 	}

--- a/pkg/resource/deploy/deploytest/pluginhost_test.go
+++ b/pkg/resource/deploy/deploytest/pluginhost_test.go
@@ -147,8 +147,7 @@ func TestPluginHostProvider(t *testing.T) {
 		t.Run("LanguageRuntime", func(t *testing.T) {
 			t.Parallel()
 			host := &pluginHost{closed: true}
-			programInfo := plugin.NewProgramInfo("/", "/", ".", nil)
-			_, err := host.LanguageRuntime("", programInfo)
+			_, err := host.LanguageRuntime("")
 			assert.ErrorIs(t, err, ErrHostIsClosed)
 		})
 		t.Run("SignalCancellation", func(t *testing.T) {

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -86,7 +86,7 @@ func (host *testPluginHost) CloseProvider(provider plugin.Provider) error {
 	return host.closeProvider(provider)
 }
 
-func (host *testPluginHost) LanguageRuntime(root string, info plugin.ProgramInfo) (plugin.LanguageRuntime, error) {
+func (host *testPluginHost) LanguageRuntime(root string) (plugin.LanguageRuntime, error) {
 	return nil, errors.New("unsupported")
 }
 

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -282,18 +282,18 @@ func (iter *evalSourceIterator) forkRun(
 
 			rt := iter.src.runinfo.Proj.Runtime.Name()
 
+			langhost, err := iter.src.plugctx.Host.LanguageRuntime(rt)
+			if err != nil {
+				return fmt.Errorf("failed to launch language host %s: %w", rt, err)
+			}
+			contract.Assertf(langhost != nil, "expected non-nil language host %s", rt)
+
 			rtopts := iter.src.runinfo.Proj.Runtime.Options()
 			programInfo := plugin.NewProgramInfo(
 				/* rootDirectory */ iter.src.runinfo.ProjectRoot,
 				/* programDirectory */ iter.src.runinfo.Pwd,
 				/* entryPoint */ iter.src.runinfo.Program,
 				/* options */ rtopts)
-
-			langhost, err := iter.src.plugctx.Host.LanguageRuntime(rt, programInfo)
-			if err != nil {
-				return fmt.Errorf("failed to launch language host %s: %w", rt, err)
-			}
-			contract.Assertf(langhost != nil, "expected non-nil language host %s", rt)
 
 			// Now run the actual program.
 			progerr, bail, err := langhost.Run(plugin.RunInfo{

--- a/pkg/workspace/plugin.go
+++ b/pkg/workspace/plugin.go
@@ -369,12 +369,12 @@ func InstallPluginAtPath(pctx *plugin.Context, proj *workspace.PluginProject, st
 	if err := proj.Validate(); err != nil {
 		return err
 	}
-	entryPoint := "." // Plugin's are not able to set a non-standard entry point.
-	pInfo := plugin.NewProgramInfo(pctx.Root, pctx.Pwd, entryPoint, proj.Runtime.Options())
-	runtime, err := pctx.Host.LanguageRuntime(proj.Runtime.Name(), pInfo)
+	runtime, err := pctx.Host.LanguageRuntime(proj.Runtime.Name())
 	if err != nil {
 		return err
 	}
+	entryPoint := "." // Plugin's are not able to set a non-standard entry point.
+	pInfo := plugin.NewProgramInfo(pctx.Root, pctx.Pwd, entryPoint, proj.Runtime.Options())
 	return cmdutil.InstallDependencies(runtime, plugin.InstallDependenciesRequest{
 		Info:                    pInfo,
 		UseLanguageVersionTools: false,

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -56,7 +56,7 @@ type langhost struct {
 
 // NewLanguageRuntime binds to a language's runtime plugin and then creates a gRPC connection to it.  If the
 // plugin could not be found, or an error occurs while creating the child process, an error is returned.
-func NewLanguageRuntime(host Host, ctx *Context, runtime, workingDirectory string, info ProgramInfo,
+func NewLanguageRuntime(host Host, ctx *Context, runtime, workingDirectory string,
 ) (LanguageRuntime, error) {
 	attachPort, err := GetLanguageAttachPort(runtime)
 	if err != nil {
@@ -120,7 +120,7 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime, workingDirectory strin
 
 		contract.Assertf(path != "", "unexpected empty path for language plugin %s", runtime)
 
-		args, err := buildArgsForNewPlugin(host, info.RootDirectory(), info.Options())
+		args, err := buildArgsForNewPlugin(host)
 		if err != nil {
 			return nil, err
 		}
@@ -206,22 +206,10 @@ func langRuntimePluginDialOptions(ctx *Context, runtime string) []grpc.DialOptio
 	return dialOpts
 }
 
-func buildArgsForNewPlugin(host Host, root string, options map[string]any) ([]string, error) {
-	root, err := filepath.Abs(root)
-	if err != nil {
-		return nil, err
-	}
-	args := slice.Prealloc[string](len(options))
-
-	for k, v := range options {
-		args = append(args, fmt.Sprintf("-%s=%v", k, v))
-	}
-
-	args = append(args, "-root="+filepath.Clean(root))
-
+func buildArgsForNewPlugin(host Host) ([]string, error) {
+	args := []string{}
 	// NOTE: positional argument for the server addresss must come last
 	args = append(args, host.ServerAddr())
-
 	return args, nil
 }
 

--- a/sdk/go/common/resource/plugin/mock.go
+++ b/sdk/go/common/resource/plugin/mock.go
@@ -33,7 +33,7 @@ type MockHost struct {
 	ListAnalyzersF      func() []Analyzer
 	ProviderF           func(descriptor workspace.PackageDescriptor) (Provider, error)
 	CloseProviderF      func(provider Provider) error
-	LanguageRuntimeF    func(runtime string, info ProgramInfo) (LanguageRuntime, error)
+	LanguageRuntimeF    func(runtime string) (LanguageRuntime, error)
 	EnsurePluginsF      func(plugins []workspace.PluginSpec, kinds Flags) error
 	ResolvePluginF      func(spec workspace.PluginSpec) (*workspace.PluginInfo, error)
 	GetProjectPluginsF  func() []workspace.ProjectPlugin
@@ -99,9 +99,9 @@ func (m *MockHost) CloseProvider(provider Provider) error {
 	return nil
 }
 
-func (m *MockHost) LanguageRuntime(runtime string, info ProgramInfo) (LanguageRuntime, error) {
+func (m *MockHost) LanguageRuntime(runtime string) (LanguageRuntime, error) {
 	if m.LanguageRuntimeF != nil {
-		return m.LanguageRuntimeF(runtime, info)
+		return m.LanguageRuntimeF(runtime)
 	}
 	return nil, errors.New("LanguageRuntime not implemented")
 }

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -483,14 +483,14 @@ func ExecPlugin(ctx *Context, bin, prefix string, kind apitype.PluginKind,
 			return nil, fmt.Errorf("getting absolute path for plugin directory: %w", err)
 		}
 
-		info := NewProgramInfo(pluginDir, pluginDir, ".", runtimeInfo.Options())
-		runtime, err := ctx.Host.LanguageRuntime(runtimeInfo.Name(), info)
+		runtime, err := ctx.Host.LanguageRuntime(runtimeInfo.Name())
 		if err != nil {
 			return nil, fmt.Errorf("loading runtime: %w", err)
 		}
 
 		rctx, kill := context.WithCancel(ctx.Request()) //nolint:govet // lostcancel
 
+		info := NewProgramInfo(pluginDir, pluginDir, ".", runtimeInfo.Options())
 		stdout, stderr, done, err := runtime.RunPlugin(rctx, RunPluginInfo{
 			Info:             info,
 			WorkingDirectory: ctx.Pwd,


### PR DESCRIPTION
Language runtimes can now be used for multiple "programs" (pulumi programs or plugins) and the correct details for the program in interest are passed as arguments to the relevant methods, e.g. `Run`, or `InstallDependencies` both take a `ProgramInfo` struct with the root directory, program directory and runtime options for that program.

As such it doesn't really make sense to pass these details (root and options) as arguments when starting the language runtime up, and none of our language runtimes look at these details anymore.

This cleans up the engine and interfaces to no longer send these arguments, and thus no longer need to take a `ProgramInfo` as a parameter to the `LanguageRuntime` constructor.