### PR TITLE
Increase stack ref perf test limits

### DIFF
--- a/tests/performance/performance_test.go
+++ b/tests/performance/performance_test.go
@@ -116,9 +116,10 @@ func TestPerfSecretsBatchUpdate(t *testing.T) {
 //nolint:paralleltest // Do not run in parallel to avoid resource contention
 func TestPerfStackReferenceSecretsBatchUpdate(t *testing.T) {
 	benchmarkEnforcer := &integration.AssertPerfBenchmark{
-		T:                  t,
-		MaxPreviewDuration: 5 * time.Second,
-		MaxUpdateDuration:  5 * time.Second,
+		T: t,
+		// TODO https://github.com/pulumi/pulumi/issues/20476: lower threshold back to 5 seconds
+		MaxPreviewDuration: 10 * time.Second,
+		MaxUpdateDuration:  10 * time.Second,
 	}
 
 	// Create an initial stack that contains secrets.


### PR DESCRIPTION
There've been some test runs that have ended up taking just over 4 seconds. This change bumps the limit back up to the temporary 10s with TODO, to avoid the flakiness.

Fixes #21521