### PR TITLE
improve startup perf by using a single request

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -192,6 +192,13 @@ type userInfo struct {
 	tokenInfo     *workspace.TokenInformation
 }
 
+// cachedUpdateData holds deployment and stack metadata fetched from BeginUpdate.
+type cachedUpdateData struct {
+	deployment *apitype.UntypedDeployment
+	stackTags  map[apitype.StackTagName]string
+	stackRef   backend.StackReference
+}
+
 type cloudBackend struct {
 	d            diag.Sink
 	url          string
@@ -204,6 +211,9 @@ type cloudBackend struct {
 	// The current project, if any.
 	currentProject              *workspace.Project
 	neoEnabledForCurrentProject *bool
+
+	// Cached data from BeginUpdate to avoid extra HTTP calls.
+	cachedUpdateData *cachedUpdateData
 }
 
 // Assert we implement the backend.Backend and backend.SpecificDeploymentExporter interfaces.
@@ -1752,14 +1762,77 @@ func (b *cloudBackend) createAndStartUpdate(
 	if err != nil {
 		return client.UpdateIdentifier{}, updateMetadata{}, err
 	}
+
 	metadata := apitype.UpdateMetadata{
 		Message:     op.M.Message,
 		Environment: op.M.Environment,
 	}
-	update, updateDetails, err := b.client.CreateUpdate(
-		ctx, action, stackID, op.Proj, op.StackConfiguration.Config, metadata, op.Opts.Engine, dryRun)
+
+	tags, err := backend.GetMergedStackTags(ctx, stack, op.Root, op.Proj, op.StackConfiguration.Config)
 	if err != nil {
-		return client.UpdateIdentifier{}, updateMetadata{}, err
+		return client.UpdateIdentifier{}, updateMetadata{}, fmt.Errorf("getting stack tags: %w", err)
+	}
+
+	var update client.UpdateIdentifier
+	var version int
+	var token string
+	var journalVersion int64
+	var requiredPolicies []apitype.RequiredPolicy
+	var messages []apitype.Message
+	var isNeoIntegrationEnabled bool
+
+	if b.Capabilities(ctx).BeginUpdate && os.Getenv("PULUMI_BEGIN_UPDATE") == "true" {
+		logging.V(7).Infof("Using combined begin-update endpoint for %s", stackRef)
+		resp, err := b.client.BeginUpdate(
+			ctx, action, stackID, op.Proj, op.StackConfiguration.Config,
+			metadata, op.Opts.Engine, tags, dryRun)
+		if err != nil {
+			if err, ok := err.(*apitype.ErrorResponse); ok && err.Code == 409 {
+				conflict := backenderr.ConflictingUpdateError{Err: err}
+				return client.UpdateIdentifier{}, updateMetadata{}, conflict
+			}
+			return client.UpdateIdentifier{}, updateMetadata{}, err
+		}
+
+		update = client.UpdateIdentifier{
+			StackIdentifier: stackID,
+			UpdateKind:      action,
+			UpdateID:        resp.UpdateID,
+		}
+		version = resp.Version
+		token = resp.Token
+		journalVersion = resp.JournalVersion
+		requiredPolicies = resp.RequiredPolicies
+		messages = resp.Messages
+		isNeoIntegrationEnabled = resp.AISettings.CopilotIsEnabled
+
+		// Cache the deployment, stack tags, and stack for later use.
+		b.cachedUpdateData = &cachedUpdateData{
+			deployment: &resp.Deployment,
+			stackTags:  resp.Stack.Tags,
+			stackRef:   stackRef,
+		}
+	} else {
+		logging.V(7).Infof("Using legacy create+start update endpoints for %s", stackRef)
+		var updateDetails client.CreateUpdateDetails
+		update, updateDetails, err = b.client.CreateUpdate(
+			ctx, action, stackID, op.Proj, op.StackConfiguration.Config, metadata, op.Opts.Engine, dryRun)
+		if err != nil {
+			return client.UpdateIdentifier{}, updateMetadata{}, err
+		}
+
+		requiredPolicies = updateDetails.RequiredPolicies
+		messages = updateDetails.Messages
+		isNeoIntegrationEnabled = updateDetails.IsNeoIntegrationEnabled
+
+		version, token, journalVersion, err = b.client.StartUpdate(ctx, update, tags)
+		if err != nil {
+			if err, ok := err.(*apitype.ErrorResponse); ok && err.Code == 409 {
+				conflict := backenderr.ConflictingUpdateError{Err: err}
+				return client.UpdateIdentifier{}, updateMetadata{}, conflict
+			}
+			return client.UpdateIdentifier{}, updateMetadata{}, err
+		}
 	}
 
 	//
@@ -1774,7 +1847,7 @@ func (b *cloudBackend) createAndStartUpdate(
 	// Once this API is implemented, we can safely move these lines to the plugin-gathering code,
 	// which is much closer to being the "correct" place for this stuff.
 	//
-	for _, policy := range updateDetails.RequiredPolicies {
+	for _, policy := range requiredPolicies {
 		op.Opts.Engine.RequiredPolicies = append(
 			op.Opts.Engine.RequiredPolicies, newCloudRequiredPolicy(b.client, b, policy, update.Owner))
 	}
@@ -1782,21 +1855,6 @@ func (b *cloudBackend) createAndStartUpdate(
 	// Provide ESC environment resolver for local policy packs.
 	op.Opts.Engine.PolicyEnvResolver = NewLocalPolicyEnvironmentResolver(b, update.Owner)
 
-	// Start the update. We use this opportunity to pass new tags to the service, to pick up any
-	// metadata changes.
-	tags, err := backend.GetMergedStackTags(ctx, stack, op.Root, op.Proj, op.StackConfiguration.Config)
-	if err != nil {
-		return client.UpdateIdentifier{}, updateMetadata{}, fmt.Errorf("getting stack tags: %w", err)
-	}
-
-	version, token, journalVersion, err := b.client.StartUpdate(ctx, update, tags)
-	if err != nil {
-		if err, ok := err.(*apitype.ErrorResponse); ok && err.Code == 409 {
-			conflict := backenderr.ConflictingUpdateError{Err: err}
-			return client.UpdateIdentifier{}, updateMetadata{}, conflict
-		}
-		return client.UpdateIdentifier{}, updateMetadata{}, err
-	}
 	// Any non-preview update will be considered part of the stack's update history.
 	if action != apitype.PreviewUpdate {
 		logging.V(7).Infof("Stack %s being updated to version %d", stackRef, version)
@@ -1807,7 +1865,7 @@ func (b *cloudBackend) createAndStartUpdate(
 		userName = "unknown"
 	}
 	// Check if the user's org (stack's owner) has Neo enabled. If not, we don't show the link to Neo.
-	isNeoEnabled := updateDetails.IsNeoIntegrationEnabled
+	isNeoEnabled := isNeoIntegrationEnabled
 	b.neoEnabledForCurrentProject = &isNeoEnabled
 	neoEnabledValueString := "is"
 	continuationString := ""
@@ -1829,7 +1887,7 @@ func (b *cloudBackend) createAndStartUpdate(
 	return update, updateMetadata{
 		version:        version,
 		leaseToken:     token,
-		messages:       updateDetails.Messages,
+		messages:       messages,
 		journalVersion: journalVersion,
 	}, nil
 }
@@ -2295,6 +2353,11 @@ func (b *cloudBackend) ExportDeploymentForVersion(
 func (b *cloudBackend) exportDeployment(
 	ctx context.Context, stackRef backend.StackReference, version *int,
 ) (*apitype.UntypedDeployment, error) {
+	if version == nil && b.cachedUpdateData != nil && b.cachedUpdateData.stackRef.String() == stackRef.String() {
+		logging.V(7).Infof("Using cached deployment from begin-update for %s", stackRef)
+		return b.cachedUpdateData.deployment, nil
+	}
+
 	stack, err := b.getCloudStackIdentifier(stackRef)
 	if err != nil {
 		return nil, err

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1781,7 +1781,7 @@ func (b *cloudBackend) createAndStartUpdate(
 	var messages []apitype.Message
 	var isNeoIntegrationEnabled bool
 
-	if b.Capabilities(ctx).BeginUpdate && os.Getenv("PULUMI_BEGIN_UPDATE") == "true" {
+	if b.Capabilities(ctx).BeginUpdate && os.Getenv("PULUMI_DISABLE_BEGIN_UPDATE") != "true" {
 		logging.V(7).Infof("Using combined begin-update endpoint for %s", stackRef)
 		resp, err := b.client.BeginUpdate(
 			ctx, action, stackID, op.Proj, op.StackConfiguration.Config,

--- a/pkg/backend/httpstate/client/api_endpoints.go
+++ b/pkg/backend/httpstate/client/api_endpoints.go
@@ -118,6 +118,7 @@ func init() {
 	addEndpoint("POST", "/api/stacks/{orgName}/{projectName}/{stackName}/destroy", "createDestroy")
 	addEndpoint("POST", "/api/stacks/{orgName}/{projectName}/{stackName}/preview", "createPreview")
 	addEndpoint("POST", "/api/stacks/{orgName}/{projectName}/{stackName}/update", "createUpdate")
+	addEndpoint("POST", "/api/stacks/{orgName}/{projectName}/{stackName}/begin-update", "beginUpdate")
 
 	addEndpoint("GET", "/api/stacks/{orgName}/{projectName}/{stackName}/{updateKind}/{updateID}", "getUpdateStatus")
 	addEndpoint("POST", "/api/stacks/{orgName}/{projectName}/{stackName}/{updateKind}/{updateID}", "startUpdate")

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1607,6 +1607,69 @@ func (pc *Client) StartUpdate(ctx context.Context, update UpdateIdentifier,
 	return resp.Version, resp.Token, resp.JournalVersion, nil
 }
 
+// BeginUpdate combines CreateUpdate, StartUpdate, ExportStackDeployment, and GetStack into a
+// single API call to reduce latency. Returns all data needed to start the engine execution.
+// This is only supported on backends with the "begin-update" capability.
+func (pc *Client) BeginUpdate(
+	ctx context.Context, kind apitype.UpdateKind, stack StackIdentifier, proj *workspace.Project,
+	cfg config.Map, m apitype.UpdateMetadata, opts engine.UpdateOptions,
+	tags map[apitype.StackTagName]string, dryRun bool,
+) (*apitype.BeginUpdateResponse, error) {
+	if err := validation.ValidateStackTags(tags); err != nil {
+		return nil, fmt.Errorf("validating stack properties: %w", err)
+	}
+
+	wireConfig := make(map[string]apitype.ConfigValue)
+	for k, cv := range cfg {
+		v, err := cv.Value(config.NopDecrypter)
+		contract.AssertNoErrorf(err, "error fetching config value for key %v", k)
+
+		wireConfig[k.String()] = apitype.ConfigValue{
+			String: v,
+			Secret: cv.Secure(),
+			Object: cv.Object(),
+		}
+	}
+
+	description := ""
+	if proj.Description != nil {
+		description = *proj.Description
+	}
+
+	updateRequest := apitype.UpdateProgramRequest{
+		Name:        string(proj.Name),
+		Runtime:     proj.Runtime.Name(),
+		Main:        proj.Main,
+		Description: description,
+		Config:      wireConfig,
+		Options: apitype.UpdateOptions{
+			LocalPolicyPackPaths: engine.ConvertLocalPolicyPacksToPaths(opts.LocalPolicyPacks),
+			Color:                colors.Raw,
+			DryRun:               dryRun,
+			Parallel:             opts.Parallel,
+		},
+		Metadata: m,
+	}
+
+	req := apitype.BeginUpdateRequest{
+		UpdateKind: kind,
+		Program:    updateRequest,
+		Tags:       tags,
+	}
+
+	if !env.DisableJournaling.Value() {
+		req.JournalVersion = 1
+	}
+
+	var resp apitype.BeginUpdateResponse
+	path := getStackPath(stack, "begin-update")
+	if err := pc.restCall(ctx, "POST", path, nil, &req, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
 // ListPolicyGroups lists all `PolicyGroups` the organization has in the Pulumi service.
 func (pc *Client) ListPolicyGroups(ctx context.Context, orgName string, inContToken *string) (
 	apitype.ListPolicyGroupsResponse, *string, error,

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -267,9 +267,16 @@ func (b *cloudBackend) getTarget(ctx context.Context, secretsProvider secrets.Pr
 		return nil, stack.FormatDeploymentDeserializationError(err, stackRef.Name().String())
 	}
 
-	stk, err := b.client.GetStack(ctx, stackID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get stack tags for %s: %w", stackRef.Name().String(), err)
+	var tags map[apitype.StackTagName]string
+	if b.cachedUpdateData != nil && b.cachedUpdateData.stackRef.String() == stackRef.String() {
+		logging.V(7).Infof("Using cached stack tags from begin-update for %s", stackRef)
+		tags = b.cachedUpdateData.stackTags
+	} else {
+		stk, err := b.client.GetStack(ctx, stackID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get stack tags for %s: %w", stackRef.Name().String(), err)
+		}
+		tags = stk.Tags
 	}
 
 	return &deploy.Target{
@@ -278,7 +285,7 @@ func (b *cloudBackend) getTarget(ctx context.Context, secretsProvider secrets.Pr
 		Config:       cfg,
 		Decrypter:    dec,
 		Snapshot:     snapshot,
-		Tags:         stk.Tags,
+		Tags:         tags,
 	}, nil
 }
 

--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -55,6 +55,9 @@ const (
 
 	// NeoCLIMode advertises minimum CLI requirements for `pulumi neo`; see NeoCLIModeConfig.
 	NeoCLIMode APICapability = "neo-cli-mode"
+
+	// Indicates that the service supports the combined begin-update endpoint.
+	BeginUpdate APICapability = "begin-update"
 )
 
 type DeltaCheckpointUploadsConfigV2 struct {
@@ -151,6 +154,9 @@ type Capabilities struct {
 	// If non-nil, indicates that the service has advertised minimum CLI requirements
 	// for `pulumi neo`.
 	NeoCLIMode *NeoCLIModeConfig
+
+	// Indicates whether the service supports the combined begin-update endpoint.
+	BeginUpdate bool
 }
 
 // Parse decodes the CapabilitiesResponse into a Capabilities struct for ease of use.
@@ -212,6 +218,10 @@ func (r CapabilitiesResponse) Parse() (Capabilities, error) {
 					return Capabilities{}, fmt.Errorf("decoding NeoCLIModeConfig returned %w", err)
 				}
 				parsed.NeoCLIMode = &cfg
+			}
+		case BeginUpdate:
+			if entry.Version == 1 {
+				parsed.BeginUpdate = true
 			}
 		default:
 			continue

--- a/sdk/go/common/apitype/updates.go
+++ b/sdk/go/common/apitype/updates.go
@@ -303,3 +303,23 @@ type StackRenameRequest struct {
 	NewName    string `json:"newName"`
 	NewProject string `json:"newProject"`
 }
+
+// BeginUpdateRequest is the combined request for creating and starting an update.
+// This endpoint combines the functionality of CreateUpdate and StartUpdate into a single
+// API call to reduce latency during startup.
+type BeginUpdateRequest struct {
+	UpdateKind UpdateKind              `json:"updateKind"`
+	Program    UpdateProgramRequest    `json:"program"`
+	Tags       map[StackTagName]string `json:"tags,omitempty"`
+	StartUpdateRequest
+}
+
+// BeginUpdateResponse is the combined response from creating and starting an update.
+// It includes all data needed to begin the engine execution, including the deployment
+// and stack metadata, eliminating the need for separate API calls.
+type BeginUpdateResponse struct {
+	StartUpdateResponse
+	UpdateProgramResponse
+	Deployment UntypedDeployment `json:"deployment"`
+	Stack      Stack             `json:"stack"`
+}


### PR DESCRIPTION
Currently during startup we make multiple requests to create an update, then start it, export the current deployment, and finally to get the stack.  Each of these calls incurs additional latency, depending on the internet connection of the user.

It's not really possible to do these calls in parallel in the client because there are ordering constraints.  The update need to be created before starting it etc.

We can instead do all of this in a single request, letting the service order the actions as necessary.  Using my WIP service PR we get the following numbers:

```
$ hyperfine -- 'PULUMI_BEGIN_UPDATE=true pulumi up --skip-preview -s another' 'pulumi up --skip-preview -s another'
Benchmark 1: PULUMI_BEGIN_UPDATE=true pulumi up --skip-preview -s another
  Time (mean ± σ):      3.137 s ±  0.192 s    [User: 1.177 s, System: 0.212 s]
  Range (min … max):    2.969 s …  3.583 s    10 runs

Benchmark 2: pulumi up --skip-preview -s another
  Time (mean ± σ):      3.756 s ±  0.112 s    [User: 1.184 s, System: 0.214 s]
  Range (min … max):    3.540 s …  3.886 s    10 runs

Summary
  PULUMI_BEGIN_UPDATE=true pulumi up --skip-preview -s another ran
    1.20 ± 0.08 times faster than pulumi up --skip-preview -s another
```

So saving ~600ms on startup (from my location). There's still work to be done to get this a bit lower for empty updates, but I think this is a step in the right direction.

The service PR is in https://github.com/pulumi/pulumi-service/pull/35647

/xref https://github.com/pulumi/pulumi/issues/3671