### PR TITLE
Guard against null resource references in `pulumi-test-language`

### DIFF
--- a/cmd/pulumi-test-language/providers/component_provider.go
+++ b/cmd/pulumi-test-language/providers/component_provider.go
@@ -17,6 +17,7 @@ package providers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -452,13 +453,13 @@ func (p *ComponentProvider) constructComponentCustomRefInputOutput(
 	// Hydrate the input resource reference, whether it's a plain value or an output (that should be known and resolved).
 	var inputRef resource.ResourceReference
 	if req.Inputs["inputRef"].IsNull() {
-		return plugin.ConstructResponse{}, fmt.Errorf("inputRef is null")
+		return plugin.ConstructResponse{}, errors.New("inputRef is null")
 	}
 
 	if req.Inputs["inputRef"].IsOutput() {
 		element := req.Inputs["inputRef"].OutputValue().Element
 		if element.IsNull() {
-			return plugin.ConstructResponse{}, fmt.Errorf("inputRef output is null")
+			return plugin.ConstructResponse{}, errors.New("inputRef output is null")
 		}
 
 		inputRef = element.ResourceReferenceValue()


### PR DESCRIPTION
While working on https://github.com/pulumi/pulumi-yaml/pull/922, I ran into an issue that then caused an engine-side panic when I fixed it. After some debugging, it looks like the problem is that a null value here causes `ResourceReferenceValue()` to panic because of a conversion error. This PR adds a null check to the inputRef and, if it's an output, the output value.