### PR TITLE
enable fuzzing for destroy in CI

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/plan.go
+++ b/pkg/engine/lifecycletest/fuzzing/plan.go
@@ -1,4 +1,4 @@
-// Copyright 2024, Pulumi Corporation.
+// Copyright 2024-2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -165,8 +165,7 @@ var operationSpecs = []OperationSpec{
 	PlanOperationRefresh,
 	// TODO[pulumi/pulumi#21274]: uncomment when refreshV2 operations are stable
 	// PlanOperationRefreshV2,
-	// TODO[pulumi/pulumi#21271]: uncomment when destroy operations are stable
-	// PlanOperationDestroy,
+	PlanOperationDestroy,
 	PlanOperationDestroyV2,
 }
 


### PR DESCRIPTION
With https://github.com/pulumi/pulumi/pull/21437 merged, it looks like fuzzing Destroy is stable locally, so let's add it to CI as well.

Fixes #21271