### PR TITLE
fuzzing: disallow RefreshProgram with destroy

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/exclude.go
+++ b/pkg/engine/lifecycletest/fuzzing/exclude.go
@@ -80,7 +80,8 @@ func ExcludeDestroyAndRefreshProgramSet(
 	_ *ProviderSpec,
 	plan *PlanSpec,
 ) bool {
-	if plan.Operation == PlanOperationDestroyV2 && plan.RefreshProgram {
+	if (plan.Operation == PlanOperationDestroyV2 || plan.Operation == PlanOperationDestroy) &&
+		plan.RefreshProgram {
 		return true
 	}
 	return false


### PR DESCRIPTION
Similar to DestroyV2, this option doesn't make any sense for Destroy. We never run the program with Destroy (DestroyV2 is responsible for that), and if anything we would be running with `DestroyProgram`, not `RefreshProgram` here.  Disallow the option in fuzz tests, so we don't get false positives for this.

This should fix the error we've seen in https://github.com/pulumi/pulumi/pull/21599