### PR TITLE
Remove `workspace.PluginSpec.PluginDir`

### DIFF
--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -148,10 +148,8 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 				testPlugin := path.Join(dir, "resource-testpackage")
 				err := os.MkdirAll(testPlugin, 0o755)
 				require.NoError(t, err)
-				readmeFile, err := os.Create(path.Join(testPlugin, "README.md"))
-				require.NoError(t, err)
-				defer contract.IgnoreClose(readmeFile)
-				_, err = readmeFile.WriteString("# README from the installed plugin\nThis is a test readme.")
+				err = os.WriteFile(path.Join(testPlugin, "README.md"),
+					[]byte("# README from the installed plugin\nThis is a test readme."), 0o600)
 				require.NoError(t, err)
 				return dir
 			},
@@ -392,7 +390,7 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 				pluginDir: pluginDir,
 			}
 
-			err := cmd.Run(context.Background(), tt.args, packageSource, tt.packageParams)
+			err := cmd.Run(t.Context(), tt.args, packageSource, tt.packageParams)
 			if tt.expectedErr != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedErr)

--- a/pkg/workspace/plugin.go
+++ b/pkg/workspace/plugin.go
@@ -194,22 +194,25 @@ func (p dirPlugin) writeToDir(dstRoot string) error {
 			return os.Mkdir(dstPath, 0o700)
 		}
 
-		src, err := os.Open(srcPath)
-		if err != nil {
-			return err
-		}
-
 		info, err := d.Info()
 		if err != nil {
 			return err
 		}
 
-		bytes, err := io.ReadAll(src)
+		src, err := os.Open(srcPath)
 		if err != nil {
 			return err
 		}
+		defer src.Close()
 
-		return os.WriteFile(dstPath, bytes, info.Mode())
+		dst, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode())
+		if err != nil {
+			return err
+		}
+		defer dst.Close()
+
+		_, err = io.Copy(dst, src)
+		return err
 	})
 }
 


### PR DESCRIPTION
While trying to understand exactly what `workspace.PluginSpec` represented, I kept getting thrown by `PluginDir`. It turns out, this is only a testing affordance. This PR removes `PluginDir`, and updates tests to use the normal plugin install location (setting `PULUMI_HOME`) to avoid polluting global state.