### PR TITLE
snapshot equal: normalize `ReplaceWith`

### DIFF
--- a/sdk/go/common/snapshot/equal.go
+++ b/sdk/go/common/snapshot/equal.go
@@ -119,6 +119,10 @@ func AssertEqual(expected, actual *apitype.DeploymentV3) error {
 		if len(mr.Inputs) == 0 {
 			mr.Inputs = make(map[string]any)
 		}
+		// Normalize ReplaceWith
+		if len(mr.ReplaceWith) == 0 {
+			mr.ReplaceWith = nil
+		}
 		resourcesMap[mr.URN] = append(resourcesMap[mr.URN], mr)
 	}
 
@@ -144,6 +148,10 @@ func AssertEqual(expected, actual *apitype.DeploymentV3) error {
 		}
 		if len(jr.Inputs) == 0 {
 			jr.Inputs = make(map[string]any)
+		}
+		// Normalize ReplaceWith
+		if len(jr.ReplaceWith) == 0 {
+			jr.ReplaceWith = nil
 		}
 		for _, mr := range resourcesMap[jr.URN] {
 			if diff := deep.Equal(jr, mr); diff != nil {


### PR DESCRIPTION
In `snapshot.AssertEqual`, we need to normalize lists and maps, as deep.Equal distinguishes between nil and empty list. However as we serialize and deserialize snapshots before feeding them this information, the information gets lost. Similar to inputs and outputs, we also need to normalize the `ReplaceWith` option here.