### PR TITLE
Bump language runtimes for dotnet, java, and yaml

### DIFF
--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -28,9 +28,9 @@ download_release() {
 # * When updating .Net, you should also update PulumiDotnetSDKVersion in pkg/codegen/testing/test/helpers.go
 #
 LANGUAGES=(
-  "dotnet v3.97.0"
-  "java v1.20.0"
-  "yaml v1.26.1"
+  "dotnet v3.98.0"
+  "java v1.21.0"
+  "yaml v1.26.2"
 )
 
 for i in "${LANGUAGES[@]}"; do


### PR DESCRIPTION
Pull in the latest release for these runtimes
