### PR TITLE
Skip `TestPendingReplaceResumeWithSameGoalsRefreshRunProgram`

### DIFF
--- a/pkg/engine/lifecycletest/pending_replace_test.go
+++ b/pkg/engine/lifecycletest/pending_replace_test.go
@@ -375,6 +375,7 @@ func TestPendingReplaceResumeWithSameGoals(t *testing.T) {
 // * remove the old resource from the state
 func TestPendingReplaceResumeWithSameGoalsRefreshRunProgram(t *testing.T) {
 	t.Parallel()
+	t.Skip("TODO[github.com/pulumi/pulumi/issues/21539]: flaky")
 
 	p := &lt.TestPlan{}
 	project := p.GetProject()


### PR DESCRIPTION
`TestPendingReplaceResumeWithSameGoalsRefreshRunProgram` is flaky. See https://github.com/pulumi/pulumi/issues/21539 for details.