### PR TITLE
journal: don't wait for sames to be sent to the service

### DIFF
--- a/pkg/backend/httpstate/journal/snapshot.go
+++ b/pkg/backend/httpstate/journal/snapshot.go
@@ -181,7 +181,7 @@ func sendBatches(
 			if req.result != nil {
 				results = append(results, req.result)
 			}
-			if cap(batch) == 0 {
+			if len(batch) == cap(batch) {
 				flush()
 			}
 		case <-ticker.C:


### PR DESCRIPTION
In the current snapshotter we don't wait for results of `SameStep`s to be sent to the service, if there were no significant changes. E.g. if only the source location changed, the step doesn't need to be sent to the service explicitly.  This is an optimization to make noop deploys faster.

We can do something similar for the journaler. We already have a batching implementation, which collects these entries, and to which we can just add them. However we do not need to wait for the batch to be sent to the service and confirmed before we move on with the deployment.

Just adding them to the batch, and then returning immediately means they will still be sent to the service whenever the next non-elided step is sent to the service, so we end up with similar semantics as we currently have for the elided steps, as currently they are implicitly sent to the service as part of the snapshot for a non-elided step.

Sometimes the entries will be sent *earlier* with the journaling implementation than with the regular snapshot manager, as the batches are sent to the service as they are getting full, or on a timer, but there's no downside to them getting there earlier, as the step has already happened.

This brings the noop deploy locally for me to 43 seconds, compared to 1:46 minutes before.  Note that we're not done yet here, there's gonna be a follow up PR optimizing the batching that will bring us to the 17 seconds the regular snapshotting takes.

Part of fixing https://github.com/pulumi/pulumi/issues/21182