### PR TITLE
Do not special case Pulumi YAML when linking a SDK

### DIFF
--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -250,14 +250,6 @@ type LinkPackagesContext struct {
 // LinkPackages links a locally generated SDK to an existing project.
 // Currently Java is not supported and will print instructions for manual linking.
 func LinkPackages(ctx *LinkPackagesContext) error {
-	if ctx.Language == "yaml" {
-		return nil // Nothing to do for YAML
-	}
-	return linkPackage(ctx)
-}
-
-// linkPackage links a locally generated SDK into a project using `Language.Link`.
-func linkPackage(ctx *LinkPackagesContext) error {
 	root, err := filepath.Abs(ctx.Root)
 	if err != nil {
 		return err

--- a/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
+++ b/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
@@ -275,14 +275,6 @@ func (w Workspace) LinkPackage(
 
 	// We have now generated a SDK, the only thing left to do is link it into the existing project.
 
-	// TODO[https://github.com/pulumi/pulumi/issues/21323]: Copied from
-	// [packages.LinkPackage]. This might be true, but we should still call into the
-	// YAML language host (which can then do nothing). Languages should not be special
-	// here.
-	if runtimeInfo.Name() == "yaml" {
-		return nil // Nothing to do for YAML
-	}
-
 	sdkPath, err := filepath.Rel(projectDir, out)
 	if err != nil {
 		return err


### PR DESCRIPTION
The CLI should be as language agnostic as possible. We can be language agnostic here.

Fixes https://github.com/pulumi/pulumi/issues/21323