### PR TITLE
extend exclusion rule for RefreshV2

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/exclude.go
+++ b/pkg/engine/lifecycletest/fuzzing/exclude.go
@@ -92,7 +92,10 @@ func ExcludeChildProviderOfDuplicateResourceRefresh(
 	_ *ProviderSpec,
 	plan *PlanSpec,
 ) bool {
-	if plan.Operation != PlanOperationRefresh && !plan.Refresh && !plan.RefreshProgram {
+	if plan.Operation != PlanOperationRefresh &&
+		plan.Operation != PlanOperationRefreshV2 &&
+		!plan.Refresh &&
+		!plan.RefreshProgram {
 		return false
 	}
 


### PR DESCRIPTION
This exclusion rule is also needed for RefreshV2.  Note that we already use it for when `RefreshProgram` is set.  While `RefreshV2` will always set `RefreshProgram`, the fuzzer won't necessarily set `RefreshProgram` for the plan, even though it will then be set internally in the engine.