### PR TITLE
upgrade pulumi-dotnet and pulumi-yaml to latest

### DIFF
--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -320,4 +320,4 @@ const (
 )
 
 // PulumiDotnetSDKVersion is the version of the Pulumi .NET SDK to use in program-gen tests
-const PulumiDotnetSDKVersion = "3.99.0"
+const PulumiDotnetSDKVersion = "3.101.0"

--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -28,9 +28,9 @@ download_release() {
 # * When updating .Net, you should also update PulumiDotnetSDKVersion in pkg/codegen/testing/test/helpers.go
 #
 LANGUAGES=(
-  "dotnet v3.99.0"
+  "dotnet v3.101.0"
   "java v1.21.0"
-  "yaml v1.27.0"
+  "yaml v1.28.0"
 )
 
 for i in "${LANGUAGES[@]}"; do


### PR DESCRIPTION
These have been released today, upgrade them ahead of getting the release out.

Not sure the changes in test/helpers.go are still needed?  Presumably we need to do that in pulumi-dotnet now?  cc @iwahbe