### PR TITLE
Change conformance test error to note if it was plugin or program installs that failed

### DIFF
--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -91,8 +91,12 @@ func installDependencies(
 	installStdout, installStderr, installDone, err := languageClient.InstallDependencies(
 		plugin.InstallDependenciesRequest{Info: programInfo, IsPlugin: isPlugin},
 	)
+	programOrPlugin := "program"
+	if isPlugin {
+		programOrPlugin = "plugin"
+	}
 	if err != nil {
-		return makeTestResponse(fmt.Sprintf("install dependencies: %v", err))
+		return makeTestResponse(fmt.Sprintf("install %s dependencies: %v", programOrPlugin, err))
 	}
 
 	// We'll use a WaitGroup to wait for the stdout (1) and stderr (2) readers to be fully drained, as well as for the
@@ -141,7 +145,7 @@ func installDependencies(
 	if err != nil {
 		return &testingrpc.RunLanguageTestResponse{
 			Success:  false,
-			Messages: []string{fmt.Sprintf("install dependencies: %v", err)},
+			Messages: []string{fmt.Sprintf("install %s dependencies: %v", programOrPlugin, err)},
 			Stdout:   string(installStdoutBytes),
 			Stderr:   string(installStderrBytes),
 		}


### PR DESCRIPTION
Hit this while doing some provider work, couldn't tell if it was the program that failed to install dependencies or the provider plugin.