### PR TITLE
fuzzing: don't allow Delete and PendingReplacement to be set on the same resource

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/snapshot.go
+++ b/pkg/engine/lifecycletest/fuzzing/snapshot.go
@@ -376,6 +376,7 @@ func generatedOldResourceSpec(
 		// retained on deletion but its replacement isn't.
 		r.Protect = rapid.Bool().Draw(t, "OldResourceSpec.Protect")
 		r.RetainOnDelete = rapid.Bool().Draw(t, "OldResourceSpec.RetainOnDelete")
+		r.PendingReplacement = false
 
 		rds.ApplyTo(r)
 


### PR DESCRIPTION
If I understand these properties correctly, they are mutually exclusive.  A resource `PendingReplacement` has been deleted in the provider already, whereas a resource marked `Delete` is kept in state, but has not been deleted in the provider.

Make sure the fuzzer doesn't generate resources that are marked as both Delete and PendingReplacement, as it doesn't make sense as a possible state.

(Somebody please double check my thinking here, I think this is an impossible situation, but I could be wrong.)