### PR TITLE
Allow setting `requiredPulumiVersion` in Pulumi.yaml

### DIFF
--- a/changelog/pending/20260130--cli--allow-setting-requiredpulumiversion-in-pulumi-yaml.yaml
+++ b/changelog/pending/20260130--cli--allow-setting-requiredpulumiversion-in-pulumi-yaml.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Allow setting `requiredPulumiVersion` in Pulumi.yaml

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -39,9 +39,11 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -228,6 +230,10 @@ func NewDestroyCmd() *cobra.Command {
 				}
 				root = ""
 			} else if err != nil {
+				return err
+			}
+
+			if err := plugin.ValidatePulumiVersionRange(proj.RequiredPulumiVersion, version.Version); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -58,6 +58,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -675,6 +676,17 @@ func NewImportCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
+			ws := pkgWorkspace.Instance
+
+			proj, root, err := ws.ReadProject()
+			if err != nil {
+				return err
+			}
+
+			if err := plugin.ValidatePulumiVersionRange(proj.RequiredPulumiVersion, version.Version); err != nil {
+				return err
+			}
+
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 
 			cwd, err := os.Getwd()
@@ -811,13 +823,6 @@ func NewImportCmd() *cobra.Command {
 				}
 				defer contract.IgnoreClose(f)
 				output = f
-			}
-
-			// Fetch the project.
-			ws := pkgWorkspace.Instance
-			proj, root, err := ws.ReadProject()
-			if err != nil {
-				return err
 			}
 
 			yes = yes || skipPreview || env.SkipConfirmations.Value()

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -47,10 +47,12 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 	sdkproviders "github.com/pulumi/pulumi/sdk/v3/go/common/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -320,6 +322,10 @@ func NewPreviewCmd() *cobra.Command {
 
 			proj, root, err := readProjectForUpdate(ws, client)
 			if err != nil {
+				return err
+			}
+
+			if err := plugin.ValidatePulumiVersionRange(proj.RequiredPulumiVersion, version.Version); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -41,7 +41,9 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -109,6 +111,15 @@ func NewRefreshCmd() *cobra.Command {
 			ctx := cmd.Context()
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 			ws := pkgWorkspace.Instance
+
+			proj, root, err := readProjectForUpdate(ws, client)
+			if err != nil {
+				return err
+			}
+
+			if err := plugin.ValidatePulumiVersionRange(proj.RequiredPulumiVersion, version.Version); err != nil {
+				return err
+			}
 
 			// Remote implies we're skipping previews.
 			if remoteArgs.Remote {
@@ -202,11 +213,6 @@ func NewRefreshCmd() *cobra.Command {
 			}
 
 			if err := parseAndSaveConfigArray(ctx, cmdutil.Diag(), ws, s, configArray, path); err != nil {
-				return err
-			}
-
-			proj, root, err := readProjectForUpdate(ws, client)
-			if err != nil {
 				return err
 			}
 

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -47,10 +47,12 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -545,6 +547,10 @@ func NewUpCmd() *cobra.Command {
 
 			proj, root, err := readProjectForUpdate(ws, client)
 			if err != nil {
+				return err
+			}
+
+			if err := plugin.ValidatePulumiVersionRange(proj.RequiredPulumiVersion, version.Version); err != nil {
 				return err
 			}
 

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -344,6 +344,13 @@ type Project struct {
 	// Handle additional keys, albeit in a way that will remove comments and trivia.
 	AdditionalKeys map[string]any `yaml:",inline"`
 
+	// Optional, validates that the CLI version satisfies the passed version range. The supported syntax for ranges is
+	// that of https://pkg.go.dev/github.com/blang/semver#ParseRange. For example ">=3.0.0", or "!3.1.2". Ranges can be
+	// AND-ed together by concatenating with spaces ">=3.5.0 !3.7.7", meaning greater-or-equal to 3.5.0 and not exactly
+	// 3.7.7. Ranges can be OR-ed with the `||` operator: "<3.4.0 || >3.8.0", meaning less-than 3.4.0 or greater-than
+	// 3.8.0.
+	RequiredPulumiVersion string `json:"requiredPulumiVersion,omitempty" yaml:"requiredPulumiVersion,omitempty"`
+
 	// The original byte representation of the file, used to attempt trivia-preserving edits
 	raw []byte
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1797,3 +1797,15 @@ func TestConfigFlag(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(configContent), "config-flag:example: an-example")
 }
+
+func TestValidatePulumiVersionRange(t *testing.T) {
+	t.Parallel()
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+	e.ImportDirectory("required_pulumi_version")
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.RunCommand("pulumi", "stack", "init", ptesting.RandomStackName())
+
+	_, stderr := e.RunCommandExpectError("pulumi", "preview")
+	require.Regexp(t, "Pulumi CLI version .* does not satisfy the version range \"<1.0.0\"", stderr)
+}

--- a/tests/integration/required_pulumi_version/Pulumi.yaml
+++ b/tests/integration/required_pulumi_version/Pulumi.yaml
@@ -1,0 +1,4 @@
+name: requiredversion
+description: project with a required version range
+runtime: go
+requiredPulumiVersion: "<1.0.0"


### PR DESCRIPTION
Add `requiredPulumiVersion` to `Pulumi.yaml` to set a version range for the Pulumi CLI. If the version of the CLI that’s running the program does not satisfy this range, we bail out.

Fixes https://github.com/pulumi/pulumi/issues/21338