### PR TITLE
Always use the default a registry for `pulumi {install,package add}`

### DIFF
--- a/changelog/pending/20260203--cli-install-package--allow-using-private-packages-as-local-dependencies-in-components.yaml
+++ b/changelog/pending/20260203--cli-install-package--allow-using-private-packages-as-local-dependencies-in-components.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/install,package
+  description: Allow using private packages as local dependencies in components

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/opentracing/opentracing-go"
-	"github.com/pulumi/pulumi/pkg/v3/backend/diy/unauthenticatedregistry"
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/newcmd"
@@ -98,11 +97,9 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 						return err
 					}
 
-					// Cloud registry is linked to a backend, but we don't have
-					// one available in a plugin. Use the unauthenticated
-					// registry.
-					reg := unauthenticatedregistry.New(cmdutil.Diag(), env.Global())
-
+					// Cloud registry is linked to a backend, but we don't have one available in a
+					// plugin. Use the global default registry.
+					reg := cmdCmd.NewDefaultRegistry(ctx, pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global())
 					if err := newcmd.InstallPackagesFromProject(cmd.Context(), proj, cwd, reg, parallel,
 						useLanguageVersionTools, cmd.OutOrStdout(), cmd.ErrOrStderr(), env.Global()); err != nil {
 						return fmt.Errorf("installing `packages` from PulumiPlugin.yaml: %w", err)

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pulumi/pulumi/pkg/v3/backend/diy/unauthenticatedregistry"
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	cmdDiag "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/diag"
@@ -227,8 +226,8 @@ func detectEnclosingPluginOrProject(ctx context.Context, wd string) (pluginOrPro
 			projectFilePath: filePath,
 			proj:            baseProject,
 			// Cloud registry is linked to a backend, but we don't have one
-			// available in a plugin. Use the unauthenticated registry.
-			reg: unauthenticatedregistry.New(cmdutil.Diag(), env.Global()),
+			// available in a plugin. Use the default backend.
+			reg: cmdCmd.NewDefaultRegistry(ctx, pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global()),
 		}, nil
 	default:
 		panic(fmt.Sprintf("workspace.LoadBaseProjectFrom promises that it will return "+


### PR DESCRIPTION
This changes `pulumi package add` & `pulumi install` to behave like `pulumi package get-schema` when in Pulumi plugin directories.

Fixes https://github.com/pulumi/pulumi/issues/20638