### PR TITLE
fuzzing: enable RefreshV2 in CI

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/plan.go
+++ b/pkg/engine/lifecycletest/fuzzing/plan.go
@@ -163,8 +163,7 @@ var operationSpecs = []OperationSpec{
 	// TODO[pulumi/pulumi#21275], [pulumi/pulumi#21273]: uncomment when update operations are stable
 	// PlanOperationUpdate,
 	PlanOperationRefresh,
-	// TODO[pulumi/pulumi#21274]: uncomment when refreshV2 operations are stable
-	// PlanOperationRefreshV2,
+	PlanOperationRefreshV2,
 	PlanOperationDestroy,
 	PlanOperationDestroyV2,
 }


### PR DESCRIPTION
We seem to have enough exclusion rules now that we can enable RefreshV2 in CI and it works. Note that we exclude a relatively big chunk of RefreshV2 test cases with the latest exclusion rules, so this should probably be one of the sooner issues we should address.

Fixes #21274