### PR TITLE
add skipped test for DestroyV2 snapshot integrity failure

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/exclude.go
+++ b/pkg/engine/lifecycletest/fuzzing/exclude.go
@@ -43,6 +43,8 @@ func DefaultExclusionRules() ExclusionRules {
 		ExcludeTargetedResourceWithAliasedParentDestroyV2,
 		// TODO[pulumi/pulumi#21384]
 		ExcludeResourceWithDependencyOnDeletedResourceDestroyV2,
+		// TODO[pulumi/pulumi#21399]
+		ExcludeResourceReferencingAliasedProviderDestroyV2,
 	}
 }
 
@@ -328,6 +330,56 @@ func ExcludeResourceWithDependencyOnDeletedResourceDestroyV2(
 				if deletedURNs[dep] {
 					return true
 				}
+			}
+		}
+	}
+
+	return false
+}
+
+func ExcludeResourceReferencingAliasedProviderDestroyV2(
+	snap *SnapshotSpec,
+	prog *ProgramSpec,
+	_ *ProviderSpec,
+	plan *PlanSpec,
+) bool {
+	if plan.Operation != PlanOperationDestroyV2 {
+		return false
+	}
+
+	snapProviders := make(map[resource.URN]bool)
+	for _, res := range snap.Resources {
+		if providers.IsProviderType(res.Type) {
+			snapProviders[res.URN()] = true
+		}
+	}
+
+	progProviders := make(map[resource.URN]bool)
+	for _, res := range prog.ResourceRegistrations {
+		if providers.IsProviderType(res.Type) {
+			progProviders[res.URN()] = true
+			for _, alias := range res.Aliases {
+				if _, ok := snapProviders[alias]; ok {
+					return true
+				}
+			}
+		}
+	}
+
+	for _, res := range snap.Resources {
+		if res.Provider == "" {
+			continue
+		}
+
+		providerRef, err := providers.ParseReference(res.Provider)
+		if err != nil {
+			continue
+		}
+
+		providerURN := providerRef.URN()
+		if _, inProg := progProviders[providerURN]; inProg {
+			if _, inSnap := snapProviders[providerURN]; inSnap {
+				return true
 			}
 		}
 	}


### PR DESCRIPTION
Another skipped test and exclusion rule for a snapshot integrity failure in DestroyV2, when a resource depends upon an aliased provider.

/xref https://github.com/pulumi/pulumi/issues/21399