### PR TITLE
`(plugin.Host).Provider` now accepts `workspace.PluginDescriptor`

### DIFF
--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -294,20 +294,11 @@ func (l *providerLoader) LoadPackageReferenceV2(
 	}
 
 	// Defer to the host to find the provider for the given package descriptor.
-	workspaceDescriptor := workspace.PackageDescriptor{
-		PluginDescriptor: workspace.PluginDescriptor{
-			Kind:              apitype.ResourcePlugin,
-			Name:              descriptor.Name,
-			Version:           descriptor.Version,
-			PluginDownloadURL: descriptor.DownloadURL,
-		},
-	}
-	if descriptor.Parameterization != nil {
-		workspaceDescriptor.Parameterization = &workspace.Parameterization{
-			Name:    descriptor.Parameterization.Name,
-			Version: descriptor.Parameterization.Version,
-			Value:   descriptor.Parameterization.Value,
-		}
+	workspaceDescriptor := workspace.PluginDescriptor{
+		Kind:              apitype.ResourcePlugin,
+		Name:              descriptor.Name,
+		Version:           descriptor.Version,
+		PluginDownloadURL: descriptor.DownloadURL,
 	}
 
 	provider, err := l.host.Provider(workspaceDescriptor)

--- a/cmd/pulumi-test-language/test_host.go
+++ b/cmd/pulumi-test-language/test_host.go
@@ -115,7 +115,7 @@ func (h *testHost) ListAnalyzers() []plugin.Analyzer {
 	return h.policies
 }
 
-func (h *testHost) Provider(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
+func (h *testHost) Provider(descriptor workspace.PluginDescriptor) (plugin.Provider, error) {
 	// If we've not been given a version, we'll try and find the provider by name alone, picking the latest if there are
 	// multiple versions of the named provider. Otherwise, we can attempt to find an exact match.
 	var key string

--- a/pkg/codegen/convert/provider_factory.go
+++ b/pkg/codegen/convert/provider_factory.go
@@ -36,7 +36,7 @@ func ProviderFactoryFromHost(ctx context.Context, host plugin.Host) ProviderFact
 			return nil, fmt.Errorf("provider factory must be a resource plugin package, was %v", descriptor.Kind)
 		}
 
-		provider, err := host.Provider(descriptor)
+		provider, err := host.Provider(descriptor.PluginDescriptor)
 		if err != nil {
 			desc := descriptor.PackageName()
 			v := descriptor.PackageVersion()

--- a/pkg/codegen/nodejs/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test.go
@@ -100,7 +100,7 @@ resource "app" "scaleway:iam/application:Application" {}
 		ResolvePluginF: func(spec workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
 			return &workspace.PluginInfo{Name: spec.Name}, nil
 		},
-		ProviderF: func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
+		ProviderF: func(descriptor workspace.PluginDescriptor) (plugin.Provider, error) {
 			return &plugin.MockProvider{
 				GetSchemaF: func(
 					ctx context.Context,

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -465,20 +465,11 @@ func (l *pluginLoader) loadSchemaBytes(
 func (l *pluginLoader) loadPluginSchemaBytes(
 	ctx context.Context, descriptor *PackageDescriptor,
 ) ([]byte, plugin.Provider, error) {
-	wsDescriptor := workspace.PackageDescriptor{
-		PluginDescriptor: workspace.PluginDescriptor{
-			Name:              descriptor.Name,
-			Version:           descriptor.Version,
-			PluginDownloadURL: descriptor.DownloadURL,
-			Kind:              apitype.ResourcePlugin,
-		},
-	}
-	if descriptor.Parameterization != nil {
-		wsDescriptor.Parameterization = &workspace.Parameterization{
-			Name:    descriptor.Parameterization.Name,
-			Version: descriptor.Parameterization.Version,
-			Value:   descriptor.Parameterization.Value,
-		}
+	wsDescriptor := workspace.PluginDescriptor{
+		Name:              descriptor.Name,
+		Version:           descriptor.Version,
+		PluginDownloadURL: descriptor.DownloadURL,
+		Kind:              apitype.ResourcePlugin,
 	}
 
 	provider, err := l.host.Provider(wsDescriptor)

--- a/pkg/codegen/schema/loader_test.go
+++ b/pkg/codegen/schema/loader_test.go
@@ -159,7 +159,7 @@ func TestLoadParameterized(t *testing.T) {
 	}
 
 	host := &plugin.MockHost{
-		ProviderF: func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
+		ProviderF: func(descriptor workspace.PluginDescriptor) (plugin.Provider, error) {
 			assert.Equal(t, "terraform-provider", descriptor.Name)
 			assert.Equal(t, semver.MustParse("1.0.0"), *descriptor.Version)
 			return mockProvider, nil
@@ -227,7 +227,7 @@ func TestLoadNameMismatch(t *testing.T) {
 	}
 
 	host := &plugin.MockHost{
-		ProviderF: func(workspace.PackageDescriptor) (plugin.Provider, error) {
+		ProviderF: func(workspace.PluginDescriptor) (plugin.Provider, error) {
 			return provider, nil
 		},
 		ResolvePluginF: func(workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
@@ -298,7 +298,7 @@ func TestLoadVersionMismatch(t *testing.T) {
 	}
 
 	host := &plugin.MockHost{
-		ProviderF: func(workspace.PackageDescriptor) (plugin.Provider, error) {
+		ProviderF: func(workspace.PluginDescriptor) (plugin.Provider, error) {
 			return provider, nil
 		},
 		ResolvePluginF: func(workspace.PluginDescriptor) (*workspace.PluginInfo, error) {

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -406,7 +406,7 @@ func (host *pluginHost) plugin(kind apitype.PluginKind, name string, version *se
 	return plug, nil
 }
 
-func (host *pluginHost) Provider(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
+func (host *pluginHost) Provider(descriptor workspace.PluginDescriptor) (plugin.Provider, error) {
 	if host.isClosed() {
 		return nil, ErrHostIsClosed
 	}

--- a/pkg/resource/deploy/deploytest/pluginhost_test.go
+++ b/pkg/resource/deploy/deploytest/pluginhost_test.go
@@ -123,11 +123,9 @@ func TestPluginHostProvider(t *testing.T) {
 		t.Parallel()
 		expectedVersion := semver.MustParse("1.0.0")
 		host := &pluginHost{}
-		_, err := host.Provider(workspace.PackageDescriptor{
-			PluginDescriptor: workspace.PluginDescriptor{
-				Name:    "pkgA",
-				Version: &expectedVersion,
-			},
+		_, err := host.Provider(workspace.PluginDescriptor{
+			Name:    "pkgA",
+			Version: &expectedVersion,
 		})
 		assert.ErrorContains(t, err, "Could not find plugin for (pkgA, 1.0.0)")
 	})
@@ -136,11 +134,9 @@ func TestPluginHostProvider(t *testing.T) {
 		t.Run("Provider", func(t *testing.T) {
 			t.Parallel()
 			host := &pluginHost{closed: true}
-			_, err := host.Provider(workspace.PackageDescriptor{
-				PluginDescriptor: workspace.PluginDescriptor{
-					Name:    "pkgA",
-					Version: &semver.Version{},
-				},
+			_, err := host.Provider(workspace.PluginDescriptor{
+				Name:    "pkgA",
+				Version: &semver.Version{},
 			})
 			assert.ErrorIs(t, err, ErrHostIsClosed)
 		})

--- a/pkg/resource/deploy/import_test.go
+++ b/pkg/resource/deploy/import_test.go
@@ -103,7 +103,7 @@ func TestImporter(t *testing.T) {
 					},
 					source: &nullSource{},
 					providers: providers.NewRegistry(&plugin.MockHost{
-						ProviderF: func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
+						ProviderF: func(descriptor workspace.PluginDescriptor) (plugin.Provider, error) {
 							assert.Equal(t, "foo", descriptor.Name)
 							assert.Equal(t, "1.0.0", descriptor.Version.String())
 							return nil, expectedErr
@@ -251,7 +251,7 @@ func TestImporterParameterizedProvider(t *testing.T) {
 			},
 			source: &nullSource{},
 			providers: providers.NewRegistry(&plugin.MockHost{
-				ProviderF: func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
+				ProviderF: func(descriptor workspace.PluginDescriptor) (plugin.Provider, error) {
 					assert.Equal(t, "foo", descriptor.Name)
 					assert.Equal(t, "1.0.0", descriptor.Version.String())
 					return &mockProvider, nil

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -314,14 +314,12 @@ func loadProvider(ctx context.Context, pkg tokens.Package, version *semver.Versi
 		return builtins, nil
 	}
 
-	descriptor := workspace.PackageDescriptor{
-		PluginDescriptor: workspace.PluginDescriptor{
-			Kind:              apitype.ResourcePlugin,
-			Name:              string(pkg),
-			Version:           version,
-			PluginDownloadURL: downloadURL,
-			Checksums:         checksums,
-		},
+	descriptor := workspace.PluginDescriptor{
+		Kind:              apitype.ResourcePlugin,
+		Name:              string(pkg),
+		Version:           version,
+		PluginDownloadURL: downloadURL,
+		Checksums:         checksums,
 	}
 
 	provider, err := host.Provider(descriptor)
@@ -349,7 +347,7 @@ func loadProvider(ctx context.Context, pkg tokens.Package, version *semver.Versi
 		host.Log(sev, "", msg, 0)
 	}
 
-	_, err = pkgWorkspace.InstallPlugin(ctx, descriptor.PluginDescriptor, log)
+	_, err = pkgWorkspace.InstallPlugin(ctx, descriptor, log)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -39,7 +39,7 @@ import (
 
 type testPluginHost struct {
 	t             *testing.T
-	provider      func(descriptor workspace.PackageDescriptor) (plugin.Provider, error)
+	provider      func(descriptor workspace.PluginDescriptor) (plugin.Provider, error)
 	closeProvider func(provider plugin.Provider) error
 }
 
@@ -78,7 +78,7 @@ func (host *testPluginHost) ListAnalyzers() []plugin.Analyzer {
 	return nil
 }
 
-func (host *testPluginHost) Provider(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
+func (host *testPluginHost) Provider(descriptor workspace.PluginDescriptor) (plugin.Provider, error) {
 	return host.provider(descriptor)
 }
 
@@ -190,7 +190,7 @@ type providerLoader struct {
 func newPluginHost(t *testing.T, loaders []*providerLoader) plugin.Host {
 	return &testPluginHost{
 		t: t,
-		provider: func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
+		provider: func(descriptor workspace.PluginDescriptor) (plugin.Provider, error) {
 			var best *providerLoader
 			for _, l := range loaders {
 				if string(l.pkg) != descriptor.Name {

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -68,7 +68,7 @@ type Host interface {
 
 	// Provider loads a new copy of the provider for a given package.  If a provider for this package could not be
 	// found, or an error occurs while creating it, a non-nil error is returned.
-	Provider(descriptor workspace.PackageDescriptor) (Provider, error)
+	Provider(descriptor workspace.PluginDescriptor) (Provider, error)
 	// CloseProvider closes the given provider plugin and deregisters it from this host.
 	CloseProvider(provider Provider) error
 	// LanguageRuntime fetches the language runtime plugin for a given language, lazily allocating if necessary.  If
@@ -486,7 +486,7 @@ func (host *defaultHost) ListAnalyzers() []Analyzer {
 	return analyzers
 }
 
-func (host *defaultHost) Provider(descriptor workspace.PackageDescriptor) (Provider, error) {
+func (host *defaultHost) Provider(descriptor workspace.PluginDescriptor) (Provider, error) {
 	plugin, err := host.loadPlugin(host.loadRequests, func() (any, error) {
 		pkg := descriptor.Name
 		version := descriptor.Version
@@ -506,7 +506,7 @@ func (host *defaultHost) Provider(descriptor workspace.PackageDescriptor) (Provi
 		}
 
 		plug, err := NewProvider(
-			host, host.ctx, descriptor.PluginDescriptor,
+			host, host.ctx, descriptor,
 			host.runtimeOptions, host.disableProviderPreview, string(jsonConfig), host.projectName)
 		if err == nil && plug != nil {
 			info, infoerr := plug.GetPluginInfo(host.ctx.Request())
@@ -605,7 +605,7 @@ func (host *defaultHost) EnsurePlugins(plugins []workspace.PluginDescriptor, kin
 			}
 		case apitype.ResourcePlugin:
 			if kinds&ResourcePlugins != 0 {
-				if _, err := host.Provider(workspace.PackageDescriptor{PluginDescriptor: plugin}); err != nil {
+				if _, err := host.Provider(plugin); err != nil {
 					result = multierror.Append(result,
 						fmt.Errorf("failed to load resource plugin %s: %w", plugin.Name, err))
 				}

--- a/sdk/go/common/resource/plugin/mock.go
+++ b/sdk/go/common/resource/plugin/mock.go
@@ -31,7 +31,7 @@ type MockHost struct {
 	AnalyzerF           func(nm tokens.QName) (Analyzer, error)
 	PolicyAnalyzerF     func(name tokens.QName, path string, opts *PolicyAnalyzerOptions) (Analyzer, error)
 	ListAnalyzersF      func() []Analyzer
-	ProviderF           func(descriptor workspace.PackageDescriptor) (Provider, error)
+	ProviderF           func(descriptor workspace.PluginDescriptor) (Provider, error)
 	CloseProviderF      func(provider Provider) error
 	LanguageRuntimeF    func(runtime string) (LanguageRuntime, error)
 	EnsurePluginsF      func(plugins []workspace.PluginDescriptor, kinds Flags) error
@@ -85,7 +85,7 @@ func (m *MockHost) ListAnalyzers() []Analyzer {
 	return nil
 }
 
-func (m *MockHost) Provider(descriptor workspace.PackageDescriptor) (Provider, error) {
+func (m *MockHost) Provider(descriptor workspace.PluginDescriptor) (Provider, error) {
 	if m.ProviderF != nil {
 		return m.ProviderF(descriptor)
 	}


### PR DESCRIPTION
I observed that no implementation of `(plugin.Host).Provider` actually does anything with
the additional information provided by `workspace.PackageDescriptor`. The old interface
made me question whether `(plugin.Host).Provider` returned a parameterized provider, so I
think having the interface take only what it needs is much clearer.