### PR TITLE
Use string interpolation in l1-config-types

### DIFF
--- a/cmd/pulumi-test-language/tests/testdata/l1-config-types/main.pp
+++ b/cmd/pulumi-test-language/tests/testdata/l1-config-types/main.pp
@@ -7,7 +7,7 @@ output "theNumber" {
 config "aString" "string" {}
 
 output "theString" {
-  value = aString + " World"
+  value = "${aString} World"
 }
 
 config "aMap" "map(int)" {}
@@ -25,8 +25,8 @@ output "theObject" {
   value = anObject.prop[0]
 }
 
-config "anyObject" {} 
+config "anyObject" {}
 
-output "theThing" { 
+output "theThing" {
   value = anyObject.a + anyObject.b
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l1-config-types/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l1-config-types/index.ts
@@ -4,7 +4,7 @@ const config = new pulumi.Config();
 const aNumber = config.requireNumber("aNumber");
 export const theNumber = aNumber + 1.25;
 const aString = config.require("aString");
-export const theString = aString + " World";
+export const theString = `${aString} World`;
 const aMap = config.requireObject<Record<string, number>>("aMap");
 export const theMap = {
     a: aMap.a + 1,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l1-config-types/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l1-config-types/index.ts
@@ -4,7 +4,7 @@ const config = new pulumi.Config();
 const aNumber = config.requireNumber("aNumber");
 export const theNumber = aNumber + 1.25;
 const aString = config.require("aString");
-export const theString = aString + " World";
+export const theString = `${aString} World`;
 const aMap = config.requireObject<Record<string, number>>("aMap");
 export const theMap = {
     a: aMap.a + 1,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l1-config-types/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l1-config-types/__main__.py
@@ -4,7 +4,7 @@ config = pulumi.Config()
 a_number = config.require_float("aNumber")
 pulumi.export("theNumber", a_number + 1.25)
 a_string = config.require("aString")
-pulumi.export("theString", a_string + " World")
+pulumi.export("theString", f"{a_string} World")
 a_map = config.require_object("aMap")
 pulumi.export("theMap", {
     "a": a_map["a"] + 1,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l1-config-types/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l1-config-types/__main__.py
@@ -4,7 +4,7 @@ config = pulumi.Config()
 a_number = config.require_float("aNumber")
 pulumi.export("theNumber", a_number + 1.25)
 a_string = config.require("aString")
-pulumi.export("theString", a_string + " World")
+pulumi.export("theString", f"{a_string} World")
 a_map = config.require_object("aMap")
 pulumi.export("theMap", {
     "a": a_map["a"] + 1,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l1-config-types/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l1-config-types/__main__.py
@@ -4,7 +4,7 @@ config = pulumi.Config()
 a_number = config.require_float("aNumber")
 pulumi.export("theNumber", a_number + 1.25)
 a_string = config.require("aString")
-pulumi.export("theString", a_string + " World")
+pulumi.export("theString", f"{a_string} World")
 a_map = config.require_object("aMap")
 pulumi.export("theMap", {
     "a": a_map["a"] + 1,


### PR DESCRIPTION
`+` is only defined for numeric types in HCL. Use string interpolation for the string map test instead.

The test using `anyObject` is still a bit dubious. It works fine in Node.js and Python, but it’s unlikely to generate compilable code for other languages.
