### PR TITLE
Fix concurrency bugs in `packageinstallation`

### DIFF
--- a/pkg/cmd/pulumi/packageinstallation/packageinstallation.go
+++ b/pkg/cmd/pulumi/packageinstallation/packageinstallation.go
@@ -367,11 +367,10 @@ func enqueueUnresolvedPackage(
 		done:         ready,
 		runBundleOut: runBundleOut,
 	})
-	// We know that resolving a spec doesn't have any concrete dependencies, so we can kick that off immediately.
-	resolveReady()
-
 	// At minimum, we need to resolve spec before spec is done.
 	contract.AssertNoErrorf(state.dag.NewEdge(resolve, specReady), "linking in a new node is safe")
+	// We know that resolving a spec doesn't have any concrete dependencies, so we can kick that off immediately.
+	resolveReady()
 	return nil
 }
 
@@ -697,8 +696,8 @@ func (step resolveStep) run(ctx context.Context, p state) error {
 			runBundleOut:    step.runBundleOut,
 			downloadCleanup: new(downloadCleanup),
 		})
-		downloadReady()
 		contract.AssertNoErrorf(p.dag.NewEdge(download, specFinished), "new nodes cannot be cyclic")
+		downloadReady()
 		return nil
 
 	case packageresolution.PluginResolution:
@@ -741,8 +740,8 @@ func (step resolveStep) run(ctx context.Context, p state) error {
 			runBundleOut:    step.runBundleOut,
 			downloadCleanup: new(downloadCleanup),
 		})
-		downloadReady()
 		contract.AssertNoErrorf(p.dag.NewEdge(download, specFinished), "new nodes cannot be cyclic")
+		downloadReady()
 		return nil
 	default:
 		panic(fmt.Sprintf("unexpected package resolution result of type %T: %[1]s", result))


### PR DESCRIPTION
`TestConcurrency` was correctly catching real concurrency bugs: specifically allowing a parent node to run before all of it's children were registered. This was caused by `downloadStep` & `resolveStep` running before they were registered into the graph. Both steps embed a reference to their parent and can trigger their parent as "ready" when done.

We should see this graph:

    1. resolve -> package
    2. download -> package
    3. install -> package

The nodes are added in this order:

1. package
2. resolve
3. download (added by resolve)
4. install (added by download)

The problem is when `resolve` was running before it was hooked into the network, it would trigger `package` to be done before `download` was added to `package` **and** before `resolve` was added into the network. That lead to `package` running before `resolve` was finished, causing the error.

The fixes for `downloadStep` were similar, and had a similar root cause.

I've verified that the fixes work by running the test 10,000 times without error:

```
go test -test.run \^TestConcurrency\$ -count 10000
```

Fixes https://github.com/pulumi/pulumi/issues/21553