### PR TITLE
Add a `pulumi policy install` command

### DIFF
--- a/changelog/pending/20260202--cli-policy--add-pulumi-policy-install-command.yaml
+++ b/changelog/pending/20260202--cli-policy--add-pulumi-policy-install-command.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/policy
+  description: Add `pulumi policy install` command

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -148,6 +148,9 @@ type Backend interface {
 	ListPolicyPacks(ctx context.Context, orgName string, inContToken ContinuationToken) (
 		apitype.ListPolicyPacksResponse, ContinuationToken, error)
 
+	// GetStackPolicyPacks gets the required policy packs currently applicable to the stack.
+	GetStackPolicyPacks(ctx context.Context, stackRef StackReference) ([]engine.RequiredPolicy, error)
+
 	// SupportsOrganizations tells whether a user can belong to multiple organizations in this backend.
 	SupportsOrganizations() bool
 

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -649,6 +649,12 @@ func (b *diyBackend) ListPolicyPacks(ctx context.Context, orgName string, _ back
 	return apitype.ListPolicyPacksResponse{}, nil, errors.New("DIY backend does not support resource policy")
 }
 
+func (b *diyBackend) GetStackPolicyPacks(
+	ctx context.Context, stackRef backend.StackReference,
+) ([]engine.RequiredPolicy, error) {
+	return nil, errors.New("DIY backend does not support resource policy")
+}
+
 func (b *diyBackend) SupportsTemplates() bool {
 	return false
 }

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1175,6 +1175,17 @@ func (pc *Client) RemovePolicyPackByVersion(ctx context.Context, orgName string,
 	return nil
 }
 
+// GetStackPolicyPacks gets the required policy packs currently applicable to the stack.
+func (pc *Client) GetStackPolicyPacks(ctx context.Context,
+	stackID StackIdentifier,
+) (apitype.GetStackPolicyPacksResponse, error) {
+	var resp apitype.GetStackPolicyPacksResponse
+	if err := pc.restCall(ctx, "GET", getStackPath(stackID, "policypacks"), nil, nil, &resp); err != nil {
+		return apitype.GetStackPolicyPacksResponse{}, err
+	}
+	return resp, nil
+}
+
 // DownloadPolicyPack downloads a `PolicyPack` from the given URL. It returns a ReadCloser to read
 // the PolicyPack and the content length. A content length of -1 indicates that the length is unknown.
 func (pc *Client) DownloadPolicyPack(ctx context.Context, url string) (io.ReadCloser, int64, error) {

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -109,6 +109,8 @@ type MockBackend struct {
 	DownloadTemplateF         func(_ context.Context, orgName, templateSource string) (TarReaderCloser, error)
 	GetCloudRegistryF         func() (CloudRegistry, error)
 	GetReadOnlyCloudRegistryF func() registry.Registry
+
+	GetStackPolicyPacksF func(ctx context.Context, stackRef StackReference) ([]engine.RequiredPolicy, error)
 }
 
 var _ Backend = (*MockBackend)(nil)
@@ -152,6 +154,15 @@ func (be *MockBackend) GetPolicyPack(
 ) (PolicyPack, error) {
 	if be.GetPolicyPackF != nil {
 		return be.GetPolicyPackF(ctx, policyPack, d)
+	}
+	panic("not implemented")
+}
+
+func (be *MockBackend) GetStackPolicyPacks(
+	ctx context.Context, stackRef StackReference,
+) ([]engine.RequiredPolicy, error) {
+	if be.GetStackPolicyPacksF != nil {
+		return be.GetStackPolicyPacksF(ctx, stackRef)
 	}
 	panic("not implemented")
 }

--- a/pkg/cmd/pulumi/policy/policy.go
+++ b/pkg/cmd/pulumi/policy/policy.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2024, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ func NewPolicyCmd() *cobra.Command {
 	cmd.AddCommand(newPolicyDisableCmd())
 	cmd.AddCommand(newPolicyEnableCmd())
 	cmd.AddCommand(newPolicyGroupCmd())
+	cmd.AddCommand(newPolicyInstallCmd())
 	cmd.AddCommand(newPolicyLsCmd())
 	cmd.AddCommand(newPolicyNewCmd())
 	cmd.AddCommand(newPolicyPublishCmd())

--- a/pkg/cmd/pulumi/policy/policy_install.go
+++ b/pkg/cmd/pulumi/policy/policy_install.go
@@ -1,0 +1,144 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/spf13/cobra"
+)
+
+func newPolicyInstallCmd() *cobra.Command {
+	var policyInstallCmd policyInstallCmd
+	var stack string
+
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install required policy packs for a stack",
+		Long: "Install required policy packs for a stack.\n" +
+			"\n" +
+			"This command installs the policy packs required by the stack's organization.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			return policyInstallCmd.Run(ctx, stack)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.PersistentFlags().StringVarP(
+		&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
+	return cmd
+}
+
+type policyInstallCmd struct {
+	getwd  func() (string, error)
+	diag   diag.Sink
+	stderr io.Writer // defaults to os.Stderr
+
+	// requireStack is a function that returns the stack to operate on.
+	// If nil, the default implementation is used.
+	requireStack func(ctx context.Context, stackName string) (backend.Stack, error)
+}
+
+func (cmd *policyInstallCmd) Run(
+	ctx context.Context,
+	stackName string,
+) error {
+	if cmd.getwd == nil {
+		cmd.getwd = os.Getwd
+	}
+	if cmd.diag == nil {
+		cmd.diag = cmdutil.Diag()
+	}
+	if cmd.stderr == nil {
+		cmd.stderr = os.Stderr
+	}
+
+	if cmd.requireStack == nil {
+		cmd.requireStack = func(ctx context.Context, stackName string) (backend.Stack, error) {
+			displayOpts := display.Options{
+				Color: cmdutil.GetGlobalColorization(),
+			}
+			return cmdStack.RequireStack(ctx, cmd.diag, pkgWorkspace.Instance,
+				cmdBackend.DefaultLoginManager, stackName, cmdStack.LoadOnly, displayOpts)
+		}
+	}
+
+	// Get the stack (uses current stack if stackName is empty).
+	s, err := cmd.requireStack(ctx, stackName)
+	if err != nil {
+		if stackName == "" && errors.Is(err, workspace.ErrProjectNotFound) {
+			return errors.New("could not find a Pulumi project in the current working directory; " +
+				"please specify a stack using the --stack flag.")
+		}
+		return err
+	}
+
+	// Fetch the required policy packs for the stack.
+	policyPacks, err := s.Backend().GetStackPolicyPacks(ctx, s.Ref())
+	if err != nil {
+		return fmt.Errorf("getting stack policy packs: %w", err)
+	}
+
+	if len(policyPacks) == 0 {
+		fmt.Fprintf(cmd.stderr, "No policy packs to install for stack %s\n", s.Ref().String())
+		return nil
+	}
+
+	cwd, err := cmd.getwd()
+	if err != nil {
+		return fmt.Errorf("getting current working directory: %w", err)
+	}
+
+	pctx, err := plugin.NewContext(ctx, cmd.diag, cmd.diag, nil, nil, cwd, nil, true, nil)
+	if err != nil {
+		return fmt.Errorf("creating plugin context: %w", err)
+	}
+	defer func() {
+		contract.IgnoreError(pctx.Close())
+	}()
+
+	// Install the required policy packs.
+	if err := engine.EnsurePoliciesAreInstalled(ctx, pctx, nil, policyPacks); err != nil {
+		return err
+	}
+
+	var plural string
+	if len(policyPacks) > 1 {
+		plural = "s"
+	}
+	fmt.Fprintf(cmd.stderr,
+		"Successfully installed %d policy pack%s for stack %s\n", len(policyPacks), plural, s.Ref().String())
+	return nil
+}

--- a/pkg/cmd/pulumi/policy/policy_install_test.go
+++ b/pkg/cmd/pulumi/policy/policy_install_test.go
@@ -1,0 +1,422 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// mockRequiredPolicy implements engine.RequiredPolicy for testing.
+type mockRequiredPolicy struct {
+	name      string
+	version   string
+	config    map[string]*json.RawMessage
+	installed bool
+	downloadF func(ctx context.Context, wrapper func(io.ReadCloser, int64) io.ReadCloser) (io.ReadCloser, int64, error)
+	installF  func(ctx *plugin.Context, content io.ReadCloser, stdout, stderr io.Writer) error
+}
+
+var _ engine.RequiredPolicy = (*mockRequiredPolicy)(nil)
+
+func (m *mockRequiredPolicy) Name() string                        { return m.name }
+func (m *mockRequiredPolicy) Version() string                     { return m.version }
+func (m *mockRequiredPolicy) Config() map[string]*json.RawMessage { return m.config }
+func (m *mockRequiredPolicy) Installed() bool                     { return m.installed }
+func (m *mockRequiredPolicy) LocalPath() (string, error)          { return "/path/to/" + m.name, nil }
+
+func (m *mockRequiredPolicy) Download(
+	ctx context.Context,
+	wrapper func(io.ReadCloser, int64) io.ReadCloser,
+) (io.ReadCloser, int64, error) {
+	if m.downloadF != nil {
+		return m.downloadF(ctx, wrapper)
+	}
+	content := io.NopCloser(bytes.NewReader([]byte("mock-tarball")))
+	size := int64(len("mock-tarball"))
+	return wrapper(content, size), size, nil
+}
+
+func (m *mockRequiredPolicy) Install(
+	ctx *plugin.Context,
+	content io.ReadCloser,
+	stdout, stderr io.Writer,
+) error {
+	if m.installF != nil {
+		return m.installF(ctx, content, stdout, stderr)
+	}
+	return nil
+}
+
+// newMockStack creates a MockStack wired to the given MockBackend.
+func newMockStack(be *backend.MockBackend) *backend.MockStack {
+	return &backend.MockStack{
+		BackendF: func() backend.Backend { return be },
+		RefF:     func() backend.StackReference { return &backend.MockStackReference{StringV: "test-stack"} },
+	}
+}
+
+func TestPolicyInstallCmd_Run(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses current stack when no stack specified", func(t *testing.T) {
+		t.Parallel()
+
+		var requestedStackName string
+		cmd := policyInstallCmd{
+			getwd: func() (string, error) { return t.TempDir(), nil },
+			requireStack: func(ctx context.Context, stackName string) (backend.Stack, error) {
+				requestedStackName = stackName
+				return newMockStack(&backend.MockBackend{
+					GetStackPolicyPacksF: func(
+						ctx context.Context, stackRef backend.StackReference,
+					) ([]engine.RequiredPolicy, error) {
+						return nil, nil
+					},
+				}), nil
+			},
+		}
+
+		err := cmd.Run(t.Context(), "")
+		require.NoError(t, err)
+		assert.Empty(t, requestedStackName, "expected empty stack name to use current stack")
+	})
+
+	t.Run("uses specified stack", func(t *testing.T) {
+		t.Parallel()
+
+		var requestedStackName string
+		cmd := policyInstallCmd{
+			getwd: func() (string, error) { return t.TempDir(), nil },
+			requireStack: func(ctx context.Context, stackName string) (backend.Stack, error) {
+				requestedStackName = stackName
+				return newMockStack(&backend.MockBackend{
+					GetStackPolicyPacksF: func(
+						ctx context.Context, stackRef backend.StackReference,
+					) ([]engine.RequiredPolicy, error) {
+						return nil, nil
+					},
+				}), nil
+			},
+		}
+
+		err := cmd.Run(t.Context(), "my-stack")
+		require.NoError(t, err)
+		assert.Equal(t, "my-stack", requestedStackName)
+	})
+
+	t.Run("returns error when stack not found", func(t *testing.T) {
+		t.Parallel()
+
+		expectedErr := errors.New("stack not found")
+		cmd := policyInstallCmd{
+			requireStack: func(ctx context.Context, stackName string) (backend.Stack, error) {
+				return nil, expectedErr
+			},
+		}
+
+		err := cmd.Run(t.Context(), "nonexistent-stack")
+		assert.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("returns friendly error when no stack specified and no project found", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := policyInstallCmd{
+			requireStack: func(ctx context.Context, stackName string) (backend.Stack, error) {
+				return nil, fmt.Errorf("loading stack: %w", workspace.ErrProjectNotFound)
+			},
+		}
+
+		err := cmd.Run(t.Context(), "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "could not find a Pulumi project")
+		assert.Contains(t, err.Error(), "--stack flag")
+		assert.NotErrorIs(t, err, workspace.ErrProjectNotFound,
+			"friendly error should not wrap the original error")
+	})
+
+	t.Run("returns original error when stack specified and no project found", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := policyInstallCmd{
+			requireStack: func(ctx context.Context, stackName string) (backend.Stack, error) {
+				return nil, workspace.ErrProjectNotFound
+			},
+		}
+
+		err := cmd.Run(t.Context(), "my-stack")
+		assert.ErrorIs(t, err, workspace.ErrProjectNotFound)
+	})
+
+	t.Run("returns error when GetStackPolicyPacks fails", func(t *testing.T) {
+		t.Parallel()
+
+		policyErr := errors.New("policy service unavailable")
+		cmd := policyInstallCmd{
+			getwd: func() (string, error) { return t.TempDir(), nil },
+			requireStack: func(ctx context.Context, stackName string) (backend.Stack, error) {
+				return newMockStack(&backend.MockBackend{
+					GetStackPolicyPacksF: func(
+						ctx context.Context, stackRef backend.StackReference,
+					) ([]engine.RequiredPolicy, error) {
+						return nil, policyErr
+					},
+				}), nil
+			},
+		}
+
+		err := cmd.Run(t.Context(), "my-stack")
+		assert.ErrorIs(t, err, policyErr)
+		assert.ErrorContains(t, err, "getting stack policy packs")
+	})
+
+	t.Run("returns error when getwd fails", func(t *testing.T) {
+		t.Parallel()
+
+		getwdErr := errors.New("filesystem error")
+		cmd := policyInstallCmd{
+			getwd: func() (string, error) { return "", getwdErr },
+			requireStack: func(ctx context.Context, stackName string) (backend.Stack, error) {
+				return newMockStack(&backend.MockBackend{
+					GetStackPolicyPacksF: func(
+						ctx context.Context, stackRef backend.StackReference,
+					) ([]engine.RequiredPolicy, error) {
+						return []engine.RequiredPolicy{
+							&mockRequiredPolicy{name: "some-pack"},
+						}, nil
+					},
+				}), nil
+			},
+		}
+
+		err := cmd.Run(t.Context(), "my-stack")
+		assert.ErrorIs(t, err, getwdErr)
+		assert.ErrorContains(t, err, "getting current working directory")
+	})
+
+	t.Run("succeeds with no policy packs", func(t *testing.T) {
+		t.Parallel()
+
+		var stderr bytes.Buffer
+		cmd := policyInstallCmd{
+			getwd:  func() (string, error) { return t.TempDir(), nil },
+			stderr: &stderr,
+			requireStack: func(ctx context.Context, stackName string) (backend.Stack, error) {
+				return newMockStack(&backend.MockBackend{
+					GetStackPolicyPacksF: func(
+						ctx context.Context, stackRef backend.StackReference,
+					) ([]engine.RequiredPolicy, error) {
+						return nil, nil
+					},
+				}), nil
+			},
+		}
+
+		err := cmd.Run(t.Context(), "my-stack")
+		require.NoError(t, err)
+	})
+
+	t.Run("no policy packs prints message to stderr", func(t *testing.T) {
+		t.Parallel()
+
+		var stderr bytes.Buffer
+		cmd := policyInstallCmd{
+			getwd:  func() (string, error) { return t.TempDir(), nil },
+			stderr: &stderr,
+			requireStack: func(ctx context.Context, stackName string) (backend.Stack, error) {
+				return newMockStack(&backend.MockBackend{
+					GetStackPolicyPacksF: func(
+						ctx context.Context, stackRef backend.StackReference,
+					) ([]engine.RequiredPolicy, error) {
+						return nil, nil
+					},
+				}), nil
+			},
+		}
+
+		err := cmd.Run(t.Context(), "")
+		require.NoError(t, err)
+		assert.Equal(t, "No policy packs to install for stack test-stack\n", stderr.String())
+	})
+
+	t.Run("installs all policy packs", func(t *testing.T) {
+		t.Parallel()
+
+		packs := []engine.RequiredPolicy{
+			&mockRequiredPolicy{name: "pack-a", installed: true},
+			&mockRequiredPolicy{name: "pack-b", installed: true},
+			&mockRequiredPolicy{name: "pack-c", installed: true},
+		}
+
+		var stderr bytes.Buffer
+		cmd := policyInstallCmd{
+			getwd:  func() (string, error) { return t.TempDir(), nil },
+			stderr: &stderr,
+			requireStack: func(ctx context.Context, stackName string) (backend.Stack, error) {
+				return newMockStack(&backend.MockBackend{
+					GetStackPolicyPacksF: func(
+						ctx context.Context, stackRef backend.StackReference,
+					) ([]engine.RequiredPolicy, error) {
+						return packs, nil
+					},
+				}), nil
+			},
+		}
+
+		err := cmd.Run(t.Context(), "my-stack")
+		require.NoError(t, err)
+		assert.Contains(t, stderr.String(), "Successfully installed 3 policy packs for stack test-stack")
+	})
+
+	t.Run("prints singular success message for one policy pack", func(t *testing.T) {
+		t.Parallel()
+
+		packs := []engine.RequiredPolicy{
+			&mockRequiredPolicy{name: "my-pack", installed: true},
+		}
+
+		var stderr bytes.Buffer
+		cmd := policyInstallCmd{
+			getwd:  func() (string, error) { return t.TempDir(), nil },
+			stderr: &stderr,
+			requireStack: func(ctx context.Context, stackName string) (backend.Stack, error) {
+				return newMockStack(&backend.MockBackend{
+					GetStackPolicyPacksF: func(
+						ctx context.Context, stackRef backend.StackReference,
+					) ([]engine.RequiredPolicy, error) {
+						return packs, nil
+					},
+				}), nil
+			},
+		}
+
+		err := cmd.Run(t.Context(), "")
+		require.NoError(t, err)
+		assert.Equal(t, "Successfully installed 1 policy pack for stack test-stack\n", stderr.String())
+	})
+
+	t.Run("prints plural success message for multiple policy packs", func(t *testing.T) {
+		t.Parallel()
+
+		packs := []engine.RequiredPolicy{
+			&mockRequiredPolicy{name: "pack-a", installed: true},
+			&mockRequiredPolicy{name: "pack-b", installed: true},
+		}
+
+		var stderr bytes.Buffer
+		cmd := policyInstallCmd{
+			getwd:  func() (string, error) { return t.TempDir(), nil },
+			stderr: &stderr,
+			requireStack: func(ctx context.Context, stackName string) (backend.Stack, error) {
+				return newMockStack(&backend.MockBackend{
+					GetStackPolicyPacksF: func(
+						ctx context.Context, stackRef backend.StackReference,
+					) ([]engine.RequiredPolicy, error) {
+						return packs, nil
+					},
+				}), nil
+			},
+		}
+
+		err := cmd.Run(t.Context(), "")
+		require.NoError(t, err)
+		assert.Equal(t, "Successfully installed 2 policy packs for stack test-stack\n", stderr.String())
+	})
+
+	t.Run("returns error when install fails", func(t *testing.T) {
+		t.Parallel()
+
+		installErr := errors.New("install failed")
+		packs := []engine.RequiredPolicy{
+			&mockRequiredPolicy{name: "good-pack", installed: true},
+			&mockRequiredPolicy{
+				name: "bad-pack",
+				downloadF: func(
+					ctx context.Context, wrapper func(io.ReadCloser, int64) io.ReadCloser,
+				) (io.ReadCloser, int64, error) {
+					return nil, 0, installErr
+				},
+			},
+		}
+
+		var stderr bytes.Buffer
+		cmd := policyInstallCmd{
+			getwd:  func() (string, error) { return t.TempDir(), nil },
+			stderr: &stderr,
+			requireStack: func(ctx context.Context, stackName string) (backend.Stack, error) {
+				return newMockStack(&backend.MockBackend{
+					GetStackPolicyPacksF: func(
+						ctx context.Context, stackRef backend.StackReference,
+					) ([]engine.RequiredPolicy, error) {
+						return packs, nil
+					},
+				}), nil
+			},
+		}
+
+		err := cmd.Run(t.Context(), "my-stack")
+		assert.ErrorIs(t, err, installErr)
+		assert.ErrorContains(t, err, "policy pack bad-pack@v")
+	})
+
+	t.Run("returns first install error", func(t *testing.T) {
+		t.Parallel()
+
+		installErr := errors.New("install failed")
+		packs := []engine.RequiredPolicy{
+			&mockRequiredPolicy{
+				name: "failing-pack",
+				downloadF: func(
+					ctx context.Context, wrapper func(io.ReadCloser, int64) io.ReadCloser,
+				) (io.ReadCloser, int64, error) {
+					return nil, 0, installErr
+				},
+			},
+			&mockRequiredPolicy{name: "other-pack", installed: true},
+		}
+
+		var stderr bytes.Buffer
+		cmd := policyInstallCmd{
+			getwd:  func() (string, error) { return t.TempDir(), nil },
+			stderr: &stderr,
+			requireStack: func(ctx context.Context, stackName string) (backend.Stack, error) {
+				return newMockStack(&backend.MockBackend{
+					GetStackPolicyPacksF: func(
+						ctx context.Context, stackRef backend.StackReference,
+					) ([]engine.RequiredPolicy, error) {
+						return packs, nil
+					},
+				}), nil
+			},
+		}
+
+		err := cmd.Run(t.Context(), "my-stack")
+		assert.ErrorIs(t, err, installErr)
+	})
+}


### PR DESCRIPTION
This change adds a new `pulumi policy install` command that can be used to install the current required policy packs for the stack. This can be used to pre-install required policy packs without having to run a Pulumi operation (such as `pulumi preview`) to install the policy packs on a machine.

Fixes #21453