### PR TITLE
extend exclusion rule to RefreshV2

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/exclude.go
+++ b/pkg/engine/lifecycletest/fuzzing/exclude.go
@@ -32,7 +32,7 @@ func DefaultExclusionRules() ExclusionRules {
 	return []ExclusionRule{
 		ExcludeDestroyAndRefreshProgramSet,
 		// TODO[pulumi/pulumi#21404]
-		ExcludeResourcePendingReplacementChangingParentUpdate,
+		ExcludeResourcePendingReplacementChangingParentRefreshProgram,
 		// TODO[pulumi/pulumi#21386]
 		ExcludeChildProviderOfDuplicateResourceRefresh,
 		// TODO[pulumi/pulumi#21277]
@@ -116,13 +116,15 @@ func ExcludeChildProviderOfDuplicateResourceRefresh(
 	return false
 }
 
-func ExcludeResourcePendingReplacementChangingParentUpdate(
+func ExcludeResourcePendingReplacementChangingParentRefreshProgram(
 	snap *SnapshotSpec,
 	prog *ProgramSpec,
 	_ *ProviderSpec,
 	plan *PlanSpec,
 ) bool {
-	if plan.Operation != PlanOperationUpdate && !plan.RefreshProgram {
+	if plan.Operation != PlanOperationUpdate &&
+		plan.Operation != PlanOperationRefreshV2 &&
+		!plan.RefreshProgram {
 		return false
 	}
 


### PR DESCRIPTION
When a resource pending replacement changes parents in the program, we get a panic in `up --refresh --run-program`.  We get the same issue with just `RefreshV2`, even without the up case.  Update the inclusion to reflect that.