### PR TITLE
IsProviderType: take parent into account

### DIFF
--- a/changelog/pending/20260112--pkg--fix-isprovidertype-when-the-provider-has-a-parent.yaml
+++ b/changelog/pending/20260112--pkg--fix-isprovidertype-when-the-provider-has-a-parent.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pkg
+  description: Fix IsProviderType when the provider has a parent

--- a/sdk/go/common/providers/reference.go
+++ b/sdk/go/common/providers/reference.go
@@ -42,6 +42,10 @@ func IsProviderType(typ tokens.Type) bool {
 	if !tokens.Token(typ).HasModuleMember() {
 		return false
 	}
+	if strings.Contains(string(typ), "$") {
+		parts := strings.SplitN(string(typ), "$", 2)
+		typ = tokens.Type(parts[1])
+	}
 	return typ.Module() == "pulumi:providers" && typ.Name() != ""
 }
 

--- a/sdk/go/common/providers/reference_test.go
+++ b/sdk/go/common/providers/reference_test.go
@@ -32,6 +32,13 @@ func TestRoundTripProviderType(t *testing.T) {
 	assert.True(t, IsProviderType(MakeProviderType(pkg)))
 }
 
+func TestProviderTypeWithParent(t *testing.T) {
+	t.Parallel()
+
+	token := "a:b:c$pulumi:providers:abc"
+	assert.True(t, IsProviderType(tokens.Type(token)))
+}
+
 func TestParseReferenceInvalidURN(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The type for pulumi resources can include the name of the parent type if the resource has a parent. We however don't take this into account when checking whether a type is a provider type.  Instead, the `IsProviderType` method currently only checks the `Module()` of the type, which, if there is a parent, is the `Module()` of the parent type.

Fix this by taking into account that it is possible for a provider to have a parent, and splitting the type token on `$`, which is our separator character.