### PR TITLE
Increase partition for the pkg module on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
               "$CODEGEN_TESTS_FLAG" \
               --platform windows-latest \
               --version-set current \
-              --partition-module pkg 1 \
+              --partition-module pkg 2 \
               --partition-module sdk 1 \
               --partition-module tests 2 \
               --partition-package github.com/pulumi/pulumi/tests/smoke tests/smoke 4 \


### PR DESCRIPTION
Using https://github.com/fchimpan/gh-workflow-stats we can retrieve stats for our CI workflows & jobs.

```
$ gh workflow-stats --org pulumi --repo pulumi --file on-pr.yml jobs --num-jobs 10
...
📊 Top 10 jobs with the longest execution average duration
  CI / Integration Test / sdk/python/cmd/pulumi-language-python on ubuntu-latest/current: 2484.48s
  CI / Acceptance Test / pkg on windows-latest/current: 1924.40s
  CI / Acceptance Test / tests/integration 1/8 on windows-latest/current: 1772.01s
  CI / Acceptance Test / tests 2/2 on windows-latest/current: 1770.95s
  CI / Acceptance Test / tests 1/2 on windows-latest/current: 1739.87s
  CI / Integration Test / sdk/nodejs/cmd/pulumi-language-nodejs on ubuntu-latest/current: 1671.00s
  CI / Acceptance Test / tests/integration 2/8 on windows-latest/current: 1622.13s
  CI / Integration Test / sdk/nodejs test_auto on ubuntu-latest/current: 1572.56s
  CI / Acceptance Test / tests/integration 3/8 on windows-latest/current: 1503.30s
  CI / Acceptance Test / tests/integration 5/8 on windows-latest/current: 1497.26s
```

We're addressing the slowest job `CI / Integration Test / sdk/python/cmd/pulumi-language-python` in https://github.com/pulumi/pulumi/pull/21367.

Next up is `CI / Acceptance Test / pkg on windows-latest/current`. Partition this into 2 jobs.

