### PR TITLE
Remove superfluous version string from marshaled `PackageSpec`

### DIFF
--- a/changelog/pending/20260102--cli-package--remove-superfluous-version-string.yaml
+++ b/changelog/pending/20260102--cli-package--remove-superfluous-version-string.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli/package
+  description: Remove superfluous version string

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -136,7 +136,7 @@ type PackageSpec struct {
 
 type packageSpecMarshalled struct {
 	Source            string            `json:"source" yaml:"source"`
-	Version           string            `json:"version" yaml:"version"`
+	Version           string            `json:"version,omitzero" yaml:"version,omitempty"`
 	Parameters        []string          `json:"parameters,omitzero" yaml:"parameters,omitempty"`
 	Checksums         map[string][]byte `json:"checksums,omitzero" yaml:"checksums,omitempty"`
 	PluginDownloadURL string            `json:"pluginDownloadURL,omitzero" yaml:"pluginDownloadURL,omitempty"`


### PR DESCRIPTION
I noticed that we marshal `Version` when we don't need to. Now we don't.