### PR TITLE
Refactor: Simplify `plugin.Context`'s cancellation mechanism

### DIFF
--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -182,7 +182,7 @@ func newDeployment(
 	}
 
 	// Keep the plugin context open until the context is terminated, to allow for graceful provider cancellation.
-	plugctx = plugctx.WithCancelChannel(ctx.Cancel.Terminated())
+	go func() { <-ctx.Cancel.Terminated(); contract.IgnoreClose(plugctx) }()
 
 	// Set up a goroutine that will signal cancellation to the source if the caller context
 	// is cancelled.


### PR DESCRIPTION
This refactor changes how `plugin.Context`'s cancellation mechanism works to defer to `context.Context`'s built in cancellation. It should not change user observable behavior.

It *can* only change behavior if we expect to be able to use a `plugin.Context` after closing it, and then close it again. This patter will stop working, since after `(plugin.Context).Close` new requests will start canceled. We don't appear to use this pattern anywhere and it isn't idiomatic Go: structs should not be used after being `Close`d.