### PR TITLE
improve error message when dependency installation failed

### DIFF
--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/errutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"gopkg.in/yaml.v2"
 )
@@ -307,7 +308,7 @@ func linkPackage(ctx *LinkPackagesContext) error {
 		if err = pkgCmdUtil.InstallDependencies(languagePlugin, plugin.InstallDependenciesRequest{
 			Info: programInfo,
 		}, ctx.Writer, ctx.Writer); err != nil {
-			return fmt.Errorf("installing dependencies: %w", err)
+			return errutil.ErrorWithStderr(err, "installing dependencies")
 		}
 	}
 

--- a/sdk/go/common/util/errutil/format_exiterr.go
+++ b/sdk/go/common/util/errutil/format_exiterr.go
@@ -23,6 +23,9 @@ import (
 
 // ErrorWithStderr returns an error that includes the stderr output if the error is an ExitError.
 func ErrorWithStderr(err error, message string) error {
+	if err == nil {
+		return nil
+	}
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
 		stderr := strings.TrimSpace(string(exitErr.Stderr))

--- a/sdk/python/toolchain/poetry.go
+++ b/sdk/python/toolchain/poetry.go
@@ -163,7 +163,7 @@ func (p *poetry) InstallDependencies(ctx context.Context,
 	poetryCmd.Dir = p.directory
 	poetryCmd.Stdout = infoWriter
 	poetryCmd.Stderr = errorWriter
-	return poetryCmd.Run()
+	return errutil.ErrorWithStderr(poetryCmd.Run(), "poetry install failed")
 }
 
 func (p *poetry) PrepareProject(

--- a/sdk/python/toolchain/uv.go
+++ b/sdk/python/toolchain/uv.go
@@ -159,10 +159,7 @@ func (u *uv) InstallDependencies(ctx context.Context, cwd string, useLanguageVer
 	// We now have either a uv.lock or at least a pyproject.toml file, and we can use uv
 	// install the dependencies.
 	syncCmd := u.uvCommand(ctx, cwd, showOutput, infoWriter, errorWriter, "sync")
-	if err := syncCmd.Run(); err != nil {
-		return errutil.ErrorWithStderr(err, "error installing dependencies")
-	}
-	return nil
+	return errutil.ErrorWithStderr(syncCmd.Run(), "error installing dependencies")
 }
 
 // PrepareProject prepares a project for use with uv. It will create a suitable pyproject.toml project file. If a


### PR DESCRIPTION
In some cases dependency installation relies on `ExitError`s from the cmd package, which unfortunately don't include the stderr output by default. Wrap the errors in with our errutil.ErrorWithStderr helper to give the user more information if the dependency installation fails.

/xref https://github.com/pulumi/pulumi/issues/21309