### PR TITLE
print and save environment variables on snapshot integrity errors

### DIFF
--- a/changelog/pending/20260206--cli--show-environment-variables-that-were-set-if-a-snapshot-integrity-error-happens.yaml
+++ b/changelog/pending/20260206--cli--show-environment-variables-that-were-set-if-a-snapshot-integrity-error-happens.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Show environment variables that were set if a snapshot integrity error happens

--- a/pkg/backend/journal.go
+++ b/pkg/backend/journal.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/snapshot"
+	utilenv "github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/maputil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
@@ -486,6 +487,7 @@ func (sj *SnapshotJournaler) saveSnapshot() error {
 			Version: strconv.FormatInt(int64(deployment.Version), 10),
 			Command: strings.Join(os.Args, " "),
 			Error:   integrityError.Error(),
+			EnvVars: utilenv.ConfiguredVariables(),
 		}
 	}
 	persister := sj.persister

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/snapshot"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	utilenv "github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 )
@@ -800,6 +801,7 @@ func (sm *SnapshotManager) saveSnapshot() error {
 			Version: strconv.FormatInt(int64(deployment.Version), 10),
 			Command: strings.Join(os.Args, " "),
 			Error:   integrityError.Error(),
+			EnvVars: utilenv.ConfiguredVariables(),
 		}
 	}
 

--- a/pkg/cmd/pulumi/about/about.go
+++ b/pkg/cmd/pulumi/about/about.go
@@ -43,7 +43,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	declared "github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -221,7 +221,7 @@ func (summary *summaryAbout) Print() {
 	if summary.Backend != nil {
 		fmt.Println(summary.Backend)
 	}
-	formatEnvironmentVariables(declared.Variables())
+	formatEnvironmentVariables(env.ConfiguredVariables())
 	if summary.Dependencies != nil {
 		fmt.Println(formatProgramDependenciesAbout(summary.Dependencies))
 	}
@@ -484,18 +484,16 @@ type programDependencyAbout struct {
 	Version string `json:"version"`
 }
 
-func formatEnvironmentVariables(vars []declared.Var) {
+func formatEnvironmentVariables(vars map[string]string) {
 	table := cmdutil.Table{
 		Headers: []string{"Name", "Value"},
 		Rows:    []cmdutil.TableRow{},
 	}
 
-	for _, v := range vars {
-		if _, present := v.Value.Underlying(); present {
-			table.Rows = append(table.Rows, cmdutil.TableRow{
-				Columns: []string{v.Name(), v.Value.String()},
-			})
-		}
+	for k, v := range vars {
+		table.Rows = append(table.Rows, cmdutil.TableRow{
+			Columns: []string{k, v},
+		})
 	}
 
 	if len(table.Rows) > 0 {

--- a/pkg/cmd/pulumi/cmd/cmd.go
+++ b/pkg/cmd/pulumi/cmd/cmd.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/snapshot"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 )
@@ -142,16 +143,20 @@ Operating System:  %s`,
 
 Write Version:     %s
 Write Command:     %s
+Write Env Vars:    %s
 Write Error:       %s
 
 Read Version:      %s
 Read Command:      %s
+Read Env Vars:     %s
 Read Error:        %s`,
 			sie.Metadata.Version,
 			sie.Metadata.Command,
+			formatEnvVars(sie.Metadata.EnvVars),
 			sie.Metadata.Error,
 			version.Version,
 			strings.Join(os.Args, " "),
+			formatEnvVars(env.ConfiguredVariables()),
 			err,
 		))
 	} else {
@@ -159,9 +164,11 @@ Read Error:        %s`,
 
 Pulumi Version:    %s
 Command:           %s
+Env Vars:          %s
 Error:             %s`,
 			version.Version,
 			strings.Join(os.Args, " "),
+			formatEnvVars(env.ConfiguredVariables()),
 			err,
 		))
 	}
@@ -176,4 +183,15 @@ Stack Trace:
 	))
 
 	cmdutil.Diag().Errorf(diag.RawMessage("" /*urn*/, message.String()))
+}
+
+func formatEnvVars(envVars map[string]string) string {
+	if len(envVars) == 0 {
+		return "(none)"
+	}
+	parts := make([]string, 0, len(envVars))
+	for k, v := range envVars {
+		parts = append(parts, fmt.Sprintf("%s=%s", k, v))
+	}
+	return strings.Join(parts, ", ")
 }

--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -281,6 +281,8 @@ type SnapshotIntegrityErrorMetadataV1 struct {
 	Command string `json:"command,omitempty" yaml:"command,omitempty"`
 	// The error message associated with the integrity error.
 	Error string `json:"error,omitempty" yaml:"error,omitempty"`
+	// EnvVars contains the Pulumi environment variables that were set when the integrity error occurred.
+	EnvVars map[string]string `json:"env_vars,omitempty" yaml:"env_vars,omitempty"`
 }
 
 // OperationType is the type of an operation initiated by the engine. Its value indicates the type of operation

--- a/sdk/go/common/util/env/env.go
+++ b/sdk/go/common/util/env/env.go
@@ -486,3 +486,18 @@ func (js joinStore) Values() iter.Seq2[string, string] {
 		}
 	}
 }
+
+// ConfiguredVariables returns a map of all declared Pulumi environment variables that are set,
+// with their names as keys and their string representations as values.
+//
+// Secret variables will be redacted.
+func ConfiguredVariables() map[string]string {
+	result := make(map[string]string)
+	for _, v := range Variables() {
+		_, present := v.Value.Underlying()
+		if present {
+			result[v.Name()] = v.Value.String()
+		}
+	}
+	return result
+}


### PR DESCRIPTION
We've introduced a bunch of environment variables for commands, but never added them to the output for snapshot integrity issues. This makes the snapshot integrity errors harder to debug when we get bug reports.

Similar to about, print them out for SIEs as well.

Note that we're simply adding the new information to the V1 struct for SIEs.  This is fine, as Go's unmarshaller will simply ignore extra fields, and we don't want to fail just because we have this extra information we can't use. It's still better to get the baseline information even if we don't have info about the SIE.

Fixes https://github.com/pulumi/pulumi/issues/20836
/xref https://github.com/pulumi/pulumi/issues/21583