### PR TITLE
Fix issue with generic subclasses of `dynamic.Resource`

### DIFF
--- a/changelog/pending/20260204--sdk-python--fix-issue-with-generic-subclasses-of-dynamic-resource.yaml
+++ b/changelog/pending/20260204--sdk-python--fix-issue-with-generic-subclasses-of-dynamic-resource.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix issue with generic subclasses of `dynamic.Resource`

--- a/sdk/python/lib/pulumi/dynamic/dynamic.py
+++ b/sdk/python/lib/pulumi/dynamic/dynamic.py
@@ -329,7 +329,9 @@ class Resource(CustomResource):
 
     _resource_type_name: ClassVar[str]
 
-    def __init_subclass__(cls, module: str = "", name: str = "Resource"):
+    def __init_subclass__(cls, module: str = "", name: str = "Resource", **kwargs):
+        super().__init_subclass__(**kwargs)
+
         if module:
             module = f"/{module}"
         cls._resource_type_name = f"dynamic{module}:{name}"


### PR DESCRIPTION
Forward the `__init_subclass__` call to the base class for compatibility as recommended by the [python docs]. Without this call, python's built-in handling of generic classes fails, which prevents constructing generic subclasses, e.g.

```python
class GenericBaseResource[ArgsT, ProviderT](pulumi.dynamic.Resource): ...

class FooArgs: ...

class FooProvider: ...

class FooResource(GenericBaseResource[FooArgs, FooProvider]): ...
```

Fixes #21669

[python docs]: https://docs.python.org/3/reference/datamodel.html#object.__init_subclass__