### PR TITLE
renovate: baseBranchPatterns -> baseBranches

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,5 +2,5 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>pulumi/renovate-config//default.json5"],
   // TODO: Remove this setting once we're happy with the configuration
-  baseBranchPatterns: ["renovate-dev"]
+  baseBranches: ["renovate-dev"]
 }


### PR DESCRIPTION
Our version of renovate still uses the old `baseBranches` setting, this is changed in https://github.com/renovatebot/renovate/pull/35579.

Since we only care about this setting while iterating on our initial config, we can just use the old name and not worry about getting our renovate instance updated immediately.

Fixes https://github.com/pulumi/pulumi/issues/21055
