### PR TITLE
Fold some go codegen code together

### DIFF
--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -1057,7 +1057,23 @@ func (g *generator) genPostamble(w io.Writer, nodes []pcl.Node) {
 
 func (g *generator) genHelpers(w io.Writer) {
 	for _, v := range g.arrayHelpers {
-		v.generateHelperMethod(w)
+		inputType := strings.TrimSuffix(v.destType, "Array")
+		parts := strings.Split(inputType, ".")
+		contract.Assertf(len(parts) == 2, "genHelpers inputType expected to have two parts.")
+		typ := parts[1]
+		promptType := typ
+		if t, ok := primitives[typ]; ok {
+			promptType = t
+		}
+
+		fnName := v.getFnName()
+		fmt.Fprintf(w, "func %s(arr []%s) %s {\n", fnName, promptType, v.destType)
+		fmt.Fprintf(w, "var pulumiArr %s\n", v.destType)
+		fmt.Fprintf(w, "for _, v := range arr {\n")
+		fmt.Fprintf(w, "pulumiArr = append(pulumiArr, %s(v))\n", inputType)
+		fmt.Fprintf(w, "}\n")
+		fmt.Fprintf(w, "return pulumiArr\n")
+		fmt.Fprintf(w, "}\n")
 	}
 }
 

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -979,7 +979,11 @@ func (g *generator) argumentTypeName(destType model.Type, isInput bool) (result 
 			switch ut := ut.(type) {
 			case *model.OpaqueType:
 				if isOptional {
-					return g.argumentTypeNamePtr(ut, isInput)
+					res := g.argumentTypeName(ut, isInput)
+					if !strings.HasPrefix(res, "pulumi.") {
+						return "*" + res
+					}
+					return res
 				}
 				return g.argumentTypeName(ut, isInput)
 			case *model.ConstType:
@@ -997,14 +1001,6 @@ func (g *generator) argumentTypeName(destType model.Type, isInput bool) (result 
 		contract.Failf("unexpected destType type %T", destType)
 	}
 	return ""
-}
-
-func (g *generator) argumentTypeNamePtr(destType model.Type, isInput bool) (result string) {
-	res := g.argumentTypeName(destType, isInput)
-	if !strings.HasPrefix(res, "pulumi.") {
-		return "*" + res
-	}
-	return res
 }
 
 func (g *generator) genRelativeTraversal(w io.Writer,

--- a/pkg/codegen/go/gen_program_utils.go
+++ b/pkg/codegen/go/gen_program_utils.go
@@ -16,7 +16,6 @@ package gen
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -34,39 +33,10 @@ var primitives = map[string]string{
 	"Float64": "float64",
 }
 
-func (p *promptToInputArrayHelper) generateHelperMethod(w io.Writer) {
-	promptType := p.getPromptItemType()
-	inputType := p.getInputItemType()
-	fnName := p.getFnName()
-	fmt.Fprintf(w, "func %s(arr []%s) %s {\n", fnName, promptType, p.destType)
-	fmt.Fprintf(w, "var pulumiArr %s\n", p.destType)
-	fmt.Fprintf(w, "for _, v := range arr {\n")
-	fmt.Fprintf(w, "pulumiArr = append(pulumiArr, %s(v))\n", inputType)
-	fmt.Fprintf(w, "}\n")
-	fmt.Fprintf(w, "return pulumiArr\n")
-	fmt.Fprintf(w, "}\n")
-}
-
 func (p *promptToInputArrayHelper) getFnName() string {
 	parts := strings.Split(p.destType, ".")
 	contract.Assertf(len(parts) == 2, "promptToInputArrayHelper destType expected to have two parts.")
 	return fmt.Sprintf("to%s%s", Title(parts[0]), Title(parts[1]))
-}
-
-func (p *promptToInputArrayHelper) getPromptItemType() string {
-	inputType := p.getInputItemType()
-	parts := strings.Split(inputType, ".")
-	contract.Assertf(len(parts) == 2, "promptToInputArrayHelper destType expected to have two parts.")
-	typ := parts[1]
-	if t, ok := primitives[typ]; ok {
-		return t
-	}
-
-	return typ
-}
-
-func (p *promptToInputArrayHelper) getInputItemType() string {
-	return strings.TrimSuffix(p.destType, "Array")
 }
 
 // Provides code for a method which will be placed in the program preamble if deemed


### PR DESCRIPTION
This inlines the calls to `argumentTypeNamePtr` and `generateHelperMethod` as they were only used in a single place, that seemed simpler to have the code just inlined rather than calling out to a separate method.

This also folds `getPromptItemType` used in `generateHelperMethod` into its single callsite which then further allows inlining of `getInputItemType`. Removing three named methods without making `genHelpers` really any harder to understand.