### PR TITLE
Update policyGroup type. Add policy group mode

### DIFF
--- a/sdk/go/common/apitype/policy.go
+++ b/sdk/go/common/apitype/policy.go
@@ -219,6 +219,15 @@ const (
 	PolicyGroupModeAudit PolicyGroupMode = "audit"
 )
 
+// IsValid returns true if the PolicyGroupMode is a valid value.
+func (m PolicyGroupMode) IsValid() bool {
+	switch m {
+	case PolicyGroupModePreventative, PolicyGroupModeAudit:
+		return true
+	}
+	return false
+}
+
 // GetPolicyPackResponse is the response to get a specific Policy Pack's
 // metadata and policies.
 type GetPolicyPackResponse struct {


### PR DESCRIPTION
The policyGroup mode = preventative | audit is different from the policyGroup type = stack|accounts and will be added right after this change to the Pulumi API. It has no current use in pulumi/pulumi, but it's part of the PolicyGroupSummary response.