### PR TITLE
Do not double install plugins with explicit parameterizations

### DIFF
--- a/changelog/pending/20260126--cli-install--do-not-double-install-plugins.yaml
+++ b/changelog/pending/20260126--cli-install--do-not-double-install-plugins.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/install
+  description: Do not double install plugins with explicit parameterizations

--- a/pkg/cmd/pulumi/packageinstallation/packageinstallation.go
+++ b/pkg/cmd/pulumi/packageinstallation/packageinstallation.go
@@ -719,6 +719,19 @@ func (step resolveStep) run(ctx context.Context, p state) error {
 			}
 		}
 
+		if result.InstalledInWorkspace {
+			defer specReady()
+			pluginDir, err := p.ws.GetPluginPath(ctx, descriptor)
+			if err != nil {
+				return err
+			}
+			// If it's already installed in it's Pulumi managed location, then assuming it was installed
+			// successfully we shouldn't need to do anything else.
+			_, err = ensureProjectDir(
+				ctx, p, specFinished, descriptor.Name, pluginDir, nil, step.runBundleOut)
+			return err
+		}
+
 		// Start with the download. The downloadStep will take care of attaching
 		// steps for (2) and (3) to specFinished.
 		download, downloadReady := p.dag.NewNode(downloadStep{

--- a/pkg/cmd/pulumi/packageinstallation/testdata/TestInstallAlreadyInstalledPlugin/steps.txt
+++ b/pkg/cmd/pulumi/packageinstallation/testdata/TestInstallAlreadyInstalledPlugin/steps.txt
@@ -1,0 +1,5 @@
+HasPlugin{PluginDescriptor{Name:"plugin", Kind:"resource", Version:Version{Major:1}}} -> {true}
+GetPluginPath{ctx, PluginDescriptor{Name:"plugin", Kind:"resource", Version:Version{Major:1}}} -> {"$HOME/.pulumi/plugins/resource-plugin-v1.0.0", nil}
+LoadPluginProjectAt{ctx, "$HOME/.pulumi/plugins/resource-plugin-v1.0.0"} -> {nil, "", wrapErrors{msg:"no project file found and no plugin file found", errs:[2]{errorString{s:"no project file found"}, errorString{s:"no plugin file found"}}}}
+IsExecutable{ctx, "$HOME/.pulumi/plugins/resource-plugin-v1.0.0/pulumi-resource-plugin"} -> {true, nil}
+RunPackage{ctx, "/tmp", "$HOME/.pulumi/plugins/resource-plugin-v1.0.0/pulumi-resource-plugin", "plugin", ParameterizeArgs{Args:[1]{"parameterization"}}} -> {nil, nil}


### PR DESCRIPTION
I noticed that `pulumi install` was doing more install work then it should have been when there was a `packages` section. This was fixed for packages (unknown parameterization), but not for plugins.

This PR fixes the problem and adds a test.