### PR TITLE
Codegen RequirePulumiVersion for Dotnet

### DIFF
--- a/changelog/pending/20260130--programgen-dotnet--codegen-requirepulumiversion-for-dotnet.yaml
+++ b/changelog/pending/20260130--programgen-dotnet--codegen-requirepulumiversion-for-dotnet.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/dotnet
+  description: Codegen RequirePulumiVersion for Dotnet

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -1090,6 +1090,14 @@ func (g *generator) genNode(w io.Writer, n pcl.Node) {
 		g.genLocalVariable(w, n)
 	case *pcl.Component:
 		g.genComponent(w, n)
+	case *pcl.PulumiBlock:
+		g.genPulumi(w, n)
+	}
+}
+
+func (g *generator) genPulumi(w io.Writer, v *pcl.PulumiBlock) {
+	if v.RequiredVersion != nil {
+		g.Fgenf(w, "%sDeployment.RequirePulumiVersionAsync(%.v).Wait();\n", g.Indent, v.RequiredVersion)
 	}
 }
 


### PR DESCRIPTION
This is the codegen part of https://github.com/pulumi/pulumi-dotnet/issues/802

Dotnet codegen lives in this repo, so we first need to update the codegen here, and then update the version of pulumi/pulumi used in pulumi/pulumi-dotnet.

I tested the SDK side implementation locally in the repo dotnet via the conformance test by `go mod replace`ing.