### PR TITLE
add failing test for DestroyV2 with refresh

### DIFF
--- a/pkg/engine/lifecycletest/destroy_test.go
+++ b/pkg/engine/lifecycletest/destroy_test.go
@@ -1345,3 +1345,89 @@ func TestDestroyV2TargetProviderWithAliasedParent(t *testing.T) {
 		p.GetProject(), p.GetTarget(t, initialSnap), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 }
+
+func TestDestroyV2ResourceWithDependencyOnDeleted(t *testing.T) {
+	t.Parallel()
+
+	// TODO[pulumi/pulumi#21384]: Remove this once the underlying issue is fixed.
+	t.Skip("Skipping test, repro for snapshot integrity issue")
+
+	p := &lt.TestPlan{
+		Project: "test-project",
+		Stack:   "test-stack",
+	}
+	project := p.GetProject()
+
+	setupSnap := func() *deploy.Snapshot {
+		s := &deploy.Snapshot{}
+
+		prov := &resource.State{
+			Type:   "pulumi:providers:pkgA",
+			URN:    "urn:pulumi:test-stack::test-project::pulumi:providers:pkgA::prov",
+			Custom: true,
+			ID:     "id1",
+		}
+		s.Resources = append(s.Resources, prov)
+
+		provRef, err := providers.NewReference(prov.URN, prov.ID)
+		require.NoError(t, err)
+
+		resA1 := &resource.State{
+			Type:     "pkgA:m:typA",
+			URN:      "urn:pulumi:test-stack::test-project::pkgA:m:typA::resA",
+			Custom:   false,
+			Provider: provRef.String(),
+		}
+		s.Resources = append(s.Resources, resA1)
+
+		resA2 := &resource.State{
+			Type:     "pkgA:m:typA",
+			URN:      "urn:pulumi:test-stack::test-project::pkgA:m:typA::resA",
+			Custom:   false,
+			Delete:   true,
+			Provider: provRef.String(),
+		}
+		s.Resources = append(s.Resources, resA2)
+
+		resB := &resource.State{
+			Type:               "pkgA:m:typB",
+			URN:                "urn:pulumi:test-stack::test-project::pkgA:m:typB::resB",
+			Custom:             true,
+			Delete:             true,
+			ID:                 "id2",
+			PendingReplacement: true,
+			Provider:           provRef.String(),
+			Dependencies:       []resource.URN{resA2.URN},
+		}
+		s.Resources = append(s.Resources, resB)
+
+		return s
+	}()
+	require.NoError(t, setupSnap.VerifyIntegrity(), "initial snapshot is not valid")
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		_, err := monitor.RegisterResource("pulumi:providers:pkgA", "prov", true, deploytest.ResourceOptions{})
+		require.NoError(t, err)
+
+		return nil
+	})
+
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p.Options = lt.TestUpdateOptions{
+		T:     t,
+		HostF: hostF,
+		UpdateOptions: engine.UpdateOptions{
+			Refresh: true,
+		},
+	}
+
+	_, err := lt.TestOp(engine.DestroyV2).
+		RunStep(project, p.GetTarget(t, setupSnap), p.Options, false, p.BackendClient, nil, "1")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
When DestroyV2 is run with --refresh, and the program is missing the dependency of an existing resource, this causes a snapshot integrity issue.  Add a failing test and an exclusion for the fuzzer for this.

/xref https://github.com/pulumi/pulumi/issues/21384