### PR TITLE
Allow setting version of python component providers

### DIFF
--- a/changelog/pending/20251205--sdk-python--allow-setting-version-for-python-component-providers.yaml
+++ b/changelog/pending/20251205--sdk-python--allow-setting-version-for-python-component-providers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Allow setting version for python component providers

--- a/sdk/python/lib/pulumi/provider/experimental/host.py
+++ b/sdk/python/lib/pulumi/provider/experimental/host.py
@@ -28,6 +28,7 @@ def component_provider_host(
     components: list[type[ComponentResource]],
     name: str,
     namespace: Optional[str] = None,
+    version: Optional[str] = None,
 ):
     """
     component_provider_host starts the provider and hosts the passed in components.
@@ -52,7 +53,8 @@ def component_provider_host(
     args = sys.argv[1:]
     # Default the version to "0.0.0" for now, otherwise SDK codegen gets
     # confused without a version.
-    version = "0.0.0"
+    if version is None:
+        version = "0.0.0"
     main(ComponentProvider(components, name, namespace, version), args)
 
 


### PR DESCRIPTION
Allow users to set the version for python component providers, this is needed for conformance tests and local sdks to have versions other than `0.0.0`.