### PR TITLE
Remove an instance of re-parsing a plugin source

### DIFF
--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	pkgCmdUtil "github.com/pulumi/pulumi/pkg/v3/util/cmdutil"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
@@ -366,10 +365,11 @@ func NewPluginContext(cwd string) (*plugin.Context, error) {
 	return pluginCtx, nil
 }
 
-func setSpecNamespace(spec *schema.PackageSpec, pluginSpec workspace.PluginDescriptor) {
-	if spec.Namespace == "" && pluginSpec.IsGitPlugin() {
-		namespaceRegex := regexp.MustCompile(`git://[^/]+/([^/]+)/`)
-		matches := namespaceRegex.FindStringSubmatch(pluginSpec.PluginDownloadURL)
+var namespaceRegex = regexp.MustCompile(`git://[^/]+/([^/]+)/`)
+
+func setSpecNamespace(spec *schema.PackageSpec) {
+	if spec.Namespace == "" && spec.PluginDownloadURL != "" {
+		matches := namespaceRegex.FindStringSubmatch(spec.PluginDownloadURL)
 		if len(matches) == 2 {
 			spec.Namespace = strings.ToLower(matches[1])
 		}
@@ -453,14 +453,8 @@ func SchemaFromSchemaSource(
 	if err != nil {
 		return nil, nil, err
 	}
-	pluginSpec, err := workspace.NewPluginDescriptor(pctx.Request(), packageSource, apitype.ResourcePlugin, nil, "", nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	if pluginSpec.PluginDownloadURL != "" {
-		spec.PluginDownloadURL = pluginSpec.PluginDownloadURL
-	}
-	setSpecNamespace(&spec, pluginSpec)
+
+	setSpecNamespace(&spec)
 	return &spec, &packageSpec, nil
 }
 

--- a/pkg/cmd/pulumi/packages/packages_test.go
+++ b/pkg/cmd/pulumi/packages/packages_test.go
@@ -184,11 +184,10 @@ func TestSetSpecNamespace(t *testing.T) {
 		t.Run(tt.pluginDownloadURL, func(t *testing.T) {
 			t.Parallel()
 
-			pluginSpec := workspace.PluginDescriptor{
+			schemaSpec := schema.PackageSpec{
 				PluginDownloadURL: tt.pluginDownloadURL,
 			}
-			schemaSpec := &schema.PackageSpec{}
-			setSpecNamespace(schemaSpec, pluginSpec)
+			setSpecNamespace(&schemaSpec)
 			assert.Equal(t, tt.wantNamespace, schemaSpec.Namespace)
 		})
 	}


### PR DESCRIPTION
We already have this information, we don't need to re-parse it out again (potentially making network calls).

This shouldn't change observable behavior.