### PR TITLE
Replace deprecated is-finite dependency in test

### DIFF
--- a/tests/integration/nodejs/codepaths-workspaces/packages/my-dynamic-provider/index.ts
+++ b/tests/integration/nodejs/codepaths-workspaces/packages/my-dynamic-provider/index.ts
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 import * as pulumi from "@pulumi/pulumi"; // @pulumi dependency is not included;
-import * as isFinite from "is-finite"; // npm dependency
+import * as isNumber from "is-number"; // npm dependency
 import * as relative from "./relative"; // local dependency
 
 const dynamicProvider: pulumi.dynamic.ResourceProvider = {
   async create(inputs) {
     return {
-      id: `dyn-${Math.ceil(Math.random() * 1000)}`, outs: { isFinite: isFinite(42), magic: relative.fun() }
+      id: `dyn-${Math.ceil(Math.random() * 1000)}`, outs: { isNumber: isNumber(42), magic: relative.fun() }
     };
   }
 }

--- a/tests/integration/nodejs/codepaths-workspaces/packages/my-dynamic-provider/package.json
+++ b/tests/integration/nodejs/codepaths-workspaces/packages/my-dynamic-provider/package.json
@@ -4,6 +4,6 @@
   "version": "1.0.0",
   "dependencies": {
     "@pulumi/pulumi": "latest",
-    "is-finite": "^2.0.0"
+    "is-number": "7.0.0"
   }
 }


### PR DESCRIPTION
This test ensures that we can reference a dependency from node_modules in a dynamic provider. The `is-finite` dep is deprecated and gets flagged by renovate. Use `is-number` instead.