### PR TITLE
fuzzing: print full test case to stdout in CI

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/fixture.go
+++ b/pkg/engine/lifecycletest/fuzzing/fixture.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025, Pulumi Corporation.
+// Copyright 2024-2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -70,14 +70,19 @@ func generateAndWriteRepro(
 	planSpec *PlanSpec,
 ) string {
 	reproTest := GenerateReproTest(t, stackSpec, snapSpec, programSpec, providerSpec, planSpec)
-	reproFile, reproErr := writeReproTest(reproTest)
 
 	var reproMessage string
-	if reproErr != nil {
-		reproMessage = fmt.Sprintf("Error writing reproduction test case:\n\n%v", reproErr)
+	if os.Getenv("CI") != "" {
+		reproMessage = "Full test case:\n\n" + reproTest + "\n\n"
 	} else {
-		reproMessage = "Reproduction test case was written to " + reproFile
+		reproFile, reproErr := writeReproTest(reproTest)
+		if reproErr != nil {
+			reproMessage = fmt.Sprintf("Error writing reproduction test case:\n\n%v", reproErr)
+		} else {
+			reproMessage = "Reproduction test case was written to " + reproFile
+		}
 	}
+
 	return reproMessage
 }
 


### PR DESCRIPTION
In a CI environment we can't access the file system after the test has finished. Which also means we can't access the repro test case. Instead write the test case to stdout.

This is more annoying to grab than from the file system when running the tests locally, but at least it makes it possible to grab the test case directly in CI.

(I noticed the test failing in https://github.com/pulumi/pulumi/pull/21599. Haven't worked out why yet, but this should at least help with getting the test case for the failure easily)