### PR TITLE
fuzzing: update dependencies on updated resources

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/program.go
+++ b/pkg/engine/lifecycletest/fuzzing/program.go
@@ -1,4 +1,4 @@
-// Copyright 2024, Pulumi Corporation.
+// Copyright 2024-2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -413,6 +413,7 @@ func GeneratedProgramSpec(
 				newSS.AddResource(r)
 			} else if action == ProgramSpecUpdate {
 				r := ss.Resources[i].Copy()
+				updateDependencies(r)
 				AddTag(r, UpdatedProgramResource)
 
 				// We'll generate a new set of dependencies for the updated resource, which means we'll automatically take any


### PR DESCRIPTION
Updated resources get a new set of dependencies from the fuzzer, and therefore we skipped running the `updateDependencies` function on them.  However this is not true for provider resources. So the fuzzer would generate programs where a resource could still refer an old provider (e.g. if its parent is updated). This isn't possible in real programs, but was causing the fuzzer to find issues because of an unknown provider.

Fix this by running `updateDependencies` on the resources anyway. This does more work than is strictly necessary, but it's simple enough, and this way we can make sure we always have correctly up-to-date dependencies.