### PR TITLE
Relax the Copyright banner linter

### DIFF
--- a/sdk/nodejs/.eslintrc.js
+++ b/sdk/nodejs/.eslintrc.js
@@ -27,7 +27,7 @@ module.exports = {
             "line",
             [
                 {
-                    pattern: "Copyright \\d{4}-\\d{4}, Pulumi Corporation.",
+                    pattern: "Copyright \\d{4}(-\\d{4})?, Pulumi Corporation.",
                 },
             ],
         ],


### PR DESCRIPTION
Previously, the NodeJS linter required that a year range be present for all copyright banners. This PR allows single years to be printed. Tested by manually editing a few files and it seems happy enough.

---

As an aside, I can't find anything that says we even need a copyright notice (nor anything that says it would make a difference) in our source files given that there's a top-level LICENSE file. Moreover, what do the years mean? There are plenty of files that have been updated more recently than their copyright year. Are we suggesting that our copyright expires? What is the intention?
