### PR TITLE
Fold fieldName function into one

### DIFF
--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -1697,7 +1697,18 @@ func (pkg *pkgContext) assignProperty(
 
 func (pkg *pkgContext) fieldName(r *schema.Resource, field *schema.Property) string {
 	contract.Assertf(field != nil, "Field must not be nil")
-	return fieldName(pkg, r, field)
+	s := Title(field.Name)
+	var name string
+	if r != nil {
+		name = disambiguatedResourceName(r, pkg)
+	}
+	if !isReservedResourceField(name, s) {
+		return s
+	}
+
+	res := s + "_"
+	contract.Assertf(!isReservedResourceField(name, res), "Name %q is reserved on resource %q", name, res)
+	return res
 }
 
 func (pkg *pkgContext) genPlainType(w io.Writer, name, comment, deprecationMessage string,

--- a/pkg/codegen/go/utilities.go
+++ b/pkg/codegen/go/utilities.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/cgstrings"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // isReservedWord returns true if s is a Go reserved word as per
@@ -136,20 +134,4 @@ func enumTitle(s string) string {
 	return cgstrings.ModifyStringAroundDelimeter(s, "-", func(next string) string {
 		return "_" + cgstrings.UppercaseFirst(next)
 	})
-}
-
-// Calculate the name of a field in a resource
-func fieldName(pkg *pkgContext, r *schema.Resource, p *schema.Property) string {
-	s := Title(p.Name)
-	var name string
-	if r != nil {
-		name = disambiguatedResourceName(r, pkg)
-	}
-	if !isReservedResourceField(name, s) {
-		return s
-	}
-
-	res := s + "_"
-	contract.Assertf(!isReservedResourceField(name, res), "Name %q is reserved on resource %q", name, res)
-	return res
 }


### PR DESCRIPTION
This function was used in just one location, so inline it to make it easier to see `pkg.fieldName` is the only function calculating field names.