### PR TITLE
ProgramTest: Fully qualify environment names

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -426,7 +426,7 @@ func (opts *ProgramTestOptions) getEnvName(name string) string {
 	contract.IgnoreError(err)
 
 	suffix := hex.EncodeToString(h.Sum(nil))
-	return fmt.Sprintf("%v-%v", name, suffix)
+	return fmt.Sprintf("default/%v-%v", name, suffix)
 }
 
 func (opts *ProgramTestOptions) getEnvNameWithOwner(name string) string {


### PR DESCRIPTION
This change updates ProgramTest to fully qualify the ESC environment name used with the `CreateEnvironments` and `Environments` options, by explicitly specifying the `default` project, to avoid ambiguous lookups.

This should prevent the types of test failures we saw in CI last week when a `moolumi` environment project was created in the `pulumi-bot` account, causing ambiguity between `pulumi-bot/moolumi/X` and the intended `moolumi/default/X` with the `TestEnvironmentsBasicNodeJS` and `TestEnvironmentsMergeNodeJS` tests.

Fixes #21555