### PR TITLE
Use package.json version for component providers

### DIFF
--- a/changelog/pending/20251201--components-nodejs--local-components-will-use-the-version-from-package-json-rather-than-0-0-0.yaml
+++ b/changelog/pending/20251201--components-nodejs--local-components-will-use-the-version-from-package-json-rather-than-0-0-0.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: components/nodejs
+  description: Local components will use the version from package.json rather than 0.0.0

--- a/sdk/nodejs/provider/experimental/provider.ts
+++ b/sdk/nodejs/provider/experimental/provider.ts
@@ -148,7 +148,7 @@ export class ComponentProvider implements Provider {
         this.packageJSON = JSON.parse(packStr);
         this.path = absDir;
         this.name = options.name;
-        this.version = options.version ?? "0.0.0";
+        this.version = options.version ?? this.packageJSON.version ?? "0.0.0";
         this.namespace = options.namespace;
         this.componentConstructors = options.components.reduce(
             (acc, component) => {
@@ -236,9 +236,6 @@ export function componentProviderHost(options: ComponentProviderOptions): Promis
             throw new Error("Could not determine caller directory");
         }
     }
-    // Default the version to "0.0.0" for now, otherwise SDK codegen gets
-    // confused without a version.
-    const version = "0.0.0";
     const prov = new ComponentProvider(options);
     return main(prov, args);
 }

--- a/tests/integration/component_provider/nodejs/component-provider-host/provider/package.json
+++ b/tests/integration/component_provider/nodejs/component-provider-host/provider/package.json
@@ -1,5 +1,6 @@
 {
     "name": "nodejs-component-provider",
+    "version": "1.0.0",
     "description": "Node.js Sample Components",
     "dependencies": {
         "@pulumi/random": "4.18.0"

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2892,7 +2892,7 @@ func TestNodejsComponentProviderGetSchema(t *testing.T) {
 	var schema map[string]any
 	require.NoError(t, json.Unmarshal([]byte(stdout), &schema))
 	require.Equal(t, "nodejs-component-provider", schema["name"].(string))
-	require.Equal(t, "0.0.0", schema["version"].(string))
+	require.Equal(t, "1.0.0", schema["version"].(string))
 	require.Equal(t, "Node.js Sample Components", schema["description"].(string))
 
 	// Check the dependencies


### PR DESCRIPTION
This is so local packages can set their version, as otherwise the engine only sets the version for packages pulled from git. This is also inline with how we pull versions for policy pack plugins.