### PR TITLE
python auto api tests: fix flakes because of existing stacks

### DIFF
--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -1229,6 +1229,8 @@ class TestLocalWorkspace(unittest.TestCase):
         destroy_res = stack.destroy(refresh=True)
         self.assertRegex(destroy_res.stdout, r".*refreshing.*")
 
+        stack.workspace.remove_stack(stack_name)
+
     def test_pulumi_command(self):
         p = PulumiCommand()
         ws = LocalWorkspace(pulumi_command=p)

--- a/sdk/python/lib/test/automation/test_utils.py
+++ b/sdk/python/lib/test/automation/test_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import os
-from random import random
+import uuid
 
 from pulumi.automation import fully_qualified_stack_name
 
@@ -28,8 +28,8 @@ def get_test_org():
     return test_org
 
 
-def get_test_suffix() -> int:
-    return int(100000 + random() * 900000)
+def get_test_suffix() -> str:
+    return str(uuid.uuid4())
 
 
 def stack_namer(project_name: str) -> str:


### PR DESCRIPTION
In the python automation API tests we currently use random numbers to generate stack names. This doesn't seem to be enough to avoid duplicate stack issues in the moolumi org, causing tests to fail.  Use an UUID instead, as those are pretty much guaranteed to be unique.

Also add a missing remove_stack call to the refresh test, which didn't clean up the stacks it created properly.

Noticed this in https://github.com/pulumi/pulumi/actions/runs/20299930564/job/58303412493?pr=20955.  We ran out of numbers because this test doesn't clean up properly, but we might as well make the name a UUID while we're at it to completely avoid these kinds of flakes in the future.