### PR TITLE
only wait for update check if we prompt

### DIFF
--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -340,7 +340,6 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 						if err != nil {
 							logging.V(3).Infof("failed to cache version info: %s", err)
 						}
-
 					}
 				default:
 					// The version didn't make it in time, so don't block the user

--- a/pkg/cmd/pulumi/pulumi_test.go
+++ b/pkg/cmd/pulumi/pulumi_test.go
@@ -477,7 +477,6 @@ func TestCheckForUpdate_AlwaysChecksVersion(t *testing.T) {
 
 //nolint:paralleltest // changes environment variables and globals
 func TestCheckForUpdate_CachesPrompts(t *testing.T) {
-	// Arrange.
 	realVersion := version.Version
 	t.Cleanup(func() {
 		version.Version = realVersion
@@ -509,10 +508,14 @@ func TestCheckForUpdate_CachesPrompts(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Act.
 	uncached := checkForUpdate(ctx, srv.URL, nil)
+	require.NotNil(t, uncached)
+	require.NoError(t, cacheVersionInfo(uncached.versionInfo))
+
 	cached := checkForUpdate(ctx, srv.URL, nil)
+	require.Nil(t, cached)
 	cachedAgain := checkForUpdate(ctx, srv.URL, nil)
+	require.Nil(t, cachedAgain)
 
 	// Store an expired last prompt timestamp
 	expiredTime := time.Now().Add(-25 * time.Hour)
@@ -523,14 +526,10 @@ func TestCheckForUpdate_CachesPrompts(t *testing.T) {
 
 	expired := checkForUpdate(ctx, srv.URL, nil)
 
-	// Assert.
 	require.Equal(t, 4, callCount, "should call API every time")
 
 	require.Contains(t, uncached.diag.Message, "A new version of Pulumi is available")
 	require.Contains(t, uncached.diag.Message, "upgrade from version '1.0.0' to '1.2.3'")
-
-	require.Nil(t, cached)
-	require.Nil(t, cachedAgain)
 
 	require.Contains(t, expired.diag.Message, "A new version of Pulumi is available")
 	require.Contains(t, expired.diag.Message, "upgrade from version '1.0.0' to '1.2.3'")
@@ -570,7 +569,6 @@ func TestCheckForUpdate_HandlesAPIFailures(t *testing.T) {
 
 //nolint:paralleltest // changes environment variables and globals
 func TestCheckForUpdate_WorksCorrectlyWithDevVersions(t *testing.T) {
-	// Arrange.
 	realVersion := version.Version
 	t.Cleanup(func() {
 		version.Version = realVersion
@@ -603,10 +601,15 @@ func TestCheckForUpdate_WorksCorrectlyWithDevVersions(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Act.
 	uncached := checkForUpdate(ctx, srv.URL, nil)
+	require.NotNil(t, uncached)
+	require.NoError(t, cacheVersionInfo(uncached.versionInfo))
+
 	cached := checkForUpdate(ctx, srv.URL, nil)
+	require.Nil(t, cached)
+
 	cachedAgain := checkForUpdate(ctx, srv.URL, nil)
+	require.Nil(t, cachedAgain)
 
 	// Store an expired last prompt timesamp
 	expiredTime := time.Now().Add(-2 * time.Hour)
@@ -616,15 +619,12 @@ func TestCheckForUpdate_WorksCorrectlyWithDevVersions(t *testing.T) {
 	require.NoError(t, cacheVersionInfo(info))
 
 	expired := checkForUpdate(ctx, srv.URL, nil)
+	require.NotNil(t, expired)
 
-	// Assert.
 	require.Equal(t, 4, callCount, "should call API every time")
 
 	require.Contains(t, uncached.diag.Message, "A new version of Pulumi is available")
 	require.Contains(t, uncached.diag.Message, "upgrade from version '1.0.0-11-g4ff08363' to '1.0.0-12-gdeadbeef'")
-
-	require.Nil(t, cached)
-	require.Nil(t, cachedAgain)
 
 	require.Contains(t, expired.diag.Message, "A new version of Pulumi is available")
 	require.Contains(t, expired.diag.Message, "upgrade from version '1.0.0-11-g4ff08363' to '1.0.0-12-gdeadbeef'")
@@ -679,7 +679,6 @@ func TestCheckForUpdate_WorksCorrectlyWithLocalVersions(t *testing.T) {
 
 //nolint:paralleltest // changes environment variables and globals
 func TestCheckForUpdate_WorksCorrectlyWithDifferentMajorVersions(t *testing.T) {
-	// Arrange.
 	realVersion := version.Version
 	t.Cleanup(func() {
 		version.Version = realVersion
@@ -712,10 +711,15 @@ func TestCheckForUpdate_WorksCorrectlyWithDifferentMajorVersions(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Act.
 	uncached := checkForUpdate(ctx, srv.URL, nil)
+	require.NotNil(t, uncached)
+	require.NoError(t, cacheVersionInfo(uncached.versionInfo))
+
 	cached := checkForUpdate(ctx, srv.URL, nil)
+	require.Nil(t, cached)
+
 	cachedAgain := checkForUpdate(ctx, srv.URL, nil)
+	require.Nil(t, cachedAgain)
 
 	// Store an expired last prompt timesamp
 	expiredTime := time.Now().Add(-25 * time.Hour)
@@ -725,15 +729,12 @@ func TestCheckForUpdate_WorksCorrectlyWithDifferentMajorVersions(t *testing.T) {
 	require.NoError(t, cacheVersionInfo(info))
 
 	expired := checkForUpdate(ctx, srv.URL, nil)
+	require.NotNil(t, expired)
 
-	// Assert.
 	require.Equal(t, 4, callCount, "should call API every time")
 
 	require.Contains(t, uncached.diag.Message, "A new version of Pulumi is available")
 	require.Contains(t, uncached.diag.Message, "upgrade from version '1.0.0' to '2.0.3'")
-
-	require.Nil(t, cached)
-	require.Nil(t, cachedAgain)
 
 	require.Contains(t, expired.diag.Message, "A new version of Pulumi is available")
 	require.Contains(t, expired.diag.Message, "upgrade from version '1.0.0' to '2.0.3'")
@@ -741,7 +742,6 @@ func TestCheckForUpdate_WorksCorrectlyWithDifferentMajorVersions(t *testing.T) {
 
 //nolint:paralleltest // changes environment variables and globals
 func TestCheckForUpdate_WorksCorrectlyWithVeryOldMinorVersions(t *testing.T) {
-	// Arrange.
 	realVersion := version.Version
 	t.Cleanup(func() {
 		version.Version = realVersion
@@ -774,10 +774,15 @@ func TestCheckForUpdate_WorksCorrectlyWithVeryOldMinorVersions(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Act.
 	uncached := checkForUpdate(ctx, srv.URL, nil)
+	require.NotNil(t, uncached)
+	require.NoError(t, cacheVersionInfo(uncached.versionInfo))
+
 	cached := checkForUpdate(ctx, srv.URL, nil)
+	require.Nil(t, cached)
+
 	cachedAgain := checkForUpdate(ctx, srv.URL, nil)
+	require.Nil(t, cachedAgain)
 
 	// Store an expired last prompt timesamp
 	expiredTime := time.Now().Add(-25 * time.Hour)
@@ -787,8 +792,8 @@ func TestCheckForUpdate_WorksCorrectlyWithVeryOldMinorVersions(t *testing.T) {
 	require.NoError(t, cacheVersionInfo(info))
 
 	expired := checkForUpdate(ctx, srv.URL, nil)
+	require.NotNil(t, expired)
 
-	// Assert.
 	require.Equal(t, 4, callCount, "should call API every time")
 
 	require.Contains(t, uncached.diag.Message, "You are running a very old version of Pulumi")


### PR DESCRIPTION
We always want to send the update check request to the service, so we can cache the results locally. However this can slow some very fast commands down, without the user knowing why. We don't really need to wait for this for fast commands, if we know we won't prompt the user.

This brings the time for `pulumi version` from:

      Time (mean ± σ):     481.7 ms ± 105.3 ms    [User: 177.9 ms, System: 29.9 ms]

to:

      Time (mean ± σ):      94.9 ms ±  10.8 ms    [User: 123.6 ms, System: 14.9 ms]

Note that we'll still send the request to the server, we just won't wait for the response, and the command will still be slower if we actually want to show the prompt.

This was prompted by the recent ideation conversation about how some commands that should be really fast are still sometimes slow. This should still allow us to send the request to the service, without the downside of having to wait for the result.