### PR TITLE
Add plugin to metadata for pulumi plugin run

### DIFF
--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -610,10 +610,7 @@ func getCLIMetadata(cmd *cobra.Command, environ []string, args []string) map[str
 
 	if command == "pulumi plugin run" {
 		if len(args) > 0 {
-			if i > 0 {
-				flags.WriteRune(' ')
-			}
-			flags.WriteString(args[0])
+			command += " " + args[0]
 		}
 	}
 

--- a/pkg/cmd/pulumi/pulumi_test.go
+++ b/pkg/cmd/pulumi/pulumi_test.go
@@ -440,8 +440,8 @@ func TestGetCLIMetadata(t *testing.T) {
 			environ: []string{"PULUMI_EXPERIMENTAL=true", "PULUMI_COPILOT=true"},
 			args:    []string{"my-plugin"},
 			metadata: map[string]string{
-				"Command":     "pulumi plugin run",
-				"Flags":       "my-plugin",
+				"Command":     "pulumi plugin run my-plugin",
+				"Flags":       "",
 				"Environment": "PULUMI_EXPERIMENTAL PULUMI_COPILOT",
 			},
 		},


### PR DESCRIPTION
This PR adds the name of the plugin to the metadata for `pulumi plugin run`.