### PR TITLE
[sdk/nodejs] Support serializing async generators

### DIFF
--- a/changelog/pending/20260108--sdk-nodejs--add-support-for-serializing-async-generators.yaml
+++ b/changelog/pending/20260108--sdk-nodejs--add-support-for-serializing-async-generators.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Add support for serializing async generators

--- a/sdk/nodejs/runtime/closure/v8.ts
+++ b/sdk/nodejs/runtime/closure/v8.ts
@@ -239,7 +239,12 @@ async function getRuntimeIdForFunctionAsync(func: Function): Promise<inspector.R
         }
 
         const remoteObject = retType.result;
-        if (remoteObject.type !== "function") {
+        // Regular functions have type "function", but async generators have type "object" with className "AsyncGeneratorFunction"
+        // and regular generators have type "function"
+        const isFunction = remoteObject.type === "function";
+        const isAsyncGenerator = remoteObject.type === "object" && remoteObject.className === "AsyncGeneratorFunction";
+
+        if (!isFunction && !isAsyncGenerator) {
             throw new Error("Remote object was not 'function': " + JSON.stringify(remoteObject));
         }
 

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/179-Async-generator-function/index.js
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/179-Async-generator-function/index.js
@@ -1,0 +1,23 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+"use strict";
+
+module.exports.description = "Async generator function";
+
+module.exports.func = async function* () {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    yield "Hello";
+    console.log("World");
+};

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/179-Async-generator-function/snapshot.txt
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/179-Async-generator-function/snapshot.txt
@@ -1,0 +1,18 @@
+exports.handler = __f0;
+
+var __f0_prototype = Object.create(Object.getPrototypeOf((async function*(){}).prototype));
+Object.defineProperty(__f0, "prototype", { writable: true, value: __f0_prototype });
+
+function __f0() {
+  return (function() {
+    with({ this: undefined, arguments: undefined }) {
+
+return function* () {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    yield "Hello";
+    console.log("World");
+};
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/180-Async-generator-with-capture/index.js
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/180-Async-generator-with-capture/index.js
@@ -1,0 +1,26 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+"use strict";
+
+module.exports.description = "Async generator function with captured variable";
+
+const delay = 100;
+const message = "Hello from captured variable";
+
+module.exports.func = async function* () {
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    yield message;
+    console.log("World");
+};

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/180-Async-generator-with-capture/snapshot.txt
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/180-Async-generator-with-capture/snapshot.txt
@@ -1,0 +1,18 @@
+exports.handler = __f0;
+
+var __f0_prototype = Object.create(Object.getPrototypeOf((async function*(){}).prototype));
+Object.defineProperty(__f0, "prototype", { writable: true, value: __f0_prototype });
+
+function __f0() {
+  return (function() {
+    with({ delay: 100, message: "Hello from captured variable", this: undefined, arguments: undefined }) {
+
+return function* () {
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    yield message;
+    console.log("World");
+};
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}


### PR DESCRIPTION
This change adds support for serializing async generators.

Fixes #9344