### PR TITLE
journaler: unlock the lock if the journaler is already closed

### DIFF
--- a/pkg/backend/httpstate/journal/snapshot.go
+++ b/pkg/backend/httpstate/journal/snapshot.go
@@ -91,6 +91,7 @@ func (j *cloudJournaler) AddJournalEntry(entry engine.JournalEntry) error {
 func (j *cloudJournaler) Close() error {
 	j.m.Lock()
 	if j.closed {
+		j.m.Unlock()
 		return nil
 	}
 	j.closed = true

--- a/pkg/backend/httpstate/journal/snapshot_test.go
+++ b/pkg/backend/httpstate/journal/snapshot_test.go
@@ -198,8 +198,11 @@ func TestJournalerCloseAfterClose(t *testing.T) {
 		50,
 	)
 
-	// Close the journaler twice.
+	// Close the journaler thrice.
 	err := journaler.Close()
+	require.NoError(t, err)
+
+	err = journaler.Close()
 	require.NoError(t, err)
 
 	err = journaler.Close()


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/21112, we started allowing `cloudJournaler.Close()` to be called multiple times. However doing so, we forgot to unlock the lock we're taking to check `j.closed`. Unlock that lock before returning, so the code doesn't deadlock if close is called more than twice.

Noticed while reviewing above PR.  /cc @pgavlin 