### PR TITLE
Optimize StackReference performance

### DIFF
--- a/changelog/pending/20260113--engine--optimize-stackreference-performance.yaml
+++ b/changelog/pending/20260113--engine--optimize-stackreference-performance.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Optimize StackReference performance

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
-	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/util/cancel"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -405,20 +404,12 @@ func (c *backendClient) GetStackOutputs(
 	}
 
 	secretsProvider := newErrorCatchingSecretsProvider(c.secretsProvider, onDecryptError)
-	snap, err := s.Snapshot(ctx, secretsProvider)
+
+	outputs, err := s.SnapshotStackOutputs(ctx, secretsProvider)
 	if err != nil {
 		return property.Map{}, err
 	}
-
-	res, err := stack.GetRootStackResource(snap)
-	if err != nil {
-		return property.Map{}, fmt.Errorf("getting root stack resources: %w", err)
-	}
-
-	if res == nil {
-		return property.Map{}, nil
-	}
-	return resource.FromResourcePropertyMap(res.Outputs), nil
+	return outputs, nil
 }
 
 func (c *backendClient) GetStackResourceOutputs(

--- a/tests/performance/performance_test.go
+++ b/tests/performance/performance_test.go
@@ -116,10 +116,9 @@ func TestPerfSecretsBatchUpdate(t *testing.T) {
 //nolint:paralleltest // Do not run in parallel to avoid resource contention
 func TestPerfStackReferenceSecretsBatchUpdate(t *testing.T) {
 	benchmarkEnforcer := &integration.AssertPerfBenchmark{
-		T: t,
-		// TODO https://github.com/pulumi/pulumi/issues/20476: lower threshold back to 5 seconds
-		MaxPreviewDuration: 10 * time.Second,
-		MaxUpdateDuration:  10 * time.Second,
+		T:                  t,
+		MaxPreviewDuration: 4 * time.Second,
+		MaxUpdateDuration:  4 * time.Second,
 	}
 
 	// Create an initial stack that contains secrets.


### PR DESCRIPTION
We recently fixed a regression that prevented StackReferences from using batch decryption (#20908). As part of that change, an additional optimization was implemented that allows the stack outputs of a snapshot to be unmarshaled without having to unmarshal the entire snapshot. The intention was to use this optimization for StackReferences and the `pulumi stack output` command, but it was only hooked up for the command.

This change adopts the optimization for StackReferences and ratchets the max time thresholds for the performance test as appropriate.

Fixes #21445