### PR TITLE
Argument specifications for policy commands

### DIFF
--- a/pkg/cmd/pulumi/policy/policy.go
+++ b/pkg/cmd/pulumi/policy/policy.go
@@ -15,7 +15,7 @@
 package policy
 
 import (
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/spf13/cobra"
 )
 
@@ -23,8 +23,9 @@ func NewPolicyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "policy",
 		Short: "Manage resource policies",
-		Args:  cmdutil.NoArgs,
 	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
 	cmd.AddCommand(newPolicyDisableCmd())
 	cmd.AddCommand(newPolicyEnableCmd())

--- a/pkg/cmd/pulumi/policy/policy_disable.go
+++ b/pkg/cmd/pulumi/policy/policy_disable.go
@@ -17,7 +17,7 @@ package policy
 import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/spf13/cobra"
 )
 
@@ -30,8 +30,7 @@ func newPolicyDisableCmd() *cobra.Command {
 	args := policyDisableArgs{}
 
 	cmd := &cobra.Command{
-		Use:   "disable <org-name>/<policy-pack-name>",
-		Args:  cmdutil.ExactArgs(1),
+		Use:   "disable",
 		Short: "Disable a Policy Pack for a Pulumi organization",
 		Long:  "Disable a Policy Pack for a Pulumi organization",
 		RunE: func(cmd *cobra.Command, cliArgs []string) error {
@@ -49,6 +48,13 @@ func newPolicyDisableCmd() *cobra.Command {
 			})
 		},
 	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "policy-pack", Usage: "<org-name>/<policy-pack-name>"},
+		},
+		Required: 1,
+	})
 
 	cmd.PersistentFlags().StringVar(
 		&args.policyGroup, "policy-group", "",

--- a/pkg/cmd/pulumi/policy/policy_enable.go
+++ b/pkg/cmd/pulumi/policy/policy_enable.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	resourceanalyzer "github.com/pulumi/pulumi/pkg/v3/resource/analyzer"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/spf13/cobra"
 )
 
@@ -36,8 +36,7 @@ func newPolicyEnableCmd() *cobra.Command {
 	args := policyEnableArgs{}
 
 	cmd := &cobra.Command{
-		Use:   "enable <org-name>/<policy-pack-name> <latest|version>",
-		Args:  cmdutil.ExactArgs(2),
+		Use:   "enable",
 		Short: "Enable a Policy Pack for a Pulumi organization",
 		Long: "Enable a Policy Pack for a Pulumi organization. " +
 			"Can specify latest to enable the latest version of the Policy Pack or a specific version number.",
@@ -73,6 +72,14 @@ func newPolicyEnableCmd() *cobra.Command {
 				})
 		},
 	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "policy-pack", Usage: "<org-name>/<policy-pack-name>"},
+			{Name: "version", Usage: "<latest|version>"},
+		},
+		Required: 2,
+	})
 
 	cmd.PersistentFlags().StringVar(
 		&args.policyGroup, "policy-group", "",

--- a/pkg/cmd/pulumi/policy/policy_group_ls.go
+++ b/pkg/cmd/pulumi/policy/policy_group_ls.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -35,8 +36,9 @@ func newPolicyGroupCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "group",
 		Short: "Manage policy groups",
-		Args:  cmdutil.NoArgs,
 	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
 	cmd.AddCommand(newPolicyGroupLsCmd())
 	return cmd
@@ -45,8 +47,7 @@ func newPolicyGroupCmd() *cobra.Command {
 func newPolicyGroupLsCmd() *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
-		Use:   "ls [org-name]",
-		Args:  cmdutil.MaximumNArgs(1),
+		Use:   "ls",
 		Short: "List all Policy Groups for a Pulumi organization",
 		Long:  "List all Policy Groups for a Pulumi organization",
 		RunE: func(cmd *cobra.Command, cliArgs []string) error {
@@ -103,6 +104,14 @@ func newPolicyGroupLsCmd() *cobra.Command {
 			return formatPolicyGroupsConsole(allPolicyGroups)
 		},
 	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "org-name"},
+		},
+		Required: 0,
+	})
+
 	cmd.PersistentFlags().BoolVarP(
 		&jsonOut, "json", "j", false, "Emit output as JSON")
 	return cmd

--- a/pkg/cmd/pulumi/policy/policy_ls.go
+++ b/pkg/cmd/pulumi/policy/policy_ls.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -35,8 +36,7 @@ func newPolicyLsCmd() *cobra.Command {
 	var jsonOut bool
 
 	cmd := &cobra.Command{
-		Use:   "ls [org-name]",
-		Args:  cmdutil.MaximumNArgs(1),
+		Use:   "ls",
 		Short: "List all Policy Packs for a Pulumi organization",
 		Long:  "List all Policy Packs for a Pulumi organization",
 		RunE: func(cmd *cobra.Command, cliArgs []string) error {
@@ -93,6 +93,14 @@ func newPolicyLsCmd() *cobra.Command {
 			return formatPolicyPacksConsole(allPolicyPacks)
 		},
 	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "org-name"},
+		},
+		Required: 0,
+	})
+
 	cmd.PersistentFlags().BoolVarP(
 		&jsonOut, "json", "j", false, "Emit output as JSON")
 	return cmd

--- a/pkg/cmd/pulumi/policy/policy_new.go
+++ b/pkg/cmd/pulumi/policy/policy_new.go
@@ -26,6 +26,7 @@ import (
 	surveycore "github.com/AlecAivazis/survey/v2/core"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/newcmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -47,7 +48,7 @@ func newPolicyNewCmd() *cobra.Command {
 	args := newPolicyArgs{}
 
 	cmd := &cobra.Command{
-		Use:        "new [template|url]",
+		Use:        "new",
 		SuggestFor: []string{"init", "create"},
 		Short:      "Create a new Pulumi Policy Pack",
 		Long: "Create a new Pulumi Policy Pack from a template.\n" +
@@ -58,7 +59,6 @@ func newPolicyNewCmd() *cobra.Command {
 			"\n" +
 			"Once you're done authoring the Policy Pack, you will need to publish the pack to your organization.\n" +
 			"Only organization administrators can publish a Policy Pack.",
-		Args: cmdutil.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := cmd.Context()
 			if len(cliArgs) > 0 {
@@ -67,6 +67,13 @@ func newPolicyNewCmd() *cobra.Command {
 			return runNewPolicyPack(ctx, args)
 		},
 	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "template", Usage: "[template|url]"},
+		},
+		Required: 0,
+	})
 
 	cmd.PersistentFlags().StringVar(
 		&args.dir, "dir", "",

--- a/pkg/cmd/pulumi/policy/policy_publish.go
+++ b/pkg/cmd/pulumi/policy/policy_publish.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -37,8 +38,7 @@ import (
 func newPolicyPublishCmd() *cobra.Command {
 	var policyPublishCmd policyPublishCmd
 	cmd := &cobra.Command{
-		Use:   "publish [org-name]",
-		Args:  cmdutil.MaximumNArgs(1),
+		Use:   "publish",
 		Short: "Publish a Policy Pack to the Pulumi Cloud",
 		Long: "Publish a Policy Pack to the Pulumi Cloud\n" +
 			"\n" +
@@ -47,6 +47,13 @@ func newPolicyPublishCmd() *cobra.Command {
 			return policyPublishCmd.Run(cmd.Context(), cmdBackend.DefaultLoginManager, args)
 		},
 	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "org-name"},
+		},
+		Required: 0,
+	})
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/policy/policy_rm.go
+++ b/pkg/cmd/pulumi/policy/policy_rm.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -34,8 +35,7 @@ const allKeyword = "all"
 func newPolicyRmCmd() *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "rm <org-name>/<policy-pack-name> <all|version>",
-		Args:  cmdutil.ExactArgs(2),
+		Use:   "rm",
 		Short: "Removes a Policy Pack from a Pulumi organization",
 		Long: "Removes a Policy Pack from a Pulumi organization. " +
 			"The Policy Pack must be disabled from all Policy Groups before it can be removed.",
@@ -77,6 +77,14 @@ func newPolicyRmCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "policy-pack", Usage: "<org-name>/<policy-pack-name>"},
+			{Name: "version", Usage: "<all|version>"},
+		},
+		Required: 2,
+	})
 
 	cmd.PersistentFlags().BoolVarP(
 		&yes, "yes", "y", false,

--- a/pkg/cmd/pulumi/policy/policy_validate.go
+++ b/pkg/cmd/pulumi/policy/policy_validate.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/spf13/cobra"
 )
 
@@ -28,8 +28,7 @@ func newPolicyValidateCmd() *cobra.Command {
 	var argConfig string
 
 	cmd := &cobra.Command{
-		Use:   "validate-config <org-name>/<policy-pack-name> <version>",
-		Args:  cmdutil.ExactArgs(2),
+		Use:   "validate-config",
 		Short: "Validate a Policy Pack configuration",
 		Long:  "Validate a Policy Pack configuration against the configuration schema of the specified version.",
 		RunE: func(cmd *cobra.Command, cliArgs []string) error {
@@ -65,6 +64,14 @@ func newPolicyValidateCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "policy-pack", Usage: "<org-name>/<policy-pack-name>"},
+			{Name: "version"},
+		},
+		Required: 2,
+	})
 
 	cmd.Flags().StringVar(&argConfig, "config", "",
 		"The file path for the Policy Pack configuration file")


### PR DESCRIPTION
More of the same: this PR adds observable specifications for the CLI arguments so that we can generate code around it.

## Related

* #21482
* #21485
* #21565