### PR TITLE
Assert that conformance tests don't use language features

### DIFF
--- a/cmd/pulumi-test-language/providers/config_grpc_provider.go
+++ b/cmd/pulumi-test-language/providers/config_grpc_provider.go
@@ -183,9 +183,6 @@ func (p *ConfigGrpcProvider) schema() pschema.PackageSpec {
 			},
 		},
 		Functions: map[string]pschema.FunctionSpec{},
-		Language: map[string]pschema.RawMessage{
-			"nodejs": []byte(`{"respectSchemaVersion": true}`),
-		},
 	}
 
 	toSecretSchema := p.generateSchema(types, 1, 3)


### PR DESCRIPTION
We want to make sure that the conformance tests don't become language specific, as such we don't allow setting of "Language" options in the schemas of the providers used here. I've had to point this out on a few reviews to multiple people, so recording it for ever via this test.