### PR TITLE
optimize journal batching implementation

### DIFF
--- a/pkg/backend/httpstate/journal/snapshot.go
+++ b/pkg/backend/httpstate/journal/snapshot.go
@@ -158,10 +158,6 @@ func (t *realTicker) C() <-chan time.Time {
 	return t.Ticker.C
 }
 
-func (t *realTicker) Reset(d time.Duration) {
-	t.Ticker.Reset(d)
-}
-
 // sendBatches reads journal entries off of the entries channel and sends batches when either the maximum batch size
 // or the maximum period between batches is reached. Batches are sent sequentially.
 func sendBatches(

--- a/pkg/backend/httpstate/journal/snapshot_test.go
+++ b/pkg/backend/httpstate/journal/snapshot_test.go
@@ -437,7 +437,7 @@ func TestSendBatchesSendsAfterTimerTick(t *testing.T) {
 	entries := make(chan saveJournalEntry, 10)
 	tick := newMockTicker()
 
-	var batchesSent int32
+	var batchesSent int
 	batches := [][]apitype.JournalEntry{}
 
 	sender := func(batch []apitype.JournalEntry) error {


### PR DESCRIPTION
To send journal entries to the service, we currently use a batching implementation. This is to make sure we only ever have one request to the service in flight at a time.

However this implementation has a few problems/is not optimal in some cases:
- We use `cap(batch) == 0` to try and detect when the batch has reached its maximum size.  However this is not correct, as `cap` just returns the maximum size of the list, not the remaining capacity of the list.
- We flush the batch synchronously, so while sending the batch is in progress, we stop picking off entries from the channel, leaving that work for later.  This also means that if the channel fills up, we stop any work that could happen at the same time. Just because we're currently sending a batch, doesn't mean we need to stop accumulating entries for the next batch.
- select/case statements in Go have no defined priority. So we might still have entries in the channel, but instead we might go flush the batch already even though it hasn't reached its max size yet. So we keep sending batches with smaller sizes more frequently, but at that point latency gets big enough to slow everything down.

To fix this, we can run the flush process in a goroutine, while also stopping the timer while the flushing is in progress. We also use a semaphore to make sure only one batch is sent at a time.

This means we can continue accumulating batches to send (and get to max batch size with them), while a batch is in flight to the service. And as soon as the previous batch finished, we unlock the semaphore, and the next batch that's waiting can be sent out already.

This is still safe, because the engine always waits for the result, so we keep the same property, of any dependents/children of resources not having started their operation until the resource has been confirmed seen by the service.

In the website example (setting up from scratch), this brings the time from 3:05 minutes to 2:25 minutes. And in the noop case we go from 43 seconds to 13 seconds, matching the performance of the regular checkpoint implementation.

This is the other part of https://github.com/pulumi/pulumi/issues/21182