### PR TITLE
Cache gradle and maven dependencies

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -239,6 +239,15 @@ jobs:
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3
         with:
           gradle-version: "7.6"
+      - name: Cache Gradle and Maven packages
+        uses: actions/cache@v5
+        with:
+          key: "maven-gradle-${{ runner.os }}-${{ github.run_id }}"
+          restore-keys: |
+            maven-gradle-${{ runner.os }}-
+          path: |
+            ~/.gradle/caches
+            ~/.m2/repository
       - name: Uninstall pre-installed Pulumi (windows)
         if: inputs.platform == 'windows-latest'
         run: |


### PR DESCRIPTION
We have some smoke tests that run pulumi-java, and we see frequent flakes when maven downloads artifacts. Cache the artefacts in the hopes of helping with these flakes.