### PR TITLE
Do not assert that the pulumi/templates repo contains aws-javascript

### DIFF
--- a/pkg/cmd/pulumi/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_test.go
@@ -1021,7 +1021,6 @@ Available Templates:
   aws-fsharp                         A minimal AWS F# Pulumi program
   aws-go                             A minimal AWS Go Pulumi program
   aws-java                           A minimal AWS Java Pulumi program
-  aws-javascript                     A minimal AWS JavaScript Pulumi program
   aws-python                         A minimal AWS Python Pulumi program
   aws-scala                          A minimal AWS Scala Pulumi program
   aws-typescript                     A minimal AWS TypeScript Pulumi program
@@ -1096,7 +1095,6 @@ Available Templates:
   aws-fsharp                         A minimal AWS F# Pulumi program
   aws-go                             A minimal AWS Go Pulumi program
   aws-java                           A minimal AWS Java Pulumi program
-  aws-javascript                     A minimal AWS JavaScript Pulumi program
   aws-python                         A minimal AWS Python Pulumi program
   aws-scala                          A minimal AWS Scala Pulumi program
   aws-typescript                     A minimal AWS TypeScript Pulumi program
@@ -1128,7 +1126,6 @@ Available Templates:
   aws-fsharp                              A minimal AWS F# Pulumi program
   aws-go                                  A minimal AWS Go Pulumi program
   aws-java                                A minimal AWS Java Pulumi program
-  aws-javascript                          A minimal AWS JavaScript Pulumi program
   aws-python                              A minimal AWS Python Pulumi program
   aws-scala                               A minimal AWS Scala Pulumi program
   aws-typescript                          A minimal AWS TypeScript Pulumi program


### PR DESCRIPTION
As of https://github.com/pulumi/templates/pull/1010, github.com/pulumi/templates does not contain any template called `aws-javascript`.