### PR TITLE
expand exclusion rule for RefreshV2

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/exclude.go
+++ b/pkg/engine/lifecycletest/fuzzing/exclude.go
@@ -92,7 +92,7 @@ func ExcludeDestroyAndRefreshProgramSet(
 // can appear after it in the resulting snapshot.
 func ExcludeChildProviderOfDuplicateResourceRefresh(
 	snap *SnapshotSpec,
-	_ *ProgramSpec,
+	prog *ProgramSpec,
 	_ *ProviderSpec,
 	plan *PlanSpec,
 ) bool {
@@ -117,6 +117,12 @@ func ExcludeChildProviderOfDuplicateResourceRefresh(
 		}
 
 		if urnCounts[res.Parent] > 1 && deletedURNs[res.Parent] {
+			return true
+		}
+	}
+
+	for _, res := range prog.ResourceRegistrations {
+		if res.Parent != "" && deletedURNs[res.Parent] {
 			return true
 		}
 	}


### PR DESCRIPTION
Expand this exclusion rule for RefreshV2.  It currently only checks if there are children of a resource that's marked `Delete` in the original snapshot.  However we also get snapshot integrity errors for children that get registered in the program.  Expand the rule, and add an additional test for this.