### PR TITLE
conformance tests: install plugin dependencies only once

### DIFF
--- a/cmd/pulumi-test-language/test_host.go
+++ b/cmd/pulumi-test-language/test_host.go
@@ -37,18 +37,16 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi-internal/gsync"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 type testHost struct {
-	engine        *languageTestServer
-	ctx           *plugin.Context
-	host          plugin.Host
-	runtime       plugin.LanguageRuntime
-	runtimeName   string
-	providersLock gsync.Map[string, *sync.Mutex]
-	providers     map[string]func() (plugin.Provider, error)
+	engine      *languageTestServer
+	ctx         *plugin.Context
+	host        plugin.Host
+	runtime     plugin.LanguageRuntime
+	runtimeName string
+	providers   map[string]func() (plugin.Provider, error)
 
 	connections map[plugin.Provider]io.Closer
 


### PR DESCRIPTION
Currently in conformance tests we install plugin dependencies potentially multiple times for the same plugin, if multiple tests are using the same one.  This can lead to package managers interfering with eachother, which leads to flakes (in addition to the extra work we're doing).

Install the dependencies only once, before running the plugin.

Fixes https://github.com/pulumi/pulumi/issues/21724