### PR TITLE
Use unittest.IsolatedAsyncioTestCase

### DIFF
--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -151,7 +151,7 @@ def pulumi_test(coro):
     return wrapper
 
 
-class NextSerializationTests(unittest.TestCase):
+class NextSerializationTests(unittest.IsolatedAsyncioTestCase):
     @pulumi_test
     async def test_list(self):
         test_list = [1, 2, 3]


### PR DESCRIPTION
The test functions are async, so they should use `unittest.IsolatedAsyncioTestCase` instead of `unittest.TestCase`.

Possibly fixes flakyness like https://github.com/pulumi/pulumi/actions/runs/20714190013/job/59461833206?pr=21360
