### PR TITLE
make DestroyProgram and RefreshProgram mutually exclusive

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/exclude.go
+++ b/pkg/engine/lifecycletest/fuzzing/exclude.go
@@ -29,6 +29,7 @@ type ExclusionRules []ExclusionRule
 // problematic patterns from being generated.
 func DefaultExclusionRules() ExclusionRules {
 	return []ExclusionRule{
+		ExcludeDestroyAndRefreshProgramSet,
 		// TODO[pulumi/pulumi#21277]
 		ExcludeProtectedResourceWithDuplicateProviderDestroyV2,
 		// TODO[pulumi/pulumi#21282]
@@ -48,6 +49,18 @@ func (er ExclusionRules) ShouldExclude(
 		if rule(snap, program, provider, plan) {
 			return true
 		}
+	}
+	return false
+}
+
+func ExcludeDestroyAndRefreshProgramSet(
+	_ *SnapshotSpec,
+	_ *ProgramSpec,
+	_ *ProviderSpec,
+	plan *PlanSpec,
+) bool {
+	if plan.Operation == PlanOperationDestroyV2 && plan.RefreshProgram {
+		return true
 	}
 	return false
 }

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -207,6 +207,9 @@ func (ex *deploymentExecutor) Execute(callerCtx context.Context) (_ *Plan, err e
 		}
 	}()
 
+	contract.Assertf(!ex.deployment.opts.RefreshProgram || !ex.deployment.opts.DestroyProgram,
+		"cannot have both RefreshProgram and DestroyProgram set to true")
+
 	// Set up a step generator for this deployment.
 	mode := updateMode
 	if ex.deployment.opts.DestroyProgram {


### PR DESCRIPTION
The DestroyProgram and RefreshProgram options cannot be used together, as DestroyProgram already implies running the program. However if RefreshProgram is set, the deployment will run in `refreshMode` instead of `destroyMode`, which is incorrect.

Note that this currently doesn't happen anywhere except for the fuzz tester. For `pulumi destroy` we never set `RefreshProgram` anywhere. This commit just encodes that in both the engine, and the fuzz tester, so we don't get spurious results from that.

/xref https://github.com/pulumi/pulumi/issues/21244