### PR TITLE
Do not install local dependencies for already installed plugins

### DIFF
--- a/changelog/pending/20260123--cli-install--do-not-install-local-dependencies-for-already-installed-plugins.yaml
+++ b/changelog/pending/20260123--cli-install--do-not-install-local-dependencies-for-already-installed-plugins.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/install
+  description: Do not install local dependencies for already installed plugins

--- a/pkg/cmd/pulumi/packageinstallation/testdata/TestDoNotInstallDependenciesOfAlreadyInstalledPackage/steps.txt
+++ b/pkg/cmd/pulumi/packageinstallation/testdata/TestDoNotInstallDependenciesOfAlreadyInstalledPackage/steps.txt
@@ -1,0 +1,4 @@
+HasPlugin{PluginDescriptor{Name:"already-installed", Kind:"resource"}} -> {true}
+GetPluginPath{ctx, PluginDescriptor{Name:"already-installed", Kind:"resource"}} -> {"$HOME/.pulumi/plugins/resource-already-installed", nil}
+LoadPluginProjectAt{ctx, "$HOME/.pulumi/plugins/resource-already-installed"} -> {PluginProject{Runtime:ProjectRuntimeInfo{name:"go"}, Packages:map[1]{"dependency":PackageSpec{Source:"dependency", PluginDownloadURL:"https://example.com/dependency.tar.gz"}}}, "$HOME/.pulumi/plugins/resource-already-installed/PulumiPlugin.yaml", nil}
+RunPackage{ctx, "/tmp", "$HOME/.pulumi/plugins/resource-already-installed", "already-installed", nil} -> {nil, nil}

--- a/pkg/cmd/pulumi/packageresolution/package_resolution.go
+++ b/pkg/cmd/pulumi/packageresolution/package_resolution.go
@@ -117,7 +117,7 @@ type (
 	PackageResolution struct {
 		Spec                 workspace.PackageSpec
 		Pkg                  workspace.PackageDescriptor
-		InstalledInWorkspace bool
+		InstalledInWorkspace bool // If package is already installed in the global workplace.
 	}
 	// A fully resolved plugin with not yet resolved parameterization.
 	//


### PR DESCRIPTION
We can assume that plugins already installed into `$PULUMI_HOME/plugins` are already correctly installed. Previously, the install logic would install dependencies of packages that had already had their dependencies installed (because they were already fully installed).