### PR TITLE
TestAzureLoginAzLogin: show full exec error

### DIFF
--- a/tests/integration/backend/diy/backend_azure_test.go
+++ b/tests/integration/backend/diy/backend_azure_test.go
@@ -62,8 +62,8 @@ func TestAzureLoginAzLogin(t *testing.T) {
 	out, err := exec.Command("az", "login", "--service-principal",
 		"--username", os.Getenv("AZURE_CLIENT_ID"),
 		"--password", os.Getenv("AZURE_CLIENT_SECRET"),
-		"--tenant", os.Getenv("AZURE_TENANT_ID")).Output()
-	require.NoError(t, err, "%s: out: %q, err: %q", err, out, err.(*exec.ExitError).Stderr)
+		"--tenant", os.Getenv("AZURE_TENANT_ID")).CombinedOutput()
+	require.NoError(t, err, "%s: %q", err, out)
 
 	t.Cleanup(func() {
 		err := exec.Command("az", "logout").Run()


### PR DESCRIPTION
The error exec.Command returns serializes as just "exit code <number>", instead of also printing the stderr, that's included with the error.  This makes things much harder to debug, as no more error information is given.  When this test fails it's useful to have that information, so use our utility to enrich the error message before asserting that there's no error.

/xref https://github.com/pulumi/pulumi/issues/21300