### PR TITLE
Fix remote components with PULUMI_NODEJS_SKIP_COMPONENT_INPUTS

### DIFF
--- a/changelog/pending/20260209--sdk-nodejs--fix-remote-components-with-pulumi_nodejs_skip_component_inputs.yaml
+++ b/changelog/pending/20260209--sdk-nodejs--fix-remote-components-with-pulumi_nodejs_skip_component_inputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix remote components with PULUMI_NODEJS_SKIP_COMPONENT_INPUTS

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -19,8 +19,8 @@ import { Input, Inputs, interpolate, Output, output } from "./output";
 import {
     getResource,
     readResource,
-    registerResource,
     registerErrorHook,
+    registerResource,
     registerResourceHook,
     registerResourceOutputs,
     SourcePosition,
@@ -1546,13 +1546,14 @@ export class ComponentResource<TData = any> extends Resource {
         remote: boolean = false,
         packageRef?: Promise<string | undefined>,
     ) {
-        // If the PULUMI_NODEJS_SKIP_COMPONENT_INPUTS environment variable is set,
-        // we skip sending the inputs to the engine.
         super(
             type,
             name,
             /*custom:*/ false,
-            process.env.PULUMI_NODEJS_SKIP_COMPONENT_INPUTS ? {} : args,
+            // If the PULUMI_NODEJS_SKIP_COMPONENT_INPUTS environment variable is set, we skip sending the
+            // inputs to the engine. Unless this is a remote component, in which case we always send the
+            // inputs.
+            process.env.PULUMI_NODEJS_SKIP_COMPONENT_INPUTS && !remote ? {} : args,
             opts,
             remote,
             false,


### PR DESCRIPTION
This fixes an issue with PULUMI_NODEJS_SKIP_COMPONENT_INPUTS where we would always skip sending the inputs for component resources when this envvar was set. That meant we also skipped sending the inputs for remote components, but those are needed and have always been sent by the SDK.