### PR TITLE
[sdk/python] Add `PropertyValue` validation checks

### DIFF
--- a/changelog/pending/20251125--sdk-python--add-propertyvalue-runtime-validation-checks.yaml
+++ b/changelog/pending/20251125--sdk-python--add-propertyvalue-runtime-validation-checks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Add `PropertyValue` runtime validation checks

--- a/sdk/python/lib/pulumi/provider/experimental/property_value.py
+++ b/sdk/python/lib/pulumi/provider/experimental/property_value.py
@@ -115,10 +115,63 @@ class PropertyValue:
         :param is_secret: Whether the value is secret.
         :param dependencies: The dependencies of the property value.
         """
-        # Wrap Sequence and Mapping types in immutable types to ensure they are hashable.
+        # Validate that value is a supported type.
+        if not (
+            value is None
+            or isinstance(value, bool)
+            or isinstance(value, float)
+            or isinstance(value, str)
+            or isinstance(value, pulumi.Asset)
+            or isinstance(value, pulumi.Archive)
+            or isinstance(value, Sequence)
+            or isinstance(value, Mapping)
+            or isinstance(value, ResourceReference)
+            or isinstance(value, Computed)
+        ):
+            raise TypeError(
+                f"Unsupported value type: {type(value).__name__}. "
+                f"Expected one of: None, bool, float, str, Asset, Archive, Sequence, Mapping, ResourceReference, or Computed."
+            )
+
+        # Validate is_secret parameter.
+        if not isinstance(is_secret, bool):
+            raise TypeError(
+                f"is_secret must be a bool, got {type(is_secret).__name__}."
+            )
+
+        # Validate dependencies parameter.
+        if dependencies is not None:
+            if not isinstance(dependencies, Iterable):
+                raise TypeError(
+                    f"dependencies must be an Iterable[str] or None, got {type(dependencies).__name__}."
+                )
+            # Validate that all items in dependencies are strings.
+            for dep in dependencies:
+                if not isinstance(dep, str):
+                    raise TypeError(
+                        f"All dependencies must be strings, found {type(dep).__name__}."
+                    )
+
+        # Validate Sequence and Mapping types and wrap in immutable types to ensure they are hashable.
         if isinstance(value, Sequence) and not isinstance(value, str):
+            # Validate all items in the sequence are PropertyValue instances.
+            for i, item in enumerate(value):
+                if not isinstance(item, PropertyValue):
+                    raise TypeError(
+                        f"Sequence items must be PropertyValue instances, found {type(item).__name__} at index {i}."
+                    )
             value = tuple(value)
         elif isinstance(value, Mapping):
+            # Validate all keys are strings and all values are PropertyValue instances.
+            for key, item in value.items():
+                if not isinstance(key, str):
+                    raise TypeError(
+                        f"Mapping keys must be strings, found {type(key).__name__}."
+                    )
+                if not isinstance(item, PropertyValue):
+                    raise TypeError(
+                        f"Mapping values must be PropertyValue instances, found {type(item).__name__} for key '{key}'."
+                    )
             value = types.MappingProxyType(value)
         elif isinstance(value, pulumi.Asset) or isinstance(value, pulumi.Archive):
             # Ensure the Asset/Archive is immutable by deep copying
@@ -184,7 +237,7 @@ class PropertyValue:
             return PropertyValueType.NULL
         if isinstance(self.value, bool):
             return PropertyValueType.BOOL
-        if isinstance(self.value, (int, float)):
+        if isinstance(self.value, float):
             return PropertyValueType.NUMBER
         if isinstance(self.value, str):
             return PropertyValueType.STRING

--- a/sdk/python/lib/test/provider/experimental/test_property_value.py
+++ b/sdk/python/lib/test/provider/experimental/test_property_value.py
@@ -1,5 +1,6 @@
 from pulumi.provider.experimental.property_value import PropertyValue, PropertyValueType
 import collections.abc as abc
+import pytest
 
 
 def test_property_value_type():
@@ -18,10 +19,10 @@ def test_property_value_type():
     value = PropertyValue.computed()
     assert value.type == PropertyValueType.COMPUTED
 
-    value = PropertyValue([1, 2, 3])
+    value = PropertyValue([PropertyValue(1.0), PropertyValue(2.0), PropertyValue(3.0)])
     assert value.type == PropertyValueType.ARRAY
 
-    value = PropertyValue({"a": 1, "b": 2})
+    value = PropertyValue({"a": PropertyValue(1.0), "b": PropertyValue(2.0)})
     assert value.type == PropertyValueType.MAP
 
 
@@ -37,7 +38,7 @@ def test_property_value_list():
 
     assert pbvalue.list_value is not None
     assert len(pbvalue.list_value.values) == 2
-    assert pbvalue.list_value.values[0].number_value == 2
+    assert pbvalue.list_value.values[0].number_value == 2.0
     assert pbvalue.list_value.values[1].string_value == "hello"
 
     value = PropertyValue.unmarshal(pbvalue)
@@ -91,3 +92,127 @@ def test_nesting():
     pbvalue = PropertyValue.marshal_map(value)
     result = PropertyValue.unmarshal_map(pbvalue)
     assert value == result
+
+
+def test_unsupported_value_type():
+    """Test that unsupported value types raise TypeError."""
+
+    # Test with an unsupported type (e.g., a custom class)
+    class UnsupportedType:
+        pass
+
+    with pytest.raises(
+        TypeError,
+        match=r"Unsupported value type: UnsupportedType\. Expected one of:",
+    ):
+        PropertyValue(UnsupportedType())  # type: ignore
+
+    # Test with int (only float is supported)
+    with pytest.raises(
+        TypeError,
+        match=r"Unsupported value type: int\. Expected one of:",
+    ):
+        PropertyValue(42)  # type: ignore
+
+
+def test_invalid_is_secret_type():
+    """Test that is_secret must be a bool."""
+    with pytest.raises(TypeError, match=r"is_secret must be a bool, got str\."):
+        PropertyValue("test", is_secret="true")  # type: ignore
+
+    with pytest.raises(TypeError, match=r"is_secret must be a bool, got int\."):
+        PropertyValue("test", is_secret=1)  # type: ignore
+
+
+def test_invalid_dependencies_type():
+    """Test that dependencies must be an Iterable[str] or None."""
+    # Test with non-iterable type
+    with pytest.raises(
+        TypeError, match=r"dependencies must be an Iterable\[str\] or None, got int\."
+    ):
+        PropertyValue("test", dependencies=123)  # type: ignore
+
+    # Test with iterable containing non-string items
+    with pytest.raises(
+        TypeError, match=r"All dependencies must be strings, found int\."
+    ):
+        PropertyValue("test", dependencies=["valid", 123, "also-valid"])  # type: ignore
+
+
+def test_invalid_sequence_items():
+    """Test that Sequence items must be PropertyValue instances."""
+    # Test with sequence containing non-PropertyValue items
+    with pytest.raises(
+        TypeError,
+        match=r"Sequence items must be PropertyValue instances, found str at index 1\.",
+    ):
+        PropertyValue([PropertyValue(1.0), "invalid", PropertyValue(3.0)])  # type: ignore
+
+    # Test with sequence containing int
+    with pytest.raises(
+        TypeError,
+        match=r"Sequence items must be PropertyValue instances, found int at index 0\.",
+    ):
+        PropertyValue([1, 2, 3])  # type: ignore
+
+
+def test_invalid_mapping_keys():
+    """Test that Mapping keys must be strings."""
+    # Test with non-string keys
+    with pytest.raises(TypeError, match=r"Mapping keys must be strings, found int\."):
+        PropertyValue({1: PropertyValue("value")})  # type: ignore
+
+    with pytest.raises(TypeError, match=r"Mapping keys must be strings, found bool\."):
+        PropertyValue({True: PropertyValue("value")})  # type: ignore
+
+
+def test_invalid_mapping_values():
+    """Test that Mapping values must be PropertyValue instances."""
+    # Test with non-PropertyValue values
+    with pytest.raises(
+        TypeError,
+        match=r"Mapping values must be PropertyValue instances, found str for key 'a'\.",
+    ):
+        PropertyValue({"a": "invalid"})  # type: ignore
+
+    with pytest.raises(
+        TypeError,
+        match=r"Mapping values must be PropertyValue instances, found int for key 'count'\.",
+    ):
+        PropertyValue({"name": PropertyValue("test"), "count": 42})  # type: ignore
+
+
+def test_valid_value_types():
+    """Test that all valid value types are accepted."""
+    from pulumi.provider.experimental.property_value import (
+        ResourceReference,
+        Computed,
+    )
+    import pulumi
+
+    # Test all supported types
+    PropertyValue(None)  # None
+    PropertyValue(True)  # bool
+    PropertyValue(3.14)  # float
+    PropertyValue("test")  # str
+    PropertyValue(pulumi.FileAsset("path/to/file"))  # Asset
+    PropertyValue(pulumi.FileArchive("path/to/archive"))  # Archive
+    PropertyValue([PropertyValue(1.0)])  # Sequence
+    PropertyValue({"key": PropertyValue(1.0)})  # Mapping
+    PropertyValue(ResourceReference(urn="urn:test"))  # ResourceReference
+    PropertyValue(Computed())  # Computed
+
+
+def test_valid_dependencies():
+    """Test that valid dependencies are accepted."""
+    # Test with list of strings
+    PropertyValue("test", dependencies=["dep1", "dep2"])
+
+    # Test with set of strings
+    PropertyValue("test", dependencies={"dep1", "dep2"})
+
+    # Test with tuple of strings
+    PropertyValue("test", dependencies=("dep1", "dep2"))
+
+    # Test with None (default)
+    PropertyValue("test", dependencies=None)


### PR DESCRIPTION
This change adds runtime checks to `PropertyValue.__init__` to ensure the passed-in value is a supported type.

Fixes #21057