### PR TITLE
The final argument specifications

### DIFF
--- a/pkg/cmd/pulumi/cancel/cancel.go
+++ b/pkg/cmd/pulumi/cancel/cancel.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -35,8 +36,7 @@ func NewCancelCmd(ws pkgWorkspace.Context) *cobra.Command {
 	var yes bool
 	var stack string
 	cmd := &cobra.Command{
-		Use:   "cancel [<stack-name>]",
-		Args:  cmdutil.MaximumNArgs(1),
+		Use:   "cancel",
 		Short: "Cancel a stack's currently running update, if any",
 		Long: "Cancel a stack's currently running update, if any.\n" +
 			"\n" +
@@ -94,7 +94,10 @@ func NewCancelCmd(ws pkgWorkspace.Context) *cobra.Command {
 			return nil
 		},
 	}
-
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "stack-name"}},
+		Required:  0,
+	})
 	cmd.PersistentFlags().BoolVarP(
 		&yes, "yes", "y", false,
 		"Skip confirmation prompts, and proceed with cancellation anyway")

--- a/pkg/cmd/pulumi/console/console.go
+++ b/pkg/cmd/pulumi/console/console.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -36,7 +37,6 @@ func NewConsoleCmd(ws pkgWorkspace.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "console",
 		Short: "Opens the current stack in the Pulumi Console",
-		Args:  cmdutil.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			opts := display.Options{
@@ -104,6 +104,8 @@ func NewConsoleCmd(ws pkgWorkspace.Context) *cobra.Command {
 			return nil
 		},
 	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 	cmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "", "The name of the stack to view")
 	return cmd

--- a/pkg/cmd/pulumi/events/replay.go
+++ b/pkg/cmd/pulumi/events/replay.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -60,7 +61,6 @@ func NewReplayEventsCmd() *cobra.Command {
 			"using either the progress view or the diff view.\n" +
 			"\n" +
 			"The <kind> argument must be one of: update, refresh, destroy, import.\n",
-		Args:   cmdutil.ExactArgs(2),
 		Hidden: !env.DebugCommands.Value(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var action apitype.UpdateKind
@@ -126,7 +126,10 @@ func NewReplayEventsCmd() *cobra.Command {
 			return nil
 		},
 	}
-
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "kind"}, {Name: "events-file"}},
+		Required:  2,
+	})
 	cmd.PersistentFlags().BoolVarP(
 		&preview, "preview", "p", false,
 		"Must be set for events from a `pulumi preview`.")

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -24,6 +24,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pulumi/pulumi/pkg/v3/backend/diy/unauthenticatedregistry"
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/newcmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/policy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -46,7 +47,6 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "install",
-		Args:  cmdutil.NoArgs,
 		Short: "Install packages and plugins for the current program or policy pack.",
 		Long: "Install packages and plugins for the current program or policy pack.\n" +
 			"\n" +
@@ -187,6 +187,7 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 			return nil
 		},
 	}
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
 	cmd.Flags().IntVar(&parallel,
 		"parallel", 4, "The max number of concurrent installs to perform. "+

--- a/pkg/cmd/pulumi/markdown/gen.go
+++ b/pkg/cmd/pulumi/markdown/gen.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
 // Used to replace the `## <command>` line in generated markdown files.
@@ -63,9 +63,8 @@ func generateMetaDescription(title, commandName string) string {
 // NewGenMarkdownCmd returns a new command that, when run, generates CLI documentation as Markdown files.
 // It is hidden by default since it's not commonly used outside of our own build processes.
 func NewGenMarkdownCmd(root *cobra.Command) *cobra.Command {
-	return &cobra.Command{
-		Use:    "gen-markdown <DIR>",
-		Args:   cmdutil.ExactArgs(1),
+	cmd := &cobra.Command{
+		Use:    "gen-markdown",
 		Short:  "Generate Pulumi CLI documentation as Markdown (one file per command)",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -130,4 +129,9 @@ func NewGenMarkdownCmd(root *cobra.Command) *cobra.Command {
 			return nil
 		},
 	}
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "dir"}},
+		Required:  1,
+	})
+	return cmd
 }

--- a/pkg/cmd/pulumi/newcmd/new.go
+++ b/pkg/cmd/pulumi/newcmd/new.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	cmdTemplates "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/templates"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
@@ -547,7 +548,6 @@ func NewNewCmd() *cobra.Command {
 			"* `pulumi new --language <language>`\n" +
 			"* `pulumi new --ai \"<prompt>\" --language <language>`\n" +
 			"Any missing but required information will be prompted for.\n",
-		Args: cmdutil.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := cmd.Context()
 			if len(cliArgs) > 0 {
@@ -574,6 +574,10 @@ func NewNewCmd() *cobra.Command {
 			return runNew(ctx, args)
 		},
 	}
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "template-or-url", Usage: "[template|url]"}},
+		Required:  0,
+	})
 
 	// Add additional help that includes a list of available templates.
 	defaultHelp := cmd.HelpFunc()


### PR DESCRIPTION
This PR adds the final argument specifications to the CLI. As far as I can tell (I'll check again once everything's merged), every command now has arguments.

* #21482
* #21485
* #21565
* #21585
* #21587
* #21588
* #21589
* #21590
* #21592
* #21626
* #21628
* #21641