### PR TITLE
Revert "Skip TestPerfManyResourcesWithJournaling"

### DIFF
--- a/tests/performance/performance_test.go
+++ b/tests/performance/performance_test.go
@@ -158,7 +158,6 @@ func TestPerfStackReferenceSecretsBatchUpdate(t *testing.T) {
 
 //nolint:paralleltest // Do not run in parallel to avoid resource contention
 func TestPerfManyResourcesWithJournaling(t *testing.T) {
-	t.Skip("https://github.com/pulumi/pulumi/issues/21632")
 	initialBenchmark := &integration.AssertPerfBenchmark{
 		T:                      t,
 		MaxUpdateDuration:      90 * time.Second,


### PR DESCRIPTION
Reverts pulumi/pulumi#21633.  The service PR should now be deployed, so this should not be necessary anymore :crossed_fingers: 

https://github.com/pulumi/pulumi/issues/21632