### PR TITLE
Use CommandContext in python language host methods to support cancellation

### DIFF
--- a/changelog/pending/20251204--sdk-python--fix-cancellation-handling-in-a-few-places-in-the-python-language-host.yaml
+++ b/changelog/pending/20251204--sdk-python--fix-cancellation-handling-in-a-few-places-in-the-python-language-host.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix cancellation handling in a few places in the python language host

--- a/sdk/python/toolchain/pip.go
+++ b/sdk/python/toolchain/pip.go
@@ -177,7 +177,7 @@ func (p *pip) Command(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 		name = name + ".exe"
 	}
 	cmdPath := filepath.Join(p.virtualenvPath, virtualEnvBinDirName(), name)
-	cmd = exec.Command(cmdPath, arg...)
+	cmd = exec.CommandContext(ctx, cmdPath, arg...)
 
 	cmd.Env = ActivateVirtualEnv(os.Environ(), p.virtualenvPath)
 

--- a/sdk/python/toolchain/poetry.go
+++ b/sdk/python/toolchain/poetry.go
@@ -148,7 +148,7 @@ func (p *poetry) InstallDependencies(ctx context.Context,
 		}
 	}
 
-	poetryCmd := exec.Command(p.poetryExecutable, "install", "--no-ansi") //nolint:gosec
+	poetryCmd := exec.CommandContext(ctx, p.poetryExecutable, "install", "--no-ansi") //nolint:gosec
 	if useLanguageVersionTools {
 		// For poetry to work nicely with pyenv, we need to make poetry use the active python,
 		// otherwise poetry will use the python version used to run poetry itself.
@@ -236,7 +236,7 @@ func (p *poetry) LinkPackages(ctx context.Context, packages map[string]string) e
 	args := []string{"add", "--lock"} // Add package to lockfile only
 	paths := slices.Collect(maps.Values(packages))
 	args = append(args, paths...)
-	cmd := exec.Command("poetry", args...)
+	cmd := exec.CommandContext(ctx, "poetry", args...)
 	if err := cmd.Run(); err != nil {
 		return errutil.ErrorWithStderr(err, "linking packages")
 	}


### PR DESCRIPTION
Noticed this while trying to run conformance tests with python providers, things didn't always cancel out correctly. Looks like it was just missing some `CommandContext` calls.