### PR TITLE
Always use `packageresolution.Resolve` for resource plugin downloads

### DIFF
--- a/pkg/cmd/pulumi/plugin/plugin.go
+++ b/pkg/cmd/pulumi/plugin/plugin.go
@@ -17,10 +17,8 @@ package plugin
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packageresolution"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -48,12 +46,7 @@ func NewPluginCmd() *cobra.Command {
 		Args: cmdutil.NoArgs,
 	}
 
-	packageResolutionOptions := packageresolution.Options{
-		ResolveWithRegistry: env.Experimental.Value() &&
-			!env.DisableRegistryResolve.Value(),
-		AllowNonInvertableLocalWorkspaceResolution: true,
-	}
-	cmd.AddCommand(newPluginInstallCmd(packageResolutionOptions))
+	cmd.AddCommand(newPluginInstallCmd())
 	cmd.AddCommand(newPluginLsCmd())
 	cmd.AddCommand(newPluginRmCmd())
 	cmd.AddCommand(newPluginRunCmd(pkgWorkspace.Instance))

--- a/pkg/cmd/pulumi/plugin/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2024, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import (
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packageresolution"
 	"github.com/pulumi/pulumi/pkg/v3/pluginstorage"
-	"github.com/pulumi/pulumi/pkg/v3/util"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -44,9 +43,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newPluginInstallCmd(packageResolutionOptions packageresolution.Options) *cobra.Command {
+func newPluginInstallCmd() *cobra.Command {
 	var picmd pluginInstallCmd
-	picmd.packageResolutionOptions = packageResolutionOptions
 	cmd := &cobra.Command{
 		Use:   "install [KIND NAME [VERSION]]",
 		Args:  cmdutil.MaximumNArgs(3),
@@ -94,8 +92,6 @@ type pluginInstallCmd struct {
 	color    colors.Colorization
 	registry registry.Registry
 
-	packageResolutionOptions packageresolution.Options
-
 	pluginGetLatestVersion func(
 		workspace.PluginDescriptor, context.Context,
 	) (*semver.Version, error) // == workspace.PluginSpec.GetLatestVersion
@@ -130,11 +126,13 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 	// Parse the kind, name, and version, if specified.
 	var installs []workspace.PluginDescriptor
 	if len(args) > 0 {
+		var kind apitype.PluginKind
 		if !apitype.IsPluginKind(args[0]) {
 			return fmt.Errorf("unrecognized plugin kind: %s", args[0])
 		} else if len(args) < 2 {
 			return errors.New("missing plugin name argument")
 		}
+		kind = apitype.PluginKind(args[0])
 
 		var version *semver.Version
 		if len(args) == 3 {
@@ -160,7 +158,7 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 		}
 
 		pluginSpec, err := workspace.NewPluginDescriptor(ctx,
-			args[1], apitype.PluginKind(args[0]), version, cmd.serverURL, checksums)
+			args[1], kind, version, cmd.serverURL, checksums)
 		if err != nil {
 			return err
 		}
@@ -169,7 +167,7 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 		// distributed with Pulumi itself. But we turn this check off if PULUMI_DEV is set so we can
 		// test installing plugins that are being moved to their own distribution (such as when we move
 		// pulumi-nodejs).
-		if !cmd.env.GetBool(env.Dev) && workspace.IsPluginBundled(pluginSpec.Kind, pluginSpec.Name) {
+		if !cmd.env.GetBool(env.Dev) && workspace.IsPluginBundled(kind, pluginSpec.Name) {
 			return fmt.Errorf(
 				"the %v %v plugin is bundled with Pulumi, and cannot be directly installed"+
 					" with this command. If you need to reinstall this plugin, reinstall"+
@@ -179,62 +177,53 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 			)
 		}
 
-		// Try and set known plugin download URLs
-		if urlSet := util.SetKnownPluginDownloadURL(&pluginSpec); urlSet {
-			cmd.diag.Infof(
-				diag.Message("", "Plugin download URL set to %s"), pluginSpec.PluginDownloadURL)
-		}
-
-		if pluginSpec.Kind == apitype.ResourcePlugin && // The registry only supports resource plugins
-			pluginSpec.PluginDownloadURL == "" && // Don't override explicit pluginDownloadURLs
-			cmd.file == "" { // We don't need help looking up the download URL when we are not downloading a file
-			cwd, err := os.Getwd()
-			if err != nil {
-				return fmt.Errorf("getting current working directory: %w", err)
-			}
-
-			source := args[1]
-			var version string
-			if parts := strings.SplitN(args[1], "@", 2); len(parts) > 1 {
-				source = parts[0]
-				version = parts[1]
-				if len(args) > 2 {
-					return fmt.Errorf(`cannot specify both "@%s" and "%s" as a version`, version, args[2])
+		if kind == apitype.ResourcePlugin {
+			if cmd.file == "" {
+				cwd, err := os.Getwd()
+				if err != nil {
+					return fmt.Errorf("getting current working directory: %w", err)
 				}
-			} else if len(args) > 2 {
-				version = args[2]
-			}
-			packageSpec := workspace.PackageSpec{
-				Source:            source,
-				Checksums:         checksums,
-				PluginDownloadURL: cmd.serverURL,
-				Version:           version,
-			}
 
-			if bp, _, err := workspace.LoadBaseProjectFrom(cwd); err == nil {
-				if p, ok := bp.GetPackageSpecs()[pluginSpec.Name]; ok {
-					packageSpec = p
+				source := args[1]
+				var version string
+				if parts := strings.SplitN(args[1], "@", 2); len(parts) > 1 {
+					source = parts[0]
+					version = parts[1]
+					if len(args) > 2 {
+						return fmt.Errorf(`cannot specify both "@%s" and "%s" as a version`, version, args[2])
+					}
+				} else if len(args) > 2 {
+					version = args[2]
 				}
-			} else if !errors.Is(err, workspace.ErrBaseProjectNotFound) {
-				return err
-			}
+				packageSpec := workspace.PackageSpec{
+					Source:            source,
+					Checksums:         checksums,
+					PluginDownloadURL: cmd.serverURL,
+					Version:           version,
+				}
 
-			updatedSpec, err := cmd.resolvePluginSpec(ctx, packageSpec)
-			if err != nil {
-				return err
-			}
-			pluginSpec = updatedSpec
-		}
+				if bp, _, err := workspace.LoadBaseProjectFrom(cwd); err == nil {
+					if p, ok := bp.GetPackageSpecs()[pluginSpec.Name]; ok {
+						packageSpec = p
+					}
+				} else if !errors.Is(err, workspace.ErrBaseProjectNotFound) {
+					return err
+				}
 
-		// If we don't have a version try to look one up
-		if version == nil && pluginSpec.Version == nil {
+				updatedSpec, err := cmd.resolvePluginSpec(ctx, packageSpec)
+				if err != nil {
+					return err
+				}
+				pluginSpec = updatedSpec
+			}
+		} else if version == nil && pluginSpec.Version == nil {
+			// If we don't have a version try to look one up
 			latestVersion, err := cmd.pluginGetLatestVersion(pluginSpec, ctx)
 			if err != nil {
 				return err
 			}
 			pluginSpec.Version = latestVersion
 		}
-
 		installs = append(installs, pluginSpec)
 	} else {
 		if cmd.file != "" {
@@ -250,9 +239,9 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 			return err
 		}
 		for _, plugin := range plugins {
-			// Skip language plugins; by definition, we already have one installed.
-			// TODO[pulumi/pulumi#956]: eventually we will want to honor and install these in the usual way.
-			if plugin.Kind != apitype.LanguagePlugin {
+			// TODO[pulumi/pulumi#956]: eventually we will want to honor and
+			// install all plugins in the usual way.
+			if !workspace.IsPluginBundled(plugin.Kind, plugin.Name) {
 				installs = append(installs, plugin)
 			}
 		}
@@ -366,9 +355,13 @@ func getFilePayload(file string, spec workspace.PluginDescriptor) (pluginstorage
 func (cmd *pluginInstallCmd) resolvePluginSpec(
 	ctx context.Context, pluginSpec workspace.PackageSpec,
 ) (workspace.PluginDescriptor, error) {
-	resolutionEnv := cmd.packageResolutionOptions
 	result, err := packageresolution.Resolve(
-		ctx, cmd.registry, packageresolution.DefaultWorkspace(), pluginSpec, resolutionEnv)
+		ctx, cmd.registry, packageresolution.DefaultWorkspace(), pluginSpec, packageresolution.Options{
+			ResolveWithRegistry: cmd.env.GetBool(env.Experimental) &&
+				!cmd.env.GetBool(env.DisableRegistryResolve),
+			ResolveVersionWithLocalWorkspace:           cmd.reinstall,
+			AllowNonInvertableLocalWorkspaceResolution: cmd.reinstall,
+		})
 	if err != nil {
 		var packageNotFoundErr *packageresolution.PackageNotFoundError
 		if errors.As(err, &packageNotFoundErr) {

--- a/pkg/cmd/pulumi/plugin/plugin_install_test.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
-	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packageresolution"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -130,9 +129,9 @@ func TestGetPluginDownloadURLFromRegistry(t *testing.T) {
 
 	cmd := &pluginInstallCmd{
 		diag: diagtest.LogSink(t),
-		packageResolutionOptions: packageresolution.Options{
-			ResolveWithRegistry: true,
-		},
+		env: env.NewEnv(env.MapStore{
+			"PULUMI_EXPERIMENTAL": "true",
+		}),
 		pluginGetLatestVersion: func(ps workspace.PluginDescriptor, ctx context.Context) (*semver.Version, error) {
 			assert.Fail(t, "GetLatestVersion should not have been called")
 			return nil, nil
@@ -248,9 +247,9 @@ func TestGetPluginDownloadForMissingPackage(t *testing.T) {
 
 		cmd := &pluginInstallCmd{
 			diag: diagtest.LogSink(t),
-			packageResolutionOptions: packageresolution.Options{
-				ResolveWithRegistry: true,
-			},
+			env: env.NewEnv(env.MapStore{
+				"PULUMI_EXPERIMENTAL": "true",
+			}),
 			pluginGetLatestVersion: func(ps workspace.PluginDescriptor, ctx context.Context) (*semver.Version, error) {
 				assert.Fail(t, "GetLatestVersion should not have been called")
 				return nil, nil
@@ -276,9 +275,9 @@ func TestGetPluginDownloadForMissingPackage(t *testing.T) {
 
 		cmd := &pluginInstallCmd{
 			diag: diagtest.LogSink(t),
-			packageResolutionOptions: packageresolution.Options{
-				ResolveWithRegistry: true,
-			},
+			env: env.NewEnv(env.MapStore{
+				"PULUMI_EXPERIMENTAL": "true",
+			}),
 			pluginGetLatestVersion: func(ps workspace.PluginDescriptor, ctx context.Context) (*semver.Version, error) {
 				assert.Fail(t, "GetLatestVersion should not have been called")
 				return nil, nil
@@ -303,10 +302,8 @@ func TestGetPluginDownloadForMissingPackage(t *testing.T) {
 func TestRegistryIsNotUsedWhenAFileIsSpecified(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-
 	var wasInstalled bool
-	defer func() { assert.True(t, wasInstalled) }()
+	defer func() { assert.True(t, wasInstalled, "Plugin was not installed") }()
 	cmd := &pluginInstallCmd{
 		diag: diagtest.LogSink(t),
 		pluginGetLatestVersion: func(ps workspace.PluginDescriptor, ctx context.Context) (*semver.Version, error) {
@@ -331,7 +328,7 @@ func TestRegistryIsNotUsedWhenAFileIsSpecified(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, cmd.Run(ctx, []string{"resource", "some-file", "v1.0.0"}))
+	require.NoError(t, cmd.Run(t.Context(), []string{"resource", "some-file", "v1.0.0"}))
 }
 
 //nolint:paralleltest // uses t.Chdir
@@ -387,9 +384,9 @@ func TestSuggestedPackagesDisplay(t *testing.T) {
 
 	cmd := &pluginInstallCmd{
 		diag: sink,
-		packageResolutionOptions: packageresolution.Options{
-			ResolveWithRegistry: true,
-		},
+		env: env.NewEnv(env.MapStore{
+			"PULUMI_EXPERIMENTAL": "true",
+		}),
 		pluginGetLatestVersion: func(ps workspace.PluginDescriptor, ctx context.Context) (*semver.Version, error) {
 			assert.Fail(t, "GetLatestVersion should not have been called")
 			return nil, nil

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -17,7 +17,6 @@ package ints
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1022,10 +1021,6 @@ func TestConstructResourceOptionsGo(t *testing.T) {
 func TestAutomation_externalPluginDownload_issue13301(t *testing.T) {
 	t.Parallel()
 
-	// Context scoped to the lifetime of the test.
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
 	e := ptesting.NewEnvironment(t)
 	defer e.DeleteIfNotFailed()
 	e.ImportDirectory(filepath.Join("go", "regress-13301"))
@@ -1066,7 +1061,7 @@ func TestAutomation_externalPluginDownload_issue13301(t *testing.T) {
 		"PULUMI_DEBUG_GRPC="+grpcLog)
 	e.RunCommand("pulumi", "plugin", "install")
 
-	ws, err := auto.NewLocalWorkspace(ctx,
+	ws, err := auto.NewLocalWorkspace(t.Context(),
 		auto.Project(workspace.Project{
 			Name:    "issue-13301",
 			Runtime: workspace.NewProjectRuntimeInfo("go", nil),
@@ -1092,10 +1087,10 @@ func TestAutomation_externalPluginDownload_issue13301(t *testing.T) {
 		return nil
 	})
 
-	stack, err := auto.UpsertStack(ctx, "foo", ws)
+	stack, err := auto.UpsertStack(t.Context(), "foo", ws)
 	require.NoError(t, err)
 
-	_, err = stack.Preview(ctx)
+	_, err = stack.Preview(t.Context())
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
`pulumi install` uses [`packages.InstallPackage`](https://github.com/pulumi/pulumi/blob/015f3ab289bdf66087d35a5034a47ce45eab956c/pkg/cmd/pulumi/install/install.go#L280-L282) to install plugins, which ultimately calls into [`packageresolution.Resolve`](https://github.com/pulumi/pulumi/blob/015f3ab289bdf66087d35a5034a47ce45eab956c/pkg/cmd/pulumi/packages/packages.go#L550-L561). `pulumi plugin install` uses [`packageresolution.Resolve`](https://github.com/pulumi/pulumi/blob/015f3ab289bdf66087d35a5034a47ce45eab956c/pkg/cmd/pulumi/plugin/plugin_install.go#L370-L371) when resolving a specific plugin (`pulumi plugin install resource my-plugin`) already when we need a pluginDownloadURL.

This PR changes our resolution path to always go through the resolution process, letting `packageresolution.Resolve` decide if injecting a pluginDownloadURL is necessary. This ensures that any normalization done by `packageresolution.Resolve` is applied consistently.