### PR TITLE
Copy files when linking instead of renaming

### DIFF
--- a/changelog/pending/20260126--cli-install--copy-files-when-linking-to-be-robust-to-copying-across-file-partitions.yaml
+++ b/changelog/pending/20260126--cli-install--copy-files-when-linking-to-be-robust-to-copying-across-file-partitions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/install
+  description: Copy files when linking to be robust to copying across file partitions

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -49,6 +49,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 
@@ -585,7 +586,7 @@ func generateAndLinkSdksForPackages(
 		}
 
 		sdkOut := filepath.Join(targetDirectory, "sdks", pkg.Parameterization.Name)
-		err = packages.CopyAll(sdkOut, filepath.Join(tempOut, language))
+		err = fsutil.CopyFile(sdkOut, filepath.Join(tempOut, language), nil)
 		if err != nil {
 			return fmt.Errorf("failed to move SDK to project: %w", err)
 		}


### PR DESCRIPTION
We generate SDKs into a temporary directory and then move the generated SDK into place afterwards. Pre v3.217.0 we did this by copying all files from the temp dir into the dst dir. v3.217.0 did this by calling `os.Rename`, which doesn't work as desired across file system partitions. This PR changes the behavior back to copying each file individually.

Fixes https://github.com/pulumi/pulumi/issues/21547