### PR TITLE
Add StackPolicyPacks API capability

### DIFF
--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -42,6 +42,9 @@ const (
 
 	// Indicates the maximum deployment schema version that the service supports.
 	DeploymentSchemaVersion APICapability = "deployment-schema-version"
+
+	// Indicates whether the service supports retrieving a stack's required policy packs.
+	StackPolicyPacks APICapability = "stack-policy-packs"
 )
 
 type DeltaCheckpointUploadsConfigV2 struct {
@@ -87,6 +90,9 @@ type Capabilities struct {
 
 	// Indicates the maximum deployment schema version that the service supports.
 	DeploymentSchemaVersion int
+
+	// Indicates whether the service supports retrieving a stack's required policy packs.
+	StackPolicyPacks bool
 }
 
 // Parse decodes the CapabilitiesResponse into a Capabilities struct for ease of use.
@@ -125,6 +131,10 @@ func (r CapabilitiesResponse) Parse() (Capabilities, error) {
 					return Capabilities{}, fmt.Errorf("decoding DeploymentSchemaVersionConfig returned %w", err)
 				}
 				parsed.DeploymentSchemaVersion = versionConfig.Version
+			}
+		case StackPolicyPacks:
+			if entry.Version == 1 {
+				parsed.StackPolicyPacks = true
 			}
 		default:
 			continue

--- a/sdk/go/common/apitype/service_test.go
+++ b/sdk/go/common/apitype/service_test.go
@@ -157,4 +157,21 @@ func TestCapabilities(t *testing.T) {
 			DeploymentSchemaVersion: 4,
 		}, actual)
 	})
+
+	t.Run("parse stack policy packs", func(t *testing.T) {
+		t.Parallel()
+		response := CapabilitiesResponse{
+			Capabilities: []APICapabilityConfig{
+				{
+					Capability: StackPolicyPacks,
+					Version:    1,
+				},
+			},
+		}
+		actual, err := response.Parse()
+		require.NoError(t, err)
+		assert.Equal(t, Capabilities{
+			StackPolicyPacks: true,
+		}, actual)
+	})
 }


### PR DESCRIPTION
The Pulumi Cloud service has long supported an endpoint that returns the required policy packs that are currently applicable to the stack:

```
/api/stacks/{orgName}/{projectName}/{stackName}/policypacks
```

The CLI will call this endpoint as part of a proposed new `pulumi policy install` command.

Even though this API endpoint has existed since the inception of policy packs, we should still have an API Capability that the CLI can check before calling the endpoint, to avoid calling the endpoint for custom backends that do not implement the endpoint.

This change adds the new API Capability.

Part of #21453