### PR TITLE
Rename `workspace.PluginSpec` to `workspace.PluginDescriptor`

### DIFF
--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -295,7 +295,7 @@ func (l *providerLoader) LoadPackageReferenceV2(
 
 	// Defer to the host to find the provider for the given package descriptor.
 	workspaceDescriptor := workspace.PackageDescriptor{
-		PluginSpec: workspace.PluginSpec{
+		PluginDescriptor: workspace.PluginDescriptor{
 			Kind:              apitype.ResourcePlugin,
 			Name:              descriptor.Name,
 			Version:           descriptor.Version,
@@ -1207,14 +1207,14 @@ func (eng *languageTestServer) RunLanguageTest(
 			var desc workspace.PackageDescriptor
 			if pkgDef.Parameterization == nil {
 				desc = workspace.PackageDescriptor{
-					PluginSpec: workspace.PluginSpec{
+					PluginDescriptor: workspace.PluginDescriptor{
 						Name:    pkgDef.Name,
 						Version: pkgDef.Version,
 					},
 				}
 			} else {
 				desc = workspace.PackageDescriptor{
-					PluginSpec: workspace.PluginSpec{
+					PluginDescriptor: workspace.PluginDescriptor{
 						Name:    pkgDef.Parameterization.BaseProvider.Name,
 						Version: &pkgDef.Parameterization.BaseProvider.Version,
 					},
@@ -1341,7 +1341,7 @@ func (eng *languageTestServer) RunLanguageTest(
 			linkDeps := []workspace.LinkablePackageDescriptor{{
 				Path: token.CoreArtifact,
 				Descriptor: workspace.PackageDescriptor{
-					PluginSpec: workspace.PluginSpec{
+					PluginDescriptor: workspace.PluginDescriptor{
 						Name: "pulumi",
 					},
 				},

--- a/cmd/pulumi-test-language/test_host.go
+++ b/cmd/pulumi-test-language/test_host.go
@@ -99,7 +99,7 @@ func (h *testHost) Analyzer(nm tokens.QName) (plugin.Analyzer, error) {
 func (h *testHost) PolicyAnalyzer(
 	name tokens.QName, path string, opts *plugin.PolicyAnalyzerOptions,
 ) (plugin.Analyzer, error) {
-	hasPlugin := func(spec workspace.PluginSpec) bool {
+	hasPlugin := func(spec workspace.PluginDescriptor) bool {
 		// This is only called for the language runtime, so we can just do a simple check.
 		return spec.Kind == apitype.LanguagePlugin && spec.Name == h.runtimeName
 	}
@@ -174,9 +174,9 @@ func (h *testHost) LanguageRuntime(runtime string) (plugin.LanguageRuntime, erro
 	return h.runtime, nil
 }
 
-func (h *testHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plugin.Flags) error {
+func (h *testHost) EnsurePlugins(plugins []workspace.PluginDescriptor, kinds plugin.Flags) error {
 	// Remove the builtin "pulumi" provider, as that's always available.
-	filtered := make([]workspace.PluginSpec, 0, len(plugins))
+	filtered := make([]workspace.PluginDescriptor, 0, len(plugins))
 	for _, plugin := range plugins {
 		if plugin.Kind == apitype.ResourcePlugin && plugin.Name == "pulumi" {
 			continue
@@ -217,7 +217,7 @@ func (h *testHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plugin.Fl
 }
 
 func (h *testHost) ResolvePlugin(
-	spec workspace.PluginSpec,
+	spec workspace.PluginDescriptor,
 ) (*workspace.PluginInfo, error) {
 	if spec.Kind == apitype.ResourcePlugin {
 		for _, provider := range h.providers {

--- a/pkg/cmd/pulumi/about/about.go
+++ b/pkg/cmd/pulumi/about/about.go
@@ -610,7 +610,7 @@ func (runtime projectRuntimeAbout) String() string {
 // getProjectPlugins.
 func getProjectPluginsSilently(
 	ctx *plugin.Context, proj *workspace.Project, pwd, main string,
-) ([]workspace.PluginSpec, error) {
+) ([]workspace.PluginDescriptor, error) {
 	_, w, err := os.Pipe()
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -200,7 +200,7 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 
 				pluginSet := engine.NewPluginSet()
 				for _, pkg := range packages {
-					pluginSet.Add(pkg.PluginSpec)
+					pluginSet.Add(pkg.PluginDescriptor)
 				}
 
 				if err = engine.EnsurePluginsAreInstalled(ctx, nil, pctx.Diag, pluginSet,

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -152,7 +152,7 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 				pulumiHomeDir := t.TempDir() // Create an isolated PULUMI_HOME directory to install into
 				t.Setenv(env.Home.Var().Name(), pulumiHomeDir)
 
-				installResourcePluginFromFiles(t, workspace.PluginSpec{
+				installResourcePluginFromFiles(t, workspace.PluginDescriptor{
 					Name: "testpackage",
 					Kind: apitype.ResourcePlugin,
 				}, map[string]string{
@@ -726,7 +726,7 @@ func TestFindReadme(t *testing.T) {
 //
 // This function should only be used after t.Setenv(workspace.PulumiHomeEnvVar,
 // pulumiHomeDir) has been called.
-func installResourcePluginFromFiles(t *testing.T, spec workspace.PluginSpec, files map[string]string) {
+func installResourcePluginFromFiles(t *testing.T, spec workspace.PluginDescriptor, files map[string]string) {
 	t.Helper()
 	dir := t.TempDir()
 	for path, content := range files {

--- a/pkg/cmd/pulumi/packageresolution/package_resolution.go
+++ b/pkg/cmd/pulumi/packageresolution/package_resolution.go
@@ -124,7 +124,7 @@ type (
 		RelativeToWorkspace bool
 	}
 	ExternalSourceResult struct {
-		Spec workspace.PluginSpec
+		Spec workspace.PluginDescriptor
 	}
 	InstalledInWorkspaceResult struct{}
 )
@@ -133,7 +133,7 @@ func Resolve(
 	ctx context.Context,
 	reg registry.Registry,
 	ws PluginWorkspace,
-	pluginSpec workspace.PluginSpec,
+	pluginSpec workspace.PluginDescriptor,
 	options Options,
 	projectOrPlugin workspace.BaseProject, // Pass nil for 'not in a project context'
 ) (Result, error) {
@@ -211,7 +211,7 @@ func Resolve(
 
 func (o Options) includeRegistryResolve() bool { return !o.DisableRegistryResolve && o.Experimental }
 
-func isAlreadyInstalled(ws PluginWorkspace, spec workspace.PluginSpec) (bool, error) {
+func isAlreadyInstalled(ws PluginWorkspace, spec workspace.PluginDescriptor) (bool, error) {
 	if spec.Version != nil {
 		return ws.HasPlugin(spec), nil
 	}
@@ -220,18 +220,18 @@ func isAlreadyInstalled(ws PluginWorkspace, spec workspace.PluginSpec) (bool, er
 
 // PluginWorkspace dictates how resolution interacts with globally installed plugins.
 type PluginWorkspace interface {
-	HasPlugin(spec workspace.PluginSpec) bool
-	HasPluginGTE(spec workspace.PluginSpec) (bool, error)
+	HasPlugin(spec workspace.PluginDescriptor) bool
+	HasPluginGTE(spec workspace.PluginDescriptor) (bool, error)
 	IsExternalURL(source string) bool
 }
 
 type defaultWorkspace struct{}
 
-func (defaultWorkspace) HasPlugin(spec workspace.PluginSpec) bool {
+func (defaultWorkspace) HasPlugin(spec workspace.PluginDescriptor) bool {
 	return workspace.HasPlugin(spec)
 }
 
-func (defaultWorkspace) HasPluginGTE(spec workspace.PluginSpec) (bool, error) {
+func (defaultWorkspace) HasPluginGTE(spec workspace.PluginDescriptor) (bool, error) {
 	return workspace.HasPluginGTE(spec)
 }
 

--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -365,7 +365,7 @@ func NewPluginContext(cwd string) (*plugin.Context, error) {
 	return pluginCtx, nil
 }
 
-func setSpecNamespace(spec *schema.PackageSpec, pluginSpec workspace.PluginSpec) {
+func setSpecNamespace(spec *schema.PackageSpec, pluginSpec workspace.PluginDescriptor) {
 	if spec.Namespace == "" && pluginSpec.IsGitPlugin() {
 		namespaceRegex := regexp.MustCompile(`git://[^/]+/([^/]+)/`)
 		matches := namespaceRegex.FindStringSubmatch(pluginSpec.PluginDownloadURL)
@@ -476,7 +476,7 @@ func ProviderFromSource(
 		return Provider{}, nil, err
 	}
 	descriptor := workspace.PackageDescriptor{
-		PluginSpec: pluginSpec,
+		PluginDescriptor: pluginSpec,
 	}
 
 	installDescriptor := func(descriptor workspace.PackageDescriptor) (Provider, error) {
@@ -503,7 +503,7 @@ func ProviderFromSource(
 			pctx.Host.Log(sev, "", msg, 0)
 		}
 
-		_, err = pkgWorkspace.InstallPlugin(pctx.Base(), descriptor.PluginSpec, log)
+		_, err = pkgWorkspace.InstallPlugin(pctx.Base(), descriptor.PluginDescriptor, log)
 		if err != nil {
 			return Provider{}, err
 		}
@@ -617,7 +617,7 @@ func setupProviderFromRegistryMeta(
 	meta apitype.PackageMetadata,
 	setupProvider func(workspace.PackageDescriptor, *workspace.PackageSpec) (Provider, *workspace.PackageSpec, error),
 ) (Provider, *workspace.PackageSpec, error) {
-	spec := workspace.PluginSpec{
+	spec := workspace.PluginDescriptor{
 		Name:              meta.Name,
 		Kind:              apitype.ResourcePlugin,
 		Version:           &meta.Version,

--- a/pkg/cmd/pulumi/packages/packages_test.go
+++ b/pkg/cmd/pulumi/packages/packages_test.go
@@ -59,7 +59,7 @@ func TestSetSpecNamespace(t *testing.T) {
 		t.Run(tt.pluginDownloadURL, func(t *testing.T) {
 			t.Parallel()
 
-			pluginSpec := workspace.PluginSpec{
+			pluginSpec := workspace.PluginDescriptor{
 				PluginDownloadURL: tt.pluginDownloadURL,
 			}
 			schemaSpec := &schema.PackageSpec{}

--- a/pkg/cmd/pulumi/plugin/plugin.go
+++ b/pkg/cmd/pulumi/plugin/plugin.go
@@ -62,7 +62,7 @@ func NewPluginCmd() *cobra.Command {
 }
 
 // getProjectPlugins fetches a list of plugins used by this project.
-func getProjectPlugins() ([]workspace.PluginSpec, error) {
+func getProjectPlugins() ([]workspace.PluginDescriptor, error) {
 	proj, root, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil {
 		return nil, err
@@ -89,7 +89,7 @@ func getProjectPlugins() ([]workspace.PluginSpec, error) {
 	return plugins, nil
 }
 
-func resolvePlugins(plugins []workspace.PluginSpec) ([]workspace.PluginInfo, error) {
+func resolvePlugins(plugins []workspace.PluginDescriptor) ([]workspace.PluginInfo, error) {
 	proj, root, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/pulumi/plugin/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install.go
@@ -96,12 +96,12 @@ type pluginInstallCmd struct {
 	packageResolutionOptions packageresolution.Options
 
 	pluginGetLatestVersion func(
-		workspace.PluginSpec, context.Context,
+		workspace.PluginDescriptor, context.Context,
 	) (*semver.Version, error) // == workspace.PluginSpec.GetLatestVersion
 
 	installPluginSpec func(
 		ctx context.Context, label string,
-		install workspace.PluginSpec, file string,
+		install workspace.PluginDescriptor, file string,
 		sink diag.Sink, color colors.Colorization, reinstall bool,
 	) error // == installPluginSpec
 }
@@ -117,7 +117,7 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 		cmd.color = cmdutil.GetGlobalColorization()
 	}
 	if cmd.pluginGetLatestVersion == nil {
-		cmd.pluginGetLatestVersion = (workspace.PluginSpec).GetLatestVersion
+		cmd.pluginGetLatestVersion = (workspace.PluginDescriptor).GetLatestVersion
 	}
 	if cmd.installPluginSpec == nil {
 		cmd.installPluginSpec = installPluginSpec
@@ -127,7 +127,7 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	// Parse the kind, name, and version, if specified.
-	var installs []workspace.PluginSpec
+	var installs []workspace.PluginDescriptor
 	if len(args) > 0 {
 		if !apitype.IsPluginKind(args[0]) {
 			return fmt.Errorf("unrecognized plugin kind: %s", args[0])
@@ -270,7 +270,7 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 
 func installPluginSpec(
 	ctx context.Context, label string,
-	install workspace.PluginSpec, file string,
+	install workspace.PluginDescriptor, file string,
 	sink diag.Sink, color colors.Colorization, reinstall bool,
 ) error {
 	// If we got here, actually try to do the download.
@@ -308,7 +308,7 @@ func installPluginSpec(
 	return nil
 }
 
-func getFilePayload(file string, spec workspace.PluginSpec) (pluginstorage.Content, error) {
+func getFilePayload(file string, spec workspace.PluginDescriptor) (pluginstorage.Content, error) {
 	source := file
 	stat, err := os.Stat(file)
 	if err != nil {
@@ -344,8 +344,8 @@ func getFilePayload(file string, spec workspace.PluginSpec) (pluginstorage.Conte
 
 // resolvePluginSpec resolves plugin specifications using various resolution strategies.
 func (cmd *pluginInstallCmd) resolvePluginSpec(
-	ctx context.Context, pluginSpec workspace.PluginSpec, project workspace.BaseProject,
-) (workspace.PluginSpec, error) {
+	ctx context.Context, pluginSpec workspace.PluginDescriptor, project workspace.BaseProject,
+) (workspace.PluginDescriptor, error) {
 	resolutionEnv := cmd.packageResolutionOptions
 	result, err := packageresolution.Resolve(
 		ctx, cmd.registry, packageresolution.DefaultWorkspace(), pluginSpec, resolutionEnv, project)
@@ -359,7 +359,7 @@ func (cmd *pluginInstallCmd) resolvePluginSpec(
 				)
 			}
 		}
-		return workspace.PluginSpec{}, fmt.Errorf("Unable to resolve package from name: %w", err)
+		return workspace.PluginDescriptor{}, fmt.Errorf("Unable to resolve package from name: %w", err)
 	}
 
 	switch res := result.(type) {

--- a/pkg/cmd/pulumi/plugin/plugin_install_test.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install_test.go
@@ -71,7 +71,7 @@ func TestBundledDev(t *testing.T) {
 		env: env.NewEnv(
 			env.MapStore{"PULUMI_DEV": "true"},
 		),
-		pluginGetLatestVersion: func(ps workspace.PluginSpec, ctx context.Context) (*semver.Version, error) {
+		pluginGetLatestVersion: func(ps workspace.PluginDescriptor, ctx context.Context) (*semver.Version, error) {
 			getLatestVersionCalled = true
 			assert.Equal(t, "nodejs", ps.Name)
 			assert.Equal(t, apitype.LanguagePlugin, ps.Kind)
@@ -93,18 +93,18 @@ func TestGetLatestPluginIncludedVersion(t *testing.T) {
 
 	cmd := &pluginInstallCmd{
 		diag: diagtest.LogSink(t),
-		pluginGetLatestVersion: func(ps workspace.PluginSpec, ctx context.Context) (*semver.Version, error) {
+		pluginGetLatestVersion: func(ps workspace.PluginDescriptor, ctx context.Context) (*semver.Version, error) {
 			assert.Fail(t, "GetLatestVersion should not have been called")
 			return nil, nil
 		},
 		installPluginSpec: func(
 			_ context.Context, _ string,
-			install workspace.PluginSpec, file string,
+			install workspace.PluginDescriptor, file string,
 			_ diag.Sink, _ colors.Colorization, _ bool,
 		) error {
 			pluginWasInstalled = true
 			assert.Empty(t, file)
-			assert.Equal(t, workspace.PluginSpec{
+			assert.Equal(t, workspace.PluginDescriptor{
 				Name: "aws",
 				Kind: apitype.ResourcePlugin,
 				Version: &semver.Version{
@@ -134,7 +134,7 @@ func TestGetPluginDownloadURLFromRegistry(t *testing.T) {
 			DisableRegistryResolve: false,
 			Experimental:           true,
 		},
-		pluginGetLatestVersion: func(ps workspace.PluginSpec, ctx context.Context) (*semver.Version, error) {
+		pluginGetLatestVersion: func(ps workspace.PluginDescriptor, ctx context.Context) (*semver.Version, error) {
 			assert.Fail(t, "GetLatestVersion should not have been called")
 			return nil, nil
 		},
@@ -157,11 +157,11 @@ func TestGetPluginDownloadURLFromRegistry(t *testing.T) {
 		},
 		installPluginSpec: func(
 			_ context.Context, _ string,
-			install workspace.PluginSpec, _ string,
+			install workspace.PluginDescriptor, _ string,
 			_ diag.Sink, _ colors.Colorization, _ bool,
 		) error {
 			pluginWasInstalled = true
-			assert.Equal(t, workspace.PluginSpec{
+			assert.Equal(t, workspace.PluginDescriptor{
 				Name: "foo",
 				Kind: apitype.ResourcePlugin,
 				Version: &semver.Version{
@@ -188,7 +188,7 @@ func TestGetPluginDownloadFromKnownUnpublishedPackage(t *testing.T) {
 
 	cmd := &pluginInstallCmd{
 		diag: diagtest.LogSink(t),
-		pluginGetLatestVersion: func(ps workspace.PluginSpec, ctx context.Context) (*semver.Version, error) {
+		pluginGetLatestVersion: func(ps workspace.PluginDescriptor, ctx context.Context) (*semver.Version, error) {
 			assert.Fail(t, "GetLatestVersion should not have been called")
 			return nil, nil
 		},
@@ -221,11 +221,11 @@ func TestGetPluginDownloadFromKnownUnpublishedPackage(t *testing.T) {
 		},
 		installPluginSpec: func(
 			_ context.Context, _ string,
-			install workspace.PluginSpec, _ string,
+			install workspace.PluginDescriptor, _ string,
 			_ diag.Sink, _ colors.Colorization, _ bool,
 		) error {
 			pluginWasInstalled = true
-			assert.Equal(t, workspace.PluginSpec{
+			assert.Equal(t, workspace.PluginDescriptor{
 				Name: "random",
 				Kind: apitype.ResourcePlugin,
 				Version: &semver.Version{
@@ -253,7 +253,7 @@ func TestGetPluginDownloadForMissingPackage(t *testing.T) {
 				DisableRegistryResolve: false,
 				Experimental:           true,
 			},
-			pluginGetLatestVersion: func(ps workspace.PluginSpec, ctx context.Context) (*semver.Version, error) {
+			pluginGetLatestVersion: func(ps workspace.PluginDescriptor, ctx context.Context) (*semver.Version, error) {
 				assert.Fail(t, "GetLatestVersion should not have been called")
 				return nil, nil
 			},
@@ -282,7 +282,7 @@ func TestGetPluginDownloadForMissingPackage(t *testing.T) {
 				DisableRegistryResolve: false,
 				Experimental:           true,
 			},
-			pluginGetLatestVersion: func(ps workspace.PluginSpec, ctx context.Context) (*semver.Version, error) {
+			pluginGetLatestVersion: func(ps workspace.PluginDescriptor, ctx context.Context) (*semver.Version, error) {
 				assert.Fail(t, "GetLatestVersion should not have been called")
 				return nil, nil
 			},
@@ -312,7 +312,7 @@ func TestRegistryIsNotUsedWhenAFileIsSpecified(t *testing.T) {
 	defer func() { assert.True(t, wasInstalled) }()
 	cmd := &pluginInstallCmd{
 		diag: diagtest.LogSink(t),
-		pluginGetLatestVersion: func(ps workspace.PluginSpec, ctx context.Context) (*semver.Version, error) {
+		pluginGetLatestVersion: func(ps workspace.PluginDescriptor, ctx context.Context) (*semver.Version, error) {
 			require.Fail(t, "GetLatestVersion should not have been called")
 			return nil, nil
 		},
@@ -320,12 +320,12 @@ func TestRegistryIsNotUsedWhenAFileIsSpecified(t *testing.T) {
 		file:     "./pulumi-resource-some-file.tar.gz", // This is a flag: --file
 		installPluginSpec: func(
 			_ context.Context, _ string,
-			install workspace.PluginSpec, file string,
+			install workspace.PluginDescriptor, file string,
 			sink diag.Sink, color colors.Colorization, reinstall bool,
 		) error {
 			wasInstalled = true
 			assert.Equal(t, "./pulumi-resource-some-file.tar.gz", file)
-			assert.Equal(t, workspace.PluginSpec{
+			assert.Equal(t, workspace.PluginDescriptor{
 				Name:    "some-file",
 				Kind:    "resource",
 				Version: &semver.Version{Major: 1},
@@ -357,7 +357,7 @@ packages:
 
 	cmd := &pluginInstallCmd{
 		diag: diagtest.LogSink(t),
-		pluginGetLatestVersion: func(ps workspace.PluginSpec, ctx context.Context) (*semver.Version, error) {
+		pluginGetLatestVersion: func(ps workspace.PluginDescriptor, ctx context.Context) (*semver.Version, error) {
 			return &semver.Version{Major: 1}, nil
 		},
 		registry: &backend.MockCloudRegistry{
@@ -368,7 +368,7 @@ packages:
 			},
 		},
 		installPluginSpec: func(
-			_ context.Context, _ string, install workspace.PluginSpec, _ string,
+			_ context.Context, _ string, install workspace.PluginDescriptor, _ string,
 			_ diag.Sink, _ colors.Colorization, _ bool,
 		) error {
 			require.Equal(t, "my-local-provider", install.Name)
@@ -394,7 +394,7 @@ func TestSuggestedPackagesDisplay(t *testing.T) {
 			DisableRegistryResolve: false,
 			Experimental:           true,
 		},
-		pluginGetLatestVersion: func(ps workspace.PluginSpec, ctx context.Context) (*semver.Version, error) {
+		pluginGetLatestVersion: func(ps workspace.PluginDescriptor, ctx context.Context) (*semver.Version, error) {
 			assert.Fail(t, "GetLatestVersion should not have been called")
 			return nil, nil
 		},
@@ -421,7 +421,7 @@ func TestSuggestedPackagesDisplay(t *testing.T) {
 			},
 		},
 		installPluginSpec: func(
-			_ context.Context, _ string, install workspace.PluginSpec, _ string,
+			_ context.Context, _ string, install workspace.PluginDescriptor, _ string,
 			_ diag.Sink, _ colors.Colorization, _ bool,
 		) error {
 			assert.Fail(t, "installPluginSpec should not have been called")

--- a/pkg/cmd/pulumi/plugin/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin/plugin_ls.go
@@ -40,7 +40,7 @@ func newPluginLsCmd() *cobra.Command {
 			var plugins []workspace.PluginInfo
 			var err error
 			if projectOnly {
-				var pluginSpecs []workspace.PluginSpec
+				var pluginSpecs []workspace.PluginDescriptor
 				if pluginSpecs, err = getProjectPlugins(); err != nil {
 					return fmt.Errorf("loading project plugins: %w", err)
 				}

--- a/pkg/cmd/pulumi/plugin/rpc.go
+++ b/pkg/cmd/pulumi/plugin/rpc.go
@@ -42,7 +42,7 @@ func newInstallPluginFunc(pctx *plugin.Context) func(string) *semver.Version {
 			return nil
 		}
 
-		pluginSpec := workspace.PluginSpec{
+		pluginSpec := workspace.PluginDescriptor{
 			Name: pluginName,
 			Kind: apitype.ResourcePlugin,
 		}

--- a/pkg/codegen/nodejs/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test.go
@@ -97,7 +97,7 @@ resource "app" "scaleway:iam/application:Application" {}
 	err = parser.ParseFile(bytes.NewReader([]byte(hcl)), "infra.tf")
 	require.NoError(t, err, "parse failed")
 	program, diags, err := pcl.BindProgram(parser.Files, pcl.PluginHost(&plugin.MockHost{
-		ResolvePluginF: func(spec workspace.PluginSpec) (*workspace.PluginInfo, error) {
+		ResolvePluginF: func(spec workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
 			return &workspace.PluginInfo{Name: spec.Name}, nil
 		},
 		ProviderF: func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -360,8 +360,8 @@ func (e *PackageReferenceVersionMismatchError) Error() string {
 	)
 }
 
-func pluginSpecFromPackageDescriptor(descriptor *PackageDescriptor) workspace.PluginSpec {
-	return workspace.PluginSpec{
+func pluginSpecFromPackageDescriptor(descriptor *PackageDescriptor) workspace.PluginDescriptor {
+	return workspace.PluginDescriptor{
 		Name:              descriptor.Name,
 		Version:           descriptor.Version,
 		PluginDownloadURL: descriptor.DownloadURL,
@@ -405,7 +405,7 @@ func (l *pluginLoader) loadSchemaBytes(
 			return nil, nil, err
 		}
 
-		spec := workspace.PluginSpec{
+		spec := workspace.PluginDescriptor{
 			Kind:              apitype.ResourcePlugin,
 			Name:              descriptor.Name,
 			Version:           descriptor.Version,
@@ -466,7 +466,7 @@ func (l *pluginLoader) loadPluginSchemaBytes(
 	ctx context.Context, descriptor *PackageDescriptor,
 ) ([]byte, plugin.Provider, error) {
 	wsDescriptor := workspace.PackageDescriptor{
-		PluginSpec: workspace.PluginSpec{
+		PluginDescriptor: workspace.PluginDescriptor{
 			Name:              descriptor.Name,
 			Version:           descriptor.Version,
 			PluginDownloadURL: descriptor.DownloadURL,

--- a/pkg/codegen/schema/loader_test.go
+++ b/pkg/codegen/schema/loader_test.go
@@ -164,7 +164,7 @@ func TestLoadParameterized(t *testing.T) {
 			assert.Equal(t, semver.MustParse("1.0.0"), *descriptor.Version)
 			return mockProvider, nil
 		},
-		ResolvePluginF: func(spec workspace.PluginSpec) (*workspace.PluginInfo, error) {
+		ResolvePluginF: func(spec workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
 			assert.Equal(t, apitype.ResourcePlugin, spec.Kind)
 			assert.Equal(t, "terraform-provider", spec.Name)
 			assert.Equal(t, semver.MustParse("1.0.0"), *spec.Version)
@@ -230,7 +230,7 @@ func TestLoadNameMismatch(t *testing.T) {
 		ProviderF: func(workspace.PackageDescriptor) (plugin.Provider, error) {
 			return provider, nil
 		},
-		ResolvePluginF: func(workspace.PluginSpec) (*workspace.PluginInfo, error) {
+		ResolvePluginF: func(workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
 			return &workspace.PluginInfo{
 				Name:    notPkg,
 				Kind:    apitype.ResourcePlugin,
@@ -301,7 +301,7 @@ func TestLoadVersionMismatch(t *testing.T) {
 		ProviderF: func(workspace.PackageDescriptor) (plugin.Provider, error) {
 			return provider, nil
 		},
-		ResolvePluginF: func(workspace.PluginSpec) (*workspace.PluginInfo, error) {
+		ResolvePluginF: func(workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
 			return &workspace.PluginInfo{
 				Name:    pkg,
 				Kind:    apitype.ResourcePlugin,

--- a/pkg/engine/lifecycletest/framework/framework.go
+++ b/pkg/engine/lifecycletest/framework/framework.go
@@ -90,30 +90,30 @@ type NopPluginManager struct{}
 func (NopPluginManager) GetPluginPath(
 	ctx context.Context,
 	d diag.Sink,
-	spec workspace.PluginSpec,
+	spec workspace.PluginDescriptor,
 	projectPlugins []workspace.ProjectPlugin,
 ) (string, error) {
 	return "installed", nil
 }
 
-func (NopPluginManager) HasPlugin(spec workspace.PluginSpec) bool {
+func (NopPluginManager) HasPlugin(spec workspace.PluginDescriptor) bool {
 	return true
 }
 
-func (NopPluginManager) HasPluginGTE(spec workspace.PluginSpec) (bool, error) {
+func (NopPluginManager) HasPluginGTE(spec workspace.PluginDescriptor) (bool, error) {
 	return true, nil
 }
 
 func (NopPluginManager) GetLatestPluginVersion(
 	ctx context.Context,
-	spec workspace.PluginSpec,
+	spec workspace.PluginDescriptor,
 ) (*semver.Version, error) {
 	return semver.New("1.0.0")
 }
 
 func (NopPluginManager) DownloadPlugin(
 	ctx context.Context,
-	plugin workspace.PluginSpec,
+	plugin workspace.PluginDescriptor,
 	wrapper func(stream io.ReadCloser, size int64) io.ReadCloser,
 	retry func(err error, attempt int, limit int, delay time.Duration),
 ) (io.ReadCloser, int64, error) {
@@ -122,7 +122,7 @@ func (NopPluginManager) DownloadPlugin(
 
 func (NopPluginManager) InstallPlugin(
 	ctx context.Context,
-	plugin workspace.PluginSpec,
+	plugin workspace.PluginDescriptor,
 	content pluginstorage.Content,
 	reinstall bool,
 ) error {

--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -1361,7 +1361,7 @@ func TestImportDefaultProvider(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		return errors.New("unexpected program execution")
 	}, workspace.PackageDescriptor{
-		PluginSpec: workspace.PluginSpec{
+		PluginDescriptor: workspace.PluginDescriptor{
 			Name:    "pkgA",
 			Kind:    apitype.ResourcePlugin,
 			Version: &pkgAVersion,

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -1513,7 +1513,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 			versions: []string{"1.0.0", "1.1.0"},
 			packages: []workspace.PackageDescriptor{
 				{
-					PluginSpec: workspace.PluginSpec{
+					PluginDescriptor: workspace.PluginDescriptor{
 						Name:              "pkgA",
 						Version:           &semver.Version{Major: 1, Minor: 1},
 						PluginDownloadURL: "example.com/default",
@@ -1533,7 +1533,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 			name:     "specified-provider",
 			versions: []string{"1.0.0", "1.1.0"},
 			packages: []workspace.PackageDescriptor{{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "pkgA",
 					Version: &semver.Version{Major: 1, Minor: 1},
 					Kind:    apitype.ResourcePlugin,
@@ -1553,7 +1553,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 			versions: []string{"1.3.0", "1.1.0"},
 			prog:     prog(),
 			packages: []workspace.PackageDescriptor{{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "pkgA",
 					Version: &semver.Version{Major: 1, Minor: 1},
 					Kind:    apitype.ResourcePlugin,

--- a/pkg/engine/lifecycletest/update_plan_test.go
+++ b/pkg/engine/lifecycletest/update_plan_test.go
@@ -1506,8 +1506,8 @@ func TestPluginsAreDownloaded(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	},
-		workspace.PackageDescriptor{PluginSpec: workspace.PluginSpec{Name: "pkgA"}},
-		workspace.PackageDescriptor{PluginSpec: workspace.PluginSpec{Name: "pkgB", Version: &semver10}})
+		workspace.PackageDescriptor{PluginDescriptor: workspace.PluginDescriptor{Name: "pkgA"}},
+		workspace.PackageDescriptor{PluginDescriptor: workspace.PluginDescriptor{Name: "pkgB", Version: &semver10}})
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 
 	p := &lt.TestPlan{

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -53,22 +53,22 @@ type PluginManager interface {
 	GetPluginPath(
 		ctx context.Context,
 		d diag.Sink,
-		spec workspace.PluginSpec,
+		spec workspace.PluginDescriptor,
 		projectPlugins []workspace.ProjectPlugin,
 	) (string, error)
-	HasPlugin(spec workspace.PluginSpec) bool
-	HasPluginGTE(spec workspace.PluginSpec) (bool, error)
+	HasPlugin(spec workspace.PluginDescriptor) bool
+	HasPluginGTE(spec workspace.PluginDescriptor) (bool, error)
 
-	GetLatestPluginVersion(ctx context.Context, spec workspace.PluginSpec) (*semver.Version, error)
+	GetLatestPluginVersion(ctx context.Context, spec workspace.PluginDescriptor) (*semver.Version, error)
 	DownloadPlugin(
 		ctx context.Context,
-		plugin workspace.PluginSpec,
+		plugin workspace.PluginDescriptor,
 		wrapper func(stream io.ReadCloser, size int64) io.ReadCloser,
 		retry func(err error, attempt int, limit int, delay time.Duration),
 	) (io.ReadCloser, int64, error)
 	InstallPlugin(
 		ctx context.Context,
-		plugin workspace.PluginSpec,
+		plugin workspace.PluginDescriptor,
 		content pluginstorage.Content,
 		reinstall bool,
 	) error
@@ -95,30 +95,30 @@ type defaultPluginManager struct{}
 func (defaultPluginManager) GetPluginPath(
 	ctx context.Context,
 	d diag.Sink,
-	spec workspace.PluginSpec,
+	spec workspace.PluginDescriptor,
 	projectPlugins []workspace.ProjectPlugin,
 ) (string, error) {
 	return workspace.GetPluginPath(ctx, d, spec, projectPlugins)
 }
 
-func (defaultPluginManager) HasPlugin(spec workspace.PluginSpec) bool {
+func (defaultPluginManager) HasPlugin(spec workspace.PluginDescriptor) bool {
 	return workspace.HasPlugin(spec)
 }
 
-func (defaultPluginManager) HasPluginGTE(spec workspace.PluginSpec) (bool, error) {
+func (defaultPluginManager) HasPluginGTE(spec workspace.PluginDescriptor) (bool, error) {
 	return workspace.HasPluginGTE(spec)
 }
 
 func (defaultPluginManager) GetLatestPluginVersion(
 	ctx context.Context,
-	spec workspace.PluginSpec,
+	spec workspace.PluginDescriptor,
 ) (*semver.Version, error) {
 	return spec.GetLatestVersion(ctx)
 }
 
 func (defaultPluginManager) DownloadPlugin(
 	ctx context.Context,
-	plugin workspace.PluginSpec,
+	plugin workspace.PluginDescriptor,
 	wrapper func(stream io.ReadCloser, size int64) io.ReadCloser,
 	retry func(err error, attempt int, limit int, delay time.Duration),
 ) (io.ReadCloser, int64, error) {
@@ -133,7 +133,7 @@ func (defaultPluginManager) DownloadPlugin(
 
 func (defaultPluginManager) InstallPlugin(
 	ctx context.Context,
-	plugin workspace.PluginSpec,
+	plugin workspace.PluginDescriptor,
 	content pluginstorage.Content,
 	reinstall bool,
 ) error {
@@ -141,11 +141,11 @@ func (defaultPluginManager) InstallPlugin(
 }
 
 // PluginSet represents a set of plugins.
-type PluginSet map[string]workspace.PluginSpec
+type PluginSet map[string]workspace.PluginDescriptor
 
 // NewPluginSet creates a new PluginSet from the specified PluginSpecs.
-func NewPluginSet(plugins ...workspace.PluginSpec) PluginSet {
-	var s PluginSet = make(map[string]workspace.PluginSpec, len(plugins))
+func NewPluginSet(plugins ...workspace.PluginDescriptor) PluginSet {
+	var s PluginSet = make(map[string]workspace.PluginDescriptor, len(plugins))
 	for _, p := range plugins {
 		s.Add(p)
 	}
@@ -153,7 +153,7 @@ func NewPluginSet(plugins ...workspace.PluginSpec) PluginSet {
 }
 
 // Add adds a plugin to this plugin set.
-func (p PluginSet) Add(plug workspace.PluginSpec) {
+func (p PluginSet) Add(plug workspace.PluginDescriptor) {
 	p[plug.String()] = plug
 }
 
@@ -161,9 +161,9 @@ func (p PluginSet) Add(plug workspace.PluginSpec) {
 //
 // For example, the plugin aws would be removed if there was an already existing plugin aws-5.4.0.
 func (p PluginSet) Deduplicate() PluginSet {
-	existing := map[string]workspace.PluginSpec{}
+	existing := map[string]workspace.PluginDescriptor{}
 	newSet := NewPluginSet()
-	add := func(p workspace.PluginSpec) {
+	add := func(p workspace.PluginDescriptor) {
 		prev, ok := existing[p.Name]
 		if ok {
 			// If either `pluginDownloadURL`, `Version` or both are set we consider the
@@ -194,8 +194,8 @@ func (p PluginSet) Deduplicate() PluginSet {
 }
 
 // Values returns a slice of all of the plugins contained within this set.
-func (p PluginSet) Values() []workspace.PluginSpec {
-	plugins := slice.Prealloc[workspace.PluginSpec](len(p))
+func (p PluginSet) Values() []workspace.PluginDescriptor {
+	plugins := slice.Prealloc[workspace.PluginDescriptor](len(p))
 	for _, value := range p {
 		plugins = append(plugins, value)
 	}
@@ -235,7 +235,7 @@ func (p PackageSet) Union(other PackageSet) PackageSet {
 func (p PackageSet) ToPluginSet() PluginSet {
 	newSet := NewPluginSet()
 	for _, value := range p {
-		newSet.Add(value.PluginSpec)
+		newSet.Add(value.PluginDescriptor)
 	}
 	return newSet
 }
@@ -298,8 +298,8 @@ func GetRequiredPlugins(
 	host plugin.Host,
 	runtime string,
 	info plugin.ProgramInfo,
-) ([]workspace.PluginSpec, error) {
-	plugins := make([]workspace.PluginSpec, 0, 1)
+) ([]workspace.PluginDescriptor, error) {
+	plugins := make([]workspace.PluginDescriptor, 0, 1)
 
 	// First make sure the language plugin is present.  We need this to load the required resource plugins.
 	// TODO: we need to think about how best to version this.  For now, it always picks the latest.
@@ -312,12 +312,12 @@ func GetRequiredPlugins(
 	if err != nil {
 		// Don't error if this fails, just warn and return the version as unknown.
 		host.Log(diag.Warning, "", fmt.Sprintf("failed to get plugin info for language plugin %s: %v", runtime, err), 0)
-		plugins = append(plugins, workspace.PluginSpec{
+		plugins = append(plugins, workspace.PluginDescriptor{
 			Name: runtime,
 			Kind: apitype.LanguagePlugin,
 		})
 	} else {
-		plugins = append(plugins, workspace.PluginSpec{
+		plugins = append(plugins, workspace.PluginDescriptor{
 			Name:    langInfo.Name,
 			Kind:    langInfo.Kind,
 			Version: langInfo.Version,
@@ -333,7 +333,7 @@ func GetRequiredPlugins(
 		return nil, fmt.Errorf("failed to discover plugin requirements: %w", err)
 	}
 	for _, dep := range deps {
-		plugins = append(plugins, dep.PluginSpec)
+		plugins = append(plugins, dep.PluginDescriptor)
 	}
 
 	return plugins, nil
@@ -415,7 +415,7 @@ func gatherPackagesFromSnapshot(plugctx *plugin.Context, target *deploy.Target) 
 		logging.V(preparePluginLog).Infof(
 			"gatherPackagesFromSnapshot(): package %s %s is required by first-class provider %q", name, version, urn)
 		set.Add(workspace.PackageDescriptor{
-			PluginSpec: workspace.PluginSpec{
+			PluginDescriptor: workspace.PluginDescriptor{
 				Name:              name.String(),
 				Kind:              apitype.ResourcePlugin,
 				Version:           version,
@@ -519,7 +519,7 @@ func installPlugin(
 	ctx context.Context,
 	opts *deploymentOptions,
 	pluginManager PluginManager,
-	plugin workspace.PluginSpec,
+	plugin workspace.PluginDescriptor,
 ) error {
 	logging.V(preparePluginLog).Infof("installPlugin(%s, %s): beginning install", plugin.Name, plugin.Version)
 

--- a/pkg/engine/plugins_test.go
+++ b/pkg/engine/plugins_test.go
@@ -37,14 +37,14 @@ func TestDefaultProvidersSingle(t *testing.T) {
 
 	languagePlugins := NewPackageSet()
 	languagePlugins.Add(workspace.PackageDescriptor{
-		PluginSpec: workspace.PluginSpec{
+		PluginDescriptor: workspace.PluginDescriptor{
 			Name:    "aws",
 			Version: mustMakeVersion("0.17.1"),
 			Kind:    apitype.ResourcePlugin,
 		},
 	})
 	languagePlugins.Add(workspace.PackageDescriptor{
-		PluginSpec: workspace.PluginSpec{
+		PluginDescriptor: workspace.PluginDescriptor{
 			Name:              "kubernetes",
 			Version:           mustMakeVersion("0.22.0"),
 			Kind:              apitype.ResourcePlugin,
@@ -74,14 +74,14 @@ func TestDefaultProvidersOverrideNoVersion(t *testing.T) {
 
 	languagePlugins := NewPackageSet()
 	languagePlugins.Add(workspace.PackageDescriptor{
-		PluginSpec: workspace.PluginSpec{
+		PluginDescriptor: workspace.PluginDescriptor{
 			Name:    "aws",
 			Version: mustMakeVersion("0.17.1"),
 			Kind:    apitype.ResourcePlugin,
 		},
 	})
 	languagePlugins.Add(workspace.PackageDescriptor{
-		PluginSpec: workspace.PluginSpec{
+		PluginDescriptor: workspace.PluginDescriptor{
 			Name:    "aws",
 			Version: nil,
 			Kind:    apitype.ResourcePlugin,
@@ -102,21 +102,21 @@ func TestDefaultProvidersOverrideNewerVersion(t *testing.T) {
 
 	languagePlugins := NewPackageSet()
 	languagePlugins.Add(workspace.PackageDescriptor{
-		PluginSpec: workspace.PluginSpec{
+		PluginDescriptor: workspace.PluginDescriptor{
 			Name:    "aws",
 			Version: mustMakeVersion("0.17.0"),
 			Kind:    apitype.ResourcePlugin,
 		},
 	})
 	languagePlugins.Add(workspace.PackageDescriptor{
-		PluginSpec: workspace.PluginSpec{
+		PluginDescriptor: workspace.PluginDescriptor{
 			Name:    "aws",
 			Version: mustMakeVersion("0.17.1"),
 			Kind:    apitype.ResourcePlugin,
 		},
 	})
 	languagePlugins.Add(workspace.PackageDescriptor{
-		PluginSpec: workspace.PluginSpec{
+		PluginDescriptor: workspace.PluginDescriptor{
 			Name:    "aws",
 			Version: mustMakeVersion("0.17.2-dev.1553126336"),
 			Kind:    apitype.ResourcePlugin,
@@ -137,14 +137,14 @@ func TestDefaultProvidersSnapshotOverrides(t *testing.T) {
 
 	languagePlugins := NewPackageSet()
 	languagePlugins.Add(workspace.PackageDescriptor{
-		PluginSpec: workspace.PluginSpec{
+		PluginDescriptor: workspace.PluginDescriptor{
 			Name: "python",
 			Kind: apitype.LanguagePlugin,
 		},
 	})
 	snapshotPlugins := NewPackageSet()
 	snapshotPlugins.Add(workspace.PackageDescriptor{
-		PluginSpec: workspace.PluginSpec{
+		PluginDescriptor: workspace.PluginDescriptor{
 			Name:    "aws",
 			Version: mustMakeVersion("0.17.0"),
 			Kind:    apitype.ResourcePlugin,
@@ -166,41 +166,41 @@ func TestPluginSetDeduplicate(t *testing.T) {
 		input    PluginSet
 		expected PluginSet
 	}{{
-		input: NewPluginSet(workspace.PluginSpec{
+		input: NewPluginSet(workspace.PluginDescriptor{
 			Name:    "foo",
 			Version: &semver.Version{Major: 1},
-		}, workspace.PluginSpec{
+		}, workspace.PluginDescriptor{
 			Name: "foo",
 		}),
-		expected: NewPluginSet(workspace.PluginSpec{
+		expected: NewPluginSet(workspace.PluginDescriptor{
 			Name:    "foo",
 			Version: &semver.Version{Major: 1},
 		}),
 	}, {
-		input: NewPluginSet(workspace.PluginSpec{
+		input: NewPluginSet(workspace.PluginDescriptor{
 			Name:    "bar",
 			Version: &semver.Version{Minor: 3},
-		}, workspace.PluginSpec{
+		}, workspace.PluginDescriptor{
 			Name:              "bar",
 			PluginDownloadURL: "example.com/bar",
-		}, workspace.PluginSpec{
+		}, workspace.PluginDescriptor{
 			Name:              "bar",
 			Version:           &semver.Version{Patch: 3},
 			PluginDownloadURL: "example.com",
-		}, workspace.PluginSpec{
+		}, workspace.PluginDescriptor{
 			Name: "foo",
 		}),
-		expected: NewPluginSet(workspace.PluginSpec{
+		expected: NewPluginSet(workspace.PluginDescriptor{
 			Name:    "bar",
 			Version: &semver.Version{Minor: 3},
-		}, workspace.PluginSpec{
+		}, workspace.PluginDescriptor{
 			Name:              "bar",
 			PluginDownloadURL: "example.com/bar",
-		}, workspace.PluginSpec{
+		}, workspace.PluginDescriptor{
 			Name:              "bar",
 			Version:           &semver.Version{Patch: 3},
 			PluginDownloadURL: "example.com",
-		}, workspace.PluginSpec{
+		}, workspace.PluginDescriptor{
 			Name: "foo",
 		}),
 	}}
@@ -233,7 +233,7 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 			name: "Olds empty",
 			olds: NewPackageSet(),
 			news: NewPackageSet(workspace.PackageDescriptor{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "foo",
 					Kind:    apitype.ResourcePlugin,
 					Version: &semver.Version{Major: 1},
@@ -244,7 +244,7 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 		{
 			name: "News empty",
 			olds: NewPackageSet(workspace.PackageDescriptor{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "foo",
 					Kind:    apitype.ResourcePlugin,
 					Version: &semver.Version{Major: 1},
@@ -256,14 +256,14 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 		{
 			name: "No matches by name",
 			olds: NewPackageSet(workspace.PackageDescriptor{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "foo",
 					Kind:    apitype.ResourcePlugin,
 					Version: &semver.Version{Major: 1},
 				},
 			}),
 			news: NewPackageSet(workspace.PackageDescriptor{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "bar",
 					Kind:    apitype.ResourcePlugin,
 					Version: &semver.Version{Major: 1},
@@ -274,14 +274,14 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 		{
 			name: "No matches by kind",
 			olds: NewPackageSet(workspace.PackageDescriptor{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "foo",
 					Kind:    apitype.ResourcePlugin,
 					Version: &semver.Version{Major: 1},
 				},
 			}),
 			news: NewPackageSet(workspace.PackageDescriptor{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "foo",
 					Kind:    apitype.AnalyzerPlugin,
 					Version: &semver.Version{Major: 1},
@@ -292,14 +292,14 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 		{
 			name: "Matches with no updates (equal)",
 			olds: NewPackageSet(workspace.PackageDescriptor{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "foo",
 					Kind:    apitype.ResourcePlugin,
 					Version: &semver.Version{Major: 1},
 				},
 			}),
 			news: NewPackageSet(workspace.PackageDescriptor{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "foo",
 					Kind:    apitype.ResourcePlugin,
 					Version: &semver.Version{Major: 1},
@@ -310,14 +310,14 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 		{
 			name: "Matches with no updates (news has an older version)",
 			olds: NewPackageSet(workspace.PackageDescriptor{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "foo",
 					Kind:    apitype.ResourcePlugin,
 					Version: &semver.Version{Major: 2},
 				},
 			}),
 			news: NewPackageSet(workspace.PackageDescriptor{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "foo",
 					Kind:    apitype.ResourcePlugin,
 					Version: &semver.Version{Major: 1},
@@ -329,14 +329,14 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 			name: "Matches with one update",
 			olds: NewPackageSet(
 				workspace.PackageDescriptor{
-					PluginSpec: workspace.PluginSpec{
+					PluginDescriptor: workspace.PluginDescriptor{
 						Name:    "foo",
 						Kind:    apitype.ResourcePlugin,
 						Version: &semver.Version{Major: 1},
 					},
 				},
 				workspace.PackageDescriptor{
-					PluginSpec: workspace.PluginSpec{
+					PluginDescriptor: workspace.PluginDescriptor{
 						Name:    "bar",
 						Kind:    apitype.ResourcePlugin,
 						Version: &semver.Version{Major: 1},
@@ -345,7 +345,7 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 			),
 			news: NewPackageSet(
 				workspace.PackageDescriptor{
-					PluginSpec: workspace.PluginSpec{
+					PluginDescriptor: workspace.PluginDescriptor{
 						Name:    "foo",
 						Kind:    apitype.ResourcePlugin,
 						Version: &semver.Version{Major: 2},
@@ -355,14 +355,14 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 			expected: []PackageUpdate{
 				{
 					Old: workspace.PackageDescriptor{
-						PluginSpec: workspace.PluginSpec{
+						PluginDescriptor: workspace.PluginDescriptor{
 							Name:    "foo",
 							Kind:    apitype.ResourcePlugin,
 							Version: &semver.Version{Major: 1},
 						},
 					},
 					New: workspace.PackageDescriptor{
-						PluginSpec: workspace.PluginSpec{
+						PluginDescriptor: workspace.PluginDescriptor{
 							Name:    "foo",
 							Kind:    apitype.ResourcePlugin,
 							Version: &semver.Version{Major: 2},
@@ -375,21 +375,21 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 			name: "Matches with multiple updates",
 			olds: NewPackageSet(
 				workspace.PackageDescriptor{
-					PluginSpec: workspace.PluginSpec{
+					PluginDescriptor: workspace.PluginDescriptor{
 						Name:    "foo",
 						Kind:    apitype.ResourcePlugin,
 						Version: &semver.Version{Major: 1},
 					},
 				},
 				workspace.PackageDescriptor{
-					PluginSpec: workspace.PluginSpec{
+					PluginDescriptor: workspace.PluginDescriptor{
 						Name:    "bar",
 						Kind:    apitype.ResourcePlugin,
 						Version: &semver.Version{Major: 2},
 					},
 				},
 				workspace.PackageDescriptor{
-					PluginSpec: workspace.PluginSpec{
+					PluginDescriptor: workspace.PluginDescriptor{
 						Name:    "baz",
 						Kind:    apitype.AnalyzerPlugin,
 						Version: &semver.Version{Major: 3},
@@ -398,21 +398,21 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 			),
 			news: NewPackageSet(
 				workspace.PackageDescriptor{
-					PluginSpec: workspace.PluginSpec{
+					PluginDescriptor: workspace.PluginDescriptor{
 						Name:    "foo",
 						Kind:    apitype.ResourcePlugin,
 						Version: &semver.Version{Major: 2},
 					},
 				},
 				workspace.PackageDescriptor{
-					PluginSpec: workspace.PluginSpec{
+					PluginDescriptor: workspace.PluginDescriptor{
 						Name:    "bar",
 						Kind:    apitype.ResourcePlugin,
 						Version: &semver.Version{Major: 2},
 					},
 				},
 				workspace.PackageDescriptor{
-					PluginSpec: workspace.PluginSpec{
+					PluginDescriptor: workspace.PluginDescriptor{
 						Name:    "baz",
 						Kind:    apitype.AnalyzerPlugin,
 						Version: &semver.Version{Major: 4},
@@ -422,7 +422,7 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 			expected: []PackageUpdate{
 				{
 					Old: workspace.PackageDescriptor{
-						PluginSpec: workspace.PluginSpec{
+						PluginDescriptor: workspace.PluginDescriptor{
 							Name:    "foo",
 							Kind:    apitype.ResourcePlugin,
 							Version: &semver.Version{Major: 1},
@@ -430,7 +430,7 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 					},
 
 					New: workspace.PackageDescriptor{
-						PluginSpec: workspace.PluginSpec{
+						PluginDescriptor: workspace.PluginDescriptor{
 							Name:    "foo",
 							Kind:    apitype.ResourcePlugin,
 							Version: &semver.Version{Major: 2},
@@ -439,14 +439,14 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 				},
 				{
 					Old: workspace.PackageDescriptor{
-						PluginSpec: workspace.PluginSpec{
+						PluginDescriptor: workspace.PluginDescriptor{
 							Name:    "baz",
 							Kind:    apitype.AnalyzerPlugin,
 							Version: &semver.Version{Major: 3},
 						},
 					},
 					New: workspace.PackageDescriptor{
-						PluginSpec: workspace.PluginSpec{
+						PluginDescriptor: workspace.PluginDescriptor{
 							Name:    "baz",
 							Kind:    apitype.AnalyzerPlugin,
 							Version: &semver.Version{Major: 4},
@@ -458,14 +458,14 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 		{
 			name: "Base plugin and parameterized package",
 			olds: NewPackageSet(workspace.PackageDescriptor{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "foo",
 					Kind:    apitype.ResourcePlugin,
 					Version: &semver.Version{Major: 1},
 				},
 			}),
 			news: NewPackageSet(workspace.PackageDescriptor{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "foo",
 					Kind:    apitype.ResourcePlugin,
 					Version: &semver.Version{Major: 2},
@@ -481,7 +481,7 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 		{
 			name: "Parameterized package update",
 			olds: NewPackageSet(workspace.PackageDescriptor{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "foo",
 					Kind:    apitype.ResourcePlugin,
 					Version: &semver.Version{Major: 1},
@@ -493,7 +493,7 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 				},
 			}),
 			news: NewPackageSet(workspace.PackageDescriptor{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "foo",
 					Kind:    apitype.ResourcePlugin,
 					Version: &semver.Version{Major: 1},
@@ -507,7 +507,7 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 			expected: []PackageUpdate{
 				{
 					Old: workspace.PackageDescriptor{
-						PluginSpec: workspace.PluginSpec{
+						PluginDescriptor: workspace.PluginDescriptor{
 							Name:    "foo",
 							Kind:    apitype.ResourcePlugin,
 							Version: &semver.Version{Major: 1},
@@ -519,7 +519,7 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 						},
 					},
 					New: workspace.PackageDescriptor{
-						PluginSpec: workspace.PluginSpec{
+						PluginDescriptor: workspace.PluginDescriptor{
 							Name:    "foo",
 							Kind:    apitype.ResourcePlugin,
 							Version: &semver.Version{Major: 1},
@@ -536,14 +536,14 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 		{
 			name: "Non-parameterized to parameterized package update",
 			olds: NewPackageSet(workspace.PackageDescriptor{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "foo",
 					Kind:    apitype.ResourcePlugin,
 					Version: &semver.Version{Major: 1},
 				},
 			}),
 			news: NewPackageSet(workspace.PackageDescriptor{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "base",
 					Kind:    apitype.ResourcePlugin,
 					Version: &semver.Version{Major: 1},
@@ -557,14 +557,14 @@ func TestPackageSetUpdatesTo(t *testing.T) {
 			expected: []PackageUpdate{
 				{
 					Old: workspace.PackageDescriptor{
-						PluginSpec: workspace.PluginSpec{
+						PluginDescriptor: workspace.PluginDescriptor{
 							Name:    "foo",
 							Kind:    apitype.ResourcePlugin,
 							Version: &semver.Version{Major: 1},
 						},
 					},
 					New: workspace.PackageDescriptor{
-						PluginSpec: workspace.PluginSpec{
+						PluginDescriptor: workspace.PluginDescriptor{
 							Name:    "base",
 							Kind:    apitype.ResourcePlugin,
 							Version: &semver.Version{Major: 1},
@@ -597,7 +597,7 @@ func TestDefaultProviderPluginsSorting(t *testing.T) {
 	t.Parallel()
 	v1 := semver.MustParse("0.0.1-alpha.10")
 	p1 := workspace.PackageDescriptor{
-		PluginSpec: workspace.PluginSpec{
+		PluginDescriptor: workspace.PluginDescriptor{
 			Name:    "foo",
 			Version: &v1,
 			Kind:    apitype.ResourcePlugin,
@@ -605,7 +605,7 @@ func TestDefaultProviderPluginsSorting(t *testing.T) {
 	}
 	v2 := semver.MustParse("0.0.1-alpha.10+dirty")
 	p2 := workspace.PackageDescriptor{
-		PluginSpec: workspace.PluginSpec{
+		PluginDescriptor: workspace.PluginDescriptor{
 			Name:    "foo",
 			Version: &v2,
 			Kind:    apitype.ResourcePlugin,

--- a/pkg/pluginstorage/content.go
+++ b/pkg/pluginstorage/content.go
@@ -35,7 +35,7 @@ type Content interface {
 	writeToDir(pathToDir string) error
 }
 
-func SingleFilePlugin(f *os.File, spec workspace.PluginSpec) Content {
+func SingleFilePlugin(f *os.File, spec workspace.PluginDescriptor) Content {
 	return singleFilePlugin{F: f, Kind: spec.Kind, Name: spec.Name}
 }
 

--- a/pkg/pluginstorage/download.go
+++ b/pkg/pluginstorage/download.go
@@ -47,7 +47,7 @@ import (
 // should be removed after the plugin is *successfully* installed, but left if the install
 // fails for any reason.
 func UnpackContents(
-	ctx context.Context, spec workspace.PluginSpec, content Content, reinstall bool,
+	ctx context.Context, spec workspace.PluginDescriptor, content Content, reinstall bool,
 ) (cleanup func(success bool), err error) {
 	defer contract.IgnoreClose(content)
 
@@ -170,7 +170,7 @@ func cleanupTempDirs(finalDir string) error {
 }
 
 // LockPluginForInstall acquires a file lock used to prevent concurrent installs.
-func lockPluginForInstall(spec workspace.PluginSpec) (func(), error) {
+func lockPluginForInstall(spec workspace.PluginDescriptor) (func(), error) {
 	finalDir, err := spec.DirPath()
 	if err != nil {
 		return nil, err

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -355,7 +355,7 @@ func addDefaultProviders(target *Target, source Source, prev *Snapshot) (bool, e
 	}
 
 	// Pull the versions we'll use for default providers from the snapshot's manifest.
-	defaultProviderInfo := make(map[tokens.Package]workspace.PluginSpec)
+	defaultProviderInfo := make(map[tokens.Package]workspace.PluginDescriptor)
 	for _, p := range prev.Manifest.Plugins {
 		defaultProviderInfo[tokens.Package(p.Name)] = p.Spec()
 	}

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -518,7 +518,7 @@ func (host *pluginHost) CloseProvider(provider plugin.Provider) error {
 	return nil
 }
 
-func (host *pluginHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plugin.Flags) error {
+func (host *pluginHost) EnsurePlugins(plugins []workspace.PluginDescriptor, kinds plugin.Flags) error {
 	if host.isClosed() {
 		return ErrHostIsClosed
 	}
@@ -526,7 +526,7 @@ func (host *pluginHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plug
 }
 
 func (host *pluginHost) ResolvePlugin(
-	spec workspace.PluginSpec,
+	spec workspace.PluginDescriptor,
 ) (*workspace.PluginInfo, error) {
 	plugins := slice.Prealloc[workspace.PluginInfo](len(host.pluginLoaders))
 

--- a/pkg/resource/deploy/deploytest/pluginhost_test.go
+++ b/pkg/resource/deploy/deploytest/pluginhost_test.go
@@ -124,7 +124,7 @@ func TestPluginHostProvider(t *testing.T) {
 		expectedVersion := semver.MustParse("1.0.0")
 		host := &pluginHost{}
 		_, err := host.Provider(workspace.PackageDescriptor{
-			PluginSpec: workspace.PluginSpec{
+			PluginDescriptor: workspace.PluginDescriptor{
 				Name:    "pkgA",
 				Version: &expectedVersion,
 			},
@@ -137,7 +137,7 @@ func TestPluginHostProvider(t *testing.T) {
 			t.Parallel()
 			host := &pluginHost{closed: true}
 			_, err := host.Provider(workspace.PackageDescriptor{
-				PluginSpec: workspace.PluginSpec{
+				PluginDescriptor: workspace.PluginDescriptor{
 					Name:    "pkgA",
 					Version: &semver.Version{},
 				},

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -315,7 +315,7 @@ func loadProvider(ctx context.Context, pkg tokens.Package, version *semver.Versi
 	}
 
 	descriptor := workspace.PackageDescriptor{
-		PluginSpec: workspace.PluginSpec{
+		PluginDescriptor: workspace.PluginDescriptor{
 			Kind:              apitype.ResourcePlugin,
 			Name:              string(pkg),
 			Version:           version,
@@ -349,7 +349,7 @@ func loadProvider(ctx context.Context, pkg tokens.Package, version *semver.Versi
 		host.Log(sev, "", msg, 0)
 	}
 
-	_, err = pkgWorkspace.InstallPlugin(ctx, descriptor.PluginSpec, log)
+	_, err = pkgWorkspace.InstallPlugin(ctx, descriptor.PluginDescriptor, log)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -90,12 +90,12 @@ func (host *testPluginHost) LanguageRuntime(root string) (plugin.LanguageRuntime
 	return nil, errors.New("unsupported")
 }
 
-func (host *testPluginHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plugin.Flags) error {
+func (host *testPluginHost) EnsurePlugins(plugins []workspace.PluginDescriptor, kinds plugin.Flags) error {
 	return nil
 }
 
 func (host *testPluginHost) ResolvePlugin(
-	spec workspace.PluginSpec,
+	spec workspace.PluginDescriptor,
 ) (*workspace.PluginInfo, error) {
 	return nil, nil
 }
@@ -818,7 +818,7 @@ func TestLoadProvider_missingError(t *testing.T) {
 	loader := newLoader(t, "myplugin", "1.2.3",
 		func(p tokens.Package, v semver.Version) (plugin.Provider, error) {
 			return nil, workspace.NewMissingError(
-				workspace.PluginSpec{
+				workspace.PluginDescriptor{
 					Kind:    apitype.ResourcePlugin,
 					Name:    "myplugin",
 					Version: &version,

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -2260,7 +2260,7 @@ func TestDefaultProviders(t *testing.T) {
 			d := &defaultProviders{
 				defaultProviderInfo: map[tokens.Package]workspace.PackageDescriptor{
 					tokens.Package("pkg"): {
-						PluginSpec: workspace.PluginSpec{
+						PluginDescriptor: workspace.PluginDescriptor{
 							Version:           &v1,
 							PluginDownloadURL: "github://owner/repo",
 							Checksums:         map[string][]byte{"key": []byte("expected-checksum-value")},

--- a/pkg/util/plugin.go
+++ b/pkg/util/plugin.go
@@ -26,7 +26,7 @@ import (
 
 // SetKnownPluginDownloadURL sets the PluginDownloadURL for the given PluginSpec if it's a known plugin.
 // Returns true if it filled in the URL.
-func SetKnownPluginDownloadURL(spec *workspace.PluginSpec) bool {
+func SetKnownPluginDownloadURL(spec *workspace.PluginDescriptor) bool {
 	// If the download url is already set don't touch it
 	if spec.PluginDownloadURL != "" {
 		return false
@@ -46,7 +46,7 @@ func SetKnownPluginDownloadURL(spec *workspace.PluginSpec) bool {
 
 // SetKnownPluginVersion sets the Version for the given PluginSpec if it's a known plugin.
 // Returns true if it filled in the version.
-func SetKnownPluginVersion(spec *workspace.PluginSpec) bool {
+func SetKnownPluginVersion(spec *workspace.PluginDescriptor) bool {
 	// If the version is already set don't touch it
 	if spec.Version != nil {
 		return false

--- a/pkg/util/plugin_test.go
+++ b/pkg/util/plugin_test.go
@@ -27,7 +27,7 @@ import (
 func TestUrlAlreadySet(t *testing.T) {
 	t.Parallel()
 
-	spec := workspace.PluginSpec{
+	spec := workspace.PluginDescriptor{
 		Name:              "acme",
 		Kind:              apitype.ResourcePlugin,
 		PluginDownloadURL: "github://api.github.com/pulumiverse",
@@ -39,7 +39,7 @@ func TestUrlAlreadySet(t *testing.T) {
 func TestKnownProvider(t *testing.T) {
 	t.Parallel()
 
-	spec := workspace.PluginSpec{
+	spec := workspace.PluginDescriptor{
 		Name: "acme",
 		Kind: apitype.ResourcePlugin,
 	}

--- a/pkg/workspace/plugin.go
+++ b/pkg/workspace/plugin.go
@@ -38,7 +38,7 @@ import (
 // InstallPluginError is returned by InstallPlugin if we couldn't install the plugin
 type InstallPluginError struct {
 	// The specification of the plugin to install
-	Spec workspace.PluginSpec
+	Spec workspace.PluginDescriptor
 	// The underlying error that occurred during the download or install.
 	Err error
 }
@@ -65,7 +65,7 @@ func (err *InstallPluginError) Unwrap() error {
 	return err.Err
 }
 
-func InstallPlugin(ctx context.Context, pluginSpec workspace.PluginSpec,
+func InstallPlugin(ctx context.Context, pluginSpec workspace.PluginDescriptor,
 	log func(sev diag.Severity, msg string),
 ) (*semver.Version, error) {
 	util.SetKnownPluginDownloadURL(&pluginSpec)
@@ -117,7 +117,7 @@ func InstallPlugin(ctx context.Context, pluginSpec workspace.PluginSpec,
 // when a plugin needs it's dependencies to be installed before it can safely be
 // installed.
 func InstallPluginContent(
-	ctx context.Context, spec workspace.PluginSpec, content pluginstorage.Content, reinstall bool,
+	ctx context.Context, spec workspace.PluginDescriptor, content pluginstorage.Content, reinstall bool,
 ) (err error) {
 	done, err := pluginstorage.UnpackContents(ctx, spec, content, reinstall)
 	if err != nil {
@@ -128,7 +128,9 @@ func InstallPluginContent(
 	return installDependenciesForPluginSpec(ctx, spec, os.Stderr /* redirect stdout to stderr */, os.Stderr)
 }
 
-func installDependenciesForPluginSpec(ctx context.Context, spec workspace.PluginSpec, stdout, stderr io.Writer) error {
+func installDependenciesForPluginSpec(
+	ctx context.Context, spec workspace.PluginDescriptor, stdout, stderr io.Writer,
+) error {
 	dir, err := spec.DirPath()
 	if err != nil {
 		return err

--- a/pkg/workspace/plugin_test.go
+++ b/pkg/workspace/plugin_test.go
@@ -42,7 +42,7 @@ func TestInstallPluginErrorText(t *testing.T) {
 			Name: "Just name",
 			Err: InstallPluginError{
 				Err: err,
-				Spec: workspace.PluginSpec{
+				Spec: workspace.PluginDescriptor{
 					Name: "myplugin",
 					Kind: apitype.ResourcePlugin,
 				},
@@ -54,7 +54,7 @@ func TestInstallPluginErrorText(t *testing.T) {
 			Name: "Different kind",
 			Err: InstallPluginError{
 				Err: err,
-				Spec: workspace.PluginSpec{
+				Spec: workspace.PluginDescriptor{
 					Name: "myplugin",
 					Kind: apitype.ConverterPlugin,
 				},
@@ -66,7 +66,7 @@ func TestInstallPluginErrorText(t *testing.T) {
 			Name: "Name and version",
 			Err: InstallPluginError{
 				Err: err,
-				Spec: workspace.PluginSpec{
+				Spec: workspace.PluginDescriptor{
 					Name:    "myplugin",
 					Kind:    apitype.ResourcePlugin,
 					Version: &v1,
@@ -79,7 +79,7 @@ func TestInstallPluginErrorText(t *testing.T) {
 			Name: "Name and version and URL",
 			Err: InstallPluginError{
 				Err: err,
-				Spec: workspace.PluginSpec{
+				Spec: workspace.PluginDescriptor{
 					Name:              "myplugin",
 					Kind:              apitype.ResourcePlugin,
 					Version:           &v1,
@@ -94,7 +94,7 @@ func TestInstallPluginErrorText(t *testing.T) {
 			Name: "Name and URL",
 			Err: InstallPluginError{
 				Err: err,
-				Spec: workspace.PluginSpec{
+				Spec: workspace.PluginDescriptor{
 					Name:              "myplugin",
 					Kind:              apitype.ResourcePlugin,
 					PluginDownloadURL: "github://owner/repo",
@@ -124,7 +124,7 @@ func TestPluginInstallCancellation(t *testing.T) {
 	// Now proceed to try various ways of installing plugins, all of which should promptly
 	// fail because we are operating on an already-cancelled context.
 	v4 := semver.MustParse("4.0.0")
-	spec := workspace.PluginSpec{
+	spec := workspace.PluginDescriptor{
 		Name:    "random",
 		Kind:    apitype.ResourcePlugin,
 		Version: &v4,

--- a/pkg/workspace/plugins_install_test.go
+++ b/pkg/workspace/plugins_install_test.go
@@ -87,11 +87,11 @@ func prepareTestPluginTGZ(t *testing.T, files map[string][]byte) io.ReadCloser {
 // Tests should set PULUMI_HOME to a temp directory before calling this function:
 //
 //	t.Setenv(workspace.PulumiHomeEnvVar, t.TempDir())
-func prepareTestDir(t *testing.T, files map[string][]byte) (string, io.ReadCloser, workspace.PluginSpec) {
+func prepareTestDir(t *testing.T, files map[string][]byte) (string, io.ReadCloser, workspace.PluginDescriptor) {
 	tarball := prepareTestPluginTGZ(t, files)
 
 	v1 := semver.MustParse("0.1.0")
-	plugin := workspace.PluginSpec{
+	plugin := workspace.PluginDescriptor{
 		Name:    "test",
 		Kind:    apitype.ResourcePlugin,
 		Version: &v1,
@@ -106,7 +106,7 @@ func prepareTestDir(t *testing.T, files map[string][]byte) (string, io.ReadClose
 	return pluginDir, tarball, plugin
 }
 
-func assertPluginInstalled(t *testing.T, dir string, plugin workspace.PluginSpec) workspace.PluginInfo {
+func assertPluginInstalled(t *testing.T, dir string, plugin workspace.PluginDescriptor) workspace.PluginInfo {
 	info, err := os.Stat(filepath.Join(dir, plugin.Dir()))
 	require.NoError(t, err)
 	assert.True(t, info.IsDir())

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -71,7 +71,7 @@ func NewAnalyzer(host Host, ctx *Context, name tokens.QName) (Analyzer, error) {
 	path, err := workspace.GetPluginPath(
 		ctx.baseContext,
 		ctx.Diag,
-		workspace.PluginSpec{
+		workspace.PluginDescriptor{
 			Name: strings.ReplaceAll(string(name), tokens.QNameDelimiter, "_"),
 			Kind: apitype.AnalyzerPlugin,
 		},
@@ -104,7 +104,7 @@ func NewAnalyzer(host Host, ctx *Context, name tokens.QName) (Analyzer, error) {
 // the plugin by path.
 func NewPolicyAnalyzer(
 	host Host, ctx *Context, name tokens.QName, policyPackPath string, opts *PolicyAnalyzerOptions,
-	hasPlugin func(workspace.PluginSpec) bool,
+	hasPlugin func(workspace.PluginDescriptor) bool,
 ) (Analyzer, error) {
 	projPath := filepath.Join(policyPackPath, "PulumiPolicy.yaml")
 	proj, err := workspace.LoadPolicyPack(projPath)
@@ -154,7 +154,7 @@ func NewPolicyAnalyzer(
 	// legacy behavior.
 	if proj.Runtime.Name() != "python" && proj.Runtime.Name() != "nodejs" {
 		if hasPlugin == nil {
-			hasPlugin = func(spec workspace.PluginSpec) bool {
+			hasPlugin = func(spec workspace.PluginDescriptor) bool {
 				path, err := workspace.GetPluginPath(
 					ctx.baseContext,
 					ctx.Diag,
@@ -164,7 +164,7 @@ func NewPolicyAnalyzer(
 			}
 		}
 
-		foundLanguagePlugin = hasPlugin(workspace.PluginSpec{Name: proj.Runtime.Name(), Kind: apitype.LanguagePlugin})
+		foundLanguagePlugin = hasPlugin(workspace.PluginDescriptor{Name: proj.Runtime.Name(), Kind: apitype.LanguagePlugin})
 	}
 	if !foundLanguagePlugin {
 		// Couldn't get a language plugin, fall back to the old behavior
@@ -180,7 +180,7 @@ func NewPolicyAnalyzer(
 		var pluginPath string
 		pluginPath, err = workspace.GetPluginPath(
 			ctx.baseContext, ctx.Diag,
-			workspace.PluginSpec{Name: policyAnalyzerName, Kind: apitype.AnalyzerPlugin}, host.GetProjectPlugins())
+			workspace.PluginDescriptor{Name: policyAnalyzerName, Kind: apitype.AnalyzerPlugin}, host.GetProjectPlugins())
 
 		var e *workspace.MissingError
 		if errors.As(err, &e) {

--- a/sdk/go/common/resource/plugin/converter_plugin.go
+++ b/sdk/go/common/resource/plugin/converter_plugin.go
@@ -47,7 +47,7 @@ func NewConverter(ctx *Context, name string, version *semver.Version) (Converter
 	// Load the plugin's path by using the standard workspace logic.
 	path, err := workspace.GetPluginPath(
 		ctx.baseContext, ctx.Diag,
-		workspace.PluginSpec{Name: name, Version: version, Kind: apitype.ConverterPlugin},
+		workspace.PluginDescriptor{Name: name, Version: version, Kind: apitype.ConverterPlugin},
 		ctx.Host.GetProjectPlugins())
 	if err != nil {
 		return nil, err

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -77,10 +77,10 @@ type Host interface {
 
 	// EnsurePlugins ensures all plugins in the given array are loaded and ready to use.  If any plugins are missing,
 	// and/or there are errors loading one or more plugins, a non-nil error is returned.
-	EnsurePlugins(plugins []workspace.PluginSpec, kinds Flags) error
+	EnsurePlugins(plugins []workspace.PluginDescriptor, kinds Flags) error
 
 	// ResolvePlugin resolves a pluginspec to a candidate plugin to load.
-	ResolvePlugin(spec workspace.PluginSpec) (*workspace.PluginInfo, error)
+	ResolvePlugin(spec workspace.PluginDescriptor) (*workspace.PluginInfo, error)
 
 	GetProjectPlugins() []workspace.ProjectPlugin
 
@@ -503,7 +503,7 @@ func (host *defaultHost) Provider(descriptor workspace.PackageDescriptor) (Provi
 		}
 
 		plug, err := NewProvider(
-			host, host.ctx, descriptor.PluginSpec,
+			host, host.ctx, descriptor.PluginDescriptor,
 			host.runtimeOptions, host.disableProviderPreview, string(jsonConfig), host.projectName)
 		if err == nil && plug != nil {
 			info, infoerr := plug.GetPluginInfo(host.ctx.Request())
@@ -581,7 +581,7 @@ func (host *defaultHost) LanguageRuntime(runtime string,
 
 // EnsurePlugins ensures all plugins in the given array are loaded and ready to use.  If any plugins are missing,
 // and/or there are errors loading one or more plugins, a non-nil error is returned.
-func (host *defaultHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds Flags) error {
+func (host *defaultHost) EnsurePlugins(plugins []workspace.PluginDescriptor, kinds Flags) error {
 	// Use a multieerror to track failures so we can return one big list of all failures at the end.
 	var result error
 	for _, plugin := range plugins {
@@ -602,7 +602,7 @@ func (host *defaultHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds Fla
 			}
 		case apitype.ResourcePlugin:
 			if kinds&ResourcePlugins != 0 {
-				if _, err := host.Provider(workspace.PackageDescriptor{PluginSpec: plugin}); err != nil {
+				if _, err := host.Provider(workspace.PackageDescriptor{PluginDescriptor: plugin}); err != nil {
 					result = multierror.Append(result,
 						fmt.Errorf("failed to load resource plugin %s: %w", plugin.Name, err))
 				}
@@ -615,7 +615,7 @@ func (host *defaultHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds Fla
 	return result
 }
 
-func (host *defaultHost) ResolvePlugin(spec workspace.PluginSpec) (*workspace.PluginInfo, error) {
+func (host *defaultHost) ResolvePlugin(spec workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
 	return workspace.GetPluginInfo(host.ctx.baseContext, host.ctx.Diag, spec, host.GetProjectPlugins())
 }
 

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -108,7 +108,7 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime, workingDirectory strin
 	} else {
 		path, err := workspace.GetPluginPath(
 			ctx.baseContext, ctx.Diag,
-			workspace.PluginSpec{
+			workspace.PluginDescriptor{
 				Name: strings.ReplaceAll(runtime, tokens.QNameDelimiter, "_"),
 				Kind: apitype.LanguagePlugin,
 			},
@@ -249,7 +249,7 @@ func (h *langhost) GetRequiredPackages(info ProgramInfo) ([]workspace.PackageDes
 			packages := make([]workspace.PackageDescriptor, len(plugins))
 			for i, plugin := range plugins {
 				packages[i] = workspace.PackageDescriptor{
-					PluginSpec: plugin,
+					PluginDescriptor: plugin,
 				}
 			}
 			return packages, nil
@@ -288,7 +288,7 @@ func (h *langhost) GetRequiredPackages(info ProgramInfo) ([]workspace.PackageDes
 		}
 
 		results = append(results, workspace.PackageDescriptor{
-			PluginSpec: workspace.PluginSpec{
+			PluginDescriptor: workspace.PluginDescriptor{
 				Name:              info.Name,
 				Kind:              apitype.PluginKind(info.Kind),
 				Version:           version,
@@ -305,7 +305,7 @@ func (h *langhost) GetRequiredPackages(info ProgramInfo) ([]workspace.PackageDes
 }
 
 // getRequiredPlugins computes the complete set of anticipated plugins required by a program.
-func (h *langhost) getRequiredPlugins(info ProgramInfo) ([]workspace.PluginSpec, error) {
+func (h *langhost) getRequiredPlugins(info ProgramInfo) ([]workspace.PluginDescriptor, error) {
 	logging.V(7).Infof("langhost[%v].GetRequiredPlugins(%s) executing",
 		h.runtime, info)
 
@@ -336,7 +336,7 @@ func (h *langhost) getRequiredPlugins(info ProgramInfo) ([]workspace.PluginSpec,
 		return nil, rpcError
 	}
 
-	results := slice.Prealloc[workspace.PluginSpec](len(resp.GetPlugins()))
+	results := slice.Prealloc[workspace.PluginDescriptor](len(resp.GetPlugins()))
 	for _, info := range resp.GetPlugins() {
 		var version *semver.Version
 		if v := info.GetVersion(); v != "" {
@@ -349,7 +349,7 @@ func (h *langhost) getRequiredPlugins(info ProgramInfo) ([]workspace.PluginSpec,
 		if !apitype.IsPluginKind(info.Kind) {
 			return nil, fmt.Errorf("unrecognized plugin kind: %s", info.Kind)
 		}
-		results = append(results, workspace.PluginSpec{
+		results = append(results, workspace.PluginDescriptor{
 			Name:              info.Name,
 			Kind:              apitype.PluginKind(info.Kind),
 			Version:           version,

--- a/sdk/go/common/resource/plugin/mock.go
+++ b/sdk/go/common/resource/plugin/mock.go
@@ -34,8 +34,8 @@ type MockHost struct {
 	ProviderF           func(descriptor workspace.PackageDescriptor) (Provider, error)
 	CloseProviderF      func(provider Provider) error
 	LanguageRuntimeF    func(runtime string) (LanguageRuntime, error)
-	EnsurePluginsF      func(plugins []workspace.PluginSpec, kinds Flags) error
-	ResolvePluginF      func(spec workspace.PluginSpec) (*workspace.PluginInfo, error)
+	EnsurePluginsF      func(plugins []workspace.PluginDescriptor, kinds Flags) error
+	ResolvePluginF      func(spec workspace.PluginDescriptor) (*workspace.PluginInfo, error)
 	GetProjectPluginsF  func() []workspace.ProjectPlugin
 	SignalCancellationF func() error
 	CloseF              func() error
@@ -106,7 +106,7 @@ func (m *MockHost) LanguageRuntime(runtime string) (LanguageRuntime, error) {
 	return nil, errors.New("LanguageRuntime not implemented")
 }
 
-func (m *MockHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds Flags) error {
+func (m *MockHost) EnsurePlugins(plugins []workspace.PluginDescriptor, kinds Flags) error {
 	if m.EnsurePluginsF != nil {
 		return m.EnsurePluginsF(plugins, kinds)
 	}
@@ -114,7 +114,7 @@ func (m *MockHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds Flags) er
 }
 
 func (m *MockHost) ResolvePlugin(
-	spec workspace.PluginSpec,
+	spec workspace.PluginDescriptor,
 ) (*workspace.PluginInfo, error) {
 	if m.ResolvePluginF != nil {
 		return m.ResolvePluginF(spec)

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -166,7 +166,7 @@ func GetProviderAttachPort(pkg tokens.Package) (*int, error) {
 
 // NewProvider attempts to bind to a given package's resource plugin and then creates a gRPC connection to it.  If the
 // plugin could not be found, or an error occurs while creating the child process, an error is returned.
-func NewProvider(host Host, ctx *Context, spec workspace.PluginSpec,
+func NewProvider(host Host, ctx *Context, spec workspace.PluginDescriptor,
 	options map[string]any, disableProviderPreview bool, jsonConfig string,
 	projectName tokens.PackageName,
 ) (Provider, error) {

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -153,14 +153,14 @@ func parsePluginDownloadURLOverrides(overrides string) (pluginDownloadOverrideAr
 // MissingError is returned by functions that attempt to load plugins if a plugin can't be located.
 type MissingError struct {
 	// PluginSpec of the plugin that couldn't be found.
-	spec PluginSpec
+	spec PluginDescriptor
 	// includeAmbient is true if we search $PATH for this plugin
 	includeAmbient bool
 }
 
 // NewMissingError allocates a new error indicating the given plugin info was not found.
 func NewMissingError(
-	spec PluginSpec, includeAmbient bool,
+	spec PluginDescriptor, includeAmbient bool,
 ) error {
 	return &MissingError{
 		spec:           spec,
@@ -890,7 +890,7 @@ type ProjectPlugin struct {
 }
 
 // Spec Return a PluginSpec object for this project plugin.
-func (pp ProjectPlugin) Spec(ctx context.Context) (PluginSpec, error) {
+func (pp ProjectPlugin) Spec(ctx context.Context) (PluginDescriptor, error) {
 	return NewPluginSpec(ctx, pp.Name, pp.Kind, pp.Version, "", nil)
 }
 
@@ -907,16 +907,16 @@ type LinkablePackageDescriptor struct {
 // that must be applied to that plugin in order to produce the package.
 type PackageDescriptor struct {
 	// A specification for the plugin that provides the package.
-	PluginSpec
+	PluginDescriptor
 
 	// An optional parameterization to apply to the providing plugin to produce
 	// the package.
 	Parameterization *Parameterization
 }
 
-func NewPackageDescriptor(spec PluginSpec, parameterization *Parameterization) PackageDescriptor {
+func NewPackageDescriptor(spec PluginDescriptor, parameterization *Parameterization) PackageDescriptor {
 	return PackageDescriptor{
-		PluginSpec:       spec,
+		PluginDescriptor: spec,
 		Parameterization: parameterization,
 	}
 }
@@ -996,8 +996,8 @@ type Parameterization struct {
 	Value []byte
 }
 
-// PluginSpec provides basic specification for a plugin.
-type PluginSpec struct {
+// PluginDescriptor is a resolved plugin, ready for download.
+type PluginDescriptor struct {
 	Name              string             // the simple name of the plugin.
 	Kind              apitype.PluginKind // the kind of the plugin (language, resource, etc).
 	Version           *semver.Version    // the plugin's semantic version, if present.
@@ -1029,7 +1029,7 @@ func NewPluginSpec(
 	version *semver.Version,
 	pluginDownloadURL string,
 	checksums map[string][]byte,
-) (PluginSpec, error) {
+) (PluginDescriptor, error) {
 	spec, inference, err := parsePluginSpec(ctx, source, kind)
 	if err != nil {
 		return spec, err
@@ -1037,14 +1037,14 @@ func NewPluginSpec(
 
 	if version != nil {
 		if inference.explicitVersion {
-			return PluginSpec{}, errors.New("cannot specify a version when the version is part of the name")
+			return PluginDescriptor{}, errors.New("cannot specify a version when the version is part of the name")
 		}
 		spec.Version = version
 	}
 
 	if pluginDownloadURL != "" {
 		if inference.explicitPluginDownloadURL {
-			return PluginSpec{}, errors.New("cannot specify a plugin download URL when the plugin name is a URL")
+			return PluginDescriptor{}, errors.New("cannot specify a plugin download URL when the plugin name is a URL")
 		}
 		spec.PluginDownloadURL = pluginDownloadURL
 	}
@@ -1060,7 +1060,7 @@ type parsePluginSpecInference struct {
 
 func parsePluginSpec(
 	ctx context.Context, source string, kind apitype.PluginKind,
-) (PluginSpec, parsePluginSpecInference, error) {
+) (PluginDescriptor, parsePluginSpecInference, error) {
 	if IsExternalURL(source) {
 		return parsePluginSpecFromURL(ctx, source, kind)
 	}
@@ -1078,7 +1078,7 @@ func (inference *parsePluginSpecInference) parseVersion(spec string, parse func(
 
 func parsePluginSpecFromURL(
 	ctx context.Context, spec string, kind apitype.PluginKind,
-) (PluginSpec, parsePluginSpecInference, error) {
+) (PluginDescriptor, parsePluginSpecInference, error) {
 	// Parse the version if available.  This can either be a simple semver version, or a git commit hash.
 	var version *semver.Version
 	var inference parsePluginSpecInference
@@ -1098,18 +1098,18 @@ func parsePluginSpecFromURL(
 		return fmt.Errorf("VERSION must be valid semver or git commit hash: %s", versionStr)
 	})
 	if err != nil {
-		return PluginSpec{}, inference, err
+		return PluginDescriptor{}, inference, err
 	}
 
 	parsedURL, err := url.Parse(spec)
 	if err != nil {
-		return PluginSpec{}, inference, fmt.Errorf("invalid URL: %w", err)
+		return PluginDescriptor{}, inference, fmt.Errorf("invalid URL: %w", err)
 	}
 	switch parsedURL.Scheme {
 	case "git", "https", "":
 		parsedURL.Scheme = "https"
 	default:
-		return PluginSpec{}, inference, errors.New(`unknown URL scheme: expected "git" or "https"`)
+		return PluginDescriptor{}, inference, errors.New(`unknown URL scheme: expected "git" or "https"`)
 	}
 	// We're purposely dropping any authentication info from the URL here. The name is used as
 	// the folder name for writing the plugin to disk, and we 1) don't want to write secrets
@@ -1122,12 +1122,12 @@ func parsePluginSpecFromURL(
 	}
 	nameURL, path, err := gitutil.ParseGitRepoURL(urlWithoutAuth.String())
 	if err != nil {
-		return PluginSpec{}, inference, err
+		return PluginDescriptor{}, inference, err
 	}
 	if path != "" {
 		path = "_" + path
 	}
-	pluginSpec := PluginSpec{
+	pluginSpec := PluginDescriptor{
 		Name:    strings.ReplaceAll(strings.TrimPrefix(nameURL, "https://")+path, "/", "_"),
 		Kind:    kind,
 		Version: version,
@@ -1144,7 +1144,7 @@ func parsePluginSpecFromURL(
 		var err error
 		gitURL, _, err := gitutil.ParseGitRepoURL(parsedURL.String())
 		if err != nil {
-			return PluginSpec{}, inference, err
+			return PluginDescriptor{}, inference, err
 		}
 		pluginSpec.Version, err = gitutil.GetLatestTagOrHash(ctx, gitURL)
 		if err != nil {
@@ -1157,7 +1157,7 @@ func parsePluginSpecFromURL(
 
 func parsePluginSpecFromName(
 	_ context.Context, spec string, kind apitype.PluginKind,
-) (PluginSpec, parsePluginSpecInference, error) {
+) (PluginDescriptor, parsePluginSpecInference, error) {
 	var version *semver.Version
 	var inference parsePluginSpecInference
 	// Parse the version if available.  This must be a simple semver version.
@@ -1170,7 +1170,7 @@ func parsePluginSpecFromName(
 		return nil
 	})
 
-	return PluginSpec{
+	return PluginDescriptor{
 		Name:    spec,
 		Kind:    kind,
 		Version: version,
@@ -1178,13 +1178,13 @@ func parsePluginSpecFromName(
 }
 
 // IsGitPlugin returns if the plugin comes from the git source
-func (spec PluginSpec) IsGitPlugin() bool {
+func (spec PluginDescriptor) IsGitPlugin() bool {
 	return strings.HasPrefix(spec.PluginDownloadURL, "git://")
 }
 
 // LocalName returns the local name of the plugin, which is used in the directory name, and a path
 // within that directory if the plugin is located in a subdirectory.
-func (spec PluginSpec) LocalName() (string, string) {
+func (spec PluginDescriptor) LocalName() (string, string) {
 	if spec.IsGitPlugin() {
 		trimmed := strings.TrimPrefix(spec.PluginDownloadURL, "git://")
 		url, path, err := gitutil.ParseGitRepoURL("https://" + strings.TrimPrefix(trimmed, "git://"))
@@ -1201,7 +1201,7 @@ func (spec PluginSpec) LocalName() (string, string) {
 }
 
 // Dir gets the expected plugin directory for this plugin.
-func (spec PluginSpec) Dir() string {
+func (spec PluginDescriptor) Dir() string {
 	localName, _ := spec.LocalName()
 	dir := fmt.Sprintf("%s-%s", spec.Kind, localName)
 	if spec.Version != nil {
@@ -1211,19 +1211,19 @@ func (spec PluginSpec) Dir() string {
 }
 
 // SubDir gets the expected subdirectory for this plugin.
-func (spec PluginSpec) SubDir() string {
+func (spec PluginDescriptor) SubDir() string {
 	_, path := spec.LocalName()
 	return path
 }
 
 // File gets the expected filename for this plugin, excluding any platform specific suffixes (e.g. ".exe" on
 // windows).
-func (spec PluginSpec) File() string {
+func (spec PluginDescriptor) File() string {
 	return fmt.Sprintf("pulumi-%s-%s", spec.Kind, spec.Name)
 }
 
 // DirPath returns the directory where this plugin should be installed.
-func (spec PluginSpec) DirPath() (string, error) {
+func (spec PluginDescriptor) DirPath() (string, error) {
 	dir, err := GetPluginDir()
 	if err != nil {
 		return "", err
@@ -1234,7 +1234,7 @@ func (spec PluginSpec) DirPath() (string, error) {
 
 // LockFilePath returns the full path to the plugin's lock file used during installation
 // to prevent concurrent installs.
-func (spec PluginSpec) LockFilePath() (string, error) {
+func (spec PluginDescriptor) LockFilePath() (string, error) {
 	dir, err := spec.DirPath()
 	if err != nil {
 		return "", err
@@ -1244,7 +1244,7 @@ func (spec PluginSpec) LockFilePath() (string, error) {
 
 // PartialFilePath returns the full path to the plugin's partial file used during installation
 // to indicate installation of the plugin hasn't completed yet.
-func (spec PluginSpec) PartialFilePath() (string, error) {
+func (spec PluginDescriptor) PartialFilePath() (string, error) {
 	dir, err := spec.DirPath()
 	if err != nil {
 		return "", err
@@ -1252,7 +1252,7 @@ func (spec PluginSpec) PartialFilePath() (string, error) {
 	return dir + ".partial", nil
 }
 
-func (spec PluginSpec) String() string {
+func (spec PluginDescriptor) String() string {
 	var version string
 	if v := spec.Version; v != nil {
 		version = fmt.Sprintf("-%s", v)
@@ -1291,8 +1291,8 @@ func (info *PluginInfo) Size() uint64 {
 }
 
 // Spec returns the PluginSpec for this PluginInfo
-func (info *PluginInfo) Spec() PluginSpec {
-	return PluginSpec{Name: info.Name, Kind: info.Kind, Version: info.Version}
+func (info *PluginInfo) Spec() PluginDescriptor {
+	return PluginDescriptor{Name: info.Name, Kind: info.Kind, Version: info.Version}
 }
 
 func (info PluginInfo) String() string {
@@ -1368,7 +1368,7 @@ func newPluginSource(name string, kind apitype.PluginKind, pluginDownloadURL str
 	}
 }
 
-func (spec PluginSpec) GetSource() (PluginSource, error) {
+func (spec PluginDescriptor) GetSource() (PluginSource, error) {
 	var source PluginSource
 	var err error
 
@@ -1401,7 +1401,7 @@ func (spec PluginSpec) GetSource() (PluginSource, error) {
 
 // GetLatestVersion tries to find the latest version for this plugin. This is currently only supported for
 // plugins we can get from github releases. The context allows for I/O cancellation.
-func (spec PluginSpec) GetLatestVersion(ctx context.Context) (*semver.Version, error) {
+func (spec PluginDescriptor) GetLatestVersion(ctx context.Context) (*semver.Version, error) {
 	source, err := spec.GetSource()
 	if err != nil {
 		return nil, err
@@ -1411,7 +1411,7 @@ func (spec PluginSpec) GetLatestVersion(ctx context.Context) (*semver.Version, e
 
 // Download fetches an io.ReadCloser for this plugin and also returns the size of the response (if known).
 // The context allows for I/O cancellation.
-func (spec PluginSpec) Download(ctx context.Context) (io.ReadCloser, int64, error) {
+func (spec PluginDescriptor) Download(ctx context.Context) (io.ReadCloser, int64, error) {
 	// Figure out the OS/ARCH pair for the download URL.
 	var opSy string
 	switch runtime.GOOS {
@@ -1604,7 +1604,9 @@ func (d *pluginDownloader) copyBuffer(dst io.Writer, src io.Reader) (written int
 	}
 }
 
-func (d *pluginDownloader) tryDownload(ctx context.Context, pkgPlugin PluginSpec, dst io.WriteCloser) (error, error) {
+func (d *pluginDownloader) tryDownload(
+	ctx context.Context, pkgPlugin PluginDescriptor, dst io.WriteCloser,
+) (error, error) {
 	defer dst.Close()
 	tarball, expectedByteCount, err := pkgPlugin.Download(ctx)
 	if err != nil {
@@ -1625,7 +1627,7 @@ func (d *pluginDownloader) tryDownload(ctx context.Context, pkgPlugin PluginSpec
 	return nil, nil
 }
 
-func (d *pluginDownloader) tryDownloadToFile(ctx context.Context, pkgPlugin PluginSpec) (string, error, error) {
+func (d *pluginDownloader) tryDownloadToFile(ctx context.Context, pkgPlugin PluginDescriptor) (string, error, error) {
 	file, err := os.CreateTemp("" /* default temp dir */, "pulumi-plugin-tar")
 	if err != nil {
 		return "", nil, err
@@ -1648,7 +1650,7 @@ func (d *pluginDownloader) tryDownloadToFile(ctx context.Context, pkgPlugin Plug
 	return file.Name(), nil, nil
 }
 
-func (d *pluginDownloader) downloadToFileWithRetry(ctx context.Context, pkgPlugin PluginSpec) (string, error) {
+func (d *pluginDownloader) downloadToFileWithRetry(ctx context.Context, pkgPlugin PluginDescriptor) (string, error) {
 	delay := 80 * time.Millisecond
 	backoff := 2.0
 	maxAttempts := 5
@@ -1701,7 +1703,7 @@ func (d *pluginDownloader) downloadToFileWithRetry(ctx context.Context, pkgPlugi
 
 // DownloadToFile downloads the given PluginSpec to a temporary file and returns that temporary file. This has
 // some retry logic to re-attempt the download if it errors for any reason.
-func (d *pluginDownloader) DownloadToFile(ctx context.Context, pkgPlugin PluginSpec) (*os.File, error) {
+func (d *pluginDownloader) DownloadToFile(ctx context.Context, pkgPlugin PluginDescriptor) (*os.File, error) {
 	tarball, err := d.downloadToFileWithRetry(ctx, pkgPlugin)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download plugin: %s: %w", pkgPlugin, err)
@@ -1718,7 +1720,7 @@ func (d *pluginDownloader) DownloadToFile(ctx context.Context, pkgPlugin PluginS
 // may be used for cancellable I/O.
 func DownloadToFile(
 	ctx context.Context,
-	pkgPlugin PluginSpec,
+	pkgPlugin PluginDescriptor,
 	wrapper func(stream io.ReadCloser, size int64) io.ReadCloser,
 	retry func(err error, attempt int, limit int, delay time.Duration),
 ) (*os.File, error) {
@@ -1753,7 +1755,7 @@ func IsPluginKind(k string) bool {
 }
 
 // HasPlugin returns true if the given plugin exists.
-func HasPlugin(spec PluginSpec) bool {
+func HasPlugin(spec PluginDescriptor) bool {
 	dir, err := spec.DirPath()
 	if err == nil {
 		_, err := os.Stat(dir)
@@ -1770,7 +1772,7 @@ func HasPlugin(spec PluginSpec) bool {
 }
 
 // HasPluginGTE returns true if the given plugin exists at the given version number or greater.
-func HasPluginGTE(spec PluginSpec) (bool, error) {
+func HasPluginGTE(spec PluginDescriptor) (bool, error) {
 	// If an exact match, return true right away.
 	if HasPlugin(spec) {
 		return true, nil
@@ -1908,7 +1910,7 @@ func IsPluginBundled(kind apitype.PluginKind, name string) bool {
 // is >= the version specified.  If no version is supplied, the latest plugin for that given kind/name pair is loaded,
 // using standard semver sorting rules.  A plugin may be overridden entirely by placing it on your $PATH, though it is
 // possible to opt out of this behavior by setting PULUMI_IGNORE_AMBIENT_PLUGINS to any non-empty value.
-func GetPluginPath(ctx context.Context, d diag.Sink, spec PluginSpec, projectPlugins []ProjectPlugin,
+func GetPluginPath(ctx context.Context, d diag.Sink, spec PluginDescriptor, projectPlugins []ProjectPlugin,
 ) (string, error) {
 	info, path, err := getPluginInfoAndPath(ctx, d, spec, true /* skipMetadata */, projectPlugins)
 	if err != nil {
@@ -1920,7 +1922,7 @@ func GetPluginPath(ctx context.Context, d diag.Sink, spec PluginSpec, projectPlu
 	return path, err
 }
 
-func GetPluginInfo(ctx context.Context, d diag.Sink, spec PluginSpec, projectPlugins []ProjectPlugin,
+func GetPluginInfo(ctx context.Context, d diag.Sink, spec PluginDescriptor, projectPlugins []ProjectPlugin,
 ) (*PluginInfo, error) {
 	info, path, err := getPluginInfoAndPath(ctx, d, spec, false, projectPlugins)
 	if err != nil {
@@ -1956,7 +1958,7 @@ func getPluginPath(info *PluginInfo) string {
 func getPluginInfoAndPath(
 	ctx context.Context,
 	d diag.Sink,
-	spec PluginSpec, skipMetadata bool,
+	spec PluginDescriptor, skipMetadata bool,
 	projectPlugins []ProjectPlugin,
 ) (*PluginInfo, string, error) {
 	filename := spec.File()
@@ -2161,7 +2163,7 @@ func (sp SortedPluginInfo) Swap(i, j int) { sp[i], sp[j] = sp[j], sp[i] }
 // SelectPrereleasePlugin selects a plugin from the list of plugins, which matches the exact version we
 // are looking for, based on the commit hash.
 func SelectPrereleasePlugin(
-	plugins []PluginInfo, spec PluginSpec,
+	plugins []PluginInfo, spec PluginDescriptor,
 ) *PluginInfo {
 	name, _ := spec.LocalName()
 	for _, cur := range plugins {
@@ -2179,7 +2181,7 @@ func SelectPrereleasePlugin(
 // If there exist plugins in the plugin list that don't have a version, LegacySelectCompatiblePlugin will select
 // them if there are no other compatible plugins available.
 func LegacySelectCompatiblePlugin(
-	plugins []PluginInfo, spec PluginSpec,
+	plugins []PluginInfo, spec PluginDescriptor,
 ) *PluginInfo {
 	name, _ := spec.LocalName()
 	var match *PluginInfo
@@ -2245,7 +2247,7 @@ func LegacySelectCompatiblePlugin(
 // If there exist plugins in the plugin list that don't have a version, SelectCompatiblePlugin will select them if there
 // are no other compatible plugins available.
 func SelectCompatiblePlugin(
-	plugins []PluginInfo, spec PluginSpec,
+	plugins []PluginInfo, spec PluginDescriptor,
 ) *PluginInfo {
 	name, _ := spec.LocalName()
 	logging.V(7).Infof("SelectCompatiblePlugin(..., %s): beginning", name)

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -141,7 +141,7 @@ func TestLegacyPluginSelection_Prerelease(t *testing.T) {
 	}
 
 	result := LegacySelectCompatiblePlugin(candidatePlugins,
-		PluginSpec{Kind: apitype.ResourcePlugin, Name: "myplugin", Version: nil})
+		PluginDescriptor{Kind: apitype.ResourcePlugin, Name: "myplugin", Version: nil})
 	require.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Equal(t, "0.2.0", result.Version.String())
@@ -183,7 +183,7 @@ func TestLegacyPluginSelection_PrereleaseRequested(t *testing.T) {
 
 	v := semver.MustParse("0.2.0")
 	result := LegacySelectCompatiblePlugin(candidatePlugins,
-		PluginSpec{Kind: apitype.ResourcePlugin, Name: "myplugin", Version: &v})
+		PluginDescriptor{Kind: apitype.ResourcePlugin, Name: "myplugin", Version: &v})
 	require.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Equal(t, "0.3.0-alpha", result.Version.String())
@@ -225,7 +225,7 @@ func TestPluginSelection_ExactMatch(t *testing.T) {
 
 	version := semver.MustParse("0.2.0")
 	result := SelectCompatiblePlugin(candidatePlugins,
-		PluginSpec{Kind: apitype.ResourcePlugin, Name: "myplugin", Version: &version})
+		PluginDescriptor{Kind: apitype.ResourcePlugin, Name: "myplugin", Version: &version})
 	require.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Equal(t, "0.2.0", result.Version.String())
@@ -267,7 +267,7 @@ func TestPluginSelection_ExactMatchNotFound(t *testing.T) {
 
 	version := semver.MustParse("0.2.0")
 	result := SelectCompatiblePlugin(candidatePlugins,
-		PluginSpec{Kind: apitype.ResourcePlugin, Name: "myplugin", Version: &version})
+		PluginDescriptor{Kind: apitype.ResourcePlugin, Name: "myplugin", Version: &version})
 	assert.Nil(t, result)
 }
 
@@ -312,7 +312,7 @@ func TestPluginSelection_EmptyVersionNoAlternatives(t *testing.T) {
 
 	version := semver.MustParse("0.2.0")
 	result := SelectCompatiblePlugin(candidatePlugins,
-		PluginSpec{Kind: apitype.ResourcePlugin, Name: "myplugin", Version: &version})
+		PluginDescriptor{Kind: apitype.ResourcePlugin, Name: "myplugin", Version: &version})
 	require.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Nil(t, result.Version)
@@ -364,7 +364,7 @@ func TestPluginSelection_EmptyVersionWithAlternatives(t *testing.T) {
 
 	version := semver.MustParse("0.2.0")
 	result := SelectCompatiblePlugin(candidatePlugins,
-		PluginSpec{Kind: apitype.ResourcePlugin, Name: "myplugin", Version: &version})
+		PluginDescriptor{Kind: apitype.ResourcePlugin, Name: "myplugin", Version: &version})
 	require.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Equal(t, "0.2.0", result.Version.String())
@@ -386,7 +386,7 @@ func TestPluginDownload(t *testing.T) {
 	t.Run("Pulumi GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", "")
 		version := semver.MustParse("4.30.0")
-		spec := PluginSpec{
+		spec := PluginDescriptor{
 			PluginDownloadURL: "",
 			Name:              "mockdl",
 			Version:           &version,
@@ -427,7 +427,7 @@ func TestPluginDownload(t *testing.T) {
 	})
 	t.Run("get.pulumi.com", func(t *testing.T) {
 		version := semver.MustParse("4.32.0")
-		spec := PluginSpec{
+		spec := PluginDescriptor{
 			PluginDownloadURL: "",
 			Name:              "otherdl",
 			Version:           &version,
@@ -454,7 +454,7 @@ func TestPluginDownload(t *testing.T) {
 	})
 	t.Run("Custom http URL", func(t *testing.T) {
 		version := semver.MustParse("4.32.0")
-		spec := PluginSpec{
+		spec := PluginDescriptor{
 			PluginDownloadURL: "http://customurl.jfrog.io/artifactory/pulumi-packages/package-name/v${VERSION}/${OS}/${ARCH}",
 			Name:              "mockdl",
 			Version:           &version,
@@ -478,7 +478,7 @@ func TestPluginDownload(t *testing.T) {
 	})
 	t.Run("Custom https URL", func(t *testing.T) {
 		version := semver.MustParse("4.32.0")
-		spec := PluginSpec{
+		spec := PluginDescriptor{
 			PluginDownloadURL: "https://customurl.jfrog.io/artifactory/pulumi-packages/" +
 				"package-name/${NAME}/v${VERSION}/${OS}/${ARCH}/",
 			Name:    "mockdl",
@@ -504,7 +504,7 @@ func TestPluginDownload(t *testing.T) {
 	t.Run("Private Pulumi GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", token)
 		version := semver.MustParse("4.32.0")
-		spec := PluginSpec{
+		spec := PluginDescriptor{
 			PluginDownloadURL: "",
 			Name:              "mockdl",
 			Version:           &version,
@@ -547,7 +547,7 @@ func TestPluginDownload(t *testing.T) {
 	t.Run("Internal GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", token)
 		version := semver.MustParse("4.32.0")
-		spec := PluginSpec{
+		spec := PluginDescriptor{
 			PluginDownloadURL: "github://api.git.org/ourorg/mock",
 			Name:              "mockdl",
 			Version:           &version,
@@ -623,7 +623,7 @@ func TestPluginDownload(t *testing.T) {
 		chksum := "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81" //nolint:gosec
 
 		t.Run("Invalid Checksum", func(t *testing.T) {
-			spec := PluginSpec{
+			spec := PluginDescriptor{
 				PluginDownloadURL: "",
 				Name:              "mockdl",
 				Version:           &version,
@@ -646,7 +646,7 @@ func TestPluginDownload(t *testing.T) {
 			checksum, err := hex.DecodeString(chksum)
 			require.NoError(t, err)
 
-			spec := PluginSpec{
+			spec := PluginDescriptor{
 				PluginDownloadURL: "",
 				Name:              "mockdl",
 				Version:           &version,
@@ -671,7 +671,7 @@ func TestPluginDownload(t *testing.T) {
 			// 1. Behave as if no checksums were specified at all, and simply fall back to not checking anything.
 			// 2. Error that the checksum for the current platform is missing.
 			// We choose to do the former, for now as that's more lenient.
-			spec := PluginSpec{
+			spec := PluginDescriptor{
 				PluginDownloadURL: "",
 				Name:              "mockdl",
 				Version:           &version,
@@ -693,7 +693,7 @@ func TestPluginDownload(t *testing.T) {
 	t.Run("GitLab Releases", func(t *testing.T) {
 		t.Setenv("GITLAB_TOKEN", token)
 		version := semver.MustParse("1.23.4")
-		spec := PluginSpec{
+		spec := PluginDescriptor{
 			PluginDownloadURL: "gitlab://gitlab.com/278964",
 			Name:              "mock-gitlab",
 			Version:           &version,
@@ -719,7 +719,7 @@ func TestPluginDownload(t *testing.T) {
 	t.Run("GitHub Releases with invalid token", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", token)
 		version := semver.MustParse("4.32.0")
-		spec := PluginSpec{
+		spec := PluginDescriptor{
 			PluginDownloadURL: "",
 			Name:              "mockdl",
 			Version:           &version,
@@ -770,7 +770,7 @@ func TestPluginDownload(t *testing.T) {
 	t.Run("GitHub Releases with disallowed", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", token)
 		version := semver.MustParse("5.32.0")
-		spec := PluginSpec{
+		spec := PluginDescriptor{
 			PluginDownloadURL: "",
 			Name:              "mockdl",
 			Version:           &version,
@@ -829,7 +829,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 
 	t.Run("Pulumi GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", "")
-		spec := PluginSpec{
+		spec := PluginDescriptor{
 			PluginDownloadURL: "",
 			Name:              "mock-latest",
 			Kind:              apitype.PluginKind("resource"),
@@ -851,7 +851,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		assert.Equal(t, expectedVersion, *version)
 	})
 	t.Run("Custom http URL", func(t *testing.T) {
-		spec := PluginSpec{
+		spec := PluginDescriptor{
 			PluginDownloadURL: "http://customurl.jfrog.io/artifactory/pulumi-packages/package-name",
 			Name:              "mock-latest",
 			Kind:              apitype.PluginKind("resource"),
@@ -863,7 +863,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		assert.EqualError(t, err, "GetLatestVersion is not supported for plugins from http sources")
 	})
 	t.Run("Custom https URL", func(t *testing.T) {
-		spec := PluginSpec{
+		spec := PluginDescriptor{
 			PluginDownloadURL: "https://customurl.jfrog.io/artifactory/pulumi-packages/package-name",
 			Name:              "mock-latest",
 			Kind:              apitype.PluginKind("resource"),
@@ -876,7 +876,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 	})
 	t.Run("Private Pulumi GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", token)
-		spec := PluginSpec{
+		spec := PluginDescriptor{
 			PluginDownloadURL: "",
 			Name:              "mock-private",
 			Kind:              apitype.PluginKind("resource"),
@@ -902,7 +902,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 	})
 	t.Run("Internal GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", token)
-		spec := PluginSpec{
+		spec := PluginDescriptor{
 			PluginDownloadURL: "github://api.git.org/ourorg/mock",
 			Name:              "mock-private",
 			Kind:              apitype.PluginKind("resource"),
@@ -928,7 +928,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 	})
 	t.Run("GitLab Releases", func(t *testing.T) {
 		t.Setenv("GITLAB_TOKEN", token)
-		spec := PluginSpec{
+		spec := PluginDescriptor{
 			PluginDownloadURL: "gitlab://gitlab.com/278964",
 			Name:              "mock-gitlab",
 			Kind:              apitype.PluginKind("resource"),
@@ -955,7 +955,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 	})
 	t.Run("Hit GitHub ratelimit", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", "")
-		spec := PluginSpec{
+		spec := PluginDescriptor{
 			PluginDownloadURL: "",
 			Name:              "mock-latest",
 			Kind:              apitype.PluginKind("resource"),
@@ -1242,7 +1242,7 @@ func TestDownloadToFile_retries(t *testing.T) {
 
 	// Create a fake plugin.
 	version := semver.MustParse("1.0.0")
-	spec := PluginSpec{
+	spec := PluginDescriptor{
 		Name:              "myplugin",
 		Kind:              apitype.LanguagePlugin,
 		Version:           &version,
@@ -1302,7 +1302,7 @@ plugins:
 func TestPluginSpec_GetSource(t *testing.T) {
 	tests := []struct {
 		name               string
-		spec               PluginSpec
+		spec               PluginDescriptor
 		overrides          pluginDownloadOverrideArray
 		expectedSourceType string
 		expectedURL        string
@@ -1310,7 +1310,7 @@ func TestPluginSpec_GetSource(t *testing.T) {
 	}{
 		{
 			name: "Use PluginDownloadURL (HTTP)",
-			spec: PluginSpec{
+			spec: PluginDescriptor{
 				Name:              "test-plugin",
 				Kind:              apitype.PluginKind("resource"),
 				PluginDownloadURL: "https://example.com/test-plugin",
@@ -1320,7 +1320,7 @@ func TestPluginSpec_GetSource(t *testing.T) {
 		},
 		{
 			name: "Use PluginDownloadURL (GitHub)",
-			spec: PluginSpec{
+			spec: PluginDescriptor{
 				Name:              "test-plugin",
 				Kind:              apitype.PluginKind("resource"),
 				PluginDownloadURL: "github://api.github.com/owner/repo",
@@ -1330,7 +1330,7 @@ func TestPluginSpec_GetSource(t *testing.T) {
 		},
 		{
 			name: "Use PluginDownloadURL (GitLab)",
-			spec: PluginSpec{
+			spec: PluginDescriptor{
 				Name:              "test-plugin",
 				Kind:              apitype.PluginKind("resource"),
 				PluginDownloadURL: "gitlab://mygitlab.example.com/proj1",
@@ -1340,7 +1340,7 @@ func TestPluginSpec_GetSource(t *testing.T) {
 		},
 		{
 			name: "Use PluginDownloadURL (Git)",
-			spec: PluginSpec{
+			spec: PluginDescriptor{
 				Name:              "test-plugin",
 				Kind:              apitype.PluginKind("resource"),
 				PluginDownloadURL: "git://github.com/test/test",
@@ -1350,7 +1350,7 @@ func TestPluginSpec_GetSource(t *testing.T) {
 		},
 		{
 			name: "Use fallback source",
-			spec: PluginSpec{
+			spec: PluginDescriptor{
 				Name: "test-plugin",
 				Kind: apitype.PluginKind("resource"),
 			},
@@ -1359,7 +1359,7 @@ func TestPluginSpec_GetSource(t *testing.T) {
 		},
 		{
 			name: "Apply override (HTTP)",
-			spec: PluginSpec{
+			spec: PluginDescriptor{
 				Name: "test-plugin",
 				Kind: apitype.PluginKind("resource"),
 			},
@@ -1371,7 +1371,7 @@ func TestPluginSpec_GetSource(t *testing.T) {
 		},
 		{
 			name: "Apply override (GitHub)",
-			spec: PluginSpec{
+			spec: PluginDescriptor{
 				Name: "test-plugin",
 				Kind: apitype.PluginKind("resource"),
 			},
@@ -1383,7 +1383,7 @@ func TestPluginSpec_GetSource(t *testing.T) {
 		},
 		{
 			name: "Apply checksums",
-			spec: PluginSpec{
+			spec: PluginDescriptor{
 				Name:      "test-plugin",
 				Kind:      apitype.PluginKind("resource"),
 				Checksums: map[string][]byte{"checksum1": []byte("checksum2")},
@@ -1393,7 +1393,7 @@ func TestPluginSpec_GetSource(t *testing.T) {
 		},
 		{
 			name: "Invalid URL",
-			spec: PluginSpec{
+			spec: PluginDescriptor{
 				Name:              "test-plugin",
 				Kind:              apitype.PluginKind("resource"),
 				PluginDownloadURL: "://invalid-url",
@@ -1402,7 +1402,7 @@ func TestPluginSpec_GetSource(t *testing.T) {
 		},
 		{
 			name: "Unknown scheme",
-			spec: PluginSpec{
+			spec: PluginDescriptor{
 				Name:              "test-plugin",
 				Kind:              apitype.PluginKind("resource"),
 				PluginDownloadURL: "unknown://example.com/plugin",
@@ -1508,7 +1508,7 @@ func TestMissingErrorText(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			err := NewMissingError(
-				PluginSpec{
+				PluginDescriptor{
 					Kind:              tt.Plugin.Kind,
 					Name:              tt.Plugin.Name,
 					Version:           tt.Plugin.Version,
@@ -1547,13 +1547,13 @@ func TestBundledPluginSearch(t *testing.T) {
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(ctx, d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
+	path, err := GetPluginPath(ctx, d, PluginDescriptor{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, ambientPath, path)
 
 	// Lookup the plugin with ambient search turned off
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "true")
-	path, err = GetPluginPath(ctx, d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
+	path, err = GetPluginPath(ctx, d, PluginDescriptor{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, bundledPath, path)
 }
@@ -1576,7 +1576,7 @@ func TestAmbientPluginsWarn(t *testing.T) {
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(ctx, d, PluginSpec{Name: "mock", Kind: apitype.ResourcePlugin}, nil)
+	path, err := GetPluginPath(ctx, d, PluginDescriptor{Name: "mock", Kind: apitype.ResourcePlugin}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, ambientPath, path)
 
@@ -1620,7 +1620,7 @@ func TestAmbientBundledPluginsWarn(t *testing.T) {
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(ctx, d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
+	path, err := GetPluginPath(ctx, d, PluginDescriptor{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, ambientPath, path)
 
@@ -1657,7 +1657,7 @@ func TestBundledPluginsDoNotWarn(t *testing.T) {
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(ctx, d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
+	path, err := GetPluginPath(ctx, d, PluginDescriptor{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, bundledPath, path)
 
@@ -1697,7 +1697,7 @@ func TestSymlinkPathPluginsDoNotWarn(t *testing.T) {
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(ctx, d, PluginSpec{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
+	path, err := GetPluginPath(ctx, d, PluginDescriptor{Name: "nodejs", Kind: apitype.LanguagePlugin}, nil)
 	require.NoError(t, err)
 	// We expect the ambient path to be returned, but not to warn because it resolves to the same file as the
 	// bundled path.
@@ -1731,7 +1731,7 @@ func TestPluginInfoShimless(t *testing.T) {
 		diag.FormatOptions{Color: "never"},
 	)
 
-	info, err := GetPluginInfo(ctx, d, PluginSpec{Kind: apitype.ResourcePlugin, Name: "mock"}, []ProjectPlugin{
+	info, err := GetPluginInfo(ctx, d, PluginDescriptor{Kind: apitype.ResourcePlugin, Name: "mock"}, []ProjectPlugin{
 		{
 			Name: "mock",
 			Kind: apitype.ResourcePlugin,
@@ -1755,7 +1755,7 @@ func TestProjectPluginsWithUncleanPath(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(ctx, diagtest.LogSink(t), PluginSpec{Kind: apitype.ResourcePlugin, Name: "aws"},
+	path, err := GetPluginPath(ctx, diagtest.LogSink(t), PluginDescriptor{Kind: apitype.ResourcePlugin, Name: "aws"},
 		[]ProjectPlugin{
 			{
 				Name: "aws",
@@ -1779,7 +1779,7 @@ func TestProjectPluginsWithSymlink(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(ctx, diagtest.LogSink(t), PluginSpec{Kind: apitype.ResourcePlugin, Name: "aws"},
+	path, err := GetPluginPath(ctx, diagtest.LogSink(t), PluginDescriptor{Kind: apitype.ResourcePlugin, Name: "aws"},
 		[]ProjectPlugin{
 			{
 				Name: "aws",
@@ -1802,14 +1802,14 @@ func TestNewPluginSpec(t *testing.T) {
 		version            *semver.Version
 		kind               apitype.PluginKind
 		pluginDownloadURL  string
-		ExpectedPluginSpec PluginSpec
+		ExpectedPluginSpec PluginDescriptor
 		Error              error
 	}{
 		{
 			name:   "regular plugin",
 			source: "pulumi-example",
 			kind:   apitype.ResourcePlugin,
-			ExpectedPluginSpec: PluginSpec{
+			ExpectedPluginSpec: PluginDescriptor{
 				Name:              "pulumi-example",
 				Kind:              apitype.ResourcePlugin,
 				Version:           nil,
@@ -1821,7 +1821,7 @@ func TestNewPluginSpec(t *testing.T) {
 			name:   "plugin with version",
 			source: "pulumi-example@v1.0.0",
 			kind:   apitype.ResourcePlugin,
-			ExpectedPluginSpec: PluginSpec{
+			ExpectedPluginSpec: PluginDescriptor{
 				Name:              "pulumi-example",
 				Kind:              apitype.ResourcePlugin,
 				Version:           &v1,
@@ -1839,7 +1839,7 @@ func TestNewPluginSpec(t *testing.T) {
 			name:   "git plugin with version",
 			source: "github.com/pulumi/pulumi-example@v1.0.0",
 			kind:   apitype.ResourcePlugin,
-			ExpectedPluginSpec: PluginSpec{
+			ExpectedPluginSpec: PluginDescriptor{
 				Name:              "github.com_pulumi_pulumi-example.git",
 				Kind:              apitype.ResourcePlugin,
 				Version:           &v1,
@@ -1851,7 +1851,7 @@ func TestNewPluginSpec(t *testing.T) {
 			name:   "git plugin with commit hash version",
 			source: "github.com/pulumi/pulumi-example@deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 			kind:   apitype.ResourcePlugin,
-			ExpectedPluginSpec: PluginSpec{
+			ExpectedPluginSpec: PluginDescriptor{
 				Name:              "github.com_pulumi_pulumi-example.git",
 				Kind:              apitype.ResourcePlugin,
 				Version:           &v0deadbeef,
@@ -1869,7 +1869,7 @@ func TestNewPluginSpec(t *testing.T) {
 			name:   "https prefixed git plugin with version",
 			source: "https://github.com/pulumi/pulumi-example@v1.0.0",
 			kind:   apitype.ResourcePlugin,
-			ExpectedPluginSpec: PluginSpec{
+			ExpectedPluginSpec: PluginDescriptor{
 				Name:              "github.com_pulumi_pulumi-example.git",
 				Kind:              apitype.ResourcePlugin,
 				Version:           &v1,
@@ -1881,7 +1881,7 @@ func TestNewPluginSpec(t *testing.T) {
 			name:   "https prefixed git plugin with commit hash version",
 			source: "https://github.com/pulumi/pulumi-example@deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 			kind:   apitype.ResourcePlugin,
-			ExpectedPluginSpec: PluginSpec{
+			ExpectedPluginSpec: PluginDescriptor{
 				Name:              "github.com_pulumi_pulumi-example.git",
 				Kind:              apitype.ResourcePlugin,
 				Version:           &v0deadbeef,
@@ -1899,7 +1899,7 @@ func TestNewPluginSpec(t *testing.T) {
 			name:   "https:// prefixed with no . in URL",
 			source: "https://localhost/test/repo@v1.0.0",
 			kind:   apitype.ResourcePlugin,
-			ExpectedPluginSpec: PluginSpec{
+			ExpectedPluginSpec: PluginDescriptor{
 				Name:              "localhost_test_repo.git",
 				Kind:              apitype.ResourcePlugin,
 				PluginDownloadURL: "git://localhost/test/repo",
@@ -1910,7 +1910,7 @@ func TestNewPluginSpec(t *testing.T) {
 			name:   "no . in URL gets treated as local path",
 			source: "localhost/test/repo",
 			kind:   apitype.ResourcePlugin,
-			ExpectedPluginSpec: PluginSpec{
+			ExpectedPluginSpec: PluginDescriptor{
 				Name: "localhost/test/repo",
 				Kind: apitype.ResourcePlugin,
 			},
@@ -1919,7 +1919,7 @@ func TestNewPluginSpec(t *testing.T) {
 			name:   "local plugin",
 			source: "./test/plugin",
 			kind:   apitype.ResourcePlugin,
-			ExpectedPluginSpec: PluginSpec{
+			ExpectedPluginSpec: PluginDescriptor{
 				Name:              "./test/plugin",
 				Kind:              apitype.ResourcePlugin,
 				Version:           nil,
@@ -1931,7 +1931,7 @@ func TestNewPluginSpec(t *testing.T) {
 			name:   "local plugin absolute path",
 			source: "/test/plugin",
 			kind:   apitype.ResourcePlugin,
-			ExpectedPluginSpec: PluginSpec{
+			ExpectedPluginSpec: PluginDescriptor{
 				Name:              "/test/plugin",
 				Kind:              apitype.ResourcePlugin,
 				Version:           nil,
@@ -1951,7 +1951,7 @@ func TestNewPluginSpec(t *testing.T) {
 			source:  "plugin",
 			kind:    apitype.ResourcePlugin,
 			version: &v1,
-			ExpectedPluginSpec: PluginSpec{
+			ExpectedPluginSpec: PluginDescriptor{
 				Name:              "plugin",
 				Kind:              apitype.ResourcePlugin,
 				Version:           &v1,
@@ -1976,7 +1976,7 @@ func TestNewPluginSpec(t *testing.T) {
 			name:   "url with auth info",
 			source: "https://abc:token@github.com/pulumi/pulumi-example@v1.0.0",
 			kind:   apitype.ResourcePlugin,
-			ExpectedPluginSpec: PluginSpec{
+			ExpectedPluginSpec: PluginDescriptor{
 				Name:              "github.com_pulumi_pulumi-example.git",
 				Kind:              apitype.ResourcePlugin,
 				Version:           &v1,
@@ -2195,7 +2195,7 @@ func TestLocalName(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			spec := PluginSpec{
+			spec := PluginDescriptor{
 				Name:              c.pluginName,
 				PluginDownloadURL: c.pluginDownloadURL,
 			}


### PR DESCRIPTION
This brings naming consistency with `workspace.PackageDescriptor`. The new name is more
consistent with our naming scheme, since we use the `*Spec` prefix to indicate that
something is in it's serialization format, not yet parsed (see `schema.PackageSpec`,
`schema.Package`).