### PR TITLE
Don't set PULUMI_ROOT with mise

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,10 +1,3 @@
-[env]
-PULUMI_ROOT = "{{config_root}}/.root"
-
-_.path = [
-  "{{env.PULUMI_ROOT}}/bin",
-]
-
 [tools]
 github-cli = "latest"
 "go:github.com/go-delve/delve/cmd/dlv" = "latest"

--- a/changelog/pending/20260114--build--dont-set-pulumi_root-with-mise.yaml
+++ b/changelog/pending/20260114--build--dont-set-pulumi_root-with-mise.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: build
+  description: Don't set PULUMI_ROOT with mise

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -43,9 +43,4 @@ which you can do as follows:
 6. Run `mise install` to ensure all tools are up to date. You may need to re-run
    this if the tool list changes.
 
-When using Mise `$PULUMI_ROOT` is set to `$REPO/.root`. This is convenient for
-working with multiple Git worktrees, since each worktree will have its binaries
-installed in `$PULUMI_ROOT/bin`. To use these binaries, add `$REPO/.root/bin` to
-your `$PATH`.
-
 Use of Mise is currently experimental and optional.


### PR DESCRIPTION
This was setting `$PULUMI_ROOT` to `$REPO/.root`, with the idea being
that it would be convenient to have a root per git checkout or worktree.
In practice it is annoying and confusing, with `make build` putting
binaries into `$REPO/bin`, and `make install` putting them into
`$REPO/.root/bin`.

Remove this setting. The makefile sets `$PULUMI_ROOT` to
`$HOME/.pulumi-dev`, so `make install` will install binaries into
`$HOME/.pulumi-dev/bin`. This is the same behaviour you get when not
using mise.

Developers that desire the old behaviour can manually set the
environment variable.
