### PR TITLE
Make the types make sense for `packageresolution.Resolve`

### DIFF
--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -132,25 +132,9 @@ from the parameters, as in:
 				return nil
 			}
 
-			version := ""
-			if pkg.Version != nil {
-				version = pkg.Version.String()
-			} else if len(pluginSplit) == 2 {
-				version = pluginSplit[1]
-			}
-			if pkg.Parameterization != nil {
-				source = pkg.Parameterization.BaseProvider.Name
-				version = pkg.Parameterization.BaseProvider.Version.String()
-			}
-			if len(parameters.Args) > 0 && packageSpec != nil {
-				packageSpec.Parameters = parameters.Args
-			} else if packageSpec == nil {
-				packageSpec = &workspace.PackageSpec{
-					Source:     source,
-					Version:    version,
-					Parameters: parameters.Args,
-				}
-			}
+			contract.Assertf(packageSpec != nil, "packageSpec should be nil if & only if source is file based")
+			packageSpec.Parameters = parameters.Args
+
 			pluginOrProject.proj.AddPackage(pkg.Name, *packageSpec)
 
 			fileName := filepath.Base(pluginOrProject.projectFilePath)

--- a/pkg/cmd/pulumi/packageresolution/package_resolution.go
+++ b/pkg/cmd/pulumi/packageresolution/package_resolution.go
@@ -26,11 +26,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
+	"strings"
 
 	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/util"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -41,13 +45,13 @@ var (
 
 type PackageNotFoundError struct {
 	Package     string
-	Version     *semver.Version
+	Version     string
 	OriginalErr error
 }
 
 func (e PackageNotFoundError) Error() string {
-	if e.Version != nil {
-		return fmt.Sprintf("package %s@%s not found", e.Package, e.Version.String())
+	if e.Version != "" {
+		return fmt.Sprintf("package %s@%s not found", e.Package, e.Version)
 	}
 	return fmt.Sprintf("package %s not found", e.Package)
 }
@@ -65,127 +69,332 @@ func (e PackageNotFoundError) Suggestions() []apitype.PackageMetadata {
 }
 
 type Options struct {
-	DisableRegistryResolve      bool
-	Experimental                bool
-	IncludeInstalledInWorkspace bool
+	// If [Resolve] should use the passed in registry to resolve packages.
+	ResolveWithRegistry bool
+
+	// If the resolution should use already installed plugins when resolving
+	// plugins without specific versions provided.
+	//
+	// Concretely, when resolving a package like aws, if a version of aws is
+	// already on disk, then that version will be preferred over latest.
+	ResolveVersionWithLocalWorkspace bool
+
+	// Resolve the source directly against the local workspace if possible.
+	//
+	// For example, consider a spec like workspace.PackageSpec{Source:
+	// "example"}. With "AllowNonInvertableLocalWorkspaceResolution: false", resolving
+	// "example" may resolve to a parameterized package with a base plugin called
+	// "base". [Resolve] wouldn't consider a local plugin called "example", and might
+	// fail if "base" couldn't be installed.
+	//
+	// "AllowNonInvertableLocalWorkspaceResolution: true" instructs [Resolve] to use a
+	// package called "example" if example is requested and present in the workspace,
+	// regardless of external lookup.
+	AllowNonInvertableLocalWorkspaceResolution bool
 }
 
 // The result of running [Resolve].
 //
-// Result will be one of 4 types:
+// Resolution will be one of 3 types:
 //
-// - [RegistryResult]: The package was resolved using Pulumi's Registry.
-// - [LocalPathResult]: The package is local and already on disk.
-// - [ExternalSourceResult]: The package is external, and should be downloaded normally.
-// - [InstalledInWorkspaceResult]: The package is already installed.
-type Result interface {
-	isResult()
+// - [PackageResolution]: The spec was resolved to a specific Pulumi package.
+//
+// - [PluginResolution]: The spec was resolved to a specific Pulumi plugin, but
+// parameterization makes resolving to a full package impossible.
+//
+// - [PathResolution]: The spec was resolved to a local plugin path on disk.
+type Resolution interface {
+	isResolution()
 }
 
-func (RegistryResult) isResult()             {}
-func (LocalPathResult) isResult()            {}
-func (ExternalSourceResult) isResult()       {}
-func (InstalledInWorkspaceResult) isResult() {}
+func (PackageResolution) isResolution() {}
+func (PluginResolution) isResolution()  {}
+func (PathResolution) isResolution()    {}
 
 type (
-	// The package should be downloaded with information from the registry.
-	RegistryResult struct {
-		Metadata apitype.PackageMetadata
+	// A fully resolved package.
+	PackageResolution struct {
+		Spec                 workspace.PackageSpec
+		Pkg                  workspace.PackageDescriptor
+		InstalledInWorkspace bool
 	}
-	// The package is referenced by a local path.
+	// A fully resolved plugin with not yet resolved parameterization.
 	//
-	// For example:
+	// For example, this would be the result of [Resolve]ing:
 	//
-	//	/a/nice/absolute/path/to/pulumi-resource-example
-	LocalPathResult struct {
+	//	workspace.PackageSpec{
+	//		Source: "terraform-provider",
+	//		Parameters: []string{"org/example"},
+	//	}
+	//
+	// We wouldn't know the name or version of the package (example@<latest>), but we
+	// would know the name and version of the the resolved plugin
+	// (terraform-provider@<latest>).
+	PluginResolution struct {
+		Spec                 workspace.PackageSpec
+		Pkg                  workspace.UnresolvedPackageDescriptor
+		InstalledInWorkspace bool
+	}
+	// A local path based plugin.
+	PathResolution struct {
+		Spec workspace.PackageSpec
 		// The path to the plugin on disk.
-		//
-		// If LocalPath is "./foo", that can mean one of 2 things:
-		// 1. That the spec contained workspace.PluginSpec{Name: "./foo"}.
-		//
-		// 2. That the spec contained workspace.PluginSpec{Name: "foo"} but the
-		//    Pulumi.yaml file that defined the packages contains
-		//
-		// 	packages: [ { name: foo, path: "./foo" } ]
-		//
-		// In the first case, the caller should resolve "./foo" as:
-		//
-		//	cwd, _ :=os.Getwd()
-		//	filepath.Join(cwd, "./foo")
-		//
-		// In the second case, the caller should resolve "./foo" as
-		//
-		//
-		//	filepath.Join(projectRootDirectory, "./foo")
-		//
-		LocalPath string
-		// RelativeToWorkspace is true if the local path was taken from the passed
-		// in workspace.BaseProject.
-		RelativeToWorkspace bool
+		Path                 string
+		ParameterizationArgs []string
 	}
-	ExternalSourceResult struct {
-		Spec workspace.PluginDescriptor
-	}
-	InstalledInWorkspaceResult struct{}
 )
+
+func naivePackageDescriptor(
+	ctx context.Context, spec workspace.PackageSpec,
+) (workspace.UnresolvedPackageDescriptor, error) {
+	pluginSpecSource := spec.Source
+	var version *semver.Version
+	if spec.Version != "" {
+		if v, err := semver.ParseTolerant(spec.Version); err != nil {
+			pluginSpecSource += "@" + spec.Version
+		} else {
+			version = &v
+		}
+	}
+	pluginDesc, err := workspace.NewPluginDescriptor(ctx, pluginSpecSource, apitype.ResourcePlugin,
+		version, spec.PluginDownloadURL, spec.Checksums)
+	return workspace.UnresolvedPackageDescriptor{
+		PluginDescriptor:     pluginDesc,
+		ParameterizationArgs: spec.Parameters,
+	}, err
+}
+
+func naiveResolution(
+	spec workspace.PackageSpec, desc workspace.UnresolvedPackageDescriptor, installed bool,
+) Resolution {
+	if desc.IsGitPlugin() && spec.PluginDownloadURL == "" {
+		spec.Source = strings.TrimPrefix(desc.PluginDownloadURL, "git://")
+		if v := desc.Version; v != nil && v.Major == 0 && v.Minor == 0 && v.Patch == 0 &&
+			len(v.Build) == 0 && len(v.Pre) == 1 && !v.Pre[0].IsNum &&
+			strings.HasPrefix(v.Pre[0].VersionStr, "x") {
+			spec.Version = v.Pre[0].VersionStr[1:]
+		}
+	}
+
+	// If there is no parameters in the spec, then we have fully resolved here.
+	if len(spec.Parameters) == 0 {
+		return PackageResolution{
+			Spec: spec,
+			Pkg: workspace.PackageDescriptor{
+				PluginDescriptor: desc.PluginDescriptor,
+			},
+			InstalledInWorkspace: installed,
+		}
+	}
+
+	// Otherwise we at least have the plugin.
+	return PluginResolution{
+		Spec:                 spec,
+		Pkg:                  desc,
+		InstalledInWorkspace: installed,
+	}
+}
+
+func registryResolution(
+	spec workspace.PackageSpec, metadata apitype.PackageMetadata, installed bool,
+) (Resolution, error) {
+	spec = workspace.PackageSpec{
+		Source:     path.Join(metadata.Source, metadata.Publisher, metadata.Name),
+		Version:    metadata.Version.String(),
+		Parameters: spec.Parameters,
+		Checksums:  spec.Checksums,
+	}
+
+	if len(spec.Parameters) > 0 && metadata.Parameterization != nil {
+		return nil, fmt.Errorf(
+			"unable to resolve package: resolved plugin to %s, which is already parameterized",
+			spec.Source,
+		)
+	}
+
+	pluginDescriptor := workspace.PluginDescriptor{
+		Name:              metadata.Name,
+		Kind:              apitype.ResourcePlugin,
+		Version:           &metadata.Version,
+		PluginDownloadURL: metadata.PluginDownloadURL,
+		Checksums:         spec.Checksums,
+	}
+
+	if len(spec.Parameters) > 0 {
+		plugin := PluginResolution{
+			Spec: spec,
+			Pkg: workspace.UnresolvedPackageDescriptor{
+				PluginDescriptor:     pluginDescriptor,
+				ParameterizationArgs: spec.Parameters,
+			},
+			InstalledInWorkspace: installed,
+		}
+		logging.V(3).Infof("Resolved package %q via the registry to plugin %#v (installedInWorkspace=%t)\n",
+			spec.Source, plugin, installed)
+
+		return plugin, nil
+	}
+
+	pkgDescriptor := workspace.PackageDescriptor{
+		PluginDescriptor: pluginDescriptor,
+	}
+
+	if metadata.Parameterization != nil {
+		pkgDescriptor.Parameterization = &workspace.Parameterization{
+			Name:    metadata.Name,
+			Version: metadata.Version,
+			Value:   metadata.Parameterization.Parameter,
+		}
+		pkgDescriptor.Name = metadata.Parameterization.BaseProvider.Name
+		pkgDescriptor.Version = &metadata.Parameterization.BaseProvider.Version
+	}
+
+	pkg := PackageResolution{
+		Spec:                 spec,
+		Pkg:                  pkgDescriptor,
+		InstalledInWorkspace: installed,
+	}
+	logging.V(3).Infof("Resolved package %q via the registry to package %#v (installedInWorkspace=%t)\n",
+		spec.Source, pkg, installed)
+	return pkg, nil
+}
 
 func Resolve(
 	ctx context.Context,
 	reg registry.Registry,
 	ws PluginWorkspace,
-	pluginSpec workspace.PluginDescriptor,
+	spec workspace.PackageSpec,
 	options Options,
-	projectOrPlugin workspace.BaseProject, // Pass nil for 'not in a project context'
-) (Result, error) {
-	sourceToCheck := pluginSpec.Name
-
-	if options.IncludeInstalledInWorkspace {
-		installed, err := isAlreadyInstalled(ws, pluginSpec)
-		if err != nil {
-			return nil, err
-		}
-		if installed {
-			return InstalledInWorkspaceResult{}, nil
-		}
-	}
-
-	var localPathIsFromProjectOrPlugin bool
-	if projectOrPlugin != nil {
-		localSource, ok := projectOrPlugin.GetPackageSpecs()[pluginSpec.Name]
-		if ok {
-			sourceToCheck = localSource.Source
-			localPathIsFromProjectOrPlugin = true
-		}
-	}
-
-	if plugin.IsLocalPluginPath(ctx, sourceToCheck) {
-		return LocalPathResult{
-			LocalPath:           sourceToCheck,
-			RelativeToWorkspace: localPathIsFromProjectOrPlugin,
+) (Resolution, error) {
+	logging.V(3).Infof("Resolving package from %#v\n", spec)
+	if plugin.IsLocalPluginPath(ctx, spec.Source) {
+		return PathResolution{
+			Path:                 spec.Source,
+			ParameterizationArgs: spec.Parameters,
+			Spec:                 spec,
 		}, nil
 	}
 
-	if ws.IsExternalURL(sourceToCheck) || pluginSpec.IsGitPlugin() {
-		return ExternalSourceResult{Spec: pluginSpec}, nil
+	naivePackageDescriptor, err := naivePackageDescriptor(ctx, spec)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse spec: %w", err)
+	}
+
+	if options.AllowNonInvertableLocalWorkspaceResolution {
+		if ws.HasPlugin(naivePackageDescriptor.PluginDescriptor) {
+			return naiveResolution(spec, naivePackageDescriptor, true), nil
+		}
+
+		if naivePackageDescriptor.Version == nil {
+			has, version, err := ws.HasPluginGTE(naivePackageDescriptor.PluginDescriptor)
+			if err != nil {
+				return nil, err
+			}
+			if has {
+				if version != nil {
+					naivePackageDescriptor.Version = version
+					spec.Version = version.String()
+				}
+				return naiveResolution(spec, naivePackageDescriptor, true), nil
+			}
+		}
+	}
+
+	remoteResolution := func() (Resolution, error) {
+		logging.V(3).Infof("Resolved package %#v to an external source %#v\n",
+			spec, naivePackageDescriptor)
+		// If we have the exact version installed, then use that
+		if ws.HasPlugin(naivePackageDescriptor.PluginDescriptor) {
+			return naiveResolution(spec, naivePackageDescriptor, true), nil
+		}
+		// If we don't have a version specified and we are referencing the local workspace
+		if naivePackageDescriptor.Version == nil && options.ResolveVersionWithLocalWorkspace {
+			has, version, err := ws.HasPluginGTE(naivePackageDescriptor.PluginDescriptor)
+			if err != nil {
+				return nil, err
+			}
+			if has {
+				if version != nil {
+					naivePackageDescriptor.Version = version
+					spec.Version = version.String()
+				}
+				return naiveResolution(spec, naivePackageDescriptor, true), nil
+			}
+		}
+
+		// We still don't have a version, so let's look up the latest version.
+		if naivePackageDescriptor.Version == nil {
+			v, err := ws.GetLatestVersion(ctx, naivePackageDescriptor.PluginDescriptor)
+			if err != nil && !errors.Is(err, workspace.ErrGetLatestVersionNotSupported) {
+				return nil, fmt.Errorf("unable to get the latest version of %q: %w",
+					naivePackageDescriptor.Name, err)
+			}
+			if v != nil {
+				naivePackageDescriptor.Version = v
+				spec.Version = v.String()
+			}
+		}
+
+		// At this point, we either have a version or aren't going to have one
+		return naiveResolution(spec, naivePackageDescriptor, false), nil
+	}
+
+	if ws.IsExternalURL(spec.Source) || naivePackageDescriptor.IsGitPlugin() {
+		return remoteResolution()
 	}
 
 	var registryNotFoundErr error
 	var registryQueryErr error
 
-	if options.includeRegistryResolve() {
-		metadata, err := registry.ResolvePackageFromName(ctx, reg, pluginSpec.Name, pluginSpec.Version)
+	if options.ResolveWithRegistry {
+		metadata, err := registry.ResolvePackageFromName(ctx, reg, spec.Source, naivePackageDescriptor.Version)
 		if err == nil {
-			if options.IncludeInstalledInWorkspace {
-				installed, err := isAlreadyInstalled(ws, pluginSpec)
-				if err != nil {
-					return nil, err
-				}
-				if installed {
-					return InstalledInWorkspaceResult{}, nil
-				}
+			pluginDescriptor := workspace.PluginDescriptor{
+				Name:              metadata.Name,
+				Kind:              apitype.ResourcePlugin,
+				Version:           &metadata.Version,
+				PluginDownloadURL: metadata.PluginDownloadURL,
+				Checksums:         spec.Checksums,
 			}
 
-			return RegistryResult{Metadata: metadata}, nil
+			// Now that we've resolved to a version, we need to check if we have a good-enough version
+			// already installed.
+
+			// If the version was specified in the request, then the only good-enough version is the correct version
+			if naivePackageDescriptor.Version != nil {
+				return registryResolution(spec, metadata, ws.HasPlugin(pluginDescriptor))
+			}
+
+			// If the version wasn't specified in the request, then good enough is any plugin with the same
+			// *major version* as what the registry gave us.
+			has, version, err := ws.HasPluginGTE(func(s workspace.PluginDescriptor) workspace.PluginDescriptor {
+				s.Version = &semver.Version{Major: s.Version.Major}
+				return s
+			}(pluginDescriptor))
+			if err != nil {
+				return nil, err
+			}
+
+			// There is no local version of this plugin that meets our version requirements, so we just
+			// request the latest.
+			if !has || version == nil {
+				return registryResolution(spec, metadata, has)
+			}
+
+			// We have a version that's already installed at the right major version, so we should use
+			// that... if it's valid in the registry. We need to check.
+			newMetadata, err := registry.ResolvePackageFromName(
+				ctx, reg, path.Join(metadata.Source, metadata.Publisher, metadata.Name), version)
+			if errors.Is(err, registry.ErrNotFound) {
+				// The version we have isn't in the registry so it doesn't
+				// count. Use the latest version from the registry.
+				return registryResolution(spec, metadata, false)
+			}
+			if err != nil {
+				return nil, err
+			}
+			spec.Version = version.String()
+			return registryResolution(spec, newMetadata, true)
 		}
 		if errors.Is(err, registry.ErrNotFound) {
 			registryNotFoundErr = err
@@ -194,35 +403,32 @@ func Resolve(
 		}
 	}
 
-	if registry.IsPreRegistryPackage(pluginSpec.Name) {
-		return ExternalSourceResult{Spec: pluginSpec}, nil
+	// If this used to work (like "aws") or if the user has specified a
+	// pluginDownloadURL themselves, then pass it through.
+	if registry.IsPreRegistryPackage(spec.Source) || spec.PluginDownloadURL != "" ||
+		util.SetKnownPluginDownloadURL(&naivePackageDescriptor.PluginDescriptor) {
+		return remoteResolution()
 	}
 
 	if registryQueryErr != nil {
+		logging.V(3).Infof("Failed to resolve package %#v\n", spec)
 		return nil, registryQueryErr
 	}
 
+	logging.V(3).Infof("Failed to resolve package %#v\n", spec)
 	return nil, &PackageNotFoundError{
-		Package:     pluginSpec.Name,
-		Version:     pluginSpec.Version,
+		Package:     spec.Source,
+		Version:     spec.Version,
 		OriginalErr: registryNotFoundErr,
 	}
-}
-
-func (o Options) includeRegistryResolve() bool { return !o.DisableRegistryResolve && o.Experimental }
-
-func isAlreadyInstalled(ws PluginWorkspace, spec workspace.PluginDescriptor) (bool, error) {
-	if spec.Version != nil {
-		return ws.HasPlugin(spec), nil
-	}
-	return ws.HasPluginGTE(spec)
 }
 
 // PluginWorkspace dictates how resolution interacts with globally installed plugins.
 type PluginWorkspace interface {
 	HasPlugin(spec workspace.PluginDescriptor) bool
-	HasPluginGTE(spec workspace.PluginDescriptor) (bool, error)
+	HasPluginGTE(spec workspace.PluginDescriptor) (bool, *semver.Version, error)
 	IsExternalURL(source string) bool
+	GetLatestVersion(ctx context.Context, spec workspace.PluginDescriptor) (*semver.Version, error)
 }
 
 type defaultWorkspace struct{}
@@ -231,12 +437,18 @@ func (defaultWorkspace) HasPlugin(spec workspace.PluginDescriptor) bool {
 	return workspace.HasPlugin(spec)
 }
 
-func (defaultWorkspace) HasPluginGTE(spec workspace.PluginDescriptor) (bool, error) {
+func (defaultWorkspace) HasPluginGTE(spec workspace.PluginDescriptor) (bool, *semver.Version, error) {
 	return workspace.HasPluginGTE(spec)
 }
 
 func (defaultWorkspace) IsExternalURL(source string) bool {
 	return workspace.IsExternalURL(source)
+}
+
+func (defaultWorkspace) GetLatestVersion(
+	ctx context.Context, spec workspace.PluginDescriptor,
+) (*semver.Version, error) {
+	return spec.GetLatestVersion(ctx)
 }
 
 func DefaultWorkspace() PluginWorkspace {

--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -380,6 +380,9 @@ func setSpecNamespace(spec *schema.PackageSpec, pluginSpec workspace.PluginDescr
 // optional version:
 //
 //	FILE.[json|y[a]ml] | PLUGIN[@VERSION] | PATH_TO_PLUGIN
+//
+// The returned workspace.PackageSpec will be non-nil if and only if the schema is sourced
+// from a plugin.
 func SchemaFromSchemaSource(
 	pctx *plugin.Context, packageSource string, parameters plugin.ParameterizeParameters, registry registry.Registry,
 	env env.Env,
@@ -414,7 +417,7 @@ func SchemaFromSchemaSource(
 		return &spec, nil, nil
 	}
 
-	p, specOverride, err := ProviderFromSource(pctx, packageSource, registry, env)
+	p, packageSpec, err := ProviderFromSource(pctx, packageSource, registry, env)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -457,7 +460,7 @@ func SchemaFromSchemaSource(
 		spec.PluginDownloadURL = pluginSpec.PluginDownloadURL
 	}
 	setSpecNamespace(&spec, pluginSpec)
-	return &spec, specOverride, nil
+	return &spec, &packageSpec, nil
 }
 
 type Provider struct {
@@ -472,14 +475,13 @@ type Provider struct {
 func ProviderFromSource(
 	pctx *plugin.Context, packageSource string, reg registry.Registry,
 	e env.Env,
-) (Provider, *workspace.PackageSpec, error) {
-	pluginSpec, err := workspace.NewPluginDescriptor(pctx.Request(), packageSource, apitype.ResourcePlugin, nil, "", nil)
-	if err != nil {
-		return Provider{}, nil, err
+) (Provider, workspace.PackageSpec, error) {
+	var version string
+	if parts := strings.SplitN(packageSource, "@", 2); len(parts) > 1 {
+		packageSource = parts[0]
+		version = parts[1]
 	}
-	descriptor := workspace.PackageDescriptor{
-		PluginDescriptor: pluginSpec,
-	}
+	packageSpec := workspace.PackageSpec{Source: packageSource, Version: version}
 
 	installDescriptor := func(descriptor workspace.PluginDescriptor) (plugin.Provider, error) {
 		p, err := pctx.Host.Provider(descriptor)
@@ -507,53 +509,56 @@ func ProviderFromSource(
 			return nil, err
 		}
 
-		return pctx.Host.Provider(descriptor)
+		p, err = pctx.Host.Provider(descriptor)
+		if err != nil {
+			return nil, err
+		}
+
+		return p, nil
 	}
 
 	setupProvider := func(
-		descriptor workspace.PackageDescriptor, specOverride *workspace.PackageSpec,
-	) (Provider, *workspace.PackageSpec, error) {
-		p, err := installDescriptor(descriptor.PluginDescriptor)
+		descriptor workspace.PluginDescriptor, params plugin.ParameterizeParameters, specOverride workspace.PackageSpec,
+	) (Provider, workspace.PackageSpec, error) {
+		p, err := installDescriptor(descriptor)
 		if err != nil {
-			return Provider{}, nil, err
+			return Provider{}, workspace.PackageSpec{}, err
 		}
-		if descriptor.Parameterization != nil {
+		if params != nil {
 			_, err := p.Parameterize(pctx.Request(), plugin.ParameterizeRequest{
-				Parameters: &plugin.ParameterizeValue{
-					Name:    descriptor.Parameterization.Name,
-					Version: descriptor.Parameterization.Version,
-					Value:   descriptor.Parameterization.Value,
-				},
+				Parameters: params,
 			})
 			if err != nil {
-				return Provider{}, nil, fmt.Errorf("failed to parameterize %s: %w", p.Pkg().Name(), err)
+				return Provider{}, workspace.PackageSpec{},
+					fmt.Errorf("failed to parameterize %s: %w", p.Pkg().Name(), err)
 			}
 		}
-		return Provider{p, descriptor.Parameterization != nil}, specOverride, nil
+		return Provider{p, params != nil}, specOverride, nil
 	}
 
-	var project workspace.BaseProject
 	if bp, path, err := workspace.LoadBaseProjectFrom(pctx.Root); err == nil {
 		// We have found the right base project if and only if its located at the
 		// root of the passed in plugin.
 		if filepath.Dir(path) == pctx.Root {
-			project = bp
+			if override, ok := bp.GetPackageSpecs()[packageSource]; ok {
+				packageSpec = override
+			}
 		}
 	} else if !errors.Is(err, workspace.ErrBaseProjectNotFound) {
-		return Provider{}, nil, err
+		return Provider{}, workspace.PackageSpec{}, err
 	}
 
 	result, err := packageresolution.Resolve(
 		pctx.Base(),
 		reg,
 		packageresolution.DefaultWorkspace(),
-		pluginSpec,
+		packageSpec,
 		packageresolution.Options{
-			DisableRegistryResolve:      e.GetBool(env.DisableRegistryResolve),
-			Experimental:                e.GetBool(env.Experimental),
-			IncludeInstalledInWorkspace: true,
+			ResolveWithRegistry: e.GetBool(env.Experimental) &&
+				!e.GetBool(env.DisableRegistryResolve),
+			ResolveVersionWithLocalWorkspace:           true,
+			AllowNonInvertableLocalWorkspaceResolution: true,
 		},
-		project,
 	)
 	if err != nil {
 		var packageNotFoundErr *packageresolution.PackageNotFoundError
@@ -563,40 +568,56 @@ func ProviderFromSource(
 					suggested.Source, suggested.Publisher, suggested.Name, suggested.Version)
 			}
 		}
-		return Provider{}, nil, fmt.Errorf("Unable to resolve package from name: %w", err)
+		return Provider{}, workspace.PackageSpec{}, fmt.Errorf("Unable to resolve package from name: %w", err)
 	}
 
 	switch res := result.(type) {
-	case packageresolution.LocalPathResult:
-		return setupProviderFromPath(res.LocalPath, pctx)
-	case packageresolution.ExternalSourceResult, packageresolution.InstalledInWorkspaceResult:
-		return setupProvider(descriptor, nil)
-	case packageresolution.RegistryResult:
-		return setupProviderFromRegistryMeta(res.Metadata, setupProvider)
+	case packageresolution.PathResolution:
+		return setupProviderFromPath(res.Path, pctx)
+	case packageresolution.PackageResolution:
+		var params plugin.ParameterizeParameters
+		if p := res.Pkg.Parameterization; p != nil {
+			params = &plugin.ParameterizeValue{
+				Name:    p.Name,
+				Version: p.Version,
+				Value:   p.Value,
+			}
+		}
+
+		return setupProvider(res.Pkg.PluginDescriptor, params, res.Spec)
+	case packageresolution.PluginResolution:
+		var params plugin.ParameterizeParameters
+		if p := res.Pkg.ParameterizationArgs; p != nil {
+			params = &plugin.ParameterizeArgs{
+				Args: p,
+			}
+		}
+
+		return setupProvider(res.Pkg.PluginDescriptor, params, res.Spec)
 	default:
 		contract.Failf("Unexpected result type: %T", result)
-		return Provider{}, nil, nil
+		return Provider{}, workspace.PackageSpec{}, nil
 	}
 }
 
-func setupProviderFromPath(packageSource string, pctx *plugin.Context) (Provider, *workspace.PackageSpec, error) {
+func setupProviderFromPath(packageSource string, pctx *plugin.Context) (Provider, workspace.PackageSpec, error) {
 	info, err := os.Stat(packageSource)
 	if os.IsNotExist(err) {
-		return Provider{}, nil, fmt.Errorf("could not find file %s", packageSource)
+		return Provider{}, workspace.PackageSpec{}, fmt.Errorf("could not find file %s", packageSource)
 	} else if err != nil {
-		return Provider{}, nil, err
+		return Provider{}, workspace.PackageSpec{}, err
 	} else if !info.IsDir() && !isExecutable(info) {
 		if p, err := filepath.Abs(packageSource); err == nil {
 			packageSource = p
 		}
-		return Provider{}, nil, fmt.Errorf("plugin at path %q not executable", packageSource)
+		return Provider{}, workspace.PackageSpec{}, fmt.Errorf("plugin at path %q not executable", packageSource)
 	}
 
 	p, err := plugin.NewProviderFromPath(pctx.Host, pctx, "", packageSource)
 	if err != nil {
-		return Provider{}, nil, err
+		return Provider{}, workspace.PackageSpec{}, err
 	}
-	return Provider{Provider: p}, nil, nil
+	return Provider{Provider: p}, workspace.PackageSpec{Source: packageSource}, nil
 }
 
 func isExecutable(info fs.FileInfo) bool {
@@ -605,30 +626,4 @@ func isExecutable(info fs.FileInfo) bool {
 		return !info.IsDir()
 	}
 	return info.Mode()&0o111 != 0 && !info.IsDir()
-}
-
-func setupProviderFromRegistryMeta(
-	meta apitype.PackageMetadata,
-	setupProvider func(workspace.PackageDescriptor, *workspace.PackageSpec) (Provider, *workspace.PackageSpec, error),
-) (Provider, *workspace.PackageSpec, error) {
-	spec := workspace.PluginDescriptor{
-		Name:              meta.Name,
-		Kind:              apitype.ResourcePlugin,
-		Version:           &meta.Version,
-		PluginDownloadURL: meta.PluginDownloadURL,
-	}
-	var params *workspace.Parameterization
-	if meta.Parameterization != nil {
-		spec.Name = meta.Parameterization.BaseProvider.Name
-		spec.Version = &meta.Parameterization.BaseProvider.Version
-		params = &workspace.Parameterization{
-			Name:    meta.Name,
-			Version: meta.Version,
-			Value:   meta.Parameterization.Parameter,
-		}
-	}
-	return setupProvider(workspace.NewPackageDescriptor(spec, params), &workspace.PackageSpec{
-		Source:  meta.Source + "/" + meta.Publisher + "/" + meta.Name,
-		Version: meta.Version.String(),
-	})
 }

--- a/pkg/cmd/pulumi/packages/packages_test.go
+++ b/pkg/cmd/pulumi/packages/packages_test.go
@@ -15,12 +15,137 @@
 package packages
 
 import (
+	"context"
+	"encoding/json"
+	"iter"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestProviderFromSource(t *testing.T) {
+	t.Parallel()
+
+	test := func(t *testing.T, yaml string, inputSource string) plugin.Provider {
+		t.Helper()
+		tempDir := t.TempDir()
+		if yaml != "" {
+			pulumiYaml := filepath.Join(tempDir, "Pulumi.yaml")
+			err := os.WriteFile(pulumiYaml, []byte(yaml), 0o600)
+			require.NoError(t, err)
+		}
+
+		mockProvider := &plugin.MockProvider{
+			PkgF: func() tokens.Package {
+				return "test-provider"
+			},
+			GetSchemaF: func(ctx context.Context, req plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
+				schemaSpec := schema.PackageSpec{
+					Name:    "test-provider",
+					Version: "1.0.0",
+				}
+				schemaBytes, err := json.Marshal(schemaSpec)
+				if err != nil {
+					return plugin.GetSchemaResponse{}, err
+				}
+				return plugin.GetSchemaResponse{
+					Schema: schemaBytes,
+				}, nil
+			},
+		}
+
+		mockHost := &plugin.MockHost{
+			ProviderF: func(descriptor workspace.PluginDescriptor) (plugin.Provider, error) {
+				return mockProvider, nil
+			},
+		}
+
+		mockRegistry := registry.Mock{
+			GetPackageF: func(
+				ctx context.Context, source, publisher, name string, version *semver.Version,
+			) (apitype.PackageMetadata, error) {
+				if name == "test-provider" {
+					return apitype.PackageMetadata{
+						Name:              "test-provider",
+						Publisher:         publisher,
+						Source:            source,
+						Version:           semver.Version{Major: 1, Minor: 0, Patch: 0},
+						PluginDownloadURL: "https://example.com/test-provider",
+					}, nil
+				}
+				return apitype.PackageMetadata{}, registry.ErrNotFound
+			},
+			ListPackagesF: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+				return func(yield func(apitype.PackageMetadata, error) bool) {
+					if name != nil && *name == "test-provider" {
+						yield(apitype.PackageMetadata{
+							Name:              "test-provider",
+							Publisher:         "pulumi",
+							Source:            "pulumi",
+							Version:           semver.Version{Major: 1, Minor: 0, Patch: 0},
+							PluginDownloadURL: "https://example.com/test-provider",
+						}, nil)
+					}
+				}
+			},
+		}
+
+		pctx, err := plugin.NewContext(
+			t.Context(),
+			nil,
+			nil,
+			mockHost,
+			nil,
+			tempDir,
+			nil,
+			false,
+			nil,
+		)
+		require.NoError(t, err)
+		defer pctx.Close()
+
+		provider, _, err := ProviderFromSource(pctx, inputSource, mockRegistry, env.NewEnv(env.MapStore{
+			"PULUMI_EXPERIMENTAL": "true",
+		}))
+		require.NoError(t, err)
+		return provider.Provider
+	}
+
+	t.Run("empy Pulumi.yaml", func(t *testing.T) {
+		t.Parallel()
+		provider := test(t, `name: test-project
+runtime: yaml
+`, "test-provider")
+		assert.Equal(t, tokens.Package("test-provider"), provider.Pkg())
+	})
+
+	t.Run("no Pulumi.yaml", func(t *testing.T) {
+		t.Parallel()
+		provider := test(t, "", "test-provider")
+		assert.Equal(t, tokens.Package("test-provider"), provider.Pkg())
+	})
+
+	t.Run("with Pulumi.yaml", func(t *testing.T) {
+		t.Parallel()
+		provider := test(t, `name: test-project
+runtime: yaml
+packages:
+    local-name: test-provider
+`, "test-provider")
+		assert.Equal(t, tokens.Package("test-provider"), provider.Pkg())
+	})
+}
 
 func TestSetSpecNamespace(t *testing.T) {
 	t.Parallel()

--- a/pkg/cmd/pulumi/plugin/plugin.go
+++ b/pkg/cmd/pulumi/plugin/plugin.go
@@ -49,9 +49,9 @@ func NewPluginCmd() *cobra.Command {
 	}
 
 	packageResolutionOptions := packageresolution.Options{
-		DisableRegistryResolve:      env.DisableRegistryResolve.Value(),
-		Experimental:                env.Experimental.Value(),
-		IncludeInstalledInWorkspace: false,
+		ResolveWithRegistry: env.Experimental.Value() &&
+			!env.DisableRegistryResolve.Value(),
+		AllowNonInvertableLocalWorkspaceResolution: true,
 	}
 	cmd.AddCommand(newPluginInstallCmd(packageResolutionOptions))
 	cmd.AddCommand(newPluginLsCmd())

--- a/pkg/cmd/pulumi/plugin/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/blang/semver"
@@ -192,14 +193,33 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 				return fmt.Errorf("getting current working directory: %w", err)
 			}
 
-			var project workspace.BaseProject
+			source := args[1]
+			var version string
+			if parts := strings.SplitN(args[1], "@", 2); len(parts) > 1 {
+				source = parts[0]
+				version = parts[1]
+				if len(args) > 2 {
+					return fmt.Errorf(`cannot specify both "@%s" and "%s" as a version`, version, args[2])
+				}
+			} else if len(args) > 2 {
+				version = args[2]
+			}
+			packageSpec := workspace.PackageSpec{
+				Source:            source,
+				Checksums:         checksums,
+				PluginDownloadURL: cmd.serverURL,
+				Version:           version,
+			}
+
 			if bp, _, err := workspace.LoadBaseProjectFrom(cwd); err == nil {
-				project = bp
+				if p, ok := bp.GetPackageSpecs()[pluginSpec.Name]; ok {
+					packageSpec = p
+				}
 			} else if !errors.Is(err, workspace.ErrBaseProjectNotFound) {
 				return err
 			}
 
-			updatedSpec, err := cmd.resolvePluginSpec(ctx, pluginSpec, project)
+			updatedSpec, err := cmd.resolvePluginSpec(ctx, packageSpec)
 			if err != nil {
 				return err
 			}
@@ -251,7 +271,7 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 					continue
 				}
 			} else {
-				if has, _ := workspace.HasPluginGTE(install); has {
+				if has, _, _ := workspace.HasPluginGTE(install); has {
 					logging.V(1).Infof("%s skipping install (existing >= match)", label)
 					continue
 				}
@@ -344,11 +364,11 @@ func getFilePayload(file string, spec workspace.PluginDescriptor) (pluginstorage
 
 // resolvePluginSpec resolves plugin specifications using various resolution strategies.
 func (cmd *pluginInstallCmd) resolvePluginSpec(
-	ctx context.Context, pluginSpec workspace.PluginDescriptor, project workspace.BaseProject,
+	ctx context.Context, pluginSpec workspace.PackageSpec,
 ) (workspace.PluginDescriptor, error) {
 	resolutionEnv := cmd.packageResolutionOptions
 	result, err := packageresolution.Resolve(
-		ctx, cmd.registry, packageresolution.DefaultWorkspace(), pluginSpec, resolutionEnv, project)
+		ctx, cmd.registry, packageresolution.DefaultWorkspace(), pluginSpec, resolutionEnv)
 	if err != nil {
 		var packageNotFoundErr *packageresolution.PackageNotFoundError
 		if errors.As(err, &packageNotFoundErr) {
@@ -363,16 +383,14 @@ func (cmd *pluginInstallCmd) resolvePluginSpec(
 	}
 
 	switch res := result.(type) {
-	case packageresolution.LocalPathResult,
-		packageresolution.ExternalSourceResult,
-		packageresolution.InstalledInWorkspaceResult:
-		return pluginSpec, nil
-	case packageresolution.RegistryResult:
-		pluginSpec.Name = res.Metadata.Name
-		pluginSpec.PluginDownloadURL = res.Metadata.PluginDownloadURL
-		return pluginSpec, nil
+	case packageresolution.PathResolution:
+		return workspace.PluginDescriptor{Name: res.Path, Kind: apitype.ResourcePlugin}, nil
+	case packageresolution.PackageResolution:
+		return res.Pkg.PluginDescriptor, nil
+	case packageresolution.PluginResolution:
+		return res.Pkg.PluginDescriptor, nil
 	default:
 		contract.Failf("Unexpected result type: %T", result)
-		return pluginSpec, nil
+		return workspace.PluginDescriptor{}, nil
 	}
 }

--- a/pkg/cmd/pulumi/plugin/plugin_install_test.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install_test.go
@@ -116,7 +116,7 @@ func TestGetLatestPluginIncludedVersion(t *testing.T) {
 		},
 	}
 
-	err := cmd.Run(context.Background(), []string{"resource", "aws@1000.78.0"})
+	err := cmd.Run(t.Context(), []string{"resource", "aws@1000.78.0"})
 	require.NoError(t, err)
 }
 
@@ -131,8 +131,7 @@ func TestGetPluginDownloadURLFromRegistry(t *testing.T) {
 	cmd := &pluginInstallCmd{
 		diag: diagtest.LogSink(t),
 		packageResolutionOptions: packageresolution.Options{
-			DisableRegistryResolve: false,
-			Experimental:           true,
+			ResolveWithRegistry: true,
 		},
 		pluginGetLatestVersion: func(ps workspace.PluginDescriptor, ctx context.Context) (*semver.Version, error) {
 			assert.Fail(t, "GetLatestVersion should not have been called")
@@ -173,7 +172,7 @@ func TestGetPluginDownloadURLFromRegistry(t *testing.T) {
 		},
 	}
 
-	err := cmd.Run(context.Background(), []string{"resource", "foo@2.0.0"})
+	err := cmd.Run(t.Context(), []string{"resource", "foo@2.0.0"})
 	require.NoError(t, err)
 }
 
@@ -250,8 +249,7 @@ func TestGetPluginDownloadForMissingPackage(t *testing.T) {
 		cmd := &pluginInstallCmd{
 			diag: diagtest.LogSink(t),
 			packageResolutionOptions: packageresolution.Options{
-				DisableRegistryResolve: false,
-				Experimental:           true,
+				ResolveWithRegistry: true,
 			},
 			pluginGetLatestVersion: func(ps workspace.PluginDescriptor, ctx context.Context) (*semver.Version, error) {
 				assert.Fail(t, "GetLatestVersion should not have been called")
@@ -279,8 +277,7 @@ func TestGetPluginDownloadForMissingPackage(t *testing.T) {
 		cmd := &pluginInstallCmd{
 			diag: diagtest.LogSink(t),
 			packageResolutionOptions: packageresolution.Options{
-				DisableRegistryResolve: false,
-				Experimental:           true,
+				ResolveWithRegistry: true,
 			},
 			pluginGetLatestVersion: func(ps workspace.PluginDescriptor, ctx context.Context) (*semver.Version, error) {
 				assert.Fail(t, "GetLatestVersion should not have been called")
@@ -371,14 +368,14 @@ packages:
 			_ context.Context, _ string, install workspace.PluginDescriptor, _ string,
 			_ diag.Sink, _ colors.Colorization, _ bool,
 		) error {
-			require.Equal(t, "my-local-provider", install.Name)
+			require.Equal(t, "./my-provider", install.Name)
 			require.NotContains(t, install.PluginDownloadURL, "github.com/pulumi/pulumi-my-local-provider")
 			installCalled = true
 			return nil
 		},
 	}
 
-	err = cmd.Run(context.Background(), []string{"resource", "my-local-provider"})
+	err = cmd.Run(t.Context(), []string{"resource", "my-local-provider"})
 	require.NoError(t, err)
 }
 
@@ -391,8 +388,7 @@ func TestSuggestedPackagesDisplay(t *testing.T) {
 	cmd := &pluginInstallCmd{
 		diag: sink,
 		packageResolutionOptions: packageresolution.Options{
-			DisableRegistryResolve: false,
-			Experimental:           true,
+			ResolveWithRegistry: true,
 		},
 		pluginGetLatestVersion: func(ps workspace.PluginDescriptor, ctx context.Context) (*semver.Version, error) {
 			assert.Fail(t, "GetLatestVersion should not have been called")

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -106,7 +106,8 @@ func (defaultPluginManager) HasPlugin(spec workspace.PluginDescriptor) bool {
 }
 
 func (defaultPluginManager) HasPluginGTE(spec workspace.PluginDescriptor) (bool, error) {
-	return workspace.HasPluginGTE(spec)
+	has, _, err := workspace.HasPluginGTE(spec)
+	return has, err
 }
 
 func (defaultPluginManager) GetLatestPluginVersion(

--- a/pkg/workspace/plugins_install_test.go
+++ b/pkg/workspace/plugins_install_test.go
@@ -124,7 +124,7 @@ func assertPluginInstalled(t *testing.T, dir string, plugin workspace.PluginDesc
 
 	assert.True(t, workspace.HasPlugin(plugin))
 
-	has, err := workspace.HasPluginGTE(plugin)
+	has, _, err := workspace.HasPluginGTE(plugin)
 	require.NoError(t, err)
 	assert.True(t, has)
 
@@ -300,7 +300,7 @@ func TestGetPluginsSkipsPartial(t *testing.T) {
 
 	assert.False(t, workspace.HasPlugin(plugin))
 
-	has, err := workspace.HasPluginGTE(plugin)
+	has, _, err := workspace.HasPluginGTE(plugin)
 	require.NoError(t, err)
 	assert.False(t, has)
 

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -63,6 +63,8 @@ const (
 
 var enableLegacyPluginBehavior = os.Getenv("PULUMI_ENABLE_LEGACY_PLUGIN_SEARCH") != ""
 
+var ErrGetLatestVersionNotSupported = errors.New("GetLatestVersion is not supported for plugins from http sources")
+
 // pluginDownloadURLOverrides is a variable instead of a constant so it can be set using the `-X` `ldflag` at build
 // time, if necessary. When non-empty, it's parsed into `pluginDownloadURLOverridesParsed` in `init()`. The expected
 // format is `regexp=URL`, and multiple pairs can be specified separated by commas, e.g. `regexp1=URL1,regexp2=URL2`.
@@ -694,7 +696,7 @@ func (source *httpSource) GetLatestVersion(
 	ctx context.Context,
 	getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error),
 ) (*semver.Version, error) {
-	return nil, errors.New("GetLatestVersion is not supported for plugins from http sources")
+	return nil, ErrGetLatestVersionNotSupported
 }
 
 func interpolateURL(serverURL string, name string, version semver.Version, os, arch string) string {
@@ -912,6 +914,17 @@ type PackageDescriptor struct {
 	// An optional parameterization to apply to the providing plugin to produce
 	// the package.
 	Parameterization *Parameterization
+}
+
+// A resolved plugin with parameterization arguments.
+//
+// This is different then a [PackageDescriptor], which holds a parameterization value.
+type UnresolvedPackageDescriptor struct {
+	// The fully resolved plugin descriptor.
+	PluginDescriptor
+
+	// The parameterization args to be applied against the plugin descriptor.
+	ParameterizationArgs []string
 }
 
 func NewPackageDescriptor(spec PluginDescriptor, parameterization *Parameterization) PackageDescriptor {
@@ -1798,17 +1811,18 @@ func HasPlugin(spec PluginDescriptor) bool {
 	return false
 }
 
-// HasPluginGTE returns true if the given plugin exists at the given version number or greater.
-func HasPluginGTE(spec PluginDescriptor) (bool, error) {
+// HasPluginGTE returns the version selected if the given plugin exists at the given
+// version number or greater.
+func HasPluginGTE(spec PluginDescriptor) (bool, *semver.Version, error) {
 	// If an exact match, return true right away.
 	if HasPlugin(spec) {
-		return true, nil
+		return true, spec.Version, nil
 	}
 
 	// Otherwise, load up the list of plugins and find one with the same name/type and >= version.
 	plugs, err := GetPlugins()
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 
 	// If we're not doing the legacy plugin behavior and we've been asked for a specific version, do the same plugin
@@ -1820,7 +1834,10 @@ func HasPluginGTE(spec PluginDescriptor) (bool, error) {
 	} else {
 		match = LegacySelectCompatiblePlugin(plugs, spec)
 	}
-	return match != nil, nil
+	if match != nil {
+		return true, match.Version, nil
+	}
+	return false, nil, nil
 }
 
 // GetPolicyDir returns the directory in which an organization's Policy Packs on the current machine are managed.

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -115,6 +115,7 @@ type PackageSpec struct {
 	// - A simple name, like "pkg"
 	// - A registry double or triple: "org/pkg", "source/org/pkg"
 	// - A git URL, "git://github.com/pulumi/pulumi-example/path"
+	// - An un-prefixed URL, like github.com/pulumi/pulumi-example/path
 	// - A local path, like /usr/bin/pkg
 	Source string
 	// The version of the provider, may be Semver 2.0 or a git hash.

--- a/sdk/go/common/workspace/project.json
+++ b/sdk/go/common/workspace/project.json
@@ -289,6 +289,17 @@
                         "type": "string"
                     },
                     "description":"Additional parameters for parameterized providers"
+                },
+                "pluginDownloadURL":{
+                    "type": "string",
+                    "description":"The server from which to download the provider plugin from"
+                },
+                "checksums":{
+                    "type": "object",
+                    "description":"The checksums of the downloaded plugin, by os-arch",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2725,7 +2725,7 @@ func TestPackageAddProviderFromRemoteSource(t *testing.T) {
 	yamlString := string(yamlContent)
 	require.Contains(t, yamlString, "packages:")
 	require.Contains(t, yamlString, "tls-self-signed-cert: "+
-		"github.com/pulumi/component-test-providers/test-provider@0.0.0-xd47cf0910e0450400775594609ee82566d1fb355")
+		"github.com/pulumi/component-test-providers/test-provider@d47cf0910e0450400775594609ee82566d1fb355")
 }
 
 func TestPackagesInstall(t *testing.T) {
@@ -2897,7 +2897,7 @@ func TestPackageAddProviderFromRemoteSourceNoVersion(t *testing.T) {
 	require.Contains(t, yamlString, "packages:")
 	require.Contains(t, yamlString,
 		"tls-self-signed-cert: github.com/pulumi/component-test-providers/test-provider@"+
-			"0.0.0-x52a8a71555d964542b308da197755c64dbe63352")
+			"52a8a71555d964542b308da197755c64dbe63352")
 
 	e.Env = []string{"PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "true"}
 	// Ensure the plugin our package needs is installed manually.  We want to turn off automatic


### PR DESCRIPTION
`packageresolution.Resolve` should be a function from an unresolved type (`package.PluginSpec`) to a resolved type (either a resolved package, a resolved plugin, or a local path). This PR changes the implementation of `packageresolution.Resolve` to do exactly that.

It also adds a bunch of tests and ensures that `packageresolution.Resolve` actually resolves the version in all cases.