### PR TITLE
fuzzing: consider `Delete` resources as "dropped"

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/program.go
+++ b/pkg/engine/lifecycletest/fuzzing/program.go
@@ -383,8 +383,11 @@ func GeneratedProgramSpec(
 
 		for i := 0; i < len(ss.Resources); {
 			if ss.Resources[i].Delete {
+				dropped[ss.Resources[i].URN()] = true
 				i++
 				continue
+			} else {
+				delete(dropped, ss.Resources[i].URN())
 			}
 
 			action := pso.Action.Draw(t, fmt.Sprintf("ProgramSpec.Action[%d]", i))


### PR DESCRIPTION
"Dropped" resources are removed from the dependency list of resources that are being registered in the program.  Resources that only have a resource marked as `Delete`, but no corresponding full resource are currently not being considered dropped, and thus can still be a dependency in the program.

However we can't really depend on a resource, unless it is also registered in the program, and the SDKs shouldn't allow us to do so. So we want to consider resources that are marked `Delete` as dropped, so we can remove them from the dependency lists correctly.