### PR TITLE
fix flaky TestRefreshV2FailedRead test

### DIFF
--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2025, Pulumi Corporation.
+// Copyright 2020-2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2837,7 +2837,7 @@ func TestRefreshV2FailedRead(t *testing.T) {
 	snap, err := lt.TestOp(RefreshV2).
 		RunStep(project, p.GetTarget(t, setupSnap), opts, false, p.BackendClient, nil, "1")
 	require.ErrorContains(t, err,
-		"BAIL: read failure for urn:pulumi:test-stack::test-project::pkgA:m:typA::resA")
+		"read failure for urn:pulumi:test-stack::test-project::pkgA:m:typA::resA")
 	require.NotNil(t, snap)
 	require.Len(t, snap.Resources, 2)
 	require.Equal(t, resource.ID("id-resA"), snap.Resources[1].ID)


### PR DESCRIPTION
This test is sometimes flaky with a slightly longer error message. Not entirely sure why this happens, but I guess it's something to do with the parallel execution of refresh that sometimes ends in a slightly different codepath.  Either way we can relax the error we're looking for a little bit here, since all we want is to make sure the read is failing, and we get an error for that, not the exact error message.

Fixes https://github.com/pulumi/pulumi/issues/21682