### PR TITLE
Implement `About` in Python automation API server

### DIFF
--- a/changelog/pending/20260116--auto-python--implement-about-in-python-automation-api-server.yaml
+++ b/changelog/pending/20260116--auto-python--implement-about-in-python-automation-api-server.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/python
+  description: Implement `About` in Python automation API server

--- a/sdk/python/lib/pulumi/automation/_server.py
+++ b/sdk/python/lib/pulumi/automation/_server.py
@@ -35,6 +35,12 @@ class LanguageServer(LanguageRuntimeServicer):
     def __init__(self, program: PulumiFn) -> None:
         self.program = program
 
+    def About(self, request, context):
+        return language_pb2.AboutResponse(
+            executable=sys.executable,
+            version=f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        )
+
     def GetRequiredPlugins(self, request, context):
         return language_pb2.GetRequiredPluginsResponse()
 

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -1648,3 +1648,21 @@ def test_config_get_float(mock_config, config_settings):
     assert mock_config.get_float("float") == float(
         config_settings.get("test-config:float")
     )
+
+
+def test_no_logs(caplog):
+    """
+    A simple inline program should not be logging messages
+    Regression test for https://github.com/pulumi/pulumi/issues/21378
+    """
+    project_name = "inline_python"
+    stack_name = stack_namer(project_name)
+    stack = create_stack(
+        stack_name, program=pulumi_program_with_resource, project_name=project_name
+    )
+
+    try:
+        stack.preview()
+        assert len(caplog.records) == 0, "Nothing should be logged"
+    finally:
+        stack.workspace.remove_stack(stack_name, force=True)


### PR DESCRIPTION
Since https://github.com/pulumi/pulumi/pull/21186 we call the language server's `About` method to grab some metadata like the underlying language runtime's version.

Because this method is not implemented, we log an error message to stdout, but not otherwise impact the run.

Implement the `About` RPC to avoid this noise.

Fixes https://github.com/pulumi/pulumi/issues/21378
