### PR TITLE
journaling perf test: increase timeout

### DIFF
--- a/tests/performance/performance_test.go
+++ b/tests/performance/performance_test.go
@@ -160,7 +160,7 @@ func TestPerfStackReferenceSecretsBatchUpdate(t *testing.T) {
 func TestPerfManyResourcesWithJournaling(t *testing.T) {
 	initialBenchmark := &integration.AssertPerfBenchmark{
 		T:                      t,
-		MaxUpdateDuration:      90 * time.Second,
+		MaxUpdateDuration:      110 * time.Second,
 		MaxEmptyUpdateDuration: 50 * time.Second,
 	}
 


### PR DESCRIPTION
With higher server loads, this can sometimes take a little longer. Increase the max update duration to account for that.