### PR TITLE
add test/exclusion showing snapshot integrity issue in DestroyV2

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/exclude.go
+++ b/pkg/engine/lifecycletest/fuzzing/exclude.go
@@ -47,6 +47,8 @@ func DefaultExclusionRules() ExclusionRules {
 		ExcludeResourceWithDependencyOnDeletedResourceDestroyV2,
 		// TODO[pulumi/pulumi#21399]
 		ExcludeResourceReferencingAliasedProviderDestroyV2,
+		// TODO[pulumi/pulumi#21402]
+		ExcludeRefreshWithTargetedProviderParentChangeDestroyV2,
 	}
 }
 
@@ -422,6 +424,45 @@ func ExcludeResourceReferencingAliasedProviderDestroyV2(
 			if _, inSnap := snapProviders[providerURN]; inSnap {
 				return true
 			}
+		}
+	}
+
+	return false
+}
+
+func ExcludeRefreshWithTargetedProviderParentChangeDestroyV2(
+	snap *SnapshotSpec,
+	prog *ProgramSpec,
+	_ *ProviderSpec,
+	plan *PlanSpec,
+) bool {
+	if plan.Operation != PlanOperationDestroyV2 {
+		return false
+	}
+
+	snapParents := make(map[resource.URN]resource.URN)
+	for _, res := range snap.Resources {
+		snapParents[res.URN()] = res.Parent
+	}
+
+	targetURNs := make(map[resource.URN]bool)
+	for _, res := range plan.TargetURNs {
+		targetURNs[res] = true
+	}
+
+	for _, res := range prog.ResourceRegistrations {
+		if !providers.IsProviderType(res.Type) {
+			continue
+		}
+
+		snapParent, inSnap := snapParents[res.URN()]
+		if inSnap && snapParent == res.Parent {
+			continue
+		}
+
+		res.Parent = snapParent
+		if targetURNs[res.URN()] {
+			return true
 		}
 	}
 


### PR DESCRIPTION
When a provider with a changed parent is targeted in DestroyV2, and
there is a resource that is not targeted, we currently get a snapshot
integrity issue. The solution here might be to just not allow
targeting this provider, but that's left for when we actually go
through and try to fix all these issues.

Add an test and exclusion showing this error.

/xref https://github.com/pulumi/pulumi/issues/21402