### PR TITLE
include dependencies and propertyDependencies in exclusion rule

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/exclude.go
+++ b/pkg/engine/lifecycletest/fuzzing/exclude.go
@@ -544,6 +544,18 @@ func ExcludeResourceDeletedWithMarkedForDeletionResourceUpdate(
 	}
 
 	for _, res := range snap.Resources {
+		for _, dep := range res.Dependencies {
+			if deletedResources[dep] {
+				return true
+			}
+		}
+		for _, deps := range res.PropertyDependencies {
+			for _, dep := range deps {
+				if deletedResources[dep] {
+					return true
+				}
+			}
+		}
 		if res.DeletedWith != "" && deletedResources[res.DeletedWith] {
 			return true
 		}


### PR DESCRIPTION
For this exclusion rule I had previously only found issues with DeletedWith, but Dependencies and PropertyDependencies are similarly affected.  Exclude them as well.