### PR TITLE
build only linux binaries with coverage

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -119,7 +119,7 @@ jobs:
         env:
           GORELEASER_CURRENT_TAG: v${{ inputs.version }}
           PULUMI_VERSION: ${{ inputs.dev-version || inputs.version }}
-          PULUMI_BUILD_MODE: ${{ inputs.enable-coverage && runner.os == 'Linux' && 'coverage' || 'normal' }}
+          PULUMI_BUILD_MODE: ${{ inputs.enable-coverage && inputs.os == 'linux' && 'coverage' || 'normal' }}
           PULUMI_ENABLE_RACE_DETECTION: ${{ inputs.enable-race-detection && 'true' || 'false' }}
         run: |
           set -euxo pipefail


### PR DESCRIPTION
I attempted this in https://github.com/pulumi/pulumi/pull/20791 originally. The background is that coverage on windows is often flaky, and the benefits of having separate coverage data from windows is neglegible since there's not much OS specific code.

However in the original PR, I didn't realize that we build all the binaries for the different OS versions on an ubuntu runner, only setting GOOS to the respective platforms. Therefore we continued to always build binaries on windows with coverage data, which continued to lead to flakes. Fix this by using `inputs.os` instead, which is the GOOS we build the binaries for instead.