### PR TITLE
fuzzing reprogen: pass pointers of bools to RegisterResource

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/reprogen.go
+++ b/pkg/engine/lifecycletest/fuzzing/reprogen.go
@@ -725,10 +725,10 @@ func writeResourceRegistrationStatements(t require.TestingT, rs []*ResourceSpec)
 					}
 
 					if r.Protect {
-						g.writeLine("Protect: true,")
+						g.writeLine("Protect: ptr(true),")
 					}
 					if r.RetainOnDelete {
-						g.writeLine("RetainOnDelete: true,")
+						g.writeLine("RetainOnDelete: prt(true),")
 					}
 
 					if r.Provider != "" {


### PR DESCRIPTION
`Protect` and `RetainOnDelete` are pointers in `deploytest.ResourceOptions`. We already have a `ptr()` convenience function defined in the lifecycltest framework, so we can use that here as well.