### PR TITLE
Extend env util library

### DIFF
--- a/sdk/go/common/util/env/env.go
+++ b/sdk/go/common/util/env/env.go
@@ -30,6 +30,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // Store holds a collection of key, value? pairs.
@@ -83,9 +85,7 @@ func (envStore) Values() iter.Seq2[string, string] {
 		vars := os.Environ()
 		for _, v := range vars {
 			parts := strings.SplitN(v, "=", 2)
-			if len(parts) == 1 {
-				panic("os.Environ promises that this won't happen")
-			}
+			contract.Assertf(len(parts) == 2, "invalid return value from os.Environ: %q", v)
 			if !yield(parts[0], parts[1]) {
 				break
 			}

--- a/sdk/go/common/util/env/env_test.go
+++ b/sdk/go/common/util/env/env_test.go
@@ -267,8 +267,6 @@ func TestJoinStoreRaw(t *testing.T) {
 }
 
 func TestEnvStoreValues(t *testing.T) {
-	t.Parallel()
-
 	testKey1 := "PULUMI_TEST_ENV_STORE_KEY1"
 	testKey2 := "PULUMI_TEST_ENV_STORE_KEY2"
 	testValue1 := "test_value_1"


### PR DESCRIPTION
This pull request extends the `util/env` helper library to do the following:

- Add a Store to the Env interface
- Add the ability to join different Stores. Note that JoinStore will use the value from the first Store in case of duplicate keys.

The purpose is for adding additional key/value pairs to a Pulumi environment: mapping extra/overridden environment values.

Also adds tests; some of them for existing functionality.