### PR TITLE
Remove outdated comment

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1477,7 +1477,6 @@ func (b *cloudBackend) createAndStartUpdate(
 	ctx context.Context, action apitype.UpdateKind, stack backend.Stack,
 	op *backend.UpdateOperation, dryRun bool,
 ) (client.UpdateIdentifier, updateMetadata, error) {
-	// Once we start an update we want to keep the machine from sleeping.
 	stackRef := stack.Ref()
 
 	stackID, err := b.getCloudStackIdentifier(stackRef)


### PR DESCRIPTION
The code this comment applied to was moved to `apply` in https://github.com/pulumi/pulumi/pull/17702. With that refactor the `defer` is right there with the code that starts the keepRunning lock, so the comment is not particularly useful anymore, and we can just get rid of it.
