### PR TITLE
journal batching: use channels instead of locks

### DIFF
--- a/pkg/backend/httpstate/journal/snapshot.go
+++ b/pkg/backend/httpstate/journal/snapshot.go
@@ -176,6 +176,9 @@ func sendBatches(
 	results := make([]chan<- error, 0, maxBatchSize)
 	batch := make([]apitype.JournalEntry, 0, maxBatchSize)
 
+	// Use a buffered channel, so we can queue up multiple batches
+	// that can then be sent as quickly as the network allows. This
+	// unblocks the engine and allows it to continue working.
 	flushCh := make(chan flushRequest, 100)
 
 	flushDone := make(chan struct{})


### PR DESCRIPTION
The current implementation uses a lock to make sure only one flush happens at a time. However it's more idiomatic in Go to use channels here. Do that instead of the locking implementation.