### PR TITLE
Print Node.js package manager information in `pulumi about`

### DIFF
--- a/changelog/pending/20251208--cli-about--print-node-js-package-manager-information-in-pulumi-about.yaml
+++ b/changelog/pending/20251208--cli-about--print-node-js-package-manager-information-in-pulumi-about.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/about
+  description: Print Node.js package manager information in `pulumi about`

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/pulumi/pulumi/pkg/v3 v3.156.0
 	github.com/pulumi/pulumi/sdk/v3 v3.210.0
 	github.com/stretchr/testify v1.10.0
+	golang.org/x/sync v0.18.0
 	google.golang.org/grpc v1.72.1
 	google.golang.org/protobuf v1.36.6
 )
@@ -95,7 +96,6 @@ require (
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
-	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect

--- a/sdk/nodejs/npm/bun.go
+++ b/sdk/nodejs/npm/bun.go
@@ -25,6 +25,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/errutil"
 )
 
 type bunManager struct {
@@ -50,6 +54,20 @@ func newBun() (*bunManager, error) {
 
 func (bun *bunManager) Name() string {
 	return "bun"
+}
+
+func (bun *bunManager) Version() (semver.Version, error) {
+	cmd := exec.Command(bun.executable, "--version") //nolint:gosec
+	output, err := cmd.Output()
+	if err != nil {
+		return semver.Version{}, errutil.ErrorWithStderr(err, cmd.String())
+	}
+	versionStr := strings.TrimSpace(string(output))
+	version, err := semver.Parse(versionStr)
+	if err != nil {
+		return semver.Version{}, err
+	}
+	return version, nil
 }
 
 func (bun *bunManager) Install(ctx context.Context, dir string, production bool, stdout, stderr io.Writer) error {

--- a/sdk/nodejs/npm/manager.go
+++ b/sdk/nodejs/npm/manager.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
@@ -51,6 +52,8 @@ type PackageManager interface {
 	// Name is the name of the binary executable used to invoke this package manager.
 	// e.g. yarn or npm
 	Name() string
+	// Version returns the version of the package manager.
+	Version() (semver.Version, error)
 }
 
 // Pack runs `npm pack` in the given directory, packaging the Node.js app located there into a

--- a/sdk/nodejs/npm/pnpm.go
+++ b/sdk/nodejs/npm/pnpm.go
@@ -26,6 +26,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/errutil"
 )
 
 // pnpm is an alternative package manager for Node.js.
@@ -52,6 +56,20 @@ func newPnpm() (*pnpmManager, error) {
 
 func (pnpm *pnpmManager) Name() string {
 	return "pnpm"
+}
+
+func (pnpm *pnpmManager) Version() (semver.Version, error) {
+	cmd := exec.Command(pnpm.executable, "--version") //nolint:gosec
+	output, err := cmd.Output()
+	if err != nil {
+		return semver.Version{}, errutil.ErrorWithStderr(err, cmd.String())
+	}
+	versionStr := strings.TrimSpace(string(output))
+	version, err := semver.Parse(versionStr)
+	if err != nil {
+		return semver.Version{}, err
+	}
+	return version, nil
 }
 
 func (pnpm *pnpmManager) Install(ctx context.Context, dir string, production bool, stdout, stderr io.Writer) error {

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1917,6 +1917,8 @@ func TestAboutNodeJS(t *testing.T) {
 		"Did not contain expected output. stderr: \n%q", stderr)
 	// Assert we parsed the language plugin, we don't assert against the minor version number
 	assert.Regexp(t, regexp.MustCompile(`language\W+nodejs\W+3\.`), stdout)
+	assert.Contains(t, stdout, "packagemanager='yarn'")
+	assert.Regexp(t, regexp.MustCompile(`packagemanagerVersion='\d+\.\d+.\d+'`), stdout)
 }
 
 func TestConstructOutputValuesNode(t *testing.T) {


### PR DESCRIPTION
Grab the package manager version information and pass it through to about. We’ll later add this to `UpdateMetadata` to attach this information to operations.

Ref https://github.com/pulumi/pulumi/issues/20856
