### PR TITLE
Fix `TestReplaceWithAndDeletedWith` flake

### DIFF
--- a/pkg/engine/lifecycletest/replace_with_test.go
+++ b/pkg/engine/lifecycletest/replace_with_test.go
@@ -238,14 +238,10 @@ func TestReplaceWithAndDeletedWith(t *testing.T) {
 	require.Equal(t, "created-id-2", snap.Resources[2].ID.String())
 
 	require.Len(t, created, 2)
-	createdNames := []string{created[0].Name(), created[1].Name()}
-	require.Contains(t, createdNames, "resC")
-	require.Contains(t, createdNames, "resA")
+	require.ElementsMatch(t, []string{created[0].Name(), created[1].Name()}, []string{"resC", "resA"})
 
 	require.Len(t, deleted, 2)
-	deletedNames := []string{deleted[0].Name(), deleted[1].Name()}
-	require.Contains(t, deletedNames, "resB")
-	require.Contains(t, deletedNames, "resC")
+	require.ElementsMatch(t, []string{deleted[0].Name(), deleted[1].Name()}, []string{"resB", "resC"})
 }
 
 func TestReplaceWithDeleteBeforeReplace(t *testing.T) {


### PR DESCRIPTION
I thought creation/deletion ordering was deterministic for any given version of Go, but it turns out it isn't. Tested with `-count 1000`.