### PR TITLE
renovate: merge base branch config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,7 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>pulumi/renovate-config//default.json5"],
-  // TODO: Remove this setting once we're happy with the configuration
-  baseBranches: ["renovate-dev"]
+  // TODO: Remove baseBranches and useBaseBranchConfig settings once we're happy with the configuration
+  baseBranches: ["renovate-dev"],
+  useBaseBranchConfig: "merge"
 }


### PR DESCRIPTION
We need to set `useBaseBranchConfig: "merge”` so that the config on the `renovate-dev` branch is merged into the config from `master` (ie the github default branch for the repo).
