### PR TITLE
Bump language runtimes for dotnet, java, and yaml

### DIFF
--- a/changelog/pending/20251211--sdk-dotnet-java-yaml--bump-language-runtimes-for-dotnet-java-and-yaml.yaml
+++ b/changelog/pending/20251211--sdk-dotnet-java-yaml--bump-language-runtimes-for-dotnet-java-and-yaml.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/dotnet,java,yaml
+  description: Bump language runtimes for dotnet, java, and yaml

--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -381,4 +381,4 @@ const (
 )
 
 // PulumiDotnetSDKVersion is the version of the Pulumi .NET SDK to use in program-gen tests
-const PulumiDotnetSDKVersion = "3.94.1"
+const PulumiDotnetSDKVersion = "3.95.0"

--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -28,9 +28,9 @@ download_release() {
 # * When updating .Net, you should also update PulumiDotnetSDKVersion in pkg/codegen/testing/test/helpers.go
 #
 LANGUAGES=(
-  "dotnet v3.94.1"
-  "java v1.18.0"
-  "yaml v1.25.1"
+  "dotnet v3.95.0"
+  "java v1.19.0"
+  "yaml v1.26.0"
 )
 
 for i in "${LANGUAGES[@]}"; do


### PR DESCRIPTION
Pull in the latest releases of the external language runtimes