### PR TITLE
Always install from registry when appropriate

### DIFF
--- a/changelog/pending/20260202--cli-install-package--use-the-pulumi-cloud-registry-by-default-to-resolve-package-names.yaml
+++ b/changelog/pending/20260202--cli-install-package--use-the-pulumi-cloud-registry-by-default-to-resolve-package-names.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/install,package
+  description: Use the Pulumi Cloud Registry by default to resolve package names

--- a/pkg/cmd/pulumi/newcmd/install.go
+++ b/pkg/cmd/pulumi/newcmd/install.go
@@ -78,8 +78,7 @@ func InstallPackagesFromProject(
 		})
 	opts := packageinstallation.Options{
 		Options: packageresolution.Options{
-			ResolveWithRegistry: env.Experimental.Value() &&
-				!env.DisableRegistryResolve.Value(),
+			ResolveWithRegistry:                        !env.DisableRegistryResolve.Value(),
 			ResolveVersionWithLocalWorkspace:           true,
 			AllowNonInvertableLocalWorkspaceResolution: true,
 		},

--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -442,8 +442,7 @@ func ProviderFromSource(
 
 	f, spec, err := packageinstallation.InstallPlugin(pctx.Request(), packageSpec, nil, "", packageinstallation.Options{
 		Options: packageresolution.Options{
-			ResolveWithRegistry: e.GetBool(env.Experimental) &&
-				!e.GetBool(env.DisableRegistryResolve),
+			ResolveWithRegistry:                        !e.GetBool(env.DisableRegistryResolve),
 			ResolveVersionWithLocalWorkspace:           true,
 			AllowNonInvertableLocalWorkspaceResolution: true,
 		},

--- a/pkg/cmd/pulumi/plugin/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install.go
@@ -370,8 +370,7 @@ func (cmd *pluginInstallCmd) resolvePluginSpec(
 ) (workspace.PluginDescriptor, error) {
 	result, err := packageresolution.Resolve(
 		ctx, cmd.registry, pluginstorage.Instance, pluginSpec, packageresolution.Options{
-			ResolveWithRegistry: cmd.env.GetBool(env.Experimental) &&
-				!cmd.env.GetBool(env.DisableRegistryResolve),
+			ResolveWithRegistry:                        !cmd.env.GetBool(env.DisableRegistryResolve),
 			ResolveVersionWithLocalWorkspace:           cmd.reinstall,
 			AllowNonInvertableLocalWorkspaceResolution: cmd.reinstall,
 		})


### PR DESCRIPTION
Registry can still be disabled by setting `PULUMI_DISABLE_REGISTRY_RESOLVE=1`. This change enabled `pulumi install`, `pulumi package add` & `pulumi get-schema` to use the Pulumi Cloud Registry by default.

Fixes https://github.com/pulumi/pulumi/issues/20968