### PR TITLE
introduce a lower bound for performance tests

### DIFF
--- a/tests/performance/performance_test.go
+++ b/tests/performance/performance_test.go
@@ -31,7 +31,7 @@ func TestPerfEmptyUpdate(t *testing.T) {
 		T:                  t,
 		MaxPreviewDuration: 6300 * time.Millisecond,
 		MaxUpdateDuration:  1600 * time.Millisecond,
-		MaxLowerPercent:    10,
+		MaxLowerPercent:    75,
 	}
 
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
@@ -52,7 +52,7 @@ func TestPerfManyComponentUpdate(t *testing.T) {
 		T:                  t,
 		MaxPreviewDuration: 18100 * time.Millisecond,
 		MaxUpdateDuration:  10000 * time.Millisecond,
-		MaxLowerPercent:    10,
+		MaxLowerPercent:    75,
 	}
 
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
@@ -74,9 +74,9 @@ func TestPerfManyComponentUpdate(t *testing.T) {
 func TestPerfParentChainUpdate(t *testing.T) {
 	benchmarkEnforcer := &integration.AssertPerfBenchmark{
 		T:                  t,
-		MaxPreviewDuration: 19300 * time.Millisecond,
-		MaxUpdateDuration:  19300 * time.Millisecond,
-		MaxLowerPercent:    10,
+		MaxPreviewDuration: 7000 * time.Millisecond,
+		MaxUpdateDuration:  7000 * time.Millisecond,
+		MaxLowerPercent:    75,
 	}
 
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
@@ -97,11 +97,10 @@ func TestPerfParentChainUpdate(t *testing.T) {
 //nolint:paralleltest // Do not run in parallel to avoid resource contention
 func TestPerfSecretsBatchUpdate(t *testing.T) {
 	benchmarkEnforcer := &integration.AssertPerfBenchmark{
-		T: t,
-		// TODO https://github.com/pulumi/pulumi/issues/20476: lower threshold back to 5 seconds
-		MaxPreviewDuration: 10 * time.Second,
-		MaxUpdateDuration:  10 * time.Second,
-		MaxLowerPercent:    10,
+		T:                  t,
+		MaxPreviewDuration: 4 * time.Second,
+		MaxUpdateDuration:  4 * time.Second,
+		MaxLowerPercent:    75,
 	}
 
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
@@ -119,11 +118,10 @@ func TestPerfSecretsBatchUpdate(t *testing.T) {
 //nolint:paralleltest // Do not run in parallel to avoid resource contention
 func TestPerfStackReferenceSecretsBatchUpdate(t *testing.T) {
 	benchmarkEnforcer := &integration.AssertPerfBenchmark{
-		T: t,
-		// TODO https://github.com/pulumi/pulumi/issues/20476: lower threshold back to 5 seconds
-		MaxPreviewDuration: 10 * time.Second,
-		MaxUpdateDuration:  10 * time.Second,
-		MaxLowerPercent:    10,
+		T:                  t,
+		MaxPreviewDuration: 4 * time.Second,
+		MaxUpdateDuration:  4 * time.Second,
+		MaxLowerPercent:    75,
 	}
 
 	// Create an initial stack that contains secrets.

--- a/tests/performance/performance_test.go
+++ b/tests/performance/performance_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
-	"github.com/stretchr/testify/require"
 )
 
 // TODO: add tests using other languages https://github.com/pulumi/pulumi/issues/17669
@@ -31,7 +30,7 @@ func TestPerfEmptyUpdate(t *testing.T) {
 	benchmarkEnforcer := &integration.AssertPerfBenchmark{
 		T:                  t,
 		MaxPreviewDuration: 6300 * time.Millisecond,
-		MaxUpdateDuration:  6300 * time.Millisecond,
+		MaxUpdateDuration:  1600 * time.Millisecond,
 		MaxLowerPercent:    10,
 	}
 
@@ -52,7 +51,7 @@ func TestPerfManyComponentUpdate(t *testing.T) {
 	benchmarkEnforcer := &integration.AssertPerfBenchmark{
 		T:                  t,
 		MaxPreviewDuration: 18100 * time.Millisecond,
-		MaxUpdateDuration:  18100 * time.Millisecond,
+		MaxUpdateDuration:  10000 * time.Millisecond,
 		MaxLowerPercent:    10,
 	}
 
@@ -156,52 +155,6 @@ func TestPerfStackReferenceSecretsBatchUpdate(t *testing.T) {
 				Quick:          false,
 				RequireService: true,
 				ReportStats:    benchmarkEnforcer,
-			})
-		},
-	})
-}
-
-//nolint:paralleltest // Do not run in parallel to avoid resource contention
-func TestPerfManyResourcesWithJournaling(t *testing.T) {
-	initialBenchmark := &integration.AssertPerfBenchmark{
-		T:                 t,
-		MaxUpdateDuration: 100 * time.Second,
-		MaxLowerPercent:   10,
-	}
-
-	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		NoParallel:     true,
-		Dir:            filepath.Join("typescript", "many_resources"),
-		Dependencies:   []string{"@pulumi/pulumi"},
-		RequireService: true,
-		ReportStats:    initialBenchmark,
-		SkipPreview:    true,
-		Env: []string{
-			"PULUMI_ENABLE_JOURNALING=true",
-		},
-		DestroyOnCleanup: true,
-		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-			require.Greater(t, len(stack.Deployment.Resources), 2000)
-
-			subsequentBenchmark := &integration.AssertPerfBenchmark{
-				T:                 t,
-				MaxUpdateDuration: 30 * time.Second,
-				MaxLowerPercent:   10,
-			}
-
-			integration.ProgramTest(t, &integration.ProgramTestOptions{
-				NoParallel:       true,
-				Dir:              filepath.Join("typescript", "many_resources"),
-				StackName:        string(stack.StackName),
-				Dependencies:     []string{"@pulumi/pulumi"},
-				RequireService:   true,
-				SkipPreview:      true,
-				SkipStackInit:    true,
-				SkipStackRemoval: true,
-				ReportStats:      subsequentBenchmark,
-				Env: []string{
-					"PULUMI_ENABLE_JOURNALING=true",
-				},
 			})
 		},
 	})


### PR DESCRIPTION
When introducing performance tests, we introduced an upper bound for performance.  This is good as it locks in the slowest expected performance.  However it can easily lead to us never updating the upper bounds when we improve the performance, and then we can accidentally regress to the old upper limit without noticing.

Introduce a lower bound (currently set at 10% less than the upper bound), so tests fail when they suddenly get faster, and we can update the upper bound.