### PR TITLE
relax pip constraint

### DIFF
--- a/changelog/pending/20260202--sdk-python--relax-pip-version-constraint.yaml
+++ b/changelog/pending/20260202--sdk-python--relax-pip-version-constraint.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/python
+  description: Relax pip version constraint

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     'semver~=3.0',
     'pyyaml~=6.0',
     'debugpy~=1.8.7',
-    'pip>=24.3.1,<26',
+    'pip>=24.3.1',
 ]
 
 [dependency-groups]

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -668,11 +668,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "25.3"
+version = "26.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/6e/74a3f0179a4a73a53d66ce57fdb4de0080a8baa1de0063de206d6167acc2/pip-25.3.tar.gz", hash = "sha256:8d0538dbbd7babbd207f261ed969c65de439f6bc9e5dbd3b3b9a77f25d95f343", size = 1803014, upload-time = "2025-10-25T00:55:41.394Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/c2/65686a7783a7c27a329706207147e82f23c41221ee9ae33128fc331670a0/pip-26.0.tar.gz", hash = "sha256:3ce220a0a17915972fbf1ab451baae1521c4539e778b28127efa79b974aff0fa", size = 1812654, upload-time = "2026-01-31T01:40:54.361Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/3c/d717024885424591d5376220b5e836c2d5293ce2011523c9de23ff7bf068/pip-25.3-py3-none-any.whl", hash = "sha256:9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd", size = 1778622, upload-time = "2025-10-25T00:55:39.247Z" },
+    { url = "https://files.pythonhosted.org/packages/69/00/5ac7aa77688ec4d34148b423d34dc0c9bc4febe0d872a9a1ad9860b2f6f1/pip-26.0-py3-none-any.whl", hash = "sha256:98436feffb9e31bc9339cf369fd55d3331b1580b6a6f1173bacacddcf9c34754", size = 1787564, upload-time = "2026-01-31T01:40:52.252Z" },
 ]
 
 [[package]]
@@ -737,7 +737,7 @@ requires-dist = [
     { name = "dill", specifier = "~=0.4" },
     { name = "grpcio", marker = "python_full_version < '3.14'", specifier = ">=1.68.1,<2" },
     { name = "grpcio", marker = "python_full_version >= '3.14'", specifier = ">=1.75.1,<2" },
-    { name = "pip", specifier = ">=24.3.1,<26" },
+    { name = "pip", specifier = ">=24.3.1" },
     { name = "protobuf", specifier = ">=3.20.3,<6" },
     { name = "pyyaml", specifier = "~=6.0" },
     { name = "semver", specifier = "~=3.0" },


### PR DESCRIPTION
Pip 26 was recently released and works fine for our usage. We use it to retrieve the list of installed dependencies, even when using poetry or uv.
