### PR TITLE
use pulumi-random 4.19.1 in python test

### DIFF
--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2908,7 +2908,8 @@ func TestInstallMultiComponentGitRepo(t *testing.T) {
 	// TODO[https://github.com/pulumi/pulumi/issues/20963]: Remove the need for this
 	// install.
 	e.Env = []string{"PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=true"}
-	e.RunCommand("pulumi", "plugin", "install", "resource", "tls", "v4.11.1")
+	e.RunCommand("pulumi", "plugin", "install", "resource", "tls", "v5.3.0")
+	e.RunCommand("pulumi", "plugin", "install", "resource", "tls", "4.11.1")
 
 	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview")
 

--- a/tests/integration/packages-install-multi-git/Pulumi.yaml
+++ b/tests/integration/packages-install-multi-git/Pulumi.yaml
@@ -2,7 +2,7 @@ name: packages-install-multi-git
 description: A TypeScript program that installs multiple components from same git repo
 packages:
   test-provider: git://github.com/pulumi/component-test-providers/test-provider@52a8a71555d964542b308da197755c64dbe63352
-  test-provider-2: git://github.com/pulumi/component-test-providers/test-provider-2@52a8a71555d964542b308da197755c64dbe63352
+  test-provider-2: git://github.com/pulumi/component-test-providers/test-provider-2@4ea1f5e4f2f2f4fdff64468850e9984a26591055
 runtime:
   name: nodejs
   options:

--- a/tests/smoke/testdata/bad_random_pp/main.pp
+++ b/tests/smoke/testdata/bad_random_pp/main.pp
@@ -1,6 +1,6 @@
 resource "pet" "random:index:RandomPet" {
     options {
-        version = "4.19.1"
+        version = "4.19.0"
     }
 
     length = aVariable

--- a/tests/smoke/testdata/component_pp/rc/main.pp
+++ b/tests/smoke/testdata/component_pp/rc/main.pp
@@ -4,7 +4,7 @@ config "prefix" "string" {
 
 resource "pet" "random:index:RandomPet" {
     options {
-        version = "4.13.0"
+        version = "4.19.0"
     }
 
     prefix = prefix

--- a/tests/smoke/testdata/random_go/go.mod
+++ b/tests/smoke/testdata/random_go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.20
 
 require (
-	github.com/pulumi/pulumi-random/sdk/v4 v4.19.1
+	github.com/pulumi/pulumi-random/sdk/v4 v4.19.0
 	github.com/pulumi/pulumi/sdk/v3 v3.156.0
 )

--- a/tests/smoke/testdata/random_pp/main.pp
+++ b/tests/smoke/testdata/random_pp/main.pp
@@ -1,6 +1,6 @@
 resource "pet" "random:index:RandomPet" {
     options {
-        version = "4.19.1"
+        version = "4.19.0"
     }
 }
 

--- a/tests/smoke/testdata/random_typescript/package.json
+++ b/tests/smoke/testdata/random_typescript/package.json
@@ -6,7 +6,7 @@
         "typescript": "5.9.3"
     },
     "dependencies": {
-        "@pulumi/random": "^4.19.1",
+        "@pulumi/random": "^4.19.0",
         "@pulumi/pulumi": "^3.113.0"
     }
 }


### PR DESCRIPTION
pulumi-random 4.13.0 depends on pkg_resources in python, which has been removed.  This causes this test to fail in CI.  This has been fixed in codegen a long time ago (https://github.com/pulumi/pulumi/pull/15266), so all we need to do here is upgrade the version of pulumi-random, and the python version of this test will work again.

Fixes https://github.com/pulumi/pulumi/issues/21699