### PR TITLE
Use slices & maps from stdlib

### DIFF
--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -20,11 +20,10 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"

--- a/pkg/engine/journal_snapshot.go
+++ b/pkg/engine/journal_snapshot.go
@@ -16,10 +16,9 @@ package engine
 
 import (
 	"reflect"
+	"slices"
 	"sync"
 	"sync/atomic"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"

--- a/pkg/engine/lifecycletest/delete_before_replace_test.go
+++ b/pkg/engine/lifecycletest/delete_before_replace_test.go
@@ -16,6 +16,8 @@ package lifecycletest
 
 import (
 	"context"
+	"maps"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -24,7 +26,6 @@ import (
 	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
@@ -281,12 +282,12 @@ func TestPropertyDependenciesAdapter(t *testing.T) {
 			assert.Empty(t, res.PropertyDependencies)
 		case urnC:
 			assert.ElementsMatch(t, []resource.URN{urnA, urnB}, res.Dependencies)
-			assert.ElementsMatch(t, []resource.PropertyKey{"A", "B"}, maps.Keys(res.PropertyDependencies))
+			assert.ElementsMatch(t, []resource.PropertyKey{"A", "B"}, slices.Collect(maps.Keys(res.PropertyDependencies)))
 			assert.ElementsMatch(t, res.Dependencies, res.PropertyDependencies["A"])
 			assert.ElementsMatch(t, res.Dependencies, res.PropertyDependencies["B"])
 		case urnD:
 			assert.ElementsMatch(t, []resource.URN{urnA, urnB, urnC}, res.Dependencies)
-			assert.ElementsMatch(t, []resource.PropertyKey{"A", "B"}, maps.Keys(res.PropertyDependencies))
+			assert.ElementsMatch(t, []resource.PropertyKey{"A", "B"}, slices.Collect(maps.Keys(res.PropertyDependencies)))
 			assert.ElementsMatch(t, []resource.URN{urnB}, res.PropertyDependencies["A"])
 			assert.ElementsMatch(t, []resource.URN{urnA, urnC}, res.PropertyDependencies["B"])
 		}

--- a/pkg/engine/lifecycletest/fuzzing/provider.go
+++ b/pkg/engine/lifecycletest/fuzzing/provider.go
@@ -17,6 +17,7 @@ package fuzzing
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 
 	"github.com/blang/semver"
@@ -25,7 +26,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"golang.org/x/exp/maps"
 	"pgregory.net/rapid"
 )
 
@@ -70,9 +70,7 @@ func (ps *ProviderSpec) AsProviderLoaders() []*deploytest.ProviderLoader {
 
 	loaders := make([]*deploytest.ProviderLoader, len(ps.Packages))
 
-	pkgs := maps.Keys(ps.Packages)
-	slices.Sort(pkgs)
-	for i, pkg := range pkgs {
+	for i, pkg := range slices.Sorted(maps.Keys(ps.Packages)) {
 		loaders[i] = deploytest.NewProviderLoader(pkg, version, load)
 	}
 
@@ -88,10 +86,7 @@ func (ps *ProviderSpec) Pretty(indent string) string {
 	} else {
 		rendered += fmt.Sprintf("\n%s  Packages (%d):", indent, len(ps.Packages))
 
-		pkgs := maps.Keys(ps.Packages)
-		slices.Sort(pkgs)
-
-		for _, p := range pkgs {
+		for _, p := range slices.Sorted(maps.Keys(ps.Packages)) {
 			rendered += fmt.Sprintf("\n%s    %s", indent, p)
 		}
 	}

--- a/pkg/engine/lifecycletest/fuzzing/reprogen.go
+++ b/pkg/engine/lifecycletest/fuzzing/reprogen.go
@@ -16,6 +16,7 @@ package fuzzing
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -24,7 +25,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 )
 
 // GenerateReproTest generates a string containing Go code for a set of lifecycle tests that reproduce the scenario
@@ -631,8 +631,7 @@ func writeSnapshotStatements(t require.TestingT, snapSpec *SnapshotSpec) func(g 
 //	...
 func writeSetupLoaderElements(provSpec *ProviderSpec) func(g *generator) {
 	return func(g *generator) {
-		pkgs := maps.Keys(provSpec.Packages)
-		slices.Sort(pkgs)
+		pkgs := slices.Sorted(maps.Keys(provSpec.Packages))
 
 		for _, pkg := range pkgs {
 			g.writeBlock(
@@ -981,8 +980,7 @@ func writeUpdateFStatements(provSpec *ProviderSpec) func(g *generator) {
 
 func writeReproLoaderElements(provSpec *ProviderSpec) func(g *generator) {
 	return func(g *generator) {
-		pkgs := maps.Keys(provSpec.Packages)
-		slices.Sort(pkgs)
+		pkgs := slices.Sorted(maps.Keys(provSpec.Packages))
 
 		for _, pkg := range pkgs {
 			g.writeBlock(

--- a/pkg/engine/lifecycletest/fuzzing/snapshot.go
+++ b/pkg/engine/lifecycletest/fuzzing/snapshot.go
@@ -16,13 +16,14 @@ package fuzzing
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"golang.org/x/exp/maps"
 	"pgregory.net/rapid"
 )
 
@@ -179,7 +180,7 @@ func GeneratedResourceDependencies(
 				rds.Dependencies = append(rds.Dependencies, sr.URN())
 			case resource.ResourcePropertyDependency:
 				k := rapid.SampledFrom(append(
-					maps.Keys(rds.PropertyDependencies),
+					slices.Collect(maps.Keys(rds.PropertyDependencies)),
 					resource.PropertyKey(
 						rapid.StringMatching("^prop-[a-z][A-Za-z0-9]{3}$").Draw(t, "SnapshotDependencies.NewPropertyKey"),
 					),

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -102,7 +102,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.36.0
 	go.pennock.tech/tabular v1.1.3
 	go.uber.org/automaxprocs v1.6.0
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/mod v0.29.0
 	golang.org/x/sys v0.38.0
 	golang.org/x/term v0.37.0
@@ -266,6 +265,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.36.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.6.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect
 	golang.org/x/tools/godoc v0.1.0-deprecated // indirect

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -51,7 +51,6 @@ require (
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231
 	github.com/pulumi/esc v0.17.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/sync v0.12.0
 	golang.org/x/term v0.37.0
 	lukechampine.com/frand v1.4.2
@@ -84,6 +83,7 @@ require (
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/skeema/knownhosts v1.3.0 // indirect
 	github.com/zclconf/go-cty v1.13.2 // indirect
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/tools v0.23.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect
 )

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"os"
 	"path/filepath"
@@ -42,7 +43,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/santhosh-tekuri/jsonschema/v5"
-	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
 )
 
@@ -603,10 +603,7 @@ func findClosestKey(
 	match := ""
 	closest := maxDistance + 1
 
-	keys := maps.Keys(haystack)
-	slices.Sort(keys)
-
-	for _, key := range keys {
+	for _, key := range slices.Sorted(maps.Keys(haystack)) {
 		d := levenshtein.DistanceForStrings(
 			[]rune(strings.ToLower(needle)),
 			[]rune(strings.ToLower(key)),
@@ -1069,7 +1066,7 @@ func (e *Environment) Remove(env string) *Environment {
 					case string:
 						match = e == env
 					case map[string]any:
-						match = len(e) == 1 && maps.Keys(e)[0] == env
+						match = len(e) == 1 && slices.Collect(maps.Keys(e))[0] == env
 					}
 					if match {
 						m["imports"] = append(imports[:i], imports[i+1:]...)

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"net/url"
 	"os"
@@ -43,7 +44,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"golang.org/x/exp/maps"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
@@ -1222,7 +1222,7 @@ func (ctx *Context) CallPackageSingle(
 			return zeroType, errors.New("result must have exactly one element")
 		}
 
-		result := maps.Values(asMap)[0]
+		result := slices.Collect(maps.Values(asMap))[0]
 		if resultType := reflect.TypeOf(result); resultType != output.ElementType() {
 			return zeroType, fmt.Errorf("result field type %s does not match expected type %s", resultType, output.ElementType())
 		}
@@ -2499,7 +2499,7 @@ func (ctx *Context) prepareResourceInputs(res Resource, props Input, t string, o
 			if err != nil {
 				return nil, fmt.Errorf("expanding replacementTrigger dependencies: %w", err)
 			}
-			replacementTriggerDeps = maps.Keys(depMap)
+			replacementTriggerDeps = slices.Collect(maps.Keys(depMap))
 		}
 
 		if !rtValue.IsNull() {
@@ -2642,7 +2642,7 @@ func (ctx *Context) getOpts(
 				return resourceOpts{}, err
 			}
 		}
-		depURNs = maps.Keys(depSet)
+		depURNs = slices.Collect(maps.Keys(depSet))
 	}
 
 	var providerRef string

--- a/sdk/go/pulumi/provider.go
+++ b/sdk/go/pulumi/provider.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 
@@ -29,7 +31,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
 	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"golang.org/x/exp/maps"
 
 	"google.golang.org/grpc"
 )
@@ -247,8 +248,7 @@ func (ci constructInput) Dependencies(ctx *Context) []Resource {
 	if ci.deps == nil {
 		return nil
 	}
-	urns := maps.Keys(ci.deps)
-	sort.Slice(urns, func(i, j int) bool { return urns[i] < urns[j] })
+	urns := slices.Sorted(maps.Keys(ci.deps))
 	var result []Resource
 	if len(urns) > 0 {
 		result = make([]Resource, len(urns))

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -19,15 +19,15 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"reflect"
-	"sort"
+	"slices"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 	grpc "google.golang.org/grpc"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -211,9 +211,7 @@ func TestResourceOptionMergingDependsOn(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		urns := maps.Keys(allDeps)
-		sort.Slice(urns, func(i, j int) bool { return urns[i] < urns[j] })
-		return urns
+		return slices.Sorted(maps.Keys(allDeps))
 	}
 
 	// two singleton options

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -18,13 +18,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 
 	"github.com/blang/semver"
-	"golang.org/x/exp/maps"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	rarchive "github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
@@ -309,8 +309,7 @@ func marshalInputOptionsImpl(v any,
 				var dependencies []resource.URN
 				if len(depSet) > 0 {
 					dependencies = make([]resource.URN, len(depSet))
-					urns := maps.Keys(depSet)
-					sort.Slice(urns, func(i, j int) bool { return urns[i] < urns[j] })
+					urns := slices.Sorted(maps.Keys(depSet))
 					for i, urn := range urns {
 						dependencies[i] = resource.URN(urn)
 					}


### PR DESCRIPTION
We're still using these from `x/exp` in some places, but these packages shipped in Go 1.23, let's use the stdlib packages!