### PR TITLE
Forbid using `os.Rename` via linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,6 +81,8 @@ linters:
           msg: Use require.Len instead
         - pattern: ^resource.New(String|Bool|Number|Array|Asset|Archive|Object|Computed|Output|Secret|ResourceReference)Property$
           msg: Use resource.NewProperty instead
+        - pattern: ^os.Rename$
+          msg: "`os.Rename` does not work across file systems and is not atomic for windows. Use with caution"
     revive:
       rules:
         - name: use-any

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -296,6 +296,8 @@ func installRequiredPolicy(ctx *plugin.Context, finalDir string, tgz io.ReadClos
 	// If two calls to `plugin install` for the same plugin are racing, the second one will be
 	// unable to rename the directory. That's OK, just ignore the error. The temp directory created
 	// as part of the install will be cleaned up when we exit by the defer above.
+	//
+	//nolint:forbidigo // historic os.Rename usage
 	if err := os.Rename(tempPackageDir, finalDir); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("moving plugin: %w", err)
 	}

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -574,7 +574,7 @@ func newConfigRefreshCmd(ws pkgWorkspace.Context, stk *string) *cobra.Command {
 			for {
 				_, err = os.Stat(backupFile)
 				if os.IsNotExist(err) {
-					if err = os.Rename(configPath, backupFile); err != nil {
+					if err = os.Rename(configPath, backupFile); err != nil { //nolint:forbidigo // historic os.Rename usage
 						return fmt.Errorf("backing up existing configuration file: %w", err)
 					}
 

--- a/pkg/cmd/pulumi/stack/stack_rename.go
+++ b/pkg/cmd/pulumi/stack/stack_rename.go
@@ -89,7 +89,7 @@ func newStackRenameCmd() *cobra.Command {
 			case os.IsNotExist(configStatErr):
 				// Stack doesn't have any configuration, ignore.
 			case configStatErr == nil:
-				if err := os.Rename(oldConfigPath, newConfigPath); err != nil {
+				if err := os.Rename(oldConfigPath, newConfigPath); err != nil { //nolint:forbidigo // historic os.Rename usage
 					return fmt.Errorf("renaming configuration file to %s: %w", filepath.Base(newConfigPath), err)
 				}
 			default:

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1793,13 +1793,13 @@ func (pt *ProgramTester) testEdit(dir string, i int, edit EditDir) error {
 
 		// Finally, replace our current temp directory with the new one.
 		dirOld := dir + ".old"
-		if err := os.Rename(dir, dirOld); err != nil {
+		if err := os.Rename(dir, dirOld); err != nil { //nolint:forbidigo // test usage is OK
 			return fmt.Errorf("Couldn't rename %v to %v: %w", dir, dirOld, err)
 		}
 
 		// There's a brief window here where the old temp dir name could be taken from us.
 
-		if err := os.Rename(newDir, dir); err != nil {
+		if err := os.Rename(newDir, dir); err != nil { //nolint:forbidigo // test usage is OK
 			return fmt.Errorf("Couldn't rename %v to %v: %w", newDir, dir, err)
 		}
 

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -158,7 +158,7 @@ func atomicWriteFile(path string, b []byte) error {
 	if err = tmp.Close(); err != nil {
 		return err
 	}
-	return os.Rename(tmp.Name(), path)
+	return os.Rename(tmp.Name(), path) //nolint:forbidigo // os.Rename is not atomic on windows
 }
 
 func (pw *projectWorkspace) readSettings() error {

--- a/sdk/go/common/tail/tail_test.go
+++ b/sdk/go/common/tail/tail_test.go
@@ -773,7 +773,7 @@ func (t *TailTest) RemoveFile(name string) {
 func (t *TailTest) RenameFile(oldname string, newname string) {
 	oldname = t.path + "/" + oldname
 	newname = t.path + "/" + newname
-	err := os.Rename(oldname, newname)
+	err := os.Rename(oldname, newname) //nolint:forbidigo // test file
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -348,7 +348,7 @@ func StorePulumiConfig(config PulumiConfig) error {
 	if err != nil {
 		return err
 	}
-	err = os.Rename(tempConfigFile.Name(), configFile)
+	err = os.Rename(tempConfigFile.Name(), configFile) //nolint:forbidigo // historic usage
 	if err != nil {
 		contract.IgnoreError(os.Remove(tempConfigFile.Name()))
 		return err

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -1026,7 +1026,7 @@ func TestAutomation_externalPluginDownload_issue13301(t *testing.T) {
 	e.ImportDirectory(filepath.Join("go", "regress-13301"))
 
 	// Rename go.mod.bad to go.mod so that the Go toolchain uses it.
-	require.NoError(t, os.Rename(
+	require.NoError(t, os.Rename( //nolint:forbidigo // os.Rename is OK for tests
 		filepath.Join(e.CWD, "go.mod.bad"),
 		filepath.Join(e.CWD, "go.mod"),
 	))

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2153,7 +2153,7 @@ func TestRegression12301Node(t *testing.T) {
 			jsonPath := filepath.Join(project.Root, "regression-12301.json")
 			dirName := filepath.Base(project.Root)
 			newPath := filepath.Join(project.Root, "..", dirName+".json")
-			return os.Rename(jsonPath, newPath)
+			return os.Rename(jsonPath, newPath) //nolint:forbidigo // os.Rename is OK for tests
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			require.Len(t, stack.Outputs, 1)


### PR DESCRIPTION
Part of the follow-up on https://github.com/pulumi/pulumi/issues/21547:

Forbid using `os.Rename` without explaining why it's safe to use cross-platform.