### PR TITLE
Guess the package name for providers from paths

### DIFF
--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -598,7 +599,8 @@ func setupProviderFromPath(packageSource string, pctx *plugin.Context) (Provider
 		return Provider{}, nil, fmt.Errorf("plugin at path %q not executable", packageSource)
 	}
 
-	p, err := plugin.NewProviderFromPath(pctx.Host, pctx, packageSource)
+	pkg := tokens.Package(filepath.Base(packageSource))
+	p, err := plugin.NewProviderFromPath(pctx.Host, pctx, pkg, packageSource)
 	if err != nil {
 		return Provider{}, nil, err
 	}

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -370,7 +370,7 @@ func providerPluginDialOptions(ctx *Context, pkg tokens.Package, path string) []
 }
 
 // NewProviderFromPath creates a new provider by loading the plugin binary located at `path`.
-func NewProviderFromPath(host Host, ctx *Context, path string) (Provider, error) {
+func NewProviderFromPath(host Host, ctx *Context, pkg tokens.Package, path string) (Provider, error) {
 	env := os.Environ()
 
 	handshake := func(
@@ -402,6 +402,7 @@ func NewProviderFromPath(host Host, ctx *Context, path string) (Provider, error)
 
 	p := &provider{
 		ctx:           ctx,
+		pkg:           pkg,
 		plug:          plug,
 		clientRaw:     pulumirpc.NewResourceProviderClient(plug.Conn),
 		legacyPreview: legacyPreview,


### PR DESCRIPTION
Plan is to also use this for providers in conformance tests where we create them from a path, but we do know their package name.