### PR TITLE
Fix README getting started example and add templates link

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ Serverless Lambdas, in minutes:
 
     ```bash
     mkdir pulumi-demo && cd pulumi-demo
-    pulumi new aws-typescript
+    pulumi new serverless-aws-typescript
     ```
 
     The `new` command offers [templates](https://github.com/pulumi/templates/) for all languages and clouds.  Run it without an argument and it'll prompt
-    you with available projects.  This command creates an Amazon S3 bucket and exports its name.
+    you with available projects.  This command creates an AWS Serverless Lambda project written in TypeScript.
 
 3. **Deploy to the Cloud**:
 


### PR DESCRIPTION
- Update `pulumi new` command from non-existent `hello-aws-javascript` template to the working `aws-typescript` template
- Add hyperlink to the templates repository for discoverability