### PR TITLE
add infrastructure to exclude known issues from fuzzing

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/exclude.go
+++ b/pkg/engine/lifecycletest/fuzzing/exclude.go
@@ -1,0 +1,44 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fuzzing
+
+// ExclusionRule represents a rule that determines if a snapshot should be excluded from fuzzing.
+// If the rule returns true, the snapshot will be rejected and a new one will be generated.
+type ExclusionRule func(*SnapshotSpec, *ProgramSpec, *ProviderSpec, *PlanSpec) bool
+
+// ExclusionRules is a collection of exclusion rules that can be applied to snapshots.
+type ExclusionRules []ExclusionRule
+
+// DefaultExclusionRules returns the default set of exclusion rules that prevent known
+// problematic patterns from being generated.
+func DefaultExclusionRules() ExclusionRules {
+	return []ExclusionRule{}
+}
+
+// ShouldExclude checks if a snapshot should be excluded based on the configured exclusion rules.
+// Returns true if any rule indicates the snapshot should be excluded.
+func (er ExclusionRules) ShouldExclude(
+	snap *SnapshotSpec,
+	program *ProgramSpec,
+	provider *ProviderSpec,
+	plan *PlanSpec,
+) bool {
+	for _, rule := range er {
+		if rule(snap, program, provider, plan) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/engine/lifecycletest/fuzzing/fixture.go
+++ b/pkg/engine/lifecycletest/fuzzing/fixture.go
@@ -1,4 +1,4 @@
-// Copyright 2024, Pulumi Corporation.
+// Copyright 2024-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -91,6 +91,12 @@ func GeneratedFixture(fo FixtureOptions) func(t *rapid.T) {
 		progSpec := GeneratedProgramSpec(snapSpec, fo.StackSpecOptions, fo.ProgramSpecOptions).Draw(t, "ProgramSpec")
 		provSpec := GeneratedProviderSpec(progSpec, fo.ProviderSpecOptions).Draw(t, "ProviderSpec")
 		planSpec := GeneratedPlanSpec(snapSpec, fo.PlanSpecOptions).Draw(t, "PlanSpec")
+
+		if fo.SnapshotSpecOptions.ExclusionRules.ShouldExclude(snapSpec, progSpec, provSpec, planSpec) {
+			// If the generated snapshot matches an exclusion rule, we skip this test case.
+			t.Skip("snapshot matches exclusion rule")
+			return
+		}
 
 		inSnap := snapSpec.AsSnapshot()
 		require.NoError(t, inSnap.VerifyIntegrity(), "initial snapshot is not valid")

--- a/pkg/engine/lifecycletest/fuzzing/snapshot.go
+++ b/pkg/engine/lifecycletest/fuzzing/snapshot.go
@@ -238,6 +238,10 @@ type SnapshotSpecOptions struct {
 
 	// A set of options for configuring the generation of resources in the snapshot.
 	ResourceOpts ResourceSpecOptions
+
+	// Exclusion rules to apply to generated snapshots. If a snapshot matches any exclusion rule,
+	// it will be rejected and a new one will be generated.
+	ExclusionRules ExclusionRules
 }
 
 // Returns a copy of the given SnapshotSpecOptions with the given overrides applied.
@@ -250,6 +254,9 @@ func (sso SnapshotSpecOptions) With(overrides SnapshotSpecOptions) SnapshotSpecO
 	}
 	if overrides.Action != nil {
 		sso.Action = overrides.Action
+	}
+	if overrides.ExclusionRules != nil {
+		sso.ExclusionRules = overrides.ExclusionRules
 	}
 	sso.ResourceOpts = sso.ResourceOpts.With(overrides.ResourceOpts)
 
@@ -276,6 +283,7 @@ var defaultSnapshotSpecOptions = SnapshotSpecOptions{
 	ResourceCount:      rapid.IntRange(2, 5),
 	Action:             rapid.SampledFrom(snapshotSpecActions),
 	ResourceOpts:       defaultResourceSpecOptions,
+	ExclusionRules:     DefaultExclusionRules(),
 }
 
 var snapshotSpecActions = []SnapshotSpecAction{


### PR DESCRIPTION
Add some infrastructure that allows us to set up exclusion rules, which can check the generated spec for the test, and return true if the spec matches a known issues.  If it returns true we will then exclude that spec from testing.

Ideally we'd fix all the problems, but this allows us to start introducing fuzzing into CI, and then fix the issues one by one, while making sure we don't introduce new regressions.

This doesn't add any exclusion roles yet, those will be added in subsequent PRs.

Fixes https://github.com/pulumi/pulumi/issues/21243