### PR TITLE
add repro + exclusion for RefreshV2 SIE

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/exclude.go
+++ b/pkg/engine/lifecycletest/fuzzing/exclude.go
@@ -57,6 +57,8 @@ func DefaultExclusionRules() ExclusionRules {
 		ExcludeRefreshWithTargetedProviderParentChangeDestroyV2,
 		// TODO[pulumi/pulumi#21645]
 		ExcludeDependenciesInProgramButNotInSnapshotRefreshV2,
+		// TODO[pulumi/pulumi#21672]
+		ExcludeParentedResourcesRefreshV2,
 	}
 }
 
@@ -618,5 +620,30 @@ func ExcludeDependenciesInProgramButNotInSnapshotRefreshV2(
 			return true
 		}
 	}
+	return false
+}
+
+func ExcludeParentedResourcesRefreshV2(
+	snap *SnapshotSpec,
+	prog *ProgramSpec,
+	_ *ProviderSpec,
+	plan *PlanSpec,
+) bool {
+	if plan.Operation != PlanOperationRefreshV2 && !plan.RefreshProgram {
+		return false
+	}
+
+	for _, res := range prog.ResourceRegistrations {
+		if res.Parent != "" {
+			return true
+		}
+	}
+
+	for _, res := range snap.Resources {
+		if res.Parent != "" {
+			return true
+		}
+	}
+
 	return false
 }


### PR DESCRIPTION
There's a lot of SIEs for RefreshV2 when parents are involved. For the exclusion rule to be more specific it quickly spiraled out of control, and since I'm guessing most/all of these have the same underlying issue that causes the SIE I'm adding a fairly wide ranging exclusion rule here.

Add a sample test as well, though for checking that the issue is actually fixed it will probably be best to remove the exclusion rule and run the fuzzer again.

/xref https://github.com/pulumi/pulumi/issues/21672